### PR TITLE
Widen user/organization column to fill parent div

### DIFF
--- a/app/views/users/show.html.haml
+++ b/app/views/users/show.html.haml
@@ -7,7 +7,7 @@
             - if @user.avatar
               - unless @user.avatar.url(:medium) == 'https://files.bikeindex.org/blank.png'
                 = image_tag @user.avatar.url(:medium), class: 'users-show-avatar'
-          .col-xs-3
+          .col-xs-9
             %header.with-subtitle
             %h2
               - if @user.title.present?


### PR DESCRIPTION
The user/organization show page squishes up its name. This PR fixes the issue. See screenshots of before and after.

## before
![before](https://user-images.githubusercontent.com/102112/45583660-279eb200-b87b-11e8-8a07-be2261be0cf4.png)

## after
![after](https://user-images.githubusercontent.com/102112/45583661-279eb200-b87b-11e8-8b67-37a402ac273b.png)

This also respects the empty column to the right, which I assume is for future advertising space. By the way, if you start to display advertising, I would turn off my ad blocker if you follow the [Ethical Ad](https://docs.readthedocs.io/en/latest/advertising/ethical-advertising.html) model established by ReadTheDocs.