### PR TITLE
Add Skylight instrumentation

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -86,6 +86,7 @@ gem 'stackprof', require: false
 gem 'memory_profiler', require: false
 gem 'flamegraph', require: false
 gem 'rack-mini-profiler', require: false # If you can't see it you can't make it better
+gem 'skylight'
 
 gem 'responders', '~> 2.0' # required because of class level respond_to blocks (API v1)
 gem 'thor', '0.19.1' # Locking it; http://stackoverflow.com/questions/40986923/meaning-of-expected-string-default-value-for-on-ruby-on-rails

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -597,6 +597,8 @@ GEM
     sitemap_generator (5.1.0)
       builder
     sixarm_ruby_unaccent (1.1.1)
+    skylight (1.2.0)
+      activesupport (>= 3.0.0)
     slop (3.6.0)
     soulheart (0.3.0)
       multi_json (~> 1.11, >= 1.11.2)
@@ -749,6 +751,7 @@ DEPENDENCIES
   sidekiq (~> 4.2.10)
   sidekiq-failures
   sitemap_generator
+  skylight
   soulheart (~> 0.3.0)
   sparkpost
   sprockets-rails (~> 3.0.4)


### PR DESCRIPTION
I discussed with @sethherr about adding Skylight instrumentation to the Bike Index website under the new [Skylight for Open Source](https://www.skylight.io/oss) program.

If you’re not already familiar with [Skylight](https://www.skylight.io), it is a smart profiler for Rails apps. Skylight makes it easy to pinpoint performance issues in Rails applications.

We work on a lot of open source projects ourselves, and in our experience it can be pretty hard to get contributors to work on application performance issues. Few contributors consider working on performance problems, and the ones that might be interested may not even know where to start.

By making performance information more accessible, we hope to inspire potential contributors to tackle slow parts of your app, and have a good way to see if their contributions helped.

Once this patch is merged and deployed*, you will be able to view the performance data we collected at the [public Skylight dashboard](https://oss.skylight.io/app/applications/j93iQ4K2pxCP). The dashboard will be accessible to anyone (no Skylight account required) to make it easy for contributors.

(*Actually, I lied a little. We still need to set the `SKYLIGHT_AUTHENTICATION` environment variable to the appropriate API key on production, but I will work with @sethherr on that off-thread.)