### PR TITLE
Fix some NoMethodError exceptions in admin templates

### DIFF
--- a/app/controllers/admin/payments_controller.rb
+++ b/app/controllers/admin/payments_controller.rb
@@ -19,8 +19,12 @@ class Admin::PaymentsController < Admin::BaseController
     else
       invoices = Invoice
     end
-    @invoices = invoices.includes(:organization, :payments)
-      .reorder(sort_column + " " + sort_direction).page(page).per(per_page)
+    @invoices =
+      invoices
+        .includes(:organization, :payments, :paid_features, :first_invoice)
+        .reorder(sort_column + " " + sort_direction)
+        .page(page)
+        .per(per_page)
   end
 
   def new

--- a/app/views/admin/bike_codes/index.html.haml
+++ b/app/views/admin/bike_codes/index.html.haml
@@ -107,17 +107,17 @@
       - @bike_codes.each do |bike_code|
         %tr
           %td
-            - if bike_code.organization_id.present?
+            - if bike_code.organization.present?
               - bike_code_url = edit_organization_sticker_path(organization_id: bike_code.organization_id, id: bike_code.code)
             - else
               - bike_code_url = "/bikes/scanned/#{bike_code.code}"
             %a.convertTime{ href: bike_code_url }
               = l bike_code.created_at, format: :convert_time
           %td
-            - if bike_code.organization_id.present?
+            - if bike_code.organization.present?
               = link_to bike_code.organization.name, admin_bike_codes_path(sortable_search_params.merge(organization_id: bike_code.organization_id))
           %td
-            - if bike_code.bike_code_batch_id.present?
+            - if bike_code.bike_code_batch.present?
               = link_to bike_code.bike_code_batch_id, admin_bike_codes_path(sortable_search_params.merge(search_bike_code_batch_id: bike_code.bike_code_batch_id))
           %td
             - if bike_code.claimed? && bike_code.claimed_at.present?

--- a/app/views/admin/news/index.html.haml
+++ b/app/views/admin/news/index.html.haml
@@ -23,7 +23,7 @@
             %span.convertTime
               = l blog.published_at, format: :convert_time
           %td.medium-screens
-            = blog.user.name || blog.user.email
+            = blog.user&.name || blog.user&.email
           %td
             %p.blog-index
               = link_to blog.title, edit_admin_news_url(blog)

--- a/app/views/admin/organizations/invoices/_table.html.haml
+++ b/app/views/admin/organizations/invoices/_table.html.haml
@@ -41,17 +41,18 @@
         Features
     %tbody
       - invoices.each do |invoice|
-        - organization = Organization.find(invoice.organization_id)
+        - organization = invoice.organization
         %tr
           %td
-            = link_to invoice.display_name, edit_admin_organization_invoice_path(organization_id: organization.to_param, id: invoice.to_param)
+            - if organization.present?
+              = link_to invoice.display_name, edit_admin_organization_invoice_path(organization_id: organization.to_param, id: invoice.to_param)
             - if invoice.active?
               %small.text-success{ style: "display: block;" }
                 Active
             - if invoice.previous_invoice.present?
               %small.less-strong{ style: "display: block; margin-top: 1rem;" }
                 Follows ##{invoice.previous_invoice.id}
-          - if display_organization
+          - if display_organization && organization.present?
             %td
               = link_to organization.short_name, admin_organization_path(organization.to_param)
               - unless invoice.organization.present?

--- a/app/views/admin/payments/index.html.haml
+++ b/app/views/admin/payments/index.html.haml
@@ -38,10 +38,10 @@
                 no user
 
           %td
-            - if payment.organization_id.present?
+            - if payment.organization.present?
               = link_to payment.organization.short_name, admin_organization_path(payment.organization)
           %td
-            - if payment.invoice_id.present?
+            - if payment.invoice.present? && payment.organization.present?
               #{link_to payment.invoice.display_name, edit_admin_organization_invoice_path(organization_id: payment.organization.to_param, id: payment.invoice.id)}
               - if payment.invoice.subscription_start_at
                 %small.convertTime


### PR DESCRIPTION
This patch resolves some breakages in the admin templates that are showing up locally due to missing data.

- Refactors to check for the presence of the associated record, not just its
  foreign key (+ `includes` to avoid an N+1 query)

```diff
- - if payment.organization_id.present?
+ - if payment.organization.present?
    = link_to payment.organization.short_name, admin_organization_path(payment.organization)
```

```diff
       - invoices.each do |invoice|
-        - organization = Organization.find(invoice.organization_id)
+        - organization = invoice.organization
```

```diff
-    @invoices = invoices.includes(:organization, :payments)
-      .reorder(sort_column + " " + sort_direction).page(page).per(per_page)
+    @invoices =
+      invoices
+        .includes(:organization, :payments, :paid_features, :first_invoice)
+        .reorder(sort_column + " " + sort_direction)
+        .page(page)
+        .per(per_page)
```

```rb
bike = BikeCode.includes(:organization).last
#  BikeCode Load (0.3ms)  SELECT  "bike_codes".* FROM "bike_codes"  ORDER BY "bike_codes"."id" DESC LIMIT 1
#  Organization Load (0.2ms)  SELECT "organizations".* FROM "organizations" WHERE "organizations"."deleted_at" IS NULL AND "organizations"."id" IN (818)  ORDER BY "organizations"."name" ASC

bike.organization_id.present?
# true

bike.organization.present?
# false
```

- Uses safe traversal operator when accessing deeply nested attributes

```diff
   %td.medium-screens
-    = blog.user.name || blog.user.email
+    = blog.user&.name || blog.user&.email
```

- Ensures url helpers have expected data

```diff
- - if display_organization
+ - if display_organization && invoice.organization.present?
    %td
    = link_to invoice.organization.short_name, admin_organization_path(invoice.organization)
```