### PR TITLE
Set attributes for ambassador organizations

### DIFF
--- a/app/javascript/packs/pages/admin/binx_admin.js
+++ b/app/javascript/packs/pages/admin/binx_admin.js
@@ -3,7 +3,7 @@ import moment from "moment-timezone";
 import LoadFancySelects from "../../utils/LoadFancySelects";
 import BinxAdminGraphs from "./graphs.js"
 import BinxAdminInvoices from "./invoices.js";
-
+import OrganizationForm from "./organization_form.js";
 
 function BinxAdmin() {
   return {
@@ -39,6 +39,11 @@ function BinxAdmin() {
       LoadFancySelects();
 
       this.enablePeriodSelection();
+
+      if ($("#admin_organizations_new,#admin_organizations_edit").length > 0) {
+        const $organizationForm = $("form").first();
+        new OrganizationForm($organizationForm);
+      }
     },
 
     // Non Fast Attr bikes edit

--- a/app/javascript/packs/pages/admin/organization_form.js
+++ b/app/javascript/packs/pages/admin/organization_form.js
@@ -14,7 +14,7 @@ class OrganizationForm {
   }
 
   setEventListeners () {
-    this.$form.on("click", "#js-organization-type input.form-check-input", e => {
+    this.$form.on("change", "#js-organization-type input.form-check-input", e => {
       this.toggleAmbassadorFields(e.target);
     });
   }

--- a/app/javascript/packs/pages/admin/organization_form.js
+++ b/app/javascript/packs/pages/admin/organization_form.js
@@ -13,8 +13,14 @@ class OrganizationForm {
     this.setEventListeners();
   }
 
+  setEventListeners () {
+    this.$form.on("click", "#js-organization-type input.form-check-input", e => {
+      this.toggleAmbassadorFields(e.target);
+    });
+  }
+
   toggleAmbassadorFields(target) {
-    const inputFieldIds = [
+    const inputFields = [
       'organization_ascend_name',
       'organization_website',
       "organization_parent_organization_id",
@@ -22,43 +28,53 @@ class OrganizationForm {
       "organization_lock_show_on_map",
       "organization_api_access_approved",
       "organization_approved"
-    ]
-    const selectizedFieldIds = [
-      "organization_parent_organization_id"
-    ]
+    ].map(fieldId => {
+      return {
+        element: this.$form.find(`#${fieldId}`),
+        label: this.$form.find(`label[for='${fieldId}']`)
+      };
+    });
 
-    const $orgType = $(target)
-    const isAmbassadorOrgSelected = $orgType.val() === "ambassador"
+    const selectizedFields = [
+      "organization_parent_organization_id"
+    ].map(fieldId => {
+      return {
+        element: this.$form.find(`#${fieldId}`),
+        label: this.$form.find(`label[for='${fieldId}-selectized']`)
+      };
+    });
+
+    const $orgType = $(target);
+    const isAmbassadorOrgSelected = $orgType.val() === "ambassador";
 
     if (isAmbassadorOrgSelected) {
-      inputFieldIds
-        .forEach(fieldId => {
-          this.$form.find(`#${fieldId}`).attr("disabled", true)
-          this.$form.find(`label[for='${fieldId}']`).addClass("text-muted")
-        })
-      selectizedFieldIds
-        .forEach(fieldId => {
-          this.$form.find(`#${fieldId}`).selectize()[0].selectize.disable()
-          this.$form.find(`label[for='${fieldId}-selectized']`).addClass("text-muted")
-        })
+      this.disableFields({inputFields, selectizedFields});
     } else {
-      inputFieldIds
-        .forEach(fieldId => {
-          this.$form.find(`#${fieldId}`).attr("disabled", false)
-          this.$form.find(`label[for='${fieldId}']`).removeClass("text-muted")
-        })
-      selectizedFieldIds
-        .forEach(fieldId => {
-          this.$form.find(`#${fieldId}`).selectize()[0].selectize.enable()
-          this.$form.find(`label[for='${fieldId}-selectized']`).removeClass("text-muted")
-        })
+      this.enableFields({inputFields, selectizedFields});
     }
   }
 
-  setEventListeners () {
-    this.$form.on("click", "#js-organization-type input.form-check-input", e => {
-      this.toggleAmbassadorFields(e.target)
-    })
+  disableFields({ inputFields, selectizedFields }) {
+    inputFields.forEach(field => {
+      field.element.attr("disabled", true);
+      field.label.addClass("text-muted");
+    });
+
+    selectizedFields.forEach(field => {
+      field.element.selectize()[0].selectize.disable();
+      field.label.addClass("text-muted");
+    });
+  }
+
+  enableFields({ inputFields, selectizedFields }) {
+    inputFields.forEach(field => {
+      field.element.attr("disabled", false);
+      field.label.removeClass("text-muted");
+    });
+    selectizedFields.forEach(field => {
+      field.element.selectize()[0].selectize.enable();
+      field.label.removeClass("text-muted");
+    });
   }
 }
 

--- a/app/javascript/packs/pages/admin/organization_form.js
+++ b/app/javascript/packs/pages/admin/organization_form.js
@@ -1,0 +1,65 @@
+class OrganizationForm {
+  constructor($form) {
+    this.$form = $form;
+
+    const $selectedType =
+          $form
+          .find("#js-organization-type")
+          .find("input:checked")
+          .first()
+
+    this.toggleAmbassadorFields($selectedType);
+
+    this.setEventListeners();
+  }
+
+  toggleAmbassadorFields(target) {
+    const inputFieldIds = [
+      'organization_ascend_name',
+      'organization_website',
+      "organization_parent_organization_id",
+      "organization_show_on_map",
+      "organization_lock_show_on_map",
+      "organization_api_access_approved",
+      "organization_approved"
+    ]
+    const selectizedFieldIds = [
+      "organization_parent_organization_id"
+    ]
+
+    const $orgType = $(target)
+    const isAmbassadorOrgSelected = $orgType.val() === "ambassador"
+
+    if (isAmbassadorOrgSelected) {
+      inputFieldIds
+        .forEach(fieldId => {
+          this.$form.find(`#${fieldId}`).attr("disabled", true)
+          this.$form.find(`label[for='${fieldId}']`).addClass("text-muted")
+        })
+      selectizedFieldIds
+        .forEach(fieldId => {
+          this.$form.find(`#${fieldId}`).selectize()[0].selectize.disable()
+          this.$form.find(`label[for='${fieldId}-selectized']`).addClass("text-muted")
+        })
+    } else {
+      inputFieldIds
+        .forEach(fieldId => {
+          this.$form.find(`#${fieldId}`).attr("disabled", false)
+          this.$form.find(`label[for='${fieldId}']`).removeClass("text-muted")
+        })
+      selectizedFieldIds
+        .forEach(fieldId => {
+          this.$form.find(`#${fieldId}`).selectize()[0].selectize.enable()
+          this.$form.find(`label[for='${fieldId}-selectized']`).removeClass("text-muted")
+        })
+    }
+  }
+
+  setEventListeners () {
+    this.$form.on("click", "#js-organization-type input.form-check-input", e => {
+      this.toggleAmbassadorFields(e.target)
+    })
+  }
+}
+
+export default OrganizationForm;

--- a/app/javascript/packs/pages/initializer.js
+++ b/app/javascript/packs/pages/initializer.js
@@ -7,7 +7,6 @@ import BinxMapping from "./binx_mapping.js";
 import BinxAppOrgExport from "./binx_org_export.js";
 import BinxAppOrgMessages from "./binx_org_messages.js";
 import BinxAdmin from "./admin/binx_admin.js";
-import OrganizationForm from "./admin/organization_form.js";
 
 window.binxApp || (window.binxApp = {});
 
@@ -125,8 +124,5 @@ $(document).ready(function() {
     case "organized_bikes_index":
       const binxAppOrgBikes = BinxAppOrgBikes();
       binxAppOrgBikes.init();
-    case "admin_organizations_new":
-    case "admin_organizations_edit":
-      window.OrganizationForm = new OrganizationForm($("form").first());
   }
 });

--- a/app/javascript/packs/pages/initializer.js
+++ b/app/javascript/packs/pages/initializer.js
@@ -7,6 +7,7 @@ import BinxMapping from "./binx_mapping.js";
 import BinxAppOrgExport from "./binx_org_export.js";
 import BinxAppOrgMessages from "./binx_org_messages.js";
 import BinxAdmin from "./admin/binx_admin.js";
+import OrganizationForm from "./admin/organization_form.js";
 
 window.binxApp || (window.binxApp = {});
 
@@ -124,5 +125,8 @@ $(document).ready(function() {
     case "organized_bikes_index":
       const binxAppOrgBikes = BinxAppOrgBikes();
       binxAppOrgBikes.init();
+    case "admin_organizations_new":
+    case "admin_organizations_edit":
+      window.OrganizationForm = new OrganizationForm($("form").first());
   }
 });

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -267,6 +267,5 @@ class Organization < ActiveRecord::Base
     self.website = nil
     self.ascend_name = nil
     self.parent_organization_id = nil
-    self.locations = locations.reload.limit(1) if locations.count > 1
   end
 end

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -61,6 +61,7 @@ class Organization < ActiveRecord::Base
   scope :bike_actions, -> { where("paid_feature_slugs ?| array[:keys]", keys: %w[messages unstolen_notifications]) }
 
   before_validation :set_calculated_attributes
+  before_save :set_ambassador_organization_defaults
 
   attr_accessor :embedable_user_email, :lightspeed_cloud_api_key
 
@@ -253,5 +254,19 @@ class Organization < ActiveRecord::Base
     begin
       self.access_token = SecureRandom.hex
     end while self.class.exists?(access_token: access_token)
+  end
+
+  private
+
+  def set_ambassador_organization_defaults
+    return unless kind == "ambassador"
+    self.show_on_map = false
+    self.lock_show_on_map = false
+    self.api_access_approved = false
+    self.approved = true
+    self.website = nil
+    self.ascend_name = nil
+    self.parent_organization_id = nil
+    self.locations = locations.reload.limit(1) if locations.count > 1
   end
 end

--- a/app/views/admin/organizations/_form.html.haml
+++ b/app/views/admin/organizations/_form.html.haml
@@ -35,7 +35,7 @@
           = @organization.slug
 .row
   .col-md-6.pl-4
-    .form-group
+    .form-group#js-organization-type
       %label
       Organization Type
       - Organization.kinds.each do |kind|

--- a/spec/factories/organizations.rb
+++ b/spec/factories/organizations.rb
@@ -3,6 +3,12 @@ FactoryBot.define do
     sequence(:name) { |n| "Organization #{n}" }
     short_name { name }
     available_invitation_count { 5 }
+    show_on_map { true }
+    lock_show_on_map { true }
+    api_access_approved { false }
+    sequence(:website) { |n| "http://organization#{n}.com" }
+    sequence(:ascend_name) { |n| "ascend-name-organization-#{n}" }
+
     # before(:create) { |organization| organization.short_name ||= organization.name }
     factory :organization_with_auto_user do
       auto_user { FactoryBot.create(:user) }
@@ -17,6 +23,16 @@ FactoryBot.define do
     factory :organization_ambassador do
       kind { "ambassador" }
       sequence(:name) { |n| "Ambassador Group #{n}" }
+    end
+
+    trait :with_locations do
+      after(:create) do |organization|
+        2.times do |n|
+          FactoryBot.create(:location,
+                            name: "location #{n}",
+                            organization: organization)
+        end
+      end
     end
   end
 end

--- a/spec/factories/organizations.rb
+++ b/spec/factories/organizations.rb
@@ -3,11 +3,10 @@ FactoryBot.define do
     sequence(:name) { |n| "Organization #{n}" }
     short_name { name }
     available_invitation_count { 5 }
-    show_on_map { true }
-    lock_show_on_map { true }
+    show_on_map { false }
+    lock_show_on_map { false }
     api_access_approved { false }
     sequence(:website) { |n| "http://organization#{n}.com" }
-    sequence(:ascend_name) { |n| "ascend-name-organization-#{n}" }
 
     # before(:create) { |organization| organization.short_name ||= organization.name }
     factory :organization_with_auto_user do

--- a/spec/models/organization_spec.rb
+++ b/spec/models/organization_spec.rb
@@ -45,9 +45,9 @@ describe Organization do
 
     context "when changing an org from a non-ambassador to ambassador kind" do
       it "sets non-applicable attributes to sensible ambassador org values" do
-        org = FactoryBot.create(:organization_child)
-        expect(org).to be_show_on_map
-        expect(org).to be_lock_show_on_map
+        org = FactoryBot.create(:organization_child, ascend_name: "ascend")
+        expect(org).to_not be_show_on_map
+        expect(org).to_not be_lock_show_on_map
         expect(org).to_not be_api_access_approved
         expect(org).to be_approved
         expect(org.website).to be_present

--- a/spec/models/organization_spec.rb
+++ b/spec/models/organization_spec.rb
@@ -39,21 +39,19 @@ describe Organization do
         expect(org).to be_approved
         expect(org.website).to be_blank
         expect(org.ascend_name).to be_blank
-        expect(org.locations).to be_empty
         expect(org.parent_organization).to be_blank
       end
     end
 
     context "when changing an org from a non-ambassador to ambassador kind" do
       it "sets non-applicable attributes to sensible ambassador org values" do
-        org = FactoryBot.create(:organization_child, :with_locations)
+        org = FactoryBot.create(:organization_child)
         expect(org).to be_show_on_map
         expect(org).to be_lock_show_on_map
         expect(org).to_not be_api_access_approved
         expect(org).to be_approved
         expect(org.website).to be_present
         expect(org.ascend_name).to be_present
-        expect(org.locations.count).to eq(2)
         expect(org.parent_organization).to be_present
 
         org.update_attributes(kind: :ambassador)
@@ -64,7 +62,6 @@ describe Organization do
         expect(org).to be_approved
         expect(org.website).to be_blank
         expect(org.ascend_name).to be_blank
-        expect(org.locations.count).to eq(1)
         expect(org.parent_organization).to be_blank
       end
     end

--- a/spec/models/organization_spec.rb
+++ b/spec/models/organization_spec.rb
@@ -17,6 +17,59 @@ describe Organization do
     it { is_expected.to belong_to :auto_user }
   end
 
+  describe "#set_ambassador_organization_defaults before_save hook" do
+    context "when saving a new ambassador org" do
+      it "sets non-applicable attributes to sensible ambassador org values" do
+        org = FactoryBot.build(
+          :organization_ambassador,
+          show_on_map: true,
+          lock_show_on_map: true,
+          api_access_approved: true,
+          approved: false,
+          website: "http://website.com",
+          ascend_name: "ascend-name",
+          parent_organization: FactoryBot.create(:organization),
+        )
+
+        org.save
+
+        expect(org).to_not be_show_on_map
+        expect(org).to_not be_lock_show_on_map
+        expect(org).to_not be_api_access_approved
+        expect(org).to be_approved
+        expect(org.website).to be_blank
+        expect(org.ascend_name).to be_blank
+        expect(org.locations).to be_empty
+        expect(org.parent_organization).to be_blank
+      end
+    end
+
+    context "when changing an org from a non-ambassador to ambassador kind" do
+      it "sets non-applicable attributes to sensible ambassador org values" do
+        org = FactoryBot.create(:organization_child, :with_locations)
+        expect(org).to be_show_on_map
+        expect(org).to be_lock_show_on_map
+        expect(org).to_not be_api_access_approved
+        expect(org).to be_approved
+        expect(org.website).to be_present
+        expect(org.ascend_name).to be_present
+        expect(org.locations.count).to eq(2)
+        expect(org.parent_organization).to be_present
+
+        org.update_attributes(kind: :ambassador)
+
+        expect(org).to_not be_show_on_map
+        expect(org).to_not be_lock_show_on_map
+        expect(org).to_not be_api_access_approved
+        expect(org).to be_approved
+        expect(org.website).to be_blank
+        expect(org.ascend_name).to be_blank
+        expect(org.locations.count).to eq(1)
+        expect(org.parent_organization).to be_blank
+      end
+    end
+  end
+
   describe "scopes" do
     it "Shown on map is shown on map *and* validated" do
       expect(Organization.shown_on_map.to_sql).to eq(Organization.where(show_on_map: true).where(approved: true).order(:name).to_sql)


### PR DESCRIPTION
- Adds a `before_save` that sets sensible defaults for ambassador organization records
- Adds client-side logic to toggle related input fields based on "ambassador" being selected as the organization type

![demo](https://user-images.githubusercontent.com/4433943/58360614-c68e9b80-7e57-11e9-945b-c74463334459.gif)

![demo2](https://user-images.githubusercontent.com/4433943/58360613-c68e9b80-7e57-11e9-845a-841d85e92a90.gif)
