### PR TITLE
Eager load relations in admin controllers

### DIFF
--- a/app/controllers/admin/bikes_controller.rb
+++ b/app/controllers/admin/bikes_controller.rb
@@ -2,7 +2,7 @@ class Admin::BikesController < Admin::BaseController
   before_filter :find_bike, only: [:edit, :destroy, :update, :get_destroy]
 
   def index
-    bikes = Bike.unscoped.includes(:creation_organization, :manufacturer, :paint, :primary_frame_color, :secondary_frame_color, :tertiary_frame_color)
+    bikes = Bike.unscoped.includes(:creation_organization, :creation_state, :paint)
     if params[:email]
       bikes = bikes.admin_text_search(params[:email])
     else

--- a/app/controllers/admin/dashboard_controller.rb
+++ b/app/controllers/admin/dashboard_controller.rb
@@ -1,6 +1,6 @@
 class Admin::DashboardController < Admin::BaseController
   def index
-    @bikes = Bike.unscoped.includes(:creation_organization, :manufacturer, :paint).order('created_at desc').limit(10)
+    @bikes = Bike.unscoped.includes(:creation_organization, :creation_state, :paint).order('created_at desc').limit(10)
     @users = User.includes(:memberships => [:organization]).limit(5).order("created_at desc")
     @flavors = FlavorText.all
     @flavor = FlavorText.new

--- a/app/controllers/admin/memberships_controller.rb
+++ b/app/controllers/admin/memberships_controller.rb
@@ -6,7 +6,7 @@ class Admin::MembershipsController < Admin::BaseController
   before_filter :find_organization, only: [:show]
 
   def index
-    @memberships = Membership.reorder(created_at: :desc)
+    @memberships = Membership.includes(:organization, :user).reorder(created_at: :desc)
   end
 
   def show

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -13,7 +13,7 @@ class Admin::UsersController < Admin::BaseController
       elsif params[:content_admins]
         users = User.where(is_content_admin: true)
       else 
-        users = User.order("created_at desc")
+        users = User.includes(memberships: [:organization]).order("created_at desc")
       end
       @users = users.page(page).per(per_page)
     end


### PR DESCRIPTION
### Overview

* Eager load relations in some admin controllers to avoid n+1's and speed up the respective queries
* Remove unnecessary relations from existing `includes`