### PR TITLE
Fix ambassador dashboard exception

### DIFF
--- a/app/controllers/organized/ambassador_dashboards_controller.rb
+++ b/app/controllers/organized/ambassador_dashboards_controller.rb
@@ -3,6 +3,8 @@ module Organized
     before_filter :ensure_ambassador_or_superuser!
     skip_before_filter :ensure_not_ambassador_organization!
 
+    decorates_assigned :ambassadors, :completed_activities, :suggested_activities
+
     def show
       @ambassadors =
         Ambassador
@@ -13,10 +15,10 @@ module Organized
 
       if current_user.ambassador?
         current_ambassador = Ambassador.find(current_user.id).decorate
-        @suggested_activities = current_ambassador.suggested_activities.decorate
-        @completed_activities = current_ambassador.completed_activities.decorate
+        @suggested_activities = current_ambassador.activities_pending
+        @completed_activities = current_ambassador.activities_completed
       else
-        @suggested_activities = AmbassadorTask.task_ordered.decorate
+        @suggested_activities = AmbassadorTask.task_ordered
         @completed_activities = []
       end
     end

--- a/app/decorators/ambassador_decorator.rb
+++ b/app/decorators/ambassador_decorator.rb
@@ -2,21 +2,6 @@ class AmbassadorDecorator < ApplicationDecorator
   delegate_all
   alias ambassador object
 
-  def ambassador_task_assignments
-    ambassador
-      .ambassador_task_assignments
-      .includes(:ambassador_task)
-      .task_ordered
-  end
-
-  def completed_activities
-    ambassador_task_assignments.locked_completed
-  end
-
-  def suggested_activities
-    ambassador_task_assignments.pending_completion
-  end
-
   def avatar
     avatar_url = ambassador.avatar&.url(:medium)
     return if avatar_url.blank? || avatar_url == "https://files.bikeindex.org/blank.png"

--- a/app/decorators/ambassador_task_decorator.rb
+++ b/app/decorators/ambassador_task_decorator.rb
@@ -1,0 +1,6 @@
+class AmbassadorTaskDecorator < ApplicationDecorator
+  delegate_all
+  alias ambassador_task_assignment object
+
+  def button_to_toggle_completion_status(*); end
+end

--- a/app/models/ambassador.rb
+++ b/app/models/ambassador.rb
@@ -1,6 +1,24 @@
 class Ambassador < User
   default_scope -> { ambassadors }
 
+  # Return all of the receiver's `AmbassadorTaskAssignment`s that are completed
+  # and locked.
+  def activities_completed
+    ambassador_task_assignments
+      .includes(:ambassador_task)
+      .locked_completed
+      .task_ordered
+  end
+
+  # Return all of the receiver's `AmbassadorTaskAssignment`s that have not been
+  # completed or have been completed but aren't locked.
+  def activities_pending
+    ambassador_task_assignments
+      .includes(:ambassador_task)
+      .pending_completion
+      .task_ordered
+  end
+
   def percent_complete
     return 0.0 if ambassador_task_assignments.empty?
     (completed_tasks_count / tasks_count.to_f).round(2)

--- a/app/views/organized/ambassador_dashboards/show.html.haml
+++ b/app/views/organized/ambassador_dashboards/show.html.haml
@@ -20,7 +20,7 @@
   our Slack channel or email
   #{link_to "lily@bikeindex.org", "mailto:lily@bikeindex.org"}.
 
-- if @suggested_activities.present?
+- if suggested_activities.present?
   %h2 Suggested Activities
   %table.table.table-striped.table-bordered.ambassador-tasks-table
     %thead.small-header
@@ -28,7 +28,7 @@
         %th Activity
         %th Actions
     %tbody
-      - @suggested_activities.each do |task|
+      - suggested_activities.each do |task|
         %tr
           %td
             %strong= task.title
@@ -37,7 +37,7 @@
           %td
             = task.button_to_toggle_completion_status(current_user, current_organization)
 
-- if @completed_activities.present?
+- if completed_activities.present?
   %h2 Completed activities
   %table.table.table-striped.table-bordered.ambassador-tasks-table
     %thead.small-header
@@ -45,7 +45,7 @@
         %th Activity
         %th Completed
     %tbody
-      - @completed_activities.each do |task|
+      - completed_activities.each do |task|
         %tr
           %td
             %strong= task.title
@@ -62,7 +62,7 @@
       %th Name
       %th Activities
   %tbody
-    - @ambassadors.each do |ambassador|
+    - ambassadors.each do |ambassador|
       %tr
         %td= ambassador.name
         %td= ambassador.progress_count

--- a/spec/requests/organized/ambassador_dashboards_request_spec.rb
+++ b/spec/requests/organized/ambassador_dashboards_request_spec.rb
@@ -1,7 +1,6 @@
 require "spec_helper"
 
 describe "Organized::AmbassadorDashboardsController" do
-  let(:base_url) { "/o/#{organization.to_param}/ambassador_dashboard" }
   # Request specs don't have cookies so we need to stub stuff if we're in request specs
   # This is suboptimal, but hey, it gets us to request specs for now
   before { allow(User).to receive(:from_auth) { user } }
@@ -12,7 +11,7 @@ describe "Organized::AmbassadorDashboardsController" do
     describe "index" do
       let(:organization) { FactoryBot.create(:organization) }
       it "redirects to the user homepage" do
-        get base_url
+        get organization_ambassador_dashboard_path(organization)
         expect(response).to redirect_to(/user_home/)
       end
     end
@@ -23,7 +22,7 @@ describe "Organized::AmbassadorDashboardsController" do
     let(:user) { FactoryBot.create(:organization_member, organization: organization) }
     describe "index" do
       it "redirects the user's homepage" do
-        get base_url
+        get organization_ambassador_dashboard_path(organization)
         expect(response).to redirect_to organization_bikes_path(organization_id: organization)
       end
     end
@@ -34,16 +33,20 @@ describe "Organized::AmbassadorDashboardsController" do
 
     describe "show" do
       it "renders the ambassador dashboard" do
-        get base_url
+        FactoryBot.create_list(:ambassador_task, 2)
+        FactoryBot.create_list(:ambassador, 2, organization: organization)
+
+        get organization_ambassador_dashboard_path(organization)
+
         expect(response.status).to eq(200)
-        expect(assigns(:ambassadors).count).to eq(1)
+        expect(assigns(:ambassadors).count).to eq(3)
         expect(response).to render_template(:show)
       end
     end
 
     describe "resources" do
       it "renders the ambassador resources" do
-        get "#{base_url}/resources"
+        get resources_organization_ambassador_dashboard_path(organization)
         expect(response.status).to eq(200)
         expect(response).to render_template(:resources)
       end
@@ -51,11 +54,45 @@ describe "Organized::AmbassadorDashboardsController" do
 
     describe "getting_started" do
       it "renders the ambassador resources" do
-        get "#{base_url}/getting_started"
+        get getting_started_organization_ambassador_dashboard_path(organization)
+        expect(response.status).to eq(200)
+        expect(response).to render_template(:getting_started)
+      end
+    end
+  end
+
+  context "given a non-ambassador super admin" do
+    let(:user) { FactoryBot.create(:admin) }
+
+    describe "show" do
+      it "renders the ambassador dashboard with ambassadors list" do
+        FactoryBot.create_list(:ambassador_task, 2)
+        FactoryBot.create_list(:ambassador, 2, organization: organization)
+
+        get organization_ambassador_dashboard_path(organization)
+
+        expect(response.status).to eq(200)
+        expect(assigns(:ambassadors).count).to eq(2)
+        expect(assigns(:suggested_activities).count).to eq(2)
+        expect(assigns(:completed_activities).count).to eq(0)
+        expect(response).to render_template(:show)
+      end
+    end
+
+    describe "resources" do
+      it "renders the ambassador resources template" do
+        get resources_organization_ambassador_dashboard_path(organization)
+        expect(response.status).to eq(200)
+        expect(response).to render_template(:resources)
+      end
+    end
+
+    describe "getting_started" do
+      it "renders the ambassador getting started template" do
+        get getting_started_organization_ambassador_dashboard_path(organization)
         expect(response.status).to eq(200)
         expect(response).to render_template(:getting_started)
       end
     end
   end
 end
-


### PR DESCRIPTION
Fixes a UninferrableDecoratorError  / NoMethodError exception that occurs when accessing the organized ambassador dashboard as a super admin who is not in the ambassador organization.

Fixes https://github.com/bikeindex/bike_index/issues/842
https://app.honeybadger.io/projects/35931/faults/50329990#notice-comments