### PR TITLE
Fix broken seed data

### DIFF
--- a/lib/tasks/seed_tasks.rake
+++ b/lib/tasks/seed_tasks.rake
@@ -30,10 +30,10 @@ task seed_test_users_and_bikes: :environment do
   @user = User.find_by_email('user@example.com')
   @member = User.find_by_email('member@example.com')
   @org = Organization.first
-  @cycle_type_id = CycleType.find_by_name('Bike').id
+  @cycle_type_id = CycleType::SLUGS[:bike]
   50.times do
     bike = Bike.new(
-      cycle_type_id: @cycle_type_id,
+      cycle_type: @cycle_type_id,
       propulsion_type: 'foot-pedal',
       manufacturer_id: (rand(Manufacturer.frames.count) + 1),
       rear_tire_narrow: true,


### PR DESCRIPTION
I was trying to get this repo up and running and it looks as though the seed data is broken when I run the command `rake seed_test_users_and_bikes` I was getting the error `NoMethodError: undefined method `find_by_name' for CycleType:Class`.

Looking at the history `CycleType` was previous an AR, once it was changed to a PORO this broke.

This PR also fixes assigning `cycle_type_id` which is now `cycle_type`.