### PR TITLE
wrote some tests for posting recoveries to the recovery app

### DIFF
--- a/app/workers/recovery_notify_worker.rb
+++ b/app/workers/recovery_notify_worker.rb
@@ -2,7 +2,7 @@ class RecoveryNotifyWorker
   include Sidekiq::Worker
   sidekiq_options queue: 'notify'
   sidekiq_options backtrace: true
-    
+
   def perform(stolen_record_id)
     stolen_record = StolenRecord.unscoped.find(stolen_record_id)
     return true if stolen_record.recovery_posted
@@ -24,11 +24,11 @@ class RecoveryNotifyWorker
       options[:recovery_information][:tweet] = stolen_record.recovery_tweet
     end
 
-    HTTParty.post(ENV['RECOVERY_APP_URL'],
+    response = HTTParty.post(ENV['RECOVERY_APP_URL'],
       body: options.to_json,
       headers: { 'Content-Type' => 'application/json' })
 
-    if response.code == '200'
+    if response.code == 200
       stolen_record.update_attribute :recovery_posted, true
     end
   end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -23,14 +23,14 @@ FactoryGirl.define do
     "#{n}0"
   end
 
-  factory :user do 
+  factory :user do
     name
     email { generate(:unique_email)}
     password "testthisthing7$"
     password_confirmation "testthisthing7$"
     terms_of_service true
   end
-  
+
   factory :bike_token do
     association :user
     association :organization
@@ -45,7 +45,7 @@ FactoryGirl.define do
     invitee_email "george@test.com"
   end
 
-  factory :cycle_type do 
+  factory :cycle_type do
     name { FactoryGirl.generate(:unique_name) }
     slug { FactoryGirl.generate(:unique_name) }
   end
@@ -55,16 +55,16 @@ FactoryGirl.define do
     frame_maker true
   end
 
-  factory :frame_material do 
+  factory :frame_material do
     name { FactoryGirl.generate(:unique_name) }
     slug { FactoryGirl.generate(:unique_name) }
   end
 
-  factory :propulsion_type do 
+  factory :propulsion_type do
     name { FactoryGirl.generate(:unique_name) }
   end
 
-  factory :wheel_size do 
+  factory :wheel_size do
     name { FactoryGirl.generate(:unique_name) }
     iso_bsd { FactoryGirl.generate(:unique_iso) }
     priority 1
@@ -76,16 +76,16 @@ FactoryGirl.define do
     slug { FactoryGirl.generate(:unique_name) }
   end
 
-  factory :color do 
+  factory :color do
     name { FactoryGirl.generate(:unique_name) }
     priority 1
   end
 
-  factory :paint do 
+  factory :paint do
     name { FactoryGirl.generate(:unique_name) }
   end
 
-  factory :b_param do 
+  factory :b_param do
     association :creator, factory: :user
   end
 
@@ -102,13 +102,21 @@ FactoryGirl.define do
     association :primary_frame_color, factory: :color
     rear_tire_narrow true
     sequence(:owner_email) {|n| "bike_owner#{n}@example.com"}
+
+    factory :stolen_bike do
+      stolen true
+      after(:create) do |bike|
+        create(:stolen_record, bike: bike)
+        bike.save # updates current_stolen_record
+      end
+    end
   end
 
-  factory :cgroup do 
+  factory :cgroup do
     name { FactoryGirl.generate(:unique_name) }
   end
 
-  factory :ctype do 
+  factory :ctype do
     sequence(:name) {|n| "Component type#{n}"}
     association :cgroup
   end
@@ -120,7 +128,7 @@ FactoryGirl.define do
     sequence(:owner_email) {|n| "owner#{n}@example.com"}
   end
 
-  factory :component do 
+  factory :component do
     association :bike, factory: :bike
     association :ctype
   end
@@ -133,8 +141,8 @@ FactoryGirl.define do
     available_invitation_count 5
   end
 
-  factory :location do 
-    name 
+  factory :location do
+    name
     association :organization
     association :country
     association :state
@@ -143,22 +151,22 @@ FactoryGirl.define do
     street 'foo address'
   end
 
-  factory :country do 
-    name 
+  factory :country do
+    name
     sequence(:iso) {|n| "D#{n}"}
   end
 
-  factory :state do 
-    name 
+  factory :state do
+    name
     association :country
     sequence(:abbreviation) {|n| "Q#{n}"}
   end
 
-  factory :lock_type do 
+  factory :lock_type do
     name { FactoryGirl.generate(:unique_name) }
   end
 
-  factory :lock do 
+  factory :lock do
     association :user
     association :manufacturer
     association :lock_type
@@ -199,12 +207,12 @@ FactoryGirl.define do
     subject 'New Stolen Notification Submitted'
   end
 
-  factory :stolen_record do 
-    association :bike 
-    date_stolen Time.now 
+  factory :stolen_record do
+    bike
+    date_stolen Time.now
   end
 
-  factory :customer_contact do 
+  factory :customer_contact do
     association :creator, factory: :user
     association :bike
     title 'Some title'

--- a/spec/workers/recovery_notify_worker_spec.rb
+++ b/spec/workers/recovery_notify_worker_spec.rb
@@ -7,23 +7,33 @@ describe RecoveryNotifyWorker do
     RecoveryNotifyWorker.perform_async
     expect(RecoveryNotifyWorker).to have_enqueued_job
   end
-  it "should post a thing to the api with no sharing" do 
+
+  it "should post to the recovery app with no sharing" do
+    Sidekiq::Testing.inline!
+    bike = FactoryGirl.create(:stolen_bike)
+    bike.current_stolen_record.can_share_recovery.should be_false
+    bike.current_stolen_record.date_recovered = Time.now
+    bike.current_stolen_record.recovered_description = "I stole it from myself so it wasn't hard to get it back"
+    bike.current_stolen_record.save
+    work = RecoveryNotifyWorker.new
+    work.perform(bike.current_stolen_record_id)
+    StolenRecord.find(bike.current_stolen_record_id).recovery_posted.should be true
   end
 
-  # it "should post to the recovery app with no sharing" do 
-  #   Sidekiq::Testing.inline!
-  #   bike = FactoryGirl.create(:bike)
-  #   stolen_record = FactoryGirl.create(:stolen_record, bike: bike)
-  #   bike.current_stolen_record.can_share_recovery.should be_false
-  #   bike.current_stolen_record.recovery_posted.should be_true
-  # end
-
-  # it "should post to the recovery app with sharing" do 
-  #   Sidekiq::Testing.inline!
-  #   bike = FactoryGirl.create(:bike)
-  #   stolen_record = FactoryGirl.create(:stolen_record, bike: bike)
-  #   bike.current_stolen_record.can_share_recovery.should be_false
-  #   bike.current_stolen_record.recovery_posted.should be_true
-  # end
+  it "should post to the recovery app with sharing" do
+    Sidekiq::Testing.inline!
+    bike = FactoryGirl.create(:stolen_bike)
+    bike.current_stolen_record.can_share_recovery = true
+    bike.current_stolen_record.date_recovered = Time.now
+    bike.current_stolen_record.recovered_description = "Lorem ipsum"
+    bike.current_stolen_record.index_helped_recovery = true
+    bike.current_stolen_record.recovery_tweet = "The BikeIndex is awesome and someone helped me find my bike!"
+    bike.current_stolen_record.recovery_share = "Some guy named Poopypants found my bike on Craigslist and posted on the BikeIndex and I called the police who checked out my BikeIndex page and went to the Craigslister and got my bike back"
+    bike.current_stolen_record.save
+    work = RecoveryNotifyWorker.new
+    work.perform(bike.current_stolen_record_id)
+    #bike.current_stolen_record.recovery_posted.should be_true
+    StolenRecord.find(bike.current_stolen_record_id).recovery_posted.should be true
+  end
 
 end


### PR DESCRIPTION
There are some tests. If you want me to update the recovery app to respond with more information (like a URL of a tweet and facebook post if they're created) I can do that. Otherwise I think this works. I had some trouble in the spec at https://github.com/adherr/bike_index/blob/a2bf1708bf737f9b1b1899d39f346670d6ba9c55/spec/workers/recovery_notify_worker_spec.rb#L20 because the local variable in the spec was not re-querying after the update to do the test. Is this normal? How do you usually deal with this?

I also created a :stolen_bike factory that correctly creates and associates current_stolen_record (please take a look at that to be sure it's sane).

Fixed two little bugs in the worker to make the tests pass (using the default .env.development, so not pushing to the real recovery app. I looked at the JSON it sends and it looks good).

And, as usual, my emacs deletes whitespace at the end of lines and adds newlines at the end of files.
