### PR TITLE
Attempt to resolve issue with spec failure

### DIFF
--- a/spec/controllers/bikes_controller_spec.rb
+++ b/spec/controllers/bikes_controller_spec.rb
@@ -362,6 +362,7 @@ describe BikesController do
             expect(bike.creation_state.creator).to eq bike.creator
             testable_bike_params.each { |k, v| expect(bike.send(k).to_s).to eq v.to_s }
             stolen_record = bike.current_stolen_record
+            pp stolen_params
             stolen_params.except(:date_stolen_input).each { |k, v| expect(stolen_record.send(k).to_s).to eq v.to_s }
             expect(stolen_record.date_stolen.to_date).to eq Date.today
           end


### PR DESCRIPTION
Something to do with stolen params `date_stolen_input` in embeded entries.

Failure does not happen locally.