### PR TITLE
Add previous slug for organizations

### DIFF
--- a/app/controllers/admin/organizations_controller.rb
+++ b/app/controllers/admin/organizations_controller.rb
@@ -74,7 +74,7 @@ class Admin::OrganizationsController < Admin::BaseController
     params.require(:organization)
           .permit(:available_invitation_count, :sent_invitation_count, :name, :short_name, :slug, :website,
                   :ascend_name, :show_on_map, :is_suspended, :embedable_user_email, :auto_user_id, :lock_show_on_map,
-                  :api_access_approved, :access_token, :avatar, :avatar_cache,
+                  :api_access_approved, :access_token, :avatar, :avatar_cache, :previous_slug,
                   :parent_organization_id, :lightspeed_cloud_api_key, :approved,
                   [locations_attributes: permitted_locations_params])
           .merge(kind: approved_kind)

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -72,7 +72,9 @@ class Organization < ActiveRecord::Base
   def self.friendly_find(n)
     return nil unless n.present?
     return find(n) if integer_slug?(n)
-    find_by_slug(Slugifyer.slugify(n)) || find_by_name(n) # Fallback, search by name just in case
+    slug = Slugifyer.slugify(n)
+    # First try slug, then previous slug, and finally, just give finding by name a shot
+    find_by_slug(slug) || find_by_previous_slug(slug) || where("LOWER(name) = LOWER(?)", n.downcase).first
   end
 
   def self.integer_slug?(n)

--- a/app/views/admin/organizations/_form.html.haml
+++ b/app/views/admin/organizations/_form.html.haml
@@ -24,15 +24,24 @@
 
 .row
   .col-md-6
-    .form-group.mt-4
+    .form-group
       = f.label :website
       = f.text_field :website, class: "form-control"
-  .col-md-6.mt-4
+  .col-6.col-lg-3
     %fieldset{:disabled => "disabled"}
       .form-group
         = f.label :slug, "Slug:"
         %p
           = @organization.slug
+  - if current_user.developer?
+    .col-6.col-lg-3
+      .form-group
+        = f.label :previous_slug do
+          Previous Slug
+          %em.small.text-warning
+            Rarely unnecessary
+        = f.text_field :previous_slug, class: "form-control"
+
 .row
   .col-md-6.pl-4
     .form-group#js-organization-type

--- a/app/views/admin/organizations/show.html.haml
+++ b/app/views/admin/organizations/show.html.haml
@@ -24,6 +24,11 @@
               = @organization.id
       %tr
         %td
+          Short Name
+        %td
+          = @organization.short_name
+      %tr
+        %td
           Map
         %td
           - unless @organization.approved
@@ -34,7 +39,8 @@
             %em
               Would be
           - if @organization.show_on_map
-            Shown on map
+            %span.less-strong
+              Shown on map
           - else
             %strong
               Not Shown
@@ -54,11 +60,6 @@
           = link_to "org's manage", organization_manage_index_path(organization_id: @organization.to_param)
       %tr
         %td
-          Auto user email
-        %td
-          = @organization.auto_user.email if @organization.auto_user.present?
-      %tr
-        %td
           Created
         %td
           %span.convertTime.preciseTime
@@ -73,6 +74,11 @@
 
   .col-md-6
     %table.table-list
+      %tr
+        %td
+          Auto user email
+        %td
+          = @organization.auto_user.email if @organization.auto_user.present?
       %tr
         %td
           Users

--- a/db/migrate/20190607174104_add_previous_slug_to_organizations.rb
+++ b/db/migrate/20190607174104_add_previous_slug_to_organizations.rb
@@ -1,0 +1,5 @@
+class AddPreviousSlugToOrganizations < ActiveRecord::Migration
+  def change
+    add_column :organizations, :previous_slug, :string
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -102,7 +102,6 @@ CREATE TABLE public.ambassador_task_assignments (
 --
 
 CREATE SEQUENCE public.ambassador_task_assignments_id_seq
-    AS integer
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -135,7 +134,6 @@ CREATE TABLE public.ambassador_tasks (
 --
 
 CREATE SEQUENCE public.ambassador_tasks_id_seq
-    AS integer
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -212,7 +210,6 @@ CREATE TABLE public.bike_code_batches (
 --
 
 CREATE SEQUENCE public.bike_code_batches_id_seq
-    AS integer
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -1525,7 +1522,8 @@ CREATE TABLE public.organizations (
     kind integer,
     ascend_name character varying,
     registration_field_labels jsonb DEFAULT '{}'::jsonb,
-    pos_kind integer DEFAULT 0
+    pos_kind integer DEFAULT 0,
+    previous_slug character varying
 );
 
 
@@ -4168,4 +4166,6 @@ INSERT INTO schema_migrations (version) VALUES ('20190517200357');
 INSERT INTO schema_migrations (version) VALUES ('20190524191139');
 
 INSERT INTO schema_migrations (version) VALUES ('20190529024835');
+
+INSERT INTO schema_migrations (version) VALUES ('20190607174104');
 

--- a/spec/controllers/admin/organizations_controller_spec.rb
+++ b/spec/controllers/admin/organizations_controller_spec.rb
@@ -41,6 +41,7 @@ describe Admin::OrganizationsController, type: :controller do
         kind: "shop",
         parent_organization_id: parent_organization.id,
         ascend_name: "party on",
+        previous_slug: "partied-on",
         locations_attributes: {
           "0" => {
             id: location_1.id,
@@ -85,6 +86,7 @@ describe Admin::OrganizationsController, type: :controller do
       expect(organization.parent_organization).to eq parent_organization
       expect(organization.name).to eq update_attributes[:name]
       expect(organization.ascend_name).to eq "party on"
+      expect(organization.previous_slug).to eq "partied-on"
       # Existing location is updated
       location_1.reload
       expect(location_1.organization).to eq organization

--- a/spec/models/organization_spec.rb
+++ b/spec/models/organization_spec.rb
@@ -115,7 +115,6 @@ describe Organization do
       expect(Organization.friendly_find(" ")).to be_nil
       expect(Organization.friendly_find("something-cool")).to eq organization
       expect(Organization.friendly_find("bike shop")).to eq organization2
-      expect(Organization.where("LOWER(name) = LOWER(?)", "trek store of SANTA CRUZ".downcase).first).to eq organization2
       expect(Organization.friendly_find("trek store of SANTA CRUZ")).to eq organization2
       expect(Organization.friendly_find("bikeeastbay")).to eq organization3
     end

--- a/spec/models/organization_spec.rb
+++ b/spec/models/organization_spec.rb
@@ -106,6 +106,21 @@ describe Organization do
     end
   end
 
+  describe "friendly find" do
+    let!(:organization) { FactoryBot.create(:organization, short_name: "something cool") }
+    let!(:organization2) { FactoryBot.create(:organization, short_name: "Bike Shop", name: "Trek Store of Santa Cruz") }
+    let!(:organization3) { FactoryBot.create(:organization, short_name: "BikeEastBay", previous_slug: "ebbc") }
+    it "finds by slug, previous_slug and name" do
+      expect(organization2.slug).to eq "bike-shop"
+      expect(Organization.friendly_find(" ")).to be_nil
+      expect(Organization.friendly_find("something-cool")).to eq organization
+      expect(Organization.friendly_find("bike shop")).to eq organization2
+      expect(Organization.where("LOWER(name) = LOWER(?)", "trek store of SANTA CRUZ".downcase).first).to eq organization2
+      expect(Organization.friendly_find("trek store of SANTA CRUZ")).to eq organization2
+      expect(Organization.friendly_find("bikeeastbay")).to eq organization3
+    end
+  end
+
   describe "map_coordinates" do
     # There is definitely a better way to do this!
     # But for now, just stubbing it because whatever, they haven't put anything in


### PR DESCRIPTION
BikeEastBay changed their name from East Bay Bike Coalition. There are still some links and references around on their site to the previous slug they had (`ebbc`). I suspect we will run into this problem again in the future, so add a way to deal with it.