### PR TITLE
remove codeclimate

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -109,9 +109,6 @@ workflows:
   commit:
     jobs:
       - build
-      - upload-coverage:
-          requires:
-            - build
       - deploy_production:
           requires:
             - build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,11 +49,6 @@ jobs:
           command: yarn install --cache-folder ~/.cache/yarn
       - run: bundle exec rake assets:precompile
       - run:
-          name: Install Code Climate Test Reporter
-          command: |
-            curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
-            chmod +x ./cc-test-reporter
-      - run:
           name: Wait for PostgreSQL to start
           command: dockerize -wait tcp://localhost:5432 -timeout 1m
       - save_cache:
@@ -92,37 +87,10 @@ jobs:
           command: yarn jest --ci --runInBand --reporters=default --reporters=jest-junit
           environment:
             JEST_JUNIT_OUTPUT: "reports/junit/js-test-results.xml"
-      - run:
-          name: Code Climate Test Coverage
-          command: |
-            ./cc-test-reporter format-coverage -t simplecov -o "coverage/codeclimate.$CIRCLE_NODE_INDEX.json"
-      - persist_to_workspace:
-          root: coverage
-          paths:
-            - codeclimate.*.json
       - store_test_results:
           path: test-results
       - store_artifacts:
           path: test-artifacts
-
-  upload-coverage:
-    docker:
-      - image: circleci/ruby:2.5.1-stretch-node
-    environment:
-      CC_TEST_REPORTER_ID: 04daa6564351115dc1515504790cd379ad8dc25e7778f0641e0f8c63185f887c
-    working_directory: ~/bikeindex/bike_index
-
-    steps:
-      - attach_workspace:
-          at: ~/bikeindex/bike_index
-      - run:
-          name: Install Code Climate Test Reporter
-          command: |
-            curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
-            chmod +x ./cc-test-reporter
-      - run:
-          command: |
-            ./cc-test-reporter sum-coverage --output - codeclimate.*.json | ./cc-test-reporter upload-coverage --debug --input -
 
   deploy_production:
     machine:

--- a/Gemfile
+++ b/Gemfile
@@ -155,7 +155,6 @@ group :test do
   gem "guard-rspec"
   gem "guard-rubocop", require: false
   gem "rspec-sidekiq"
-  gem "simplecov", require: false
   gem "vcr" # Stub external HTTP requests
   gem "webmock" # mocking for VCR
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -113,7 +113,6 @@ GEM
     descendants_tracker (0.0.4)
       thread_safe (~> 0.3, >= 0.3.1)
     diff-lcs (1.3)
-    docile (1.1.5)
     domain_name (0.5.20180417)
       unf (>= 0.0.5, < 1.0.0)
     doorkeeper (3.1.0)
@@ -515,11 +514,6 @@ GEM
     simple_spark (1.0.6)
       excon (>= 0.16.0, < 1.0)
       json (>= 1.7.7, < 2.0)
-    simplecov (0.13.0)
-      docile (~> 1.1.0)
-      json (>= 1.8, < 3)
-      simplecov-html (~> 0.10.0)
-    simplecov-html (0.10.2)
     sinatra (1.4.8)
       rack (~> 1.5)
       rack-protection (~> 1.4)
@@ -707,7 +701,6 @@ DEPENDENCIES
   sidekiq (~> 5.1.0)
   sidekiq-failures
   simple_spark
-  simplecov
   sitemap_generator (~> 6)
   skylight
   soulheart (~> 0.3.0)

--- a/README.markdown
+++ b/README.markdown
@@ -1,10 +1,8 @@
-# <p align="center">![BIKE INDEX][bike-index-logo]</p> [Bike Index][bike-index] 🚲 ![Cloud66 Deployment Status][cloud66-badge] [![CircleCI][circleci-badge]][circleci] [![Test Coverage][codeclimate-badge]][codeclimate] [![View performance data on Skylight][skylight-badge]][skylight]
+# <p align="center">![BIKE INDEX][bike-index-logo]</p> [Bike Index][bike-index] 🚲 ![Cloud66 Deployment Status][cloud66-badge] [![CircleCI][circleci-badge]][circleci] [![View performance data on Skylight][skylight-badge]][skylight]
 
 [bike-index-logo]: https://github.com/bikeindex/bike_index/blob/master/bike_index.png?raw=true
 [circleci]: https://circleci.com/gh/bikeindex/bike_index/tree/master
 [circleci-badge]: https://circleci.com/gh/bikeindex/bike_index/tree/master.svg?style=svg
-[codeclimate]: https://codeclimate.com/github/bikeindex/bike_index
-[codeclimate-badge]: https://codeclimate.com/github/bikeindex/bike_index/badges/coverage.svg
 [skylight]: https://oss.skylight.io/app/applications/j93iQ4K2pxCP
 [skylight-badge]: https://badges.skylight.io/status/j93iQ4K2pxCP.svg
 [bike-index]: https://www.bikeindex.org

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -8,12 +8,6 @@ VCR.configure do |config|
   config.hook_into :webmock
 end
 
-# For codeclimate test coverage. Only enable if the environmental variable is set - i.e. on CI
-if ENV["COVERAGE"]
-  require "simplecov"
-  SimpleCov.start "rails"
-end
-
 ENV["RAILS_ENV"] ||= "test"
 require File.expand_path("../../config/environment", __FILE__)
 require "rspec/rails"


### PR DESCRIPTION
- We aren't really using the PR features (eg ["Feel free to ignore codeclimate suggestions if they aren't useful"](https://github.com/bikeindex/bike_index/pull/792#issuecomment-495812808))
- I just looked at the codeclimate page and didn't get any value (even from its test coverage view)
- I think it's vanity metrics, not meaningful, and just a distraction

Please let me know if you see a reason to keep it! If it is providing any value, it should stick around, 