### PR TITLE
Never trust manufacturer_id on bike create

### DIFF
--- a/app/controllers/admin/bikes_controller.rb
+++ b/app/controllers/admin/bikes_controller.rb
@@ -19,7 +19,7 @@ class Admin::BikesController < Admin::BaseController
 
   def missing_manufacturer
     session[:missing_manufacturer_time_order] = params[:time_ordered] if params[:time_ordered].present?
-    bikes = Bike.unscoped.where(manufacturer_id: Manufacturer.other_manufacturer.id)
+    bikes = Bike.unscoped.where(manufacturer_id: Manufacturer.other.id)
     bikes = session[:missing_manufacturer_time_order] ? bikes.order('created_at desc') : bikes.order('manufacturer_other ASC')
     page = params[:page] || 1
     per_page = params[:per_page] || 100

--- a/app/controllers/admin/dashboard_controller.rb
+++ b/app/controllers/admin/dashboard_controller.rb
@@ -15,7 +15,7 @@ class Admin::DashboardController < Admin::BaseController
   def maintenance
     # @bikes here because this is the only one we're using the standard admin bikes table
     @bikes = Bike.unscoped.order('created_at desc').where(example: true).limit(10)
-    mnfg_other_id = Manufacturer.other_manufacturer.id
+    mnfg_other_id = Manufacturer.other.id
     @component_mnfgs = Component.where(manufacturer_id: mnfg_other_id)
     @bike_mnfgs = Bike.where(manufacturer_id: mnfg_other_id)
     @component_types = Component.where(ctype_id: Ctype.other.id)

--- a/app/models/manufacturer.rb
+++ b/app/models/manufacturer.rb
@@ -43,7 +43,7 @@ class Manufacturer < ActiveRecord::Base
       m && m.id
     end
 
-    def other_manufacturer
+    def other
       where(name: 'Other', frame_maker: true).first_or_create
     end
 

--- a/app/views/bikes/edit_accessories.html.haml
+++ b/app/views/bikes/edit_accessories.html.haml
@@ -1,5 +1,5 @@
 - @ctype_other_id = Ctype.other.id
-- @manufacturer_other_id = Manufacturer.other_manufacturer.id
+- @manufacturer_other_id = Manufacturer.other.id
 = form_for @bike, multipart: true, html: { class: 'primary-edit-bike-form' } do |f|
   .form-well-container.container{ class: "edit-bike-page-#{@edit_template}" }
     .row

--- a/app/views/locks/_form.html.haml
+++ b/app/views/locks/_form.html.haml
@@ -27,7 +27,7 @@
     .row
       .col-md-6
         .related-fields
-          .form-group.unfancy.fancy-select.manufacturer-select{ data: { otherid: Manufacturer.other_manufacturer.id } }
+          .form-group.unfancy.fancy-select.manufacturer-select{ data: { otherid: Manufacturer.other.id } }
             = f.label :manufacturer_id, class: "form-label"
             = f.collection_select(:manufacturer_id, Manufacturer.all, :id, :name, { required: true, prompt: "Choose manufacturer" }, class: 'form-control')
           .hidden-other.form-group

--- a/app/views/organizations/embed_sf_safe.html.haml
+++ b/app/views/organizations/embed_sf_safe.html.haml
@@ -46,7 +46,7 @@
         %span.help-block
           Select 'Other' if manufacturer isn't listed
     %p.other-value
-      = Manufacturer.other_manufacturer.id
+      = Manufacturer.other.id
     .hidden-other.control-group.manufacturer-other-input
       = f.label :manufacturer_other, "Other manufacturer", class: "control-label"
       .controls

--- a/spec/controllers/bikes_controller_spec.rb
+++ b/spec/controllers/bikes_controller_spec.rb
@@ -444,16 +444,19 @@ describe BikesController do
             expect(bike.owner_email).to eq bike_params[:owner_email].downcase
             expect(bike.creation_state.origin).to eq 'embed_extended'
             expect(bike.creation_state.organization).to eq organization
+            expect(bike.manufacturer).to eq manufacturer
           end
         end
       end
       context 'with persisted email' do
         it 'registers a bike and redirects with persist_email' do
-          post :create, bike: bike_params, persist_email: true
+          post :create, bike: bike_params.merge(manufacturer_id: 'A crazy different thing'), persist_email: true
           expect(response).to redirect_to(embed_extended_organization_url(organization, email: 'flow@goodtimes.com'))
           bike = Bike.last
           expect(bike.creation_state.origin).to eq 'embed_extended'
           expect(bike.creation_state.organization).to eq organization
+          expect(bike.manufacturer).to eq Manufacturer.other
+          expect(bike.manufacturer_other).to eq 'A crazy different thing'
         end
       end
     end

--- a/spec/models/b_param_spec.rb
+++ b/spec/models/b_param_spec.rb
@@ -166,22 +166,66 @@ describe BParam do
   end
 
   describe 'set_manufacturer_key' do
-    it 'adds other manufacturer name and set the set the foreign keys' do
-      m = FactoryGirl.create(:manufacturer, name: 'Other')
-      bike = { manufacturer: 'gobble gobble' }
-      b_param = BParam.new(params: { bike: bike })
-      b_param.set_manufacturer_key
-      expect(b_param.bike['manufacturer']).not_to be_present
-      expect(b_param.bike['manufacturer_id']).to eq(m.id)
-      expect(b_param.bike['manufacturer_other']).to eq('Gobble Gobble')
+    context 'attr set on manufacturer_id' do
+      context 'other' do
+        it 'adds other manufacturer name and set the set the foreign keys' do
+          bike = { manufacturer_id: 'lololol' }
+          b_param = BParam.new(params: { bike: bike })
+          b_param.set_manufacturer_key
+          expect(b_param.bike['manufacturer']).not_to be_present
+          expect(b_param.bike['manufacturer_id']).to eq(Manufacturer.other.id)
+          expect(b_param.bike['manufacturer_other']).to eq('lololol')
+        end
+      end
+      context 'existing manufacturer' do
+        let(:manufacturer) { FactoryGirl.create(:manufacturer) }
+        context 'manufacturer name' do
+          it 'uses manufacturer' do
+            bike = { manufacturer_id: manufacturer.id }
+            b_param = BParam.new(params: { bike: bike })
+            b_param.set_manufacturer_key
+            expect(b_param.bike['manufacturer_id']).to eq(manufacturer.id)
+          end
+        end
+        context 'manufacturer id' do
+          it 'sets the manufacturer' do
+            bike = { manufacturer_id: manufacturer.id }
+            b_param = BParam.new(params: { bike:  bike })
+            b_param.set_manufacturer_key
+            expect(b_param.bike['manufacturer_id']).to eq(manufacturer.id)
+          end
+        end
+      end
+      context 'no manufacturer or manufacturer_id' do
+        it 'does not set anything' do
+          bike = { manufacturer_id: ' ' }
+          b_param = BParam.new(params: { bike:  bike })
+          b_param.set_manufacturer_key
+          expect(b_param.bike['manufacturer_id']).to be_nil
+        end
+      end
     end
-    it 'looks through book slug' do
-      m = FactoryGirl.create(:manufacturer, name: 'Something Cycles')
-      bike = { manufacturer: 'something' }
-      b_param = BParam.new(params: { bike: bike })
-      b_param.set_manufacturer_key
-      expect(b_param.bike['manufacturer']).not_to be_present
-      expect(b_param.bike['manufacturer_id']).to eq(m.id)
+    context 'attr set on manufacturer' do
+      context 'other manufacturer' do
+        it 'adds other manufacturer name and set the set the foreign keys' do
+          bike = { manufacturer: 'gobble gobble' }
+          b_param = BParam.new(params: { bike: bike })
+          b_param.set_manufacturer_key
+          expect(b_param.bike['manufacturer']).not_to be_present
+          expect(b_param.bike['manufacturer_id']).to eq(Manufacturer.other.id)
+          expect(b_param.bike['manufacturer_other']).to eq('gobble gobble')
+        end
+      end
+      context 'existing manufacturer' do
+        it 'looks through book slug' do
+          manufacturer = FactoryGirl.create(:manufacturer, name: 'Something Cycles')
+          bike = { manufacturer: 'something' }
+          b_param = BParam.new(params: { bike: bike })
+          b_param.set_manufacturer_key
+          expect(b_param.bike['manufacturer']).not_to be_present
+          expect(b_param.bike['manufacturer_id']).to eq(manufacturer.id)
+        end
+      end
     end
   end
 


### PR DESCRIPTION
Fix break when `manufacturer_id` is a random strings - probs due to disabled javascript

Also, make `Manufacturer.other` consistent with other models `other` method.