### PR TITLE
Demonstrate potential bug in bike update endpoint

### DIFF
--- a/spec/requests/api/v3/bikes_request_spec.rb
+++ b/spec/requests/api/v3/bikes_request_spec.rb
@@ -442,6 +442,19 @@ describe 'Bikes API V3' do
       expect(bike.owner).to eq(user)
       expect(bike.year).to eq(params[:year])
     end
+
+    it 'can update rear_wheel_bsd' do
+      params[:rear_wheel_bsd] = '559'
+      params[:rear_wheel_narrow] =  'true'
+
+      expect(bike.rear_wheel_bsd).to be_nil
+      expect(bike.rear_wheel_narrow).to be_nil
+      put url, params.to_json, json_headers
+      expect(response.code).to eq('200')
+      expect(response.headers['Content-Type'].match('json')).to be_present
+      expect(bike.reload.rear_wheel_bsd).to eq('559')
+      expect(bike.rear_wheel_narrow).to eq('true')
+    end
   end
 
   describe 'image' do


### PR DESCRIPTION
Came across this case when working on another PR and wanted to throw it up to see if I'm missing something obvious or not using a `selection` correctly.

Sample request in documentation page running locally:
<img width="810" alt="image" src="https://user-images.githubusercontent.com/2475615/52957875-1fbcde00-33d6-11e9-9106-f94086678df2.png">

Response from documentation page running locally:
<img width="918" alt="image" src="https://user-images.githubusercontent.com/2475615/52957848-0fa4fe80-33d6-11e9-9009-d43b6fccca4c.png">

Also added a test to replicate the issue I faced.