### PR TITLE
Revert unintended API v1

### DIFF
--- a/app/controllers/api/v1/bikes_controller.rb
+++ b/app/controllers/api/v1/bikes_controller.rb
@@ -46,7 +46,7 @@ module Api
           since_date = Time.at(params[:updated_since].to_i).utc.to_datetime
           stolen = stolen.where("updated_at >= ?", since_date)
         end
-        render json: stolen.pluck(:bike_id).to_json
+        render json: { bikes: stolen.pluck(:bike_id) }
       end
 
       def close_serials

--- a/spec/controllers/api/v1/bikes_controller_spec.rb
+++ b/spec/controllers/api/v1/bikes_controller_spec.rb
@@ -27,7 +27,7 @@ describe Api::V1::BikesController do
       get :stolen_ids, options.as_json
       expect(response.code).to eq('200')
       # pp response
-      bikes = JSON.parse(response.body)
+      bikes = JSON.parse(response.body)['bikes']
       expect(bikes.count).to eq(1)
       expect(bikes.first).to eq(stole2.bike.id)
     end


### PR DESCRIPTION
`stolen_ids` should respond with a hash that looks like `{ bikes: [] }`, not a raw array.

Fix the unintended issue caused by #261