### PR TITLE
Add ambassador organization type, ambassador dashboard

### DIFF
--- a/app/controllers/api/v3/organizations.rb
+++ b/app/controllers/api/v3/organizations.rb
@@ -15,7 +15,7 @@ module API
           authorizations: { oauth2: [{ scope: :write_organizations }] },
           notes: <<-NOTES,
           **Requires** `write_organizations` **in the access token** you use to create the organization.
-          <hr> 
+          <hr>
           **Location:** You may optionally include `locations` for the organization.
 
           <hr>
@@ -25,7 +25,7 @@ module API
         params do
           requires :name, type: String, desc: "The organization name"
           requires :website, type: String, desc: "The organization website", regexp: URI::regexp(%w(http https))
-          requires :kind, type: String, desc: "The kind of organization", values: Organization.kinds
+          requires :kind, type: String, desc: "The kind of organization", values: Organization.creatable_kinds
 
           optional :locations, type: Array, desc: "The organization locations" do
             requires :name, type: String, desc: "The location's name"
@@ -40,7 +40,7 @@ module API
 
         # POST /api/v3/organizations
         post serializer: OrganizationSerializer, root: "organization" do
-          error!("Unauthorized. Cannot write organiztions", 401) if !allowed_write_organizations
+          error!("Unauthorized. Cannot write organizations", 401) if !allowed_write_organizations
 
           permitted = declared(params, include_missing: false)
           organization = Organization.new(

--- a/app/controllers/organizations_controller.rb
+++ b/app/controllers/organizations_controller.rb
@@ -27,7 +27,7 @@ class OrganizationsController < ApplicationController
   def create
     @organization = Organization.new(permitted_create_params)
     if @organization.save
-      membership = Membership.create(user_id: current_user.id, role: "admin", organization_id: @organization.id)
+      Membership.create(user_id: current_user.id, role: "admin", organization_id: @organization.id)
       notify_admins("organization_created")
       flash[:success] = "Organization Created successfully!"
       if current_user.present?
@@ -102,7 +102,7 @@ class OrganizationsController < ApplicationController
 
   def permitted_create_params
     approved_kind = params.dig(:organization, :kind)
-    approved_kind = "other" unless Organization.kinds.include?(approved_kind)
+    approved_kind = "other" unless Organization.creatable_kinds.include?(approved_kind)
     params.require(:organization)
           .permit(:name, :website)
           .merge(auto_user_id: current_user.id, kind: approved_kind)

--- a/app/controllers/organized/ambassadors_controller.rb
+++ b/app/controllers/organized/ambassadors_controller.rb
@@ -1,0 +1,8 @@
+module Organized
+  class AmbassadorsController < Organized::BaseController
+    def index
+      @ambassadors = current_organization.users
+      @tasks = []
+    end
+  end
+end

--- a/app/controllers/organized/base_controller.rb
+++ b/app/controllers/organized/base_controller.rb
@@ -4,6 +4,14 @@ module Organized
     before_filter :ensure_member!
     layout "application_revised"
 
+    def index
+      if current_organization.ambassador?
+        redirect_to organization_ambassadors_path
+      else
+        redirect_to organization_bikes_path
+      end
+    end
+
     def ensure_member!
       return true if current_user && current_user.member_of?(current_organization)
       set_passive_organization(nil) # remove the active organization, because it failed so don't show it anymore

--- a/app/models/membership.rb
+++ b/app/models/membership.rb
@@ -12,6 +12,8 @@ class Membership < ActiveRecord::Base
 
   after_commit :update_relationships
 
+  scope :ambassador_organizations, -> { where(organization: Organization.ambassador).order(:created_at) }
+
   def self.membership_types
     MEMBERSHIP_TYPES
   end

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -9,6 +9,7 @@ class Organization < ActiveRecord::Base
     software: 5,
     property_management: 6,
     other: 7,
+    ambassador: 8,
   }.freeze
 
   acts_as_paranoid
@@ -81,6 +82,11 @@ class Organization < ActiveRecord::Base
     matching_slugs = PaidFeature.matching_slugs(slugs)
     return nil unless matching_slugs.present?
     where("paid_feature_slugs ?& array[:keys]", keys: matching_slugs)
+  end
+
+  # Organization kinds creatable by non-superadmins
+  def self.creatable_kinds
+    kinds.reject { |kind| kind == "ambassador" }
   end
 
   def to_param

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -37,6 +37,7 @@ class User < ActiveRecord::Base
 
   scope :confirmed, -> { where(confirmed: true) }
   scope :unconfirmed, -> { where(confirmed: false) }
+  scope :ambassadors, -> { where(id: Membership.ambassador_organizations.select(:user_id)).order(created_at: :asc) }
 
   validates_uniqueness_of :username, case_sensitive: false
 
@@ -120,6 +121,10 @@ class User < ActiveRecord::Base
   def superuser?; superuser end
 
   def developer?; developer end
+
+  def ambassador?
+    memberships.ambassador_organizations.any?
+  end
 
   def to_param; username end
 

--- a/app/views/bikes/_organized_access_panel.html.haml
+++ b/app/views/bikes/_organized_access_panel.html.haml
@@ -35,6 +35,16 @@
               %em
                 so you can
               = link_to "Edit it", edit_bike_path(@bike), class: "btn btn-success btn-sm"
+        - elsif current_user.ambassador?
+          .col-xs-12.mb-2
+            .text-right.less-strong
+              %em
+                %span.hidden-md-down
+                  This #{@bike.type} is not claimed yet. As a Bike Index ambassador,
+              %em
+                you can edit it to mark it as returned:
+              = link_to "EDIT", edit_bike_path(@bike), class: "btn btn-success btn-sm"
+
         .mb-2{ class: display_unstolen_notification_form ? "col-md-7" : "col-sm-12" }
           %ul.attr-list{ class: display_unstolen_notification_form ? "" : "split-sm" }
             - if passive_organization.paid_for?("bike_codes") # Always display stickers if org has paid for them

--- a/app/views/bikes/edit_stolen.html.haml
+++ b/app/views/bikes/edit_stolen.html.haml
@@ -102,7 +102,7 @@
   - modal_title = "We're so glad you got your #{@bike.type} back!"
   - alert_body = capture_haml do
     %p
-      Please tell us how you got your #{@bike.type} back, we really care! 
+      Please tell us how you got your #{@bike.type} back, we really care!
     %p
       It's how we get better at recovering bikes.
   - modal_body = capture_haml do
@@ -130,7 +130,7 @@
             .col-xs-6.col-xs-pull-6
               %button.btn.btn-secondary{ 'data-dismiss' => 'modal', type: 'button' }
                 Nevermind
-              
+
 
 - else
   - modal_title = 'Oh no!'

--- a/app/views/landing_pages/ambassadors_current.haml
+++ b/app/views/landing_pages/ambassadors_current.haml
@@ -13,6 +13,7 @@
     .ribbon
       .container
         .noribbon
+  -# TODO: Un-hardcode this list
   .container.ambassadors-list
     // Right now, this looks better with justify-content: center - but space-around looks better depending on the item count.
     .row

--- a/app/views/layouts/application_revised.html.haml
+++ b/app/views/layouts/application_revised.html.haml
@@ -92,7 +92,7 @@
                   - memberships.each do |membership|
                     - organization = membership.organization
                     %li
-                      %a.nav-link{ href: organization_bikes_path(organization_id: organization.to_param) }
+                      %a.nav-link{ href: organization_root_path(organization_id: organization.to_param) }
                         View #{organization.name}
             %li.divider-nav-item
             - if current_user_or_unconfirmed_user.superuser?

--- a/app/views/organizations/_new_form.html.haml
+++ b/app/views/organizations/_new_form.html.haml
@@ -46,7 +46,7 @@
             %label.org-form-label
               Organization kind
             .col-sm-4
-              - Organization.kinds.each do |kind|
+              - Organization.creatable_kinds.each do |kind|
                 .radio
                   %label
                     = f.radio_button :kind, kind

--- a/app/views/organized/ambassadors/index.html.haml
+++ b/app/views/organized/ambassadors/index.html.haml
@@ -1,0 +1,32 @@
+%h1 Ambassadors
+
+%p
+  = link_to "Search for Stolen Bikes", bikes_path, class: "menu-item"
+
+%h2 Leaderboard
+
+%table.table.table-striped.table-hover.table-bordered.table-sm.without-exterior-border
+  %thead.small-header
+    %tr
+      %th Name
+      %th Email
+      %th Progress
+  %tbody
+    - @ambassadors.each do |ambassador|
+      %tr
+        %td= ambassador.name
+        %td= ambassador.email
+        %td=# AmbassadorTask.completion_progress(ambassador)
+
+%h2 Tasks
+
+%table.table.table-striped.table-hover.table-bordered.table-sm.without-exterior-border
+  %thead.small-header
+    %tr
+      %th Description
+      %th Completed
+  %tbody
+    - @tasks.each do |task|
+      %tr
+        %td= task.description
+        %td= task.completed?

--- a/app/views/shared/_organized_skeleton.html.haml
+++ b/app/views/shared/_organized_skeleton.html.haml
@@ -9,58 +9,62 @@
           = current_organization.name
 
     %ul.organized-mainmenu
-      %li
-        - on_bikes_path = controller_name == "bikes" && action_name == "index" # Because we want to ignore queries and stuff
-        = link_to "#{current_organization.short_name} Bikes", organization_bikes_path(organization_id: current_organization.to_param), match_controller: true, class: "menu-item #{on_bikes_path ? 'active' : ''}"
-      %li
-        = active_link "Add a bike", new_organization_bike_path(current_organization), class: "menu-item"
-      %li
-        - if current_organization.paid_for?("show_partial_registrations")
-          = active_link "Incomplete registrations", incompletes_organization_bikes_path(current_organization), class: "menu-item"
-        - else
-          %span.disabled-menu-item.menu-item
-            Incomplete registrations
-      - if current_organization.show_multi_serial?
+      - if current_organization.ambassador?
         %li
-          = active_link "Multi serial search", multi_serial_search_organization_bikes_path(current_organization), class: "menu-item"
-      - if current_organization.paid_for?("show_recoveries") # I don't want to show a grayed link for this
-        %li
-          = active_link "Recoveries", recoveries_organization_bikes_path(current_organization), class: "menu-item"
-
-      - if current_organization.show_bulk_import?
-        %li
-          - bulk_link_name = current_organization.ascend_imports? ? "Ascend Imports" : "Bulk Imports"
-          = active_link bulk_link_name, organization_bulk_imports_path(organization_id: current_organization.to_param), match_controller: true, class: "menu-item"
-      %li.divider-above
-        - if current_organization.paid_for?("bike_codes")
-          = active_link "Registration stickers", organization_stickers_path(organization_id: current_organization.to_param), match_controller: true, class: "menu-item"
-        - else
-          %span.disabled-menu-item.menu-item
-            Registration stickers
-      - if current_organization.paid_for?("csv_exports")
-        %li
-          = active_link "Exports", organization_exports_path(organization_id: current_organization.to_param), match_controller: true, class: "menu-item"
-      - if current_organization.message_kinds.any?
-        - current_organization.message_kinds.each_with_index do |message_kind, index|
-          %li{ class: index == 0 ? "divider-above" : "" }
-            / (params[:kind] == message_kind ? "active" : "")
-            - if message_kind == "geolocated_messages"
-              - link_title = "GeoMessaging"
-            - else
-              - link_title = message_kind.gsub("_messages", "").titleize
-            = active_link link_title, organization_messages_path(organization_id: current_organization.to_param, kind: message_kind), class: "menu-item"
-
+          = active_link "Ambassadors", organization_ambassadors_path, class: "menu-item"
       - else
-        %li.divider-above
-          %span.disabled-menu-item.menu-item
-            GeoMessaging
-      - if current_user.admin_of?(current_organization) || current_user.superuser?
-        %li.divider-above
-          = active_link "Users", organization_users_path(organization_id: current_organization.to_param), match_controller: true, class: "menu-item"
         %li
-          = active_link "#{current_organization.short_name} profile", organization_manage_index_path(organization_id: current_organization.to_param), class: "menu-item"
+          - on_bikes_path = controller_name == "bikes" && action_name == "index" # Because we want to ignore queries and stuff
+          = link_to "Bikes", organization_bikes_path(organization_id: current_organization.to_param), match_controller: true, class: "menu-item #{on_bikes_path ? 'active' : ''}"
         %li
-          = active_link "#{current_organization.short_name} locations", locations_organization_manage_index_path(organization_id: current_organization.to_param), class: "menu-item"
+          = active_link "Add a bike", new_organization_bike_path(current_organization), class: "menu-item"
+        %li
+          - if current_organization.paid_for?("show_partial_registrations")
+            = active_link "Incomplete registrations", incompletes_organization_bikes_path(current_organization), class: "menu-item"
+          - else
+            %span.disabled-menu-item.menu-item
+              Incomplete registrations
+        - if current_organization.show_multi_serial?
+          %li
+            = active_link "Multi serial search", multi_serial_search_organization_bikes_path(current_organization), class: "menu-item"
+        - if current_organization.paid_for?("show_recoveries") # I don't want to show a grayed link for this
+          %li
+            = active_link "Recoveries", recoveries_organization_bikes_path(current_organization), class: "menu-item"
+
+        - if current_organization.show_bulk_import?
+          %li
+            - bulk_link_name = current_organization.ascend_imports? ? "Ascend Imports" : "Bulk Imports"
+            = active_link bulk_link_name, organization_bulk_imports_path(organization_id: current_organization.to_param), match_controller: true, class: "menu-item"
+        %li.divider-above
+          - if current_organization.paid_for?("bike_codes")
+            = active_link "Registration stickers", organization_stickers_path(organization_id: current_organization.to_param), match_controller: true, class: "menu-item"
+          - else
+            %span.disabled-menu-item.menu-item
+              Registration stickers
+        - if current_organization.paid_for?("csv_exports")
+          %li
+            = active_link "Exports", organization_exports_path(organization_id: current_organization.to_param), match_controller: true, class: "menu-item"
+        - if current_organization.message_kinds.any?
+          - current_organization.message_kinds.each_with_index do |message_kind, index|
+            %li{ class: index == 0 ? "divider-above" : "" }
+              / (params[:kind] == message_kind ? "active" : "")
+              - if message_kind == "geolocated_messages"
+                - link_title = "GeoMessaging"
+              - else
+                - link_title = message_kind.gsub("_messages", "").titleize
+              = active_link link_title, organization_messages_path(organization_id: current_organization.to_param, kind: message_kind), class: "menu-item"
+
+        - else
+          %li.divider-above
+            %span.disabled-menu-item.menu-item
+              GeoMessaging
+        - if current_user.admin_of?(current_organization) || current_user.superuser?
+          %li.divider-above
+            = active_link "Users", organization_users_path(organization_id: current_organization.to_param), match_controller: true, class: "menu-item"
+          %li
+            = active_link "#{current_organization.short_name} profile", organization_manage_index_path(organization_id: current_organization.to_param), class: "menu-item"
+          %li
+            = active_link "#{current_organization.short_name} locations", locations_organization_manage_index_path(organization_id: current_organization.to_param), class: "menu-item"
 
 .organized-wrap
   - orgcontainer = "container-fluid" if controller_name == "bikes" && action_name == "index" || controller_name == "messages"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -267,7 +267,7 @@ Bikeindex::Application.routes.draw do
   # prepends a :organization_id/ to every nested URL.
   # Down here so that it doesn't override any other routes
   resources :organizations, only: [], path: "o", module: "organized" do
-    get "/", to: "bikes#index", as: :root
+    get "/", to: "base#index", as: :root
     get "landing", to: "manage#landing", as: :landing
     resources :bikes, only: %i[index new show] do
       collection do
@@ -280,6 +280,7 @@ Bikeindex::Application.routes.draw do
     resources :bulk_imports, only: %i[index show new create]
     resources :messages, only: %i[index show create]
     resources :stickers, only: %i[index show edit update]
+    resources :ambassadors, only: %i[index]
 
     # Organized Admin resources (below here controllers should inherit Organized::AdminController)
     resources :manage, only: %i[index update destroy] do

--- a/spec/controllers/organizations_controller_spec.rb
+++ b/spec/controllers/organizations_controller_spec.rb
@@ -77,6 +77,16 @@ describe OrganizationsController do
       expect(organization.website).not_to eq("<script>alert(document.cookie)</script>")
       expect(organization.kind).to eq "other"
     end
+
+    it "prevents creating privileged organization kinds" do
+      user = FactoryBot.create(:user_confirmed)
+      set_current_user(user)
+
+      post :create, organization: org_attrs.merge(kind: "ambassador")
+
+      expect(Organization.count).to eq(1)
+      expect(Organization.last.kind).to eq("other")
+    end
   end
 
   describe "legacy embeds" do

--- a/spec/controllers/organized/ambassadors_controller_spec.rb
+++ b/spec/controllers/organized/ambassadors_controller_spec.rb
@@ -1,0 +1,37 @@
+require "spec_helper"
+
+describe Organized::AmbassadorsController, type: :controller do
+  describe "#index" do
+    context "given an unauthenticated user" do
+      it "redirects to the user homepage" do
+        organization = FactoryBot.create(:organization)
+        get :index, organization_id: organization.to_param
+        expect(response).to redirect_to(user_home_url)
+      end
+    end
+
+    context "given an authenticated ambassador" do
+      include_context :logged_in_as_ambassador
+
+      it "renders the ambassador dashboard" do
+        ambassador_org = user.organizations.first
+
+        get :index, organization_id: ambassador_org.to_param
+
+        expect(response).to be_ok
+        expect(assigns(:ambassadors).count).to eq(1)
+        expect(response).to render_template(:index)
+      end
+    end
+
+    context "given an authenticated non-ambassador" do
+      include_context :logged_in_as_user
+
+      it "redirects the user's homepage" do
+        organization = FactoryBot.create(:organization)
+        get :index, organization_id: organization.to_param
+        expect(response).to redirect_to(user_home_url)
+      end
+    end
+  end
+end

--- a/spec/controllers/organized/base_controller_spec.rb
+++ b/spec/controllers/organized/base_controller_spec.rb
@@ -1,0 +1,25 @@
+require "spec_helper"
+
+describe Organized::BaseController, type: :controller do
+  describe "#index" do
+    context "if not viewing an ambassador organization" do
+      include_context :logged_in_as_organization_member
+
+      it "redirects to the bikes page" do
+        organization = user.organizations.first
+        get :index, organization_id: organization.to_param
+        expect(response).to redirect_to(organization_bikes_path(organization))
+      end
+    end
+
+    context "if viewing an ambassador organization" do
+      include_context :logged_in_as_ambassador
+
+      it "redirects to the ambassador dashboard" do
+        ambassador_org = user.organizations.first
+        get :index, organization_id: ambassador_org.to_param
+        expect(response).to redirect_to(organization_ambassadors_path(ambassador_org))
+      end
+    end
+  end
+end

--- a/spec/factories/memberships.rb
+++ b/spec/factories/memberships.rb
@@ -5,5 +5,11 @@ FactoryBot.define do
     factory :existing_membership do
       user { FactoryBot.create(:user) }
     end
+
+    factory :membership_ambassador do
+      role { "member" }
+      organization { FactoryBot.create(:organization_ambassador) }
+      user { FactoryBot.create(:user) }
+    end
   end
 end

--- a/spec/factories/organizations.rb
+++ b/spec/factories/organizations.rb
@@ -13,5 +13,10 @@ FactoryBot.define do
     factory :organization_child do
       parent_organization { FactoryBot.create(:organization) }
     end
+
+    factory :organization_ambassador do
+      kind { "ambassador" }
+      sequence(:name) { |n| "Ambassador Group #{n}" }
+    end
   end
 end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -19,6 +19,11 @@ FactoryBot.define do
       factory :developer do
         developer { true }
       end
+      factory :user_ambassador do
+        after(:create) do |user, _evaluator|
+          FactoryBot.create(:membership_ambassador, user: user)
+        end
+      end
       factory :organized_user do
         # This factory should not be used directly, it's here to wrap organization
         # Use `organization_member` or `organization_admin`

--- a/spec/models/membership_spec.rb
+++ b/spec/models/membership_spec.rb
@@ -7,6 +7,15 @@ describe Membership do
     it { is_expected.to validate_presence_of(:user).with_message(/user/) }
   end
 
+  describe ".ambassador_organizations" do
+    it "returns all and only ambassador organizations" do
+      FactoryBot.create(:existing_membership)
+      ambassador_orgs = FactoryBot.create_list(:membership_ambassador, 3)
+      found_orgs = Membership.ambassador_organizations
+      expect(found_orgs).to eq(ambassador_orgs.sort_by(&:created_at))
+    end
+  end
+
   describe "admin?" do
     context "admin" do
       it "returns true" do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,6 +1,33 @@
 require "spec_helper"
 
 describe User do
+  describe ".ambassadors" do
+    context "given ambassadors and no org filter" do
+      it "returns any and only users who are ambassadors" do
+        FactoryBot.create(:user)
+        FactoryBot.create(:developer)
+        ambassadors = FactoryBot.create_list(:user_ambassador, 3)
+
+        found_ambassadors = User.ambassadors
+
+        expect(found_ambassadors).to eq(ambassadors.sort_by(&:created_at))
+      end
+    end
+
+    context "with no ambassadors" do
+      it "returns an empty array" do
+        expect(User.ambassadors).to eq([])
+      end
+    end
+
+    context "with no matching users" do
+      it "returns an empty array" do
+        FactoryBot.create(:developer)
+        expect(User.ambassadors).to eq([])
+      end
+    end
+  end
+
   describe "validations" do
     it { is_expected.to have_many :user_emails }
     it { is_expected.to have_many :payments }
@@ -563,6 +590,21 @@ describe User do
           expect(user.member_of?(nil)).to be_falsey
         end
       end
+    end
+  end
+
+  describe "ambassador?" do
+    it "returns true if the user has any ambassadorship" do
+      user = FactoryBot.create(:user_ambassador)
+      user.memberships << FactoryBot.create(:membership, user: user)
+      user.save
+
+      expect(user).to be_ambassador
+    end
+
+    it "returns false if the user has no ambassadorships" do
+      user = FactoryBot.create(:organization_member)
+      expect(user).to_not be_ambassador
     end
   end
 

--- a/spec/requests/api/v3/organizations_request_spec.rb
+++ b/spec/requests/api/v3/organizations_request_spec.rb
@@ -63,7 +63,7 @@ describe "Organization API V3" do
           ENV["ALLOWED_WRITE_ORGANIZATIONS"] = "some-other-uid"
           post url, organization_json, json_headers
           expect_status 401
-          expect_json(error: "Unauthorized. Cannot write organiztions")
+          expect_json(error: "Unauthorized. Cannot write organizations")
         end
       end
     end
@@ -82,6 +82,13 @@ describe "Organization API V3" do
 
       it "requires a valid kind" do
         org_json = organization_attrs.merge(kind: "The best kind ever").to_json
+        post url, org_json, json_headers
+        expect_status 400
+        expect_json(error: "kind does not have a valid value")
+      end
+
+      it "forbids creating non-privileged organization kinds" do
+        org_json = organization_attrs.merge(kind: "ambassador").to_json
         post url, org_json, json_headers
         expect_status 400
         expect_json(error: "kind does not have a valid value")

--- a/spec/routing/organizations_rounting_spec.rb
+++ b/spec/routing/organizations_rounting_spec.rb
@@ -1,6 +1,6 @@
 require "spec_helper"
 
-describe "organizations routing" do
+describe "organizations routing", type: :routing do
   describe "landing_pages" do
     it "routes root to " do
       expect(LandingPages::ORGANIZATIONS).to include("university")
@@ -13,9 +13,9 @@ describe "organizations routing" do
   end
   context "organized module" do # At least for now...
     describe "root" do
-      it "roots to bikes" do
+      it "routes to base index action" do
         expect(get: "/o/university").to route_to(
-          controller: "organized/bikes",
+          controller: "organized/base",
           action: "index",
           organization_id: "university",
         )

--- a/spec/support/request_spec_helpers.rb
+++ b/spec/support/request_spec_helpers.rb
@@ -24,6 +24,11 @@ shared_context :logged_in_as_organization_member do
   end
 end
 
+shared_context :logged_in_as_ambassador do
+  let(:user) { FactoryBot.create(:user_ambassador) }
+  before { set_current_user(user) }
+end
+
 shared_context :test_csrf_token do
   before { ActionController::Base.allow_forgery_protection = true }
   after { ActionController::Base.allow_forgery_protection = false }


### PR DESCRIPTION
- Introduces an "ambassador" organization type
- Adds an ambassador dashboard endpoint in the `organized` namespace
- Directs user to the either the ambassador dashboard or the bikes page based on whether the current org is an ambassador org
- Introduces `User.ambassadors` to list all ambassadors, optionally filtering by organization
- Introduces `User#ambassador?` 
- Allows ambassador users to edit bikes (and mark them as recovered)


<img width="497" alt="Screen Shot 2019-05-14 at 9 42 58 AM" src="https://user-images.githubusercontent.com/4433943/57702839-e25e9a00-762c-11e9-99cc-72afc0c52f07.png">


<img width="1268" alt="Screen Shot 2019-05-14 at 9 42 43 AM" src="https://user-images.githubusercontent.com/4433943/57702781-c955e900-762c-11e9-9dc5-8e4ba35e8213.png">


<img width="1269" alt="Screen Shot 2019-05-14 at 9 43 29 AM" src="https://user-images.githubusercontent.com/4433943/57702791-cce97000-762c-11e9-962f-a1bbb2616887.png">

<img width="1156" alt="Screen Shot 2019-05-14 at 11 37 29 AM" src="https://user-images.githubusercontent.com/4433943/57711420-acc1ad00-763c-11e9-88ae-80aec753e9f1.png">
