### PR TITLE
Fix various issues with Vagrant

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,5 @@
 source 'https://rubygems.org'
+# If you bump the Ruby version, make sure to update the Vagrantfile appropriately 
 ruby "2.5.1"
 gem "rails", "4.2.11"
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -43,7 +43,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   # Use echo to create a provisioning script, chmod +x it, and execute it.
   config.vm.provision "recompose", type: "shell",
 	  run: "reload", privileged: false, inline: <<-SHELL
-  echo -e '#!/bin/bash -l\nsudo -u postgres -H bash << EOL\npsql -c "CREATE ROLE vagrant WITH PASSWORD '"'vagrant'"' SUPERUSER CREATEDB LOGIN;"\nEOL\ncreatedb vagrant\nnewgrp rvm\nrvm install 2.2.5\ngem install bundler\ncd /vagrant\nbundle install\nrake db:setup\nrake seed_test_users_and_bikes' > ~/rubydevprovision.sh && chmod +x rubydevprovision.sh
+  echo -e '#!/bin/bash -l\nsudo -u postgres -H bash << EOL\npsql -c "CREATE ROLE vagrant WITH PASSWORD '"'vagrant'"' SUPERUSER CREATEDB LOGIN;"\nEOL\ncreatedb vagrant\nnewgrp rvm\nrvm install 2.5.1\ngem update --system\ngem install bundler\ncd /vagrant\nbundle install\nrake db:setup\nrake seed_test_users_and_bikes' > ~/rubydevprovision.sh && chmod +x rubydevprovision.sh
   sg rvm -c './rubydevprovision.sh'
   echo -e 'Vagrant provisioning has completed. You can now "vagrant ssh" and start using it. If any\nerrors were thrown during provisioning, try running "./rubydevprovision.sh" inside the\nvagrant environment or run all of the provisioning scripts a second time\nwith "vagrant provision". You can find your local git repo in /vagrant.'
   SHELL


### PR DESCRIPTION
While setting up my dev environment, I ran into a few issues with Vagrant. The first is below:
```
    default: there was an error installing gem bundler
    default: .......................................................
    default: ruby-2.2.5 - #generating global wrappers
    default: .......
    default: ruby-2.2.5 - #gemset created /usr/share/rvm/gems/ruby-2.2.5
    default: ruby-2.2.5 - #importing gemsetfile /usr/share/rvm/gemsets/default.gems evaluated to empty gem list
    default: ruby-2.2.5 - #generating default wrappers
    default: .......
    default: ERROR:  Error installing bundler:
    default: 	bundler requires Ruby version >= 2.3.0.
    default: Required ruby-2.5.1 is not installed.
    default: To install do: 'rvm install "ruby-2.5.1"'
    default: ./rubydevprovision.sh: line 10: bundle: command not found
    default: rake aborted!
    default: LoadError: cannot load such file -- bundler/setup
    default: /vagrant/config/boot.rb:3:in `<top (required)>'
    default: /vagrant/config/application.rb:1:in `<top (required)>'
    default: /vagrant/rakefile:5:in `<top (required)>'
    default: (See full trace by running task with --trace)
    default: rake aborted!
    default: LoadError: cannot load such file -- bundler/setup
    default: /vagrant/config/boot.rb:3:in `<top (required)>'
    default: /vagrant/config/application.rb:1:in `<top (required)>'
    default: /vagrant/rakefile:5:in `<top (required)>'
    default: (See full trace by running task with --trace)
```
Fixing this required manually bumping the Ruby version we install via `rvm` within the `Vagrantfile`. Re-running `vagrant up` now reveals a new error:
```
/usr/share/rvm/rubies/ruby-2.5.1/lib/ruby/2.5.0/rubygems.rb:289:in `find_spec_for_exe': can't find gem bundler (>= 0.a) with executable bundle (Gem::GemNotFoundException)
```

This error was recently introduced and is explained [here](https://bundler.io/blog/2019/01/04/an-update-on-the-bundler-2-release.html). Since the bug is fixed in RubyGems 3.0.0 and backports are not yet available, I manually force-update RubyGems in the install script although I realize it's a bit heavy-handed.

This allows the provisioning script to run to completion successfully.

