### PR TITLE
Create ambassador task assignments on task / membership creation asynchronously

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,7 @@ ruby "2.5.1"
 gem "rails", "4.2.11"
 
 gem "active_model_serializers", "~> 0.9.3"
+gem "activerecord-import"
 gem "aws-sdk", "~> 1.33"
 gem "bcrypt", "~> 3.1.7"
 gem "jquery-rails"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -33,6 +33,8 @@ GEM
       activemodel (= 4.2.11)
       activesupport (= 4.2.11)
       arel (~> 6.0)
+    activerecord-import (1.0.2)
+      activerecord (>= 3.2)
     activesupport (4.2.11)
       i18n (~> 0.7)
       minitest (~> 5.1)
@@ -610,6 +612,7 @@ PLATFORMS
 
 DEPENDENCIES
   active_model_serializers (~> 0.9.3)
+  activerecord-import
   airborne
   api-pagination
   aws-sdk (~> 1.33)

--- a/app/models/ambassador_task.rb
+++ b/app/models/ambassador_task.rb
@@ -20,9 +20,6 @@ class AmbassadorTask < ActiveRecord::Base
 
   # Assigns the task to all ambassadors, if not already assigned
   def ensure_assigned_to_all_ambassadors!
-    Ambassador.find_each do |ambassador|
-      next if ambassador_task_assignments.exists?(ambassador: ambassador)
-      assign_to(ambassador)
-    end
+    AmbassadorTaskAfterCreateWorker.perform_async(id)
   end
 end

--- a/app/services/ambassador_task_assignment_creator.rb
+++ b/app/services/ambassador_task_assignment_creator.rb
@@ -1,12 +1,9 @@
 module AmbassadorTaskAssignmentCreator
-  def self.assign_task_to_all_ambassadors(ambassador_task_id)
-    return unless ambassador_task_id.present?
-    return unless AmbassadorTask.exists?(ambassador_task_id)
-
+  def self.assign_task_to_all_ambassadors(ambassador_task)
     already_assigned_ambassador_ids =
       Ambassador
         .includes(ambassador_task_assignments: :ambassador_task)
-        .where(ambassador_task_assignments: { ambassador_task_id: ambassador_task_id })
+        .where(ambassador_task_assignments: { ambassador_task: ambassador_task })
         .select(:id)
 
     new_assignments =
@@ -15,19 +12,16 @@ module AmbassadorTaskAssignmentCreator
         .where
         .not(id: already_assigned_ambassador_ids)
         .pluck(:id)
-        .map { |ambassador_id| { user_id: ambassador_id, ambassador_task_id: ambassador_task_id } }
+        .map { |ambassador_id| { user_id: ambassador_id, ambassador_task_id: ambassador_task.id } }
 
     AmbassadorTaskAssignment.import(new_assignments, validate: true)
   end
 
-  def self.assign_all_ambassador_tasks_to(ambassador_id)
-    return unless ambassador_id.present?
-    return unless Ambassador.exists?(ambassador_id)
-
+  def self.assign_all_ambassador_tasks_to(ambassador)
     already_assigned_task_ids =
       AmbassadorTask
         .includes(ambassador_task_assignments: :ambassador)
-        .where(ambassador_task_assignments: { user_id: ambassador_id })
+        .where(ambassador_task_assignments: { user_id: ambassador.id })
         .select(:id)
 
     new_assignments =
@@ -36,7 +30,7 @@ module AmbassadorTaskAssignmentCreator
         .where
         .not(id: already_assigned_task_ids)
         .pluck(:id)
-        .map { |t_id| { ambassador_task_id: t_id, user_id: ambassador_id } }
+        .map { |t_id| { ambassador_task_id: t_id, user_id: ambassador.id } }
 
     AmbassadorTaskAssignment.import(new_assignments, validate: true)
   end

--- a/app/services/ambassador_task_assignment_creator.rb
+++ b/app/services/ambassador_task_assignment_creator.rb
@@ -1,0 +1,42 @@
+module AmbassadorTaskAssignmentCreator
+  def self.assign_task_to_all_ambassadors(ambassador_task_or_id)
+    ambassador_task =
+      case ambassador_task_or_id
+      when AmbassadorTask then ambassador_task_or_id
+      when Integer then AmbassadorTask.find(ambassador_task_or_id)
+      else raise ArgumentError,
+                 "Not an AmbassadorTask or AmbassadorTask id: #{ambassador_task_or_id}"
+      end
+
+    already_assigned_ambassador_ids =
+      Ambassador
+        .includes(:ambassador_task_assignments)
+        .where(ambassador_task_assignments: { ambassador_task_id: ambassador_task.id })
+        .select(:id)
+
+    not_assigned_ambassador_ids =
+      Ambassador
+        .includes(:ambassador_task_assignments)
+        .where.not(id: already_assigned_ambassador_ids)
+        .pluck(:id)
+
+    new_assignments =
+      not_assigned_ambassador_ids
+        .map { |ambassador_id| { user_id: ambassador_id, ambassador_task: ambassador_task } }
+
+    AmbassadorTaskAssignment.create(new_assignments)
+  end
+
+  def self.assign_all_ambassador_tasks_to(ambassador_or_id)
+    ambassador =
+      case ambassador_or_id
+      when Ambassador then ambassador_or_id
+      when User then Ambassador.find(ambassador_or_id.id)
+      when Integer then Ambassador.find(ambassador_or_id)
+      else raise ArgumentError,
+                 "Not an Ambassador or Ambassador id: #{ambassador_or_id}"
+      end
+
+    AmbassadorTask.find_each { |task| task.assign_to(ambassador) }
+  end
+end

--- a/app/workers/ambassador_membership_after_create_worker.rb
+++ b/app/workers/ambassador_membership_after_create_worker.rb
@@ -3,10 +3,10 @@ class AmbassadorMembershipAfterCreateWorker
   sidekiq_options queue: "high_priority", backtrace: true
 
   def perform(membership_id)
-    membership = Membership.includes(:organization).find(membership_id)
+    membership = Membership.includes(:organization, :user).find(membership_id)
     return unless membership.ambassador?
 
     AmbassadorTaskAssignmentCreator
-      .assign_all_ambassador_tasks_to(membership.user_id)
+      .assign_all_ambassador_tasks_to(membership.user)
   end
 end

--- a/app/workers/ambassador_membership_after_create_worker.rb
+++ b/app/workers/ambassador_membership_after_create_worker.rb
@@ -1,0 +1,12 @@
+class AmbassadorMembershipAfterCreateWorker
+  include Sidekiq::Worker
+  sidekiq_options queue: "high_priority", backtrace: true
+
+  def perform(membership_id)
+    membership = Membership.includes(:organization).find(membership_id)
+    return unless membership.ambassador?
+
+    AmbassadorTaskAssignmentCreator
+      .assign_all_ambassador_tasks_to(membership.user_id)
+  end
+end

--- a/app/workers/ambassador_task_after_create_worker.rb
+++ b/app/workers/ambassador_task_after_create_worker.rb
@@ -1,0 +1,8 @@
+class AmbassadorTaskAfterCreateWorker
+  include Sidekiq::Worker
+  sidekiq_options queue: "high_priority", backtrace: true
+
+  def perform(ambassador_task_id)
+    AmbassadorTaskAssignmentCreator.assign_task_to_all_ambassadors(ambassador_task_id)
+  end
+end

--- a/app/workers/ambassador_task_after_create_worker.rb
+++ b/app/workers/ambassador_task_after_create_worker.rb
@@ -3,6 +3,9 @@ class AmbassadorTaskAfterCreateWorker
   sidekiq_options queue: "high_priority", backtrace: true
 
   def perform(ambassador_task_id)
-    AmbassadorTaskAssignmentCreator.assign_task_to_all_ambassadors(ambassador_task_id)
+    ambassador_task = AmbassadorTask.find(ambassador_task_id)
+
+    AmbassadorTaskAssignmentCreator
+      .assign_task_to_all_ambassadors(ambassador_task)
   end
 end

--- a/spec/factories/amabassador_tasks.rb
+++ b/spec/factories/amabassador_tasks.rb
@@ -3,6 +3,9 @@ FactoryBot.define do
     before(:create) do
       AmbassadorTask.skip_callback(:create, :after, :ensure_assigned_to_all_ambassadors!)
     end
+    after(:create) do
+      AmbassadorTask.set_callback(:create, :after, :ensure_assigned_to_all_ambassadors!)
+    end
     sequence(:title) { |n| "Task ##{n.to_s.rjust(3, "0")}" }
     sequence(:description) { |n| "Task ##{n.to_s.rjust(3, "0")} description" }
   end

--- a/spec/factories/memberships.rb
+++ b/spec/factories/memberships.rb
@@ -8,7 +8,10 @@ FactoryBot.define do
 
     factory :membership_ambassador do
       before(:create) do
-        Membership.skip_callback(:create, :after, :assign_ambassador_tasks!)
+        Membership.skip_callback(:create, :after, :ensure_ambassador_tasks_assigned!)
+      end
+      after(:create) do
+        Membership.set_callback(:create, :after, :ensure_ambassador_tasks_assigned!)
       end
       role { "member" }
       organization { FactoryBot.create(:organization_ambassador) }

--- a/spec/models/ambassador_task_spec.rb
+++ b/spec/models/ambassador_task_spec.rb
@@ -2,24 +2,11 @@ require "spec_helper"
 
 describe AmbassadorTask, type: :model do
   describe "#ensure_assigned_to_all_ambassadors!" do
-    it "idempotently creates assignments to the given task for all ambassadors" do
-      user = FactoryBot.create(:user_confirmed)
-      a1, a2, a3 = FactoryBot.create_list(:ambassador, 3)
+    it "enqueues a job to assign the new task to all ambassadors" do
       task = FactoryBot.create(:ambassador_task)
 
-      task.ensure_assigned_to_all_ambassadors!
-
-      expect(user.ambassador_task_assignments.count).to eq(0)
-      expect(a1.ambassador_task_assignments.count).to eq(1)
-      expect(a2.ambassador_task_assignments.count).to eq(1)
-      expect(a3.ambassador_task_assignments.count).to eq(1)
-
-      task.ensure_assigned_to_all_ambassadors!
-
-      expect(user.ambassador_task_assignments.count).to eq(0)
-      expect(a1.ambassador_task_assignments.count).to eq(1)
-      expect(a2.ambassador_task_assignments.count).to eq(1)
-      expect(a3.ambassador_task_assignments.count).to eq(1)
+      expect { task.ensure_assigned_to_all_ambassadors! }
+        .to(change { AmbassadorTaskAfterCreateWorker.jobs.size }.by(1))
     end
   end
 

--- a/spec/models/membership_spec.rb
+++ b/spec/models/membership_spec.rb
@@ -1,6 +1,24 @@
 require "spec_helper"
 
 describe Membership do
+  describe "#ensure_ambassador_tasks_assigned!" do
+    context "given an ambassador organization" do
+      it "enqueues a job to assign ambassador tasks to the given user" do
+        membership = FactoryBot.create(:membership_ambassador)
+        expect { membership.ensure_ambassador_tasks_assigned! }
+          .to(change { AmbassadorMembershipAfterCreateWorker.jobs.size }.by(1))
+      end
+    end
+
+    context "given a non-ambassador organization" do
+      it "does not enqueue a job to assign ambassador tasks to the given user" do
+        membership = FactoryBot.create(:existing_membership)
+        expect { membership.ensure_ambassador_tasks_assigned! }
+          .to_not(change { AmbassadorMembershipAfterCreateWorker.jobs.size })
+      end
+    end
+  end
+
   describe ".ambassador_organizations" do
     it "returns all and only ambassador organizations" do
       FactoryBot.create(:existing_membership)

--- a/spec/services/ambassador_task_assignment_creator_spec.rb
+++ b/spec/services/ambassador_task_assignment_creator_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe AmbassadorTaskAssignmentCreator do
         a1, a2, a3 = FactoryBot.create_list(:ambassador, 3)
         task = FactoryBot.create(:ambassador_task)
 
-        AmbassadorTaskAssignmentCreator.assign_task_to_all_ambassadors(task.id)
+        AmbassadorTaskAssignmentCreator.assign_task_to_all_ambassadors(task)
 
         expect(AmbassadorTaskAssignment.count).to eq(3)
         expect(user.ambassador_task_assignments.count).to eq(0)
@@ -16,20 +16,13 @@ RSpec.describe AmbassadorTaskAssignmentCreator do
         expect(a2.ambassador_task_assignments.count).to eq(1)
         expect(a3.ambassador_task_assignments.count).to eq(1)
 
-        AmbassadorTaskAssignmentCreator.assign_task_to_all_ambassadors(task.id)
+        AmbassadorTaskAssignmentCreator.assign_task_to_all_ambassadors(task)
 
         expect(AmbassadorTaskAssignment.count).to eq(3)
         expect(user.ambassador_task_assignments.count).to eq(0)
         expect(a1.ambassador_task_assignments.count).to eq(1)
         expect(a2.ambassador_task_assignments.count).to eq(1)
         expect(a3.ambassador_task_assignments.count).to eq(1)
-      end
-    end
-
-    context "given a not-found Ambassador id" do
-      it "no-ops" do
-        expect { AmbassadorTaskAssignmentCreator.assign_task_to_all_ambassadors(99) }
-          .to_not(change { AmbassadorTaskAssignment.count })
       end
     end
   end
@@ -40,22 +33,15 @@ RSpec.describe AmbassadorTaskAssignmentCreator do
         task_ids = FactoryBot.create_list(:ambassador_task, 3).map(&:id)
         ambassador = FactoryBot.create(:ambassador)
 
-        AmbassadorTaskAssignmentCreator.assign_all_ambassador_tasks_to(ambassador.id)
+        AmbassadorTaskAssignmentCreator.assign_all_ambassador_tasks_to(ambassador)
 
         found_task_ids = ambassador.ambassador_task_assignments.pluck(:ambassador_task_id)
         expect(found_task_ids).to match_array(task_ids)
 
-        AmbassadorTaskAssignmentCreator.assign_all_ambassador_tasks_to(ambassador.id)
+        AmbassadorTaskAssignmentCreator.assign_all_ambassador_tasks_to(ambassador)
 
         found_task_ids = ambassador.ambassador_task_assignments.pluck(:ambassador_task_id)
         expect(found_task_ids).to match_array(task_ids)
-      end
-    end
-
-    context "given an Ambassador that can't be found" do
-      it "no-ops" do
-        expect { AmbassadorTaskAssignmentCreator.assign_all_ambassador_tasks_to(99) }
-          .to_not(change { AmbassadorTaskAssignment.count })
       end
     end
   end

--- a/spec/services/ambassador_task_assignment_creator_spec.rb
+++ b/spec/services/ambassador_task_assignment_creator_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe AmbassadorTaskAssignmentCreator do
 
         AmbassadorTaskAssignmentCreator.assign_task_to_all_ambassadors(task)
 
+        expect(AmbassadorTaskAssignment.count).to eq(3)
         expect(user.ambassador_task_assignments.count).to eq(0)
         expect(a1.ambassador_task_assignments.count).to eq(1)
         expect(a2.ambassador_task_assignments.count).to eq(1)
@@ -17,6 +18,7 @@ RSpec.describe AmbassadorTaskAssignmentCreator do
 
         AmbassadorTaskAssignmentCreator.assign_task_to_all_ambassadors(task.id)
 
+        expect(AmbassadorTaskAssignment.count).to eq(3)
         expect(user.ambassador_task_assignments.count).to eq(0)
         expect(a1.ambassador_task_assignments.count).to eq(1)
         expect(a2.ambassador_task_assignments.count).to eq(1)

--- a/spec/services/ambassador_task_assignment_creator_spec.rb
+++ b/spec/services/ambassador_task_assignment_creator_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe AmbassadorTaskAssignmentCreator do
         a1, a2, a3 = FactoryBot.create_list(:ambassador, 3)
         task = FactoryBot.create(:ambassador_task)
 
-        AmbassadorTaskAssignmentCreator.assign_task_to_all_ambassadors(task)
+        AmbassadorTaskAssignmentCreator.assign_task_to_all_ambassadors(task.id)
 
         expect(AmbassadorTaskAssignment.count).to eq(3)
         expect(user.ambassador_task_assignments.count).to eq(0)
@@ -26,20 +26,11 @@ RSpec.describe AmbassadorTaskAssignmentCreator do
       end
     end
 
-    context "given anything other than an AmbassadorTask or AmbassadorTask id" do
-      it "raises ArgumentError" do
-        invocation = -> {
-          AmbassadorTaskAssignmentCreator.assign_task_to_all_ambassadors({})
-        }
-        expect { invocation.call }.to raise_error(ArgumentError)
+    context "given a not-found Ambassador id" do
+      it "no-ops" do
+        expect { AmbassadorTaskAssignmentCreator.assign_task_to_all_ambassadors(99) }
+          .to_not(change { AmbassadorTaskAssignment.count })
       end
-    end
-
-    it "raises ActiveRecord::RecordNotFound" do
-      invocation = -> {
-        AmbassadorTaskAssignmentCreator.assign_task_to_all_ambassadors(99)
-      }
-      expect { invocation.call }.to raise_error(ActiveRecord::RecordNotFound)
     end
   end
 
@@ -49,7 +40,7 @@ RSpec.describe AmbassadorTaskAssignmentCreator do
         task_ids = FactoryBot.create_list(:ambassador_task, 3).map(&:id)
         ambassador = FactoryBot.create(:ambassador)
 
-        AmbassadorTaskAssignmentCreator.assign_all_ambassador_tasks_to(ambassador)
+        AmbassadorTaskAssignmentCreator.assign_all_ambassador_tasks_to(ambassador.id)
 
         found_task_ids = ambassador.ambassador_task_assignments.pluck(:ambassador_task_id)
         expect(found_task_ids).to match_array(task_ids)
@@ -62,20 +53,9 @@ RSpec.describe AmbassadorTaskAssignmentCreator do
     end
 
     context "given an Ambassador that can't be found" do
-      it "raises ActiveRecord::RecordNotFound" do
-        invocation = -> {
-          AmbassadorTaskAssignmentCreator.assign_all_ambassador_tasks_to(99)
-        }
-        expect { invocation.call }.to raise_error(ActiveRecord::RecordNotFound)
-      end
-    end
-
-    context "given anything other than an Ambassador or Ambassador id" do
-      it "raises ArgumentError" do
-        invocation = -> {
-          AmbassadorTaskAssignmentCreator.assign_all_ambassador_tasks_to({})
-        }
-        expect { invocation.call }.to raise_error(ArgumentError)
+      it "no-ops" do
+        expect { AmbassadorTaskAssignmentCreator.assign_all_ambassador_tasks_to(99) }
+          .to_not(change { AmbassadorTaskAssignment.count })
       end
     end
   end

--- a/spec/services/ambassador_task_assignment_creator_spec.rb
+++ b/spec/services/ambassador_task_assignment_creator_spec.rb
@@ -1,0 +1,80 @@
+require "spec_helper"
+
+RSpec.describe AmbassadorTaskAssignmentCreator do
+  describe ".assign_task_to_all_ambassadors" do
+    context "given an AmbassadorTask or AmbassadorTask id" do
+      it "idempotently creates assignments to the given task for all ambassadors" do
+        user = FactoryBot.create(:user_confirmed)
+        a1, a2, a3 = FactoryBot.create_list(:ambassador, 3)
+        task = FactoryBot.create(:ambassador_task)
+
+        AmbassadorTaskAssignmentCreator.assign_task_to_all_ambassadors(task)
+
+        expect(user.ambassador_task_assignments.count).to eq(0)
+        expect(a1.ambassador_task_assignments.count).to eq(1)
+        expect(a2.ambassador_task_assignments.count).to eq(1)
+        expect(a3.ambassador_task_assignments.count).to eq(1)
+
+        AmbassadorTaskAssignmentCreator.assign_task_to_all_ambassadors(task.id)
+
+        expect(user.ambassador_task_assignments.count).to eq(0)
+        expect(a1.ambassador_task_assignments.count).to eq(1)
+        expect(a2.ambassador_task_assignments.count).to eq(1)
+        expect(a3.ambassador_task_assignments.count).to eq(1)
+      end
+    end
+
+    context "given anything other than an AmbassadorTask or AmbassadorTask id" do
+      it "raises ArgumentError" do
+        invocation = -> {
+          AmbassadorTaskAssignmentCreator.assign_task_to_all_ambassadors({})
+        }
+        expect { invocation.call }.to raise_error(ArgumentError)
+      end
+    end
+
+    it "raises ActiveRecord::RecordNotFound" do
+      invocation = -> {
+        AmbassadorTaskAssignmentCreator.assign_task_to_all_ambassadors(99)
+      }
+      expect { invocation.call }.to raise_error(ActiveRecord::RecordNotFound)
+    end
+  end
+
+  describe ".assign_all_ambassador_tasks_to" do
+    context "given an Ambassador or Ambassador id" do
+      it "idempotently creates all assignments for the given ambassador" do
+        task_ids = FactoryBot.create_list(:ambassador_task, 3).map(&:id)
+        ambassador = FactoryBot.create(:ambassador)
+
+        AmbassadorTaskAssignmentCreator.assign_all_ambassador_tasks_to(ambassador)
+
+        found_task_ids = ambassador.ambassador_task_assignments.pluck(:ambassador_task_id)
+        expect(found_task_ids).to match_array(task_ids)
+
+        AmbassadorTaskAssignmentCreator.assign_all_ambassador_tasks_to(ambassador.id)
+
+        found_task_ids = ambassador.ambassador_task_assignments.pluck(:ambassador_task_id)
+        expect(found_task_ids).to match_array(task_ids)
+      end
+    end
+
+    context "given an Ambassador that can't be found" do
+      it "raises ActiveRecord::RecordNotFound" do
+        invocation = -> {
+          AmbassadorTaskAssignmentCreator.assign_all_ambassador_tasks_to(99)
+        }
+        expect { invocation.call }.to raise_error(ActiveRecord::RecordNotFound)
+      end
+    end
+
+    context "given anything other than an Ambassador or Ambassador id" do
+      it "raises ArgumentError" do
+        invocation = -> {
+          AmbassadorTaskAssignmentCreator.assign_all_ambassador_tasks_to({})
+        }
+        expect { invocation.call }.to raise_error(ArgumentError)
+      end
+    end
+  end
+end

--- a/spec/workers/ambassador_membership_after_create_worker_spec.rb
+++ b/spec/workers/ambassador_membership_after_create_worker_spec.rb
@@ -2,18 +2,11 @@ require "spec_helper"
 
 describe AmbassadorMembershipAfterCreateWorker do
   describe "#perform" do
-    context "given a not found membership id" do
-      it "raises RecordNotFound" do
-        job = -> { described_class.new.perform(0) }
-        expect { job.call }.to raise_error(ActiveRecord::RecordNotFound)
-      end
-    end
-
-    context "given a non-ambassador membership id" do
+    context "given a non-ambassador" do
       it "no-ops" do
         membership = FactoryBot.create(:existing_membership)
         allow(AmbassadorTaskAssignmentCreator)
-          .to(receive(:assign_all_ambassador_tasks_to).with(membership.user_id))
+          .to(receive(:assign_all_ambassador_tasks_to).with(membership.user))
 
         described_class.new.perform(membership.id)
 
@@ -22,11 +15,12 @@ describe AmbassadorMembershipAfterCreateWorker do
       end
     end
 
-    context "given an ambassador membership id" do
+    context "given an ambassador" do
       it "assigns all given task to the given ambassador" do
-        membership = FactoryBot.create(:membership_ambassador)
+        user = FactoryBot.create(:user_confirmed)
+        membership = FactoryBot.create(:membership_ambassador, user_id: user.id)
         allow(AmbassadorTaskAssignmentCreator)
-          .to(receive(:assign_all_ambassador_tasks_to).with(membership.user_id))
+          .to(receive(:assign_all_ambassador_tasks_to).with(user))
 
         described_class.new.perform(membership.id)
 

--- a/spec/workers/ambassador_membership_after_create_worker_spec.rb
+++ b/spec/workers/ambassador_membership_after_create_worker_spec.rb
@@ -1,0 +1,38 @@
+require "spec_helper"
+
+describe AmbassadorMembershipAfterCreateWorker do
+  describe "#perform" do
+    context "given a not found membership id" do
+      it "raises RecordNotFound" do
+        job = -> { described_class.new.perform(0) }
+        expect { job.call }.to raise_error(ActiveRecord::RecordNotFound)
+      end
+    end
+
+    context "given a non-ambassador membership id" do
+      it "no-ops" do
+        membership = FactoryBot.create(:existing_membership)
+        allow(AmbassadorTaskAssignmentCreator)
+          .to(receive(:assign_all_ambassador_tasks_to).with(membership.user_id))
+
+        described_class.new.perform(membership.id)
+
+        expect(AmbassadorTaskAssignmentCreator)
+          .to_not(have_received(:assign_all_ambassador_tasks_to))
+      end
+    end
+
+    context "given an ambassador membership id" do
+      it "assigns all given task to the given ambassador" do
+        membership = FactoryBot.create(:membership_ambassador)
+        allow(AmbassadorTaskAssignmentCreator)
+          .to(receive(:assign_all_ambassador_tasks_to).with(membership.user_id))
+
+        described_class.new.perform(membership.id)
+
+        expect(AmbassadorTaskAssignmentCreator)
+          .to(have_received(:assign_all_ambassador_tasks_to).once)
+      end
+    end
+  end
+end

--- a/spec/workers/ambassador_task_after_create_worker_spec.rb
+++ b/spec/workers/ambassador_task_after_create_worker_spec.rb
@@ -1,0 +1,16 @@
+require "spec_helper"
+
+describe AmbassadorTaskAfterCreateWorker do
+  describe "#perform" do
+    it "assigns the given task to all ambassadors" do
+      task_id = 1
+      allow(AmbassadorTaskAssignmentCreator)
+        .to(receive(:assign_task_to_all_ambassadors).with(task_id))
+
+      described_class.new.perform(task_id)
+
+      expect(AmbassadorTaskAssignmentCreator)
+        .to(have_received(:assign_task_to_all_ambassadors).once)
+    end
+  end
+end

--- a/spec/workers/ambassador_task_after_create_worker_spec.rb
+++ b/spec/workers/ambassador_task_after_create_worker_spec.rb
@@ -3,11 +3,11 @@ require "spec_helper"
 describe AmbassadorTaskAfterCreateWorker do
   describe "#perform" do
     it "assigns the given task to all ambassadors" do
-      task_id = 1
+      task = FactoryBot.create(:ambassador_task)
       allow(AmbassadorTaskAssignmentCreator)
-        .to(receive(:assign_task_to_all_ambassadors).with(task_id))
+        .to(receive(:assign_task_to_all_ambassadors).with(task))
 
-      described_class.new.perform(task_id)
+      described_class.new.perform(task.id)
 
       expect(AmbassadorTaskAssignmentCreator)
         .to(have_received(:assign_task_to_all_ambassadors).once)


### PR DESCRIPTION
- Moves the logic for assigning a newly created `AmbassadorTask` to all existing `Ambassador`s from an AR callback in `AmbassadorTask` to `AmbassadorTaskAssignmentCreator.assign_task_to_all_ambassadors`, which is enqueued upon creation of a new task.

- Moves the logic for assigning existing tasks to a new `Ambassador` from an AR callback in `Membership` to `AmbassadorTaskAssignmentCreator.assign_all_ambassador_tasks_to`, which is enqueued upon creation of a new ambassador membership.

- Assignments are created in bulk (`activerecord-import` added in d1a469d)

```
2.5.1 (bikeindex)[5] » AmbassadorTaskAssignmentCreator.assign_task_to_all_ambassadors(AmbassadorTask.fifth)
...
AmbassadorTaskAssignment Create Many Without Validations Or Callbacks (8.2ms)
INSERT INTO "ambassador_task_assignments"
("user_id","ambassador_task_id","created_at","updated_at")
VALUES
(1,29,'2019-06-07 01:15:01.629558','2019-06-07 01:15:01.629558')
(100,29,'2019-06-07 01:15:01.629558','2019-06-07 01:15:01.629558')
...

RETURNING "id"

#<Struct:ActiveRecord::Import::Result:0x7fa8c1a99bf8
  failed_instances = [],
  ids = ["958", "959", "960", "961", "962", "963", "964", "965", "966"...],
  num_inserts = 1,
  results = []>

```

Resolves #839