### PR TITLE
Update UIs for Recovery Stories

### DIFF
--- a/app/assets/javascripts/revised/pages/welcome/recovery_stories.coffee
+++ b/app/assets/javascripts/revised/pages/welcome/recovery_stories.coffee
@@ -1,7 +1,9 @@
 class BikeIndex.RecoveryStories extends BikeIndex
   constructor: ->
-    $recovery_stories = $('#recovery-stories-container')
-    $recovery_stories.slick
-      lazyLoad: 'ondemand'
-      slidesToShow: $recovery_stories.data('stories-count')
-      vertical: true
+    $recovery_stories = $('.recovery-stories-container')
+    for recovery_story in $recovery_stories
+        $recovery_story = $(recovery_story)
+        $recovery_story.slick
+          lazyLoad: 'ondemand'
+          slidesToShow: $recovery_story.data('stories-count')
+          vertical: true

--- a/app/assets/javascripts/revised/pages/welcome/recovery_stories.coffee
+++ b/app/assets/javascripts/revised/pages/welcome/recovery_stories.coffee
@@ -1,9 +1,9 @@
 class BikeIndex.RecoveryStories extends BikeIndex
   constructor: ->
-    $recovery_stories = $('.recovery-stories-container')
-    for recovery_story in $recovery_stories
-        $recovery_story = $(recovery_story)
-        $recovery_story.slick
-          lazyLoad: 'ondemand'
-          slidesToShow: $recovery_story.data('stories-count')
-          vertical: true
+    $recovery_stories_containers = $('#recovery-stories-container').find('.recovery-stories-container')
+    for $recovery_stories_container in $recovery_stories_containers
+      num_slides = $recovery_stories_container.data('stories-count')
+      $recovery_stories_containers.slick
+        lazyLoad: 'ondemand'
+        slidesToShow: num_slides + 1
+        vertical: true

--- a/app/assets/stylesheets/revised/pages/landing/_recoveries.scss
+++ b/app/assets/stylesheets/revised/pages/landing/_recoveries.scss
@@ -111,6 +111,16 @@ $recovery-text-bg: #fff;
   }
 }
 
+@media (min-width: $grid-breakpoint-xl) {
+  #recovery-stories-listing {
+    .recovery-stories-container {
+      width: 48%;
+      margin: 10px;
+      float: left;
+    }
+  }
+}
+
 @media (min-width: $grid-breakpoint-sm+1) {
   .recovery-block {
     .recovery-user {

--- a/app/assets/stylesheets/revised/pages/landing/_recoveries.scss
+++ b/app/assets/stylesheets/revised/pages/landing/_recoveries.scss
@@ -103,6 +103,12 @@ $recovery-text-bg: #fff;
       line-height: 1.2em;
     }
   }
+  .see-more-link {
+    font-size: 2rem;
+    display: flex;
+    justify-content: center;
+    margin: 17%;
+  }
 }
 
 @media (min-width: $grid-breakpoint-sm+1) {
@@ -173,6 +179,9 @@ $recovery-tri-2: 15px;
         border-bottom: $recovery-tri-2*1.5 solid transparent; 
         border-right: $recovery-tri-2 solid $gray;
       }
+    }
+    .see-more-link {
+      margin: 35%;
     }
   }
 }

--- a/app/controllers/welcome_controller.rb
+++ b/app/controllers/welcome_controller.rb
@@ -44,6 +44,10 @@ class WelcomeController < ApplicationController
     page = params[:page] || 1
     @per_page = params[:per_page] || 10
     @recovery_displays = RecoveryDisplay.page(page).per(@per_page)
+
+    slice_size = (@recovery_displays.length / 2.0).ceil
+    @left, @right = @recovery_displays.each_slice(slice_size).entries
+    @right ||= []
   end
 
   private

--- a/app/controllers/welcome_controller.rb
+++ b/app/controllers/welcome_controller.rb
@@ -44,15 +44,18 @@ class WelcomeController < ApplicationController
     page = params[:page] || 1
     @per_page = params[:per_page] || 10
     @recovery_displays = RecoveryDisplay.page(page).per(@per_page)
-
-    slice_size = (@recovery_displays.length / 2.0).ceil
-    @left, @right = @recovery_displays.each_slice(slice_size).entries
-    @right ||= []
+    @slice1, @slice2 = list_halves(@recovery_displays)
   end
 
   private
 
   def authenticate_user_for_welcome_controller
     authenticate_user('Please create an account', flash_type: :info)
+  end
+
+  def list_halves(list)
+    slice_size = (list.length / 2.0).ceil
+    slice1, slice2 = list.each_slice(slice_size).entries
+    [slice1, slice2 || []]
   end
 end

--- a/app/controllers/welcome_controller.rb
+++ b/app/controllers/welcome_controller.rb
@@ -53,6 +53,8 @@ class WelcomeController < ApplicationController
     authenticate_user('Please create an account', flash_type: :info)
   end
 
+  # Split the given array `list` into two halves
+  # Return a tuple with each half as an array.
   def list_halves(list)
     slice_size = (list.length / 2.0).ceil
     slice1, slice2 = list.each_slice(slice_size).entries

--- a/app/controllers/welcome_controller.rb
+++ b/app/controllers/welcome_controller.rb
@@ -42,7 +42,7 @@ class WelcomeController < ApplicationController
 
   def recovery_stories
     page = params[:page] || 1
-    @per_page = params[:per_page] || 5
+    @per_page = params[:per_page] || 10
     @recovery_displays = RecoveryDisplay.page(page).per(@per_page)
   end
 

--- a/app/views/welcome/index.html.haml
+++ b/app/views/welcome/index.html.haml
@@ -43,8 +43,9 @@
       .container
         #recovery-stories-container.extras-hidden
           = render @recovery_displays
-          %a.float-right{href: recovery_stories_path}
-            Read more recovery stories
+          .recovery-block.recovery-see-more
+            %a.see-more-link{href: recovery_stories_path}
+              Read more recovery stories
 
     .root-landing-how-it-works
       .container

--- a/app/views/welcome/recovery_stories.html.haml
+++ b/app/views/welcome/recovery_stories.html.haml
@@ -5,10 +5,10 @@
 
   #recovery-stories-listing
     .container.clearfix
-      .recovery-stories-container{data: {stories_count: @left.length}}
-        = render @left
-      .recovery-stories-container{data: {stories_count: @right.length}}
-        = render @right
+      .recovery-stories-container{data: {stories_count: @slice1.length}}
+        = render @slice1
+      .recovery-stories-container{data: {stories_count: @slice2.length}}
+        = render @slice2
 
     .paginate-container.paginate-container-bottom
       = paginate @recovery_displays

--- a/app/views/welcome/recovery_stories.html.haml
+++ b/app/views/welcome/recovery_stories.html.haml
@@ -4,9 +4,11 @@
       Recovery Stories
 
   #recovery-stories-listing
-    .container
-      #recovery-stories-container{data: {stories_count: @recovery_displays.length}}
-        = render @recovery_displays
+    .container.clearfix
+      .recovery-stories-container{data: {stories_count: @left.length}}
+        = render @left
+      .recovery-stories-container{data: {stories_count: @right.length}}
+        = render @right
 
     .paginate-container.paginate-container-bottom
       = paginate @recovery_displays

--- a/config/sitemap.rb
+++ b/config/sitemap.rb
@@ -53,7 +53,12 @@ SitemapGenerator::Sitemap.create do
   end
 
   group(filename: :contact) do
-    paths = ['/help']
+    paths = ["help"]
+    paths.each { |i| add "/#{i}", priority: 0.8 }
+  end
+
+  group(filename: :recovery_stories) do
+    paths = ["recovery_stories"]
     paths.each { |i| add "/#{i}", priority: 0.8 }
   end
 


### PR DESCRIPTION
- Moves the "read more recovery stories" link to the end of the slideshow
- Doubles the number of recovery stories displayed
- Displays recovery stories in two columns (past "xl" width breakpoint)
- Adds the recovery stories page to the sitemap


### Demos

Full width

![demo](https://user-images.githubusercontent.com/4433943/56527555-d2ff9b80-651b-11e9-874a-fa2a92c33e4e.gif)


Narrow

![demo2](https://user-images.githubusercontent.com/4433943/56527537-cbd88d80-651b-11e9-83ea-64a1e6f947c3.gif)


Implements suggestions from https://github.com/bikeindex/bike_index/pull/668