### PR TITLE
Updated nav scroll in the API docs page

### DIFF
--- a/app/assets/javascripts/documentation/swagger_inlined.coffee
+++ b/app/assets/javascripts/documentation/swagger_inlined.coffee
@@ -1,9 +1,10 @@
 scrollToRef = (event) ->
   event.preventDefault()
   target = $(event.target).attr('href')
-  $('body').animate( 
-    scrollTop: ($(target).offset().top - 10), 'fast' 
-  )
+  window.scrollTo({
+    top: $(target).offset().top - 90,
+    behavior: 'smooth'
+  })
 
 waypointer = ->
   for l in $('#navmenu-fixed a')
@@ -72,6 +73,7 @@ $ ->
     return
 
   $('#header').headroom()
+
   $('.set-token').click (e) ->
     e.preventDefault()
     $('#header').addClass('headroom--pinned').removeClass('headroom--unpinned')
@@ -80,14 +82,14 @@ $ ->
       input_key.val($(e.target).attr('data-token')).change()
       input_key.fadeIn('fast')
     )
-    
-  
+
+
   $('.newtoken-scope-check').change (e) ->
     app = $(e.target).parents('.application_list_box')
     link = app.find('.authorize_new_token_link')
     checked = app.find('.newtoken-scope-check input:checked')
     scopes = []
-    scopes.push($(s).attr('id')) for s in checked   
+    scopes.push($(s).attr('id')) for s in checked
     url = link.attr('data-base')
     url = "#{url}&scope=#{scopes.join('+')}" if scopes.length > 0
     link.attr('href', url).text(url)
@@ -112,4 +114,3 @@ $ ->
   window.setTimeout (->
     operationsAfterSwaggerLoads()
   ), 2000
-  

--- a/app/assets/javascripts/documentation/swagger_inlined.coffee
+++ b/app/assets/javascripts/documentation/swagger_inlined.coffee
@@ -29,7 +29,7 @@ $ ->
       log "added key " + key
       window.authorizations.add "access_token", new ApiKeyAuthorization("access_token", key, "query")
     return
-  
+
   url = window.swagger_url
   window.swaggerUi = new SwaggerUi(
     url: url
@@ -71,8 +71,6 @@ $ ->
     addApiKeyAuthorization()
     localStorage.setItem('access_token', $('#input_apiKey').val())
     return
-
-  $('#header').headroom()
 
   $('.set-token').click (e) ->
     e.preventDefault()


### PR DESCRIPTION
Clicking the links in the API docs nav wasn't scrolling to the corresponding page position. I updated `scrollToRef` to scroll using `window.scrollTo`. 
Additionally, I removed `$('#header').headroom()` to keep the API token header fixed and keep the offset consistent as sometimes it would appear with scrolling and other times it wouldn't.

Happy to make additional changes!

Note: Scroll animation works fine in Chrome and Mozilla but jumps to the position in Safari. 
![bike_index_api_scroll_to](https://user-images.githubusercontent.com/3513997/44116200-202751ec-9fcd-11e8-85c2-e40daf662258.gif)
