### PR TITLE
Restrict ambassador access to non-ambassador endpoints

### DIFF
--- a/app/assets/javascripts/revised/pages/organized/ambassador_dashboard_index.coffee
+++ b/app/assets/javascripts/revised/pages/organized/ambassador_dashboard_index.coffee
@@ -14,4 +14,4 @@ class BikeIndex.OrganizedAmbassadorDashboardIndex extends BikeIndex
         data: JSON.stringify
           id: $input.data("ambassador-task-assignment-id")
           completed: $input.is(":checked")
-        error: (xhr) -> console.error(JSON.parse(xhr.responseText))
+        error: (xhr) -> console.error(xhr.responseText)

--- a/app/controllers/organized/admin_controller.rb
+++ b/app/controllers/organized/admin_controller.rb
@@ -2,5 +2,6 @@ module Organized
   class AdminController < Organized::BaseController
     before_filter :ensure_admin!
     skip_before_filter :ensure_member!
+    before_filter :ensure_not_ambassador_organization!
   end
 end

--- a/app/controllers/organized/admin_controller.rb
+++ b/app/controllers/organized/admin_controller.rb
@@ -2,6 +2,5 @@ module Organized
   class AdminController < Organized::BaseController
     before_filter :ensure_admin!
     skip_before_filter :ensure_member!
-    before_filter :ensure_not_ambassador_organization!
   end
 end

--- a/app/controllers/organized/ambassador_dashboard_controller.rb
+++ b/app/controllers/organized/ambassador_dashboard_controller.rb
@@ -1,6 +1,7 @@
 module Organized
   class AmbassadorDashboardController < Organized::BaseController
     before_filter :ensure_ambassador_or_superuser!
+    skip_before_filter :ensure_not_ambassador_organization!
 
     def index
       @ambassadors =

--- a/app/controllers/organized/ambassador_task_assignments_controller.rb
+++ b/app/controllers/organized/ambassador_task_assignments_controller.rb
@@ -1,6 +1,7 @@
 module Organized
   class AmbassadorTaskAssignmentsController < Organized::BaseController
     before_filter :ensure_ambassador_or_superuser!
+    skip_before_filter :ensure_not_ambassador_organization!
 
     def update
       ambassador_task_assignment = AmbassadorTaskAssignment.find(params[:id])

--- a/app/controllers/organized/base_controller.rb
+++ b/app/controllers/organized/base_controller.rb
@@ -1,10 +1,12 @@
 module Organized
   class BaseController < ApplicationController
+    before_filter :ensure_not_ambassador_organization!, except: :root
     before_filter :ensure_current_organization!
     before_filter :ensure_member!
+
     layout "application_revised"
 
-    def index
+    def root
       if current_organization.ambassador?
         redirect_to organization_ambassador_dashboard_index_path
       else
@@ -22,13 +24,19 @@ module Organized
     def ensure_admin!
       return true if current_user && current_user.admin_of?(current_organization)
       flash[:error] = "You have to be an organization administrator to do that!"
-      redirect_to organization_bikes_path(organization_id: current_organization.to_param) and return
+      redirect_to organization_root_path and return
     end
 
     def ensure_ambassador_or_superuser!
       return true if current_user && current_user.superuser? || current_user.ambassador?
       flash[:error] = "You have to be an ambassador to do that!"
       redirect_to user_root_url
+    end
+
+    def ensure_not_ambassador_organization!
+      return true unless current_organization&.ambassador?
+      flash[:error] = "You have to be an admin to do that!"
+      redirect_to organization_root_path
     end
 
     def ensure_current_organization!

--- a/app/controllers/organized/bulk_imports_controller.rb
+++ b/app/controllers/organized/bulk_imports_controller.rb
@@ -76,11 +76,15 @@ module Organized
 
     def ensure_access_to_bulk_import!
       return unless ensure_current_organization!
-      return false unless ensure_admin! # Need to return so we don't double render
-      return true if current_user.superuser? # ensure_admin! passes with superuser - this allow superuser to see even if org not enabled
-      return true if current_organization.show_bulk_import?
+
+      # Need to return so we don't double render
+      return false unless ensure_admin!
+
+      # ensure_admin! passes with superuser - this allow superuser to see even if org not enabled
+      return true if current_user.superuser? || current_organization.show_bulk_import?
+
       flash[:error] = "Your organization doesn't have access to that, please contact Bike Index support"
-      redirect_to organization_bikes_path(organization_id: current_organization.to_param) and return
+      redirect_to organization_root_path and return
     end
 
     def permitted_parameters

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -270,7 +270,7 @@ Bikeindex::Application.routes.draw do
   # prepends a :organization_id/ to every nested URL.
   # Down here so that it doesn't override any other routes
   resources :organizations, only: [], path: "o", module: "organized" do
-    get "/", to: "base#index", as: :root
+    get "/", to: "base#root", as: :root
     get "landing", to: "manage#landing", as: :landing
     resources :bikes, only: %i[index new show] do
       collection do

--- a/spec/controllers/organized/base_controller_spec.rb
+++ b/spec/controllers/organized/base_controller_spec.rb
@@ -1,12 +1,12 @@
 require "spec_helper"
 
 describe Organized::BaseController, type: :controller do
-  describe "#index" do
+  describe "#root" do
     context "if not viewing an ambassador organization" do
       include_context :logged_in_as_organization_member
 
       it "redirects to the bikes page" do
-        get :index, organization_id: organization.to_param
+        get :root, organization_id: organization.to_param
         expect(response).to redirect_to(organization_bikes_path)
       end
     end
@@ -15,7 +15,7 @@ describe Organized::BaseController, type: :controller do
       include_context :logged_in_as_ambassador
 
       it "redirects to the ambassador dashboard" do
-        get :index, organization_id: organization.to_param
+        get :root, organization_id: organization.to_param
         expect(response).to redirect_to(organization_ambassador_dashboard_index_path)
       end
     end

--- a/spec/controllers/organized/bikes_controller_spec.rb
+++ b/spec/controllers/organized/bikes_controller_spec.rb
@@ -1,6 +1,17 @@
 require "spec_helper"
 
 describe Organized::BikesController, type: :controller do
+  context "given an authenticated ambassador" do
+    include_context :logged_in_as_ambassador
+    it "redirects to the organization root path" do
+      expect(get(:index, organization_id: organization)).to redirect_to(organization_root_path)
+      expect(get(:recoveries, organization_id: organization)).to redirect_to(organization_root_path)
+      expect(get(:incompletes, organization_id: organization)).to redirect_to(organization_root_path)
+      expect(get(:new, organization_id: organization)).to redirect_to(organization_root_path)
+      expect(get(:multi_serial_search, organization_id: organization)).to redirect_to(organization_root_path)
+    end
+  end
+
   let(:non_organization_bike) { FactoryBot.create(:bike) }
   before do
     expect(non_organization_bike).to be_present

--- a/spec/controllers/organized/bulk_imports_controller_spec.rb
+++ b/spec/controllers/organized/bulk_imports_controller_spec.rb
@@ -1,7 +1,6 @@
 require "spec_helper"
 
 describe Organized::BulkImportsController, type: :controller do
-  let(:root_path) { organization_bikes_path(organization_id: organization.to_param) }
   let(:bulk_import) { FactoryBot.create(:bulk_import, organization: organization) }
 
   before { set_current_user(user) if user.present? }
@@ -12,7 +11,7 @@ describe Organized::BulkImportsController, type: :controller do
       let(:user) { nil }
       it "redirects" do
         get :index, organization_id: organization.to_param
-        expect(response).to redirect_to root_path
+        expect(response).to redirect_to(organization_root_path)
       end
     end
 
@@ -21,19 +20,19 @@ describe Organized::BulkImportsController, type: :controller do
       describe "index" do
         it "redirects" do
           get :index, organization_id: organization.to_param
-          expect(response).to redirect_to root_path
+          expect(response).to redirect_to(organization_root_path)
         end
       end
       describe "new" do
         it "redirects" do
           get :new, organization_id: organization.to_param
-          expect(response).to redirect_to root_path
+          expect(response).to redirect_to(organization_root_path)
         end
       end
       describe "show" do
         it "redirects" do
           get :show, id: bulk_import.id, organization_id: organization.to_param
-          expect(response).to redirect_to root_path
+          expect(response).to redirect_to(organization_root_path)
         end
       end
     end
@@ -71,19 +70,19 @@ describe Organized::BulkImportsController, type: :controller do
       describe "index" do
         it "redirects" do
           get :index, organization_id: organization.to_param
-          expect(response).to redirect_to root_path
+          expect(response).to redirect_to(organization_root_path)
         end
       end
       describe "new" do
         it "redirects" do
           get :new, organization_id: organization.to_param
-          expect(response).to redirect_to root_path
+          expect(response).to redirect_to(organization_root_path)
         end
       end
       describe "show" do
         it "redirects" do
           get :show, id: bulk_import.id, organization_id: organization.to_param
-          expect(response).to redirect_to root_path
+          expect(response).to redirect_to(organization_root_path)
         end
       end
     end

--- a/spec/controllers/organized/users_controller_spec.rb
+++ b/spec/controllers/organized/users_controller_spec.rb
@@ -6,7 +6,7 @@ describe Organized::UsersController, type: :controller do
     describe "index" do
       it "redirects" do
         get :index, organization_id: organization.to_param
-        expect(response.location).to match(organization_bikes_path(organization_id: organization.to_param))
+        expect(response).to redirect_to(organization_root_path)
         expect(flash[:error]).to be_present
       end
     end
@@ -14,7 +14,7 @@ describe Organized::UsersController, type: :controller do
     describe "new" do
       it "redirects" do
         get :new, organization_id: organization.to_param
-        expect(response.location).to match(organization_bikes_path(organization_id: organization.to_param))
+        expect(response).to redirect_to(organization_root_path)
         expect(flash[:error]).to be_present
       end
     end
@@ -37,7 +37,7 @@ describe Organized::UsersController, type: :controller do
                          id: organization_invitation.id,
                          is_invitation: true, organization_invitation: organization_invitation_params
           end.to change(OrganizationInvitation, :count).by(0)
-          expect(response.location).to match(organization_bikes_path(organization_id: organization.to_param))
+          expect(response).to redirect_to(organization_root_path)
           expect(flash[:error]).to be_present
           organization_invitation.reload
           expect(organization_invitation.membership_role).to eq "member"

--- a/spec/routing/organizations_rounting_spec.rb
+++ b/spec/routing/organizations_rounting_spec.rb
@@ -16,7 +16,7 @@ describe "organizations routing", type: :routing do
       it "routes to base index action" do
         expect(get: "/o/university").to route_to(
           controller: "organized/base",
-          action: "index",
+          action: "root",
           organization_id: "university",
         )
       end


### PR DESCRIPTION
- Adds `before_action`s prohibiting access to `organized` endpoints for ambassador organizations (exceptions for ambassador controllers and `Organized::BaseController#root`

