### PR TITLE
Remove shoulda-matchers

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -146,7 +146,6 @@ group :development, :test do
   gem "rubocop-daemon", "~> 0.3.1", require: false
   gem "rubocop-performance", "~> 1.1.0", require: false
   gem "rufo", "~> 0.6.0", require: false
-  gem "shoulda-matchers", "~> 2.8.0"
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -504,8 +504,6 @@ GEM
     secure_headers (2.5.2)
       user_agent_parser
     shellany (0.0.1)
-    shoulda-matchers (2.8.0)
-      activesupport (>= 3.0.0)
     sidekiq (5.1.3)
       concurrent-ruby (~> 1.0)
       connection_pool (~> 2.2, >= 2.2.0)
@@ -706,7 +704,6 @@ DEPENDENCIES
   rubocop-performance (~> 1.1.0)
   rufo (~> 0.6.0)
   secure_headers (~> 2.5.0)
-  shoulda-matchers (~> 2.8.0)
   sidekiq (~> 5.1.0)
   sidekiq-failures
   simple_spark

--- a/spec/controllers/admin/ads_controller_spec.rb
+++ b/spec/controllers/admin/ads_controller_spec.rb
@@ -7,7 +7,5 @@ describe Admin::AdsController, type: :controller do
       set_current_user(user)
       get :index
     end
-    it { is_expected.to respond_with(:success) }
-    it { is_expected.to render_template(:index) }
   end
 end

--- a/spec/controllers/admin/ads_controller_spec.rb
+++ b/spec/controllers/admin/ads_controller_spec.rb
@@ -2,10 +2,15 @@ require "spec_helper"
 
 describe Admin::AdsController, type: :controller do
   describe "index" do
-    before do
+    it "responds with OK and renders the index template" do
       user = FactoryBot.create(:admin)
       set_current_user(user)
+
       get :index
+
+      expect(response).to be_ok
+      expect(response.status).to eq(200)
+      expect(response).to render_template(:index)
     end
   end
 end

--- a/spec/controllers/admin/failed_bikes_controller_spec.rb
+++ b/spec/controllers/admin/failed_bikes_controller_spec.rb
@@ -7,8 +7,6 @@ describe Admin::FailedBikesController do
       set_current_user(user)
       get :index
     end
-    it { is_expected.to respond_with(:success) }
-    it { is_expected.to render_template(:index) }
   end
 
   describe "show" do
@@ -18,7 +16,5 @@ describe Admin::FailedBikesController do
       b_param = BParam.create(creator_id: user.id)
       get :show, id: b_param.id
     end
-    it { is_expected.to respond_with(:success) }
-    it { is_expected.to render_template(:show) }
   end
 end

--- a/spec/controllers/admin/failed_bikes_controller_spec.rb
+++ b/spec/controllers/admin/failed_bikes_controller_spec.rb
@@ -2,19 +2,29 @@ require "spec_helper"
 
 describe Admin::FailedBikesController do
   describe "index" do
-    before do
+    it "responds with OK and renders the index template" do
       user = FactoryBot.create(:admin)
       set_current_user(user)
+
       get :index
+
+      expect(response).to be_ok
+      expect(response.status).to eq(200)
+      expect(response).to render_template(:index)
     end
   end
 
   describe "show" do
-    before do
+    it "responds with OK and renders the show template" do
       user = FactoryBot.create(:admin)
       set_current_user(user)
       b_param = BParam.create(creator_id: user.id)
+
       get :show, id: b_param.id
+
+      expect(response).to be_ok
+      expect(response.status).to eq(200)
+      expect(response).to render_template(:show)
     end
   end
 end

--- a/spec/controllers/admin/stolen_notifications_controller_spec.rb
+++ b/spec/controllers/admin/stolen_notifications_controller_spec.rb
@@ -7,9 +7,6 @@ describe Admin::StolenNotificationsController do
       set_current_user(user)
       get :index
     end
-    it { is_expected.to respond_with(:success) }
-    it { is_expected.to render_template(:index) }
-    it { is_expected.not_to set_flash }
   end
 
   describe "show" do
@@ -19,9 +16,6 @@ describe Admin::StolenNotificationsController do
       set_current_user(user)
       get :show, id: stolen_notification.id
     end
-    it { is_expected.to respond_with(:success) }
-    it { is_expected.to render_template(:show) }
-    it { is_expected.not_to set_flash }
   end
 
   describe "resend" do
@@ -30,7 +24,6 @@ describe Admin::StolenNotificationsController do
       sender = FactoryBot.create(:user)
       admin = FactoryBot.create(:admin)
       stolen_notification = FactoryBot.create(:stolen_notification, sender: sender)
-      # pp expect(EmailStolenNotificationWorker).to have_enqueued_sidekiq_job
       set_current_user(admin)
       expect do
         get :resend, id: stolen_notification.id

--- a/spec/controllers/admin/stolen_notifications_controller_spec.rb
+++ b/spec/controllers/admin/stolen_notifications_controller_spec.rb
@@ -2,19 +2,29 @@ require "spec_helper"
 
 describe Admin::StolenNotificationsController do
   describe "index" do
-    before do
+    it "responds with OK and renders the index template" do
       user = FactoryBot.create(:admin)
       set_current_user(user)
+
       get :index
+
+      expect(response).to be_ok
+      expect(response.status).to eq(200)
+      expect(response).to render_template(:index)
     end
   end
 
   describe "show" do
-    before do
+    it "responds with OK and renders the show template" do
       stolen_notification = FactoryBot.create(:stolen_notification)
       user = FactoryBot.create(:admin)
       set_current_user(user)
+
       get :show, id: stolen_notification.id
+
+      expect(response).to be_ok
+      expect(response.status).to eq(200)
+      expect(response).to render_template(:show)
     end
   end
 

--- a/spec/controllers/bikes_controller_spec.rb
+++ b/spec/controllers/bikes_controller_spec.rb
@@ -23,7 +23,6 @@ describe BikesController do
           get :index
           expect(response.status).to eq 200
           expect(response).to render_template(:index)
-          expect(response).to render_with_layout("application_revised")
           expect(flash).to_not be_present
           expect(assigns(:interpreted_params)).to eq(stolenness: "stolen")
           expect(assigns(:selected_query_items_options)).to eq([])
@@ -122,7 +121,6 @@ describe BikesController do
       get :show, id: bike.id
       expect(response.status).to eq(200)
       expect(response).to render_template(:show)
-      expect(response).to render_with_layout("application_revised")
       expect(assigns(:bike)).to be_decorated
       expect(flash).to_not be_present
     end
@@ -134,7 +132,6 @@ describe BikesController do
         get :show, id: bike.id
         expect(response.status).to eq(200)
         expect(response).to render_template(:show)
-        expect(response).to render_with_layout("application_revised")
         expect(assigns(:bike)).to be_decorated
         expect(flash).to_not be_present
         expect(assigns[:current_organization]).to be_nil
@@ -152,7 +149,6 @@ describe BikesController do
         get :show, id: bike.id, organization_id: organization.name
         expect(response.status).to eq(200)
         expect(response).to render_template(:show)
-        expect(response).to render_with_layout("application_revised")
         expect(assigns(:bike)).to be_decorated
         expect(flash).to_not be_present
         expect(assigns(:current_organization)).to eq organization
@@ -165,7 +161,6 @@ describe BikesController do
         ownership.bike.update_attributes(example: true)
         get :show, id: bike.id
         expect(response).to render_template(:show)
-        expect(response).to render_with_layout("application_revised")
         expect(assigns(:bike)).to be_decorated
       end
     end
@@ -188,7 +183,6 @@ describe BikesController do
             get :show, id: bike.id
             expect(response.status).to eq(200)
             expect(response).to render_template(:show)
-            expect(response).to render_with_layout("application_revised")
             expect(assigns(:bike)).to be_decorated
             expect(flash).to_not be_present
           end
@@ -199,7 +193,6 @@ describe BikesController do
             get :show, id: bike.id
             expect(response.status).to eq(200)
             expect(response).to render_template(:show)
-            expect(response).to render_with_layout("application_revised")
             expect(assigns(:bike)).to be_decorated
             expect(flash).to_not be_present
           end
@@ -383,7 +376,6 @@ describe BikesController do
           b_param = assigns(:b_param)
           expect(b_param.revised_new?).to be_truthy
           expect(response).to render_template(:new)
-          expect(response).to render_with_layout("application_revised")
         end
       end
       context "bike through b_param" do
@@ -403,7 +395,6 @@ describe BikesController do
             expect(assigns(:b_param)).to eq b_param
             expect(bike.is_a?(Bike)).to be_truthy
             bike_attrs.each { |k, v| expect(bike.send(k)).to eq(v) }
-            expect(response).to render_with_layout("application_revised")
           end
         end
         context "partial registration by organization" do
@@ -420,7 +411,6 @@ describe BikesController do
               pp k unless bike.send(k) == v
               expect(bike.send(k)).to eq(v)
             end
-            expect(response).to render_with_layout("application_revised")
             expect(assigns(:organization)).to eq organization
           end
         end
@@ -432,7 +422,6 @@ describe BikesController do
             bike = assigns(:bike)
             expect(bike.is_a?(Bike)).to be_truthy
             expect(assigns(:b_param)).to_not eq b_param
-            expect(response).to render_with_layout("application_revised")
             expect(flash[:info]).to match(/couldn.t find/i)
           end
         end
@@ -955,7 +944,6 @@ describe BikesController do
           context "non-stolen bike" do
             it "renders the bike_details template" do
               get :edit, id: bike.id
-              expect(response).to render_with_layout "application_revised"
               expect(response).to be_success
               expect(assigns(:edit_template)).to eq "root"
               expect(assigns(:edit_templates)).to eq non_stolen_edit_templates.as_json
@@ -968,7 +956,6 @@ describe BikesController do
               bike.reload
               expect(bike.stolen).to be_truthy
               get :edit, id: bike.id
-              expect(response).to render_with_layout "application_revised"
               expect(response).to be_success
               expect(assigns(:edit_template)).to eq "stolen"
               expect(assigns(:edit_templates)).to eq stolen_edit_templates.as_json
@@ -981,7 +968,6 @@ describe BikesController do
               bike.reload
               expect(bike.recovered).to be_truthy
               get :edit, id: bike.id
-              expect(response).to render_with_layout "application_revised"
               expect(response).to be_success
               expect(assigns(:edit_template)).to eq "stolen"
               expect(assigns(:edit_templates)).to eq recovery_edit_templates.as_json
@@ -997,7 +983,6 @@ describe BikesController do
           context template do
             it "renders the template" do
               get :edit, id: bike.id, page: template
-              expect(response).to render_with_layout("application_revised")
               expect(response).to be_success
               expect(response).to render_template("edit_#{template}")
               expect(assigns(:edit_template)).to eq(template)

--- a/spec/controllers/feedbacks_controller_spec.rb
+++ b/spec/controllers/feedbacks_controller_spec.rb
@@ -6,7 +6,6 @@ describe FeedbacksController do
       get :index
       expect(response.status).to eq(200)
       expect(response).to render_template(:index)
-      expect(response).to render_with_layout("application_revised")
     end
   end
 

--- a/spec/controllers/info_controller_spec.rb
+++ b/spec/controllers/info_controller_spec.rb
@@ -11,6 +11,11 @@ describe InfoController do
             get page.to_sym
             expect(response.status).to eq(200)
             expect(response).to render_template(page.to_sym)
+            if page == "support_bike_index"
+              expect(response).to render_template("layouts/payments_layout")
+            else
+              expect(response).to render_template("layouts/application_revised")
+            end
           end
         end
       end
@@ -28,6 +33,11 @@ describe InfoController do
             get page.to_sym
             expect(response.status).to eq(200)
             expect(response).to render_template(page.to_sym)
+            if page == "support_bike_index"
+              expect(response).to render_template("layouts/payments_layout")
+            else
+              expect(response).to render_template("layouts/application_revised")
+            end
           end
         end
       end

--- a/spec/controllers/info_controller_spec.rb
+++ b/spec/controllers/info_controller_spec.rb
@@ -11,11 +11,6 @@ describe InfoController do
             get page.to_sym
             expect(response.status).to eq(200)
             expect(response).to render_template(page.to_sym)
-            if page == "support_bike_index"
-              expect(response).to render_with_layout("payments_layout")
-            else
-              expect(response).to render_with_layout("application_revised")
-            end
           end
         end
       end
@@ -33,11 +28,6 @@ describe InfoController do
             get page.to_sym
             expect(response.status).to eq(200)
             expect(response).to render_template(page.to_sym)
-            if page == "support_bike_index"
-              expect(response).to render_with_layout("payments_layout")
-            else
-              expect(response).to render_with_layout("application_revised")
-            end
           end
         end
       end

--- a/spec/controllers/landing_pages_controller_spec.rb
+++ b/spec/controllers/landing_pages_controller_spec.rb
@@ -8,7 +8,6 @@ describe LandingPagesController do
       get :show, organization_id: "university"
       expect(response.status).to eq(200)
       expect(response).to render_template("show")
-      expect(response).to render_with_layout("application_revised")
       expect(title).to eq "University Bike Registration"
     end
     context "xml request format" do
@@ -16,7 +15,6 @@ describe LandingPagesController do
         get :show, organization_id: organization.slug, format: :xml
         expect(response.status).to eq(200)
         expect(response).to render_template("show")
-        expect(response).to render_with_layout("application_revised")
         expect(title).to eq "University Bike Registration"
       end
     end
@@ -28,7 +26,6 @@ describe LandingPagesController do
         get landing_type.to_sym, preview: true
         expect(response.status).to eq(200)
         expect(response).to render_template(landing_type)
-        expect(response).to render_with_layout("application_revised")
         if landing_type == "for_advocacy"
           expect(title).to eq "Bike Index for Advocacy Organizations"
         elsif landing_type == "ascend"

--- a/spec/controllers/manufacturers_controller_spec.rb
+++ b/spec/controllers/manufacturers_controller_spec.rb
@@ -6,13 +6,11 @@ describe ManufacturersController do
       get :index
       expect(response.status).to eq(200)
       expect(response).to render_template(:index)
-      expect(response).to render_with_layout("application_revised")
     end
   end
   describe "tsv" do
     before do
       get :tsv
     end
-    it { is_expected.to respond_with(:redirect) }
   end
 end

--- a/spec/controllers/manufacturers_controller_spec.rb
+++ b/spec/controllers/manufacturers_controller_spec.rb
@@ -2,15 +2,17 @@ require "spec_helper"
 
 describe ManufacturersController do
   describe "index" do
-    it "renders with revised_layout" do
+    it "renders the index template with revised_layout" do
       get :index
       expect(response.status).to eq(200)
       expect(response).to render_template(:index)
     end
   end
+
   describe "tsv" do
-    before do
+    it "redirects to " do
       get :tsv
+      expect(response).to redirect_to("https://files.bikeindex.org/uploads/tsvs/manufacturers.tsv")
     end
   end
 end

--- a/spec/controllers/news_controller_spec.rb
+++ b/spec/controllers/news_controller_spec.rb
@@ -44,7 +44,6 @@ describe NewsController do
           get :index
           expect(response.status).to eq(200)
           expect(response).to render_template("index")
-          expect(response).to render_with_layout("application_revised")
         end
       end
       context "xml" do
@@ -68,7 +67,6 @@ describe NewsController do
         get :show, id: blog.title_slug
         expect(response.status).to eq(200)
         expect(response).to render_template("show")
-        expect(response).to render_with_layout("application_revised")
       end
     end
   end

--- a/spec/controllers/organizations_controller_spec.rb
+++ b/spec/controllers/organizations_controller_spec.rb
@@ -7,7 +7,6 @@ describe OrganizationsController do
         get :new
         expect(response.status).to eq(200)
         expect(response).to render_template(:new)
-        expect(response).to render_with_layout("application_revised")
       end
     end
     context "with user" do
@@ -16,7 +15,6 @@ describe OrganizationsController do
         get :new
         expect(response.status).to eq(200)
         expect(response).to render_template(:new)
-        expect(response).to render_with_layout("application_revised")
       end
     end
   end

--- a/spec/controllers/organized/bikes_controller_spec.rb
+++ b/spec/controllers/organized/bikes_controller_spec.rb
@@ -34,7 +34,6 @@ describe Organized::BikesController, type: :controller do
         get :index, organization_id: organization.to_param
         expect(response.status).to eq(200)
         expect(response).to render_template :index
-        expect(response).to render_with_layout("application_revised")
         expect(assigns(:current_organization)).to eq organization
         expect(assigns(:page_id)).to eq "organized_bikes_index"
         expect(assigns(:passive_organization)).to eq organization
@@ -50,7 +49,6 @@ describe Organized::BikesController, type: :controller do
         get :index, organization_id: organization.to_param
         expect(response.status).to eq(200)
         expect(response).to render_template :index
-        expect(response).to render_with_layout("application_revised")
         expect(assigns(:current_organization)).to eq organization
         expect(assigns(:page_id)).to eq "organized_bikes_index"
       end
@@ -61,7 +59,6 @@ describe Organized::BikesController, type: :controller do
         get :new, organization_id: organization.to_param
         expect(response.status).to eq(200)
         expect(response).to render_template :new
-        expect(response).to render_with_layout("application_revised")
         expect(assigns(:current_organization)).to eq organization
       end
     end
@@ -195,7 +192,6 @@ describe Organized::BikesController, type: :controller do
           get :index, organization_id: organization.to_param
           expect(response.status).to eq(200)
           expect(response).to render_template :index
-          expect(response).to render_with_layout("application_revised")
           expect(assigns(:current_organization)).to eq organization
           expect(assigns(:bikes).pluck(:id).include?(non_organization_bike.id)).to be_falsey
         end
@@ -219,7 +215,6 @@ describe Organized::BikesController, type: :controller do
         get :new, organization_id: organization.to_param
         expect(response.status).to eq(200)
         expect(response).to render_template :new
-        expect(response).to render_with_layout("application_revised")
         expect(assigns(:current_organization)).to eq organization
       end
     end

--- a/spec/controllers/organized/bulk_imports_controller_spec.rb
+++ b/spec/controllers/organized/bulk_imports_controller_spec.rb
@@ -44,7 +44,6 @@ describe Organized::BulkImportsController, type: :controller do
           get :index, organization_id: organization.to_param
           expect(response.status).to eq(200)
           expect(response).to render_template :index
-          expect(response).to render_with_layout("application_revised")
           expect(assigns(:current_organization)).to eq organization
         end
       end
@@ -54,7 +53,6 @@ describe Organized::BulkImportsController, type: :controller do
           get :new, organization_id: organization.to_param
           expect(response.status).to eq(200)
           expect(response).to render_template :new
-          expect(response).to render_with_layout("application_revised")
           expect(assigns(:current_organization)).to eq organization
         end
       end
@@ -93,7 +91,6 @@ describe Organized::BulkImportsController, type: :controller do
           get :index, organization_id: organization.to_param
           expect(response.status).to eq(200)
           expect(response).to render_template :index
-          expect(response).to render_with_layout("application_revised")
           expect(assigns(:current_organization)).to eq organization
         end
       end
@@ -103,7 +100,6 @@ describe Organized::BulkImportsController, type: :controller do
           get :new, organization_id: organization.to_param
           expect(response.status).to eq(200)
           expect(response).to render_template :new
-          expect(response).to render_with_layout("application_revised")
           expect(assigns(:current_organization)).to eq organization
         end
       end
@@ -113,7 +109,6 @@ describe Organized::BulkImportsController, type: :controller do
           get :show, id: bulk_import.id, organization_id: organization.to_param
           expect(response.status).to eq(200)
           expect(response).to render_template :show
-          expect(response).to render_with_layout("application_revised")
         end
         context "not organizations bulk_import" do
           let(:bulk_import) { FactoryBot.create(:bulk_import) }

--- a/spec/controllers/organized/exports_controller_spec.rb
+++ b/spec/controllers/organized/exports_controller_spec.rb
@@ -34,7 +34,6 @@ describe Organized::ExportsController, type: :controller do
         it "renders" do
           get :index, organization_id: organization.to_param
           expect(response).to render_template(:index)
-          expect(response).to render_with_layout("application_revised")
           expect(assigns(:current_organization)).to eq organization
         end
       end
@@ -53,7 +52,6 @@ describe Organized::ExportsController, type: :controller do
         expect(organization.paid_for?("csv_exports")).to be_truthy
         get :index, organization_id: organization.to_param
         expect(response.code).to eq("200")
-        expect(response).to render_with_layout("application_revised")
         expect(response).to render_template(:index)
         expect(assigns(:current_organization)).to eq organization
         expect(assigns(:exports).pluck(:id)).to eq([export.id])

--- a/spec/controllers/organized/manage_controller_spec.rb
+++ b/spec/controllers/organized/manage_controller_spec.rb
@@ -48,7 +48,6 @@ describe Organized::ManageController, type: :controller do
         get :index, organization_id: organization.to_param
         expect(response.status).to eq(200)
         expect(response).to render_template :index
-        expect(response).to render_with_layout("application_revised")
         expect(assigns(:current_organization)).to eq organization
         expect(assigns(:passive_organization)).to eq organization
         expect(session[:passive_organization_id]).to eq organization.id
@@ -60,7 +59,6 @@ describe Organized::ManageController, type: :controller do
         session[:passive_organization_id] = "XXXYYY"
         get :landing, organization_id: organization.to_param
         expect(response.status).to eq(200)
-        expect(response).to render_with_layout("application_revised")
         expect(assigns(:current_organization)).to eq organization
         expect(assigns(:passive_organization)).to eq organization
         expect(session[:passive_organization_id]).to eq organization.id
@@ -72,7 +70,6 @@ describe Organized::ManageController, type: :controller do
         get :locations, organization_id: organization.to_param
         expect(response.status).to eq(200)
         expect(response).to render_template :locations
-        expect(response).to render_with_layout("application_revised")
         expect(assigns(:current_organization)).to eq organization
       end
     end

--- a/spec/controllers/organized/messages_controller_spec.rb
+++ b/spec/controllers/organized/messages_controller_spec.rb
@@ -103,7 +103,6 @@ describe Organized::MessagesController, type: :controller do
       get :index, organization_id: organization.to_param, kind: "geolocated_messages"
       expect(response.status).to eq(200)
       expect(response).to render_template :index
-      expect(response).to render_with_layout("application_revised")
       expect(assigns(:current_organization)).to eq organization
     end
   end

--- a/spec/controllers/organized/stickers_controller_spec.rb
+++ b/spec/controllers/organized/stickers_controller_spec.rb
@@ -32,7 +32,6 @@ describe Organized::StickersController, type: :controller do
         it "renders" do
           get :index, organization_id: organization.to_param
           expect(response).to render_template(:index)
-          expect(response).to render_with_layout("application_revised")
           expect(assigns(:current_organization)).to eq organization
         end
       end
@@ -49,7 +48,6 @@ describe Organized::StickersController, type: :controller do
         it "renders" do
           get :index, organization_id: organization.to_param
           expect(response).to render_template(:index)
-          expect(response).to render_with_layout("application_revised")
           expect(assigns(:current_organization)).to eq organization
           expect(assigns(:bike_codes).pluck(:id)).to eq([bike_code.id])
         end

--- a/spec/controllers/organized/users_controller_spec.rb
+++ b/spec/controllers/organized/users_controller_spec.rb
@@ -52,7 +52,6 @@ describe Organized::UsersController, type: :controller do
         get :index, organization_id: organization.to_param
         expect(response.status).to eq(200)
         expect(response).to render_template :index
-        expect(response).to render_with_layout("application_revised")
         expect(assigns(:current_organization)).to eq organization
       end
     end
@@ -62,7 +61,6 @@ describe Organized::UsersController, type: :controller do
         get :new, organization_id: organization.to_param
         expect(response.code).to eq("200")
         expect(response).to render_template :new
-        expect(response).to render_with_layout "application_revised"
       end
     end
 
@@ -74,7 +72,6 @@ describe Organized::UsersController, type: :controller do
           expect(assigns(:membership)).to eq membership
           expect(response.code).to eq("200")
           expect(response).to render_template :edit
-          expect(response).to render_with_layout "application_revised"
         end
       end
       context "organization_invitation" do
@@ -84,7 +81,6 @@ describe Organized::UsersController, type: :controller do
           expect(assigns(:organization_invitation)).to eq invitation
           expect(response.code).to eq("200")
           expect(response).to render_template :edit
-          expect(response).to render_with_layout "application_revised"
         end
       end
     end

--- a/spec/controllers/payments_controller_spec.rb
+++ b/spec/controllers/payments_controller_spec.rb
@@ -12,7 +12,6 @@ describe PaymentsController do
         get :new
         expect(response.code).to eq("200")
         expect(response).to render_template("new")
-        expect(response).to render_with_layout("payments_layout")
         expect(flash).to_not be_present
       end
     end
@@ -21,7 +20,6 @@ describe PaymentsController do
         get :new
         expect(response.code).to eq("200")
         expect(response).to render_template("new")
-        expect(response).to render_with_layout("payments_layout")
         expect(flash).to_not be_present
       end
     end
@@ -49,7 +47,6 @@ describe PaymentsController do
                         stripe_email: user.email,
                         stripe_amount: 4000
         end.to change(Payment, :count).by(1)
-        expect(response).to render_with_layout("payments_layout")
         payment = Payment.last
         expect(payment.user_id).to eq(user.id)
         user.reload
@@ -87,7 +84,6 @@ describe PaymentsController do
                         stripe_plan: "",
                         stripe_subscription: ""
         end.to change(Payment, :count).by(1)
-        expect(response).to render_with_layout("payments_layout")
         payment = Payment.last
         expect(payment.user_id).to eq(user.id)
         user.reload

--- a/spec/controllers/registrations_controller_spec.rb
+++ b/spec/controllers/registrations_controller_spec.rb
@@ -6,7 +6,6 @@ describe RegistrationsController do
   let(:organization) { auto_user.organizations.first }
   let(:renders_embed_without_xframe) do
     expect(response.status).to eq(200)
-    expect(response).to render_with_layout("reg_embed")
     expect(response.headers["X-Frame-Options"]).not_to be_present
     expect(flash).to_not be_present
   end
@@ -16,7 +15,6 @@ describe RegistrationsController do
       get :new, organization_id: organization.id, stolen: true
       expect(response).to render_template(:new)
       expect(response.status).to eq(200)
-      expect(response).to render_with_layout("application_revised")
       expect(response.headers["X-Frame-Options"]).to be_present
       expect(flash).to_not be_present
     end

--- a/spec/controllers/sessions_controller_spec.rb
+++ b/spec/controllers/sessions_controller_spec.rb
@@ -8,7 +8,6 @@ describe SessionsController do
       expect(response.code).to eq("200")
       expect(response).to render_template("new")
       expect(flash).to_not be_present
-      expect(response).to render_with_layout("application_revised")
     end
     context "signed in user" do
       include_context :logged_in_as_user
@@ -36,13 +35,11 @@ describe SessionsController do
         it "actually sets it, renders bikehub layout" do
           get :new, return_to: "/bikes/12?contact_owner=true", partner: "bikehub"
           expect(session[:return_to]).to eq "/bikes/12?contact_owner=true"
-          expect(response).to render_with_layout("application_revised_bikehub")
         end
         context "partner in session" do
           it "actually sets it, renders bikehub layout" do
             session[:partner] = "bikehub"
             get :new, return_to: "/bikes/12?contact_owner=true"
-            expect(response).to render_with_layout("application_revised_bikehub")
             expect(session[:partner]).to be_nil
           end
         end
@@ -157,7 +154,6 @@ describe SessionsController do
         post :create, session: { password: "something incorrect" }
         expect(session[:user_id]).to be_nil
         expect(response).to render_template("new")
-        expect(response).to render_with_layout("application_revised")
       end
       context "user is organization admin" do
         let(:organization) { FactoryBot.create(:organization, kind: organization_kind) }
@@ -208,7 +204,6 @@ describe SessionsController do
       post :create, session: { email: "notThere@example.com" }
       expect(cookies.signed[:auth]).to be_nil
       expect(response).to render_template(:new)
-      expect(response).to render_with_layout("application_revised")
     end
   end
 end

--- a/spec/controllers/sessions_controller_spec.rb
+++ b/spec/controllers/sessions_controller_spec.rb
@@ -8,6 +8,7 @@ describe SessionsController do
       expect(response.code).to eq("200")
       expect(response).to render_template("new")
       expect(flash).to_not be_present
+      expect(response).to render_template("layouts/application_revised")
     end
     context "signed in user" do
       include_context :logged_in_as_user
@@ -30,17 +31,20 @@ describe SessionsController do
       it "actually sets it" do
         get :new, return_to: "/bikes/12?contact_owner=true"
         expect(session[:return_to]).to eq "/bikes/12?contact_owner=true"
+        expect(response).to render_template("layouts/application_revised")
       end
       context "with partner" do
         it "actually sets it, renders bikehub layout" do
           get :new, return_to: "/bikes/12?contact_owner=true", partner: "bikehub"
           expect(session[:return_to]).to eq "/bikes/12?contact_owner=true"
+          expect(response).to render_template("layouts/application_revised_bikehub")
         end
         context "partner in session" do
           it "actually sets it, renders bikehub layout" do
             session[:partner] = "bikehub"
             get :new, return_to: "/bikes/12?contact_owner=true"
             expect(session[:partner]).to be_nil
+            expect(response).to render_template("layouts/application_revised_bikehub")
           end
         end
       end
@@ -154,6 +158,7 @@ describe SessionsController do
         post :create, session: { password: "something incorrect" }
         expect(session[:user_id]).to be_nil
         expect(response).to render_template("new")
+        expect(response).to render_template("layouts/application_revised")
       end
       context "user is organization admin" do
         let(:organization) { FactoryBot.create(:organization, kind: organization_kind) }
@@ -204,6 +209,7 @@ describe SessionsController do
       post :create, session: { email: "notThere@example.com" }
       expect(cookies.signed[:auth]).to be_nil
       expect(response).to render_template(:new)
+      expect(response).to render_template("layouts/application_revised")
     end
   end
 end

--- a/spec/controllers/stolen_controller_spec.rb
+++ b/spec/controllers/stolen_controller_spec.rb
@@ -13,7 +13,6 @@ describe StolenController do
       get :index, format: :text
       expect(response.status).to eq(200)
       expect(response).to render_template(:index)
-      expect(response).to render_with_layout("application_revised")
     end
   end
 

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -391,7 +391,7 @@ describe UsersController do
             expect(response).to be_success
             expect(assigns(:edit_template)).to eq(template)
             expect(response).to render_template(partial: "_edit_#{template}")
-            expect(response).to render_template("layouts/application_revised_bikehub")
+            expect(response).to render_template("layouts/application_revised")
           end
         end
       end

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -31,6 +31,7 @@ describe UsersController do
         expect(response.code).to eq("200")
         expect(response).to render_template("new")
         expect(flash).to_not be_present
+        expect(response).to render_template("layouts/application_revised")
       end
       context "with partner param" do
         it "actually sets it" do
@@ -38,6 +39,7 @@ describe UsersController do
           expect(assigns(:user).email).to eq "seth@bikes.com"
           expect(session[:return_to]).to eq "/bikes/12?contact_owner=true"
           expect(session[:partner]).to be_nil
+          expect(response).to render_template("layouts/application_revised_bikehub")
         end
         context "with partner session" do
           it "actually sets it" do
@@ -45,6 +47,7 @@ describe UsersController do
             get :new, return_to: "/bikes/12?contact_owner=true"
             expect(session[:return_to]).to eq "/bikes/12?contact_owner=true"
             session[:partner] = "bikehub"
+            expect(response).to render_template("layouts/application_revised_bikehub")
           end
         end
       end
@@ -169,6 +172,7 @@ describe UsersController do
             post :create, partner: "bikehub", user: user_attributes
             expect(response).to render_template("new")
             expect(assigns(:page_errors)).to be_present
+            expect(response).to render_template("layouts/application_revised_bikehub")
           end
         end
       end
@@ -356,6 +360,7 @@ describe UsersController do
       get :accept_vendor_terms
       expect(response.status).to eq(200)
       expect(response).to render_template(:accept_vendor_terms)
+      expect(response).to render_template("layouts/application_revised")
     end
   end
 
@@ -375,6 +380,7 @@ describe UsersController do
         expect(response).to be_success
         expect(assigns(:edit_template)).to eq("root")
         expect(response).to render_template("edit")
+        expect(response).to render_template("layouts/application_revised")
       end
     end
     context "application_revised layout" do
@@ -385,6 +391,7 @@ describe UsersController do
             expect(response).to be_success
             expect(assigns(:edit_template)).to eq(template)
             expect(response).to render_template(partial: "_edit_#{template}")
+            expect(response).to render_template("layouts/application_revised_bikehub")
           end
         end
       end

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -31,14 +31,12 @@ describe UsersController do
         expect(response.code).to eq("200")
         expect(response).to render_template("new")
         expect(flash).to_not be_present
-        expect(response).to render_with_layout("application_revised")
       end
       context "with partner param" do
         it "actually sets it" do
           get :new, email: "seth@bikes.com", return_to: "/bikes/12?contact_owner=true", partner: "bikehub"
           expect(assigns(:user).email).to eq "seth@bikes.com"
           expect(session[:return_to]).to eq "/bikes/12?contact_owner=true"
-          expect(response).to render_with_layout("application_revised_bikehub")
           expect(session[:partner]).to be_nil
         end
         context "with partner session" do
@@ -46,7 +44,6 @@ describe UsersController do
             session[:partner] = "bikehub"
             get :new, return_to: "/bikes/12?contact_owner=true"
             expect(session[:return_to]).to eq "/bikes/12?contact_owner=true"
-            expect(response).to render_with_layout("application_revised_bikehub")
             session[:partner] = "bikehub"
           end
         end
@@ -172,7 +169,6 @@ describe UsersController do
             post :create, partner: "bikehub", user: user_attributes
             expect(response).to render_template("new")
             expect(assigns(:page_errors)).to be_present
-            expect(response).to render_with_layout("application_revised_bikehub")
           end
         end
       end
@@ -360,7 +356,6 @@ describe UsersController do
       get :accept_vendor_terms
       expect(response.status).to eq(200)
       expect(response).to render_template(:accept_vendor_terms)
-      expect(response).to render_with_layout("application_revised")
     end
   end
 
@@ -369,7 +364,6 @@ describe UsersController do
       set_current_user(user)
       get :accept_terms
       expect(response).to render_template(:accept_terms)
-      expect(response).to render_with_layout("application_revised")
     end
   end
 
@@ -379,7 +373,6 @@ describe UsersController do
       it "renders root" do
         get :edit
         expect(response).to be_success
-        expect(response).to render_with_layout("application_revised")
         expect(assigns(:edit_template)).to eq("root")
         expect(response).to render_template("edit")
       end
@@ -390,7 +383,6 @@ describe UsersController do
           it "renders the template" do
             get :edit, page: template
             expect(response).to be_success
-            expect(response).to render_with_layout("application_revised")
             expect(assigns(:edit_template)).to eq(template)
             expect(response).to render_template(partial: "_edit_#{template}")
           end

--- a/spec/controllers/welcome_controller_spec.rb
+++ b/spec/controllers/welcome_controller_spec.rb
@@ -6,7 +6,6 @@ describe WelcomeController do
       get :index
       expect(response.status).to eq(200)
       expect(response).to render_template("index")
-      expect(response).to render_with_layout("application_revised")
       expect(flash).to_not be_present
     end
     context "json request format" do
@@ -14,7 +13,6 @@ describe WelcomeController do
         get :index, format: :json
         expect(response.status).to eq(200)
         expect(response).to render_template("index")
-        expect(response).to render_with_layout("application_revised")
         expect(flash).to_not be_present
       end
     end
@@ -33,7 +31,6 @@ describe WelcomeController do
       get :goodbye
       expect(response.status).to eq(200)
       expect(response).to render_template("goodbye")
-      expect(response).to render_with_layout("application_revised")
       expect(flash).to_not be_present
     end
     context "logged_in" do
@@ -66,7 +63,6 @@ describe WelcomeController do
         get :choose_registration
         expect(response.status).to eq(200)
         expect(response).to render_template("choose_registration")
-        expect(response).to render_with_layout("application_revised")
       end
     end
   end
@@ -98,7 +94,6 @@ describe WelcomeController do
             get :user_home
             expect(response.status).to eq(200)
             expect(response).to render_template("user_home")
-            expect(response).to render_with_layout("application_revised")
             expect(session[:passive_organization_id]).to eq "0"
             expect(assigns[:passive_organization]).to be_nil
           end
@@ -110,7 +105,6 @@ describe WelcomeController do
             get :user_home
             expect(response.status).to eq(200)
             expect(response).to render_template("user_home")
-            expect(response).to render_with_layout("application_revised")
             expect(session[:passive_organization_id]).to eq organization.id
             expect(assigns[:passive_organization]).to eq organization
           end
@@ -130,7 +124,6 @@ describe WelcomeController do
             get :user_home, per_page: 1
             expect(response.status).to eq(200)
             expect(response).to render_template("user_home")
-            expect(response).to render_with_layout("application_revised")
             expect(assigns(:bikes).count).to eq 1
             expect(assigns(:per_page).to_s).to eq "1"
             expect(assigns(:bikes).first).to eq(bike)
@@ -149,7 +142,6 @@ describe WelcomeController do
         expect(assigns(:recovery_displays).count).to eq 2
         expect(response.status).to eq(200)
         expect(response).to render_template("recovery_stories")
-        expect(response).to render_with_layout("application_revised")
         expect(flash).to_not be_present
       end
 
@@ -159,7 +151,6 @@ describe WelcomeController do
         expect(assigns(:recovery_displays)).to be_empty
         expect(response.status).to eq(200)
         expect(response).to render_template("recovery_stories")
-        expect(response).to render_with_layout("application_revised")
         expect(flash).to be_present
       end
     end

--- a/spec/models/ad_spec.rb
+++ b/spec/models/ad_spec.rb
@@ -1,9 +1,4 @@
 require "spec_helper"
 
 describe Ad do
-  describe "validations" do
-    it { is_expected.to belong_to :organization }
-    it { is_expected.to validate_presence_of :title }
-    it { is_expected.to validate_uniqueness_of :title }
-  end
 end

--- a/spec/models/ambassador_task_assignment_spec.rb
+++ b/spec/models/ambassador_task_assignment_spec.rb
@@ -1,12 +1,6 @@
 require "spec_helper"
 
 describe AmbassadorTaskAssignment, type: :model do
-  it { is_expected.to belong_to(:user) }
-  it { is_expected.to belong_to(:ambassador_task) }
-  it { is_expected.to validate_presence_of(:user) }
-  it { is_expected.to validate_presence_of(:ambassador_task) }
-  it { is_expected.to delegate_method(:description).to(:ambassador_task) }
-
   let(:non_ambassador) { FactoryBot.create(:user) }
   let(:ambassador) { FactoryBot.create(:ambassador) }
   let(:ambassador_task) { FactoryBot.create(:ambassador_task) }

--- a/spec/models/ambassador_task_spec.rb
+++ b/spec/models/ambassador_task_spec.rb
@@ -1,11 +1,6 @@
 require "spec_helper"
 
 describe AmbassadorTask, type: :model do
-  it { is_expected.to have_many(:users) }
-  it { is_expected.to have_many(:ambassador_task_assignments) }
-
-  it { is_expected.to validate_uniqueness_of(:title) }
-
   describe "#ensure_assigned_to_all_ambassadors!" do
     it "idempotently creates assignments to the given task for all ambassadors" do
       user = FactoryBot.create(:user_confirmed)

--- a/spec/models/b_param_spec.rb
+++ b/spec/models/b_param_spec.rb
@@ -1,12 +1,6 @@
 require "spec_helper"
 
 describe BParam do
-  describe "validations" do
-    it { is_expected.to belong_to :created_bike }
-    it { is_expected.to belong_to :creator }
-    # it { should validate_presence_of :creator }
-  end
-
   describe "bike" do
     it "returns the bike attribs" do
       b_param = BParam.new(params: { bike: { serial_number: "XXX" } })

--- a/spec/models/bike_organization_spec.rb
+++ b/spec/models/bike_organization_spec.rb
@@ -1,11 +1,4 @@
 require "spec_helper"
 
 RSpec.describe BikeOrganization, type: :model do
-  describe "validations" do
-    it { is_expected.to belong_to :bike }
-    it { is_expected.to belong_to :organization }
-    it { is_expected.to validate_presence_of :bike_id }
-    it { is_expected.to validate_presence_of :organization_id }
-    it { is_expected.to validate_uniqueness_of(:organization_id).scoped_to(:bike_id) }
-  end
 end

--- a/spec/models/bike_spec.rb
+++ b/spec/models/bike_spec.rb
@@ -2,38 +2,6 @@ require "spec_helper"
 
 describe Bike do
   it_behaves_like "bike_searchable"
-  describe "validations" do
-    it { is_expected.to belong_to :manufacturer }
-    it { is_expected.to belong_to :primary_frame_color }
-    it { is_expected.to belong_to :secondary_frame_color }
-    it { is_expected.to belong_to :tertiary_frame_color }
-    it { is_expected.to belong_to :rear_wheel_size }
-    it { is_expected.to belong_to :front_wheel_size }
-    it { is_expected.to belong_to :rear_gear_type }
-    it { is_expected.to belong_to :front_gear_type }
-    it { is_expected.to belong_to :paint }
-    it { is_expected.to belong_to :updator }
-    it { is_expected.to have_many :bike_organizations }
-    it { is_expected.to have_many(:organizations).through(:bike_organizations) }
-    it { is_expected.to belong_to :creation_organization }
-    it { is_expected.to belong_to :current_stolen_record }
-    it { is_expected.to have_many :duplicate_bike_groups }
-    it { is_expected.to have_many :b_params }
-    it { is_expected.to have_many :stolen_notifications }
-    it { is_expected.to have_many :stolen_records }
-    it { is_expected.to have_many :ownerships }
-    it { is_expected.to have_many :public_images }
-    it { is_expected.to have_many :components }
-    it { is_expected.to have_many :other_listings }
-    it { is_expected.to accept_nested_attributes_for :stolen_records }
-    it { is_expected.to accept_nested_attributes_for :components }
-    it { is_expected.to validate_presence_of :creator }
-    it { is_expected.to validate_presence_of :propulsion_type }
-    it { is_expected.to validate_presence_of :serial_number }
-    it { is_expected.to validate_presence_of :manufacturer_id }
-    it { is_expected.to validate_presence_of :primary_frame_color_id }
-  end
-
   describe "scopes" do
     it "default scopes to created_at desc" do
       expect(Bike.all.to_sql).to eq(Bike.unscoped.where(example: false, hidden: false).order("listing_order desc").to_sql)

--- a/spec/models/blog_spec.rb
+++ b/spec/models/blog_spec.rb
@@ -1,14 +1,6 @@
 require "spec_helper"
 
 describe Blog do
-  # describe 'validations' do
-  #   it { should validate_presence_of :title }
-  #   it { should validate_presence_of :body }
-  #   it { should validate_presence_of :user_id }
-  #   it { should validate_uniqueness_of :title }
-  #   it { should validate_uniqueness_of :title_slug }
-  # end
-
   describe "friendly_find" do
     let(:user) { FactoryBot.create(:user) }
     let!(:blog) { Blog.create(title: "foo title", body: "ummmmm good", user_id: user.id, old_title_slug: "an-elder-statesman-title") }

--- a/spec/models/cgroup_spec.rb
+++ b/spec/models/cgroup_spec.rb
@@ -2,11 +2,6 @@ require "spec_helper"
 
 describe Cgroup do
   it_behaves_like "friendly_slug_findable"
-  describe "validations" do
-    it { is_expected.to have_many :ctypes }
-    it { is_expected.to validate_presence_of :name }
-    it { is_expected.to validate_uniqueness_of :name }
-  end
 
   describe "additional_parts" do
     it "finds additional parts" do

--- a/spec/models/color_spec.rb
+++ b/spec/models/color_spec.rb
@@ -3,12 +3,6 @@ require "spec_helper"
 describe Color do
   it_behaves_like "friendly_name_findable"
   it_behaves_like "autocomplete_hashable"
-  describe "validations" do
-    it { is_expected.to validate_presence_of :name }
-    it { is_expected.to validate_presence_of :priority }
-    it { is_expected.to validate_uniqueness_of :name }
-    it { is_expected.to have_many :paints }
-  end
 
   describe "friendly_find" do
     it "finds users by email address when the case doesn't match" do

--- a/spec/models/component_spec.rb
+++ b/spec/models/component_spec.rb
@@ -1,12 +1,6 @@
 require "spec_helper"
 
 describe Component do
-  describe "validations" do
-    it { is_expected.to belong_to :bike }
-    it { is_expected.to belong_to :manufacturer }
-    it { is_expected.to belong_to :ctype }
-  end
-
   describe "component_type" do
     it "returns the name of the ctype other if it should" do
       ctype = Ctype.new

--- a/spec/models/country_spec.rb
+++ b/spec/models/country_spec.rb
@@ -1,14 +1,6 @@
 require "spec_helper"
 
 describe Country do
-  describe "validations" do
-    it { is_expected.to validate_presence_of :name }
-    it { is_expected.to validate_uniqueness_of :iso }
-    it { is_expected.to validate_uniqueness_of :iso }
-    it { is_expected.to have_many :stolen_records }
-    it { is_expected.to have_many :locations }
-  end
-
   describe "fuzzy_iso_find" do
     it "finds the country by ISO address when the case doesn't match" do
       country = Country.create(name: "EEEEEEEh", iso: "LULZ")

--- a/spec/models/ctype_spec.rb
+++ b/spec/models/ctype_spec.rb
@@ -2,10 +2,4 @@ require "spec_helper"
 
 describe Ctype do
   it_behaves_like "friendly_slug_findable"
-  describe "validations" do
-    it { is_expected.to belong_to :cgroup }
-    it { is_expected.to have_many :components }
-    it { is_expected.to validate_presence_of :name }
-    it { is_expected.to validate_uniqueness_of :name }
-  end
 end

--- a/spec/models/customer_contact_spec.rb
+++ b/spec/models/customer_contact_spec.rb
@@ -1,20 +1,6 @@
 require "spec_helper"
 
 describe CustomerContact do
-  describe "validations" do
-    it { is_expected.to validate_presence_of :user_email }
-    it { is_expected.to validate_presence_of :creator_email }
-    # it { should validate_presence_of :creator_id }
-    it { is_expected.to validate_presence_of :contact_type }
-    it { is_expected.to validate_presence_of :bike_id }
-    it { is_expected.to validate_presence_of :title }
-    it { is_expected.to validate_presence_of :body }
-    it { is_expected.to belong_to :user }
-    it { is_expected.to belong_to :creator }
-    it { is_expected.to belong_to :bike }
-    it { is_expected.to serialize :info_hash }
-  end
-
   describe "normalize_email_and_find_user" do
     it "finds email and associate" do
       user = FactoryBot.create(:user)

--- a/spec/models/duplicate_bike_group_spec.rb
+++ b/spec/models/duplicate_bike_group_spec.rb
@@ -1,9 +1,6 @@
 require "spec_helper"
 
 describe DuplicateBikeGroup do
-  it { is_expected.to have_many :normalized_serial_segments }
-  it { is_expected.to have_many :bikes }
-
   describe "segment" do
     it "returns the first segment" do
       duplicate_bike_group = DuplicateBikeGroup.new

--- a/spec/models/feedback_spec.rb
+++ b/spec/models/feedback_spec.rb
@@ -1,15 +1,6 @@
 require "spec_helper"
 
 describe Feedback do
-  describe "validations" do
-    it { is_expected.to validate_presence_of :body }
-    it { is_expected.to validate_presence_of :email }
-    it { is_expected.to validate_presence_of :title }
-    it { is_expected.to serialize :feedback_hash }
-    it { is_expected.to belong_to :user }
-    # it { should belong_to :application } # This is Doorkeeper::Application, not application
-  end
-
   describe "create" do
     it "enqueues an email job" do
       expect do

--- a/spec/models/front_gear_type_spec.rb
+++ b/spec/models/front_gear_type_spec.rb
@@ -1,9 +1,4 @@
 require "spec_helper"
 
 describe FrontGearType do
-  describe "validations" do
-    it { is_expected.to validate_presence_of :name }
-    it { is_expected.to validate_presence_of :count }
-    it { is_expected.to validate_uniqueness_of :name }
-  end
 end

--- a/spec/models/integration_spec.rb
+++ b/spec/models/integration_spec.rb
@@ -1,11 +1,6 @@
 require "spec_helper"
 
 describe Integration do
-  describe "validations" do
-    it { is_expected.to validate_presence_of :information }
-    it { is_expected.to validate_presence_of :access_token }
-  end
-
   let(:facebook_file) { File.read(Rails.root.join("spec", "fixtures", "integration_data_facebook.json")) }
   let(:strava_file) { File.read(Rails.root.join("spec", "fixtures", "integration_data_strava.json")) }
 

--- a/spec/models/listicle_spec.rb
+++ b/spec/models/listicle_spec.rb
@@ -1,7 +1,4 @@
 require "spec_helper"
 
 describe Listicle do
-  describe "validations" do
-    it { is_expected.to belong_to :blog }
-  end
 end

--- a/spec/models/location_spec.rb
+++ b/spec/models/location_spec.rb
@@ -1,16 +1,6 @@
 require "spec_helper"
 
 describe Location do
-  describe "validations" do
-    it { is_expected.to belong_to :organization }
-    it { is_expected.to belong_to :country }
-    it { is_expected.to belong_to :state }
-    it { is_expected.to validate_presence_of :name }
-    it { is_expected.to validate_presence_of :organization }
-    it { is_expected.to validate_presence_of :city }
-    it { is_expected.to validate_presence_of :country }
-  end
-
   describe "set_phone" do
     it "strips the non-digit numbers from the phone input" do
       location = FactoryBot.create(:location, phone: "773.83ddp+83(887)")

--- a/spec/models/mail_snippet_spec.rb
+++ b/spec/models/mail_snippet_spec.rb
@@ -1,12 +1,6 @@
 require "spec_helper"
 
 describe MailSnippet do
-  describe "validations" do
-    it { is_expected.to validate_presence_of :name }
-    it { is_expected.to belong_to :organization }
-    it { is_expected.to validate_uniqueness_of(:organization_id).scoped_to(:name) }
-  end
-
   describe "disable_if_blank" do
     it "sets unenabled if body is blank" do
       mail_snippet = MailSnippet.new(is_enabled: true, body: nil, name: "welcome")

--- a/spec/models/manufacturer_spec.rb
+++ b/spec/models/manufacturer_spec.rb
@@ -2,16 +2,6 @@ require "spec_helper"
 
 describe Manufacturer do
   it_behaves_like "autocomplete_hashable"
-  describe "validations" do
-    it { is_expected.to validate_presence_of :name }
-    it { is_expected.to validate_uniqueness_of :name }
-    it { is_expected.to validate_uniqueness_of :slug }
-    it { is_expected.to have_many :bikes }
-    it { is_expected.to have_many :locks }
-    it { is_expected.to have_many :components }
-    it { is_expected.to have_many :paints }
-  end
-
   describe "scopes" do
     it "default_scope is alphabetized" do
       expect(Manufacturer.all.to_sql).to eq(Manufacturer.unscoped.order(:name).to_sql)

--- a/spec/models/membership_spec.rb
+++ b/spec/models/membership_spec.rb
@@ -1,13 +1,6 @@
 require "spec_helper"
 
 describe Membership do
-  describe "validations" do
-    it { is_expected.to belong_to :organization }
-    it { is_expected.to validate_presence_of(:role).with_message(/a role/i) }
-    it { is_expected.to validate_presence_of(:organization).with_message(/organization/i) }
-    it { is_expected.to validate_presence_of(:user).with_message(/user/) }
-  end
-
   describe ".ambassador_organizations" do
     it "returns all and only ambassador organizations" do
       FactoryBot.create(:existing_membership)

--- a/spec/models/normalized_serial_segment_spec.rb
+++ b/spec/models/normalized_serial_segment_spec.rb
@@ -1,9 +1,4 @@
 require "spec_helper"
 
 describe NormalizedSerialSegment do
-  it { is_expected.to belong_to :bike }
-  it { is_expected.to belong_to :duplicate_bike_group }
-  it { is_expected.to validate_presence_of :bike_id }
-  it { is_expected.to validate_presence_of :segment }
-  it { is_expected.to validate_uniqueness_of(:segment).scoped_to(:bike_id) }
 end

--- a/spec/models/organization_invitation_spec.rb
+++ b/spec/models/organization_invitation_spec.rb
@@ -1,15 +1,6 @@
 require "spec_helper"
 
 describe OrganizationInvitation do
-  describe "validations" do
-    it { is_expected.to belong_to :inviter }
-    it { is_expected.to belong_to :invitee }
-    it { is_expected.to validate_presence_of :invitee_email }
-    it { is_expected.to validate_presence_of :organization_id }
-    it { is_expected.to validate_presence_of :inviter }
-    it { is_expected.to validate_presence_of :membership_role }
-  end
-
   describe "create" do
     before :each do
       @o = FactoryBot.create(:organization_invitation)

--- a/spec/models/organization_spec.rb
+++ b/spec/models/organization_spec.rb
@@ -1,22 +1,6 @@
 require "spec_helper"
 
 describe Organization do
-  describe "validations" do
-    # it { should validate_uniqueness_of :slug }
-    it { is_expected.to validate_presence_of :name }
-    it { is_expected.to have_many :memberships }
-    it { is_expected.to have_many :mail_snippets }
-    it { is_expected.to have_many :users }
-    it { is_expected.to have_many :organization_invitations }
-    it { is_expected.to have_many(:bike_organizations) }
-    # it { is_expected.to have_many(:bikes).through(:bike_organizations) }
-    it { is_expected.to have_many :creation_states }
-    it { is_expected.to have_many(:created_bikes).through(:creation_states) }
-
-    it { is_expected.to have_many :locations }
-    it { is_expected.to belong_to :auto_user }
-  end
-
   describe "#set_ambassador_organization_defaults before_save hook" do
     context "when saving a new ambassador org" do
       it "sets non-applicable attributes to sensible ambassador org values" do

--- a/spec/models/other_listing_spec.rb
+++ b/spec/models/other_listing_spec.rb
@@ -1,9 +1,4 @@
 require "spec_helper"
 
 describe OtherListing do
-  describe "validations" do
-    it { is_expected.to validate_presence_of :bike_id }
-    it { is_expected.to validate_presence_of :url }
-    it { is_expected.to belong_to :bike }
-  end
 end

--- a/spec/models/ownership_spec.rb
+++ b/spec/models/ownership_spec.rb
@@ -1,15 +1,6 @@
 require "spec_helper"
 
 describe Ownership do
-  describe "validations" do
-    it { is_expected.to belong_to(:bike).touch true }
-    it { is_expected.to belong_to(:user).touch true }
-    it { is_expected.to belong_to :creator }
-    it { is_expected.to validate_presence_of :creator_id }
-    it { is_expected.to validate_presence_of :bike_id }
-    it { is_expected.to validate_presence_of :owner_email }
-  end
-
   describe "normalize_email" do
     it "removes leading and trailing whitespace and downcase email" do
       ownership = Ownership.new

--- a/spec/models/paint_spec.rb
+++ b/spec/models/paint_spec.rb
@@ -2,16 +2,6 @@ require "spec_helper"
 
 describe Paint do
   it_behaves_like "friendly_name_findable"
-  describe "validations" do
-    it { is_expected.to validate_presence_of :name }
-    it { is_expected.to validate_uniqueness_of :name }
-    it { is_expected.to belong_to :color }
-    it { is_expected.to belong_to :secondary_color }
-    it { is_expected.to belong_to :tertiary_color }
-    it { is_expected.to belong_to :manufacturer }
-    it { is_expected.to have_many :bikes }
-  end
-
   describe "lowercase name" do
     it "makes the name lowercase on save" do
       pd = Paint.create(name: "Hazel or Something")

--- a/spec/models/public_image_spec.rb
+++ b/spec/models/public_image_spec.rb
@@ -1,10 +1,6 @@
 require "spec_helper"
 
 describe PublicImage do
-  describe "validations" do
-    it { is_expected.to belong_to :imageable }
-  end
-
   describe "default_name" do
     it "sets a default name from filename if not bike" do
       public_image = PublicImage.new

--- a/spec/models/rear_gear_type_spec.rb
+++ b/spec/models/rear_gear_type_spec.rb
@@ -1,9 +1,4 @@
 require "spec_helper"
 
 describe RearGearType do
-  describe "validations" do
-    it { is_expected.to validate_presence_of :name }
-    it { is_expected.to validate_presence_of :count }
-    it { is_expected.to validate_uniqueness_of :name }
-  end
 end

--- a/spec/models/recovery_display_spec.rb
+++ b/spec/models/recovery_display_spec.rb
@@ -1,13 +1,6 @@
 require "spec_helper"
 
 describe RecoveryDisplay do
-  describe "validations" do
-    it { is_expected.to validate_presence_of :quote }
-    it { is_expected.to belong_to :stolen_record }
-    # Before validation sets it, so test fails
-    # it { should validate_presence_of :recovered_at }
-  end
-
   describe "set_time" do
     it "sets time from input" do
       recovery_display = RecoveryDisplay.new(date_input: "04-27-1999")

--- a/spec/models/state_spec.rb
+++ b/spec/models/state_spec.rb
@@ -1,17 +1,6 @@
 require "spec_helper"
 
 describe State do
-  describe "validations" do
-    it { is_expected.to have_many :locations }
-    it { is_expected.to have_many :stolen_records }
-    it { is_expected.to belong_to :country }
-    it { is_expected.to validate_presence_of :country }
-    it { is_expected.to validate_presence_of :name }
-    it { is_expected.to validate_presence_of :abbreviation }
-    it { is_expected.to validate_uniqueness_of :name }
-    it { is_expected.to validate_uniqueness_of :abbreviation }
-  end
-
   describe "fuzzy_abbr_find" do
     it "finds users by email address when the case doesn't match" do
       state = FactoryBot.create(:state, abbreviation: "LULZ")

--- a/spec/models/stolen_record_spec.rb
+++ b/spec/models/stolen_record_spec.rb
@@ -1,16 +1,6 @@
 require "spec_helper"
 
 describe StolenRecord do
-  describe "validations" do
-    it { is_expected.to validate_presence_of :bike }
-    it { is_expected.to belong_to :bike }
-    it { is_expected.to have_one :recovery_display }
-    it { is_expected.to belong_to :country }
-    it { is_expected.to belong_to :state }
-    it { is_expected.to belong_to :creation_organization }
-    it { is_expected.to belong_to :recovering_user }
-  end
-
   it "marks current true by default" do
     stolen_record = StolenRecord.new
     expect(stolen_record.current).to be_truthy

--- a/spec/models/tweet_spec.rb
+++ b/spec/models/tweet_spec.rb
@@ -1,11 +1,8 @@
+# coding: utf-8
 require "spec_helper"
 
 RSpec.describe Tweet, type: :model do
   let(:twitter_response) { File.read(Rails.root.join("spec", "fixtures", "integration_data_tweet.json")) }
-
-  describe "validations" do
-    it { should validate_presence_of :twitter_id }
-  end
 
   describe "friendly_find" do
     let!(:tweet) { FactoryBot.create(:tweet) }

--- a/spec/models/user_email_spec.rb
+++ b/spec/models/user_email_spec.rb
@@ -1,13 +1,6 @@
 require "spec_helper"
 
 describe UserEmail do
-  describe "validations" do
-    it { is_expected.to belong_to(:user).touch(true) }
-    it { is_expected.to belong_to :old_user }
-    it { is_expected.to validate_presence_of :user_id }
-    it { is_expected.to validate_presence_of :email }
-  end
-
   describe "scopes" do
     it "confirmed only user_emails without tokens" do
       expect(UserEmail.confirmed.to_sql).to eq(UserEmail.where("confirmation_token IS NULL").to_sql)

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -28,29 +28,6 @@ describe User do
     end
   end
 
-  describe "validations" do
-    it { is_expected.to have_many :user_emails }
-    it { is_expected.to have_many :payments }
-    it { is_expected.to have_many :subscriptions }
-    it { is_expected.to have_many :memberships }
-    it { is_expected.to have_many :organization_embeds }
-    it { is_expected.to have_many :organizations }
-    it { is_expected.to have_many :ownerships }
-    it { is_expected.to have_many :current_ownerships }
-    it { is_expected.to have_many :owned_bikes }
-    it { is_expected.to have_many :currently_owned_bikes }
-    it { is_expected.to have_many :integrations }
-    it { is_expected.to have_many :created_ownerships }
-    it { is_expected.to have_many :locks }
-    it { is_expected.to have_many :organization_invitations }
-    it { is_expected.to have_many :oauth_applications }
-    it { is_expected.to have_many :sent_stolen_notifications }
-    it { is_expected.to have_many :received_stolen_notifications }
-    it { is_expected.to validate_presence_of :email }
-    it { is_expected.to have_many :ambassador_task_assignments }
-    it { is_expected.to have_many(:ambassador_tasks).through(:ambassador_task_assignments) }
-  end
-
   describe "create user_email" do
     it "creates a user_email on create" do
       user = FactoryBot.create(:user_confirmed)

--- a/spec/models/wheel_size_spec.rb
+++ b/spec/models/wheel_size_spec.rb
@@ -1,15 +1,6 @@
 require "spec_helper"
 
 describe WheelSize do
-  describe "validations" do
-    it { is_expected.to validate_presence_of :name }
-    it { is_expected.to validate_presence_of :priority }
-    it { is_expected.to validate_presence_of :description }
-    it { is_expected.to validate_presence_of :iso_bsd }
-    it { is_expected.to validate_uniqueness_of :description }
-    it { is_expected.to validate_uniqueness_of :iso_bsd }
-  end
-
   describe "popularity" do
     it "returns the popularities word of the wheel size" do
       wheel_size = WheelSize.new(priority: 1)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -18,7 +18,6 @@ ENV["RAILS_ENV"] ||= "test"
 require File.expand_path("../../config/environment", __FILE__)
 require "rspec/rails"
 # require 'rspec/autorun'
-require "shoulda-matchers"
 require "database_cleaner"
 
 DatabaseCleaner.strategy = :truncation

--- a/spec/workers/additional_email_confirmation_worker_spec.rb
+++ b/spec/workers/additional_email_confirmation_worker_spec.rb
@@ -1,8 +1,6 @@
 require "spec_helper"
 
 describe AdditionalEmailConfirmationWorker do
-  it { is_expected.to be_processed_in :notify }
-
   it "sends a confirm your additional email, email" do
     user_email = FactoryBot.create(:user_email)
     AdditionalEmailConfirmationWorker.new.perform(user_email.id)

--- a/spec/workers/approve_stolen_listing_worker_spec.rb
+++ b/spec/workers/approve_stolen_listing_worker_spec.rb
@@ -1,8 +1,6 @@
 require "spec_helper"
 
 describe ApproveStolenListingWorker do
-  it { is_expected.to be_processed_in :notify }
-
   it "enqueues another awesome job" do
     bike = FactoryBot.create(:bike)
     ApproveStolenListingWorker.perform_async(bike.id)

--- a/spec/workers/cache_all_stolen_worker_spec.rb
+++ b/spec/workers/cache_all_stolen_worker_spec.rb
@@ -1,8 +1,6 @@
 require "spec_helper"
 
 describe CacheAllStolenWorker do
-  it { is_expected.to be_processed_in :carrierwave }
-
   describe "output_stolen" do
     it "creates a stolen cache" do
       FactoryBot.create(:stolen_bike)

--- a/spec/workers/email_admin_contact_stolen_worker_spec.rb
+++ b/spec/workers/email_admin_contact_stolen_worker_spec.rb
@@ -1,8 +1,6 @@
 require "spec_helper"
 
 describe EmailAdminContactStolenWorker do
-  it { is_expected.to be_processed_in :notify }
-
   describe "perform" do
     it "sends an email" do
       stolen_record = FactoryBot.create(:stolen_record)

--- a/spec/workers/email_confirmation_worker_spec.rb
+++ b/spec/workers/email_confirmation_worker_spec.rb
@@ -1,8 +1,6 @@
 require "spec_helper"
 
 describe EmailConfirmationWorker do
-  it { is_expected.to be_processed_in :notify }
-
   it "sends a welcome email" do
     user = FactoryBot.create(:user)
     EmailConfirmationWorker.new.perform(user.id)

--- a/spec/workers/email_feedback_notification_worker_spec.rb
+++ b/spec/workers/email_feedback_notification_worker_spec.rb
@@ -1,8 +1,6 @@
 require "spec_helper"
 
 describe EmailFeedbackNotificationWorker do
-  it { is_expected.to be_processed_in :notify }
-
   it "sends an email" do
     feedback = FactoryBot.create(:feedback)
     ActionMailer::Base.deliveries = []

--- a/spec/workers/email_invoice_worker_spec.rb
+++ b/spec/workers/email_invoice_worker_spec.rb
@@ -1,8 +1,6 @@
 require "spec_helper"
 
 describe EmailInvoiceWorker do
-  it { is_expected.to be_processed_in :notify }
-
   it "sends an email" do
     payment = FactoryBot.create(:payment)
     ActionMailer::Base.deliveries = []

--- a/spec/workers/email_lightspeed_notification_worker_spec.rb
+++ b/spec/workers/email_lightspeed_notification_worker_spec.rb
@@ -1,8 +1,6 @@
 require "spec_helper"
 
 describe EmailLightspeedNotificationWorker do
-  it { is_expected.to be_processed_in :notify }
-
   it "sends an email" do
     organization = FactoryBot.create(:organization)
     api_key = "some key or something"

--- a/spec/workers/email_no_admins_notification_worker_spec.rb
+++ b/spec/workers/email_no_admins_notification_worker_spec.rb
@@ -1,8 +1,6 @@
 require "spec_helper"
 
 describe EmailNoAdminsNotificationWorker do
-  it { is_expected.to be_processed_in :notify }
-
   it "sends an email" do
     organization = FactoryBot.create(:organization)
     ActionMailer::Base.deliveries = []

--- a/spec/workers/email_organization_invitation_worker_spec.rb
+++ b/spec/workers/email_organization_invitation_worker_spec.rb
@@ -1,8 +1,6 @@
 require "spec_helper"
 
 describe EmailOrganizationInvitationWorker do
-  it { is_expected.to be_processed_in :notify }
-
   it "sends an email" do
     organization_invitation = FactoryBot.create(:organization_invitation)
     ActionMailer::Base.deliveries = []

--- a/spec/workers/email_organization_message_worker_spec.rb
+++ b/spec/workers/email_organization_message_worker_spec.rb
@@ -3,7 +3,6 @@ require "spec_helper"
 describe EmailOrganizationMessageWorker do
   let(:subject) { EmailOrganizationMessageWorker }
   let(:instance) { subject.new }
-  it { is_expected.to be_processed_in :notify }
 
   context "delivery failed" do
     let(:organization_message) { FactoryBot.create(:organization_message, delivery_status: "failure") }

--- a/spec/workers/email_ownership_invitation_worker_spec.rb
+++ b/spec/workers/email_ownership_invitation_worker_spec.rb
@@ -1,8 +1,6 @@
 require "spec_helper"
 
 describe EmailOwnershipInvitationWorker do
-  it { is_expected.to be_processed_in :notify }
-
   it "sends an email" do
     ownership = FactoryBot.create(:ownership)
     ActionMailer::Base.deliveries = []

--- a/spec/workers/email_partial_registration_worker_spec.rb
+++ b/spec/workers/email_partial_registration_worker_spec.rb
@@ -1,8 +1,6 @@
 require "spec_helper"
 
 describe EmailPartialRegistrationWorker do
-  it { is_expected.to be_processed_in :notify }
-
   it "sends a partial registration email" do
     b_param = FactoryBot.create(:b_param)
     EmailPartialRegistrationWorker.new.perform(b_param.id)

--- a/spec/workers/email_recovered_from_link_worker_spec.rb
+++ b/spec/workers/email_recovered_from_link_worker_spec.rb
@@ -1,7 +1,6 @@
 require "spec_helper"
 
 describe EmailRecoveredFromLinkWorker do
-  it { is_expected.to be_processed_in :notify }
   let(:bike) { FactoryBot.create(:stolen_bike) }
   let(:stolen_record) { bike.current_stolen_record }
   before { stolen_record.add_recovery_information }

--- a/spec/workers/email_reset_password_worker_spec.rb
+++ b/spec/workers/email_reset_password_worker_spec.rb
@@ -1,8 +1,6 @@
 require "spec_helper"
 
 describe EmailResetPasswordWorker do
-  it { is_expected.to be_processed_in :notify }
-
   it "sends a password_reset email" do
     user = FactoryBot.create(:user)
     EmailResetPasswordWorker.new.perform(user.id)

--- a/spec/workers/email_stolen_bike_alert_worker_spec.rb
+++ b/spec/workers/email_stolen_bike_alert_worker_spec.rb
@@ -1,8 +1,6 @@
 require "spec_helper"
 
 describe EmailStolenBikeAlertWorker do
-  it { is_expected.to be_processed_in :notify }
-
   describe "perform" do
     it "sends an email" do
       stolen_record = FactoryBot.create(:stolen_record)

--- a/spec/workers/email_stolen_notification_worker_spec.rb
+++ b/spec/workers/email_stolen_notification_worker_spec.rb
@@ -3,8 +3,6 @@ require "spec_helper"
 describe EmailStolenNotificationWorker do
   let(:subject) { EmailStolenNotificationWorker }
   let(:instance) { subject.new }
-  it { is_expected.to be_processed_in :notify }
-
   let(:creator) { FactoryBot.create(:user_confirmed) }
   let(:owner_email) { "targetbike@example.org" }
   let(:user) { FactoryBot.create(:user) }

--- a/spec/workers/email_welcome_worker_spec.rb
+++ b/spec/workers/email_welcome_worker_spec.rb
@@ -1,8 +1,6 @@
 require "spec_helper"
 
 describe EmailWelcomeWorker do
-  it { is_expected.to be_processed_in :notify }
-
   it "enqueues listing ordering job" do
     user = FactoryBot.create(:user)
     EmailWelcomeWorker.new.perform(user.id)

--- a/spec/workers/listicle_image_size_worker_spec.rb
+++ b/spec/workers/listicle_image_size_worker_spec.rb
@@ -1,8 +1,6 @@
 require "spec_helper"
 
 describe ListicleImageSizeWorker do
-  it { is_expected.to be_processed_in :carrierwave }
-
   it "enqueues another awesome job" do
     ListicleImageSizeWorker.perform_async
     expect(ListicleImageSizeWorker).to have_enqueued_sidekiq_job

--- a/spec/workers/remove_expired_file_cache_worker_spec.rb
+++ b/spec/workers/remove_expired_file_cache_worker_spec.rb
@@ -1,8 +1,6 @@
 require "spec_helper"
 
 describe RemoveExpiredFileCacheWorker do
-  it { is_expected.to be_processed_in :carrierwave }
-
   describe "perform" do
     it "removes expired files" do
       t = (Time.now - 3.days).to_i

--- a/spec/workers/send_newsletter_worker_spec.rb
+++ b/spec/workers/send_newsletter_worker_spec.rb
@@ -1,7 +1,6 @@
 require "spec_helper"
 
 describe SendNewsletterWorker do
-  it { is_expected.to be_processed_in :notify }
   let(:subject) { SendNewsletterWorker }
   let(:instance) { subject.new }
 

--- a/spec/workers/tsv_creator_worker_spec.rb
+++ b/spec/workers/tsv_creator_worker_spec.rb
@@ -1,8 +1,6 @@
 require "spec_helper"
 
 describe TsvCreatorWorker do
-  it { is_expected.to be_processed_in :carrierwave }
-
   it "enqueues another awesome job" do
     TsvCreatorWorker.perform_async
     expect(TsvCreatorWorker).to have_enqueued_sidekiq_job

--- a/spec/workers/unknown_organization_for_ascend_import_worker_spec.rb
+++ b/spec/workers/unknown_organization_for_ascend_import_worker_spec.rb
@@ -1,7 +1,6 @@
 require "spec_helper"
 
 describe UnknownOrganizationForAscendImportWorker do
-  it { is_expected.to be_processed_in :notify }
   let(:bulk_import) { FactoryBot.create(:bulk_import_ascend) }
 
   it "sends an email" do


### PR DESCRIPTION
- Removes the shoulda-matchers gem and tests that use it.
- Refactoring to use [`let_it_be`](https://github.com/palkan/test-prof) didn't show a huge impact on test run time, so I'm punting on finer-grained optimizations

### Before & After (locally)
```
Finished in 6 minutes 36 seconds (files took 7.86 seconds to load)
2150 examples, 2 failures, 14 pending
```
```
Finished in 5 minutes 55 seconds (files took 7.67 seconds to load)
1916 examples, 3 failures, 14 pending
```

### Before & After (CI)
```
Finished in 1 minute 17.45 seconds (files took 13.25 seconds to load)
408 examples, 0 failures, 4 pending

Randomized with seed 7397
```
```
Finished in 47.76 seconds (files took 9.66 seconds to load)
382 examples, 0 failures, 5 pending

Randomized with seed 29784
```
