### PR TITLE
Add jazz_fingers, pry-rails

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -129,13 +129,15 @@ group :development do
   # gem 'test-unit', '~> 3.0'
   gem "bullet"
   gem "rerun"
-  # gem 'pry-rails'
 end
 
 group :development, :test do
   gem "database_cleaner"
   gem "dotenv-rails"
   gem "foreman"
+  gem "jazz_fingers"
+  gem "pry-byebug"
+  gem "pry-rails"
   gem "rb-fsevent", "~> 0.9.1"
   gem "rspec", "~> 3.3.0"
   gem "rspec-rails", "~> 3.3.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -50,6 +50,7 @@ GEM
     ast (2.4.0)
     autoprefixer-rails (6.5.0.2)
       execjs
+    awesome_print (1.8.0)
     aws-sdk (1.66.0)
       aws-sdk-v1 (= 1.66.0)
     aws-sdk-v1 (1.66.0)
@@ -76,6 +77,7 @@ GEM
     bullet (5.9.0)
       activesupport (>= 3.0.0)
       uniform_notifier (~> 1.11)
+    byebug (11.0.1)
     carrierwave (0.11.2)
       activemodel (>= 3.2.0)
       activesupport (>= 3.2.0)
@@ -98,6 +100,8 @@ GEM
     coffee-script-source (1.12.2)
     concurrent-ruby (1.1.4)
     connection_pool (2.2.2)
+    coolline (0.5.0)
+      unicode_utils (~> 1.4)
     crack (0.4.3)
       safe_yaml (~> 1.0.0)
     crass (1.0.4)
@@ -226,6 +230,11 @@ GEM
     ice_nine (0.11.2)
     ipaddress (0.8.3)
     jaro_winkler (1.5.2)
+    jazz_fingers (5.0.0)
+      awesome_print (~> 1.6)
+      pry (~> 0.10)
+      pry-byebug (~> 3.4)
+      pry-coolline (~> 0.2)
     journey (1.0.4)
     jquery-datatables-rails (3.4.0)
       actionpack (>= 3.1)
@@ -334,6 +343,13 @@ GEM
     pry (0.12.2)
       coderay (~> 1.1.0)
       method_source (~> 0.9.0)
+    pry-byebug (3.7.0)
+      byebug (~> 11.0)
+      pry (~> 0.10)
+    pry-coolline (0.2.5)
+      coolline (~> 0.5)
+    pry-rails (0.3.9)
+      pry (>= 0.10.4)
     psych (3.1.0)
     rack (1.6.11)
     rack-accept (0.4.5)
@@ -537,6 +553,7 @@ GEM
       unf_ext
     unf_ext (0.0.7.5)
     unicode-display_width (1.5.0)
+    unicode_utils (1.4.0)
     unicorn (5.4.1)
       kgio (~> 2.6)
       raindrops (~> 0.7)
@@ -612,6 +629,7 @@ DEPENDENCIES
   honeybadger (~> 2.0)
   httparty
   i18n
+  jazz_fingers
   journey (~> 1.0.3)
   jquery-datatables-rails (~> 3.4.0)
   jquery-rails
@@ -631,6 +649,8 @@ DEPENDENCIES
   pg
   pg_search
   premailer-rails
+  pry-byebug
+  pry-rails
   rack-contrib
   rack-mini-profiler
   rack-throttle

--- a/config/initializers/jazz_fingers.rb
+++ b/config/initializers/jazz_fingers.rb
@@ -1,0 +1,1 @@
+JazzFingers.setup! if defined?(JazzFingers)


### PR DESCRIPTION
@sethherr Any objection to using Pry? I noticed it was commented out in the Gemfile.

Adds some debugging enhancements for the rails console: [pry-rails](https://github.com/rweng/pry-rails), [pry-byebug](https://github.com/deivid-rodriguez/pry-byebug), [jazz_fingers](https://github.com/plribeiro3000/jazz_fingers)

```
2.5.1 (bikeindex)[42] » User.joins(:user_emails).where("users.email = ? OR user_emails.email = ?", owner_email, owner_email).select(:id).uniq
   (45.2ms)  SELECT DISTINCT COUNT(DISTINCT "users"."id") FROM "users" INNER JOIN "user_emails" ON "user_emails"."user_id" = "users"."id" WHERE (users.email = 'dawnwind2014@gmail.com' OR user_emails.email = 'dawnwind2014@gmail.com')
  User Load (44.4ms)  SELECT DISTINCT "users"."id" FROM "users" INNER JOIN "user_emails" ON "user_emails"."user_id" = "users"."id" WHERE (users.email = 'dawnwind2014@gmail.com' OR user_emails.email = 'dawnwind2014@gmail.com')
[
  [0] #<User:0x00007fe755f7ea38> {
    "id" => 43317
  }
]
2.5.1 (bikeindex)[43] » User.joins(:user_emails).where("users.email = ? OR user_emails.email = ?", owner_email, owner_email).select(:id).uniq
2.5.1 (bikeindex)[43] »

```