### PR TITLE
fix reply_to in stolen_notification emails

### DIFF
--- a/app/mailers/customer_mailer.rb
+++ b/app/mailers/customer_mailer.rb
@@ -49,7 +49,9 @@ class CustomerMailer < ActionMailer::Base
 
   def stolen_notification_email(stolen_notification)
     @stolen_notification = stolen_notification
-    mail(to: [@stolen_notification.receiver_email, "lily@bikeindex.org", "bryan@bikeindex.org"],
+    mail(to: @stolen_notification.receiver_email,
+         cc: ["lily@bikeindex.org", "bryan@bikeindex.org"],
+         reply_to: @stolen_notification.sender.email,
          from: "bryan@bikeindex.org", subject: @stolen_notification.display_subject)
     dates = stolen_notification.send_dates_parsed + [Time.now.to_i]
     stolen_notification.update_attribute :send_dates, dates

--- a/app/mailers/customer_mailer.rb
+++ b/app/mailers/customer_mailer.rb
@@ -50,7 +50,7 @@ class CustomerMailer < ActionMailer::Base
   def stolen_notification_email(stolen_notification)
     @stolen_notification = stolen_notification
     mail(to: @stolen_notification.receiver_email,
-         cc: ["lily@bikeindex.org", "bryan@bikeindex.org"],
+         cc: ["bryan@bikeindex.org", "lily@bikeindex.org"],
          reply_to: @stolen_notification.sender.email,
          from: "bryan@bikeindex.org", subject: @stolen_notification.display_subject)
     dates = stolen_notification.send_dates_parsed + [Time.now.to_i]

--- a/spec/mailers/customer_mailer_spec.rb
+++ b/spec/mailers/customer_mailer_spec.rb
@@ -137,7 +137,8 @@ describe CustomerMailer do
   describe "stolen_notification_email" do
     let(:stolen_record) { FactoryBot.create(:stolen_record) }
     let!(:ownership) { FactoryBot.create(:ownership, bike: stolen_record.bike) }
-    let(:stolen_notification) { FactoryBot.create(:stolen_notification, message: "Test Message", reference_url: "something.com", bike: stolen_record.bike) }
+    let(:sender) { FactoryBot.create(:user, email: "party@example.com") }
+    let(:stolen_notification) { FactoryBot.create(:stolen_notification, message: "Test Message", reference_url: "something.com", bike: stolen_record.bike, sender: sender) }
     it "renders email and update sent_dates" do
       mail = CustomerMailer.stolen_notification_email(stolen_notification)
       expect(mail.subject).to eq(stolen_notification.default_subject)
@@ -145,6 +146,8 @@ describe CustomerMailer do
       expect(mail.from.first).to eq("bryan@bikeindex.org")
       expect(mail.body.encoded).to match(stolen_notification.message)
       expect(mail.body.encoded).to match(stolen_notification.reference_url)
+      expect(mail.reply_to).to eq(["party@example.com"])
+      expect(mail.cc).to eq(["bryan@bikeindex.org", "lily@bikeindex.org"])
       stolen_notification.reload
       expect(stolen_notification.send_dates).to be_present
       expect(stolen_notification.send_dates[0]).to eq(stolen_notification.updated_at.to_i)


### PR DESCRIPTION
According to this [Stack Overflow answer](https://stackoverflow.com/questions/2421234/gmail-appearing-to-ignore-reply-to), it looks like we shouldn't include the from address in the to address, or it won't do reply-to correctly in gmail.

... Also, it looks like I wasn't setting reply_to at all 😢