### PR TITLE
Ensure bike creation API endpoint upserts

### DIFF
--- a/app/controllers/api/v2/bikes.rb
+++ b/app/controllers/api/v2/bikes.rb
@@ -73,7 +73,6 @@ module API
             is_bulk: params[:is_bulk],
             is_pos: params[:is_pos],
             is_new: params[:is_new],
-            no_duplicate: params[:no_duplicate],
           }
         end
 
@@ -189,7 +188,6 @@ module API
             hash["bike"].delete("is_bulk")
             hash["bike"].delete("is_pos")
             hash["bike"].delete("is_new")
-            hash["bike"].delete("no_duplicate")
 
             begin
               BikeUpdator

--- a/app/controllers/api/v2/bikes.rb
+++ b/app/controllers/api/v2/bikes.rb
@@ -73,7 +73,7 @@ module API
             is_bulk: params[:is_bulk],
             is_pos: params[:is_pos],
             is_new: params[:is_new],
-          }
+          }.as_json
         end
 
         def find_bike
@@ -141,12 +141,14 @@ module API
           # Search for a bike matching the provided serial number / owner email
           bike_attrs = %w{serial owner_email}.map { |key| [key.to_sym, params[key]] }.to_h
           found_bike = BikeFinder.find_matching(**bike_attrs)
+          declared_p = { "declared_params" => declared(params, include_missing: false).merge(creation_state_params) }
+          b_param = BParam.new(creator_id: creation_user_id, params: declared_p["declared_params"].as_json, origin: "api_v2")
+          b_param.clean_params
+          ensure_required_stolen_attrs(b_param.params)
 
           # bike was not found, create it
           if found_bike.blank?
-            declared_p = { "declared_params" => declared(params, include_missing: false).merge(creation_state_params) }
-            b_param = BParam.create(creator_id: creation_user_id, params: declared_p["declared_params"], origin: "api_v2")
-            ensure_required_stolen_attrs(b_param.params)
+            b_param.save
             bike = BikeCreator.new(b_param).create_bike
 
             if b_param.errors.blank? && b_param.bike_errors.blank? && bike.present? && bike.errors.blank?
@@ -162,36 +164,13 @@ module API
             @bike = found_bike
             authorize_bike_for_user
 
-            declared_p = { "declared_params" => declared(params, include_missing: false) }
-            hash = BParam.v2_params(declared_p["declared_params"].as_json)
-            if hash["stolen_record"].present? && @bike.stolen != true
-              ensure_required_stolen_attrs(hash)
+            if b_param.params.dig("bike", "external_image_urls").present?
+              @bike.load_external_images(b_param.params["bike"]["external_image_urls"])
             end
-
-            if hash.dig("bike", "external_image_urls").present?
-              @bike.load_external_images(hash["bike"]["external_image_urls"])
-            end
-
-            hash["bike"]["primary_frame_color"] =
-              Color.find_by(name: hash["bike"].delete("color"))
-
-            hash["bike"]["cycle_type"] =
-              CycleType.friendly_find(hash["bike"].delete("cycle_type_name")).id
-
-            rear_size = hash["bike"].delete("rear_wheel_bsd")
-            front_size = hash["bike"].delete("front_wheel_bsd")
-            hash["bike"]["front_wheel_size_id"] = front_size
-            hash["bike"]["rear_wheel_size_id"] = rear_size
-
-            # Don't update
-            hash["bike"].delete("manufacturer")
-            hash["bike"].delete("is_bulk")
-            hash["bike"].delete("is_pos")
-            hash["bike"].delete("is_new")
 
             begin
               BikeUpdator
-                .new(user: current_user, bike: @bike, b_params: hash)
+                .new(user: current_user, bike: @bike, b_params: b_param.params.except(*creation_state_params.keys))
                 .update_available_attributes
             rescue => e
               error!("Unable to update bike: #{e}", 401)
@@ -225,7 +204,9 @@ module API
           declared_p = { "declared_params" => declared(params, include_missing: false) }
           find_bike
           authorize_bike_for_user
-          hash = BParam.v2_params(declared_p["declared_params"].as_json)
+          b_param = BParam.new(params: declared_p["declared_params"].as_json, origin: "api_v2")
+          b_param.clean_params
+          hash = b_param.params
           ensure_required_stolen_attrs(hash) if hash["stolen_record"].present? && @bike.stolen != true
           @bike.load_external_images(hash["bike"]["external_image_urls"]) if hash.dig("bike", "external_image_urls").present?
           begin

--- a/app/models/b_param.rb
+++ b/app/models/b_param.rb
@@ -212,7 +212,6 @@ class BParam < ActiveRecord::Base
     end
     rbsd = params["bike"].delete("rear#{key}")
     fbsd = params["bike"].delete("front#{key}")
-    # binding.pry
     params["bike"]["rear_wheel_size_id"] = WheelSize.id_for_bsd(rbsd)
     params["bike"]["front_wheel_size_id"] = WheelSize.id_for_bsd(fbsd)
   end

--- a/app/models/b_param.rb
+++ b/app/models/b_param.rb
@@ -20,14 +20,15 @@ class BParam < ActiveRecord::Base
 
   def self.v2_params(hash)
     h = hash["bike"].present? ? hash : { "bike" => hash.with_indifferent_access }
-    h["bike"]["serial_number"] = h["bike"].delete "serial"
-    h["bike"]["send_email"] = !(h["bike"].delete "no_notify")
+    h["bike"]["serial_number"] ||= h["bike"].delete "serial"
+    # Only assign if the key hasn't been assigned - since it's boolean, can't use conditional assignment
+    h["bike"]["send_email"] = !(h["bike"].delete "no_notify") unless h["bike"].key?("send_email")
     org = Organization.friendly_find(h["bike"].delete "organization_slug")
     h["bike"]["creation_organization_id"] = org.id if org.present?
     # Move un-nested params outside of bike
-    %w(test id components).each { |k| h[k] = h["bike"].delete k }
+    %w(test id components).each { |k| h[k] = h["bike"].delete(k) if h["bike"].key?(k) }
     stolen_attrs = h["bike"].delete "stolen_record"
-    if stolen_attrs && stolen_attrs.delete_if { |k, v| v.blank? } && stolen_attrs.keys.any?
+    if stolen_attrs.present? && stolen_attrs.delete_if { |k, v| v.blank? } && stolen_attrs.keys.any?
       h["bike"]["stolen"] = true
       h["stolen_record"] = stolen_attrs
     end

--- a/app/models/b_param.rb
+++ b/app/models/b_param.rb
@@ -211,6 +211,7 @@ class BParam < ActiveRecord::Base
     end
     rbsd = params["bike"].delete("rear#{key}")
     fbsd = params["bike"].delete("front#{key}")
+    # binding.pry
     params["bike"]["rear_wheel_size_id"] = WheelSize.id_for_bsd(rbsd)
     params["bike"]["front_wheel_size_id"] = WheelSize.id_for_bsd(fbsd)
   end

--- a/app/models/bike.rb
+++ b/app/models/bike.rb
@@ -53,9 +53,9 @@ class Bike < ActiveRecord::Base
   validates_presence_of :primary_frame_color_id
 
   attr_accessor :other_listing_urls, :date_stolen, :receive_notifications,
-    :image, :b_param_id, :embeded, :embeded_extended, :paint_name,
-    :bike_image_cache, :send_email, :marked_user_hidden, :marked_user_unhidden,
-    :b_param_id_token, :address, :address_city, :address_state, :address_zipcode
+                :image, :b_param_id, :embeded, :embeded_extended, :paint_name,
+                :bike_image_cache, :send_email, :marked_user_hidden, :marked_user_unhidden,
+                :b_param_id_token, :address, :address_city, :address_state, :address_zipcode
 
   attr_writer :phone, :user_name, :organization_affiliation, :external_image_urls # reading is managed by a method
 
@@ -90,9 +90,9 @@ class Bike < ActiveRecord::Base
                               }
 
   pg_search_scope :admin_search,
-    against: { owner_email: "A" },
-    associated_against: { ownerships: :owner_email, creator: :email },
-    using: { tsearch: { dictionary: "english", prefix: true } }
+                  against: { owner_email: "A" },
+                  associated_against: { ownerships: :owner_email, creator: :email },
+                  using: { tsearch: { dictionary: "english", prefix: true } }
 
   class << self
     def old_attr_accessible
@@ -208,7 +208,11 @@ class Bike < ActiveRecord::Base
   def first_ownership; ownerships.reorder(:id).first end
 
   def organized?(org = nil)
-    org.present? ? bike_organization_ids.include?(org.id) : bike_organizations.any?
+    if org.present?
+      bike_organization_ids.include?(org.id)
+    else
+      bike_organizations.any?
+    end
   end
 
   # check if this is the first ownership - or if no owner, which means testing probably

--- a/app/services/bike_finder.rb
+++ b/app/services/bike_finder.rb
@@ -11,10 +11,12 @@ module BikeFinder
   #
   # Return a Bike object, or nil
   def self.find_matching(serial:, owner_email:)
+    email = EmailNormalizer.normalize(owner_email)
+
     candidate_user_ids =
       User
         .joins("LEFT JOIN user_emails ON user_emails.user_id = users.id")
-        .where("users.email = ? OR user_emails.email = ?", owner_email, owner_email)
+        .where("users.email = ? OR user_emails.email = ?", email, email)
         .select(:id)
         .uniq
 

--- a/app/services/bike_finder.rb
+++ b/app/services/bike_finder.rb
@@ -1,0 +1,32 @@
+module BikeFinder
+  # Find a bike with the given serial number `serial` associated with email
+  # address `owner_email`.
+  #
+  # Matches based on the normalized serial number, and `owner_email` should be
+  # found via:
+  #
+  # - the bike's owner_email attribute
+  # - the email attribute of any of the bike's owner's (user / creator: via bike.ownerships)
+  # - any email associated with any owner (via user.user_emails)
+  #
+  # Return a Bike object, or nil
+  def self.find_matching(serial:, owner_email:)
+    candidate_user_ids =
+      User
+        .joins("LEFT JOIN user_emails ON user_emails.user_id = users.id")
+        .where("users.email = ? OR user_emails.email = ?", owner_email, owner_email)
+        .select(:id)
+        .uniq
+
+    Bike
+      .joins("LEFT JOIN ownerships ON bikes.id = ownerships.bike_id")
+      .where(serial_normalized: SerialNormalizer.new(serial: serial).normalized)
+      .where(
+        "bikes.owner_email = ? OR ownerships.user_id IN (?) OR ownerships.creator_id IN (?)",
+        owner_email,
+        candidate_user_ids,
+        candidate_user_ids
+      )
+      .first
+  end
+end

--- a/spec/models/b_param_spec.rb
+++ b/spec/models/b_param_spec.rb
@@ -77,10 +77,7 @@ describe BParam do
       b_param.clean_params
       clean_params2 = b_param.params
 
-      clean_params2["bike"]
-        .sort
-        .zip(clean_params1["bike"].sort)
-        .each { |(k1, v1), (_, v2)| expect(v1).to eq(v2), "#{k1} : #{v1} != #{v2}" }
+      expect_hashes_to_match(clean_params2["bike"], clean_params1["bike"])
       expect(clean_params2["bike"].keys).to match_array(clean_params1["bike"].keys)
       expect(clean_params2).to eq(clean_params1)
     end

--- a/spec/models/b_param_spec.rb
+++ b/spec/models/b_param_spec.rb
@@ -46,63 +46,43 @@ describe BParam do
         expect(b_param.params["stolen_record"]["phone"]).to eq("171-829-2625")
       end
     end
+
     it "has before_save_callback_method of clean_params" do
       expect(BParam._save_callbacks.select { |cb| cb.kind.eql?(:before) }.map(&:raw_filter).include?(:clean_params)).to eq(true)
     end
-    context "run multiple times" do
-      let(:initial_params) do
-        { "serial" => "69 non-example",
-          "manufacturer" => "Special_name3",
-          "owner_email" => "fun_times@examples.com",
-          "color" => "Special_name4",
-          "cycle_type_name" => "bike",
-          "rear_wheel_bsd" => 559,
-          "rear_tire_narrow" => true,
-          "year" => 1969,
-          "frame_material" => "steel",
-          "is_bulk" => nil,
-          "is_pos" => nil,
-          "is_new" => nil }
-      end
-      let(:target_params) do
-        { "bike" => {
-          "serial_number" => "69 non-example",
-          "manufacturer_id" => manufacturer.id,
-          "owner_email" => "fun_times@examples.com",
-          "primary_frame_color_id" => color.id,
-          "cycle_type" => :bike,
-          "front_wheel_size_id" => nil,
-          "rear_wheel_size_id" => wheel_size.id,
-          "rear_tire_narrow" => true,
-          "handlebar_type" => nil,
-          "year" => 1969,
-          "frame_material" => "steel",
-          "is_bulk" => nil,
-          "is_pos" => nil,
-          "is_new" => nil,
-          "send_email" => true,
-        },
-          "test" => nil,
-          "id" => nil,
-          "components" => nil }
-      end
-      let(:b_param) { BParam.new(params: initial_params, origin: "api_v2") }
-      let!(:wheel_size) { FactoryBot.create(:wheel_size, iso_bsd: 559) }
-      let!(:color) { FactoryBot.create(:color, name: "Special_name4") }
-      let!(:manufacturer) { FactoryBot.create(:manufacturer, name: "Special name3") }
-      it "returns the same thing" do
-        b_param.clean_params
-        expect(b_param.params.keys).to eq target_params.keys
-        expect(b_param.params["bike"].keys).to match_array target_params["bike"].keys
-        expect(b_param.params).to eq target_params
-        b_param.clean_params
-        expect(b_param.params["bike"].keys).to match_array target_params["bike"].keys
-        b_param.params["bike"].keys.each do |k|
-          pp k
-          expect(b_param.params["bike"][k]).to eq target_params["bike"][k]
-        end
-        expect(b_param.params).to eq target_params
-      end
+
+    it "cleans params idempotently if invoked multiple times" do
+      wheel_size = FactoryBot.create(:wheel_size, iso_bsd: 559)
+      color = FactoryBot.create(:color, name: "Special_name4")
+      manufacturer = FactoryBot.create(:manufacturer, name: "Special name3")
+      params = {
+        "serial" => "69 non-example",
+        "manufacturer" => manufacturer.name,
+        "owner_email" => "fun_times@examples.com",
+        "color" => color.name,
+        "cycle_type_name" => "bike",
+        "rear_wheel_bsd" => wheel_size.iso_bsd,
+        "rear_tire_narrow" => true,
+        "year" => 1969,
+        "frame_material" => "steel",
+        "is_bulk" => nil,
+        "is_pos" => nil,
+        "is_new" => nil,
+      }
+      b_param = BParam.new(params: params, origin: "api_v2")
+
+      b_param.clean_params
+      clean_params1 = b_param.params
+
+      b_param.clean_params
+      clean_params2 = b_param.params
+
+      clean_params2["bike"]
+        .sort
+        .zip(clean_params1["bike"].sort)
+        .each { |(k1, v1), (_, v2)| expect(v1).to eq(v2), "#{k1} : #{v1} != #{v2}" }
+      expect(clean_params2["bike"].keys).to match_array(clean_params1["bike"].keys)
+      expect(clean_params2).to eq(clean_params1)
     end
   end
 

--- a/spec/requests/api/v2/bikes_request_spec.rb
+++ b/spec/requests/api/v2/bikes_request_spec.rb
@@ -68,7 +68,7 @@ describe "Bikes API V2" do
           component_type: "headset",
           description: "yeah yay!",
           serial_number: "69",
-          model_name: "Richie rich",
+          model: "Richie rich",
         },
         {
           manufacturer: "BLUE TEETH",
@@ -98,6 +98,7 @@ describe "Bikes API V2" do
       expect(bike.components.count).to eq(3)
       expect(bike.components.pluck(:manufacturer_id).include?(manufacturer.id)).to be_truthy
       expect(bike.components.pluck(:ctype_id).uniq.count).to eq(2)
+      expect(bike.components.map(&:cmodel_name).compact).to eq(["Richie rich"])
       expect(bike.front_gear_type).to eq(front_gear_type)
       expect(bike.handlebar_type).to eq(handlebar_type_slug)
       creation_state = bike.creation_state
@@ -323,23 +324,21 @@ describe "Bikes API V2" do
     end
 
     it "updates a bike, adds and removes components" do
-      # FactoryBot.create(:manufacturer, name: 'Other')
       wheels = FactoryBot.create(:ctype, name: "wheel")
       headsets = FactoryBot.create(:ctype, name: "Headset")
       comp = FactoryBot.create(:component, bike: bike, ctype: headsets)
       comp2 = FactoryBot.create(:component, bike: bike, ctype: wheels)
       FactoryBot.create(:component)
-      # pp comp2
       bike.reload
       expect(bike.components.count).to eq(2)
       components = [
         {
-          manufacturer: manufacturer.name,
+          manufacturer: manufacturer.slug,
           year: "1999",
           component_type: "headset",
           description: "Second component",
           serial_number: "69",
-          model_name: "Richie rich",
+          model: "Richie rich",
         }, {
           manufacturer: "BLUE TEETH",
           front_or_rear: "Rear",
@@ -353,10 +352,8 @@ describe "Bikes API V2" do
           description: "First component",
         },
       ]
-      params[:is_for_sale] = true
-      params[:components] = components
       expect do
-        put url, params.to_json, json_headers
+        put url, params.merge(is_for_sale: true, components: components).to_json, json_headers
       end.to change(Ownership, :count).by(0)
       expect(response.code).to eq("200")
       bike.reload
@@ -364,6 +361,10 @@ describe "Bikes API V2" do
       expect(bike.is_for_sale).to be_truthy
       expect(bike.year).to eq(params[:year])
       expect(comp2.reload.year).to eq(1999)
+      pp "---"
+      pp bike.components.pluck(:cmodel_name), bike.components.map(&:manufacturer_name)
+      expect(bike.components.pluck(:cmodel_name)).to match_array([nil, nil, "Richie rich"])
+      expect(bike.components.map(&:manufacturer_name).compact).to match_array(["BLUE TEETH", manufacturer.name])
       expect(bike.components.pluck(:manufacturer_id).include?(manufacturer.id)).to be_truthy
       expect(bike.components.count).to eq(3)
     end

--- a/spec/requests/api/v2/bikes_request_spec.rb
+++ b/spec/requests/api/v2/bikes_request_spec.rb
@@ -361,8 +361,6 @@ describe "Bikes API V2" do
       expect(bike.is_for_sale).to be_truthy
       expect(bike.year).to eq(params[:year])
       expect(comp2.reload.year).to eq(1999)
-      pp "---"
-      pp bike.components.pluck(:cmodel_name), bike.components.map(&:manufacturer_name)
       expect(bike.components.pluck(:cmodel_name)).to match_array([nil, nil, "Richie rich"])
       expect(bike.components.map(&:manufacturer_name).compact).to match_array(["BLUE TEETH", manufacturer.name])
       expect(bike.components.pluck(:manufacturer_id).include?(manufacturer.id)).to be_truthy
@@ -386,8 +384,6 @@ describe "Bikes API V2" do
       put url, params.to_json, json_headers
       expect(response.code).to eq("401")
       expect(response.headers["Content-Type"].match("json")).to be_present
-      # response.headers['Access-Control-Allow-Origin'].should eq('*')
-      # response.headers['Access-Control-Request-Method'].should eq('*')
       expect(bike.reload.components.reload.count).to eq(1)
       expect(bike.components.pluck(:year).first).to eq(1999) # Feature, not a bug?
       expect(not_urs.reload.id).to be_present

--- a/spec/requests/api/v3/bikes_request_spec.rb
+++ b/spec/requests/api/v3/bikes_request_spec.rb
@@ -80,13 +80,13 @@ describe "Bikes API V3" do
 
         expect(response.status).to eq(201)
         expect(response.status_message).to eq("Created")
-        bike1 = JSON.parse(response.body)["bike"]
+        bike1 = json_result["bike"]
 
         post "/api/v3/bikes?access_token=#{token.token}",
              bike_attrs.to_json,
              json_headers
-        pp json_result
-        bike2 = JSON.parse(response.body)["bike"]
+
+        bike2 = json_result["bike"]
         expect(response.status).to eq(302)
         expect(response.status_message).to eq("Found")
         expect(bike1["id"]).to eq(bike2["id"])
@@ -220,7 +220,6 @@ describe "Bikes API V3" do
         post "/api/v3/bikes?access_token=#{token.token}",
              bike_attrs.merge(no_notify: true).to_json,
              json_headers
-        pp json_result
       end.to change(EmailOwnershipInvitationWorker.jobs, :size).by(0)
       expect(response.code).to eq("201")
     end
@@ -461,7 +460,6 @@ describe "Bikes API V3" do
       comp = FactoryBot.create(:component, bike: bike, ctype: headsets)
       comp2 = FactoryBot.create(:component, bike: bike, ctype: wheels)
       not_urs = FactoryBot.create(:component)
-      # pp comp2
       bike.reload
       expect(bike.components.count).to eq(2)
       components = [

--- a/spec/requests/api/v3/bikes_request_spec.rb
+++ b/spec/requests/api/v3/bikes_request_spec.rb
@@ -135,7 +135,7 @@ describe "Bikes API V3" do
              bike_attrs.to_json,
              json_headers
 
-        bike2 = json["bike"]
+        bike2 = json_result["bike"]
         expect(bike2["id"]).to eq(bike1.id)
         expect(bike2["serial"]).to eq(bike1.serial)
         expect(bike2["year"]).to eq(new_year)

--- a/spec/requests/api/v3/bikes_request_spec.rb
+++ b/spec/requests/api/v3/bikes_request_spec.rb
@@ -95,16 +95,15 @@ describe "Bikes API V3" do
       it "updates the pre-existing record if the bike has already been registered" do
         old_color = FactoryBot.create(:color, name: "old_color")
         new_color = FactoryBot.create(:color, name: "new_color")
-        old_year = 1969
-        new_year = 2001
-        old_cycle_type = CycleType.new("unicycle")
-        new_cycle_type = CycleType.new("tricycle")
         old_manufacturer = FactoryBot.create(:manufacturer, name: "old_manufacturer")
         new_manufacturer = FactoryBot.create(:manufacturer, name: "new_manufacturer")
         old_wheel_size = FactoryBot.create(:wheel_size, name: "old_wheel_size", iso_bsd: 10)
         new_rear_wheel_size = FactoryBot.create(:wheel_size, name: "new_rear_wheel_size", iso_bsd: 11)
         new_front_wheel_size = FactoryBot.create(:wheel_size, name: "new_front_wheel_size", iso_bsd: 12)
-
+        old_cycle_type = CycleType.new("unicycle")
+        new_cycle_type = CycleType.new("tricycle")
+        old_year = 1969
+        new_year = 2001
         bike1 = FactoryBot.create(
           :bike,
           creator: user,
@@ -116,14 +115,6 @@ describe "Bikes API V3" do
           rear_wheel_size: old_wheel_size,
           front_wheel_size: old_wheel_size,
         )
-        expect(bike1.year).to eq(old_year)
-        expect(bike1.primary_frame_color.name).to eq(old_color.name)
-        expect(bike1.cycle_type).to eq(old_cycle_type.slug.to_s)
-        expect(bike1.manufacturer.name).to eq(old_manufacturer.name)
-        expect(bike1.rear_wheel_size.name).to eq(old_wheel_size.name)
-        expect(bike1.rear_wheel_size.iso_bsd).to eq(old_wheel_size.iso_bsd)
-        expect(bike1.front_wheel_size.name).to eq(old_wheel_size.name)
-        expect(bike1.front_wheel_size.iso_bsd).to eq(old_wheel_size.iso_bsd)
         FactoryBot.create(:ownership, bike: bike1, creator: user, owner_email: user.email)
 
         bike_attrs = {
@@ -138,12 +129,9 @@ describe "Bikes API V3" do
           frame_material: "steel",
           cycle_type_name: new_cycle_type.slug.to_s,
         }
-
         post "/api/v3/bikes?access_token=#{token.token}",
              bike_attrs.to_json,
              json_headers
-        json = JSON.parse(response.body)
-        expect(json["error"]).to be_blank
 
         bike2 = json["bike"]
         expect(bike2["id"]).to eq(bike1.id)

--- a/spec/requests/api/v3/bikes_request_spec.rb
+++ b/spec/requests/api/v3/bikes_request_spec.rb
@@ -85,7 +85,7 @@ describe "Bikes API V3" do
         post "/api/v3/bikes?access_token=#{token.token}",
              bike_attrs.to_json,
              json_headers
-
+        pp json_result
         bike2 = JSON.parse(response.body)["bike"]
         expect(response.status).to eq(302)
         expect(response.status_message).to eq("Found")
@@ -142,7 +142,6 @@ describe "Bikes API V3" do
         post "/api/v3/bikes?access_token=#{token.token}",
              bike_attrs.to_json,
              json_headers
-
         json = JSON.parse(response.body)
         expect(json["error"]).to be_blank
 
@@ -171,7 +170,7 @@ describe "Bikes API V3" do
           component_type: "headset",
           description: "yeah yay!",
           serial_number: "69",
-          model_name: "Richie rich",
+          model: "Richie rich",
         },
         {
           manufacturer: "BLUE TEETH",
@@ -221,6 +220,7 @@ describe "Bikes API V3" do
         post "/api/v3/bikes?access_token=#{token.token}",
              bike_attrs.merge(no_notify: true).to_json,
              json_headers
+        pp json_result
       end.to change(EmailOwnershipInvitationWorker.jobs, :size).by(0)
       expect(response.code).to eq("201")
     end
@@ -471,7 +471,7 @@ describe "Bikes API V3" do
           component_type: "headset",
           description: "Second component",
           serial_number: "69",
-          model_name: "Richie rich",
+          model: "Sram GXP Eagle",
         }, {
           manufacturer: "BLUE TEETH",
           front_or_rear: "Rear",
@@ -497,6 +497,7 @@ describe "Bikes API V3" do
       expect(bike.year).to eq(params[:year])
       expect(comp2.reload.year).to eq(1999)
       expect(bike.components.pluck(:manufacturer_id).include?(manufacturer.id)).to be_truthy
+      expect(bike.components.map(&:cmodel_name).compact).to eq(["Sram GXP Eagle"])
       expect(bike.components.count).to eq(3)
     end
 

--- a/spec/requests/api/v3/bikes_request_spec.rb
+++ b/spec/requests/api/v3/bikes_request_spec.rb
@@ -114,13 +114,15 @@ describe "Bikes API V3" do
           cycle_type: old_cycle_type.id,
           rear_wheel_size: old_wheel_size,
           front_wheel_size: old_wheel_size,
+          rear_tire_narrow: false,
+          frame_material: "aluminum",
         )
         FactoryBot.create(:ownership, bike: bike1, creator: user, owner_email: user.email)
 
         bike_attrs = {
           serial: bike1.serial_number,
           manufacturer: new_manufacturer.name,
-          rear_tire_narrow: "true",
+          rear_tire_narrow: true,
           front_wheel_bsd: new_front_wheel_size.iso_bsd,
           rear_wheel_bsd: new_rear_wheel_size.iso_bsd,
           color: new_color.name,
@@ -142,6 +144,8 @@ describe "Bikes API V3" do
         expect(bike2["manufacturer_id"]).to eq(old_manufacturer.id)
         expect(bike2["front_wheel_size_iso_bsd"]).to eq(new_front_wheel_size.iso_bsd)
         expect(bike2["rear_wheel_size_iso_bsd"]).to eq(new_rear_wheel_size.iso_bsd)
+        expect(bike2["rear_tire_narrow"]).to eq(true)
+        expect(bike2["frame_material"]).to eq("Steel")
       end
     end
 

--- a/spec/services/bike_finder_spec.rb
+++ b/spec/services/bike_finder_spec.rb
@@ -1,0 +1,99 @@
+require "spec_helper"
+
+RSpec.describe BikeFinder do
+  describe ".find_matching" do
+    it "returns nil when the target email is not present on any bike, user, or user_email record" do
+      bike = FactoryBot.create(:ownership).bike
+      missing_email = "bad-email@example.com"
+      expect(Bike.exists?(owner_email: missing_email)).to eq(false)
+      expect(User.exists?(email: missing_email)).to eq(false)
+      expect(UserEmail.exists?(email: missing_email)).to eq(false)
+
+      result = BikeFinder.find_matching(
+        serial: bike.serial_number,
+        owner_email: missing_email,
+      )
+
+      expect(result).to be_nil
+    end
+
+    it "returns match when the target email is present on a user record and the serial matches" do
+      bike = FactoryBot.create(:ownership).bike
+      UserEmail.delete_all
+      expect(User.exists?(email: bike.creator.email)).to eq(true)
+      expect(UserEmail.exists?(email: bike.creator.email)).to eq(false)
+
+      result = BikeFinder.find_matching(
+        serial: bike.serial_number,
+        owner_email: bike.creator.email,
+      )
+
+      expect(result).to eq(bike)
+    end
+
+    it "returns match when the target email is present on a user_email record and the serial matches" do
+      bike = FactoryBot.create(:ownership).bike
+      User.first.update(email: "new-email@example.com")
+      expect(User.exists?(email: bike.creator.email)).to eq(false)
+      expect(UserEmail.exists?(email: bike.creator.email)).to eq(true)
+
+      result = BikeFinder.find_matching(
+        serial: bike.serial_number,
+        owner_email: bike.creator.email,
+      )
+
+      expect(result).to eq(bike)
+    end
+
+    it "returns match when the target email is present on a bike record and the serial matches" do
+      bike = FactoryBot.create(:bike)
+      expect(User.find_by(email: bike.owner_email)).to be_nil
+      expect(UserEmail.find_by(email: bike.owner_email)).to be_nil
+
+      result = BikeFinder.find_matching(
+        serial: bike.serial_number,
+        owner_email: bike.owner_email,
+      )
+
+      expect(result).to eq(bike)
+    end
+
+    it "returns nil if neither the serial nor the normalized serial match a bike record" do
+      bike = FactoryBot.create(:ownership).bike
+
+      result = BikeFinder.find_matching(
+        serial: "bad-serial-number",
+        owner_email: bike.creator.email,
+      )
+
+      expect(result).to be_nil
+    end
+
+    it "returns match if an email and the normalized serial number match" do
+      serial = "SOCOOL"
+      normalized_serial = "50C001"
+      bike = FactoryBot.create(:ownership).bike
+      bike.update(serial_number: normalized_serial)
+
+      result = BikeFinder.find_matching(
+        serial: serial,
+        owner_email: bike.creator.email,
+      )
+
+      expect(result).to eq(bike)
+    end
+
+    it "returns match if an email and the un-normalized serial number match" do
+      serial = "SOCOOL"
+      bike = FactoryBot.create(:ownership).bike
+      bike.update(serial_number: serial)
+
+      result = BikeFinder.find_matching(
+        serial: serial,
+        owner_email: bike.creator.email,
+      )
+
+      expect(result).to eq(bike)
+    end
+  end
+end


### PR DESCRIPTION
When creating a bike, first [search for the record](https://github.com/bikeindex/bike_index/pull/715/files#diff-2a964c740a025559cefad2c1348689ba) being created by serial number and email address (tests [here](https://github.com/bikeindex/bike_index/pull/715/files#diff-9aa7bec756e779b03037858befd4f7ff)):

```rb
# app/controllers/api/v2/bikes.rb L140-143 (d171f69d)

post "/", serializer: BikeV2ShowSerializer, root: "bike" do
  # Search for a bike matching the provided serial number / owner email
  bike_attrs = %w{serial owner_email}.map { |key| [key.to_sym, params[key]] }.to_h
  found_bike = BikeFinder.find_matching(**bike_attrs)
```

<details>

<summary>BikeFinder generated SQL</summary>

```sql
-- BikeFinder.find_matching(serial: "serial-1", owner_email: "user@example.com")
-- Bike Load (12.4ms)

SELECT
  "bikes".* 
FROM
  "bikes" 
  RIGHT JOIN
    ownerships 
    ON bikes.id = ownerships.bike_id 
WHERE
  "bikes"."example" = false
  AND "bikes"."hidden" = false 
  AND "bikes"."serial_normalized" = 'serial-1'
  AND 
  (
    bikes.owner_email = 'user@example.com' 
    OR ownerships.user_id IN 
    (
      SELECT DISTINCT
        "users"."id" 
      FROM
        "users" 
        LEFT JOIN
          user_emails 
          ON user_emails.user_id = users.id 
      WHERE
        (
          users.email = 'user@example.com' 
          OR user_emails.email = 'user@example.com'
        )
    )
    OR ownerships.creator_id IN 
    (
      SELECT DISTINCT
        "users"."id" 
      FROM
        "users" 
        LEFT JOIN
          user_emails 
          ON user_emails.user_id = users.id 
      WHERE
        (
          users.email = 'user@example.com' 
          OR user_emails.email = 'user@example.com'
        )
    )
  )
ORDER BY
  listing_order desc LIMIT 1 

```
</details>

If the bike is not found, proceed as we currently do, creating the bike record. 

If it is found, update instead of creating:

```rb
# app/controllers/api/v2/bikes.rb L164-190 (795dbb2d)

  # bike was found, update instead of creating
  if found_bike.present?
    # prepare params
    declared_p = { "declared_params" => declared(params, include_missing: false) }
    b_param = BParam.new(creator_id: creation_user_id, params: declared_p["declared_params"].as_json, origin: "api_v2")
    b_param.clean_params
    ensure_required_stolen_attrs(b_param.params)

    @bike = found_bike
    authorize_bike_for_user

    if b_param.params.dig("bike", "external_image_urls").present?
      @bike.load_external_images(b_param.params["bike"]["external_image_urls"])
    end

    begin
      BikeUpdator
        .new(user: current_user, bike: @bike, b_params: b_param.params)
        .update_available_attributes
    rescue => e
      error!("Unable to update bike: #{e}", 401)
    end

    status :found
    return @bike.reload
  end
end
```

Tests: [spec/requests/api/v3/bikes_request_spec.rb](https://github.com/bikeindex/bike_index/pull/715/files#diff-bcd0e37d08fb96ca09bc0c02dbc423f2)


Fixes #517 
Related: https://github.com/bikeindex/bike_index/pull/542

