### PR TITLE
add cruiser handlebar type

### DIFF
--- a/db/seeds/seed_bike_associations.rb
+++ b/db/seeds/seed_bike_associations.rb
@@ -53,6 +53,7 @@ end
 # Seed the handlebar types
 handlebar_types = [
   { name: 'Flat or riser', slug: 'flat' },
+  { name: 'Cruiser', slug: 'cruiser' },
   { name: 'Drop', slug: 'drop' },
   { name: 'Forward facing', slug: 'forward' },
   { name: 'Rear facing', slug: 'rearward' },


### PR DESCRIPTION
Went to add a bike that has cruiser bars, which doesn't exist in the handlebar type dropdown. Pretty sure this commit will fix that moving forward.
