### PR TITLE
Add admin/tweets management facilities

### DIFF
--- a/app/controllers/admin/tweets_controller.rb
+++ b/app/controllers/admin/tweets_controller.rb
@@ -36,6 +36,16 @@ class Admin::TweetsController < Admin::BaseController
     end
   end
 
+  def destroy
+    if @tweet.present? && @tweet.destroy
+      flash[:info] = "Tweet deleted."
+      redirect_to admin_tweets_url
+    else
+      flash[:error] = "Could not delete tweet."
+      redirect_to edit_admin_tweet_url(@tweet.id)
+    end
+  end
+
   private
 
   def permitted_parameters

--- a/app/models/tweet.rb
+++ b/app/models/tweet.rb
@@ -6,13 +6,10 @@ class Tweet < ActiveRecord::Base
   before_validation :ensure_valid_alignment
 
   def self.friendly_find(id)
-    return nil unless id.present?
+    return nil if id.blank?
     id = id.to_s
-    if id.length > 7
-      Tweet.where(twitter_id: id).first
-    else
-      Tweet.where(id: id).first
-    end
+    query = id.length > 7 ? { twitter_id: id } : { id: id }
+    order(created_at: :desc).find_by(query)
   end
 
   def self.auto_link_text(text)

--- a/app/models/tweet.rb
+++ b/app/models/tweet.rb
@@ -1,5 +1,5 @@
 class Tweet < ActiveRecord::Base
-  validates_presence_of :twitter_id
+  validates :twitter_id, presence: true, uniqueness: true
   has_many :public_images, as: :imageable, dependent: :destroy
   mount_uploader :image, ImageUploader
   before_save :set_body_from_response

--- a/app/models/twitter_client.rb
+++ b/app/models/twitter_client.rb
@@ -12,8 +12,8 @@ class TwitterClient
       Twitter::REST::Client.new do |config|
         config.consumer_key = ENV["TWITTER_CONSUMER_KEY"]
         config.consumer_secret = ENV["TWITTER_CONSUMER_SECRET"]
-        config.access_token = ENV["TWITTER_OAUTH_TOKEN"]
-        config.access_token_secret = ENV["TWITTER_OAUTH_TOKEN_SECRET"]
+        config.access_token = ENV["TWITTER_ACCESS_TOKEN"]
+        config.access_token_secret = ENV["TWITTER_ACCESS_SECRET"]
       end
   end
 end

--- a/app/views/admin/tweets/edit.html.haml
+++ b/app/views/admin/tweets/edit.html.haml
@@ -57,7 +57,13 @@
             = f.label :alignment, "Bottom-right", {:for => "tweet_alignment_bottom-right", class: "form-check-label pl-0"}
   .row.justify-content-end
     .col-auto
-      = f.submit 'Save', class: 'btn btn-success float-right'
+      = f.submit "Save", class: "btn btn-success"
+      = link_to "Delete",
+      { controller: "admin/tweets", id: @tweet.id, action: :destroy},
+      confirm: "Are you sure you want to delete this tweet?",
+      method: :delete,
+      class: "btn btn-danger"
+
 %h3
   Landing page rendering:
 .mt-4

--- a/app/views/admin/tweets/index.html.haml
+++ b/app/views/admin/tweets/index.html.haml
@@ -23,7 +23,7 @@
       - @tweets.each do |tweet|
         %tr
           %td
-            %a.convertTime{ href: admin_tweet_path(tweet.twitter_id) }
+            %a.convertTime{ href: admin_tweet_path(tweet.id) }
               = l tweet.created_at, format: :convert_time
           %td
             %small.less-strong

--- a/app/views/landing_pages/_tweet.html.haml
+++ b/app/views/landing_pages/_tweet.html.haml
@@ -1,10 +1,9 @@
 - tweet_id ||= nil # ensure we don't explode when not passed key thing
-- asset_host = Rails.env.development? ? "https://files.bikeindex.org" : ""
 - tweet = Tweet.friendly_find(tweet_id)
 
 - if tweet.present?
   .embeded-tweet
-    = image_tag "#{asset_host}#{tweet.image}"
+    = image_tag tweet.image
     .tweet-display{ class: "tweet-align-#{tweet.alignment}" }
       %a.tweetor-header{ href: tweet.tweetor_link, target: '_blank' }
         = image_tag tweet.tweetor_avatar

--- a/app/views/landing_pages/for_cities.haml
+++ b/app/views/landing_pages/for_cities.haml
@@ -41,7 +41,7 @@
 
 
         %p
-          = render partial: "/landing_pages/tweet", locals: { tweet_id: 12 }
+          = render partial: "/landing_pages/tweet", locals: { tweet_id: 1033174779585605633 }
 
         %h3 Our community is your community
 

--- a/spec/controllers/admin/tweets_controller_spec.rb
+++ b/spec/controllers/admin/tweets_controller_spec.rb
@@ -39,4 +39,32 @@ describe Admin::TweetsController do
       tweet = assigns(:tweet)
     end
   end
+
+  describe "#destroy" do
+    context "given a successful deletion" do
+      it "deletes the tweet, redirects to tweet index url with an appropriate flash" do
+        tweet = FactoryBot.create(:tweet)
+
+        delete :destroy, id: tweet.id
+
+        expect(response).to redirect_to(admin_tweets_url)
+        expect(flash[:error]).to be_blank
+        expect(flash[:info]).to match("deleted")
+      end
+    end
+
+    context "given a failed deletion" do
+      it "redirects to tweet edit url with an appropriate flash" do
+        tweet = FactoryBot.create(:tweet)
+        allow(tweet).to receive(:destroy).and_return(false)
+        allow(Tweet).to receive(:friendly_find).with(tweet.id.to_s).and_return(tweet)
+
+        delete :destroy, id: tweet.id
+
+        expect(response).to redirect_to(edit_admin_tweet_url)
+        expect(flash[:info]).to be_blank
+        expect(flash[:error]).to match("Could not delete")
+      end
+    end
+  end
 end


### PR DESCRIPTION
Prompted by the expedient workaround in https://github.com/bikeindex/bike_index/pull/826:

- Updates the Twitter API ENV keys to match C66 config (possibly a long-standing bug)
- Navigate from admin tweets index to edit page using tweet id rather than twitter id
- Updates `friendly_find` to return the most recent version of a tweet
- Ensures duplicate records (by `twitter_id`) are disallowed (if this is undesirable, please advise)
- Adds ability to delete tweet records

Resolves #827 