### PR TITLE
Remove google ads

### DIFF
--- a/app/views/layouts/application_updated.html.haml
+++ b/app/views/layouts/application_updated.html.haml
@@ -53,10 +53,10 @@
               = hidden_field_tag :stolen, params[:stolen] || true
               = hidden_field_tag :non_stolen, params[:non_stolen] || ''
               = hidden_field_tag :non_proximity, params[:non_proximity] || ''
-      - if @ad.present?
-        .container.partner-block-container
-          .partner-block
-            = render '/shared/google_text_ad'
+      / - if @ad.present?
+      /   .container.partner-block-container
+      /     .partner-block
+      /       / google ad went here
 
       = yield
       

--- a/app/views/news/show.html.haml
+++ b/app/views/news/show.html.haml
@@ -23,7 +23,7 @@
   :markdown
     #{@blog.body}
 
-= render '/shared/content_footer_ad'
+/ = render '/shared/content_footer_ad'
 
 - if Rails.env.production? && @blog.published
   / Clear the ad overhang with a padded block

--- a/app/views/shared/_bikes_footer_ad.html.haml
+++ b/app/views/shared/_bikes_footer_ad.html.haml
@@ -1,5 +1,0 @@
-- if @ad.present?
-  - cache 'bikes_footer_ad' do
-    .container
-      = render '/shared/google_text_ad'
-    .padded

--- a/app/views/shared/_content_footer_ad.html.haml
+++ b/app/views/shared/_content_footer_ad.html.haml
@@ -1,3 +1,3 @@
-- cache 'content_footer_ad' do
-  %article.padded
-    = render '/shared/google_text_ad'
+/ - cache 'content_footer_ad' do
+/   %article.padded
+/     google ad went here

--- a/app/views/shared/_google_text_ad.html.erb
+++ b/app/views/shared/_google_text_ad.html.erb
@@ -1,8 +1,0 @@
-<script async src="//pagead2.googlesyndication.com/pagead/js/adsbygoogle.js"></script>
-<!-- Minimalist text ad -->
-<ins class="adsbygoogle"
-     style="display:block"
-     data-ad-client="ca-pub-8140931939249510"
-     data-ad-slot="7159478183"
-     data-ad-format="auto"></ins>
-<script>(adsbygoogle = window.adsbygoogle || []).push({});</script>

--- a/app/views/stolen/index.html.haml
+++ b/app/views/stolen/index.html.haml
@@ -38,8 +38,8 @@
         
         #bikes_returned.padded
 
-.container
-  = render '/shared/google_text_ad'
+/ .container
+/ google ad went here
 
 .sbr-wrap#sbr-body
   


### PR DESCRIPTION
Remove google ads to most comply with the [Ethical Ads](https://docs.readthedocs.io/en/latest/advertising/ethical-advertising.html) model - as brought up by @stevepiercy in #441 