### PR TITLE
Display admin ambassador tasks when ambassadors filter selected

### DIFF
--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -66,7 +66,7 @@ class Admin::UsersController < Admin::BaseController
     else
       users = User
     end
-    users = users.ambassadors if @search_ambassadors
+    users = Ambassador.all if @search_ambassadors
     users = users.superusers if @search_superusers
     users = users.admin_text_search(params[:query]) if params[:query].present?
     users

--- a/app/views/admin/users/_table.html.haml
+++ b/app/views/admin/users/_table.html.haml
@@ -21,12 +21,10 @@
         Bikes
       %th
         Memberships
+      - if @search_ambassadors
+        %th Ambassador tasks
       %th
-        %small
-          Ambassador tasks
-
-      %th
-        Admin?
+        Roles
       %th
         %small
           Confirmed
@@ -64,13 +62,12 @@
                   - else
                     - first_org_rendered = true
                   = link_to membership.organization.name.gsub(" ", "\u00a0"), admin_users_path(organization_id: membership.organization_id), class: "small"
-            %td
-              - if user.ambassador?
-                - ambassador = Ambassador.find(user.id)
-                = ambassador.progress_count
+            - if @search_ambassadors
+              %td= user.progress_count
             %td
               %small
                 = "super" if user.superuser?
                 = "developer" if user.developer?
+                = "ambassador" if user.ambassador?
             %td.table-cell-check
               = "&#x2713;".html_safe if user.confirmed


### PR DESCRIPTION
In the admin users display, displays the "ambassador tasks" column conditionally if the "ambassadors" search filter is selected.

<img width="502" alt="Screen Shot 2019-05-29 at 8 47 38 AM" src="https://user-images.githubusercontent.com/4433943/58558490-01ddf100-81ef-11e9-86c8-0ec146bd2e09.png">
<img width="604" alt="Screen Shot 2019-05-29 at 8 47 56 AM" src="https://user-images.githubusercontent.com/4433943/58558492-01ddf100-81ef-11e9-836d-e346069b3d34.png">
<img width="661" alt="Screen Shot 2019-05-29 at 8 48 04 AM" src="https://user-images.githubusercontent.com/4433943/58558493-01ddf100-81ef-11e9-898e-29b0b7d94417.png">
