### PR TITLE
Enhancement/continue oauth after accepting terms

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,6 @@ log/localeapp.yml
 sm_import_*.json
 spec/fixtures/bikes/*.json
 manufacturer.tsv
+
+# RubyMIne
+.idea/*

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -775,7 +775,7 @@ DEPENDENCIES
   wkhtmltopdf-binary
 
 RUBY VERSION
-   ruby 2.2.5p319
+   ruby 2.2.2p95
 
 BUNDLED WITH
-   1.13.5
+   1.12.5

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -775,7 +775,7 @@ DEPENDENCIES
   wkhtmltopdf-binary
 
 RUBY VERSION
-   ruby 2.2.2p95
+   ruby 2.2.5p319
 
 BUNDLED WITH
-   1.12.5
+   1.13.5

--- a/app/controllers/welcome_controller.rb
+++ b/app/controllers/welcome_controller.rb
@@ -20,13 +20,16 @@ class WelcomeController < ApplicationController
   end
 
   def user_home
-    bikes = current_user.bikes
-    page = params[:page] || 1
-    @locks_active_tab = params[:active_tab] == 'locks'
-    @per_page = params[:per_page] || 20
-    paginated_bikes = Kaminari.paginate_array(bikes).page(page).per(@per_page)
-    @bikes = BikeDecorator.decorate_collection(paginated_bikes)
-    @locks = LockDecorator.decorate_collection(current_user.locks)
+
+    unless return_to_if_present
+      bikes = current_user.bikes
+      page = params[:page] || 1
+      @locks_active_tab = params[:active_tab] == 'locks'
+      @per_page = params[:per_page] || 20
+      paginated_bikes = Kaminari.paginate_array(bikes).page(page).per(@per_page)
+      @bikes = BikeDecorator.decorate_collection(paginated_bikes)
+      @locks = LockDecorator.decorate_collection(current_user.locks)
+    end
   end
 
   def choose_registration

--- a/config/initializers/doorkeeper.rb
+++ b/config/initializers/doorkeeper.rb
@@ -10,7 +10,7 @@ Doorkeeper.configure do
   # This block will be called to check whether the resource owner is authenticated or not.
   resource_owner_authenticator do
     @user ||= User.from_auth(cookies.signed[:auth])
-    unless @user
+    if @user.blank? || !@user.terms_of_service
       session[:return_to] = request.fullpath
       redirect_to(new_session_url)
     end


### PR DESCRIPTION
Continue the oAuth 2.0 doorkeeper flow when the user is signing up with Facebook or Strava for the first time. It will help the mobile/other clients to receive the access token immediately.