### PR TITLE
Define bike upsert behavior for pre-existing but claimed bikes

### DIFF
--- a/spec/requests/api/v3/bikes_request_spec.rb
+++ b/spec/requests/api/v3/bikes_request_spec.rb
@@ -148,51 +148,51 @@ describe "Bikes API V3" do
           expect(bike2["rear_tire_narrow"]).to eq(true)
           expect(bike2["frame_material"]).to eq("Steel")
         end
+      end
 
-        context "if the matching bike is unclaimed" do
-          it "updates if the submitting org is the creation org" do
-            bike = FactoryBot.create(:creation_organization_bike)
-            FactoryBot.create(:ownership, creator: bike.creator, bike: bike)
-            FactoryBot.create(:existing_membership, user: user, organization: bike.creation_organization)
+      context "if the matching bike is unclaimed" do
+        it "updates if the submitting org is the creation org" do
+          bike = FactoryBot.create(:creation_organization_bike)
+          FactoryBot.create(:ownership, creator: bike.creator, bike: bike)
+          FactoryBot.create(:existing_membership, user: user, organization: bike.creation_organization)
 
-            bike_attrs = {
-              serial: bike.serial,
-              manufacturer: bike.manufacturer.name,
-              color: color.name,
-              year: bike.year,
-              owner_email: bike.owner_email,
-            }
-            post "/api/v3/bikes?access_token=#{token.token}",
-                 bike_attrs.to_json,
-                 json_headers
+          bike_attrs = {
+            serial: bike.serial,
+            manufacturer: bike.manufacturer.name,
+            color: color.name,
+            year: bike.year,
+            owner_email: bike.owner_email,
+          }
+          post "/api/v3/bikes?access_token=#{token.token}",
+               bike_attrs.to_json,
+               json_headers
 
-            returned_bike = json_result["bike"]
-            expect(response.status).to eq(302)
-            expect(response.status_message).to eq("Found")
-            expect(returned_bike["id"]).to eq(bike.id)
-          end
+          returned_bike = json_result["bike"]
+          expect(response.status).to eq(302)
+          expect(response.status_message).to eq("Found")
+          expect(returned_bike["id"]).to eq(bike.id)
+        end
 
-          it "creates a new record if the submitting org isn't the creation org" do
-            bike = FactoryBot.create(:creation_organization_bike)
-            FactoryBot.create(:ownership, creator: bike.creator, bike: bike)
-            FactoryBot.create(:existing_membership, user: user)
+        it "creates a new record if the submitting org isn't the creation org" do
+          bike = FactoryBot.create(:creation_organization_bike)
+          FactoryBot.create(:ownership, creator: bike.creator, bike: bike)
+          FactoryBot.create(:existing_membership, user: user)
 
-            bike_attrs = {
-              serial: bike.serial,
-              manufacturer: bike.manufacturer.name,
-              color: color.name,
-              year: bike.year,
-              owner_email: bike.owner_email,
-            }
-            post "/api/v3/bikes?access_token=#{token.token}",
-                 bike_attrs.to_json,
-                 json_headers
+          bike_attrs = {
+            serial: bike.serial,
+            manufacturer: bike.manufacturer.name,
+            color: color.name,
+            year: bike.year,
+            owner_email: bike.owner_email,
+          }
+          post "/api/v3/bikes?access_token=#{token.token}",
+               bike_attrs.to_json,
+               json_headers
 
-            returned_bike = json_result["bike"]
-            expect(response.status).to eq(201)
-            expect(response.status_message).to eq("Created")
-            expect(returned_bike["id"]).to_not eq(bike.id)
-          end
+          returned_bike = json_result["bike"]
+          expect(response.status).to eq(201)
+          expect(response.status_message).to eq("Created")
+          expect(returned_bike["id"]).to_not eq(bike.id)
         end
       end
 

--- a/spec/requests/api/v3/bikes_request_spec.rb
+++ b/spec/requests/api/v3/bikes_request_spec.rb
@@ -252,6 +252,30 @@ describe "Bikes API V3" do
       end
     end
 
+    context "given an update on a claimed bike from its creation organization" do
+      it "creates a new bike even if a match is found" do
+        bike = FactoryBot.create(:creation_organization_bike)
+        FactoryBot.create(:ownership_claimed, creator: bike.creator, bike: bike)
+        FactoryBot.create(:existing_membership, user: user, organization: bike.creation_organization)
+
+        bike_attrs = {
+          serial: bike.serial,
+          manufacturer: bike.manufacturer.name,
+          color: color.name,
+          year: bike.year,
+          owner_email: bike.owner_email,
+        }
+        post "/api/v3/bikes?access_token=#{token.token}",
+             bike_attrs.to_json,
+             json_headers
+
+        returned_bike = json_result["bike"]
+        expect(response.status).to eq(201)
+        expect(response.status_message).to eq("Created")
+        expect(returned_bike["id"]).to_not eq(bike.id)
+      end
+    end
+
     it "creates a non example bike, with components" do
       manufacturer = FactoryBot.create(:manufacturer)
       FactoryBot.create(:ctype, name: "wheel")

--- a/spec/requests/api/v3/bikes_request_spec.rb
+++ b/spec/requests/api/v3/bikes_request_spec.rb
@@ -292,7 +292,7 @@ describe "Bikes API V3" do
              json_headers
 
         returned_bike = json_result["bike"]
-        expect(response.status).to eq(301)
+        expect(response.status).to eq(302)
         expect(response.status_message).to eq("Found")
         expect(returned_bike["id"]).to eq(bike.id)
       end


### PR DESCRIPTION
Updates tests and implementation for the bike upsert endpoint to cover the following cases:

```
create
    given a matching pre-existing bike record
      if the POSTer is authorized to update
        does not create a new record
        updates the pre-existing record
      if the matching bike is unclaimed
        updates if the submitting org is the creation org
        creates a new record if the submitting org isn't the creation org
      if the matching bike is claimed
        creates a new bike
    given a bike with a pre-existing match by a normalized serial number
      responds with the match instead of creating a duplicate
    given a bike with a pre-existing match by a normalized email
      responds with the match instead of creating a duplicate
    given a bike with a pre-existing match by an owning user's secondary email
      responds with the match instead of creating a duplicate
    given a bike with a pre-existing match by serial
      creates a new bike if the match has a different owner

```