### PR TITLE
Deprecate Draper

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,7 +23,7 @@ gem "soulheart", "~> 0.3.0"
 gem "carrierwave", "~> 0.11.2"
 gem "carrierwave_backgrounder"
 gem "dalli"
-gem "draper", require: false
+gem "draper", require: false # NB: Draper is deprecated in this project
 gem "eventmachine"
 gem "fog-aws"
 gem "geocoder"

--- a/app/controllers/admin/manufacturers_controller.rb
+++ b/app/controllers/admin/manufacturers_controller.rb
@@ -9,7 +9,6 @@ class Admin::ManufacturersController < Admin::BaseController
 
   def show
     raise ActionController::RoutingError.new("Not Found") unless @manufacturer.present?
-    @manufacturer = @manufacturer.decorate
   end
 
   def new

--- a/app/controllers/admin/organizations_controller.rb
+++ b/app/controllers/admin/organizations_controller.rb
@@ -10,12 +10,11 @@ class Admin::OrganizationsController < Admin::BaseController
   end
 
   def show
-    @locations = @organization.locations.decorate
+    @locations = @organization.locations
     bikes = @organization.bikes.reorder("created_at desc")
     page = params[:page] || 1
     per_page = params[:per_page] || 25
     @bikes = bikes.page(page).per(per_page)
-    @organization = @organization.decorate
     render layout: "new_admin"
   end
 

--- a/app/controllers/admin/stolen_notifications_controller.rb
+++ b/app/controllers/admin/stolen_notifications_controller.rb
@@ -22,7 +22,6 @@ class Admin::StolenNotificationsController < Admin::BaseController
 
   def show
     @bike = @stolen_notification.bike
-    @stolen_notification = @stolen_notification.decorate
   end
 
   def find_notification

--- a/app/controllers/bikes_controller.rb
+++ b/app/controllers/bikes_controller.rb
@@ -26,11 +26,11 @@ class BikesController < ApplicationController
   end
 
   def show
-    @components = @bike.components.decorate
+    @components = @bike.components
     if @bike.stolen and @bike.current_stolen_record.present?
       # Show contact owner box on load - happens if user has clicked on it and then logged in
       @contact_owner_open = @bike.contact_owner?(current_user) && params[:contact_owner].present?
-      @stolen_record = @bike.current_stolen_record.decorate
+      @stolen_record = @bike.current_stolen_record
     end
     @bike = @bike.decorate
     respond_to do |format|
@@ -41,7 +41,7 @@ class BikesController < ApplicationController
 
   def pdf
     if @bike.stolen and @bike.current_stolen_record.present?
-      @stolen_record = @bike.current_stolen_record.decorate
+      @stolen_record = @bike.current_stolen_record
     end
     @bike = @bike.decorate
     filename = "Registration_" + @bike.updated_at.strftime("%m%d_%H%M")[0..-1]

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -82,7 +82,7 @@ class UsersController < ApplicationController
       raise ActionController::RoutingError.new("Not Found")
     end
     @owner = user
-    @user = user.decorate
+    @user = user
     unless user == current_user || @user.show_bikes
       redirect_to user_home_url, notice: "Sorry, that user isn't sharing their bikes" and return
     end

--- a/app/decorators/ambassador_decorator.rb
+++ b/app/decorators/ambassador_decorator.rb
@@ -1,6 +1,8 @@
+# NB: Decorators are deprecated in this project.
+#     Use Helper methods for view logic, consider incrementally refactoring
+#     existing view logic from decorators to view helpers.
 class AmbassadorDecorator < ApplicationDecorator
   delegate_all
-  alias ambassador object
 
   def avatar
     avatar_url = ambassador.avatar&.url(:medium)

--- a/app/decorators/ambassador_task_assignment_decorator.rb
+++ b/app/decorators/ambassador_task_assignment_decorator.rb
@@ -1,6 +1,8 @@
+# NB: Decorators are deprecated in this project.
+#     Use Helper methods for view logic, consider incrementally refactoring
+#     existing view logic from decorators to view helpers.
 class AmbassadorTaskAssignmentDecorator < ApplicationDecorator
   delegate_all
-  alias ambassador_task_assignment object
 
   def button_to_toggle_completion_status(current_user, current_organization)
     return unless current_user.ambassador?

--- a/app/decorators/ambassador_task_decorator.rb
+++ b/app/decorators/ambassador_task_decorator.rb
@@ -1,6 +1,8 @@
+# NB: Decorators are deprecated in this project.
+#     Use Helper methods for view logic, consider incrementally refactoring
+#     existing view logic from decorators to view helpers.
 class AmbassadorTaskDecorator < ApplicationDecorator
   delegate_all
-  alias ambassador_task_assignment object
 
   def button_to_toggle_completion_status(*); end
 end

--- a/app/decorators/application_decorator.rb
+++ b/app/decorators/application_decorator.rb
@@ -82,15 +82,4 @@ class ApplicationDecorator < Draper::Decorator
     html << " - #{item.country.iso}"
     html
   end
-
-  def display_phone(str = nil)
-    str ||= object&.phone
-    if str.blank?
-      nil
-    elsif str[/\+/]
-      number_to_phone(str.gsub(/\+\d*/, ""), country_code: str[/\A.\d*/].gsub("+", ""), delimiter: " ")
-    else
-      number_to_phone(str, delimiter: " ")
-    end
-  end
 end

--- a/app/decorators/application_decorator.rb
+++ b/app/decorators/application_decorator.rb
@@ -53,31 +53,6 @@ class ApplicationDecorator < Draper::Decorator
     end
   end
 
-  def twitterable(user)
-    if user.show_twitter and user.twitter
-      h.link_to "Twitter", "https://twitter.com/#{user.twitter}"
-    end
-  end
-
-  def websiteable(user)
-    if user.show_website and user.website
-      h.link_to "Website", user.website
-    end
-  end
-
-  def show_twitter_and_website(user)
-    if twitterable(user) or websiteable(user)
-      html = ""
-      if twitterable(user)
-        html << twitterable(user)
-        html << " and #{websiteable(user)}" if websiteable(user)
-      else
-        html << websiteable(user)
-      end
-      html.html_safe
-    end
-  end
-
   def short_address(item)
     return nil unless item.country
     html = "#{item.city}"

--- a/app/decorators/application_decorator.rb
+++ b/app/decorators/application_decorator.rb
@@ -1,3 +1,6 @@
+# NB: Decorators are deprecated in this project.
+#     Use Helper methods for view logic, consider incrementally refactoring
+#     existing view logic from decorators to view helpers.
 class ApplicationDecorator < Draper::Decorator
   delegate_all
   include ActionView::Helpers::NumberHelper

--- a/app/decorators/bike_decorator.rb
+++ b/app/decorators/bike_decorator.rb
@@ -18,12 +18,6 @@ class BikeDecorator < ApplicationDecorator
     html.html_safe
   end
 
-  def bike_show_twitter_and_website
-    return nil unless object.user?
-    user = object.user
-    show_twitter_and_website(user)
-  end
-
   def title
     t = ""
     t += "#{object.year} " if object.year.present?

--- a/app/decorators/bike_decorator.rb
+++ b/app/decorators/bike_decorator.rb
@@ -1,3 +1,6 @@
+# NB: Decorators are deprecated in this project.
+#     Use Helper methods for view logic, consider incrementally refactoring
+#     existing view logic from decorators to view helpers.
 class BikeDecorator < ApplicationDecorator
   delegate_all
 

--- a/app/decorators/component_decorator.rb
+++ b/app/decorators/component_decorator.rb
@@ -1,3 +1,0 @@
-class ComponentDecorator < ApplicationDecorator
-  delegate_all
-end

--- a/app/decorators/location_decorator.rb
+++ b/app/decorators/location_decorator.rb
@@ -1,3 +1,0 @@
-class LocationDecorator < ApplicationDecorator
-  delegate_all
-end

--- a/app/decorators/lock_decorator.rb
+++ b/app/decorators/lock_decorator.rb
@@ -1,3 +1,6 @@
+# NB: Decorators are deprecated in this project.
+#     Use Helper methods for view logic, consider incrementally refactoring
+#     existing view logic from decorators to view helpers.
 class LockDecorator < ApplicationDecorator
   delegate_all
 

--- a/app/decorators/manufacturer_decorator.rb
+++ b/app/decorators/manufacturer_decorator.rb
@@ -1,3 +1,0 @@
-class ManufacturerDecorator < ApplicationDecorator
-  delegate_all
-end

--- a/app/decorators/organization_decorator.rb
+++ b/app/decorators/organization_decorator.rb
@@ -1,3 +1,0 @@
-class OrganizationDecorator < ApplicationDecorator
-  delegate_all
-end

--- a/app/decorators/paginating_decorator.rb
+++ b/app/decorators/paginating_decorator.rb
@@ -1,3 +1,6 @@
+# NB: Decorators are deprecated in this project.
+#     Use Helper methods for view logic, consider incrementally refactoring
+#     existing view logic from decorators to view helpers.
 class PaginatingDecorator < Draper::CollectionDecorator
   delegate :current_page, :total_pages, :limit_value
 end

--- a/app/decorators/stolen_notification_decorator.rb
+++ b/app/decorators/stolen_notification_decorator.rb
@@ -1,3 +1,0 @@
-class StolenNotificationDecorator < ApplicationDecorator
-  delegate_all
-end

--- a/app/decorators/stolen_record_decorator.rb
+++ b/app/decorators/stolen_record_decorator.rb
@@ -1,3 +1,0 @@
-class StolenRecordDecorator < ApplicationDecorator
-  delegate_all
-end

--- a/app/decorators/user_decorator.rb
+++ b/app/decorators/user_decorator.rb
@@ -1,3 +1,0 @@
-class UserDecorator < ApplicationDecorator
-  delegate_all
-end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -177,4 +177,29 @@ module ApplicationHelper
       number_to_phone(str, delimiter: " ")
     end
   end
+
+  def twitterable(user)
+    if user.show_twitter and user.twitter
+      link_to "Twitter", "https://twitter.com/#{user.twitter}"
+    end
+  end
+
+  def websiteable(user)
+    if user.show_website and user.website
+      link_to "Website", user.website
+    end
+  end
+
+  def show_twitter_and_website(user)
+    if twitterable(user) or websiteable(user)
+      html = ""
+      if twitterable(user)
+        html << twitterable(user)
+        html << " and #{websiteable(user)}" if websiteable(user)
+      else
+        html << websiteable(user)
+      end
+      html.html_safe
+    end
+  end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -167,4 +167,14 @@ module ApplicationHelper
       :group_by_month
     end
   end
+
+  def display_phone(str = nil)
+    if str.blank?
+      nil
+    elsif str[/\+/]
+      number_to_phone(str.gsub(/\+\d*/, ""), country_code: str[/\A.\d*/].gsub("+", ""), delimiter: " ")
+    else
+      number_to_phone(str, delimiter: " ")
+    end
+  end
 end

--- a/app/views/admin/organizations/show.html.haml
+++ b/app/views/admin/organizations/show.html.haml
@@ -311,7 +311,7 @@
               = location.name
             %p
               Phone:
-              = location.display_phone
+              = display_phone(location.phone)
             %p
               Address:
               = location.address

--- a/app/views/bikes/pdf.html.haml
+++ b/app/views/bikes/pdf.html.haml
@@ -65,7 +65,7 @@
                   Owner phone
                 %td
                   %a.phone-number-link{ href: "tell:#{@stolen_record.phone}" }
-                    = @stolen_record.display_phone
+                    = display_phone(@stolen_record.phone)
             - if @stolen_record.police_report_number.present?
               %tr
                 %td.td-title
@@ -96,7 +96,7 @@
               Registered
             %td
               = @bike.created_at.strftime("%Y-%m-%d")
-              to 
+              to
               - if @bike.owner.present? && @bike.owner.name.present?
                 = @bike.owner.name
               - else

--- a/app/views/info/where.html.haml
+++ b/app/views/info/where.html.haml
@@ -28,7 +28,6 @@
       %ul.state-list
         - state.locations.each do |location|
           - next unless location.shown
-          - location = location.decorate
           %li
             .collapse-faq
               %a.shop-title-link.collapsed{ href: "#shop#{location.org_location_id}", data: { toggle: "collapse"} }
@@ -46,7 +45,7 @@
               - if location.phone
                 %p
                   %a{ href: "tel:#{ location.phone }" }
-                    = location.display_phone
+                    = display_phone(location.phone)
               - if location&.organization&.website.present?
                 %p
                   = link_to "#{location.organization.name} website", location.organization.website, target: "_blank", class: "shop-site"
@@ -72,7 +71,6 @@
       %ul.state-list
         - country.locations.each do |location|
           - next unless location.shown
-          - location = location.decorate
           %li
             .collapse-faq
               %a.shop-title-link.collapsed{ href: "#shop#{location.org_location_id}", data: { toggle: "collapse"} }
@@ -90,7 +88,7 @@
               - if location.phone
                 %p
                   %a{ href: "tel:#{ location.phone }" }
-                    = location.display_phone
+                    = display_phone(location.phone)
               - if location&.organization&.website.present?
                 %p
                   = link_to "#{location.organization.name} website", location.organization.website, target: "_blank", class: "shop-site"

--- a/app/views/users/show.html.haml
+++ b/app/views/users/show.html.haml
@@ -15,7 +15,7 @@
               - else
                 This user's bikes
             %p.sharing-links
-              = @user.show_twitter_and_website(@user)
+              = show_twitter_and_website(@user)
       .col-md-6.ad-col
         .ad-block#top468x60
     - if @user.description

--- a/spec/decorators/application_decorator_spec.rb
+++ b/spec/decorators/application_decorator_spec.rb
@@ -33,44 +33,6 @@ describe ApplicationDecorator do
     end
   end
 
-  describe "websiteable" do
-    it "creates a link if bike owner wants one shown" do
-      user = User.new
-      allow(user).to receive(:show_website).and_return(true)
-      allow(user).to receive(:website).and_return("website")
-      decorator = ApplicationDecorator.new(user).websiteable(user)
-      expect(decorator).to eq('<a href="website">Website</a>')
-    end
-  end
-
-  describe "twitterable" do
-    it "creates a link if bike owner wants one shown" do
-      user = User.new
-      allow(user).to receive(:show_twitter).and_return(true)
-      allow(user).to receive(:twitter).and_return("twitter")
-      decorator = ApplicationDecorator.new(user).twitterable(user)
-      expect(decorator).to eq('<a href="https://twitter.com/twitter">Twitter</a>')
-    end
-  end
-
-  describe "show_twitter_and_website" do
-    it "combines twitter and website" do
-      user = User.new
-      decorator = ApplicationDecorator.new(user)
-      allow(decorator).to receive(:twitterable).and_return("twitter")
-      allow(decorator).to receive(:websiteable).and_return("website")
-      expect(decorator.show_twitter_and_website(user)).to eq("twitter and website")
-    end
-    it "justs return website if no twitter" do
-      user = User.new
-      decorator = ApplicationDecorator.new(user)
-      allow(decorator).to receive(:user?).and_return(true)
-      allow(decorator).to receive(:twitterable).and_return(nil)
-      allow(decorator).to receive(:websiteable).and_return("website")
-      expect(decorator.show_twitter_and_website(user)).to eq("website")
-    end
-  end
-
   describe "ass_name" do
     it "grabs the association name" do
       wheel_size = FactoryBot.create(:wheel_size, name: "foobar", iso_bsd: 559)

--- a/spec/decorators/application_decorator_spec.rb
+++ b/spec/decorators/application_decorator_spec.rb
@@ -78,17 +78,4 @@ describe ApplicationDecorator do
       expect(ApplicationDecorator.new(bike).ass_name("front_wheel_size")).to eq("foobar")
     end
   end
-
-  describe "display_phone" do
-    it "displays the phone with an area code" do
-      location = Location.new
-      allow(location).to receive(:phone).and_return("999 999 9999")
-      expect(ApplicationDecorator.new(location).display_phone).to eq("999 999 9999")
-    end
-    it "displays the phone with a country code" do
-      location = Location.new
-      allow(location).to receive(:phone).and_return("+91 8041505583")
-      expect(ApplicationDecorator.new(location).display_phone).to eq("+91 804 150 5583")
-    end
-  end
 end

--- a/spec/decorators/bike_decorator_spec.rb
+++ b/spec/decorators/bike_decorator_spec.rb
@@ -14,18 +14,6 @@ describe BikeDecorator do
     end
   end
 
-  describe "bike_show_twitter_and_website" do
-    it "calls the method from application decorator" do
-      user = User.new
-      bike = Bike.new
-      allow(bike).to receive(:user).and_return(user)
-      decorator = BikeDecorator.new(bike)
-      allow(bike).to receive(:user?).and_return(true)
-      expect(decorator).to receive(:show_twitter_and_website).with(user)
-      decorator.bike_show_twitter_and_website
-    end
-  end
-
   describe "title" do
     it "returns the major bike attribs formatted" do
       bike = Bike.new

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -10,6 +10,42 @@ describe ApplicationHelper do
     end
   end
 
+  describe "#show_twitter_and_website" do
+    it "combines twitter and website" do
+      user = User.new(show_website: true,
+                      website: "website",
+                      show_twitter: true,
+                      twitter: "twitter")
+      html = show_twitter_and_website(user)
+      expect(html).to eq("<a href=\"https://twitter.com/twitter\">Twitter</a> and <a href=\"website\">Website</a>")
+    end
+    it "justs return website if no twitter" do
+      user = User.new(show_website: true, website: "website")
+      html = show_twitter_and_website(user)
+      expect(html).to eq("<a href=\"website\">Website</a>")
+    end
+  end
+
+  describe "#websiteable" do
+    it "creates a link if bike owner wants one shown" do
+      user = User.new
+      allow(user).to receive(:show_website).and_return(true)
+      allow(user).to receive(:website).and_return("website")
+      html = websiteable(user)
+      expect(html).to eq('<a href="website">Website</a>')
+    end
+  end
+
+  describe "#twitterable" do
+    it "creates a link if bike owner wants one shown" do
+      user = User.new
+      allow(user).to receive(:show_twitter).and_return(true)
+      allow(user).to receive(:twitter).and_return("twitter")
+      html = twitterable(user)
+      expect(html).to eq('<a href="https://twitter.com/twitter">Twitter</a>')
+    end
+  end
+
   describe "active_link" do
     context "without a class" do
       it "returns the link active if it ought to be" do

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -1,6 +1,15 @@
 require "spec_helper"
 
 describe ApplicationHelper do
+  describe "#display_phone" do
+    it "displays the phone with an area code" do
+      expect(display_phone("999 999 9999")).to eq("999 999 9999")
+    end
+    it "displays the phone with a country code" do
+      expect(display_phone("+91 8041505583")).to eq("+91 804 150 5583")
+    end
+  end
+
   describe "active_link" do
     context "without a class" do
       it "returns the link active if it ought to be" do


### PR DESCRIPTION
- Removes empty decorators in `app/decorators`
- Move any cheap-to-refactor methods into helpers
- Add deprecation comment in any remaining decorators and to the Gemfile

Resolves #853