### PR TITLE
Add support for Vagrant development environment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,10 @@ spec/fixtures/tsv_creation/*.json
 .ruby-version
 .powenv
 
+# Ignore Chef stuff
+Cheffile.lock
+cookbooks/*
+
 # Ignore localeapp
 .localeapp
 log/localeapp.yml

--- a/Cheffile
+++ b/Cheffile
@@ -1,0 +1,9 @@
+site "http://community.opscode.com/api/v1"
+
+cookbook 'apt'
+cookbook 'build-essential'
+cookbook 'system'
+cookbook 'ruby_build'
+cookbook 'ruby_rbenv', '~> 1.1.0'
+cookbook 'postgresql', git:'https://github.com/phlipper/chef-postgresql'
+cookbook 'vim'

--- a/README.markdown
+++ b/README.markdown
@@ -73,8 +73,6 @@ For your convenience, this repository includes both a Cheffile and Vagrantfile w
 
 - At least 1.5GB of free memory
 
-- `vagrant plugin install vagrant-vbguest` & `vagrant plugin install vagrant-librarian-chef-nochef`. This only needs done once. Read https://gorails.com/guides/using-vagrant-for-rails-development for more info
-
 Run `vagrant up` to start the virtual machine, then `vagrant ssh` and `cd /vagrant`, which will point to the root of this repository on your host machine. Port 3001 is forwarded locally for testing. Be warned, it will take around a half hour or longer (depending on your internet connection) on first run to download additional Vagrant/Chef dependencies and to provision the dev environment. You may observe some informational warning messages during the initial setup which you can safely ignore. `vagrant halt` to shutdown the VM. Subsequent startups will take considerably less time after the initial run.
 
 ### Troubleshooting

--- a/README.markdown
+++ b/README.markdown
@@ -60,6 +60,26 @@ CREATE EXTENSION fuzzystrmatch;
 
 - If you're working on frontend development, you can use [Guard::LiveReload](https://github.com/guard/guard-livereload) to reload the frontend as you work with `bundle exec guard -G Guardfile_frontend`
 
+## Vagrant development box
+
+For your convenience, this repository includes both a Cheffile and Vagrantfile which are used to automatically set up and configure a virtual local (Xenial) development environment with all of the required dependencies preinstalled and configured (via Chef, because Ruby) for anyone wishing to contribute without needing to set everything up beforehand. This explanation assumes you're somewhat familiar with Vagrant/VirtualBox, Chef, automation, et al.
+
+### Dependencies/Requirements
+- A computer that supports hardware virtualization (Intel VT-x/AMD-V)
+
+- Vagrant
+
+- VirtualBox
+
+- At least 1.5GB of free memory
+
+- `vagrant plugin install vagrant-vbguest` & `vagrant plugin install vagrant-librarian-chef-nochef`. This only needs done once. Read https://gorails.com/guides/using-vagrant-for-rails-development for more info
+
+Run `vagrant up` to start the virtual machine, then `vagrant ssh` and `cd /vagrant`, which will point to the root of this repository on your host machine. Port 3001 is forwarded locally for testing. Be warned, it will take around a half hour or longer (depending on your internet connection) on first run to download additional Vagrant/Chef dependencies and to provision the dev environment. You may observe some informational warning messages during the initial setup which you can safely ignore. `vagrant halt` to shutdown the VM. Subsequent startups will take considerably less time after the initial run.
+
+### Troubleshooting
+If the initial setup fails for any reason, try `vagrant reload && vagrant provision` and see if the provision command completes without error. Please try to troubleshoot/google issues as much as possible before filing an issue. Be sure to include all relevant stdout messages and errors.
+
 ## Bug tracker
 
 Have a bug or a feature request? [Open a new issue](https://github.com/bikeindex/bike_index/issues/new).

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -51,24 +51,24 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 				global: "2.2.5",
 				gems: {
 					"2.2.5" => [
-					 { name:	"bundler" }
+					 { name: "bundler" }
 					]
 				}
 			}]
 		},
 		system: {
-			:packages	=>	{
-				:install	=>	["pkg-config libmagickcore-dev libmagickwand-dev redis-server"]
+			:packages => {
+				:install => ["pkg-config libmagickcore-dev libmagickwand-dev redis-server"]
 			}
 		},
 		postgresql: {
-			:version	=>	"9.4",
-			:apt_distribution	=>	"xenial",
-			:pg_hba	=>	[{
+			:version => "9.4",
+			:apt_distribution => "xenial",
+			:pg_hba	=> [{
 				:comment => "# Add vagrant role",
 				:type => 'local', :db => 'all', :user => 'vagrant', :addr => nil, :method => 'trust'
 			}],
-			:users	=> [{
+			:users => [{
 				"username": "vagrant",
 				"password": "vagrant",
 				"superuser": true,
@@ -79,8 +79,8 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 				"login": true
 			}]
 		},
-		"build-essential"	=>	{
-			"compiletime"	=>	true
+		"build-essential" => {
+			"compiletime" => true
 		}
 	}
   end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -3,6 +3,18 @@
 
 VAGRANTFILE_API_VERSION = "2"
 
+required_plugins = %w(vagrant-vbguest vagrant-librarian-chef-nochef)
+
+plugins_to_install = required_plugins.select { |plugin| not Vagrant.has_plugin? plugin }
+if not plugins_to_install.empty?
+  puts "Installing required plugins: #{plugins_to_install.join(' ')}"
+  if system "vagrant plugin install #{plugins_to_install.join(' ')}"
+    exec "vagrant #{ARGV.join(' ')}"
+  else
+    abort "Installation of one or more plugins has failed. Aborting. Please read the Bike Index README."
+  end
+end
+
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   # Use David Warkentin's Ubuntu 16.04 Xenial Xerus 64-bit as our operating system (https://bugs.launchpad.net/cloud-images/+bug/1569237/comments/33)
   config.vm.box = "v0rtex/xenial64"

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -21,7 +21,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
   # Configurate the virtual machine to use 1.5GB of RAM
   config.vm.provider :virtualbox do |vb|
-    vb.customize ["modifyvm", :id, "--memory", "1536"]
+	  vb.customize ["modifyvm", :id, "--memory", "1536"]
   end
 
   # Forward the Rails server default port to the host
@@ -31,16 +31,16 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.vm.provision :chef_solo do |chef|
     chef.cookbooks_path = ["cookbooks", "site-cookbooks"]
 
-    chef.add_recipe "apt"
+	chef.add_recipe "apt"
 	chef.add_recipe "build-essential"
 	chef.add_recipe "system::install_packages"
-    chef.add_recipe "ruby_build"
-    chef.add_recipe "ruby_rbenv::user"
-    chef.add_recipe "ruby_rbenv::user_install"
-    chef.add_recipe "vim"
-    chef.add_recipe "postgresql::server"
-    chef.add_recipe "postgresql::client"
-    chef.add_recipe "postgresql::setup_users"
+	chef.add_recipe "ruby_build"
+	chef.add_recipe "ruby_rbenv::user"
+	chef.add_recipe "ruby_rbenv::user_install"
+	chef.add_recipe "vim"
+   	chef.add_recipe "postgresql::server"
+   	chef.add_recipe "postgresql::client"
+   	chef.add_recipe "postgresql::setup_users"
 
     # Install Ruby 2.2.5 and Bundler
     chef.json = {
@@ -58,17 +58,17 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 		},
 		system: {
 			:packages	=>	{
-				:install =>	["pkg-config libmagickcore-dev libmagickwand-dev redis-server"]
+				:install	=>	["pkg-config libmagickcore-dev libmagickwand-dev redis-server"]
 			}
 		},
 		postgresql: {
-			:version			=>	"9.4",
+			:version	=>	"9.4",
 			:apt_distribution	=>	"xenial",
-			:pg_hba				=> [{
+			:pg_hba	=>	[{
 				:comment => "# Add vagrant role",
 				:type => 'local', :db => 'all', :user => 'vagrant', :addr => nil, :method => 'trust'
 			}],
-			:users				=> [{
+			:users	=> [{
 				"username": "vagrant",
 				"password": "vagrant",
 				"superuser": true,
@@ -79,8 +79,8 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 				"login": true
 			}]
 		},
-		"build-essential" => {
-			"compiletime" => true
+		"build-essential"	=>	{
+			"compiletime"	=>	true
 		}
 	}
   end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,75 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+VAGRANTFILE_API_VERSION = "2"
+
+Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
+  # Use David Warkentin's Ubuntu 16.04 Xenial Xerus 64-bit as our operating system (https://bugs.launchpad.net/cloud-images/+bug/1569237/comments/33)
+  config.vm.box = "v0rtex/xenial64"
+
+  # Configurate the virtual machine to use 1.5GB of RAM
+  config.vm.provider :virtualbox do |vb|
+    vb.customize ["modifyvm", :id, "--memory", "1536"]
+  end
+
+  # Forward the Rails server default port to the host
+  config.vm.network :forwarded_port, guest: 3001, host: 3001
+
+  # Use Chef Solo to provision our virtual machine
+  config.vm.provision :chef_solo do |chef|
+    chef.cookbooks_path = ["cookbooks", "site-cookbooks"]
+
+    chef.add_recipe "apt"
+	chef.add_recipe "build-essential"
+	chef.add_recipe "system::install_packages"
+    chef.add_recipe "ruby_build"
+    chef.add_recipe "ruby_rbenv::user"
+    chef.add_recipe "ruby_rbenv::user_install"
+    chef.add_recipe "vim"
+    chef.add_recipe "postgresql::server"
+    chef.add_recipe "postgresql::client"
+    chef.add_recipe "postgresql::setup_users"
+
+    # Install Ruby 2.2.5 and Bundler
+    chef.json = {
+		rbenv: {
+			user_installs: [{
+				user: 'vagrant',
+				rubies: ["2.2.5"],
+				global: "2.2.5",
+				gems: {
+					"2.2.5" => [
+					 { name:	"bundler" }
+					]
+				}
+			}]
+		},
+		system: {
+			:packages	=>	{
+				:install =>	["pkg-config libmagickcore-dev libmagickwand-dev redis-server"]
+			}
+		},
+		postgresql: {
+			:version			=>	"9.4",
+			:apt_distribution	=>	"xenial",
+			:pg_hba				=> [{
+				:comment => "# Add vagrant role",
+				:type => 'local', :db => 'all', :user => 'vagrant', :addr => nil, :method => 'trust'
+			}],
+			:users				=> [{
+				"username": "vagrant",
+				"password": "vagrant",
+				"superuser": true,
+				"replication": false,
+				"createdb": true,
+				"createrole": false,
+				"inherit": false,
+				"login": true
+			}]
+		},
+		"build-essential" => {
+			"compiletime" => true
+		}
+	}
+  end
+end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -29,7 +29,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
   # Use Chef Solo to provision our virtual machine
   config.vm.provision :chef_solo do |chef|
-    chef.cookbooks_path = ["cookbooks", "site-cookbooks"]
+	  chef.cookbooks_path = ["cookbooks", "site-cookbooks"]
 
 	chef.add_recipe "apt"
 	chef.add_recipe "build-essential"

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -58,7 +58,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 		},
 		system: {
 			:packages => {
-				:install => ["pkg-config libmagickcore-dev libmagickwand-dev redis-server"]
+				:install => ["pkg-config libmagickcore-dev libmagickwand-dev libpq-dev redis-server"]
 			}
 		},
 		postgresql: {


### PR DESCRIPTION
This commit adds Vagrantfile and Cheffile, which are used by Vagrant to
automatically set up a virtual development environment designed to be
used for local Bike Index development. Chef is used to automatically
provision the environment with all of the required dependencies and
configures PostgreSQL. This makes the process of setting up a local
development environment much quicker and straightforward. As long as
Vagrant/VirtualBox is installed with the required Vagrant plugins, the
environment can be brought up just by running `vagrant up`. After SSHing
in, the "Running Bike Index locally" intructions in the README can be
followed verbatim without any additional configuration.

This commit also updates README.markdown to acknowledge this feature.