### PR TITLE
Add deployment step to CircleCI config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -124,14 +124,14 @@ jobs:
           command: |
             ./cc-test-reporter sum-coverage --output - codeclimate.*.json | ./cc-test-reporter upload-coverage --debug --input -
 
-  deploy:
+  deploy_production:
     machine:
       enabled: true
     working_directory: ~/bikeindex/bike_index
     steps:
       - checkout
       - run:
-          name: Deploying master to Cloud66
+          name: Deploying to Cloud66 production
           command: |
             curl -X POST -d "" https://hooks.cloud66.com/stacks/redeploy/${CLOUD66_REDEPLOYMENT_PATH}
 
@@ -144,7 +144,7 @@ workflows:
       - upload-coverage:
           requires:
             - build
-      - deploy:
+      - deploy_production:
           requires:
             - build
           filters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -125,6 +125,9 @@ jobs:
             ./cc-test-reporter sum-coverage --output - codeclimate.*.json | ./cc-test-reporter upload-coverage --debug --input -
 
   deploy:
+    machine:
+      enabled: true
+    working_directory: ~/bikeindex/bike_index
     steps:
       - checkout
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -85,7 +85,7 @@ jobs:
           name: "eslint"
           command: "yarn lint"
       - run:
-          name: "Jest: Install junit coverage" 
+          name: "Jest: Install junit coverage"
           command: yarn add --dev jest-junit
       - run:
           name: "Jest: Tests"
@@ -124,6 +124,12 @@ jobs:
           command: |
             ./cc-test-reporter sum-coverage --output - codeclimate.*.json | ./cc-test-reporter upload-coverage --debug --input -
 
+  deployment:
+    production:
+      branch: master
+      commands:
+        - curl -X POST -d "" https://hooks.cloud66.com/stacks/redeploy/${CLOUD66_REDEPLOYMENT_PATH}
+
 workflows:
   version: 2
 
@@ -133,3 +139,4 @@ workflows:
       - upload-coverage:
           requires:
             - build
+      - deployment

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -124,13 +124,13 @@ jobs:
           command: |
             ./cc-test-reporter sum-coverage --output - codeclimate.*.json | ./cc-test-reporter upload-coverage --debug --input -
 
-  deployment:
-    production:
-      branch: master
-      steps:
-        - run:
-            name: Deploying
-            command: curl -X POST -d "" https://hooks.cloud66.com/stacks/redeploy/${CLOUD66_REDEPLOYMENT_PATH}
+  deploy:
+    steps:
+      - checkout
+      - run:
+          name: Deploying master to Cloud66
+          command: |
+            curl -X POST -d "" https://hooks.cloud66.com/stacks/redeploy/${CLOUD66_REDEPLOYMENT_PATH}
 
 workflows:
   version: 2
@@ -141,4 +141,9 @@ workflows:
       - upload-coverage:
           requires:
             - build
-      - deployment
+      - deploy:
+          requires:
+            - build
+          filters:
+            branches:
+              only: master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -127,8 +127,10 @@ jobs:
   deployment:
     production:
       branch: master
-      commands:
-        - curl -X POST -d "" https://hooks.cloud66.com/stacks/redeploy/${CLOUD66_REDEPLOYMENT_PATH}
+      steps:
+        - run:
+            name: Deploying
+            command: curl -X POST -d "" https://hooks.cloud66.com/stacks/redeploy/${CLOUD66_REDEPLOYMENT_PATH}
 
 workflows:
   version: 2

--- a/README.markdown
+++ b/README.markdown
@@ -1,14 +1,4 @@
-<p align="center">
-![BIKE INDEX][bike-index-logo]
-</p>
-
-[Bike Index][bike-index] 🚲
-===========================
-
-![Cloud66 Deployment Status][cloud66-badge]
-[![CircleCI][circleci-badge]][circleci]
-[![Test Coverage][codeclimate-badge]][codeclimate]
-[![View performance data on Skylight][skylight-badge]][skylight]
+# <p align="center">![BIKE INDEX][bike-index-logo]</p> [Bike Index][bike-index] 🚲 ![Cloud66 Deployment Status][cloud66-badge] [![CircleCI][circleci-badge]][circleci] [![Test Coverage][codeclimate-badge]][codeclimate] [![View performance data on Skylight][skylight-badge]][skylight]
 
 [bike-index-logo]: https://github.com/bikeindex/bike_index/blob/master/bike_index.png?raw=true
 [circleci]: https://circleci.com/gh/bikeindex/bike_index/tree/master

--- a/README.markdown
+++ b/README.markdown
@@ -1,6 +1,20 @@
-# ![BIKE INDEX](https://github.com/bikeindex/bike_index/blob/master/bike_index.png?raw=true)  [Bike Index](https://www.bikeindex.org) 🚲 [![CircleCI](https://circleci.com/gh/bikeindex/bike_index/tree/master.svg?style=svg)](https://circleci.com/gh/bikeindex/bike_index/tree/master) [![Test Coverage](https://codeclimate.com/github/bikeindex/bike_index/badges/coverage.svg)](https://codeclimate.com/github/bikeindex/bike_index) [![View performance data on Skylight](https://badges.skylight.io/status/j93iQ4K2pxCP.svg)](https://oss.skylight.io/app/applications/j93iQ4K2pxCP)
+![BIKE INDEX][bike-index-logo] [Bike Index][bike-index] 🚲
+==========================================================
 
-![Cloud66 Deployment Status](https://app.cloud66.com/stacks/badge/ff54cf1d55d7eb91ef09c90f125ae4f1.svg)
+[![CircleCI][circleci-badge]][circleci]
+[![Test Coverage][codeclimate-badge]][codeclimate]
+[![View performance data on Skylight][skylight-badge]][skylight]
+![Cloud66 Deployment Status][cloud66-badge]
+
+[bike-index-logo]: https://github.com/bikeindex/bike_index/blob/master/bike_index.png?raw=true
+[circleci]: https://circleci.com/gh/bikeindex/bike_index/tree/master
+[circleci-badge]: https://circleci.com/gh/bikeindex/bike_index/tree/master.svg?style=svg
+[codeclimate]: https://codeclimate.com/github/bikeindex/bike_index
+[codeclimate-badge]: https://codeclimate.com/github/bikeindex/bike_index/badges/coverage.svg
+[skylight]: https://oss.skylight.io/app/applications/j93iQ4K2pxCP
+[skylight-badge]: https://badges.skylight.io/status/j93iQ4K2pxCP.svg
+[bike-index]: https://www.bikeindex.org
+[cloud66-badge]: https://app.cloud66.com/stacks/badge/ff54cf1d55d7eb91ef09c90f125ae4f1.svg
 
 Bike registration that works: online, powerful, free.
 

--- a/README.markdown
+++ b/README.markdown
@@ -1,5 +1,9 @@
-![BIKE INDEX][bike-index-logo] [Bike Index][bike-index] 🚲
-==========================================================
+<p align="center">
+![BIKE INDEX][bike-index-logo]
+</p>
+
+[Bike Index][bike-index] 🚲
+===========================
 
 ![Cloud66 Deployment Status][cloud66-badge]
 [![CircleCI][circleci-badge]][circleci]

--- a/README.markdown
+++ b/README.markdown
@@ -1,6 +1,6 @@
 # ![BIKE INDEX](https://github.com/bikeindex/bike_index/blob/master/bike_index.png?raw=true)  [Bike Index](https://www.bikeindex.org) 🚲 [![CircleCI](https://circleci.com/gh/bikeindex/bike_index/tree/master.svg?style=svg)](https://circleci.com/gh/bikeindex/bike_index/tree/master) [![Test Coverage](https://codeclimate.com/github/bikeindex/bike_index/badges/coverage.svg)](https://codeclimate.com/github/bikeindex/bike_index) [![View performance data on Skylight](https://badges.skylight.io/status/j93iQ4K2pxCP.svg)](https://oss.skylight.io/app/applications/j93iQ4K2pxCP)
 
-
+![Cloud66 Deployment Status](https://app.cloud66.com/stacks/badge/ff54cf1d55d7eb91ef09c90f125ae4f1.svg)
 
 Bike registration that works: online, powerful, free.
 

--- a/README.markdown
+++ b/README.markdown
@@ -1,10 +1,10 @@
 ![BIKE INDEX][bike-index-logo] [Bike Index][bike-index] 🚲
 ==========================================================
 
+![Cloud66 Deployment Status][cloud66-badge]
 [![CircleCI][circleci-badge]][circleci]
 [![Test Coverage][codeclimate-badge]][codeclimate]
 [![View performance data on Skylight][skylight-badge]][skylight]
-![Cloud66 Deployment Status][cloud66-badge]
 
 [bike-index-logo]: https://github.com/bikeindex/bike_index/blob/master/bike_index.png?raw=true
 [circleci]: https://circleci.com/gh/bikeindex/bike_index/tree/master


### PR DESCRIPTION
Integrates [CI with Cloud 66 deployments](https://help.cloud66.com/node/integrations/integration-with-circle-ci.html)

- Adds a deployment step to the CircleCI config
- Adds the deployment status to the README

TODO
- Requires adding a `CLOUD66_REDEPLOYMENT_PATH` env var on CircleCI