### PR TITLE
Update ambassador dashboard coffeescript class name

### DIFF
--- a/app/assets/javascripts/init.coffee
+++ b/app/assets/javascripts/init.coffee
@@ -44,7 +44,7 @@ class BikeIndex.Init extends BikeIndex
       welcome_choose_registration: BikeIndex.ChooseRegistration
       stolen_index: BikeIndex.LegacyStolenIndex
       organized_manage_locations: BikeIndex.OrganizedManageLocations
-      organized_ambassador_dashboard_index: BikeIndex.OrganizedAmbassadorDashboardIndex
+      organized_ambassador_dashboards_show: BikeIndex.OrganizedAmbassadorDashboardsShow
       locks_new: BikeIndex.LocksForm
       locks_edit: BikeIndex.LocksForm
       locks_create: BikeIndex.LocksForm

--- a/app/assets/javascripts/revised/pages/organized/ambassador_dashboards_show.coffee
+++ b/app/assets/javascripts/revised/pages/organized/ambassador_dashboards_show.coffee
@@ -1,4 +1,4 @@
-class BikeIndex.OrganizedAmbassadorDashboardIndex extends BikeIndex
+class BikeIndex.OrganizedAmbassadorDashboardsShow extends BikeIndex
   constructor: ->
     super()
     @initializeEventListeners()


### PR DESCRIPTION
This patch updates the body class name for the ambassador dashboard, which was changed from `organized_ambassador_dashboard_index` to `organized_ambassador_dashboards_show`. 

This restores the ability to update the completion status of ambassador task assignments from the organized ambassador dashboard.