### PR TITLE
Fix bug in Slick initialization

### DIFF
--- a/app/assets/javascripts/revised/pages/welcome/recovery_stories.coffee
+++ b/app/assets/javascripts/revised/pages/welcome/recovery_stories.coffee
@@ -1,9 +1,10 @@
 class BikeIndex.RecoveryStories extends BikeIndex
   constructor: ->
-    $recovery_stories_containers = $('#recovery-stories-container').find('.recovery-stories-container')
-    for $recovery_stories_container in $recovery_stories_containers
+    $recovery_stories_containers = $('.recovery-stories-container')
+    for recovery_stories_container in $recovery_stories_containers
+      $recovery_stories_container = $(recovery_stories_container)
       num_slides = $recovery_stories_container.data('stories-count')
       $recovery_stories_containers.slick
         lazyLoad: 'ondemand'
-        slidesToShow: num_slides + 1
+        slidesToShow: num_slides
         vertical: true

--- a/app/views/welcome/recovery_stories.html.haml
+++ b/app/views/welcome/recovery_stories.html.haml
@@ -5,9 +5,9 @@
 
   #recovery-stories-listing
     .container.clearfix
-      .recovery-stories-container{data: {stories_count: @slice1.length}}
+      .recovery-stories-container{data: {"stories-count" => @slice1.length}}
         = render @slice1
-      .recovery-stories-container{data: {stories_count: @slice2.length}}
+      .recovery-stories-container{data: {"stories-count" => @slice2.length}}
         = render @slice2
 
     .paginate-container.paginate-container-bottom


### PR DESCRIPTION
Currently `slick` isn't being initialized on recovery stories containers, so images aren't loading. This patch fixes that by correcting the dom query string to `.recovery-stories-container`. 

NB: There's an issue where the height of a container isn't computed correctly by slick if elements within it are missing images, but all the recovery stories on prod seem to have images, so this wouldn't be an issue in practice.

![demo](https://user-images.githubusercontent.com/4433943/56534716-3a234d00-6528-11e9-805b-70814aaa4452.gif)
