### PR TITLE
Add caching for active_model_serializers

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,11 +5,12 @@ gem "rails", "4.2.10"
 gem 'pg'
 gem 'jquery-rails'
 gem 'bcrypt', '~> 3.1.7'
-gem 'active_model_serializers', '~> 0.9.3'
 gem 'aws-sdk', '~> 1.33'
 
 # Speed
-gem 'fast_blank', '~> 1.0'
+gem "fast_blank", "~> 1.0"
+gem "dalli"
+gem "active_model_serializers", "~> 0.8.3" # Use active model serializers to serialize JSON. Use version 0.8 because it supports caching
 
 # Redis and redis dependents
 gem 'hiredis', '~> 0.6.0'
@@ -44,7 +45,6 @@ gem 'omniauth-facebook'
 gem 'omniauth-strava'
 gem 'omniauth', '~> 1.3.1'
 gem "fog-aws"
-gem 'dalli'
 gem 'draper', require: false
 gem 'eventmachine'
 gem 'httparty'

--- a/Gemfile
+++ b/Gemfile
@@ -66,7 +66,7 @@ gem 'simple_spark' # Sparkpost gem - we use it to send newsletters
 gem 'doorkeeper', '~> 3.1.0'
 gem 'wine_bouncer'
 gem 'grape', '~> 0.14.0'
-gem 'grape-active_model_serializers', '~> 1.4.0'
+gem 'grape-active_model_serializers'
 gem 'grape-swagger', '~> 0.10.4'
 gem 'swagger-ui_rails'
 gem 'api-pagination'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -28,8 +28,8 @@ GEM
       erubis (~> 2.7.0)
       rails-dom-testing (~> 1.0, >= 1.0.5)
       rails-html-sanitizer (~> 1.0, >= 1.0.3)
-    active_model_serializers (0.9.5)
-      activemodel (>= 3.2)
+    active_model_serializers (0.8.4)
+      activemodel (>= 3.0)
     activejob (4.2.10)
       activesupport (= 4.2.10)
       globalid (>= 0.3.0)
@@ -173,9 +173,9 @@ GEM
       rack-accept
       rack-mount
       virtus (>= 1.0.0)
-    grape-active_model_serializers (1.4.0)
-      active_model_serializers (>= 0.9.0)
-      grape
+    grape-active_model_serializers (1.2.0)
+      active_model_serializers (>= 0.8.1)
+      grape (~> 0.3)
     grape-entity (0.4.8)
       activesupport
       multi_json (>= 1.3.2)
@@ -208,7 +208,7 @@ GEM
       thor
       tilt
     hashdiff (0.3.7)
-    hashie (3.5.7)
+    hashie (3.6.0)
     high_voltage (3.0.0)
     hiredis (0.6.1)
     honeybadger (2.6.0)
@@ -273,7 +273,7 @@ GEM
       money (~> 6.7)
       railties (>= 3.0)
     multi_json (1.13.1)
-    multi_xml (0.5.5)
+    multi_xml (0.6.0)
     multipart-post (2.0.0)
     nenv (0.3.0)
     netrc (0.11.0)
@@ -546,7 +546,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  active_model_serializers (~> 0.9.3)
+  active_model_serializers (~> 0.8.3)
   api-pagination
   aws-sdk (~> 1.33)
   backbone-on-rails (~> 0.9.10.0)
@@ -571,7 +571,7 @@ DEPENDENCIES
   foreman
   geocoder
   grape (~> 0.14.0)
-  grape-active_model_serializers (~> 1.4.0)
+  grape-active_model_serializers
   grape-swagger (~> 0.10.4)
   grape_logging
   groupdate

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -35,10 +35,8 @@ class SessionsController < ApplicationController
 
   def destroy
     remove_session
-    if params[:redirect_location].present?
-      if params[:redirect_location].match('new_user')
-        redirect_to new_user_path, notice: 'Logged out!' and return
-      end
+    if params[:redirect_location]&.match('new_user')
+      redirect_to new_user_path, notice: 'Logged out!' and return
     end
     redirect_to goodbye_url(subdomain: false), notice: 'Logged out!'
   end

--- a/app/serializers/application_serializer.rb
+++ b/app/serializers/application_serializer.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class ApplicationSerializer < ActiveModel::Serializer
+  delegate :cache_key, to: :object
+
+  def perform_caching; false end # otherwise it's true, inexplicably. Manually override
+end

--- a/app/serializers/bike_serializer.rb
+++ b/app/serializers/bike_serializer.rb
@@ -1,4 +1,4 @@
-class BikeSerializer < ActiveModel::Serializer
+class BikeSerializer < ApplicationSerializer
 
   attributes :id,
     :serial,

--- a/app/serializers/bike_v2_serializer.rb
+++ b/app/serializers/bike_v2_serializer.rb
@@ -1,4 +1,4 @@
-class BikeV2Serializer < ActiveModel::Serializer
+class BikeV2Serializer < ApplicationSerializer
   attributes :id,
     :title,
     :serial,

--- a/app/serializers/organized_message_serializer.rb
+++ b/app/serializers/organized_message_serializer.rb
@@ -1,4 +1,5 @@
-class OrganizedMessageSerializer < ActiveModel::Serializer
+class OrganizedMessageSerializer < ApplicationSerializer
+  def perform_caching; true end
   attributes :id, :kind, :created_at, :lat, :lng, :sender_id, :bike
 
   def created_at

--- a/spec/serializers/bike_serializer_spec.rb
+++ b/spec/serializers/bike_serializer_spec.rb
@@ -1,32 +1,41 @@
-require 'spec_helper'
+require "spec_helper"
 
-describe BikeSerializer do
-  describe 'standard validations' do
+describe BikeSerializer, type: :lib  do
+  describe "standard validations" do
     let(:bike) { FactoryGirl.create(:bike, frame_size: '42') }
     let(:component) { FactoryGirl.create(:component, bike: bike) }
     let(:public_image) { FactoryGirl.create(:public_image, imageable_type: 'Bike', imageable_id: bike.id) }
-    subject { BikeSerializer.new(bike) }
+    let(:serializer) { BikeSerializer.new(bike) }
 
-    it { expect(subject.manufacturer_name).to eq(bike.mnfg_name) }
-    it { expect(subject.manufacturer_id).to eq(bike.manufacturer_id) }
-    it { expect(subject.stolen).to eq(bike.stolen) }
-    it { expect(subject.type_of_cycle).to eq(bike.cycle_type.name) }
-    it { expect(subject.name).to eq(bike.name) }
-    it { expect(subject.year).to eq(bike.year) }
-    it { expect(subject.frame_model).to eq(bike.frame_model) }
-    it { expect(subject.description).to eq(bike.description) }
-    it { expect(subject.rear_tire_narrow).to eq(bike.rear_tire_narrow) }
-    it { expect(subject.front_tire_narrow).to eq(bike.front_tire_narrow) }
-    it { expect(subject.rear_wheel_size).to eq(bike.rear_wheel_size) }
-    it { expect(subject.serial).to eq(bike.serial_number) }
-    it { expect(subject.front_wheel_size).to eq(bike.front_wheel_size) }
-    it { expect(subject.handlebar_type).to eq(bike.handlebar_type) }
-    it { expect(subject.frame_material).to eq(bike.frame_material) }
-    it { expect(subject.front_gear_type).to eq(bike.front_gear_type) }
-    it { expect(subject.rear_gear_type).to eq(bike.rear_gear_type) }
-    it { expect(subject.stolen_record).to eq(bike.current_stolen_record) }
-    it { expect(subject.frame_size).to eq('42cm') }
-    # it { subject.photo.should == bike.reload.public_images.first.image_url(:large) }
-    # it { subject.thumb.should == bike.reload.public_images.first.image_url(:small) }
+    it "is as expected" do
+      expect(serializer.manufacturer_name).to eq(bike.mnfg_name)
+      expect(serializer.manufacturer_id).to eq(bike.manufacturer_id)
+      expect(serializer.stolen).to eq(bike.stolen)
+      expect(serializer.type_of_cycle).to eq(bike.cycle_type.name)
+      expect(serializer.name).to eq(bike.name)
+      expect(serializer.year).to eq(bike.year)
+      expect(serializer.frame_model).to eq(bike.frame_model)
+      expect(serializer.description).to eq(bike.description)
+      expect(serializer.rear_tire_narrow).to eq(bike.rear_tire_narrow)
+      expect(serializer.front_tire_narrow).to eq(bike.front_tire_narrow)
+      expect(serializer.rear_wheel_size).to eq(bike.rear_wheel_size)
+      expect(serializer.serial).to eq(bike.serial_number)
+      expect(serializer.front_wheel_size).to eq(bike.front_wheel_size)
+      expect(serializer.handlebar_type).to eq(bike.handlebar_type)
+      expect(serializer.frame_material).to eq(bike.frame_material)
+      expect(serializer.front_gear_type).to eq(bike.front_gear_type)
+      expect(serializer.rear_gear_type).to eq(bike.rear_gear_type)
+      expect(serializer.stolen_record).to eq(bike.current_stolen_record)
+      expect(serializer.frame_size).to eq('42cm')
+      # expect(serializer.photo).to == bike.reload.public_images.first.image_url(:large)
+      # expect(serializer.thumb).to == bike.reload.public_images.first.image_url(:small)
+    end
+    describe "caching" do
+      include_context :caching_basic
+      it "is not cached" do
+        expect(serializer.perform_caching).to be_falsey
+        expect(serializer.as_json.is_a?(Hash)).to be_truthy
+      end
+    end
   end
 end

--- a/spec/serializers/ctypes_serializer_spec.rb
+++ b/spec/serializers/ctypes_serializer_spec.rb
@@ -1,10 +1,12 @@
 require 'spec_helper'
 
-describe CtypeSerializer do
+describe CtypeSerializer, type: :lib do
   let(:ctype) { FactoryGirl.create(:ctype, has_multiple: true) }
-  subject { CtypeSerializer.new(ctype) }
+  let(:serializer) { CtypeSerializer.new(ctype) }
 
-  it { expect(subject.name).to eq(ctype.name) }
-  it { expect(subject.slug).to eq(ctype.slug) }
-  it { expect(subject.has_multiple).to be_truthy }
+  it "is as expected" do
+    expect(serializer.name).to eq(ctype.name)
+    expect(serializer.slug).to eq(ctype.slug)
+    expect(serializer.has_multiple).to be_truthy
+  end
 end

--- a/spec/serializers/organized_message_serializer_spec.rb
+++ b/spec/serializers/organized_message_serializer_spec.rb
@@ -1,0 +1,15 @@
+require "spec_helper"
+
+describe OrganizedMessageSerializer, type: :lib do
+  let(:subject) { OrganizedMessageSerializer }
+  let(:obj) { FactoryGirl.create(:organization_message) }
+  let(:serializer) { subject.new(obj, root: false) }
+
+  describe "caching" do
+    include_context :caching_basic
+    it "is cached" do
+      expect(serializer.perform_caching).to be_truthy
+      expect(serializer.as_json.is_a?(Hash)).to be_truthy
+    end
+  end
+end

--- a/spec/support/caching_spec_helpers.rb
+++ b/spec/support/caching_spec_helpers.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+shared_context :caching_enabled do
+  RSpec.configure do |config|
+    config.around(:each, :caching) do |example|
+      ActionController::Base.perform_caching = true
+      ActionController::Base.cache_store = cache
+      example.run
+      ActionController::Base.perform_caching = false
+      ActionController::Base.cache_store = :null_store
+    end
+  end
+end
+
+shared_context :caching_basic do
+  include_context :caching_enabled
+
+  class MemoryCacheStore
+    def fetch(key)
+      return store[key] if store[key]
+      store[key] = yield
+    end
+
+    def clear
+      store.clear
+    end
+
+    def store
+      @store ||= {}
+    end
+
+    def read(key)
+      store[key]
+    end
+
+    def as_json
+      store.as_json
+    end
+  end
+
+  let(:cache) { MemoryCacheStore.new }
+end
+
+shared_context :caching_full do
+  include_context :caching_enabled
+  let(:cache) { Readthis::Cache.new }
+end


### PR DESCRIPTION
`active_model_serializers` after version `0.8` don't actually support caching (yeah, wtf ¯\\\_(ツ)\_/¯).

So switch to that version and cache us some serialializers.