### PR TITLE
Update grape-swagger to 0.11

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -70,7 +70,7 @@ gem "api-pagination"
 gem "doorkeeper", "~> 3.1.0"
 gem "grape", "~> 0.19.1"
 gem "grape-active_model_serializers", "~> 1.4.0"
-gem "grape-swagger", "~> 0.10.4"
+gem "grape-swagger", "0.11"
 gem "swagger-ui_rails"
 gem "wine_bouncer"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -190,8 +190,8 @@ GEM
     grape-entity (0.4.8)
       activesupport
       multi_json (>= 1.3.2)
-    grape-swagger (0.10.5)
-      grape (>= 0.10.0)
+    grape-swagger (0.11.0)
+      grape (>= 0.16.2)
       grape-entity (< 0.5.0)
     grape_logging (1.3.0)
       grape
@@ -649,7 +649,7 @@ DEPENDENCIES
   geocoder
   grape (~> 0.19.1)
   grape-active_model_serializers (~> 1.4.0)
-  grape-swagger (~> 0.10.4)
+  grape-swagger (= 0.11)
   grape_logging
   groupdate
   guard

--- a/app/controllers/api/v2/users.rb
+++ b/app/controllers/api/v2/users.rb
@@ -3,7 +3,7 @@ module API
     class Users < API::Base
       include API::V2::Defaults
 
-      resource :users do
+      resource :users, desc: "Deprecated" do
         helpers do
           def user_info
             {

--- a/spec/requests/api/v2/swagger_request_spec.rb
+++ b/spec/requests/api/v2/swagger_request_spec.rb
@@ -4,11 +4,16 @@ RSpec.describe "Swagger API V2 docs", type: :request do
   describe "all the paths" do
     it "responds with swagger for all the apis" do
       get "/api/v2/swagger_doc"
-      result = json_result
+
       expect(response.code).to eq("200")
-      result["apis"].each do |api|
-        get "/api/v2/swagger_doc#{api["path"]}"
-        expect(response.code).to eq("200")
+
+      json_result["apis"].each do |endpoint|
+        path, desc = endpoint["path"], endpoint["description"]
+
+        get "/api/v2/swagger_doc#{path}"
+
+        code = (desc =~ /deprecated/i) ? 404 : 200
+        expect(response.status).to eq(code)
       end
     end
 


### PR DESCRIPTION
Resolves the following deprecations:

```
The route_xxx methods such as route_method have been deprecated, please use request_method.
The route_xxx methods such as route_path have been deprecated, please use path.
```

### Before

<details>

```
% bin/rails c

/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:26: The route_xxx methods such as route_path have been deprecated, please use path.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:27: The route_xxx methods such as route_prefix have been deprecated, please use prefix.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:34: The route_xxx methods such as route_path have been deprecated, please use path.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:26: The route_xxx methods such as route_path have been deprecated, please use path.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:27: The route_xxx methods such as route_prefix have been deprecated, please use prefix.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:34: The route_xxx methods such as route_path have been deprecated, please use path.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:26: The route_xxx methods such as route_path have been deprecated, please use path.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:27: The route_xxx methods such as route_prefix have been deprecated, please use prefix.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:34: The route_xxx methods such as route_path have been deprecated, please use path.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:26: The route_xxx methods such as route_path have been deprecated, please use path.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:27: The route_xxx methods such as route_prefix have been deprecated, please use prefix.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:34: The route_xxx methods such as route_path have been deprecated, please use path.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:26: The route_xxx methods such as route_path have been deprecated, please use path.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:27: The route_xxx methods such as route_prefix have been deprecated, please use prefix.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:34: The route_xxx methods such as route_path have been deprecated, please use path.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:26: The route_xxx methods such as route_path have been deprecated, please use path.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:27: The route_xxx methods such as route_prefix have been deprecated, please use prefix.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:34: The route_xxx methods such as route_path have been deprecated, please use path.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:26: The route_xxx methods such as route_path have been deprecated, please use path.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:27: The route_xxx methods such as route_prefix have been deprecated, please use prefix.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:34: The route_xxx methods such as route_path have been deprecated, please use path.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:26: The route_xxx methods such as route_path have been deprecated, please use path.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:27: The route_xxx methods such as route_prefix have been deprecated, please use prefix.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:34: The route_xxx methods such as route_path have been deprecated, please use path.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:26: The route_xxx methods such as route_path have been deprecated, please use path.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:27: The route_xxx methods such as route_prefix have been deprecated, please use prefix.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:34: The route_xxx methods such as route_path have been deprecated, please use path.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:26: The route_xxx methods such as route_path have been deprecated, please use path.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:27: The route_xxx methods such as route_prefix have been deprecated, please use prefix.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:34: The route_xxx methods such as route_path have been deprecated, please use path.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:26: The route_xxx methods such as route_path have been deprecated, please use path.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:27: The route_xxx methods such as route_prefix have been deprecated, please use prefix.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:34: The route_xxx methods such as route_path have been deprecated, please use path.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:26: The route_xxx methods such as route_path have been deprecated, please use path.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:27: The route_xxx methods such as route_prefix have been deprecated, please use prefix.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:34: The route_xxx methods such as route_path have been deprecated, please use path.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:26: The route_xxx methods such as route_path have been deprecated, please use path.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:27: The route_xxx methods such as route_prefix have been deprecated, please use prefix.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:34: The route_xxx methods such as route_path have been deprecated, please use path.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:26: The route_xxx methods such as route_path have been deprecated, please use path.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:27: The route_xxx methods such as route_prefix have been deprecated, please use prefix.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:34: The route_xxx methods such as route_path have been deprecated, please use path.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:26: The route_xxx methods such as route_path have been deprecated, please use path.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:27: The route_xxx methods such as route_prefix have been deprecated, please use prefix.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:34: The route_xxx methods such as route_path have been deprecated, please use path.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:26: The route_xxx methods such as route_path have been deprecated, please use path.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:27: The route_xxx methods such as route_prefix have been deprecated, please use prefix.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:34: The route_xxx methods such as route_path have been deprecated, please use path.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:26: The route_xxx methods such as route_path have been deprecated, please use path.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:27: The route_xxx methods such as route_prefix have been deprecated, please use prefix.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:34: The route_xxx methods such as route_path have been deprecated, please use path.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:26: The route_xxx methods such as route_path have been deprecated, please use path.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:27: The route_xxx methods such as route_prefix have been deprecated, please use prefix.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:34: The route_xxx methods such as route_path have been deprecated, please use path.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:26: The route_xxx methods such as route_path have been deprecated, please use path.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:27: The route_xxx methods such as route_prefix have been deprecated, please use prefix.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:34: The route_xxx methods such as route_path have been deprecated, please use path.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:26: The route_xxx methods such as route_path have been deprecated, please use path.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:27: The route_xxx methods such as route_prefix have been deprecated, please use prefix.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:34: The route_xxx methods such as route_path have been deprecated, please use path.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:26: The route_xxx methods such as route_path have been deprecated, please use path.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:27: The route_xxx methods such as route_prefix have been deprecated, please use prefix.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:34: The route_xxx methods such as route_path have been deprecated, please use path.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:26: The route_xxx methods such as route_path have been deprecated, please use path.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:27: The route_xxx methods such as route_prefix have been deprecated, please use prefix.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:34: The route_xxx methods such as route_path have been deprecated, please use path.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:26: The route_xxx methods such as route_path have been deprecated, please use path.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:27: The route_xxx methods such as route_prefix have been deprecated, please use prefix.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:34: The route_xxx methods such as route_path have been deprecated, please use path.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:26: The route_xxx methods such as route_path have been deprecated, please use path.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:27: The route_xxx methods such as route_prefix have been deprecated, please use prefix.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:34: The route_xxx methods such as route_path have been deprecated, please use path.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:80: The route_xxx methods such as route_path have been deprecated, please use path.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:80: The route_xxx methods such as route_prefix have been deprecated, please use prefix.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:80: The route_xxx methods such as route_path have been deprecated, please use path.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:80: The route_xxx methods such as route_prefix have been deprecated, please use prefix.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:80: The route_xxx methods such as route_path have been deprecated, please use path.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:80: The route_xxx methods such as route_prefix have been deprecated, please use prefix.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:80: The route_xxx methods such as route_path have been deprecated, please use path.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:80: The route_xxx methods such as route_prefix have been deprecated, please use prefix.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:80: The route_xxx methods such as route_path have been deprecated, please use path.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:80: The route_xxx methods such as route_prefix have been deprecated, please use prefix.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:80: The route_xxx methods such as route_path have been deprecated, please use path.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:80: The route_xxx methods such as route_prefix have been deprecated, please use prefix.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:80: The route_xxx methods such as route_path have been deprecated, please use path.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:80: The route_xxx methods such as route_prefix have been deprecated, please use prefix.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:80: The route_xxx methods such as route_path have been deprecated, please use path.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:80: The route_xxx methods such as route_prefix have been deprecated, please use prefix.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:80: The route_xxx methods such as route_path have been deprecated, please use path.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:80: The route_xxx methods such as route_prefix have been deprecated, please use prefix.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:80: The route_xxx methods such as route_path have been deprecated, please use path.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:80: The route_xxx methods such as route_prefix have been deprecated, please use prefix.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:80: The route_xxx methods such as route_path have been deprecated, please use path.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:80: The route_xxx methods such as route_prefix have been deprecated, please use prefix.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:80: The route_xxx methods such as route_path have been deprecated, please use path.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:80: The route_xxx methods such as route_prefix have been deprecated, please use prefix.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:80: The route_xxx methods such as route_path have been deprecated, please use path.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:80: The route_xxx methods such as route_prefix have been deprecated, please use prefix.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:80: The route_xxx methods such as route_path have been deprecated, please use path.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:80: The route_xxx methods such as route_prefix have been deprecated, please use prefix.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:80: The route_xxx methods such as route_path have been deprecated, please use path.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:80: The route_xxx methods such as route_prefix have been deprecated, please use prefix.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:80: The route_xxx methods such as route_path have been deprecated, please use path.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:80: The route_xxx methods such as route_prefix have been deprecated, please use prefix.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:80: The route_xxx methods such as route_path have been deprecated, please use path.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:80: The route_xxx methods such as route_prefix have been deprecated, please use prefix.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:80: The route_xxx methods such as route_path have been deprecated, please use path.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:80: The route_xxx methods such as route_prefix have been deprecated, please use prefix.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:80: The route_xxx methods such as route_path have been deprecated, please use path.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:80: The route_xxx methods such as route_prefix have been deprecated, please use prefix.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:80: The route_xxx methods such as route_path have been deprecated, please use path.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:80: The route_xxx methods such as route_prefix have been deprecated, please use prefix.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:80: The route_xxx methods such as route_path have been deprecated, please use path.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:80: The route_xxx methods such as route_prefix have been deprecated, please use prefix.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:80: The route_xxx methods such as route_path have been deprecated, please use path.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:80: The route_xxx methods such as route_prefix have been deprecated, please use prefix.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:80: The route_xxx methods such as route_path have been deprecated, please use path.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:80: The route_xxx methods such as route_prefix have been deprecated, please use prefix.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:80: The route_xxx methods such as route_path have been deprecated, please use path.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:80: The route_xxx methods such as route_prefix have been deprecated, please use prefix.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:80: The route_xxx methods such as route_path have been deprecated, please use path.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:80: The route_xxx methods such as route_prefix have been deprecated, please use prefix.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:80: The route_xxx methods such as route_path have been deprecated, please use path.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:80: The route_xxx methods such as route_prefix have been deprecated, please use prefix.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:80: The route_xxx methods such as route_path have been deprecated, please use path.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:80: The route_xxx methods such as route_prefix have been deprecated, please use prefix.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:80: The route_xxx methods such as route_path have been deprecated, please use path.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:80: The route_xxx methods such as route_prefix have been deprecated, please use prefix.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:80: The route_xxx methods such as route_path have been deprecated, please use path.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:80: The route_xxx methods such as route_prefix have been deprecated, please use prefix.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:80: The route_xxx methods such as route_path have been deprecated, please use path.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:80: The route_xxx methods such as route_prefix have been deprecated, please use prefix.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:80: The route_xxx methods such as route_path have been deprecated, please use path.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:80: The route_xxx methods such as route_prefix have been deprecated, please use prefix.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:80: The route_xxx methods such as route_path have been deprecated, please use path.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:80: The route_xxx methods such as route_prefix have been deprecated, please use prefix.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:80: The route_xxx methods such as route_path have been deprecated, please use path.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:80: The route_xxx methods such as route_prefix have been deprecated, please use prefix.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:80: The route_xxx methods such as route_path have been deprecated, please use path.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:80: The route_xxx methods such as route_prefix have been deprecated, please use prefix.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:80: The route_xxx methods such as route_path have been deprecated, please use path.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:80: The route_xxx methods such as route_prefix have been deprecated, please use prefix.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:80: The route_xxx methods such as route_path have been deprecated, please use path.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:80: The route_xxx methods such as route_prefix have been deprecated, please use prefix.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:80: The route_xxx methods such as route_path have been deprecated, please use path.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:80: The route_xxx methods such as route_prefix have been deprecated, please use prefix.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:80: The route_xxx methods such as route_path have been deprecated, please use path.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:80: The route_xxx methods such as route_prefix have been deprecated, please use prefix.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:80: The route_xxx methods such as route_path have been deprecated, please use path.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:80: The route_xxx methods such as route_prefix have been deprecated, please use prefix.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:80: The route_xxx methods such as route_path have been deprecated, please use path.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:80: The route_xxx methods such as route_prefix have been deprecated, please use prefix.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:80: The route_xxx methods such as route_path have been deprecated, please use path.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:80: The route_xxx methods such as route_prefix have been deprecated, please use prefix.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:80: The route_xxx methods such as route_path have been deprecated, please use path.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:80: The route_xxx methods such as route_prefix have been deprecated, please use prefix.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:80: The route_xxx methods such as route_path have been deprecated, please use path.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:80: The route_xxx methods such as route_prefix have been deprecated, please use prefix.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:80: The route_xxx methods such as route_path have been deprecated, please use path.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:80: The route_xxx methods such as route_prefix have been deprecated, please use prefix.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:26: The route_xxx methods such as route_path have been deprecated, please use path.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:27: The route_xxx methods such as route_prefix have been deprecated, please use prefix.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:34: The route_xxx methods such as route_path have been deprecated, please use path.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:26: The route_xxx methods such as route_path have been deprecated, please use path.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:27: The route_xxx methods such as route_prefix have been deprecated, please use prefix.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:34: The route_xxx methods such as route_path have been deprecated, please use path.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:26: The route_xxx methods such as route_path have been deprecated, please use path.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:27: The route_xxx methods such as route_prefix have been deprecated, please use prefix.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:34: The route_xxx methods such as route_path have been deprecated, please use path.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:26: The route_xxx methods such as route_path have been deprecated, please use path.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:27: The route_xxx methods such as route_prefix have been deprecated, please use prefix.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:34: The route_xxx methods such as route_path have been deprecated, please use path.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:26: The route_xxx methods such as route_path have been deprecated, please use path.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:27: The route_xxx methods such as route_prefix have been deprecated, please use prefix.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:34: The route_xxx methods such as route_path have been deprecated, please use path.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:26: The route_xxx methods such as route_path have been deprecated, please use path.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:27: The route_xxx methods such as route_prefix have been deprecated, please use prefix.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:34: The route_xxx methods such as route_path have been deprecated, please use path.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:26: The route_xxx methods such as route_path have been deprecated, please use path.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:27: The route_xxx methods such as route_prefix have been deprecated, please use prefix.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:34: The route_xxx methods such as route_path have been deprecated, please use path.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:26: The route_xxx methods such as route_path have been deprecated, please use path.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:27: The route_xxx methods such as route_prefix have been deprecated, please use prefix.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:34: The route_xxx methods such as route_path have been deprecated, please use path.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:26: The route_xxx methods such as route_path have been deprecated, please use path.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:27: The route_xxx methods such as route_prefix have been deprecated, please use prefix.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:34: The route_xxx methods such as route_path have been deprecated, please use path.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:26: The route_xxx methods such as route_path have been deprecated, please use path.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:27: The route_xxx methods such as route_prefix have been deprecated, please use prefix.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:34: The route_xxx methods such as route_path have been deprecated, please use path.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:26: The route_xxx methods such as route_path have been deprecated, please use path.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:27: The route_xxx methods such as route_prefix have been deprecated, please use prefix.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:34: The route_xxx methods such as route_path have been deprecated, please use path.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:26: The route_xxx methods such as route_path have been deprecated, please use path.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:27: The route_xxx methods such as route_prefix have been deprecated, please use prefix.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:34: The route_xxx methods such as route_path have been deprecated, please use path.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:26: The route_xxx methods such as route_path have been deprecated, please use path.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:27: The route_xxx methods such as route_prefix have been deprecated, please use prefix.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:34: The route_xxx methods such as route_path have been deprecated, please use path.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:26: The route_xxx methods such as route_path have been deprecated, please use path.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:27: The route_xxx methods such as route_prefix have been deprecated, please use prefix.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:34: The route_xxx methods such as route_path have been deprecated, please use path.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:26: The route_xxx methods such as route_path have been deprecated, please use path.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:27: The route_xxx methods such as route_prefix have been deprecated, please use prefix.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:34: The route_xxx methods such as route_path have been deprecated, please use path.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:26: The route_xxx methods such as route_path have been deprecated, please use path.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:27: The route_xxx methods such as route_prefix have been deprecated, please use prefix.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:34: The route_xxx methods such as route_path have been deprecated, please use path.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:26: The route_xxx methods such as route_path have been deprecated, please use path.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:27: The route_xxx methods such as route_prefix have been deprecated, please use prefix.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:34: The route_xxx methods such as route_path have been deprecated, please use path.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:26: The route_xxx methods such as route_path have been deprecated, please use path.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:27: The route_xxx methods such as route_prefix have been deprecated, please use prefix.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:34: The route_xxx methods such as route_path have been deprecated, please use path.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:26: The route_xxx methods such as route_path have been deprecated, please use path.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:27: The route_xxx methods such as route_prefix have been deprecated, please use prefix.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:34: The route_xxx methods such as route_path have been deprecated, please use path.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:26: The route_xxx methods such as route_path have been deprecated, please use path.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:27: The route_xxx methods such as route_prefix have been deprecated, please use prefix.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:34: The route_xxx methods such as route_path have been deprecated, please use path.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:26: The route_xxx methods such as route_path have been deprecated, please use path.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:27: The route_xxx methods such as route_prefix have been deprecated, please use prefix.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:34: The route_xxx methods such as route_path have been deprecated, please use path.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:26: The route_xxx methods such as route_path have been deprecated, please use path.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:27: The route_xxx methods such as route_prefix have been deprecated, please use prefix.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:34: The route_xxx methods such as route_path have been deprecated, please use path.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:26: The route_xxx methods such as route_path have been deprecated, please use path.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:27: The route_xxx methods such as route_prefix have been deprecated, please use prefix.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:34: The route_xxx methods such as route_path have been deprecated, please use path.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:26: The route_xxx methods such as route_path have been deprecated, please use path.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:27: The route_xxx methods such as route_prefix have been deprecated, please use prefix.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:34: The route_xxx methods such as route_path have been deprecated, please use path.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:26: The route_xxx methods such as route_path have been deprecated, please use path.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:27: The route_xxx methods such as route_prefix have been deprecated, please use prefix.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:34: The route_xxx methods such as route_path have been deprecated, please use path.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:26: The route_xxx methods such as route_path have been deprecated, please use path.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:27: The route_xxx methods such as route_prefix have been deprecated, please use prefix.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:34: The route_xxx methods such as route_path have been deprecated, please use path.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:26: The route_xxx methods such as route_path have been deprecated, please use path.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:27: The route_xxx methods such as route_prefix have been deprecated, please use prefix.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:34: The route_xxx methods such as route_path have been deprecated, please use path.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:26: The route_xxx methods such as route_path have been deprecated, please use path.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:27: The route_xxx methods such as route_prefix have been deprecated, please use prefix.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:34: The route_xxx methods such as route_path have been deprecated, please use path.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:80: The route_xxx methods such as route_path have been deprecated, please use path.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:80: The route_xxx methods such as route_prefix have been deprecated, please use prefix.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:80: The route_xxx methods such as route_path have been deprecated, please use path.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:80: The route_xxx methods such as route_prefix have been deprecated, please use prefix.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:80: The route_xxx methods such as route_path have been deprecated, please use path.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:80: The route_xxx methods such as route_prefix have been deprecated, please use prefix.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:80: The route_xxx methods such as route_path have been deprecated, please use path.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:80: The route_xxx methods such as route_prefix have been deprecated, please use prefix.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:80: The route_xxx methods such as route_path have been deprecated, please use path.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:80: The route_xxx methods such as route_prefix have been deprecated, please use prefix.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:80: The route_xxx methods such as route_path have been deprecated, please use path.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:80: The route_xxx methods such as route_prefix have been deprecated, please use prefix.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:80: The route_xxx methods such as route_path have been deprecated, please use path.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:80: The route_xxx methods such as route_prefix have been deprecated, please use prefix.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:80: The route_xxx methods such as route_path have been deprecated, please use path.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:80: The route_xxx methods such as route_prefix have been deprecated, please use prefix.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:80: The route_xxx methods such as route_path have been deprecated, please use path.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:80: The route_xxx methods such as route_prefix have been deprecated, please use prefix.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:80: The route_xxx methods such as route_path have been deprecated, please use path.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:80: The route_xxx methods such as route_prefix have been deprecated, please use prefix.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:80: The route_xxx methods such as route_path have been deprecated, please use path.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:80: The route_xxx methods such as route_prefix have been deprecated, please use prefix.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:80: The route_xxx methods such as route_path have been deprecated, please use path.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:80: The route_xxx methods such as route_prefix have been deprecated, please use prefix.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:80: The route_xxx methods such as route_path have been deprecated, please use path.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:80: The route_xxx methods such as route_prefix have been deprecated, please use prefix.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:80: The route_xxx methods such as route_path have been deprecated, please use path.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:80: The route_xxx methods such as route_prefix have been deprecated, please use prefix.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:80: The route_xxx methods such as route_path have been deprecated, please use path.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:80: The route_xxx methods such as route_prefix have been deprecated, please use prefix.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:80: The route_xxx methods such as route_path have been deprecated, please use path.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:80: The route_xxx methods such as route_prefix have been deprecated, please use prefix.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:80: The route_xxx methods such as route_path have been deprecated, please use path.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:80: The route_xxx methods such as route_prefix have been deprecated, please use prefix.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:80: The route_xxx methods such as route_path have been deprecated, please use path.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:80: The route_xxx methods such as route_prefix have been deprecated, please use prefix.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:80: The route_xxx methods such as route_path have been deprecated, please use path.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:80: The route_xxx methods such as route_prefix have been deprecated, please use prefix.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:80: The route_xxx methods such as route_path have been deprecated, please use path.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:80: The route_xxx methods such as route_prefix have been deprecated, please use prefix.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:80: The route_xxx methods such as route_path have been deprecated, please use path.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:80: The route_xxx methods such as route_prefix have been deprecated, please use prefix.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:80: The route_xxx methods such as route_path have been deprecated, please use path.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:80: The route_xxx methods such as route_prefix have been deprecated, please use prefix.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:80: The route_xxx methods such as route_path have been deprecated, please use path.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:80: The route_xxx methods such as route_prefix have been deprecated, please use prefix.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:80: The route_xxx methods such as route_path have been deprecated, please use path.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:80: The route_xxx methods such as route_prefix have been deprecated, please use prefix.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:80: The route_xxx methods such as route_path have been deprecated, please use path.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:80: The route_xxx methods such as route_prefix have been deprecated, please use prefix.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:80: The route_xxx methods such as route_path have been deprecated, please use path.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:80: The route_xxx methods such as route_prefix have been deprecated, please use prefix.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:80: The route_xxx methods such as route_path have been deprecated, please use path.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:80: The route_xxx methods such as route_prefix have been deprecated, please use prefix.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:80: The route_xxx methods such as route_path have been deprecated, please use path.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:80: The route_xxx methods such as route_prefix have been deprecated, please use prefix.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:80: The route_xxx methods such as route_path have been deprecated, please use path.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:80: The route_xxx methods such as route_prefix have been deprecated, please use prefix.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:80: The route_xxx methods such as route_path have been deprecated, please use path.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:80: The route_xxx methods such as route_prefix have been deprecated, please use prefix.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:80: The route_xxx methods such as route_path have been deprecated, please use path.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:80: The route_xxx methods such as route_prefix have been deprecated, please use prefix.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:80: The route_xxx methods such as route_path have been deprecated, please use path.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:80: The route_xxx methods such as route_prefix have been deprecated, please use prefix.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:80: The route_xxx methods such as route_path have been deprecated, please use path.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:80: The route_xxx methods such as route_prefix have been deprecated, please use prefix.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:80: The route_xxx methods such as route_path have been deprecated, please use path.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:80: The route_xxx methods such as route_prefix have been deprecated, please use prefix.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:80: The route_xxx methods such as route_path have been deprecated, please use path.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:80: The route_xxx methods such as route_prefix have been deprecated, please use prefix.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:80: The route_xxx methods such as route_path have been deprecated, please use path.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:80: The route_xxx methods such as route_prefix have been deprecated, please use prefix.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:80: The route_xxx methods such as route_path have been deprecated, please use path.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:80: The route_xxx methods such as route_prefix have been deprecated, please use prefix.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:80: The route_xxx methods such as route_path have been deprecated, please use path.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:80: The route_xxx methods such as route_prefix have been deprecated, please use prefix.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:80: The route_xxx methods such as route_path have been deprecated, please use path.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:80: The route_xxx methods such as route_prefix have been deprecated, please use prefix.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:80: The route_xxx methods such as route_path have been deprecated, please use path.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:80: The route_xxx methods such as route_prefix have been deprecated, please use prefix.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:80: The route_xxx methods such as route_path have been deprecated, please use path.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:80: The route_xxx methods such as route_prefix have been deprecated, please use prefix.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:80: The route_xxx methods such as route_path have been deprecated, please use path.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:80: The route_xxx methods such as route_prefix have been deprecated, please use prefix.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:80: The route_xxx methods such as route_path have been deprecated, please use path.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:80: The route_xxx methods such as route_prefix have been deprecated, please use prefix.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:80: The route_xxx methods such as route_path have been deprecated, please use path.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:80: The route_xxx methods such as route_prefix have been deprecated, please use prefix.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:80: The route_xxx methods such as route_path have been deprecated, please use path.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:80: The route_xxx methods such as route_prefix have been deprecated, please use prefix.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:80: The route_xxx methods such as route_path have been deprecated, please use path.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:80: The route_xxx methods such as route_prefix have been deprecated, please use prefix.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:80: The route_xxx methods such as route_path have been deprecated, please use path.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:80: The route_xxx methods such as route_prefix have been deprecated, please use prefix.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:80: The route_xxx methods such as route_path have been deprecated, please use path.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:80: The route_xxx methods such as route_prefix have been deprecated, please use prefix.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:80: The route_xxx methods such as route_path have been deprecated, please use path.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:80: The route_xxx methods such as route_prefix have been deprecated, please use prefix.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:80: The route_xxx methods such as route_path have been deprecated, please use path.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:80: The route_xxx methods such as route_prefix have been deprecated, please use prefix.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:80: The route_xxx methods such as route_path have been deprecated, please use path.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:80: The route_xxx methods such as route_prefix have been deprecated, please use prefix.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:80: The route_xxx methods such as route_path have been deprecated, please use path.
/Users/jmromer/.asdf/installs/ruby/2.5.1/lib/ruby/gems/2.5.0/gems/grape-swagger-0.10.5/lib/grape-swagger.rb:80: The route_xxx methods such as route_prefix have been deprecated, please use prefix.
Running via Spring preloader in process 52773
Loading development environment (Rails 4.2.11)
```
</details>

### After

```
% bin/rails c

Running via Spring preloader in process 53712
Loading development environment (Rails 4.2.11)
2.5.1 (bikeindex)[1] »
```

grape [compatibility chart](https://github.com/ruby-grape/grape-swagger#compatibility-)
grape [changelog](https://github.com/ruby-grape/grape/blob/master/CHANGELOG.md#0162-2016412)
grape-swagger [changelog](https://github.com/ruby-grape/grape-swagger/blob/master/CHANGELOG.md#0105-april-12-2016)