### PR TITLE
Create a cumulative graph of bikes

### DIFF
--- a/app/controllers/welcome_controller.rb
+++ b/app/controllers/welcome_controller.rb
@@ -1,8 +1,13 @@
 class WelcomeController < ApplicationController
   layout 'application_revised'
   before_filter :authenticate_user_for_welcome_controller, only: [:user_home, :choose_registration]
+  skip_before_filter :set_x_frame_options_header, only: [:creation_graph]
 
   def index
+  end
+
+  def creation_graph
+    render layout: false
   end
 
   def update_browser

--- a/app/controllers/welcome_controller.rb
+++ b/app/controllers/welcome_controller.rb
@@ -1,12 +1,13 @@
 class WelcomeController < ApplicationController
   layout 'application_revised'
   before_filter :authenticate_user_for_welcome_controller, only: [:user_home, :choose_registration]
-  skip_before_filter :set_x_frame_options_header, only: [:creation_graph]
+  skip_before_filter :set_x_frame_options_header, only: [:bike_creation_graph]
 
   def index
   end
 
-  def creation_graph
+  def bike_creation_graph
+    @height = (params[:height] || 300).to_i
     render layout: false
   end
 

--- a/app/views/welcome/bike_creation_graph.haml
+++ b/app/views/welcome/bike_creation_graph.haml
@@ -1,9 +1,9 @@
 = javascript_include_tag "//www.google.com/jsapi", "chartkick"
 
-- cache('bike_chart', expires_in: 1.hour) do
+- cache("bike_chart_#{@height}", expires_in: 1.hour) do
   - merge = DateTime.strptime('07-01-2014 0', '%m-%d-%Y %H')
   - post_merge = Bike.unscoped.where(example: false).where(hidden: false).where('created_at > ?', merge).group_by_month(:created_at).count
   - sum = Bike.unscoped.where(example: false).where(hidden: false).where('created_at < ?', merge).count
   - result = post_merge.to_a.sort{|x,y| x[0] <=> y[0]}.map { |x,y| { x => (sum += y)} }.reduce({}, :merge)
 
-  = line_chart result
+  = line_chart result, height: "#{@height}px"

--- a/app/views/welcome/creation_graph.haml
+++ b/app/views/welcome/creation_graph.haml
@@ -1,0 +1,9 @@
+= javascript_include_tag "//www.google.com/jsapi", "chartkick"
+
+- cache('bike_chart', expires_in: 1.hour) do
+  - merge = DateTime.strptime('07-01-2014 0', '%m-%d-%Y %H')
+  - post_merge = Bike.unscoped.where(example: false).where(hidden: false).where('created_at > ?', merge).group_by_month(:created_at).count
+  - sum = Bike.unscoped.where(example: false).where(hidden: false).where('created_at < ?', merge).count
+  - result = post_merge.to_a.sort{|x,y| x[0] <=> y[0]}.map { |x,y| { x => (sum += y)} }.reduce({}, :merge)
+
+  = line_chart result

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -30,6 +30,7 @@ Bikeindex::Application.routes.draw do
   get 'user_home', to: 'welcome#user_home'
   get 'choose_registration', to: 'welcome#choose_registration'
   get 'goodbye', to: 'welcome#goodbye'
+  get 'creation_graph', to: 'welcome#creation_graph'
 
   resource :session, only: [:new, :create, :destroy]
   get 'logout', to: 'sessions#destroy'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -30,7 +30,7 @@ Bikeindex::Application.routes.draw do
   get 'user_home', to: 'welcome#user_home'
   get 'choose_registration', to: 'welcome#choose_registration'
   get 'goodbye', to: 'welcome#goodbye'
-  get 'creation_graph', to: 'welcome#creation_graph'
+  get 'bike_creation_graph', to: 'welcome#bike_creation_graph'
 
   resource :session, only: [:new, :create, :destroy]
   get 'logout', to: 'sessions#destroy'

--- a/spec/controllers/welcome_controller_spec.rb
+++ b/spec/controllers/welcome_controller_spec.rb
@@ -11,6 +11,14 @@ describe WelcomeController do
     end
   end
 
+  describe 'creation_graph' do
+    it 'renders embed without xframe block' do
+      get :creation_graph
+      expect(response.code).to eq('200')
+      expect(response.headers['X-Frame-Options']).not_to be_present
+    end
+  end
+
   describe 'goodbye' do
     it 'renders' do
       get :goodbye

--- a/spec/controllers/welcome_controller_spec.rb
+++ b/spec/controllers/welcome_controller_spec.rb
@@ -11,9 +11,9 @@ describe WelcomeController do
     end
   end
 
-  describe 'creation_graph' do
+  describe 'bike_creation_graph' do
     it 'renders embed without xframe block' do
-      get :creation_graph
+      get :bike_creation_graph
       expect(response.code).to eq('200')
       expect(response.headers['X-Frame-Options']).not_to be_present
     end


### PR DESCRIPTION
Initially did from when Bike Index was started, but decided to use from merger with SBR instead.

To get the graph of all time (in a terrible, non-performant way) I did:

```ruby
creation = DateTime.strptime('01-01-2013 0', '%m-%d-%Y %H')
merge_end = DateTime.strptime('07-01-2014 0', '%m-%d-%Y %H')
sbr_bikes = Bike.where(creation_organization_id: 36).where('created_at < ?', merge_end)
sbr_bikes_ids = sbr_bikes.pluck(:id)
sbr_bikes_count = sbr_bikes.count + Bike.unscoped.where('created_at < ?', creation).where.not(id: sbr_bikes_ids).count # Primarily Bike Portland ;)
pre_merge = Bike.unscoped.where('created_at < ?', merge_end).where('created_at > ?', creation).where.not(id: sbr_bikes_ids).group_by_month(:created_at).count
pre_merge[pre_merge.keys.last] = pre_merge[pre_merge.keys.last] + sbr_bikes_count
post_merge = Bike.unscoped.where('created_at > ?', merge_end + 1.day).group_by_month(:created_at).count
all_counts = pre_merge.merge(post_merge)
sum = 0
result = all_counts.to_a.sort{|x,y| x[0] <=> y[0]}.map { |x,y| { x => (sum += y)} }.reduce({}, :merge)
```