### PR TITLE
Switch to passive_organization

### DIFF
--- a/app/controllers/admin/bikes_controller.rb
+++ b/app/controllers/admin/bikes_controller.rb
@@ -137,14 +137,14 @@ class Admin::BikesController < Admin::BaseController
 
   def matching_bikes
     return @matching_bikes if defined?(@matching_bikes)
-    if passive_organization.present?
-      bikes = passive_organization.bikes.includes(:creation_organization, :creation_states, :paint)
+    if current_organization.present?
+      bikes = current_organization.bikes.includes(:creation_organization, :creation_states, :paint)
     else
       bikes = Bike.unscoped.includes(:creation_organization, :creation_states, :paint)
     end
     bikes = bikes.admin_text_search(params[:search_email]) if params[:search_email]
-    bikes = bikes.ascend_pos if params[:ascend_pos].present?
-    bikes = bikes.lightspeed_pos if params[:lightspeed_pos].present?
+    bikes = bikes.ascend_pos if params[:search_ascend].present?
+    bikes = bikes.lightspeed_pos if params[:search_lightspeed].present?
     @matching_bikes = bikes
   end
 end

--- a/app/controllers/admin/bikes_controller.rb
+++ b/app/controllers/admin/bikes_controller.rb
@@ -137,8 +137,8 @@ class Admin::BikesController < Admin::BaseController
 
   def matching_bikes
     return @matching_bikes if defined?(@matching_bikes)
-    if current_organization.present?
-      bikes = current_organization.bikes.includes(:creation_organization, :creation_states, :paint)
+    if passive_organization.present?
+      bikes = passive_organization.bikes.includes(:creation_organization, :creation_states, :paint)
     else
       bikes = Bike.unscoped.includes(:creation_organization, :creation_states, :paint)
     end

--- a/app/controllers/admin/bulk_imports_controller.rb
+++ b/app/controllers/admin/bulk_imports_controller.rb
@@ -64,9 +64,9 @@ class Admin::BulkImportsController < Admin::BaseController
     elsif params[:not_ascend].present?
       bulk_imports = bulk_imports.not_ascend
     end
-        
+
     if params[:organization_id].present?
-      bulk_imports = bulk_imports.where(organization_id: active_organization.id)
+      bulk_imports = bulk_imports.where(organization_id: current_organization.id)
     end
     @matching_bulk_imports = bulk_imports
   end

--- a/app/controllers/admin/exports_controller.rb
+++ b/app/controllers/admin/exports_controller.rb
@@ -5,7 +5,7 @@ class Admin::ExportsController < Admin::BaseController
     page = params[:page] || 1
     per_page = params[:per_page] || 10
     if params[:organization_id].present?
-      exports = Export.where(organization_id: active_organization.id)
+      exports = Export.where(organization_id: current_organization.id)
     else
       exports = Export.all
     end

--- a/app/controllers/admin/organization_invitations_controller.rb
+++ b/app/controllers/admin/organization_invitations_controller.rb
@@ -57,7 +57,7 @@ class Admin::OrganizationInvitationsController < Admin::BaseController
   protected
 
   def find_organization
-    @organization = active_organization
+    @organization = current_organization
   end
 
   def permitted_parameters

--- a/app/controllers/bike_codes_controller.rb
+++ b/app/controllers/bike_codes_controller.rb
@@ -31,7 +31,7 @@ class BikeCodesController < ApplicationController
       redirect_to :back
       return
     end
-    bike_code = BikeCode.lookup_with_fallback(bike_code_code, organization_id: current_organization&.id, user: current_user)
+    bike_code = BikeCode.lookup_with_fallback(bike_code_code, organization_id: passive_organization&.id, user: current_user)
     # use the loosest lookup, but only permit it if the user can claim that
     @bike_code = bike_code if bike_code.present? && bike_code.claimable_by?(current_user)
     return @bike_code if @bike_code.present?

--- a/app/controllers/bikes_controller.rb
+++ b/app/controllers/bikes_controller.rb
@@ -68,8 +68,8 @@ class BikesController < ApplicationController
       @page = params[:page] || 1
       @per_page = params[:per_page] || 25
       if current_user.member_of?(@bike_code.organization)
-        set_current_organization(@bike_code.organization)
-        redirect_to organization_bikes_path(organization_id: current_organization.to_param, bike_code: @bike_code.code) and return
+        set_passive_organization(@bike_code.organization)
+        redirect_to organization_bikes_path(organization_id: passive_organization.to_param, bike_code: @bike_code.code) and return
       else
         @bikes = current_user.bikes.reorder(created_at: :desc).limit(100)
       end
@@ -92,8 +92,8 @@ class BikesController < ApplicationController
     # Let them know if they sent an invalid b_param token - use flash#info rather than error because we're aggressive about removing b_params
     flash[:info] = "Oops! We couldn't find that registration, please re-enter the information here" if @b_param.id.blank? && params[:b_param_token].present?
     @bike ||= @b_param.bike_from_attrs(is_stolen: params[:stolen], recovered: params[:recovered])
-    # Fallback to active (i.e. passed organization_id), then current_organization
-    @bike.creation_organization ||= active_organization || current_organization
+    # Fallback to active (i.e. passed organization_id), then passive_organization
+    @bike.creation_organization ||= current_organization || passive_organization
     @organization = @bike.creation_organization
     if @bike.stolen
       @stolen_record = @bike.stolen_records.build(@b_param.params["stolen_record"])

--- a/app/controllers/concerns/controller_helpers.rb
+++ b/app/controllers/concerns/controller_helpers.rb
@@ -6,7 +6,7 @@ module ControllerHelpers
 
   included do
     helper_method :current_user, :current_user_or_unconfirmed_user, :sign_in_partner, :user_root_url,
-                  :active_organization, :current_organization,
+                  :current_organization, :passive_organization, :set_passive_organization,
                   :controller_namespace, :page_id, :recovered_bike_count
     before_filter :enable_rack_profiler
   end
@@ -100,34 +100,34 @@ module ControllerHelpers
     redirect_to user_root_url and return
   end
 
-  def set_current_organization(organization)
-    session[:current_organization_id] = organization&.id || "0"
-    @active_organization = organization
+  def set_passive_organization(organization)
+    session[:passive_organization_id] = organization&.id || "0"
     @current_organization = organization
+    @passive_organization = organization
   end
 
   protected
 
-  # current_organization is the organization set for the user - which is persisted in session
-  # The user may or may not be interacting with the active_organization in any given request
-  def current_organization
-    return @current_organization if defined?(@current_organization)
-    if session[:current_organization_id].present?
-      return @current_organization = nil if session[:current_organization_id].to_i == 0
-      @current_organization = Organization.friendly_find(session[:current_organization_id])
+  # passive_organization is the organization set for the user - which is persisted in session
+  # The user may or may not be interacting with the current_organization in any given request
+  def passive_organization
+    return @passive_organization if defined?(@passive_organization)
+    if session[:passive_organization_id].present?
+      return @passive_organization = nil if session[:passive_organization_id].to_i == 0
+      @passive_organization = Organization.friendly_find(session[:passive_organization_id])
     end
-    @current_organization ||= set_current_organization(current_user&.default_organization)
+    @passive_organization ||= set_passive_organization(current_user&.default_organization)
   end
 
-  # active_organization is the organization currently being used.
+  # current_organization is the organization currently being used.
   # If set, the user *is* interacting with the organization in said request
-  def active_organization
+  def current_organization
     # We call this multiple times - make sure nil stays nil
-    return @active_organization if defined?(@active_organization)
-    @active_organization = Organization.friendly_find(params[:organization_id])
-    # Only set current_organization if user is authorized for said organization
-    return @active_organization unless @active_organization.present? && current_user&.authorized?(@active_organization)
-    set_current_organization(@active_organization)
+    return @current_organization if defined?(@current_organization)
+    @current_organization = Organization.friendly_find(params[:organization_id])
+    # Only set passive_organization if user is authorized for said organization
+    return @current_organization unless @current_organization.present? && current_user&.authorized?(@current_organization)
+    set_passive_organization(@current_organization)
   end
 
   def current_user
@@ -166,13 +166,13 @@ module ControllerHelpers
   end
 
   def require_member!
-    return true if current_user.member_of?(active_organization)
+    return true if current_user.member_of?(current_organization)
     flash[:error] = "You're not a member of that organization!"
     redirect_to user_home_url(subdomain: false) and return
   end
 
   def require_admin!
-    return true if current_user.admin_of?(active_organization)
+    return true if current_user.admin_of?(current_organization)
     flash[:error] = "You have to be an organization administrator to do that!"
     redirect_to user_home_url and return
   end

--- a/app/controllers/concerns/controller_helpers.rb
+++ b/app/controllers/concerns/controller_helpers.rb
@@ -6,7 +6,7 @@ module ControllerHelpers
 
   included do
     helper_method :current_user, :current_user_or_unconfirmed_user, :sign_in_partner, :user_root_url,
-                  :active_organization, :current_organization, :set_current_organization,
+                  :active_organization, :current_organization,
                   :controller_namespace, :page_id, :recovered_bike_count
     before_filter :enable_rack_profiler
   end

--- a/app/controllers/concerns/sessionable.rb
+++ b/app/controllers/concerns/sessionable.rb
@@ -17,7 +17,7 @@ module Sessionable
   def sign_in_and_redirect(user)
     session[:last_seen] = Time.now
     session[:render_donation_request] = user.render_donation_request if user&.render_donation_request
-    set_current_organization(user.default_organization) # Set that organization!
+    set_passive_organization(user.default_organization) # Set that organization!
     if ActiveRecord::Type::Boolean.new.type_cast_from_database(params.dig(:session, :remember_me))
       cookies.permanent.signed[:auth] = cookie_options(user)
     else

--- a/app/controllers/landing_pages_controller.rb
+++ b/app/controllers/landing_pages_controller.rb
@@ -4,7 +4,7 @@ class LandingPagesController < ApplicationController
   before_filter :instantiate_feedback, except: [:show]
 
   def show
-    raise ActionController::RoutingError, "Not found" unless active_organization.present?
+    raise ActionController::RoutingError, "Not found" unless current_organization.present?
   end
 
   def for_shops; end

--- a/app/controllers/organized/base_controller.rb
+++ b/app/controllers/organized/base_controller.rb
@@ -1,24 +1,24 @@
 module Organized
   class BaseController < ApplicationController
-    before_filter :ensure_active_organization!
+    before_filter :ensure_current_organization!
     before_filter :ensure_member!
     layout "application_revised"
 
     def ensure_member!
-      return true if current_user && current_user.member_of?(active_organization)
-      set_current_organization(nil) # remove the active organization, because it failed so don't show it anymore
+      return true if current_user && current_user.member_of?(current_organization)
+      set_passive_organization(nil) # remove the active organization, because it failed so don't show it anymore
       flash[:error] = "You're not a member of that organization!"
       redirect_to user_home_url(subdomain: false) and return
     end
 
     def ensure_admin!
-      return true if current_user && current_user.admin_of?(active_organization)
+      return true if current_user && current_user.admin_of?(current_organization)
       flash[:error] = "You have to be an organization administrator to do that!"
-      redirect_to organization_bikes_path(organization_id: active_organization.to_param) and return
+      redirect_to organization_bikes_path(organization_id: current_organization.to_param) and return
     end
 
-    def ensure_active_organization!
-      return true if active_organization.present?
+    def ensure_current_organization!
+      return true if current_organization.present?
       fail ActiveRecord::RecordNotFound
     end
   end

--- a/app/controllers/organized/bikes_controller.rb
+++ b/app/controllers/organized/bikes_controller.rb
@@ -3,8 +3,8 @@ module Organized
     def index
       @page = params[:page] || 1
       @per_page = params[:per_page] || 25
-      @bike_code = BikeCode.lookup_with_fallback(params[:bike_code], organization_id: active_organization.id) if params[:bike_code].present?
-      if active_organization.paid_for?("bike_search")
+      @bike_code = BikeCode.lookup_with_fallback(params[:bike_code], organization_id: current_organization.id) if params[:bike_code].present?
+      if current_organization.paid_for?("bike_search")
         search_organization_bikes
       else
         @bikes = organization_bikes.order("bikes.created_at desc").page(@page).per(@per_page)
@@ -12,17 +12,17 @@ module Organized
     end
 
     def recoveries
-      redirect_to current_index_path and return unless active_organization.paid_for?("show_recoveries")
+      redirect_to current_index_path and return unless current_organization.paid_for?("show_recoveries")
       @page = params[:page] || 1
       @per_page = params[:per_page] || 25
-      @recoveries = active_organization.recovered_records.order(date_recovered: :desc).page(@page).per(@per_page)
+      @recoveries = current_organization.recovered_records.order(date_recovered: :desc).page(@page).per(@per_page)
     end
 
     def incompletes
-      redirect_to current_index_path and return unless active_organization.paid_for?("show_partial_registrations")
+      redirect_to current_index_path and return unless current_organization.paid_for?("show_partial_registrations")
       @page = params[:page] || 1
       @per_page = params[:per_page] || 25
-      b_params = active_organization.incomplete_b_params
+      b_params = current_organization.incomplete_b_params
       b_params = b_params.email_search(params[:query]) if params[:query].present?
       @b_params = b_params.order(created_at: :desc).page(@page).per(@per_page)
     end
@@ -34,17 +34,17 @@ module Organized
     private
 
     def organization_bikes
-      active_organization.bikes.reorder("bikes.created_at desc")
+      current_organization.bikes.reorder("bikes.created_at desc")
     end
 
     def current_index_path
-      organization_bikes_path(organization_id: active_organization.to_param)
+      organization_bikes_path(organization_id: current_organization.to_param)
     end
 
     def search_organization_bikes
       @search_query_present = permitted_org_bike_search_params.except(:stolenness).values.reject(&:blank?).any?
       @interpreted_params = Bike.searchable_interpreted_params(permitted_org_bike_search_params, ip: forwarded_ip_address)
-      org = active_organization || current_organization
+      org = current_organization || passive_organization
       if org.present?
         bikes = org.bikes.reorder("bikes.created_at desc").search(@interpreted_params)
         bikes = bikes.organized_email_search(params[:email]) if params[:email].present?

--- a/app/controllers/organized/bulk_imports_controller.rb
+++ b/app/controllers/organized/bulk_imports_controller.rb
@@ -1,7 +1,7 @@
 module Organized
   class BulkImportsController < Organized::BaseController
     skip_before_filter :ensure_member!
-    skip_before_filter :ensure_active_organization!, only: [:create]
+    skip_before_filter :ensure_current_organization!, only: [:create]
     skip_before_filter :verify_authenticity_token, only: [:create]
     before_action :ensure_access_to_bulk_import!, except: [:create] # Because this checks ensure_admin
 
@@ -18,7 +18,7 @@ module Organized
       @bulk_import = bulk_imports.where(id: params[:id]).first
       unless @bulk_import.present?
         flash[:error] = "Unable to find that import"
-        redirect_to organization_bulk_imports_path(organization_id: active_organization.to_param) and return
+        redirect_to organization_bulk_imports_path(organization_id: current_organization.to_param) and return
       end
       page = params[:page] || 1
       per_page = params[:per_page] || 25
@@ -38,7 +38,7 @@ module Organized
           render json: { success: "File imported" }, status: 201
         else
           flash[:success] = "Bulk Import created!"
-          redirect_to organization_bulk_imports_path(organization_id: active_organization.to_param)
+          redirect_to organization_bulk_imports_path(organization_id: current_organization.to_param)
         end
       else
         if @is_api
@@ -53,7 +53,7 @@ module Organized
     private
 
     def bulk_imports
-      BulkImport.where(organization_id: active_organization.id)
+      BulkImport.where(organization_id: current_organization.id)
     end
 
     def ensure_can_create_import!
@@ -67,20 +67,20 @@ module Organized
         @ascend_import = true
         return true if request.headers["Authorization"] == BulkImport.ascend_api_token
       else
-        ensure_active_organization!
-        @current_user = active_organization.auto_user # Crazy override to make current user work
-        return true if request.headers["Authorization"] == active_organization.access_token
+        ensure_current_organization!
+        @current_user = current_organization.auto_user # Crazy override to make current user work
+        return true if request.headers["Authorization"] == current_organization.access_token
       end
       render json: { error: "Not permitted" }, status: 401 and return
     end
 
     def ensure_access_to_bulk_import!
-      return unless ensure_active_organization!
+      return unless ensure_current_organization!
       return false unless ensure_admin! # Need to return so we don't double render
       return true if current_user.superuser? # ensure_admin! passes with superuser - this allow superuser to see even if org not enabled
-      return true if active_organization.show_bulk_import?
+      return true if current_organization.show_bulk_import?
       flash[:error] = "Your organization doesn't have access to that, please contact Bike Index support"
-      redirect_to organization_bikes_path(organization_id: active_organization.to_param) and return
+      redirect_to organization_bikes_path(organization_id: current_organization.to_param) and return
     end
 
     def permitted_parameters
@@ -95,7 +95,7 @@ module Organized
       if @ascend_import
         { is_ascend: true }
       else
-        { user_id: (@current_user || current_user).id, organization_id: active_organization&.id }
+        { user_id: (@current_user || current_user).id, organization_id: current_organization&.id }
       end
     end
   end

--- a/app/controllers/organized/exports_controller.rb
+++ b/app/controllers/organized/exports_controller.rb
@@ -24,14 +24,14 @@ module Organized
       else
         @export = Export.new(permitted_parameters)
       end
-      if flash[:error].blank? && @export.update_attributes(kind: "organization", organization_id: active_organization.id, user_id: current_user.id)
+      if flash[:error].blank? && @export.update_attributes(kind: "organization", organization_id: current_organization.id, user_id: current_user.id)
         OrganizationExportWorker.perform_async(@export.id)
         if @export.avery_export? # Send to the show page, with avery export parameter set so we can redirect when the processing is finished
           flash[:success] = "Export Created. Once it's finished processing you will be automatically directed to download the Avery labels"
-          redirect_to organization_export_path(organization_id: active_organization.to_param, id: @export.id, avery_redirect: true)
+          redirect_to organization_export_path(organization_id: current_organization.to_param, id: @export.id, avery_redirect: true)
         else
           flash[:success] = "Export Created. Please wait for it to finish processing to be able to download it"
-          redirect_to organization_exports_path(organization_id: active_organization.to_param)
+          redirect_to organization_exports_path(organization_id: current_organization.to_param)
         end
       else
         @export ||= Export.new
@@ -46,22 +46,22 @@ module Organized
       else
         flash[:error] = "Unknown update action!"
       end
-      redirect_to organization_export_path(organization_id: active_organization.to_param, id: @export.id)
+      redirect_to organization_export_path(organization_id: current_organization.to_param, id: @export.id)
     end
 
     def destroy
       @export.remove_bike_codes
       @export.destroy
       flash[:success] = "export was successfully deleted!"
-      redirect_to organization_exports_path(organization_id: active_organization.to_param)
+      redirect_to organization_exports_path(organization_id: current_organization.to_param)
     end
 
     private
 
     def create_avery_export
-      if active_organization.paid_for?("avery_export")
+      if current_organization.paid_for?("avery_export")
         @export = Export.new(avery_export_parameters)
-        bike_code = active_organization.bike_codes.lookup(@export.bike_code_start) if @export.bike_code_start.present?
+        bike_code = current_organization.bike_codes.lookup(@export.bike_code_start) if @export.bike_code_start.present?
         if bike_code.present? && bike_code.claimed?
           flash[:error] = "That sticker has already been assigned! Please choose a new initial Sticker"
         end
@@ -84,13 +84,13 @@ module Organized
     end
 
     def exports
-      Export.where(organization_id: active_organization.id, kind: "organization")
+      Export.where(organization_id: current_organization.id, kind: "organization")
     end
 
     def ensure_access_to_exports!
-      return true if active_organization.paid_for?("csv_exports") || current_user.superuser?
+      return true if current_organization.paid_for?("csv_exports") || current_user.superuser?
       flash[:error] = "Your organization doesn't have access to that, please contact Bike Index support"
-      redirect_to organization_bikes_path(organization_id: active_organization.to_param) and return
+      redirect_to organization_bikes_path(organization_id: current_organization.to_param) and return
     end
   end
 end

--- a/app/controllers/organized/manage_controller.rb
+++ b/app/controllers/organized/manage_controller.rb
@@ -11,24 +11,24 @@ module Organized
 
     def update
       if @organization.update_attributes(permitted_parameters)
-        flash[:success] = "#{active_organization.name} updated successfully"
-        redirect_path = params[:locations_page] ? locations_organization_manage_index_path(organization_id: active_organization.to_param) : current_index_path
+        flash[:success] = "#{current_organization.name} updated successfully"
+        redirect_path = params[:locations_page] ? locations_organization_manage_index_path(organization_id: current_organization.to_param) : current_index_path
         redirect_to redirect_path
       else
         @page_errors = @organization.errors
-        flash[:error] = "We're sorry, we had trouble updating #{active_organization.name}"
+        flash[:error] = "We're sorry, we had trouble updating #{current_organization.name}"
         render :index
       end
     end
 
     def destroy
-      organization_name = active_organization.name
-      if active_organization.is_paid
+      organization_name = current_organization.name
+      if current_organization.is_paid
         flash[:info] = "Please contact support@bikeindex.org to delete #{organization_name}"
         redirect_to current_index_path and return
       end
       notify_admins("organization_destroyed")
-      active_organization.destroy
+      current_organization.destroy
       flash[:info] = "Deleted #{organization_name}"
       redirect_to user_root_url
     end
@@ -40,11 +40,11 @@ module Organized
     private
 
     def assign_organization
-      @organization = active_organization
+      @organization = current_organization
     end
 
     def current_index_path
-      organization_manage_index_path(organization_id: active_organization.to_param)
+      organization_manage_index_path(organization_id: current_organization.to_param)
     end
 
     def permitted_parameters
@@ -54,11 +54,11 @@ module Organized
     end
 
     def show_on_map_if_permitted
-      active_organization.lock_show_on_map ? [] : [:show_on_map]
+      current_organization.lock_show_on_map ? [] : [:show_on_map]
     end
 
     def paid_attributes
-      active_organization.is_paid ? [:avatar] : []
+      current_organization.is_paid ? [:avatar] : []
     end
 
     def permitted_locations_params
@@ -66,7 +66,7 @@ module Organized
     end
 
     def notify_admins(type)
-      AdminNotifier.new.for_organization(organization: active_organization, user: current_user, type: type)
+      AdminNotifier.new.for_organization(organization: current_organization, user: current_user, type: type)
     end
   end
 end

--- a/app/controllers/organized/messages_controller.rb
+++ b/app/controllers/organized/messages_controller.rb
@@ -34,30 +34,30 @@ module Organized
     private
 
     def organization_messages
-      active_organization.organization_messages
+      current_organization.organization_messages
     end
 
     def ensure_permitted_message_kind!
       @kind = params[:organization_message].present? ? params[:organization_message][:kind_slug] : params[:kind]
-      @kind ||= active_organization.message_kinds
-      return true if active_organization.paid_for?(@kind)
+      @kind ||= current_organization.message_kinds
+      return true if current_organization.paid_for?(@kind)
       flash[:error] = "Your organization doesn't have access to that, please contact Bike Index support"
-      if active_organization.message_kinds.any?
-        redirect_to organization_messages_path(organization_id: active_organization.to_param, kind: active_organization.message_kinds.first)
+      if current_organization.message_kinds.any?
+        redirect_to organization_messages_path(organization_id: current_organization.to_param, kind: current_organization.message_kinds.first)
       else
-        redirect_to organization_bikes_path(organization_id: active_organization.to_param)
+        redirect_to organization_bikes_path(organization_id: current_organization.to_param)
       end
       return
     end
 
     def permitted_parameters
       params.require(:organization_message).permit(:kind_slug, :body, :bike_id, :latitude, :longitude, :accuracy)
-            .merge(sender_id: current_user.id, organization_id: active_organization.id)
+            .merge(sender_id: current_user.id, organization_id: current_organization.id)
     end
 
     def redirect_back
-      redirect_kind = @kind || active_organization.message_kinds.first
-      redirect_to organization_messages_path(organization_id: active_organization.to_param, kind: redirect_kind)
+      redirect_kind = @kind || current_organization.message_kinds.first
+      redirect_to organization_messages_path(organization_id: current_organization.to_param, kind: redirect_kind)
       return
     end
   end

--- a/app/controllers/organized/stickers_controller.rb
+++ b/app/controllers/organized/stickers_controller.rb
@@ -39,16 +39,16 @@ module Organized
     end
 
     def find_bike_code
-      bike_code = BikeCode.lookup_with_fallback(bike_code_code, organization_id: active_organization.id, user: current_user)
+      bike_code = BikeCode.lookup_with_fallback(bike_code_code, organization_id: current_organization.id, user: current_user)
       # use the loosest lookup, but only permit it if the user can claim that
       @bike_code = bike_code if bike_code.present? && bike_code.claimable_by?(current_user)
       return @bike_code if @bike_code.present?
       flash[:error] = "Unable to find sticker with code: #{bike_code_code}"
-      redirect_to organization_stickers_path(organization_id: active_organization.to_param) and return
+      redirect_to organization_stickers_path(organization_id: current_organization.to_param) and return
     end
 
     def searched
-      searched_codes = BikeCode.where(organization_id: active_organization.id)
+      searched_codes = BikeCode.where(organization_id: current_organization.id)
       if params[:bike_query].present?
         searched_codes = searched_codes.claimed.where(bike_id: Bike.friendly_find(params[:bike_query])&.id)
       elsif params[:claimedness] && params[:claimedness] != "all"
@@ -58,13 +58,13 @@ module Organized
     end
 
     def ensure_access_to_bike_codes!
-      return true if active_organization.paid_for?("bike_codes") || current_user.superuser?
+      return true if current_organization.paid_for?("bike_codes") || current_user.superuser?
       flash[:error] = "Your organization doesn't have access to that, please contact Bike Index support"
-      redirect_to organization_bikes_path(organization_id: active_organization.to_param) and return
+      redirect_to organization_bikes_path(organization_id: current_organization.to_param) and return
     end
 
     def redirect_back
-      redirect_back_path = @bike_code.present? ? edit_organization_sticker_path(organization_id: active_organization.to_param, id: @bike_code.code) : organization_stickers_path(organization_id: params[:organization_id])
+      redirect_back_path = @bike_code.present? ? edit_organization_sticker_path(organization_id: current_organization.to_param, id: @bike_code.code) : organization_stickers_path(organization_id: params[:organization_id])
       redirect_to redirect_back_path
       return
     end

--- a/app/controllers/organized/users_controller.rb
+++ b/app/controllers/organized/users_controller.rb
@@ -4,15 +4,15 @@ module Organized
     before_filter :reject_self_updates, only: [:update, :destroy]
 
     def index
-      @organization_invitations = active_organization.organization_invitations.unclaimed
-      @memberships = active_organization.memberships.order("created_at desc")
+      @organization_invitations = current_organization.organization_invitations.unclaimed
+      @memberships = current_organization.memberships.order("created_at desc")
     end
 
     def edit
       if @is_invitation
-        @organization_invitation = active_organization.organization_invitations.unclaimed.find(params[:id])
+        @organization_invitation = current_organization.organization_invitations.unclaimed.find(params[:id])
       else
-        @membership = active_organization.memberships.find(params[:id])
+        @membership = current_organization.memberships.find(params[:id])
       end
       @name = @organization_invitation && @organization_invitation.invitee_name || @membership && @membership.user.name
     end
@@ -35,24 +35,24 @@ module Organized
         @membership.destroy
       end
       flash[:success] = "Deleted user from your organization"
-      new_invites_count = active_organization.available_invitation_count + 1
-      active_organization.update_attribute :available_invitation_count, new_invites_count
+      new_invites_count = current_organization.available_invitation_count + 1
+      current_organization.update_attribute :available_invitation_count, new_invites_count
       redirect_to current_index_path
     end
 
     def new
-      @organization_invitation = OrganizationInvitation.new(organization_id: active_organization.id)
+      @organization_invitation = OrganizationInvitation.new(organization_id: current_organization.id)
       @page_errors = @organization_invitation.errors
     end
 
     def create
-      unless active_organization.available_invitation_count > 0
-        flash[:error] = "#{active_organization.name} is out of user invitations. Contact support@bikeindex.org"
+      unless current_organization.available_invitation_count > 0
+        flash[:error] = "#{current_organization.name} is out of user invitations. Contact support@bikeindex.org"
         redirect_to current_index_path and return
       end
       @organization_invitation = OrganizationInvitation.new(create_organization_invitation_params)
       if @organization_invitation.save
-        flash[:success] = "#{@organization_invitation.invitee_email} was invited to #{active_organization.name}!"
+        flash[:success] = "#{@organization_invitation.invitee_email} was invited to #{current_organization.name}!"
         redirect_to current_index_path
       else
         flash[:error] = "Whoops! Looks like we're missing some information"
@@ -63,22 +63,22 @@ module Organized
     private
 
     def current_index_path
-      organization_users_path(organization_id: active_organization.to_param)
+      organization_users_path(organization_id: current_organization.to_param)
     end
 
     def find_invitation_or_membership
       @is_invitation = params[:is_invitation]
       if @is_invitation
-        @organization_invitation = active_organization.organization_invitations.unclaimed.find(params[:id])
+        @organization_invitation = current_organization.organization_invitations.unclaimed.find(params[:id])
       else
-        @membership = active_organization.memberships.find(params[:id])
+        @membership = current_organization.memberships.find(params[:id])
       end
     end
 
     def reject_self_updates
       if @membership && @membership.user == current_user
         flash[:error] = "Sorry, you can't remove yourself from the organization. Contact us at support@bikeindex.org if this is problematic."
-        redirect_to organization_users_path(organization_id: active_organization) and return
+        redirect_to organization_users_path(organization_id: current_organization) and return
       end
     end
 
@@ -86,7 +86,7 @@ module Organized
       {
         invitee_email: params[:organization_invitation][:invitee_email],
         invitee_name: params[:organization_invitation][:invitee_name],
-        organization: active_organization,
+        organization: current_organization,
         inviter: current_user,
         membership_role: params[:organization_invitation][:membership_role],
       }

--- a/app/controllers/public_images_controller.rb
+++ b/app/controllers/public_images_controller.rb
@@ -22,7 +22,7 @@ class PublicImagesController < ApplicationController
       elsif params[:mail_snippet_id]
         @public_image.imageable = MailSnippet.find(params[:mail_snippet_id])
       else
-        @public_image.imageable = active_organization
+        @public_image.imageable = current_organization
       end
       @public_image.save
       render "create" and return

--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -9,7 +9,7 @@ class RegistrationsController < ApplicationController
   end
 
   def embed # Attributes assigned in the partial, but can be overridden so it can be used anywhere
-    @organization = active_organization
+    @organization = current_organization
     @owner_email = current_user && current_user.email
     @selectable_child_organizations = find_selectable_child_organizations
     @stolen = params[:stolen] ? 1 : 0

--- a/app/helpers/header_tag_helper.rb
+++ b/app/helpers/header_tag_helper.rb
@@ -114,8 +114,8 @@ module HeaderTagHelper
   end
 
   def landing_pages_header_tags
-    if active_organization
-      args = { default: "", organization: active_organization.short_name }
+    if current_organization
+      args = { default: "", organization: current_organization.short_name }
       self.page_title = translation_title(translation_args: args)
       self.page_description = translation_description(translation_args: args)
     end
@@ -165,7 +165,7 @@ module HeaderTagHelper
 
   def default_translation_args
     return { default: "" } unless controller_namespace == "organized"
-    { default: "", organization: active_organization.short_name }
+    { default: "", organization: current_organization.short_name }
   end
 
   def translation_title(location: nil, translation_args: default_translation_args)
@@ -193,7 +193,7 @@ module HeaderTagHelper
     if controller_namespace == "admin"
       "Admin |"
     elsif controller_namespace == "organized"
-      active_organization.short_name
+      current_organization.short_name
     end
   end
 

--- a/app/views/admin/bikes/index.html.haml
+++ b/app/views/admin/bikes/index.html.haml
@@ -5,37 +5,35 @@
   .col-md-6
     %ul
       %li.nav-item
-        - all_active = !@unknown && params[:email].blank? && (params.keys & %w[ascend lightspeed organization_id]).blank?
-        = link_to "All", admin_bikes_path(sortable_search_params), class: "nav-link #{all_active ? 'active' : ''}"
+        - all_active = !@unknown && sortable_search_params.keys.blank?
+        = link_to "All", admin_bikes_path, class: "nav-link #{all_active ? 'active' : ''}"
       %li.nav-item
-        = link_to "unknown manufacturers", missing_manufacturer_admin_bikes_path, class: "nav-link #{@unknown ? 'active' : ''}"
+        = link_to "Unknown Manufacturers", missing_manufacturer_admin_bikes_path, class: "nav-link #{@unknown ? 'active' : ''}"
       %li.nav-item
-        = link_to "Ascend", admin_bikes_path(sortable_search_params.merge(ascend_pos: true)), class: "nav-link #{params[:ascend_pos].present? ? 'active' : ''}"
+        = link_to "Ascend", admin_bikes_path(sortable_search_params.merge(search_lightspeed: nil, search_ascend: true)), class: "nav-link #{params[:search_ascend].present? ? 'active' : ''}"
       %li.nav-item
-        = link_to "Lightspeed", admin_bikes_path(sortable_search_params.merge(lightspeed_pos: true)), class: "nav-link #{params[:lightspeed_pos].present? ? 'active' : ''}"
+        = link_to "Lightspeed", admin_bikes_path(sortable_search_params.merge(search_ascend: nil, search_lightspeed: true)), class: "nav-link #{params[:search_lightspeed].present? ? 'active' : ''}"
   - if current_organization.present?
     %p.subtitle
       #{link_to current_organization.name, admin_organization_path(current_organization.to_param)} bikes
-      %small
+      %em.small
         = link_to "orgs view", organization_bikes_path(organization_id: current_organization.to_param), class: "less-strong"
-.row
-  .col-auto
-    %p
-      There are currently #{number_with_delimiter(PublicImage.count)} bike images
-      %em
-        (#{PublicImage.where("created_at >= ?", Time.zone.now.beginning_of_day).count} today)
 
-.row.mb-2
-  .col-md-6
-    %p
-      = number_with_delimiter(Bike.count)
-      indexed,
-      %em
-        (#{Bike.where("created_at >= ?", Time.zone.now.beginning_of_day).count} today)
-      = number_with_delimiter(Ownership.where(current: true).where(claimed: true).count)
-      are claimed
+- if all_active
+  %p
+    There are currently #{number_with_delimiter(PublicImage.count)} bike images
+    %em
+      (#{PublicImage.where("created_at >= ?", Time.zone.now.beginning_of_day).count} today)
 
-.row
+  %p
+    = number_with_delimiter(Bike.count)
+    publicly registered,
+    %em
+      (#{Bike.where("created_at >= ?", Time.zone.now.beginning_of_day).count} today)
+    = number_with_delimiter(Ownership.where(current: true).where(claimed: true).count)
+    are claimed
+
+.row.mt-4
   .col-md-5
     %h4
       = number_with_delimiter(@bikes.total_count)
@@ -46,7 +44,7 @@
       = hidden_field_tag :direction
       = hidden_field_tag :organization_id
       .form-group.ml-auto.mr-2.mb-2
-        = text_field_tag :email, params[:search_email], placeholder: "Search bikes by email", class: "form-control"
+        = text_field_tag :search_email, params[:search_email], placeholder: "Search bikes by email", class: "form-control"
       = submit_tag "Search", name: "search", class: "btn btn-primary mb-2"
 
 .row.mt-4

--- a/app/views/admin/bikes/index.html.haml
+++ b/app/views/admin/bikes/index.html.haml
@@ -13,11 +13,11 @@
         = link_to "Ascend", admin_bikes_path(sortable_search_params.merge(ascend_pos: true)), class: "nav-link #{params[:ascend_pos].present? ? 'active' : ''}"
       %li.nav-item
         = link_to "Lightspeed", admin_bikes_path(sortable_search_params.merge(lightspeed_pos: true)), class: "nav-link #{params[:lightspeed_pos].present? ? 'active' : ''}"
-  - if active_organization.present?
+  - if current_organization.present?
     %p.subtitle
-      #{link_to active_organization.name, admin_organization_path(active_organization.to_param)} bikes
+      #{link_to current_organization.name, admin_organization_path(current_organization.to_param)} bikes
       %small
-        = link_to "orgs view", organization_bikes_path(organization_id: active_organization.to_param), class: "less-strong"
+        = link_to "orgs view", organization_bikes_path(organization_id: current_organization.to_param), class: "less-strong"
 .row
   .col-auto
     %p

--- a/app/views/admin/bulk_imports/index.html.haml
+++ b/app/views/admin/bulk_imports/index.html.haml
@@ -15,11 +15,11 @@
         = link_to "Not Ascend", admin_bulk_imports_path(sortable_search_params.merge(not_ascend: true)), class: "nav-link #{params[:not_ascend].present? ? 'active' : ''}"
       %li.nav-item
         = link_to "New bulk import", new_admin_bulk_import_url, class: "nav-link"
-  - if active_organization.present?
+  - if current_organization.present?
     %p.subtitle
-      #{link_to active_organization.name, admin_organization_path(active_organization)} bulk imports
+      #{link_to current_organization.name, admin_organization_path(current_organization)} bulk imports
       %small
-        = link_to "orgs view", organization_bulk_imports_path(organization_id: active_organization.to_param), class: "less-strong"
+        = link_to "orgs view", organization_bulk_imports_path(organization_id: current_organization.to_param), class: "less-strong"
 
 = line_chart matching_bulk_imports.group_by_day(:created_at, range: 1.month.ago.midnight..Time.now).count
 

--- a/app/views/admin/exports/index.html.haml
+++ b/app/views/admin/exports/index.html.haml
@@ -4,11 +4,11 @@
 %p
   #{pluralize(@exports.total_count, "Matching Export")}
 
-- if active_organization.present?
+- if current_organization.present?
   %h4.mt-4
-    #{link_to active_organization.name, admin_organization_path(active_organization)} Exports
+    #{link_to current_organization.name, admin_organization_path(current_organization)} Exports
     %small
-      = link_to "view orgs view", organization_exports_path(organization_id: active_organization.to_param), class: "less-strong"
+      = link_to "view orgs view", organization_exports_path(organization_id: current_organization.to_param), class: "less-strong"
 
 
 = paginate @exports, views_prefix: "admin"

--- a/app/views/admin/organization_invitations/index.html.haml
+++ b/app/views/admin/organization_invitations/index.html.haml
@@ -1,9 +1,9 @@
 %header.with-subtitle
   %h1 Manage Organization Invitations
-  = link_to 'Send an invitation', new_admin_organization_invitation_url(organization_id: active_organization.to_param), class: "button-green sharing-links"
+  = link_to 'Send an invitation', new_admin_organization_invitation_url(organization_id: current_organization.to_param), class: "button-green sharing-links"
 
 
-  
+
 %h3.invitations-sent
   #{ pluralize(OrganizationInvitation.unclaimed.count, "invitation") } haven't been claimed yet
 
@@ -29,7 +29,7 @@
       - @organization_invitations.each do |org_invite|
         %tr
           %td
-            = link_to org_invite.id, edit_admin_organization_invitation_url(org_invite.id, organization_id: active_organization.to_param)
+            = link_to org_invite.id, edit_admin_organization_invitation_url(org_invite.id, organization_id: current_organization.to_param)
           %td.large-screens
             %span.convert-time
               = l org_invite.created_at, format: :convert_time

--- a/app/views/admin/organization_invitations/show.html.haml
+++ b/app/views/admin/organization_invitations/show.html.haml
@@ -1,5 +1,5 @@
 %header.with-subtitle
-  %h1 
+  %h1
     Manage
     %strong
       #{@organization.name}'s
@@ -14,9 +14,9 @@
   %h3.organization-description-list
     #{@organization.name} has sent #{pluralize(@organization.sent_invitation_count, "invitation")},
     %br
-    and has 
+    and has
     = @organization.available_invitation_count
-    remaining #{"invitation".pluralize(active_organization.available_invitation_count)}.
+    remaining #{"invitation".pluralize(current_organization.available_invitation_count)}.
   %hr
 
 - if @organization.organization_invitations.any?

--- a/app/views/bikes/_organized_access_panel.html.haml
+++ b/app/views/bikes/_organized_access_panel.html.haml
@@ -7,37 +7,37 @@
         .col-xs-6
           %h3.header-font-alt
             %span.hidden-sm-down
-              = current_organization.short_name
+              = passive_organization.short_name
             Access Panel
         .col-xs-6
-          - if @bike.organized?(current_organization)
+          - if @bike.organized?(passive_organization)
             %p.text-success.text-right
               %span.hidden-md-down
-                This #{@bike.type} is registered with #{current_organization.short_name}
+                This #{@bike.type} is registered with #{passive_organization.short_name}
               %span.hidden-lg-up
-                reged with #{current_organization.short_name}
+                reged with #{passive_organization.short_name}
           - else
             %p.text-warning.text-right
               %span.hidden-md-down
-                This #{@bike.type} is <em>not</em> registered with #{current_organization.short_name}
+                This #{@bike.type} is <em>not</em> registered with #{passive_organization.short_name}
               %span.hidden-lg-up
-                <em>not</em> reged with #{current_organization.short_name}
+                <em>not</em> reged with #{passive_organization.short_name}
     .card-body
       .row
-        - display_unstolen_notification_form = !@bike.stolen? && current_organization.paid_for?("unstolen_notifications")
-        - if @bike.authorized_by_organization?(org: current_organization)
+        - display_unstolen_notification_form = !@bike.stolen? && passive_organization.paid_for?("unstolen_notifications")
+        - if @bike.authorized_by_organization?(org: passive_organization)
           .col-xs-12.mb-2
             .text-right.less-strong
               %em
                 %span.hidden-md-down
-                  #{current_organization.short_name} registered this #{@bike.type} and it is
+                  #{passive_organization.short_name} registered this #{@bike.type} and it is
               not claimed yet,
               %em
                 so you can
               = link_to "Edit it", edit_bike_path(@bike), class: "btn btn-success btn-sm"
         .mb-2{ class: display_unstolen_notification_form ? "col-md-7" : "col-sm-12" }
           %ul.attr-list{ class: display_unstolen_notification_form ? "" : "split-sm" }
-            - if current_organization.paid_for?("bike_codes") # Always display stickers if org has paid for them
+            - if passive_organization.paid_for?("bike_codes") # Always display stickers if org has paid for them
               %li
                 %span.attr-title
                   Sticker:
@@ -50,7 +50,7 @@
                   - show_sticker_modal = true
                   %a{ href: "#", style: "opacity: 0.8; text-align: right;", data: { toggle: "modal", target: "#assignStickerModal" } }
                     Link Sticker
-            - if @bike.organized?(current_organization) # Only display information about the bike if bike is registered through org
+            - if @bike.organized?(passive_organization) # Only display information about the bike if bike is registered through org
               = @bike.attr_list_item(@bike.user&.name, "Owner name", with_colon: true)
               = @bike.attr_list_item(@bike.owner_email, "Owner email", with_colon: true)
               %li
@@ -62,7 +62,7 @@
                 = @bike.creator&.display_name
                 %em.small.less-strong
                   = @bike.creation_description
-              - current_organization.additional_registration_fields.each do |reg_field|
+              - passive_organization.additional_registration_fields.each do |reg_field|
                 - bike_attr = Export.additional_registration_fields[reg_field.to_sym]
                 - if bike_attr == "registration_address"
                   %li
@@ -89,10 +89,10 @@
                     - elsif reg_field == "reg_affiliation"
                       = @bike.organization_affiliation
 
-          - if !@bike.organized?(current_organization) # Apologize, bike isn't organizations
+          - if !@bike.organized?(passive_organization) # Apologize, bike isn't organizations
             %p.less-strong.mt-4
               %em
-                Unable to display additional information because #{@bike.type} is not registered with #{current_organization.name}
+                Unable to display additional information because #{@bike.type} is not registered with #{passive_organization.name}
         - if display_unstolen_notification_form
           .col-md-5.unstolen-notification-box
             %p
@@ -117,11 +117,11 @@
                 .send-message
                   = f.submit "Send message", class: 'btn btn-primary btn-lg'
 
-  - if current_organization.message_kinds.any?
+  - if passive_organization.message_kinds.any?
     .geomessages-wrap
       %span
         Send
-      - current_organization.message_kinds.each do |kind|
+      - passive_organization.message_kinds.each do |kind|
         / %a.btn.btn-secondary.openMessageModal{ target: "#organizationMessageModal", "data-kind" => kind, "data-toggle" => "modal" }
         %a.btn.btn-secondary.openMessageModal{ "data-kind" => kind }
           - if kind == "geolocated_messages"
@@ -129,10 +129,10 @@
           - else
             #{kind.humanize}
 
-- if current_organization.message_kinds.any?
+- if passive_organization.message_kinds.any?
   - modal_body = capture_haml do
     .modal-body
-      = form_for OrganizationMessage.new(bike_id: @bike.id), url: organization_messages_path(organization_id: current_organization) do |f|
+      = form_for OrganizationMessage.new(bike_id: @bike.id), url: organization_messages_path(organization_id: passive_organization) do |f|
         = f.hidden_field :bike_id
         = f.hidden_field :kind_slug
         = f.hidden_field :latitude
@@ -151,7 +151,7 @@
 - if show_sticker_modal
   - sticker_modal_body = capture_haml do
     .modal-body
-      = form_for BikeCode.new, { url: organization_sticker_path(id: "code", organization_id: current_organization.to_param), action: "update", method: "PUT" } do |f|
+      = form_for BikeCode.new, { url: organization_sticker_path(id: "code", organization_id: passive_organization.to_param), action: "update", method: "PUT" } do |f|
         = f.hidden_field :bike_id, value: @bike.id
         .form-group
           = f.label :code, "Sticker Code", class: "org-form-label"

--- a/app/views/bikes/show.html.haml
+++ b/app/views/bikes/show.html.haml
@@ -7,11 +7,11 @@
       no one but the user (and Bike Index admins) can see it
 
 .container
-  - if current_user.present? && current_organization.present?
-    - if current_user.authorized?(current_organization) # Authorize here, because otherwise we're displaying user data
+  - if current_user.present? && passive_organization.present?
+    - if current_user.authorized?(passive_organization) # Authorize here, because otherwise we're displaying user data
       = render partial: "organized_access_panel"
-    - else # If they aren't authorized, nix their current_organization
-      - set_current_organization(current_user.default_organization) # maybe this breaks, but whatever, they're being creepers
+    - else # If they aren't authorized, nix their passive_organization
+      - set_passive_organization(current_user.default_organization) # maybe this breaks, but whatever, they're being creepers
   .row
     .col-md-8
       %h1

--- a/app/views/landing_pages/show.haml
+++ b/app/views/landing_pages/show.haml
@@ -1,3 +1,3 @@
 .organization-landing-page-wrap
-  - cache(["org_landing_#{active_organization.to_param}", active_organization.updated_at]) do
-    = active_organization.landing_html && active_organization.landing_html.html_safe
+  - cache(["org_landing_#{current_organization.to_param}", current_organization.updated_at]) do
+    = current_organization.landing_html && current_organization.landing_html.html_safe

--- a/app/views/layouts/application_revised.html.haml
+++ b/app/views/layouts/application_revised.html.haml
@@ -16,56 +16,56 @@
           the non-profit
           %br
           bike registry
-        - if current_organization.present? && current_user.present?
+        - if passive_organization.present? && current_user.present?
           %span.current-organization-nav-item
-            %a#current_organization_submenu{ "aria-haspopup" => "true", "aria-expanded" => "false", data: { toggle: "dropdown" } }
-              = current_organization.short_name
+            %a#passive_organization_submenu{ "aria-haspopup" => "true", "aria-expanded" => "false", data: { toggle: "dropdown" } }
+              = passive_organization.short_name
               <span class="caret-down">v</span>
-            %ul.current-organization-submenu{ "aria-labelledby" => "#current_organization_submenu" }
+            %ul.current-organization-submenu{ "aria-labelledby" => "#passive_organization_submenu" }
               %li
-                = active_link "#{current_organization.short_name} Bikes", organization_bikes_path(organization_id: current_organization.to_param), class: "nav-link"
+                = active_link "#{passive_organization.short_name} Bikes", organization_bikes_path(organization_id: passive_organization.to_param), class: "nav-link"
               %li
-                = active_link "Add a bike", new_organization_bike_path(current_organization), class: "nav-link"
-              - if current_organization.paid_for?("show_partial_registrations")
+                = active_link "Add a bike", new_organization_bike_path(passive_organization), class: "nav-link"
+              - if passive_organization.paid_for?("show_partial_registrations")
                 %li
-                  = active_link "Incomplete registrations", incompletes_organization_bikes_path(current_organization), class: "nav-link"
-              - if current_organization.paid_for?("show_recoveries") # I don't want to show a grayed link for this
+                  = active_link "Incomplete registrations", incompletes_organization_bikes_path(passive_organization), class: "nav-link"
+              - if passive_organization.paid_for?("show_recoveries") # I don't want to show a grayed link for this
                 %li
-                  = active_link "Recoveries", recoveries_organization_bikes_path(current_organization), class: "nav-link"
+                  = active_link "Recoveries", recoveries_organization_bikes_path(passive_organization), class: "nav-link"
 
-              - if current_organization.show_bulk_import?
+              - if passive_organization.show_bulk_import?
                 %li
-                  - bulk_link_name = current_organization.ascend_imports? ? "Ascend Imports" : "Bulk Imports"
-                  = active_link bulk_link_name, organization_bulk_imports_path(organization_id: current_organization.to_param), match_controller: true, class: "nav-link"
-              - if current_organization.paid_for?("bike_codes")
+                  - bulk_link_name = passive_organization.ascend_imports? ? "Ascend Imports" : "Bulk Imports"
+                  = active_link bulk_link_name, organization_bulk_imports_path(organization_id: passive_organization.to_param), match_controller: true, class: "nav-link"
+              - if passive_organization.paid_for?("bike_codes")
                 %li.divider-nav-item
                 %li
-                  = active_link "Registration stickers", organization_stickers_path(organization_id: current_organization.to_param), match_controller: true, class: "nav-link"
-              - if current_organization.paid_for?("csv_exports")
+                  = active_link "Registration stickers", organization_stickers_path(organization_id: passive_organization.to_param), match_controller: true, class: "nav-link"
+              - if passive_organization.paid_for?("csv_exports")
                 %li
-                  = active_link "Exports", organization_exports_path(organization_id: current_organization.to_param), match_controller: true, class: "nav-link"
-              - if current_organization.message_kinds.any?
+                  = active_link "Exports", organization_exports_path(organization_id: passive_organization.to_param), match_controller: true, class: "nav-link"
+              - if passive_organization.message_kinds.any?
                 %li.divider-nav-item
-                - current_organization.message_kinds.each_with_index do |message_kind, index|
+                - passive_organization.message_kinds.each_with_index do |message_kind, index|
                   %li
                     / (params[:kind] == message_kind ? "active" : "")
                     - if message_kind == "geolocated_messages"
                       - link_title = "GeoMessaging"
                     - else
                       - link_title = message_kind.gsub("_messages", "").titleize
-                    = active_link link_title, organization_messages_path(organization_id: current_organization.to_param, kind: message_kind), class: "nav-link"
-              - if current_user.admin_of?(current_organization) || current_user.superuser?
+                    = active_link link_title, organization_messages_path(organization_id: passive_organization.to_param, kind: message_kind), class: "nav-link"
+              - if current_user.admin_of?(passive_organization) || current_user.superuser?
                 %li.divider-nav-item
                 %li
-                  = active_link "Users", organization_users_path(organization_id: current_organization.to_param), match_controller: true, class: "nav-link"
+                  = active_link "Users", organization_users_path(organization_id: passive_organization.to_param), match_controller: true, class: "nav-link"
                 %li
-                  = active_link "#{current_organization.short_name} profile", organization_manage_index_path(organization_id: current_organization.to_param), class: "nav-link"
+                  = active_link "#{passive_organization.short_name} profile", organization_manage_index_path(organization_id: passive_organization.to_param), class: "nav-link"
                 %li
-                  = active_link "#{current_organization.short_name} locations", locations_organization_manage_index_path(organization_id: current_organization.to_param), class: "nav-link"
+                  = active_link "#{passive_organization.short_name} locations", locations_organization_manage_index_path(organization_id: passive_organization.to_param), class: "nav-link"
               - if current_user&.superuser?
                 %li.divider-nav-item
                 %li
-                  = link_to "Super Admin view #{current_organization.short_name}", admin_organization_path(current_organization)
+                  = link_to "Super Admin view #{passive_organization.short_name}", admin_organization_path(passive_organization)
             
         %a#menu-opened-backdrop
         .hamburgler

--- a/app/views/organized/bikes/_list.html.haml
+++ b/app/views/organized/bikes/_list.html.haml
@@ -1,7 +1,7 @@
 .organized-page-header
   %h1
     %em
-      = active_organization.name
+      = current_organization.name
     bikes
   %p
     %strong

--- a/app/views/organized/bikes/_search.html.haml
+++ b/app/views/organized/bikes/_search.html.haml
@@ -1,5 +1,5 @@
 / If no url_for_search passed in, default to organization bike search
-- path_for_search ||= organization_bikes_path(organization_id: active_organization.to_param)
+- path_for_search ||= organization_bikes_path(organization_id: current_organization.to_param)
 - skip_view_just_stolen ||= @bike_code.present?
 
 .mb-4
@@ -22,7 +22,7 @@
         :plain
           <svg id="search-button" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 29 29"><defs><style>.cls-1,.cls-2{fill:none;stroke:#fff;stroke-miterlimit:10;stroke-width:2px;}.cls-2{stroke-linecap:round;}</style></defs><title>searcher</title><circle class="cls-1" cx="10.39" cy="10.39" r="9.39"/><line class="cls-2" x1="17.03" y1="17.03" x2="28" y2="28"/></svg>
     = hidden_field_tag :stolenness, @stolenness
-    = hidden_field_tag :organization_id, current_organization&.to_param
+    = hidden_field_tag :organization_id, passive_organization&.to_param
 
 %hr{ style: "opacity: .3;" }
 
@@ -36,7 +36,7 @@
     = number_with_delimiter(@bikes.total_count)
     = "bike".pluralize(@bikes.total_count)
     registered
-  - search_params = @interpreted_params.merge(organization_id: active_organization.to_param)
+  - search_params = @interpreted_params.merge(organization_id: current_organization.to_param)
 
   - unless skip_view_just_stolen
     - if @stolenness == 'all'

--- a/app/views/organized/bikes/incompletes.html.haml
+++ b/app/views/organized/bikes/incompletes.html.haml
@@ -1,7 +1,7 @@
 .organized-page-header
   %h1
     %em
-      = active_organization.name
+      = current_organization.name
     Incomplete Registrations
 
 %p
@@ -12,7 +12,7 @@
     incomplete
     = "registration".pluralize(@b_params.total_count)
 .mt-4.mb-2
-  = form_tag incompletes_organization_bikes_path(organization_id: active_organization.to_param), method: :get do
+  = form_tag incompletes_organization_bikes_path(organization_id: current_organization.to_param), method: :get do
     .row
       .col-sm-8.col-md-10
         .form-group
@@ -21,7 +21,7 @@
         .actions
           = submit_tag "Search", class: "btn btn-primary"
 
-- include_child_org = active_organization.child_ids.any?
+- include_child_org = current_organization.child_ids.any?
 %table.table.table-striped.table-hover.table-bordered.table-sm.without-exterior-border
   %thead.small-header
     %th
@@ -42,7 +42,7 @@
           = b_param.mnfg_name
         %td
           = b_param.owner_email
-          - if include_child_org && b_param.organization != active_organization
+          - if include_child_org && b_param.organization != current_organization
             %small.less-strong{ style: "display: block; line-height: 1;" }
               through #{b_param.organization.short_name}
 

--- a/app/views/organized/bikes/index.html.haml
+++ b/app/views/organized/bikes/index.html.haml
@@ -1,7 +1,7 @@
 - if @bike_code.present?
   - if @bike_code.claimed?
     %h2
-      %a{ href: edit_organization_sticker_path(organization_id: active_organization.id, id: @bike_code.code) }
+      %a{ href: edit_organization_sticker_path(organization_id: current_organization.id, id: @bike_code.code) }
         = @bike_code.kind
         = @bike_code.code
       is currently linked.
@@ -11,24 +11,24 @@
     %h1
       Oh no!
     %h2
-      %a{ href: edit_organization_sticker_path(organization_id: active_organization.id, id: @bike_code.code) }
+      %a{ href: edit_organization_sticker_path(organization_id: current_organization.id, id: @bike_code.code) }
         = @bike_code.kind
         %em
           = @bike_code.code
       isn't linked to a bike.
   %p
     You can enter the URL of the bike you would like to link this #{@bike_code.kind} to:
-  = form_tag bike_code_path(id: @bike_code.code, organization_id: active_organization.id), method: "PUT", class: "row" do
+  = form_tag bike_code_path(id: @bike_code.code, organization_id: current_organization.id), method: "PUT", class: "row" do
     .col-sm-8.col-lg-10
       .form-group
         = text_field_tag :bike_id, "", placeholder: "https://bikeindex.org/bikes/1234", class: "form-control"
     .col-sm-4.col-lg-2
       = submit_tag "Update", class: "btn btn-success"
-    
+
   %p.less-strong
-    Or, browse #{active_organization.short_name}'s bikes and click <em>link it</em> to connect it to this #{@bike_code.kind}
+    Or, browse #{current_organization.short_name}'s bikes and click <em>link it</em> to connect it to this #{@bike_code.kind}
   %hr.mt-4.mb-4.less-strong
-- if active_organization.paid_for?("bike_search")
+- if current_organization.paid_for?("bike_search")
   = render "/organized/bikes/search"
 - else
   = render "/organized/bikes/list"

--- a/app/views/organized/bikes/new.html.haml
+++ b/app/views/organized/bikes/new.html.haml
@@ -1,1 +1,1 @@
-<iframe src="#{ENV['BASE_URL']}/organizations/#{active_organization.slug}/embed_extended" style="width: 100%; border: none; height: 1030px;"></iframe>
+<iframe src="#{ENV['BASE_URL']}/organizations/#{current_organization.slug}/embed_extended" style="width: 100%; border: none; height: 1030px;"></iframe>

--- a/app/views/organized/bikes/recoveries.html.haml
+++ b/app/views/organized/bikes/recoveries.html.haml
@@ -1,7 +1,7 @@
 .mb-4
   %h1
     %em
-      = active_organization.name
+      = current_organization.name
     Recoveries
   %p
     %strong

--- a/app/views/organized/bulk_imports/index.html.haml
+++ b/app/views/organized/bulk_imports/index.html.haml
@@ -1,8 +1,8 @@
 .organized-page-header.mb-4
   %h1
     %em
-      = active_organization.name
-    - if active_organization.ascend_imports?
+      = current_organization.name
+    - if current_organization.ascend_imports?
       Ascend Imports
     - else
       Bulk Imports
@@ -10,9 +10,9 @@
 .paginate-container
   .paginate{ style: "margin: 12px auto 12px 0;" }
     - if @show_empty
-      = link_to "Exclude Empty imports", organization_bulk_imports_path(organization_id: active_organization.to_param, without_empty: true), class: "btn btn-lg btn-secondary"
+      = link_to "Exclude Empty imports", organization_bulk_imports_path(organization_id: current_organization.to_param, without_empty: true), class: "btn btn-lg btn-secondary"
     - else
-      = link_to "Include Empty imports", organization_bulk_imports_path(organization_id: active_organization.to_param), class: "btn btn-lg btn-secondary"
+      = link_to "Include Empty imports", organization_bulk_imports_path(organization_id: current_organization.to_param), class: "btn btn-lg btn-secondary"
   = paginate @bulk_imports
 
 %table.table.table-striped.table-hover.table-bordered.table-sm.without-exterior-border
@@ -31,7 +31,7 @@
     - @bulk_imports.each do |bulk_import|
       %tr
         %td
-          %a.convertTime{ href: organization_bulk_import_path(bulk_import, organization_id: active_organization.to_param) }
+          %a.convertTime{ href: organization_bulk_import_path(bulk_import, organization_id: current_organization.to_param) }
             = l bulk_import.created_at, format: :convert_time
         %td
           - if bulk_import.blocking_error?
@@ -53,4 +53,4 @@
           = bulk_import.creation_states.count # Don't need to do bikes through creation states
 
 %p.text-right
-  = link_to "New import", new_organization_bulk_import_path(organization_id: active_organization.to_param), class: "btn btn-primary"
+  = link_to "New import", new_organization_bulk_import_path(organization_id: current_organization.to_param), class: "btn btn-primary"

--- a/app/views/organized/bulk_imports/new.html.haml
+++ b/app/views/organized/bulk_imports/new.html.haml
@@ -20,7 +20,7 @@
     %li
       Doing an import for the first time? Try importing a sample of your CSV with just 1 or 2 rows, and replace the email with your own email - so if the bikes don't import correctly, you can make adjustments and delete the bikes, without having to delete a large number of bikes.
 
-= form_for @bulk_import, { url: organization_bulk_imports_path(organization_id: active_organization.to_param), action: "create", html: { class: "organized-form" } } do |f|
+= form_for @bulk_import, { url: organization_bulk_imports_path(organization_id: current_organization.to_param), action: "create", html: { class: "organized-form" } } do |f|
   .card.col-sm-6
     .card-block
       = f.label :file, "CSV File with bikes"

--- a/app/views/organized/exports/index.html.haml
+++ b/app/views/organized/exports/index.html.haml
@@ -2,11 +2,11 @@
   .organized-page-header
     %h1
       %em
-        = active_organization.name
+        = current_organization.name
       Exports
 
   .text-right
-    = link_to "New Export", new_organization_export_path(organization_id: active_organization.to_param), class: "btn btn-secondary pull-right"
+    = link_to "New Export", new_organization_export_path(organization_id: current_organization.to_param), class: "btn btn-secondary pull-right"
 
   .table-responsive.mt-4
     %p{ style: "margin-bottom: 0;" }
@@ -31,7 +31,7 @@
         - @exports.each do |export|
           %tr
             %td
-              %a.convertTime{ href: organization_export_path(export, organization_id: active_organization.to_param) }
+              %a.convertTime{ href: organization_export_path(export, organization_id: current_organization.to_param) }
                 = l export.created_at, format: :convert_time
             %td
               - if export.user.present?
@@ -47,7 +47,7 @@
                 = link_to "Download", export.file.url
             %td
               %small
-                = link_to "Delete", organization_export_path(export, organization_id: active_organization.to_param), method: :delete 
+                = link_to "Delete", organization_export_path(export, organization_id: current_organization.to_param), method: :delete
 
 
 

--- a/app/views/organized/exports/new.html.haml
+++ b/app/views/organized/exports/new.html.haml
@@ -2,12 +2,12 @@
   .organized-page-header
     %h1
       %em
-        = active_organization.name
+        = current_organization.name
       new export
 
-  = form_for @export, { url: organization_exports_path(organization_id: active_organization.to_param), action: "create", html: { class: "organized-form" } } do |f|
+  = form_for @export, { url: organization_exports_path(organization_id: current_organization.to_param), action: "create", html: { class: "organized-form" } } do |f|
     = f.hidden_field :timezone, value: "", class: "hiddenFieldTimezone"
-    - if active_organization.paid_for?("avery_export")
+    - if current_organization.paid_for?("avery_export")
       .form-group.row
         = f.label :avery_export, "Avery Label Export", class: "org-form-label"
         .col-sm-4
@@ -15,7 +15,7 @@
       .form-group.row.shownOnAveryExport
         = f.label :bike_code_start, "Initial Sticker #", class: 'org-form-label'
         .col-sm-6
-          = f.text_field :bike_code_start, value: active_organization.bike_codes.next_unclaimed_code&.code, class: "form-control"
+          = f.text_field :bike_code_start, value: current_organization.bike_codes.next_unclaimed_code&.code, class: "form-control"
           %span.below-input-help
             Starting with given input, stickers will be incrementally assigned to bikes. Leave blank to skip assigning stickers to bikes
     .row.mt-2.hiddenOnAveryExport
@@ -24,7 +24,7 @@
           Included columns:
       .col-lg-8
         .row
-          - Export.permitted_headers(active_organization).each do |header|
+          - Export.permitted_headers(current_organization).each do |header|
             - next if Export::HIDDEN_HEADERS.include?(header)
             .form-group.col-xs-6.col-md-4
               %label.checkbox

--- a/app/views/organized/exports/show.html.haml
+++ b/app/views/organized/exports/show.html.haml
@@ -101,12 +101,12 @@
                 %ul{ style: "font-size: 80%;" }
                   - @export.bike_codes.each_with_index do |code, index|
                     %li
-                      = link_to code, edit_organization_sticker_path(code, organization_id: active_organization.to_param)
+                      = link_to code, edit_organization_sticker_path(code, organization_id: current_organization.to_param)
                 - if @export.bike_codes_removed?
                   %em.text-danger
                     Stickers have been unassigned
                 - else
-                  = link_to "Unassign stickers", organization_export_path(@export.id, organization_id: active_organization.to_param, remove_bike_codes: true), method: :put, class: "btn btn-warning float-right"
+                  = link_to "Unassign stickers", organization_export_path(@export.id, organization_id: current_organization.to_param, remove_bike_codes: true), method: :put, class: "btn btn-warning float-right"
               - else
                 %small.less-strong
                   No stickers assigned

--- a/app/views/organized/manage/index.html.haml
+++ b/app/views/organized/manage/index.html.haml
@@ -38,12 +38,12 @@
     .col-sm-4
       = f.text_field :website, class: 'form-control'
 
-  - if active_organization.is_paid
+  - if current_organization.is_paid
     .form-group.row.avatar-upload-wrapper
       %label.org-form-label
         Organization logo
       .col-sm-4
-        - if @organization.avatar? 
+        - if @organization.avatar?
           = image_tag(@organization.avatar_url(:thumb))
         / - else
         /   %p
@@ -59,11 +59,11 @@
       = f.submit 'Update', class: 'btn btn-success btn-lg'
 
 
-- unless active_organization.is_paid
+- unless current_organization.is_paid
   %hr.delete-organization-section
   %p.text-md-center
     %a.collapsed{ href: '#', data: { toggle: 'collapse', target: '#delete-organization' } }
       I would like to terminate my account with Bike Index
   #delete-organization.collapse
     .text-md-center
-      = link_to 'Delete organization', organization_manage_path(id: active_organization.id, organization_id: active_organization.to_param), method: :delete, confirm: "Are you positive you want to remove #{active_organization.name} from Bike Index?", class: 'btn btn-danger'
+      = link_to 'Delete organization', organization_manage_path(id: current_organization.id, organization_id: current_organization.to_param), method: :delete, confirm: "Are you positive you want to remove #{current_organization.name} from Bike Index?", class: 'btn btn-danger'

--- a/app/views/organized/messages/index.html.haml
+++ b/app/views/organized/messages/index.html.haml
@@ -21,14 +21,14 @@
         Sender
     %tbody
 
-- serialized_members = active_organization.users.map { |u| u && [u.id.to_s, { name: u.display_name }] }.compact.to_h.to_json
+- serialized_members = current_organization.users.map { |u| u && [u.id.to_s, { name: u.display_name }] }.compact.to_h.to_json
 :javascript
   window.pageInfo = {
     "google_maps_key": "#{ENV["GOOGLE_MAPS"]}",
-    "map_center_lat": #{active_organization.map_focus_coordinates[:latitude]},
-    "map_center_lng": #{active_organization.map_focus_coordinates[:longitude]},
+    "map_center_lat": #{current_organization.map_focus_coordinates[:latitude]},
+    "map_center_lng": #{current_organization.map_focus_coordinates[:longitude]},
     "members": #{serialized_members},
-    "message_root_path": "#{organization_messages_path(organization_id: active_organization.to_param)}"
+    "message_root_path": "#{organization_messages_path(organization_id: current_organization.to_param)}"
   }
 
 = javascript_pack_tag "application"

--- a/app/views/organized/messages/show.html.haml
+++ b/app/views/organized/messages/show.html.haml
@@ -1,7 +1,7 @@
 .organized-page-header
   %h1
     %em
-      = active_organization.name
+      = current_organization.name
     #{@organization_message.kind.titleize} Message
 
 %table.organized-list-table

--- a/app/views/organized/stickers/edit.html.haml
+++ b/app/views/organized/stickers/edit.html.haml
@@ -5,7 +5,7 @@
       = @bike_code.code
   - if @bike_code.claimed?
     %p.text-right
-      = link_to "Remove Bike link", organization_sticker_path(id: @bike_code.code, organization_id: active_organization.to_param, bike_id: nil), method: :put, class: "btn btn-danger"
+      = link_to "Remove Bike link", organization_sticker_path(id: @bike_code.code, organization_id: current_organization.to_param, bike_id: nil), method: :put, class: "btn btn-danger"
 %ul.attr-list
   %li
     %span.attr-title
@@ -35,7 +35,7 @@
 
 %hr.mt-4.mb-4
 
-= form_for @bike_code, { url: organization_sticker_path(id: @bike_code.code, organization_id: active_organization.to_param), action: "update", html: { class: "organized-form" } } do |f|
+= form_for @bike_code, { url: organization_sticker_path(id: @bike_code.code, organization_id: current_organization.to_param), action: "update", html: { class: "organized-form" } } do |f|
 
   .form-group.row
     = f.label :bike_id, "Bike ID/URL", class: "org-form-label"

--- a/app/views/organized/stickers/index.html.haml
+++ b/app/views/organized/stickers/index.html.haml
@@ -1,10 +1,10 @@
 .organized-page-header.mb-4
   %h1
     %em
-      = active_organization.name
+      = current_organization.name
     Stickers
 
-= form_tag organization_stickers_path(organization_id: active_organization.to_param), method: :get, class: "stickers-form" do
+= form_tag organization_stickers_path(organization_id: current_organization.to_param), method: :get, class: "stickers-form" do
   .row
     .col-md-4
       = text_field_tag :query, params[:query], placeholder: "Search Sticker ID", class: "form-control"
@@ -46,7 +46,7 @@
       - @bike_codes.each do |bike_code|
         %tr
           %td
-            %a.convertTime{ href: edit_organization_sticker_path(organization_id: active_organization.id, id: bike_code.code) }
+            %a.convertTime{ href: edit_organization_sticker_path(organization_id: current_organization.id, id: bike_code.code) }
               = l bike_code.created_at, format: :convert_time
           %td
             - if bike_code.claimed? && bike_code.claimed_at.present?
@@ -57,7 +57,7 @@
               / For these, use bike_id to avoid loading association
               = organized_bike_text(bike_code.bike)
           %td
-            = link_to bike_code.code, "/bikes/scanned/#{bike_code.code}?organization_id=#{active_organization.to_param}"
+            = link_to bike_code.code, "/bikes/scanned/#{bike_code.code}?organization_id=#{current_organization.to_param}"
 
 .paginate-container.paginate-container-bottom
   = paginate @bike_codes

--- a/app/views/organized/users/edit.html.haml
+++ b/app/views/organized/users/edit.html.haml
@@ -6,7 +6,7 @@
 %p
   .clearfix
     - id = (@organization_invitation || @membership).id
-    = link_to 'remove from organization', organization_user_path(id: id, organization_id: active_organization.to_param, is_invitation: @is_invitation), method: :delete, confirm: "Are you sure you want to remove #{@name} from #{active_organization.name}? (They will still be to use their personal account)", class: 'btn btn-danger pull-right'
+    = link_to 'remove from organization', organization_user_path(id: id, organization_id: current_organization.to_param, is_invitation: @is_invitation), method: :delete, confirm: "Are you sure you want to remove #{@name} from #{current_organization.name}? (They will still be to use their personal account)", class: 'btn btn-danger pull-right'
   - if @is_invitation
     %p
       Invited
@@ -23,7 +23,7 @@
         = l @membership.created_at, format: :short_with_year
 
 - if @is_invitation
-  = form_for @organization_invitation, { as: :organization_invitation, url: organization_user_path(id: @organization_invitation.id, organization_id: active_organization.to_param, is_invitation: @is_invitation), action: 'update', html: { class: 'organized-form' } } do |f|
+  = form_for @organization_invitation, { as: :organization_invitation, url: organization_user_path(id: @organization_invitation.id, organization_id: current_organization.to_param, is_invitation: @is_invitation), action: 'update', html: { class: 'organized-form' } } do |f|
 
     .form-group.row
       = f.label :invitee_email, 'Email', class: 'org-form-label'
@@ -58,7 +58,7 @@
         = f.submit 'Update', class: 'btn btn-success btn-lg'
 
 - else
-  = form_for @membership, { as: :organization_invitation, url: organization_user_path(id: @membership.id, organization_id: active_organization.to_param), action: 'update', html: { class: 'organized-form' } } do |f|
+  = form_for @membership, { as: :organization_invitation, url: organization_user_path(id: @membership.id, organization_id: current_organization.to_param), action: 'update', html: { class: 'organized-form' } } do |f|
 
     .form-group.row
       %label.org-form-label

--- a/app/views/organized/users/index.html.haml
+++ b/app/views/organized/users/index.html.haml
@@ -4,15 +4,15 @@
   %p
     You have added
     %strong
-      #{ pluralize(active_organization.users.count, 'user') }
+      #{ pluralize(current_organization.users.count, 'user') }
   %p
     And can add
     %strong
-      #{active_organization.available_invitation_count} more.
-    = link_to 'Invite another user', new_organization_user_path(organization_id: active_organization.to_param)
+      #{current_organization.available_invitation_count} more.
+    = link_to 'Invite another user', new_organization_user_path(organization_id: current_organization.to_param)
   %p
-    - if active_organization.auto_user.present?
-      Emails are currently sent from <em>#{active_organization.auto_user.email}</em>. #{ link_to 'Update email', organization_manage_index_path(organization_id: active_organization.to_param) }
+    - if current_organization.auto_user.present?
+      Emails are currently sent from <em>#{current_organization.auto_user.email}</em>. #{ link_to 'Update email', organization_manage_index_path(organization_id: current_organization.to_param) }
 
 .organized-table
   %table.table.table-striped.table-bordered
@@ -29,7 +29,7 @@
       - @memberships.each do |membership|
         %tr
           %td
-            = link_to membership.user.name, edit_organization_user_path(membership.id, organization_id: active_organization.to_param)
+            = link_to membership.user.name, edit_organization_user_path(membership.id, organization_id: current_organization.to_param)
           %td
             = membership.user.email
           %td
@@ -37,11 +37,11 @@
               = l membership.created_at, format: :convert_time
             %small.convertTimezone
           %td.hidden-md-down
-            = membership.user.creation_states.where(organization_id: active_organization.id).count
+            = membership.user.creation_states.where(organization_id: current_organization.id).count
       - @organization_invitations.each do |organization_invitation|
         %tr
           %td
-            = link_to organization_invitation.invitee_name, edit_organization_user_path(organization_invitation.id, is_invitation: true, organization_id: active_organization.to_param)
+            = link_to organization_invitation.invitee_name, edit_organization_user_path(organization_invitation.id, is_invitation: true, organization_id: current_organization.to_param)
           %td
             = organization_invitation.invitee_email
           %td

--- a/app/views/organized/users/new.html.haml
+++ b/app/views/organized/users/new.html.haml
@@ -4,13 +4,13 @@
   %p
     You have invited
     %strong
-      #{ pluralize(active_organization.sent_invitation_count, 'user') },
+      #{ pluralize(current_organization.sent_invitation_count, 'user') },
     %br
     And can add
     %strong
-      #{active_organization.available_invitation_count} more.
+      #{current_organization.available_invitation_count} more.
 
-= form_for @organization_invitation, { as: :organization_invitation, url: organization_users_path(organization_id: active_organization.to_param), action: 'create', html: { class: 'organized-form' } } do |f|
+= form_for @organization_invitation, { as: :organization_invitation, url: organization_users_path(organization_id: current_organization.to_param), action: 'create', html: { class: 'organized-form' } } do |f|
 
   .form-group.row
     = f.label :invitee_email, "Email you're inviting", class: 'org-form-label'

--- a/app/views/registrations/embed.html.haml
+++ b/app/views/registrations/embed.html.haml
@@ -1,6 +1,6 @@
 = form_for @b_param, { url: registrations_path, action: 'create' } do |f|
   .form-group
-    - email_placeholder = active_organization && active_organization.school? ? "#{active_organization.slug} email" : 'your email'
+    - email_placeholder = current_organization && current_organization.school? ? "#{current_organization.slug} email" : 'your email'
     = f.email_field :owner_email, required: true, value: @owner_email, placeholder: email_placeholder, class: 'form-control'
   .form-group
     - initial_mnfg = @b_param.manufacturer && { id: @b_param.manufacturer.id, text: @b_param.manufacturer.name }.to_json

--- a/app/views/shared/_organized_skeleton.html.haml
+++ b/app/views/shared/_organized_skeleton.html.haml
@@ -1,66 +1,66 @@
 %nav.organized-left-menu
   .organized-menu-wrapper
     %header
-      - if active_organization.display_avatar
-        = image_tag active_organization.avatar.url(:medium)
+      - if current_organization.display_avatar
+        = image_tag current_organization.avatar.url(:medium)
       %h3
         Admin panel
         %span
-          = active_organization.name
-        
+          = current_organization.name
+
     %ul.organized-mainmenu
       %li
         - on_bikes_path = controller_name == "bikes" && action_name == "index" # Because we want to ignore queries and stuff
-        = link_to "#{active_organization.short_name} Bikes", organization_bikes_path(organization_id: active_organization.to_param), match_controller: true, class: "menu-item #{on_bikes_path ? 'active' : ''}"
+        = link_to "#{current_organization.short_name} Bikes", organization_bikes_path(organization_id: current_organization.to_param), match_controller: true, class: "menu-item #{on_bikes_path ? 'active' : ''}"
       %li
-        = active_link "Add a bike", new_organization_bike_path(active_organization), class: "menu-item"
+        = active_link "Add a bike", new_organization_bike_path(current_organization), class: "menu-item"
       %li
-        - if active_organization.paid_for?("show_partial_registrations")
-          = active_link "Incomplete registrations", incompletes_organization_bikes_path(active_organization), class: "menu-item"
+        - if current_organization.paid_for?("show_partial_registrations")
+          = active_link "Incomplete registrations", incompletes_organization_bikes_path(current_organization), class: "menu-item"
         - else
           %span.disabled-menu-item.menu-item
             Incomplete registrations
-      - if active_organization.show_multi_serial?
+      - if current_organization.show_multi_serial?
         %li
-          = active_link "Multi serial search", multi_serial_search_organization_bikes_path(active_organization), class: "menu-item"
-      - if active_organization.paid_for?("show_recoveries") # I don't want to show a grayed link for this
+          = active_link "Multi serial search", multi_serial_search_organization_bikes_path(current_organization), class: "menu-item"
+      - if current_organization.paid_for?("show_recoveries") # I don't want to show a grayed link for this
         %li
-          = active_link "Recoveries", recoveries_organization_bikes_path(active_organization), class: "menu-item"
+          = active_link "Recoveries", recoveries_organization_bikes_path(current_organization), class: "menu-item"
 
-      - if active_organization.show_bulk_import?
+      - if current_organization.show_bulk_import?
         %li
-          - bulk_link_name = active_organization.ascend_imports? ? "Ascend Imports" : "Bulk Imports"
-          = active_link bulk_link_name, organization_bulk_imports_path(organization_id: active_organization.to_param), match_controller: true, class: "menu-item"
+          - bulk_link_name = current_organization.ascend_imports? ? "Ascend Imports" : "Bulk Imports"
+          = active_link bulk_link_name, organization_bulk_imports_path(organization_id: current_organization.to_param), match_controller: true, class: "menu-item"
       %li.divider-above
-        - if active_organization.paid_for?("bike_codes")
-          = active_link "Registration stickers", organization_stickers_path(organization_id: active_organization.to_param), match_controller: true, class: "menu-item"
+        - if current_organization.paid_for?("bike_codes")
+          = active_link "Registration stickers", organization_stickers_path(organization_id: current_organization.to_param), match_controller: true, class: "menu-item"
         - else
           %span.disabled-menu-item.menu-item
             Registration stickers
-      - if active_organization.paid_for?("csv_exports")
+      - if current_organization.paid_for?("csv_exports")
         %li
-          = active_link "Exports", organization_exports_path(organization_id: active_organization.to_param), match_controller: true, class: "menu-item"
-      - if active_organization.message_kinds.any?
-        - active_organization.message_kinds.each_with_index do |message_kind, index|
+          = active_link "Exports", organization_exports_path(organization_id: current_organization.to_param), match_controller: true, class: "menu-item"
+      - if current_organization.message_kinds.any?
+        - current_organization.message_kinds.each_with_index do |message_kind, index|
           %li{ class: index == 0 ? "divider-above" : "" }
             / (params[:kind] == message_kind ? "active" : "")
             - if message_kind == "geolocated_messages"
               - link_title = "GeoMessaging"
             - else
               - link_title = message_kind.gsub("_messages", "").titleize
-            = active_link link_title, organization_messages_path(organization_id: active_organization.to_param, kind: message_kind), class: "menu-item"
-              
+            = active_link link_title, organization_messages_path(organization_id: current_organization.to_param, kind: message_kind), class: "menu-item"
+
       - else
         %li.divider-above
           %span.disabled-menu-item.menu-item
             GeoMessaging
-      - if current_user.admin_of?(active_organization) || current_user.superuser?
+      - if current_user.admin_of?(current_organization) || current_user.superuser?
         %li.divider-above
-          = active_link "Users", organization_users_path(organization_id: active_organization.to_param), match_controller: true, class: "menu-item"
+          = active_link "Users", organization_users_path(organization_id: current_organization.to_param), match_controller: true, class: "menu-item"
         %li
-          = active_link "#{active_organization.short_name} profile", organization_manage_index_path(organization_id: active_organization.to_param), class: "menu-item"
+          = active_link "#{current_organization.short_name} profile", organization_manage_index_path(organization_id: current_organization.to_param), class: "menu-item"
         %li
-          = active_link "#{active_organization.short_name} locations", locations_organization_manage_index_path(organization_id: active_organization.to_param), class: "menu-item"
+          = active_link "#{current_organization.short_name} locations", locations_organization_manage_index_path(organization_id: current_organization.to_param), class: "menu-item"
 
 .organized-wrap
   .container

--- a/spec/controllers/bikes_controller_spec.rb
+++ b/spec/controllers/bikes_controller_spec.rb
@@ -126,17 +126,17 @@ describe BikesController do
       expect(assigns(:bike)).to be_decorated
       expect(flash).to_not be_present
     end
-    context "illegally set current_organization" do
+    context "illegally set passive_organization" do
       include_context :logged_in_as_user
-      it "renders, resets current_organization_id" do
-        session[:current_organization_id] = organization.id
+      it "renders, resets passive_organization_id" do
+        session[:passive_organization_id] = organization.id
         get :show, id: bike.id
         expect(response.status).to eq(200)
         expect(response).to render_template(:show)
         expect(response).to render_with_layout("application_revised")
         expect(assigns(:bike)).to be_decorated
         expect(flash).to_not be_present
-        expect(session[:current_organization_id]).to eq "0"
+        expect(session[:passive_organization_id]).to eq "0"
       end
     end
     context "example bike" do
@@ -202,7 +202,7 @@ describe BikesController do
         expect(response.status).to eq(200)
         expect(response).to render_template(:show)
         expect(flash).to_not be_present
-        expect(session[:current_organization_id]).to eq organization.id
+        expect(session[:passive_organization_id]).to eq organization.id
       end
       context "bike created by organization" do
         let(:ownership) { FactoryBot.create(:ownership_organization_bike, organization: organization) }
@@ -211,7 +211,7 @@ describe BikesController do
           expect(response.status).to eq(200)
           expect(response).to render_template(:show)
           expect(flash).to_not be_present
-          expect(session[:current_organization_id]).to eq organization.id
+          expect(session[:passive_organization_id]).to eq organization.id
         end
       end
       context "bike owned by organization" do
@@ -222,7 +222,7 @@ describe BikesController do
           expect(response.status).to eq(200)
           expect(response).to render_template(:show)
           expect(flash).to_not be_present
-          expect(session[:current_organization_id]).to eq organization.id
+          expect(session[:passive_organization_id]).to eq organization.id
         end
       end
     end
@@ -263,24 +263,24 @@ describe BikesController do
         expect(response).to render_template(:scanned)
         expect(response.code).to eq("200")
         expect(assigns(:show_organization_bikes)).to be_falsey
-        expect(session[:current_organization_id]).to eq "0"
+        expect(session[:passive_organization_id]).to eq "0"
       end
       context "user part of organization" do
         let!(:user) { FactoryBot.create(:organization_member, organization: organization) }
-        it "makes active_organization the organization" do
+        it "makes current_organization the organization" do
           get :scanned, id: "000#{bike_code2.code}", organization_id: organization.to_param
           expect(assigns(:bike_code)).to eq bike_code2
-          expect(session[:current_organization_id]).to eq organization.id
+          expect(session[:passive_organization_id]).to eq organization.id
           expect(response).to redirect_to organization_bikes_path(organization_id: organization.to_param, bike_code: bike_code2.code)
         end
         context "passed a different organization id" do
           let!(:other_organization) { FactoryBot.create(:organization, short_name: "BikeIndex") }
-          it "makes active_organization the organization" do
+          it "makes current_organization the organization" do
             expect(user.memberships&.pluck(:organization_id)).to eq([organization.id])
             expect(bike_code2.organization).to eq organization
             get :scanned, id: "000#{bike_code2.code}", organization_id: "BikeIndex"
             expect(assigns(:bike_code)).to eq bike_code2
-            expect(session[:current_organization_id]).to eq organization.id
+            expect(session[:passive_organization_id]).to eq organization.id
             expect(response).to redirect_to organization_bikes_path(organization_id: organization.to_param, bike_code: bike_code2.code)
           end
         end
@@ -342,7 +342,7 @@ describe BikesController do
           get :new, organization_id: organization.to_param
           expect(response.code).to eq("200")
           expect(assigns(:bike).creation_organization).to eq organization
-          expect(assigns[:current_organization]).to be_nil # Because the user isn't necessarily a member of an org
+          expect(assigns[:passive_organization]).to be_nil # Because the user isn't necessarily a member of an org
         end
       end
       context "with organization member" do
@@ -351,7 +351,7 @@ describe BikesController do
           get :new
           expect(response.code).to eq("200")
           expect(assigns(:bike).creation_organization).to eq organization
-          expect(assigns[:current_organization]).to eq organization
+          expect(assigns[:passive_organization]).to eq organization
         end
       end
       context "stolen from params" do

--- a/spec/controllers/organized/bikes_controller_spec.rb
+++ b/spec/controllers/organized/bikes_controller_spec.rb
@@ -9,25 +9,25 @@ describe Organized::BikesController, type: :controller do
   context "not organization member" do
     include_context :logged_in_as_user
     let!(:organization) { FactoryBot.create(:organization) }
-    it "redirects the user, reassigns current_organization_id" do
-      session[:current_organization_id] = organization.id # Even though the user isn't part of the organization
+    it "redirects the user, reassigns passive_organization_id" do
+      session[:passive_organization_id] = organization.id # Even though the user isn't part of the organization
       get :index, organization_id: organization.to_param
       expect(response.location).to eq user_home_url
       expect(flash[:error]).to be_present
-      expect(session[:current_organization_id]).to eq "0" # sets it to zero so we don't look it up again
+      expect(session[:passive_organization_id]).to eq "0" # sets it to zero so we don't look it up again
     end
     context "admin user" do
       let(:user) { FactoryBot.create(:admin) }
-      it "renders, doesn't reassign current_organization_id" do
-        session[:current_organization_id] = organization.to_param # Admin, so user has access
+      it "renders, doesn't reassign passive_organization_id" do
+        session[:passive_organization_id] = organization.to_param # Admin, so user has access
         get :index, organization_id: organization.to_param
         expect(response.status).to eq(200)
         expect(response).to render_template :index
         expect(response).to render_with_layout("application_revised")
-        expect(assigns(:active_organization)).to eq organization
-        expect(assigns(:page_id)).to eq "organized_bikes_index"
         expect(assigns(:current_organization)).to eq organization
-        expect(session[:current_organization_id]).to eq organization.id
+        expect(assigns(:page_id)).to eq "organized_bikes_index"
+        expect(assigns(:passive_organization)).to eq organization
+        expect(session[:passive_organization_id]).to eq organization.id
       end
     end
   end
@@ -40,7 +40,7 @@ describe Organized::BikesController, type: :controller do
         expect(response.status).to eq(200)
         expect(response).to render_template :index
         expect(response).to render_with_layout("application_revised")
-        expect(assigns(:active_organization)).to eq organization
+        expect(assigns(:current_organization)).to eq organization
         expect(assigns(:page_id)).to eq "organized_bikes_index"
       end
     end
@@ -51,7 +51,7 @@ describe Organized::BikesController, type: :controller do
         expect(response.status).to eq(200)
         expect(response).to render_template :new
         expect(response).to render_with_layout("application_revised")
-        expect(assigns(:active_organization)).to eq organization
+        expect(assigns(:current_organization)).to eq organization
       end
     end
   end
@@ -76,13 +76,13 @@ describe Organized::BikesController, type: :controller do
           end
           let(:organization_bikes) { organization.bikes }
           it "sends all the params and renders search template to organization_bikes" do
-            session[:current_organization_id] = "0" # Because, who knows! Maybe they don't have org access at some point.
+            session[:passive_organization_id] = "0" # Because, who knows! Maybe they don't have org access at some point.
             get :index, query_params.merge(organization_id: organization.to_param)
             expect(response.status).to eq(200)
-            expect(assigns(:active_organization)).to eq organization
+            expect(assigns(:current_organization)).to eq organization
             expect(assigns(:search_query_present)).to be_truthy
             expect(assigns(:bikes).pluck(:id).include?(non_organization_bike.id)).to be_falsey
-            expect(session[:current_organization_id]).to eq organization.id
+            expect(session[:passive_organization_id]).to eq organization.id
           end
         end
         context "without params" do
@@ -90,7 +90,7 @@ describe Organized::BikesController, type: :controller do
             get :index, organization_id: organization.to_param
             expect(response.status).to eq(200)
             expect(assigns(:interpreted_params)[:stolenness]).to eq "all"
-            expect(assigns(:active_organization)).to eq organization
+            expect(assigns(:current_organization)).to eq organization
             expect(assigns(:search_query_present)).to be_falsey
             expect(assigns(:bikes).pluck(:id).include?(non_organization_bike.id)).to be_falsey
           end
@@ -172,7 +172,7 @@ describe Organized::BikesController, type: :controller do
           expect(response.status).to eq(200)
           expect(response).to render_template :index
           expect(response).to render_with_layout("application_revised")
-          expect(assigns(:active_organization)).to eq organization
+          expect(assigns(:current_organization)).to eq organization
           expect(assigns(:bikes).pluck(:id).include?(non_organization_bike.id)).to be_falsey
         end
       end
@@ -196,7 +196,7 @@ describe Organized::BikesController, type: :controller do
         expect(response.status).to eq(200)
         expect(response).to render_template :new
         expect(response).to render_with_layout("application_revised")
-        expect(assigns(:active_organization)).to eq organization
+        expect(assigns(:current_organization)).to eq organization
       end
     end
   end

--- a/spec/controllers/organized/bulk_imports_controller_spec.rb
+++ b/spec/controllers/organized/bulk_imports_controller_spec.rb
@@ -46,7 +46,7 @@ describe Organized::BulkImportsController, type: :controller do
           expect(response.status).to eq(200)
           expect(response).to render_template :index
           expect(response).to render_with_layout("application_revised")
-          expect(assigns(:active_organization)).to eq organization
+          expect(assigns(:current_organization)).to eq organization
         end
       end
 
@@ -56,7 +56,7 @@ describe Organized::BulkImportsController, type: :controller do
           expect(response.status).to eq(200)
           expect(response).to render_template :new
           expect(response).to render_with_layout("application_revised")
-          expect(assigns(:active_organization)).to eq organization
+          expect(assigns(:current_organization)).to eq organization
         end
       end
     end
@@ -95,7 +95,7 @@ describe Organized::BulkImportsController, type: :controller do
           expect(response.status).to eq(200)
           expect(response).to render_template :index
           expect(response).to render_with_layout("application_revised")
-          expect(assigns(:active_organization)).to eq organization
+          expect(assigns(:current_organization)).to eq organization
         end
       end
 
@@ -105,7 +105,7 @@ describe Organized::BulkImportsController, type: :controller do
           expect(response.status).to eq(200)
           expect(response).to render_template :new
           expect(response).to render_with_layout("application_revised")
-          expect(assigns(:active_organization)).to eq organization
+          expect(assigns(:current_organization)).to eq organization
         end
       end
 

--- a/spec/controllers/organized/exports_controller_spec.rb
+++ b/spec/controllers/organized/exports_controller_spec.rb
@@ -35,7 +35,7 @@ describe Organized::ExportsController, type: :controller do
           get :index, organization_id: organization.to_param
           expect(response).to render_template(:index)
           expect(response).to render_with_layout("application_revised")
-          expect(assigns(:active_organization)).to eq organization
+          expect(assigns(:current_organization)).to eq organization
         end
       end
     end
@@ -55,7 +55,7 @@ describe Organized::ExportsController, type: :controller do
         expect(response.code).to eq("200")
         expect(response).to render_with_layout("application_revised")
         expect(response).to render_template(:index)
-        expect(assigns(:active_organization)).to eq organization
+        expect(assigns(:current_organization)).to eq organization
         expect(assigns(:exports).pluck(:id)).to eq([export.id])
       end
     end

--- a/spec/controllers/organized/manage_controller_spec.rb
+++ b/spec/controllers/organized/manage_controller_spec.rb
@@ -33,26 +33,26 @@ describe Organized::ManageController, type: :controller do
     include_context :logged_in_as_organization_admin
     describe "index" do
       it "renders, sets active organization" do
-        session[:current_organization_id] = "XXXYYY"
+        session[:passive_organization_id] = "XXXYYY"
         get :index, organization_id: organization.to_param
         expect(response.status).to eq(200)
         expect(response).to render_template :index
         expect(response).to render_with_layout("application_revised")
-        expect(assigns(:active_organization)).to eq organization
         expect(assigns(:current_organization)).to eq organization
-        expect(session[:current_organization_id]).to eq organization.id
+        expect(assigns(:passive_organization)).to eq organization
+        expect(session[:passive_organization_id]).to eq organization.id
       end
     end
 
     describe "landing" do
       it "renders" do
-        session[:current_organization_id] = "XXXYYY"
+        session[:passive_organization_id] = "XXXYYY"
         get :landing, organization_id: organization.to_param
         expect(response.status).to eq(200)
         expect(response).to render_with_layout("application_revised")
-        expect(assigns(:active_organization)).to eq organization
         expect(assigns(:current_organization)).to eq organization
-        expect(session[:current_organization_id]).to eq organization.id
+        expect(assigns(:passive_organization)).to eq organization
+        expect(session[:passive_organization_id]).to eq organization.id
       end
     end
 
@@ -62,7 +62,7 @@ describe Organized::ManageController, type: :controller do
         expect(response.status).to eq(200)
         expect(response).to render_template :locations
         expect(response).to render_with_layout("application_revised")
-        expect(assigns(:active_organization)).to eq organization
+        expect(assigns(:current_organization)).to eq organization
       end
     end
 

--- a/spec/controllers/organized/messages_controller_spec.rb
+++ b/spec/controllers/organized/messages_controller_spec.rb
@@ -104,7 +104,7 @@ describe Organized::MessagesController, type: :controller do
       expect(response.status).to eq(200)
       expect(response).to render_template :index
       expect(response).to render_with_layout("application_revised")
-      expect(assigns(:active_organization)).to eq organization
+      expect(assigns(:current_organization)).to eq organization
     end
   end
 

--- a/spec/controllers/organized/stickers_controller_spec.rb
+++ b/spec/controllers/organized/stickers_controller_spec.rb
@@ -33,7 +33,7 @@ describe Organized::StickersController, type: :controller do
           get :index, organization_id: organization.to_param
           expect(response).to render_template(:index)
           expect(response).to render_with_layout("application_revised")
-          expect(assigns(:active_organization)).to eq organization
+          expect(assigns(:current_organization)).to eq organization
         end
       end
     end
@@ -50,7 +50,7 @@ describe Organized::StickersController, type: :controller do
           get :index, organization_id: organization.to_param
           expect(response).to render_template(:index)
           expect(response).to render_with_layout("application_revised")
-          expect(assigns(:active_organization)).to eq organization
+          expect(assigns(:current_organization)).to eq organization
           expect(assigns(:bike_codes).pluck(:id)).to eq([bike_code.id])
         end
         context "with query search" do
@@ -60,7 +60,7 @@ describe Organized::StickersController, type: :controller do
           it "renders" do
             get :index, organization_id: organization.to_param, claimedness: "unclaimed", query: "part"
             expect(response).to render_template(:index)
-            expect(assigns(:active_organization)).to eq organization
+            expect(assigns(:current_organization)).to eq organization
             expect(assigns(:bike_codes).pluck(:id)).to eq([bike_code.id])
           end
         end
@@ -72,7 +72,7 @@ describe Organized::StickersController, type: :controller do
             expect(BikeCode.where(bike_id: bike.id).pluck(:id)).to eq([bike_code_claimed.id])
             get :index, organization_id: organization.to_param, bike_query: "https://bikeindex.org/bikes/#{bike.id}/edit?cool=stuff"
             expect(response).to render_template(:index)
-            expect(assigns(:active_organization)).to eq organization
+            expect(assigns(:current_organization)).to eq organization
             expect(assigns(:bike_codes).pluck(:id)).to eq([bike_code_claimed.id])
           end
         end
@@ -82,7 +82,7 @@ describe Organized::StickersController, type: :controller do
         it "renders" do
           get :edit, id: bike_code.code, organization_id: organization.to_param
           expect(response).to render_template(:edit)
-          expect(assigns(:active_organization)).to eq organization
+          expect(assigns(:current_organization)).to eq organization
         end
       end
 
@@ -92,7 +92,7 @@ describe Organized::StickersController, type: :controller do
         let(:bike2) { FactoryBot.create(:bike) }
         it "updates" do
           put :update, id: bike_code.code, organization_id: organization.id, bike_code: { bike_id: "https://bikeindex.org/bikes/#{bike2.id} " }
-          expect(assigns(:active_organization)).to eq organization
+          expect(assigns(:current_organization)).to eq organization
           expect(flash[:success]).to be_present
           expect(response).to redirect_to bike_path(bike2)
           bike_code.reload
@@ -103,7 +103,7 @@ describe Organized::StickersController, type: :controller do
           it "updates" do
             request.env["HTTP_REFERER"] = bike_path(bike2)
             put :update, id: "code", organization_id: organization.id, bike_code: { bike_id: bike2.id, code: bike_code.code }
-            expect(assigns(:active_organization)).to eq organization
+            expect(assigns(:current_organization)).to eq organization
             expect(flash[:success]).to be_present
             expect(response).to redirect_to bike_path(bike2)
             bike_code.reload
@@ -114,7 +114,7 @@ describe Organized::StickersController, type: :controller do
             it "redirects back" do
               request.env["HTTP_REFERER"] = bike_path(bike2)
               put :update, id: "code", organization_id: organization.id, bike_code: { bike_id: bike2.id, code: "" }
-              expect(assigns(:active_organization)).to eq organization
+              expect(assigns(:current_organization)).to eq organization
               expect(flash[:error]).to be_present
               bike_code.reload
               expect(bike_code.bike_id).to eq bike.id
@@ -125,7 +125,7 @@ describe Organized::StickersController, type: :controller do
             it "updates" do
               request.env["HTTP_REFERER"] = bike_path(bike2)
               put :update, id: "code", organization_id: organization.id, bike_code: { bike_id: bike2.id, code: "151515" }
-              expect(assigns(:active_organization)).to eq organization
+              expect(assigns(:current_organization)).to eq organization
               expect(flash[:success]).to be_present
               expect(response).to redirect_to bike_path(bike2)
               bike_code.reload

--- a/spec/controllers/organized/users_controller_spec.rb
+++ b/spec/controllers/organized/users_controller_spec.rb
@@ -53,7 +53,7 @@ describe Organized::UsersController, type: :controller do
         expect(response.status).to eq(200)
         expect(response).to render_template :index
         expect(response).to render_with_layout("application_revised")
-        expect(assigns(:active_organization)).to eq organization
+        expect(assigns(:current_organization)).to eq organization
       end
     end
 

--- a/spec/controllers/sessions_controller_spec.rb
+++ b/spec/controllers/sessions_controller_spec.rb
@@ -55,7 +55,7 @@ describe SessionsController do
     it "logs out the current user" do
       session[:return_to] = "/bikes/12?contact_owner=true"
       session[:partner] = "bikehub"
-      session[:current_organization_id] = 12
+      session[:passive_organization_id] = 12
       session[:whatever] = "XXXXXX"
       get :destroy
       expect(cookies.signed[:auth]).to be_nil
@@ -64,7 +64,7 @@ describe SessionsController do
       expect(flash[:notice]).to be_present
       expect(session[:return_to]).to be_nil
       expect(session[:partner]).to be_nil
-      expect(session[:current_organization_id]).to be_nil
+      expect(session[:passive_organization_id]).to be_nil
       expect(session[:whatever]).to be_nil
     end
     context "unconfirmed user" do

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -98,13 +98,13 @@ describe UsersController do
         context "with organization_invitation, partner param" do
           let!(:organization_invitation) { FactoryBot.create(:organization_invitation, invitee_email: "poo@pile.com") }
           it "creates a confirmed user, log in, and send welcome" do
-            session[:current_organization_id] = "0"
+            session[:passive_organization_id] = "0"
             expect_any_instance_of(AfterUserCreateWorker).to receive(:send_welcoming_email)
             post :create, user: user_attributes, partner: "bikehub"
             expect(response).to redirect_to("https://new.bikehub.com/account")
             expect(User.order(:created_at).last.partner_sign_up).to eq "bikehub"
             expect(User.from_auth(cookies.signed[:auth])).to eq(User.fuzzy_email_find("poo@pile.com"))
-            expect(session[:current_organization_id]).to eq organization_invitation.organization_id
+            expect(session[:passive_organization_id]).to eq organization_invitation.organization_id
           end
         end
         context "with partner session" do

--- a/spec/controllers/welcome_controller_spec.rb
+++ b/spec/controllers/welcome_controller_spec.rb
@@ -99,20 +99,20 @@ describe WelcomeController do
             expect(response.status).to eq(200)
             expect(response).to render_template("user_home")
             expect(response).to render_with_layout("application_revised")
-            expect(session[:current_organization_id]).to eq "0"
-            expect(assigns[:current_organization]).to be_nil
+            expect(session[:passive_organization_id]).to eq "0"
+            expect(assigns[:passive_organization]).to be_nil
           end
         end
         context "with organization" do
           let(:organization) { FactoryBot.create(:organization) }
           let(:user) { FactoryBot.create(:organization_member, organization: organization) }
-          it "sets current_organization_id" do
+          it "sets passive_organization_id" do
             get :user_home
             expect(response.status).to eq(200)
             expect(response).to render_template("user_home")
             expect(response).to render_with_layout("application_revised")
-            expect(session[:current_organization_id]).to eq organization.id
-            expect(assigns[:current_organization]).to eq organization
+            expect(session[:passive_organization_id]).to eq organization.id
+            expect(assigns[:passive_organization]).to eq organization
           end
         end
         context "with stuff" do
@@ -126,7 +126,7 @@ describe WelcomeController do
             allow_any_instance_of(User).to receive(:locks) { [lock] }
           end
           it "renders and user things are assigned" do
-            session[:current_organization_id] = organization.id # Even though the user isn't part of the organization, permit it
+            session[:passive_organization_id] = organization.id # Even though the user isn't part of the organization, permit it
             get :user_home, per_page: 1
             expect(response.status).to eq(200)
             expect(response).to render_template("user_home")
@@ -135,8 +135,8 @@ describe WelcomeController do
             expect(assigns(:per_page).to_s).to eq "1"
             expect(assigns(:bikes).first).to eq(bike)
             expect(assigns(:locks).first).to eq(lock)
-            expect(session[:current_organization_id]).to eq organization.id
-            expect(assigns[:current_organization]).to eq organization
+            expect(session[:passive_organization_id]).to eq organization.id
+            expect(assigns[:passive_organization]).to eq organization
           end
         end
       end

--- a/spec/helpers/header_tag_helper_spec.rb
+++ b/spec/helpers/header_tag_helper_spec.rb
@@ -106,7 +106,7 @@ describe HeaderTagHelper do
       let(:controller_namespace) { "organized" }
       let(:organization) { FactoryBot.build(:organization, short_name: "Sweet Bike Org") }
       before do
-        allow(view).to receive(:active_organization) { organization }
+        allow(view).to receive(:current_organization) { organization }
       end
       describe "bikes" do
         let(:controller_name) { "bikes" }
@@ -209,7 +209,7 @@ describe HeaderTagHelper do
       let(:action_name) { "show" }
       let(:organization) { FactoryBot.build(:organization, name: "Sweet University") }
       it "sets the page title" do
-        allow(view).to receive(:active_organization) { organization }
+        allow(view).to receive(:current_organization) { organization }
         helper.landing_pages_header_tags
         expect(helper.page_title).to eq "Sweet University Bike Registration"
         expect(helper.page_description).to eq "Register your bicycle with Sweet University - powered by Bike Index"


### PR DESCRIPTION
The two existing methods are `active_organization` and `current_organization` - which is confusing, because the names suggest the same thing.

Switch to using `current_organization` for times when the parameters include an organization, and `passive_organization` for times when the organization is pulled from the session

**NOTE:** this actually means that the change that occurs is `current_organization` > `passive_organization` then `active_organization` > `current_organization`