### PR TITLE
Fix homepage copy

### DIFF
--- a/app/views/welcome/index.html.haml
+++ b/app/views/welcome/index.html.haml
@@ -3,7 +3,7 @@
     .container
       .root-landing-header-text
         %h2
-          $#{number_with_delimiter(Counts.recoveries_value)} Bikes Recovered
+          Over $#{number_with_delimiter(Counts.recoveries_value)} Worth of Bikes Recovered
         %h1.upcase
           Bike registration that works
         %h2


### PR DESCRIPTION
Update "bikes recovered" figure to read more naturally

<img width="641" alt="Screen Shot 2019-05-30 at 7 35 31 PM" src="https://user-images.githubusercontent.com/4433943/58671896-444c1e80-8312-11e9-9790-2f4d70363736.png">
