### PR TITLE
Add recovered bikes page

### DIFF
--- a/app/assets/javascripts/init.coffee
+++ b/app/assets/javascripts/init.coffee
@@ -26,6 +26,7 @@ class BikeIndex.Init extends BikeIndex
     # All the rest per-page javascripts
     pageClasses =
       welcome_index: BikeIndex.WelcomeIndex
+      welcome_recovery_stories: BikeIndex.RecoveryStories
       info_where: BikeIndex.InfoWhere
       info_support_bike_index: BikeIndex.Payments
       payments_new: BikeIndex.Payments

--- a/app/assets/javascripts/revised/pages/welcome/recovery_stories.coffee
+++ b/app/assets/javascripts/revised/pages/welcome/recovery_stories.coffee
@@ -1,0 +1,6 @@
+class BikeIndex.RecoveryStories extends BikeIndex
+  constructor: ->
+    $('#recovery-stories-container').slick
+      lazyLoad: 'ondemand'
+      slidesToShow: $('#recovery_displays_count').val()
+      vertical: true

--- a/app/assets/javascripts/revised/pages/welcome/recovery_stories.coffee
+++ b/app/assets/javascripts/revised/pages/welcome/recovery_stories.coffee
@@ -1,6 +1,7 @@
 class BikeIndex.RecoveryStories extends BikeIndex
   constructor: ->
-    $('#recovery-stories-container').slick
+    $recovery_stories = $('#recovery-stories-container')
+    $recovery_stories.slick
       lazyLoad: 'ondemand'
-      slidesToShow: $('#recovery_displays_count').val()
+      slidesToShow: $recovery_stories.data('stories-count')
       vertical: true

--- a/app/assets/stylesheets/revised/pages/landing/_recoveries.scss
+++ b/app/assets/stylesheets/revised/pages/landing/_recoveries.scss
@@ -3,6 +3,12 @@
   padding: 4*$vertical-height 0;
 }
 
+#recovery-stories-listing {
+  .recovery-block {
+    margin: 1rem auto;
+  }
+}
+
 #recovery-stories-container {
   width: 90%;
   margin: 0 auto;

--- a/app/controllers/feedbacks_controller.rb
+++ b/app/controllers/feedbacks_controller.rb
@@ -22,8 +22,10 @@ class FeedbacksController < ApplicationController
     else
       @page_errors = @feedback.errors
       re_path = Rails.application.routes.recognize_path(request.referer)
-      @force_landing_page_render = re_path[:controller] == 'landing_pages'
-      render template: "#{re_path[:controller]}/#{re_path[:action]}"
+      template = "#{re_path[:controller]}/#{re_path[:action]}"
+      @force_landing_page_render = re_path[:controller] == "landing_pages"
+      @recovery_displays = RecoveryDisplay.limit(5) if template == "welcome/index"
+      render template: template
     end
   end
 

--- a/app/controllers/welcome_controller.rb
+++ b/app/controllers/welcome_controller.rb
@@ -6,6 +6,7 @@ class WelcomeController < ApplicationController
   skip_before_filter :set_x_frame_options_header, only: [:bike_creation_graph, :index]
 
   def index
+    @recovery_displays = RecoveryDisplay.limit(5)
   end
 
   def bike_creation_graph
@@ -41,7 +42,7 @@ class WelcomeController < ApplicationController
 
   def recovery_stories
     page = params[:page] || 1
-    @per_page = params[:per_page] || 20
+    @per_page = params[:per_page] || 5
     @recovery_displays = RecoveryDisplay.page(page).per(@per_page)
   end
 

--- a/app/controllers/welcome_controller.rb
+++ b/app/controllers/welcome_controller.rb
@@ -39,6 +39,12 @@ class WelcomeController < ApplicationController
   def choose_registration
   end
 
+  def recovery_stories
+    page = params[:page] || 1
+    @per_page = params[:per_page] || 20
+    @recovery_displays = RecoveryDisplay.page(page).per(@per_page)
+  end
+
   private
 
   def authenticate_user_for_welcome_controller

--- a/app/views/recovery_displays/_recovery_display.html.haml
+++ b/app/views/recovery_displays/_recovery_display.html.haml
@@ -1,0 +1,23 @@
+- cache(recovery_display) do
+  .recovery-block{ class: "recovery-#{recovery_display.id}" }
+    %p.recovery-quote
+      <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 31.75 23.54"><path class="svg-q-p" d="M15.68,2.74q-2,1-3.8,2.11a25.37,25.37,0,0,0-3,2.11A13.08,13.08,0,0,0,6.43,9.64a14.15,14.15,0,0,0-1.65,3.69H6.64a5,5,0,0,1,3.93,1.35,4.41,4.41,0,0,1,1.19,3,6.07,6.07,0,0,1-1.61,4,5.46,5.46,0,0,1-4.39,1.89,5.43,5.43,0,0,1-4.36-1.65A6.45,6.45,0,0,1,0,17.54a13.41,13.41,0,0,1,1.52-6.38A20.73,20.73,0,0,1,5.34,6a25.06,25.06,0,0,1,4.71-3.61Q12.51,1,14.37,0Zm16.07,0q-2,1-3.8,2.11a25.37,25.37,0,0,0-3,2.11A13.08,13.08,0,0,0,22.5,9.64a14.15,14.15,0,0,0-1.65,3.69h1.87a5,5,0,0,1,3.93,1.35,4.41,4.41,0,0,1,1.19,3,6.07,6.07,0,0,1-1.61,4,5.46,5.46,0,0,1-4.39,1.89,5.43,5.43,0,0,1-4.36-1.65,6.45,6.45,0,0,1-1.41-4.34,13.41,13.41,0,0,1,1.52-6.38A20.73,20.73,0,0,1,21.41,6a25.06,25.06,0,0,1,4.71-3.61Q28.57,1,30.44,0Z"/></svg>
+
+      %span.precovery
+        = recovery_display.quote.html_safe
+    %span.recovery-user
+      - if recovery_display.image.present?
+        %img{ data: { lazy: recovery_display.image_url(:medium) }}
+      - else
+        %span.no-image-spacer
+      - if recovery_display.quote_by
+        %span.h3recovery
+          = recovery_display.quote_by
+      %span.h4recovery
+        - txt = recovery_display.bike.present? ? recovery_display.bike.type.titleize : 'Bike'
+        - txt += " <span class='recover-date'>recovered #{l recovery_display.date_recovered, format: :dotted}</span>"
+        - if recovery_display.link.present?
+          %a.recover-date{ href: recovery_display.link }
+            = txt.html_safe
+        - else
+          = txt.html_safe

--- a/app/views/welcome/index.html.haml
+++ b/app/views/welcome/index.html.haml
@@ -42,32 +42,9 @@
     .root-landing-recovery-stories
       .container
         #recovery-stories-container.extras-hidden
-          - RecoveryDisplay.limit(5).each_with_index do |recovery, i|
-            - cache(recovery) do
-              .recovery-block{ class: "recovery-#{recovery.id}" }
-                %p.recovery-quote
-                  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 31.75 23.54"><path class="svg-q-p" d="M15.68,2.74q-2,1-3.8,2.11a25.37,25.37,0,0,0-3,2.11A13.08,13.08,0,0,0,6.43,9.64a14.15,14.15,0,0,0-1.65,3.69H6.64a5,5,0,0,1,3.93,1.35,4.41,4.41,0,0,1,1.19,3,6.07,6.07,0,0,1-1.61,4,5.46,5.46,0,0,1-4.39,1.89,5.43,5.43,0,0,1-4.36-1.65A6.45,6.45,0,0,1,0,17.54a13.41,13.41,0,0,1,1.52-6.38A20.73,20.73,0,0,1,5.34,6a25.06,25.06,0,0,1,4.71-3.61Q12.51,1,14.37,0Zm16.07,0q-2,1-3.8,2.11a25.37,25.37,0,0,0-3,2.11A13.08,13.08,0,0,0,22.5,9.64a14.15,14.15,0,0,0-1.65,3.69h1.87a5,5,0,0,1,3.93,1.35,4.41,4.41,0,0,1,1.19,3,6.07,6.07,0,0,1-1.61,4,5.46,5.46,0,0,1-4.39,1.89,5.43,5.43,0,0,1-4.36-1.65,6.45,6.45,0,0,1-1.41-4.34,13.41,13.41,0,0,1,1.52-6.38A20.73,20.73,0,0,1,21.41,6a25.06,25.06,0,0,1,4.71-3.61Q28.57,1,30.44,0Z"/></svg>
-
-                  %span.precovery
-                    = recovery.quote.html_safe
-                %span.recovery-user
-                  - if recovery.image.present?
-                    %img{ data: { lazy: recovery.image_url(:medium) }}
-                  - else
-                    %span.no-image-spacer
-                  - if recovery.quote_by
-                    %span.h3recovery
-                      = recovery.quote_by
-                  %span.h4recovery
-                    - txt = recovery.bike.present? ? recovery.bike.type.titleize : 'Bike'
-                    - txt += " <span class='recover-date'>recovered #{l recovery.date_recovered, format: :dotted}</span>"
-                    - if recovery.link.present?
-                      %a.recover-date{ href: recovery.link }
-                        = txt.html_safe
-                    - else
-                      = txt.html_safe
-        %a{href: recovery_stories_path}
-          Read more recovery stories here
+          = render @recovery_displays
+          %a.float-right{href: recovery_stories_path}
+            Read more recovery stories
 
     .root-landing-how-it-works
       .container

--- a/app/views/welcome/index.html.haml
+++ b/app/views/welcome/index.html.haml
@@ -42,7 +42,7 @@
     .root-landing-recovery-stories
       .container
         #recovery-stories-container.extras-hidden
-          - RecoveryDisplay.limit(10).each_with_index do |recovery, i|
+          - RecoveryDisplay.limit(5).each_with_index do |recovery, i|
             - cache(recovery) do
               .recovery-block{ class: "recovery-#{recovery.id}" }
                 %p.recovery-quote
@@ -66,6 +66,8 @@
                         = txt.html_safe
                     - else
                       = txt.html_safe
+        %a{href: recovery_stories_path}
+          Read more recovery stories here
 
     .root-landing-how-it-works
       .container
@@ -149,5 +151,3 @@
             = image_tag 'landing_pages/partners/BYU.png', alt: 'Brigham Young University'
           .root-landing-who-square
             = image_tag 'landing_pages/partners/Bike-Portland.png', alt: 'Bike Portland'
-
-

--- a/app/views/welcome/recovery_stories.html.haml
+++ b/app/views/welcome/recovery_stories.html.haml
@@ -1,0 +1,25 @@
+.root-landing-recovery-stories
+  .container
+    - @recovery_displays.each do |recovery|
+      .recovery-block{ class: "recovery-#{recovery.id}" }
+        %p.recovery-quote
+          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 31.75 23.54"><path class="svg-q-p" d="M15.68,2.74q-2,1-3.8,2.11a25.37,25.37,0,0,0-3,2.11A13.08,13.08,0,0,0,6.43,9.64a14.15,14.15,0,0,0-1.65,3.69H6.64a5,5,0,0,1,3.93,1.35,4.41,4.41,0,0,1,1.19,3,6.07,6.07,0,0,1-1.61,4,5.46,5.46,0,0,1-4.39,1.89,5.43,5.43,0,0,1-4.36-1.65A6.45,6.45,0,0,1,0,17.54a13.41,13.41,0,0,1,1.52-6.38A20.73,20.73,0,0,1,5.34,6a25.06,25.06,0,0,1,4.71-3.61Q12.51,1,14.37,0Zm16.07,0q-2,1-3.8,2.11a25.37,25.37,0,0,0-3,2.11A13.08,13.08,0,0,0,22.5,9.64a14.15,14.15,0,0,0-1.65,3.69h1.87a5,5,0,0,1,3.93,1.35,4.41,4.41,0,0,1,1.19,3,6.07,6.07,0,0,1-1.61,4,5.46,5.46,0,0,1-4.39,1.89,5.43,5.43,0,0,1-4.36-1.65,6.45,6.45,0,0,1-1.41-4.34,13.41,13.41,0,0,1,1.52-6.38A20.73,20.73,0,0,1,21.41,6a25.06,25.06,0,0,1,4.71-3.61Q28.57,1,30.44,0Z"/></svg>
+
+          %span.precovery
+            = recovery.quote.html_safe
+        %span.recovery-user
+          - if recovery.image.present?
+            %img{src: recovery.image_url(:medium) }
+          - else
+            %span.no-image-spacer
+          - if recovery.quote_by
+            %span.h3recovery
+              = recovery.quote_by
+          %span.h4recovery
+            - txt = recovery.bike.present? ? recovery.bike.type.titleize : 'Bike'
+            - txt += " <span class='recover-date'>recovered #{l recovery.date_recovered, format: :dotted}</span>"
+            - if recovery.link.present?
+              %a.recover-date{ href: recovery.link }
+                = txt.html_safe
+            - else
+              = txt.html_safe

--- a/app/views/welcome/recovery_stories.html.haml
+++ b/app/views/welcome/recovery_stories.html.haml
@@ -1,25 +1,15 @@
-.root-landing-recovery-stories
-  .container
-    - @recovery_displays.each do |recovery|
-      .recovery-block{ class: "recovery-#{recovery.id}" }
-        %p.recovery-quote
-          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 31.75 23.54"><path class="svg-q-p" d="M15.68,2.74q-2,1-3.8,2.11a25.37,25.37,0,0,0-3,2.11A13.08,13.08,0,0,0,6.43,9.64a14.15,14.15,0,0,0-1.65,3.69H6.64a5,5,0,0,1,3.93,1.35,4.41,4.41,0,0,1,1.19,3,6.07,6.07,0,0,1-1.61,4,5.46,5.46,0,0,1-4.39,1.89,5.43,5.43,0,0,1-4.36-1.65A6.45,6.45,0,0,1,0,17.54a13.41,13.41,0,0,1,1.52-6.38A20.73,20.73,0,0,1,5.34,6a25.06,25.06,0,0,1,4.71-3.61Q12.51,1,14.37,0Zm16.07,0q-2,1-3.8,2.11a25.37,25.37,0,0,0-3,2.11A13.08,13.08,0,0,0,22.5,9.64a14.15,14.15,0,0,0-1.65,3.69h1.87a5,5,0,0,1,3.93,1.35,4.41,4.41,0,0,1,1.19,3,6.07,6.07,0,0,1-1.61,4,5.46,5.46,0,0,1-4.39,1.89,5.43,5.43,0,0,1-4.36-1.65,6.45,6.45,0,0,1-1.41-4.34,13.41,13.41,0,0,1,1.52-6.38A20.73,20.73,0,0,1,21.41,6a25.06,25.06,0,0,1,4.71-3.61Q28.57,1,30.44,0Z"/></svg>
+.container
+  .row
+    %h3
+      Recovery Stories
 
-          %span.precovery
-            = recovery.quote.html_safe
-        %span.recovery-user
-          - if recovery.image.present?
-            %img{src: recovery.image_url(:medium) }
-          - else
-            %span.no-image-spacer
-          - if recovery.quote_by
-            %span.h3recovery
-              = recovery.quote_by
-          %span.h4recovery
-            - txt = recovery.bike.present? ? recovery.bike.type.titleize : 'Bike'
-            - txt += " <span class='recover-date'>recovered #{l recovery.date_recovered, format: :dotted}</span>"
-            - if recovery.link.present?
-              %a.recover-date{ href: recovery.link }
-                = txt.html_safe
-            - else
-              = txt.html_safe
+  -# Read by BikeIndex.RecoveryStories to configure slick
+  %input{type: :hidden, id: :recovery_displays_count, value: @recovery_displays.length}
+
+  #recovery-stories-listing
+    .container
+      #recovery-stories-container
+        = render @recovery_displays
+
+    .paginate-container.paginate-container-bottom
+      = paginate @recovery_displays

--- a/app/views/welcome/recovery_stories.html.haml
+++ b/app/views/welcome/recovery_stories.html.haml
@@ -3,12 +3,9 @@
     %h3
       Recovery Stories
 
-  -# Read by BikeIndex.RecoveryStories to configure slick
-  %input{type: :hidden, id: :recovery_displays_count, value: @recovery_displays.length}
-
   #recovery-stories-listing
     .container
-      #recovery-stories-container
+      #recovery-stories-container{data: {stories_count: @recovery_displays.length}}
         = render @recovery_displays
 
     .paginate-container.paginate-container-bottom

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -43,6 +43,7 @@ Bikeindex::Application.routes.draw do
   get 'choose_registration', to: 'welcome#choose_registration'
   get 'goodbye', to: 'welcome#goodbye'
   get 'bike_creation_graph', to: 'welcome#bike_creation_graph'
+  get "recovery_stories", to: "welcome#recovery_stories", as: :recovery_stories
 
   resource :session, only: [:new, :create, :destroy]
   get 'logout', to: 'sessions#destroy'

--- a/spec/controllers/welcome_controller_spec.rb
+++ b/spec/controllers/welcome_controller_spec.rb
@@ -141,5 +141,17 @@ describe WelcomeController do
         end
       end
     end
+
+    describe "recovery_stories" do
+      it "renders recovery stories" do
+        FactoryBot.create_list(:recovery_display, 3)
+        get :recovery_stories, per_page: 2
+        expect(assigns(:recovery_displays).count).to eq 2
+        expect(response.status).to eq(200)
+        expect(response).to render_template("recovery_stories")
+        expect(response).to render_with_layout("application_revised")
+        expect(flash).to_not be_present
+      end
+    end
   end
 end

--- a/spec/factories/recovery_displays.rb
+++ b/spec/factories/recovery_displays.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :recovery_display do
+    quote { "Recovered!" }
+  end
+end


### PR DESCRIPTION
- Updates the home page to display 5 recovery displays
- Adds a link to `/recovery_stories`
- Displays 5 displays at a time, paginated, at `/recovery_stories`

Resolves #524 

### Demo

![demo](https://user-images.githubusercontent.com/4433943/55601230-e47c3180-572d-11e9-8d8d-d9ff2b38d698.gif)
