### PR TITLE
Render views globally

### DIFF
--- a/spec/controllers/admin/bikes_controller_spec.rb
+++ b/spec/controllers/admin/bikes_controller_spec.rb
@@ -1,8 +1,6 @@
 require "rails_helper"
 
 RSpec.describe Admin::BikesController, type: :controller do
-  render_views
-
   let(:user) { FactoryBot.create(:admin) }
   before do
     set_current_user(user)

--- a/spec/controllers/admin/stolen_bikes_controller_spec.rb
+++ b/spec/controllers/admin/stolen_bikes_controller_spec.rb
@@ -1,8 +1,6 @@
 require "rails_helper"
 
 RSpec.describe Admin::StolenBikesController, type: :controller do
-  render_views
-
   let(:user) { FactoryBot.create(:admin) }
   before do
     set_current_user(user)

--- a/spec/controllers/bikes_controller_spec.rb
+++ b/spec/controllers/bikes_controller_spec.rb
@@ -1,8 +1,6 @@
 require "rails_helper"
 
 RSpec.describe BikesController, type: :controller do
-  render_views
-
   describe "index" do
     include_context :geocoder_default_location
     let!(:non_stolen_bike) { FactoryBot.create(:bike, serial_number: "1234567890") }

--- a/spec/controllers/landing_pages_controller_spec.rb
+++ b/spec/controllers/landing_pages_controller_spec.rb
@@ -1,7 +1,6 @@
 require "rails_helper"
 
 RSpec.describe LandingPagesController, type: :controller do
-  render_views
   include_context :page_content_values
 
   describe "show" do

--- a/spec/controllers/organized/bikes_controller_spec.rb
+++ b/spec/controllers/organized/bikes_controller_spec.rb
@@ -1,8 +1,6 @@
 require "rails_helper"
 
 RSpec.describe Organized::BikesController, type: :controller do
-  render_views
-
   context "given an authenticated ambassador" do
     include_context :logged_in_as_ambassador
     it "redirects to the organization root path" do

--- a/spec/controllers/registrations_controller_spec.rb
+++ b/spec/controllers/registrations_controller_spec.rb
@@ -1,8 +1,6 @@
 require "rails_helper"
 
 RSpec.describe RegistrationsController, type: :controller do
-  render_views
-
   let(:user) { FactoryBot.create(:user_confirmed) }
   let(:auto_user) { FactoryBot.create(:organization_auto_user) }
   let(:organization) { auto_user.organizations.first }

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -1,8 +1,6 @@
 require "rails_helper"
 
 RSpec.describe UsersController, type: :controller do
-  render_views
-
   let(:user) { FactoryBot.create(:user_confirmed) }
   describe "new" do
     context "already signed in" do

--- a/spec/controllers/welcome_controller_spec.rb
+++ b/spec/controllers/welcome_controller_spec.rb
@@ -1,8 +1,6 @@
 require "rails_helper"
 
 RSpec.describe WelcomeController, type: :controller do
-  render_views
-
   describe "index" do
     it "renders" do
       get :index

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -20,6 +20,7 @@ Dir[Rails.root.join("spec", "support", "**", "*.rb")].each { |f| require f }
 
 RSpec.configure do |config|
   config.use_transactional_fixtures = true
+  config.render_views
 
   # Add our request spec helpers
   config.include RequestSpecHelpers, type: :request


### PR DESCRIPTION
Re-enables rendering views in all controller specs, not just those
in which we're asserting against rendered templates. The performance
impact is minimal and we still get some value from potentially
triggering exceptions from rendered templates.

```
Randomized with seed 29268
1964 examples, 0 failures, 13 pendings
Took 24 seconds
```