### PR TITLE
Fix for cities tweet

### DIFF
--- a/app/views/landing_pages/_tweet.html.haml
+++ b/app/views/landing_pages/_tweet.html.haml
@@ -1,8 +1,10 @@
 - tweet_id ||= nil # ensure we don't explode when not passed key thing
+- asset_host = Rails.env.development? ? "https://files.bikeindex.org" : ""
 - tweet = Tweet.friendly_find(tweet_id)
+
 - if tweet.present?
   .embeded-tweet
-    = image_tag tweet.image
+    = image_tag "#{asset_host}#{tweet.image}"
     .tweet-display{ class: "tweet-align-#{tweet.alignment}" }
       %a.tweetor-header{ href: tweet.tweetor_link, target: '_blank' }
         = image_tag tweet.tweetor_avatar

--- a/app/views/landing_pages/for_cities.haml
+++ b/app/views/landing_pages/for_cities.haml
@@ -41,7 +41,7 @@
 
 
         %p
-          = render partial: "/landing_pages/tweet", locals: { tweet_id: 1033174779585605633 }
+          = render partial: "/landing_pages/tweet", locals: { tweet_id: 12 }
 
         %h3 Our community is your community
 


### PR DESCRIPTION
The tweet currently persisted has an outdated avatar url. This patch updates the tweet
partial to use a newly fetched version of the same tweet.

### Before

<img width="644" alt="Screen Shot 2019-05-30 at 9 49 19 PM" src="https://user-images.githubusercontent.com/4433943/58676047-e117b780-8324-11e9-9416-d0ed7c39eb84.png">

### After

<img width="633" alt="Screen Shot 2019-05-30 at 9 49 35 PM" src="https://user-images.githubusercontent.com/4433943/58676043-dceb9a00-8324-11e9-8c16-147922ab3451.png">
