### PR TITLE
Replace JSON.parse / JSON() in specs with `json_result`

### DIFF
--- a/spec/controllers/admin/bulk_imports_controller_spec.rb
+++ b/spec/controllers/admin/bulk_imports_controller_spec.rb
@@ -1,6 +1,6 @@
 require "spec_helper"
 
-describe Admin::BulkImportsController do
+describe Admin::BulkImportsController, type: :controller do
   let(:user) { FactoryBot.create(:admin) }
   before do
     set_current_user(user)

--- a/spec/controllers/api/v1/manufacturers_controller_spec.rb
+++ b/spec/controllers/api/v1/manufacturers_controller_spec.rb
@@ -6,7 +6,7 @@ describe Api::V1::ManufacturersController do
       m = FactoryBot.create(:manufacturer, name: "AAAA manufacturer")
       get :index, format: :json
       expect(response.code).to eq("200")
-      expect(JSON.parse(response.body)["manufacturers"].first["name"]).to eq(m.name)
+      expect(json_result["manufacturers"].first["name"]).to eq(m.name)
       expect(response.headers["Access-Control-Allow-Origin"]).to eq("*")
       expect(response.headers["Access-Control-Allow-Methods"]).to eq("POST, PUT, GET, OPTIONS")
       expect(response.headers["Access-Control-Request-Method"]).to eq("*")

--- a/spec/controllers/api/v1/manufacturers_controller_spec.rb
+++ b/spec/controllers/api/v1/manufacturers_controller_spec.rb
@@ -1,6 +1,6 @@
 require "spec_helper"
 
-describe Api::V1::ManufacturersController do
+describe Api::V1::ManufacturersController, type: :controller do
   describe "index" do
     it "loads the request" do
       m = FactoryBot.create(:manufacturer, name: "AAAA manufacturer")

--- a/spec/controllers/organized/bulk_imports_controller_spec.rb
+++ b/spec/controllers/organized/bulk_imports_controller_spec.rb
@@ -152,7 +152,6 @@ describe Organized::BulkImportsController, type: :controller do
               request.headers["Authorization"] = "a9s0dfsdf" # Rspec doesn't support headers key here. TODO: Rails 5 update
               post :create, organization_id: organization.to_param, file: file
               expect(response.status).to eq(401)
-              json_result = json_result
               expect(json_result["error"]).to be_present
             end
           end
@@ -162,7 +161,6 @@ describe Organized::BulkImportsController, type: :controller do
               request.headers["Authorization"] = organization.access_token # Rspec doesn't support headers key here. TODO: Rails 5 update
               post :create, organization_id: organization.to_param, file: file
               expect(response.status).to eq(201)
-              json_result = json_result
               expect(json_result["success"]).to be_present
 
               bulk_import = BulkImport.last
@@ -183,7 +181,6 @@ describe Organized::BulkImportsController, type: :controller do
                 post :create, organization_id: "ascend", file: file
               end.to change(BulkImport, :count).by 0
               expect(response.status).to eq(401)
-              json_result = json_result
               expect(json_result["error"]).to be_present
             end
             context "valid ascend token" do
@@ -193,7 +190,6 @@ describe Organized::BulkImportsController, type: :controller do
                   post :create, organization_id: "ascend", file: file
                 end.to change(BulkImport, :count).by 1
                 expect(response.status).to eq(201)
-                json_result = json_result
                 expect(json_result["success"]).to be_present
 
                 bulk_import = BulkImport.last

--- a/spec/controllers/organized/bulk_imports_controller_spec.rb
+++ b/spec/controllers/organized/bulk_imports_controller_spec.rb
@@ -152,7 +152,7 @@ describe Organized::BulkImportsController, type: :controller do
               request.headers["Authorization"] = "a9s0dfsdf" # Rspec doesn't support headers key here. TODO: Rails 5 update
               post :create, organization_id: organization.to_param, file: file
               expect(response.status).to eq(401)
-              json_result = JSON.parse(response.body)
+              json_result = json_result
               expect(json_result["error"]).to be_present
             end
           end
@@ -162,7 +162,7 @@ describe Organized::BulkImportsController, type: :controller do
               request.headers["Authorization"] = organization.access_token # Rspec doesn't support headers key here. TODO: Rails 5 update
               post :create, organization_id: organization.to_param, file: file
               expect(response.status).to eq(201)
-              json_result = JSON.parse(response.body)
+              json_result = json_result
               expect(json_result["success"]).to be_present
 
               bulk_import = BulkImport.last
@@ -183,7 +183,7 @@ describe Organized::BulkImportsController, type: :controller do
                 post :create, organization_id: "ascend", file: file
               end.to change(BulkImport, :count).by 0
               expect(response.status).to eq(401)
-              json_result = JSON.parse(response.body)
+              json_result = json_result
               expect(json_result["error"]).to be_present
             end
             context "valid ascend token" do
@@ -193,7 +193,7 @@ describe Organized::BulkImportsController, type: :controller do
                   post :create, organization_id: "ascend", file: file
                 end.to change(BulkImport, :count).by 1
                 expect(response.status).to eq(201)
-                json_result = JSON.parse(response.body)
+                json_result = json_result
                 expect(json_result["success"]).to be_present
 
                 bulk_import = BulkImport.last

--- a/spec/requests/api/manufacturers_request_spec.rb
+++ b/spec/requests/api/manufacturers_request_spec.rb
@@ -29,7 +29,7 @@ describe "Manufacturers API V3" do
     it "responds with missing and cors headers" do
       get "/api/v3/manufacturers/10000"
       expect(response.code).to eq("404")
-      expect(JSON(response.body)["error"].present?).to be_truthy
+      expect(json_result["error"].present?).to be_truthy
       expect(response.headers["Access-Control-Allow-Origin"]).to eq("*")
       expect(response.headers["Access-Control-Request-Method"]).to eq("*")
       expect(response.headers["Content-Type"].match("json")).to be_present
@@ -49,9 +49,8 @@ describe "Manufacturers API V3" do
   describe "JUST CRAZY 404" do
     it "responds with missing and cors headers" do
       get "/api/v3/manufacturersdddd"
-      # pp JSON.parse(response.body)
       expect(response.code).to eq("404")
-      expect(JSON(response.body)["error"].present?).to be_truthy
+      expect(json_result["error"].present?).to be_truthy
       expect(response.headers["Access-Control-Allow-Origin"]).to eq("*")
       expect(response.headers["Access-Control-Request-Method"]).to eq("*")
       expect(response.headers["Content-Type"].match("json")).to be_present

--- a/spec/requests/api/v2/manufacturers_request_spec.rb
+++ b/spec/requests/api/v2/manufacturers_request_spec.rb
@@ -30,7 +30,7 @@ describe "Manufacturers API V2" do
     it "responds with missing and cors headers" do
       get "/api/v2/manufacturers/10000"
       expect(response.code).to eq("404")
-      expect(JSON(response.body)["error"].present?).to be_truthy
+      expect(json_result["error"].present?).to be_truthy
       expect(response.headers["Access-Control-Allow-Origin"]).to eq("*")
       expect(response.headers["Access-Control-Request-Method"]).to eq("*")
       expect(response.headers["Content-Type"].match("json")).to be_present
@@ -52,7 +52,7 @@ describe "Manufacturers API V2" do
       get "/api/v2/manufacturersdddd"
       # pp JSON.parse(response.body)
       expect(response.code).to eq("404")
-      expect(JSON(response.body)["error"].present?).to be_truthy
+      expect(json_result["error"].present?).to be_truthy
       expect(response.headers["Access-Control-Allow-Origin"]).to eq("*")
       expect(response.headers["Access-Control-Request-Method"]).to eq("*")
       expect(response.headers["Content-Type"].match("json")).to be_present

--- a/spec/requests/api/v2/swagger_request_spec.rb
+++ b/spec/requests/api/v2/swagger_request_spec.rb
@@ -4,7 +4,7 @@ describe "Swagger API V2 docs" do
   describe "all the paths" do
     it "responds with swagger for all the apis" do
       get "/api/v2/swagger_doc"
-      result = JSON(response.body)
+      result = json_result
       expect(response.code).to eq("200")
       result["apis"].each do |api|
         get "/api/v2/swagger_doc#{api["path"]}"

--- a/spec/requests/api/v3/bikes_request_spec.rb
+++ b/spec/requests/api/v3/bikes_request_spec.rb
@@ -9,9 +9,8 @@ describe "Bikes API V3" do
     it "returns one with from an id" do
       bike = FactoryBot.create(:bike)
       get "/api/v3/bikes/#{bike.id}", format: :json
-      result = JSON.parse(response.body)
       expect(response.code).to eq("200")
-      expect(result["bike"]["id"]).to eq(bike.id)
+      expect(json_result["bike"]["id"]).to eq(bike.id)
       expect(response.headers["Content-Type"].match("json")).to be_present
       expect(response.headers["Access-Control-Allow-Origin"]).to eq("*")
       expect(response.headers["Access-Control-Request-Method"]).to eq("*")
@@ -19,9 +18,8 @@ describe "Bikes API V3" do
 
     it "responds with missing" do
       get "/api/v3/bikes/10", format: :json
-      result = JSON(response.body)
       expect(response.code).to eq("404")
-      expect(result["error"].present?).to be_truthy
+      expect(json_result["error"].present?).to be_truthy
       expect(response.headers["Content-Type"].match("json")).to be_present
       expect(response.headers["Access-Control-Allow-Origin"]).to eq("*")
       expect(response.headers["Access-Control-Request-Method"]).to eq("*")
@@ -110,7 +108,7 @@ describe "Bikes API V3" do
              json_headers
       end.to change(EmailOwnershipInvitationWorker.jobs, :size).by(1)
       expect(response.code).to eq("201")
-      result = JSON.parse(response.body)["bike"]
+      result = json_result["bike"]
       expect(result["serial"]).to eq(bike_attrs[:serial])
       expect(result["manufacturer_name"]).to eq(bike_attrs[:manufacturer])
       bike = Bike.find(result["id"])
@@ -149,7 +147,7 @@ describe "Bikes API V3" do
              json_headers
       end.to change(EmailOwnershipInvitationWorker.jobs, :size).by(0)
       expect(response.code).to eq("201")
-      result = JSON.parse(response.body)["bike"]
+      result = json_result["bike"]
       expect(result["serial"]).to eq(bike_attrs[:serial])
       expect(result["manufacturer_name"]).to eq(bike_attrs[:manufacturer])
       bike = Bike.unscoped.find(result["id"])
@@ -213,8 +211,7 @@ describe "Bikes API V3" do
              bike_attrs.to_json,
              json_headers
       end.to change(Ownership, :count).by 0
-      result = JSON.parse(response.body)
-      expect(result["error"]).to be_present
+      expect(json_result["error"]).to be_present
     end
   end
 
@@ -256,7 +253,7 @@ describe "Bikes API V3" do
             expect do
               post tokenized_url, bike_attrs.merge(no_duplicate: true).to_json, json_headers
             end.to change(Bike, :count).by 0
-            result = JSON.parse(response.body)["bike"]
+            result = json_result["bike"]
             expect(response.code).to eq("201")
             expect(result["id"]).to eq bike.id
             EmailOwnershipInvitationWorker.drain
@@ -271,7 +268,7 @@ describe "Bikes API V3" do
             expect do
               post tokenized_url, bike_attrs.to_json, json_headers
             end.to change(Bike, :count).by 1
-            result = JSON.parse(response.body)["bike"]
+            result = json_result["bike"]
 
             expect(response.code).to eq("201")
             bike = Bike.find(result["id"])
@@ -292,11 +289,8 @@ describe "Bikes API V3" do
 
       it "doesn't create a bike without an organization with v3_accessor" do
         post tokenized_url, bike_attrs.except(:organization_slug).to_json, json_headers
-        result = JSON.parse(response.body)
-
         expect(response.code).to eq("403")
-        result = JSON.parse(response.body)
-        expect(result["error"].is_a?(String)).to be_truthy
+        expect(json_result["error"].is_a?(String)).to be_truthy
         EmailOwnershipInvitationWorker.drain
         expect(ActionMailer::Base.deliveries).to be_empty
       end
@@ -305,10 +299,8 @@ describe "Bikes API V3" do
     it "fails to create a bike if the app owner isn't a member of the organization" do
       expect(user.has_membership?).to be_falsey
       post tokenized_url, bike_attrs.to_json, json_headers
-      result = JSON.parse(response.body)
       expect(response.code).to eq("403")
-      result = JSON.parse(response.body)
-      expect(result["error"].is_a?(String)).to be_truthy
+      expect(json_result["error"].is_a?(String)).to be_truthy
     end
   end
 

--- a/spec/requests/api/v3/swagger_request_spec.rb
+++ b/spec/requests/api/v3/swagger_request_spec.rb
@@ -4,7 +4,7 @@ describe "Swagger API V3 docs" do
   describe "all the paths" do
     it "responds with swagger for all the endpoints" do
       get "/api/v3/swagger_doc"
-      result = JSON(response.body)
+      result = json_result
       expect(response.code).to eq("200")
       result["apis"].each do |api|
         get "/api/v3/swagger_doc#{api["path"]}"

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -38,6 +38,7 @@ RSpec.configure do |config|
 
   # Add our request spec helpers
   config.include RequestSpecHelpers, type: :request
+  config.include RequestSpecHelpers, type: :controller
 
   config.before :suite do
     DatabaseCleaner.clean


### PR DESCRIPTION
For consistency, replaces `JSON.parse()` and `JSON()` invocations in specs with the `json_result` spec helpers.