### PR TITLE
Update omniauth, jazz_fingers

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -38,7 +38,7 @@ gem "libv8", "~> 3.16.14.7"
 gem "mini_magick" # a smaller implementation of rmagick, required for rqrcode
 gem "money-rails"
 gem "nokogiri", "~> 1.8.1"
-gem "omniauth", "~> 1.3.2"
+gem "omniauth", "~> 1.6"
 gem "omniauth-facebook"
 gem "omniauth-strava"
 gem "paranoia"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -238,7 +238,7 @@ GEM
     ice_nine (0.11.2)
     ipaddress (0.8.3)
     jaro_winkler (1.5.2)
-    jazz_fingers (5.0.0)
+    jazz_fingers (5.0.1)
       awesome_print (~> 1.6)
       pry (~> 0.10)
       pry-byebug (~> 3.4)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -328,9 +328,9 @@ GEM
       multi_json (~> 1.3)
       multi_xml (~> 0.5)
       rack (>= 1.2, < 3)
-    omniauth (1.3.2)
-      hashie (>= 1.2, < 4)
-      rack (>= 1.0, < 3)
+    omniauth (1.9.0)
+      hashie (>= 3.4.6, < 3.7.0)
+      rack (>= 1.6.2, < 3)
     omniauth-facebook (4.0.0)
       omniauth-oauth2 (~> 1.2)
     omniauth-oauth2 (1.4.0)
@@ -663,7 +663,7 @@ DEPENDENCIES
   mini_magick
   money-rails
   nokogiri (~> 1.8.1)
-  omniauth (~> 1.3.2)
+  omniauth (~> 1.6)
   omniauth-facebook
   omniauth-strava
   paranoia


### PR DESCRIPTION
Eliminates deprecation warnings from outdated versions of omniauth, jazz_fingers.

### Before

```
% bin/rails c

W, [2019-06-02T10:15:34.073533 #83787]  WARN -- : You are setting a key that conflicts with a built-in method OmniAuth::AuthHash::InfoHash#name defined at ~/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/omniauth-1.3.2/lib/omniauth/auth_hash.rb:34. This can cause unexpected behavior when accessing the key as a property. You can still access the key via the #[] method.
~/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/jazz_fingers-5.0.0/lib/jazz_fingers/prompt.rb:40:
warning: method Pry#input_array is deprecated. Use Pry#input_ring instead
Loading development environment (Rails 4.2.11)
2.5.1 (bikeindex)[1] »
```

### After

```
bike_index task-completion-feedback % bin/rails c
Loading development environment (Rails 4.2.11)
2.5.1 (bikeindex)[1] »
```

See: 
https://github.com/omniauth/omniauth/issues/872
https://github.com/plribeiro3000/jazz_fingers/issues/20