### PR TITLE
Ambassadors recovery flow

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -126,8 +126,8 @@ group :production do
 end
 
 group :development do
-  # gem 'test-unit', '~> 3.0'
   gem "bullet"
+  gem "letter_opener"
   gem "rerun"
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -269,6 +269,10 @@ GEM
     kaminari-core (1.1.1)
     kgio (2.11.2)
     kramdown (1.11.1)
+    launchy (2.4.3)
+      addressable (~> 2.3)
+    letter_opener (1.7.0)
+      launchy (~> 2.2)
     libv8 (3.16.14.19)
     listen (3.1.5)
       rb-fsevent (~> 0.9, >= 0.9.4)
@@ -653,6 +657,7 @@ DEPENDENCIES
   jquery-rails
   kaminari
   kramdown
+  letter_opener
   libv8 (~> 3.16.14.7)
   lograge
   logstash-event

--- a/app/controllers/bikes/recovery_controller.rb
+++ b/app/controllers/bikes/recovery_controller.rb
@@ -24,8 +24,14 @@ module Bikes
     private
 
     def permitted_params
-      params.require(:stolen_record).permit(:date_recovered, :timezone, :recovered_description,
-                                            :index_helped_recovery, :can_share_recovery)
+      params.require(:stolen_record).permit(
+        :date_recovered,
+        :timezone,
+        :recovering_user_id,
+        :recovered_description,
+        :index_helped_recovery,
+        :can_share_recovery
+      )
     end
 
     def find_bike

--- a/app/controllers/bikes/recovery_controller.rb
+++ b/app/controllers/bikes/recovery_controller.rb
@@ -12,7 +12,8 @@ module Bikes
     end
 
     def update
-      if @stolen_record.add_recovery_information(permitted_params)
+      update_params = permitted_params.merge(recovering_user: current_user)
+      if @stolen_record.add_recovery_information(update_params)
         EmailRecoveredFromLinkWorker.perform_async(@stolen_record.id)
         flash[:success] = "Bike marked recovered! Thank you!"
         redirect_to bike_path(@bike)
@@ -27,7 +28,6 @@ module Bikes
       params.require(:stolen_record).permit(
         :date_recovered,
         :timezone,
-        :recovering_user_id,
         :recovered_description,
         :index_helped_recovery,
         :can_share_recovery

--- a/app/decorators/bike_decorator.rb
+++ b/app/decorators/bike_decorator.rb
@@ -1,6 +1,10 @@
 class BikeDecorator < ApplicationDecorator
   delegate_all
 
+  def creation_organization_name
+    object.creation_organization&.name
+  end
+
   def should_show_other_bikes
     object.user? && object.user.show_bikes
   end

--- a/app/mailers/customer_mailer.rb
+++ b/app/mailers/customer_mailer.rb
@@ -61,6 +61,7 @@ class CustomerMailer < ActionMailer::Base
     @stolen_record = stolen_record
     @bike = stolen_record.bike
     @biketype = @bike.cycle_type_name&.downcase
+    @recovering_user = stolen_record.recovering_user
     mail(to: [@bike.owner_email],
          from: "bryan@bikeindex.org",
          subject: "Your #{@biketype} has been marked recovered!")

--- a/app/models/stolen_record.rb
+++ b/app/models/stolen_record.rb
@@ -166,7 +166,7 @@ class StolenRecord < ActiveRecord::Base
     self.date_recovered = TimeParser.parse(info[:date_recovered], info[:timezone]) || Time.now
     update_attributes(current: false,
                       recovered_description: info[:recovered_description],
-                      recovering_user: User.find_by(id: info[:recovering_user_id]),
+                      recovering_user: info[:recovering_user],
                       index_helped_recovery: ("#{info[:index_helped_recovery]}" =~ /t|1/i).present?,
                       can_share_recovery: ("#{info[:can_share_recovery]}" =~ /t|1/i).present?)
     bike.stolen = false

--- a/app/models/stolen_record.rb
+++ b/app/models/stolen_record.rb
@@ -20,6 +20,7 @@ class StolenRecord < ActiveRecord::Base
   belongs_to :country
   belongs_to :state
   belongs_to :creation_organization, class_name: "Organization"
+  belongs_to :recovering_user, class_name: "User"
 
   validates_presence_of :bike
   validates_presence_of :date_stolen

--- a/app/models/stolen_record.rb
+++ b/app/models/stolen_record.rb
@@ -166,6 +166,7 @@ class StolenRecord < ActiveRecord::Base
     self.date_recovered = TimeParser.parse(info[:date_recovered], info[:timezone]) || Time.now
     update_attributes(current: false,
                       recovered_description: info[:recovered_description],
+                      recovering_user: User.find_by(id: info[:recovering_user_id]),
                       index_helped_recovery: ("#{info[:index_helped_recovery]}" =~ /t|1/i).present?,
                       can_share_recovery: ("#{info[:can_share_recovery]}" =~ /t|1/i).present?)
     bike.stolen = false

--- a/app/views/admin/stolen_bikes/edit.html.haml
+++ b/app/views/admin/stolen_bikes/edit.html.haml
@@ -52,7 +52,7 @@
                   %td
                     Organization name
                   %td
-                    = @bike.creation_organization.name
+                    = @bike.creation_organization_name
               %tr
                 %td
                   Callable by

--- a/app/views/bikes/_bike_show_overlays.html.haml
+++ b/app/views/bikes/_bike_show_overlays.html.haml
@@ -6,7 +6,7 @@
     - modal_body = capture_haml do
       .modal-body
         %p
-          Please tell us how you got your #{@bike.type} back, we really care! 
+          Please tell us how you got your #{@bike.type} back, we really care!
           %br
           %strong
             It's also how we get better at recovering bikes.
@@ -35,7 +35,7 @@
               .col-xs-6.col-xs-pull-6
                 %button.btn.btn-secondary{ 'data-dismiss' => 'modal', type: 'button' }
                   Nevermind
-              
+
 
 - elsif current_user.present?
   - if @bike.claimable_by?(current_user)
@@ -43,14 +43,14 @@
     - modal_body = capture_haml do
       .modal-body
         %p
-          We're honored to have your #{@bike.type} on the Index.  
+          We're honored to have your #{@bike.type} on the Index.
         %p
           Claim it so you can update your listing.
       .modal-btn-footer
         .row
           .col-xs-6.col-xs-push-3
             %a.btn.btn-success{ href: "/ownerships/#{@bike.current_ownership.id}" }
-              Claim #{@bike.type} 
+              Claim #{@bike.type}
   - elsif @bike.authorize_for_user(current_user) && !@bike.authorized_by_organization?(u: current_user)
     .bike-overlay-wrapper
       .bike-edit-overlay

--- a/app/views/bikes/_bike_show_overlays.html.haml
+++ b/app/views/bikes/_bike_show_overlays.html.haml
@@ -12,7 +12,6 @@
             It's also how we get better at recovering bikes.
         = form_for @stolen_record, url: bike_recovery_path(bike_id: @bike.id) do |f|
           = hidden_field_tag :token, stolen_record.recovery_link_token
-          = f.hidden_field :recovering_user_id, value: current_user&.id
           .form-group
             = f.label :recovered_description, 'How did you get it back?'
             = f.text_area :recovered_description, class: 'form-control'

--- a/app/views/bikes/_bike_show_overlays.html.haml
+++ b/app/views/bikes/_bike_show_overlays.html.haml
@@ -12,6 +12,7 @@
             It's also how we get better at recovering bikes.
         = form_for @stolen_record, url: bike_recovery_path(bike_id: @bike.id) do |f|
           = hidden_field_tag :token, stolen_record.recovery_link_token
+          = f.hidden_field :recovering_user_id, value: current_user&.id
           .form-group
             = f.label :recovered_description, 'How did you get it back?'
             = f.text_area :recovered_description, class: 'form-control'

--- a/app/views/bikes/_organized_access_panel.html.haml
+++ b/app/views/bikes/_organized_access_panel.html.haml
@@ -35,7 +35,7 @@
               %em
                 so you can
               = link_to "Edit it", edit_bike_path(@bike), class: "btn btn-success btn-sm"
-        - elsif current_user.ambassador?
+        - elsif current_user.ambassador? && @bike.current_stolen_record.present?
           .col-xs-12.mb-2
             .text-right.less-strong
               %em
@@ -43,7 +43,9 @@
                   This #{@bike.type} is not claimed yet. As a Bike Index ambassador,
               %em
                 you can edit it to mark it as returned:
-              = link_to "EDIT", edit_bike_path(@bike), class: "btn btn-success btn-sm"
+              = link_to "Mark bike recovered",
+                edit_bike_recovery_url(bike_id: @bike.id, token: @bike.current_stolen_record.find_or_create_recovery_link_token),
+                class: "btn btn-success btn-sm"
 
         .mb-2{ class: display_unstolen_notification_form ? "col-md-7" : "col-sm-12" }
           %ul.attr-list{ class: display_unstolen_notification_form ? "" : "split-sm" }

--- a/app/views/bikes/_organized_access_panel.html.haml
+++ b/app/views/bikes/_organized_access_panel.html.haml
@@ -42,7 +42,7 @@
                 %span.hidden-md-down
                   This #{@bike.type} is not claimed yet. As a Bike Index ambassador,
               %em
-                you can edit it to mark it as returned:
+                you can mark it as recovered:
               = link_to "Mark bike recovered",
                 edit_bike_recovery_url(bike_id: @bike.id, token: @bike.current_stolen_record.find_or_create_recovery_link_token),
                 class: "btn btn-success btn-sm"

--- a/app/views/customer_mailer/recovered_from_link.html.haml
+++ b/app/views/customer_mailer/recovered_from_link.html.haml
@@ -5,10 +5,18 @@
 
 = render partial: '/shared/email_bike_box', locals: { bike_url: bike_url(@bike) }
 
-%p
-  The description of the recovery was:
-  %span.less-strong
-    = @stolen_record.recovered_description
+- if @stolen_record.recovered_description.present?
+  %p
+    The description of the recovery was:
+    %span.less-strong
+      = @stolen_record.recovered_description
+
+- if @recovering_user.present?
+  %p
+    Marked recovered by:
+    %span.less-strong
+      = @recovering_user.email
+      = "(#{@recovering_user.name})" if @recovering_user.name
 
 %hr
 

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -18,12 +18,8 @@ Rails.application.configure do
 
   config.action_mailer.raise_delivery_errors = true
   config.action_mailer.default_url_options = { host: "localhost", port: 3001 }
-  config.action_mailer.delivery_method = :smtp
+  config.action_mailer.delivery_method = :letter_opener
   config.action_mailer.perform_deliveries = true
-  config.action_mailer.smtp_settings = {
-    address: "localhost",
-    port: 1025,
-  }
 
   # Print deprecation notices to the Rails logger.
   config.active_support.deprecation = :log

--- a/db/migrate/20190524191139_add_recovering_user_id_to_stolen_records.rb
+++ b/db/migrate/20190524191139_add_recovering_user_id_to_stolen_records.rb
@@ -1,0 +1,7 @@
+class AddRecoveringUserIdToStolenRecords < ActiveRecord::Migration
+  def change
+    change_table(:stolen_records) do |t|
+      t.references(:recovering_user, index: true)
+    end
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -1955,7 +1955,8 @@ CREATE TABLE public.stolen_records (
     tsved_at timestamp without time zone,
     estimated_value integer,
     recovery_link_token text,
-    show_address boolean DEFAULT false
+    show_address boolean DEFAULT false,
+    recovering_user_id integer
 );
 
 
@@ -3402,6 +3403,13 @@ CREATE INDEX index_stolen_records_on_latitude_and_longitude ON public.stolen_rec
 
 
 --
+-- Name: index_stolen_records_on_recovering_user_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_stolen_records_on_recovering_user_id ON public.stolen_records USING btree (recovering_user_id);
+
+
+--
 -- Name: index_user_emails_on_user_id; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -4143,3 +4151,6 @@ INSERT INTO schema_migrations (version) VALUES ('20190516222221');
 INSERT INTO schema_migrations (version) VALUES ('20190517161246');
 
 INSERT INTO schema_migrations (version) VALUES ('20190517200357');
+
+INSERT INTO schema_migrations (version) VALUES ('20190524191139');
+

--- a/spec/decorators/bike_decorator_spec.rb
+++ b/spec/decorators/bike_decorator_spec.rb
@@ -37,6 +37,25 @@ describe BikeDecorator do
     end
   end
 
+  describe "#creation_organization_name" do
+    context "given an associated creation_organization" do
+      it "returns the organization's name" do
+        org = FactoryBot.create(:organization, name: "Creation Organization")
+        bike = FactoryBot.create(:bike, creation_organization: org).decorate
+        name = bike.creation_organization_name
+        expect(name).to eq(org.name)
+      end
+    end
+
+    context "given no associated creation_organization" do
+      it "returns nil" do
+        bike = FactoryBot.create(:bike, creation_organization: nil).decorate
+        name = bike.creation_organization_name
+        expect(name).to be_nil
+      end
+    end
+  end
+
   describe "phoneable_by?" do
     it "does not return anything if there isn't a stolen record" do
       bike = Bike.new

--- a/spec/models/stolen_record_spec.rb
+++ b/spec/models/stolen_record_spec.rb
@@ -8,6 +8,7 @@ describe StolenRecord do
     it { is_expected.to belong_to :country }
     it { is_expected.to belong_to :state }
     it { is_expected.to belong_to :creation_organization }
+    it { is_expected.to belong_to :recovering_user }
   end
 
   it "marks current true by default" do


### PR DESCRIPTION
- Adds a "recover bike" link to the organized bike access panel for ambassador orgs
- Adds the letter_opener gem to view html emails in browser
- Introduces `BikeDecorator#creation_organization_name`

![demo](https://user-images.githubusercontent.com/4433943/58343442-fbcbc700-7e20-11e9-898b-db04e1a7b19a.gif)

Email:
<img width="746" alt="Screen Shot 2019-05-24 at 3 34 57 PM" src="https://user-images.githubusercontent.com/4433943/58353020-5540ef80-7e3b-11e9-85aa-ee19bddffed4.png">
