### PR TITLE
Indicate that a hidden bike can be shown

### DIFF
--- a/app/views/bikes/edit_remove.html.haml
+++ b/app/views/bikes/edit_remove.html.haml
@@ -25,7 +25,7 @@
                   %p
                     You can read more about why this is important to us in our #{link_to "FAQs", support_path(anchor: 'public-serials')}.
                   %p
-                    We strongly recommend keeping your #{@bike.type} visible, but you can hide this #{@bike.type} if you prefer. Even though we don't think it's a good idea.
+                    We strongly recommend keeping your #{@bike.type} visible, but you can hide this #{@bike.type} if you prefer. Even though we don't think it's a good idea. You can always toggle this setting to show and hide a bike.
                   %p.text-xs-center
                     - btn_type = @bike.user_hidden ? 'btn-success' : 'btn-danger'
                     %a.btn.btn-lg#hide_bike_toggle{role: 'button', class: btn_type }


### PR DESCRIPTION
Without this statement, I assumed that the setting would be permanent.