### PR TITLE
Fix IE11 time parsing failure

### DIFF
--- a/config/initializers/time_parser.rb
+++ b/config/initializers/time_parser.rb
@@ -15,12 +15,21 @@ class TimeParser
     end
   rescue ArgumentError => e
     # Try to parse some other, unexpected formats - for now, just one
-    raise e unless time_str[%r{\d+/\d+/\d}] # IE 11 sends this format
+    ie11_formatted = %r{(?<month>\d+)/(?<day>\d+)/(?<year>\d+)}.match(time_str)
+    raise e unless ie11_formatted
+
     # Time zones are hell
     Time.zone = parse_timezone(timezone_str)
-    time = Time.strptime(time_str, "%m/%d/%Y")
+
+    time_str =
+      %i(year month day)
+        .map { |component| ie11_formatted[component] }
+        .join("-")
+
+    time = Time.zone.parse(time_str)
                .in_time_zone(parse_timezone(timezone_str))
                .beginning_of_day
+
     Time.zone = DEFAULT_TIMEZONE
     time
   end


### PR DESCRIPTION
This patch fixes a local timezone-based failure in `TimeParser`: `Time.strptime` parses time in the machine's timezone, not the Rails timezone, so this test can fail if it's not run in Central Time.

```rb
Time.zone.parse("2018-09-30").in_time_zone(ActiveSupport::TimeZone["Central Time (US & Canada)"])
# Sun, 30 Sep 2018 00:00:00 CDT -05:00

Time.strptime("2018-09-30", "%Y-%m-%d").in_time_zone(ActiveSupport::TimeZone["Central Time (US & Canada)"])
# Sat, 29 Sep 2018 23:00:00 CDT -05:00
```

Local runs

Before:
```
2) TimeParser parse with cray IE 11 time params parses it, resets the zone over and over again
     Failure/Error: expect(subject.parse(time_str, "").to_i).to eq target_time

       expected: 1538283600
            got: 1538197200

       (compared using ==)
     # ./spec/initializers/time_parser_spec.rb:38:in `block (4 levels) in <top (required)>'
```

After:
```
Finished in 6 minutes 32 seconds (files took 10.94 seconds to load)
1953 examples, 0 failures, 13 pending

Randomized with seed 59789
```

