### PR TITLE
added xyz_code to bikes

### DIFF
--- a/app/models/bike.rb
+++ b/app/models/bike.rb
@@ -169,6 +169,13 @@ class Bike < ActiveRecord::Base
     end
   end
 
+  before_save :set_xyz_code
+  def set_xyz_code
+    if xyz_code.blank?
+      self.xyz_code = LookupCode.next_code
+    end
+  end
+  
   before_save :set_paints
   def set_paints
     return true unless paint_name.present?

--- a/app/models/lookup_code.rb
+++ b/app/models/lookup_code.rb
@@ -1,0 +1,90 @@
+class LookupCode < ActiveRecord::Base
+  RESERVED_XYZ_CODES = %w{
+    QPQFP
+    VFP1FV
+    FAQ
+    A8QV7
+    CQN7AC7
+    MAPX1NC
+    WHV
+    5FAPCH
+    PFCFN7
+    M1NF
+    PFC157FP
+    1NQFX
+    AQM1N
+  }
+
+  before_create :init_xyz_code
+  def init_xyz_code
+    self.xyz_code = LookupCode.generate_random
+  end
+
+  def LookupCode.release_unused_codes
+    # Find codes that are in the lookup_codes table, 
+    # but NOT in the bikes table. And that were
+    # created a while ago.
+    LookupCode.joins("LEFT OUTER JOIN bikes on bikes.xyz_code = lookup_codes.xyz_code").
+      where("bikes.xyz_code is null").
+      where("lookup_codes.created_at < ?", DateTime.now - 6.hours).
+      select("lookup_codes.id").each do |r|
+        r.destroy
+      end
+  end
+
+  # 21^3 = 9_261
+  # 21^4 = 194_481
+  # 21^5 = 4_084_101
+  # 21^6 = 85_766_121
+  # 21^7 = 1_801_088_541
+  # 21^8 = 37_822_859_361
+  # 21^9 = 794_280_046_581
+
+  def LookupCode.generate_random
+    # four digit:
+    # n = Random.rand(194_480 - 9_261) + 9_261
+    # five digit:
+    # n = Random.rand(4_084_100 - 194_481) + 194_481
+    # six digit:
+    n = Random.rand(85_766_120 - 4_084_101) + 4_084_101
+    LookupCode.n_to_obscode(n)
+  end
+
+  def LookupCode.next_code(max_tries=100)    
+    begin
+      x = LookupCode.create!
+      if RESERVED_XYZ_CODES.include? x.xyz_code
+        return LookupCode.next_code(max_tries - 1)
+      end
+      if x.xyz_code =~ /^\d+$/
+        # We don't want any all-numeric codes
+        return LookupCode.next_code(max_tries - 1)
+      end
+      if x.xyz_code =~ /VV/
+        # don't allow fake Ws
+        return LookupCode.next_code(max_tries - 1)
+      end    
+    rescue ActiveRecord::RecordNotUnique
+      if max_tries > 1
+        return LookupCode.next_code(max_tries - 1)
+      else
+        raise
+      end
+    end
+    return x.xyz_code
+  end
+
+  def LookupCode.n_to_obscode(n)
+    n.to_s(21).tr("0123456789abcdefghijk", "a8cqfh1j7xmnp5vw23469").upcase
+  end
+    
+  def LookupCode.obscode_to_n(c)
+    # Once we've generated the code, we probably don't
+    # care what the integer value was anymore.
+    LookupCode.disambiguate(c).downcase.tr("a8cqfh1j7xmnp5vw23469", "0123456789abcdefghijk").to_i(21)
+  end
+  
+  def LookupCode.disambiguate(c)
+    c.downcase.tr("0123456789abcdefghijklmnopqrstuvwxyz", "q123456789a8cqffch1jx1mnqpqp57vvwxv2").upcase
+  end
+end

--- a/db/migrate/20140129060122_create_lookup_codes.rb
+++ b/db/migrate/20140129060122_create_lookup_codes.rb
@@ -1,0 +1,10 @@
+class CreateLookupCodes < ActiveRecord::Migration
+  def change
+    create_table :lookup_codes do |t|
+      t.string :xyz_code
+      t.timestamps
+    end
+    
+    add_index :lookup_codes, :xyz_code, :unique => true
+  end
+end

--- a/db/migrate/20140129060423_add_xyz_code_to_bikes.rb
+++ b/db/migrate/20140129060423_add_xyz_code_to_bikes.rb
@@ -1,0 +1,6 @@
+class AddXyzCodeToBikes < ActiveRecord::Migration
+  def change
+    add_column :bikes, :xyz_code, :string
+    add_index :bikes, :xyz_code, :unique => true
+  end
+end

--- a/db/migrate/20140129072003_assign_lookup_codes.rb
+++ b/db/migrate/20140129072003_assign_lookup_codes.rb
@@ -1,0 +1,15 @@
+class AssignLookupCodes < ActiveRecord::Migration
+  def up
+    User.connection.schema_cache.clear!
+    User.reset_column_information
+
+    Bike.where(:xyz_code => nil).find_each do |b|
+      xyz = LookupCode.next_code
+      b.update_attribute(:xyz_code, xyz)
+    end
+  end
+
+  def down
+    # leave a mesg after the beep
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20140122181308) do
+ActiveRecord::Schema.define(:version => 20140129072003) do
 
   create_table "b_params", :force => true do |t|
     t.text     "params"
@@ -102,9 +102,11 @@ ActiveRecord::Schema.define(:version => 20140122181308) do
     t.integer  "creation_country_id"
     t.integer  "country_id"
     t.string   "serial_normalized"
+    t.string   "xyz_code"
   end
 
   add_index "bikes", ["creation_organization_id"], :name => "index_bikes_on_organization_id"
+  add_index "bikes", ["xyz_code"], :name => "index_bikes_on_xyz_code", :unique => true
 
   create_table "blogs", :force => true do |t|
     t.text     "title"
@@ -266,6 +268,14 @@ ActiveRecord::Schema.define(:version => 20140122181308) do
   end
 
   add_index "locks", ["user_id"], :name => "index_locks_on_user_id"
+
+  create_table "lookup_codes", :force => true do |t|
+    t.string   "xyz_code"
+    t.datetime "created_at", :null => false
+    t.datetime "updated_at", :null => false
+  end
+
+  add_index "lookup_codes", ["xyz_code"], :name => "index_lookup_codes_on_xyz_code", :unique => true
 
   create_table "manufacturers", :force => true do |t|
     t.string   "name"

--- a/spec/models/lookup_code_spec.rb
+++ b/spec/models/lookup_code_spec.rb
@@ -1,0 +1,5 @@
+require 'spec_helper'
+
+describe LookupCode do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
I included the bits to exclude lookup codes that have only digits, and the double V thing. You should be able to do a regexp on the id param and decide to lookup by id or by xyz_code. No need to do 2 queries to figure out which key to use.

There's a migration to set lookup codes for existing bikes (using update_attribute for minimal data disruption). And there's a simple before_save callback to set the code for any new records.
