### PR TITLE
update automailer subject to something more accurate

### DIFF
--- a/spec/mailers/organized_mailer_spec.rb
+++ b/spec/mailers/organized_mailer_spec.rb
@@ -53,7 +53,7 @@ describe OrganizedMailer do
         let(:bike) { FactoryGirl.create(:bike, owner_email: 'someotheremail@stuff.com', creator_id: user.id) }
         it 'renders email' do
           expect(ownership_1).to be_present
-          expect(mail.subject).to eq('Confirm your Bike Index registration')
+          expect(mail.subject).to eq('New Bike Index registration successful')
           expect(mail.reply_to).to eq(['contact@bikeindex.org'])
         end
       end


### PR DESCRIPTION
Registered a new bike, received an email with the subject "Confirm your Bike Index registration", but since I've already registered other bikes, the email was more of a welcome email and I didn't need to confirm anything. This commit should update the subject to something more relevant for future emails sent to existing users. Feel free to rework the wording if necessary.
