### PR TITLE
Extract form, add Markdown guide link to Admin AmbassadorTask

### DIFF
--- a/app/views/admin/ambassador_tasks/_form.html.haml
+++ b/app/views/admin/ambassador_tasks/_form.html.haml
@@ -1,0 +1,21 @@
+= form_for ambassador_task,
+  url: action,
+  method: method,
+  html: { class: "form" } do |f|
+
+  = f.label :title, "Title", class: "form-label"
+  = f.text_field :title, class: 'form-control'
+
+  = f.label :description, "Description", class: "form-label"
+  = f.text_area :description, class: 'form-control'
+
+  .float-right
+    [
+    = link_to "Markdown",
+      "https://www.markdownguide.org/getting-started",
+      target: "_blank"
+    permitted
+    ]
+
+  %br
+  = submit_tag submit_label, class: 'btn btn-success btn-lg'

--- a/app/views/admin/ambassador_tasks/edit.html.haml
+++ b/app/views/admin/ambassador_tasks/edit.html.haml
@@ -1,13 +1,8 @@
-%h1 Edit Ambassador Task
+.container
+  %h1 Edit Ambassador Task
 
-= form_for @ambassador_task,
-  url: admin_ambassador_task_path(@ambassador_task),
-  method: :put,
-  html: { class: "form" } do |f|
-  = f.label :title, "Title", class: "form-label"
-  = f.text_field :title, class: 'form-control'
-
-  = f.label :description, "Description", class: "form-label"
-  = f.text_field :description, class: 'form-control'
-
-  = submit_tag "Save", class: 'btn btn-success btn-lg'
+  = render "form",
+    ambassador_task: @ambassador_task,
+    action: admin_ambassador_task_path(@ambassador_task),
+    method: :put,
+    submit_label: "Save"

--- a/app/views/admin/ambassador_tasks/new.html.haml
+++ b/app/views/admin/ambassador_tasks/new.html.haml
@@ -1,12 +1,8 @@
-%h1 New Ambassador Task
+.container
+  %h1 New Ambassador Task
 
-= form_for @ambassador_task,
-  url: admin_ambassador_tasks_path,
-  html: { class: "form" } do |f|
-  = f.label :title, "Title", class: "form-label"
-  = f.text_field :title, class: 'form-control'
-
-  = f.label :description, "Description", class: "form-label"
-  = f.text_field :description, class: 'form-control'
-
-  = submit_tag "Create", class: 'btn btn-success btn-lg'
+  = render "form",
+    ambassador_task: @ambassador_task,
+    action: admin_ambassador_tasks_path,
+    method: :post,
+    submit_label: "Create"


### PR DESCRIPTION
- Adds some UI polish to the AmbassadorTask create/edit pages
- Extracts the ambassador task form to a partial

<img width="1205" alt="Screen Shot 2019-05-23 at 4 07 08 PM" src="https://user-images.githubusercontent.com/4433943/58282862-e6995e80-7d74-11e9-90b8-f2ce127c8457.png">
<img width="1172" alt="Screen Shot 2019-05-23 at 4 07 18 PM" src="https://user-images.githubusercontent.com/4433943/58282863-e731f500-7d74-11e9-8db6-3c9df986ee60.png">
