### PR TITLE
WIP: Update bootstrap gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,7 @@ gem "active_model_serializers", "~> 0.9.3"
 gem "aws-sdk", "~> 1.33"
 gem "bcrypt", "~> 3.1.7"
 gem "jquery-rails"
-gem "pg"
+gem "pg", "~> 0.18.4"
 
 # Speed
 gem "fast_blank", "~> 1.0"
@@ -87,7 +87,7 @@ gem "secure_headers", "~> 2.5.0"
 
 # Frontend
 gem "backbone-on-rails", "~>0.9.10.0" # Legacy js
-gem "bootstrap", "~> 4.0.0.alpha3" # Bootstrap 4 - used for revised stylesheets
+gem "bootstrap"
 gem "chartkick" # Display charts
 gem "coffee-rails"
 gem "groupdate" # Required for charts

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -285,7 +285,7 @@ GEM
       addressable (~> 2.3)
     letter_opener (1.7.0)
       launchy (~> 2.2)
-    libv8 (3.16.14.19)
+    libv8 (3.16.14.19-x86_64-darwin-18)
     listen (3.1.5)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
@@ -641,7 +641,7 @@ DEPENDENCIES
   axlsx
   backbone-on-rails (~> 0.9.10.0)
   bcrypt (~> 3.1.7)
-  bootstrap (~> 4.0.0.alpha3)
+  bootstrap
   bullet
   bundler (>= 1.8.4)
   carrierwave (~> 0.11.2)
@@ -697,7 +697,7 @@ DEPENDENCIES
   omniauth-strava
   parallel_tests
   paranoia
-  pg
+  pg (~> 0.18.4)
   pg_search
   premailer-rails
   pry-byebug

--- a/app/assets/stylesheets/revised.scss
+++ b/app/assets/stylesheets/revised.scss
@@ -33,7 +33,7 @@ $border-radius-sm: 1px;
 @import "bootstrap/mixins";
 
 // Reset and dependencies
-@import "bootstrap/normalize";
+// @import "bootstrap/normalize"; // Error: File to import not found or unreadable: bootstrap/normalize.
 @import "bootstrap/print";
 
 // Core CSS
@@ -76,7 +76,7 @@ $border-radius-sm: 1px;
 // @import "bootstrap/buttons"; // Override buttons with our own buttons
 
 // Components
-@import "bootstrap/animation";
+// @import "bootstrap/animation";  // Error: File to import not found or unreadable: bootstrap/animation.
 @import "bootstrap/dropdown";
 @import "bootstrap/button-group";
 @import "bootstrap/input-group";
@@ -94,7 +94,7 @@ $border-radius-sm: 1px;
 @import "bootstrap/progress";
 @import "bootstrap/media";
 @import "bootstrap/list-group";
-@import "bootstrap/responsive-embed";
+// @import "bootstrap/responsive-embed";  // Error: File to import not found or unreadable: bootstrap/responsive-embed.
 @import "bootstrap/close";
 
 // Components w/ JavaScript

--- a/app/views/welcome/index.html.haml
+++ b/app/views/welcome/index.html.haml
@@ -27,7 +27,13 @@
         .row
           .col-md-2.root-landing-how-icon
             = render '/landing_pages/icons/how_icon_register_svg'
-            = image_tag 'landing_pages/dashed_line.svg', class: 'root-icon-connector'
+            =# image_tag 'landing_pages/dashed_line.svg', class: 'root-icon-connector'
+            -# Error: argument `$color` of `darken($color, $amount)` must be a color
+            -#         on line 174 of ../../.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/bootstrap-4.3.1/assets/stylesheets/bootstrap/_variables.scss, in function `darken`
+            -#         from line 174 of ../../.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/bootstrap-4.3.1/assets/stylesheets/bootstrap/_variables.scss
+            -#         from line 16 of app/assets/stylesheets/revised.scss
+            -# >> $link-hover-color:                        darken($link-color, 15%) !default;
+            -#    ------------------------------------------^
           .col-md-7.root-landing-explanation
             .root-landing-explanation-wrap
               %h4 Register Your Bike


### PR DESCRIPTION
- Bumps bootstrap to the latest version
- Runs `bundle update` to resolve dependency errors
- Pins pg gem to its previously locked version to fix the startup error in 9ae5f91
- Comments out the first few blocking SCSS errors in 2a5311b (these seem to be due to changes in bootstrap's mixins)

Possibly helpful:
https://getbootstrap.com/docs/4.0/migration/
https://github.com/seyhunak/twitter-bootstrap-rails