### PR TITLE
Fix failed bikes page exception

### DIFF
--- a/app/controllers/admin/failed_bikes_controller.rb
+++ b/app/controllers/admin/failed_bikes_controller.rb
@@ -5,6 +5,8 @@ class Admin::FailedBikesController < Admin::BaseController
     page = params.fetch(:page, 1)
     per_page = params.fetch(:per_page, 25)
 
+    @b_params_total_count = BParam.where("created_bike_id IS NOT NULL").count
+
     @b_params =
       BParam
         .where("created_bike_id IS NOT NULL")

--- a/app/controllers/admin/failed_bikes_controller.rb
+++ b/app/controllers/admin/failed_bikes_controller.rb
@@ -5,10 +5,9 @@ class Admin::FailedBikesController < Admin::BaseController
     page = params.fetch(:page, 1)
     per_page = params.fetch(:per_page, 25)
 
-    @b_params_total_count = BParam.where("created_bike_id IS NOT NULL").count
-
     @b_params =
       BParam
+        .includes(:creator)
         .where("created_bike_id IS NOT NULL")
         .order("created_at desc")
         .page(page)

--- a/app/controllers/admin/failed_bikes_controller.rb
+++ b/app/controllers/admin/failed_bikes_controller.rb
@@ -2,7 +2,15 @@ class Admin::FailedBikesController < Admin::BaseController
   layout "new_admin"
 
   def index
-    @b_params = BParam.where("created_bike_id IS NOT NULL").order("created_at desc")
+    page = params.fetch(:page, 1)
+    per_page = params.fetch(:per_page, 25)
+
+    @b_params =
+      BParam
+        .where("created_bike_id IS NOT NULL")
+        .order("created_at desc")
+        .page(page)
+        .per(per_page)
   end
 
   def show

--- a/app/javascript/stylesheets/_admin.scss
+++ b/app/javascript/stylesheets/_admin.scss
@@ -36,3 +36,25 @@
 .show-admin-bike-table-serial-cell .admin-bike-table-serial-cell {
   display: table-cell;
 }
+
+.paginate-container {
+  display: flex;
+  flex: wrap;
+  justify-content: center;
+
+  .pagination {
+    flex: 0 1 auto;
+    display: inline-block;
+    padding-left: 0;
+    margin-top: 10px;
+    margin-bottom: 10px;
+  }
+
+  ul {
+    list-item-type: none;
+  }
+
+  li {
+    display: inline;
+  }
+}

--- a/app/views/admin/failed_bikes/index.html.haml
+++ b/app/views/admin/failed_bikes/index.html.haml
@@ -2,7 +2,7 @@
   Manage Failed Bikes
 
 %h4
-  = number_with_delimiter(@b_params_total_count, delimiter: ',')
+  = number_with_delimiter(@b_params.total_count, delimiter: ',')
   failed bikes,
   %em
     = @b_params.where(BParam.arel_table[:created_at].gt(Date.yesterday)).count
@@ -18,7 +18,7 @@
       %th
         Errors
     %tbody
-      - @b_params.includes(:creator).each do |b_param|
+      - @b_params.each do |b_param|
         %tr
           %td
             %a.convertTime.preciseTime{ href: admin_failed_bike_url(b_param.id) }

--- a/app/views/admin/failed_bikes/index.html.haml
+++ b/app/views/admin/failed_bikes/index.html.haml
@@ -1,4 +1,3 @@
-
 %h1
   Manage Failed Bikes
 
@@ -8,8 +7,6 @@
   %em
     = @b_params.where(BParam.arel_table[:created_at].gt(Date.yesterday)).count
     today
-
-
 
 .full-screen-table-wrapper
   %table.table.table-striped.table-bordered
@@ -21,7 +18,7 @@
       %th
         Errors
     %tbody
-      - @b_params.each do |b_param|
+      - @b_params.includes(:creator).each do |b_param|
         %tr
           %td
             %a.convertTime.preciseTime{ href: admin_failed_bike_url(b_param.id) }
@@ -30,9 +27,12 @@
             = b_param.creator.email if b_param.creator
           %td
             - if b_param.bike_errors.present?
-              = b_param.bike_errors.each_key { |f| f.to_s.humanize}
+              = b_param.bike_errors.each { |f| f.to_s.humanize}
             - if b_param.errors.present?
               = b_param.errors.each_key { |f| f.to_s.humanize}
             / - if b_param.params.creation_organization_id && b_param.params.creation_organization_id
             /   - organization = Organization.find(b_param.params.creation_organization_id)
             /   = organization.name
+
+.paginate-container
+  = paginate @b_params

--- a/app/views/admin/failed_bikes/index.html.haml
+++ b/app/views/admin/failed_bikes/index.html.haml
@@ -2,7 +2,7 @@
   Manage Failed Bikes
 
 %h4
-  = @b_params.count
+  = number_with_delimiter(@b_params_total_count, delimiter: ',')
   failed bikes,
   %em
     = @b_params.where(BParam.arel_table[:created_at].gt(Date.yesterday)).count


### PR DESCRIPTION
Fixes #714:

- Replaces `each_key` invocation on Array with `each`
- Eliminates N+1 query by preloading associated creators
- Paginates failed bike output (otherwise the page loads extremely slowly)

**Screenshot**

<img width="2214" alt="Screen Shot 2019-05-02 at 2 19 20 PM" src="https://user-images.githubusercontent.com/4433943/57097252-4c01ae80-6ce5-11e9-8a88-e37827ccb436.png">
