### PR TITLE
Add easy path for disabling spring locally

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,6 +51,3 @@ coverage
 # Ignore test results
 test-results/
 spec/examples.txt
-
-# Make it possible to skip spring
-.offspring

--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,6 @@ coverage
 # Ignore test results
 test-results/
 spec/examples.txt
+
+# Make it possible to skip spring
+.offspring

--- a/README.markdown
+++ b/README.markdown
@@ -58,6 +58,11 @@ This explanation assumes you're familiar with developing Ruby on Rails applicati
   - if you want to use [Pow](http://pow.cx/) (or some other setup that isn't through localhost:3001), change the appropriate values in [session_store.rb](config/initializers/session_store.rb) and [.env](.env).
 
 
+Toggle Spring with `rake dev:spring` (defaults to enabled)
+
+Toggle Caching in development with `rake dev:cache` (defaults to disabled)
+
+
 ## Testing
 
 We use [RSpec](https://github.com/rspec/rspec) and

--- a/bin/spring
+++ b/bin/spring
@@ -3,15 +3,17 @@
 # This file loads spring without using Bundler, in order to be fast.
 # It gets overwritten when you run the `spring binstub` command.
 
+ENV["DISABLE_SPRING"] = "1" if File.exists?(File.join(__dir__, "../.offspring"))
+
 unless defined?(Spring)
-  require 'rubygems'
-  require 'bundler'
+  require "rubygems"
+  require "bundler"
 
   lockfile = Bundler::LockfileParser.new(Bundler.default_lockfile.read)
   spring = lockfile.specs.detect { |spec| spec.name == "spring" }
   if spring
     Gem.use_paths Gem.dir, Bundler.bundle_path.to_s, *Gem.path
-    gem 'spring', spring.version
-    require 'spring/binstub'
+    gem "spring", spring.version
+    require "spring/binstub"
   end
 end

--- a/bin/spring
+++ b/bin/spring
@@ -3,7 +3,8 @@
 # This file loads spring without using Bundler, in order to be fast.
 # It gets overwritten when you run the `spring binstub` command.
 
-ENV["DISABLE_SPRING"] = "1" if File.exists?(File.join(__dir__, "../.offspring"))
+# Run rake dev:spring to toggle spring
+ENV["DISABLE_SPRING"] = "1" if File.exists?(File.join(__dir__, "..", "tmp", "spring-off.txt"))
 
 unless defined?(Spring)
   require "rubygems"

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -13,7 +13,7 @@ Rails.application.configure do
   # Show full error reports
   config.consider_all_requests_local = true
 
-  # Enable/disable caching
+  # Run rake dev:cache to toggle caching in development
   if Rails.root.join("tmp", "caching-dev.txt").exist?
     config.action_controller.perform_caching = true
     config.cache_store = :dalli_store,

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -10,11 +10,19 @@ Rails.application.configure do
   # Do not eager load code on boot.
   config.eager_load = false
 
-  # Show full error reports and disable caching.
+  # Show full error reports
   config.consider_all_requests_local = true
-  config.action_controller.perform_caching = false
-  config.cache_store = :dalli_store,
-  { namespace: Bikeindex, expires_in: 0, compress: true }
+
+  # Enable/disable caching
+  if Rails.root.join("tmp", "caching-dev.txt").exist?
+    config.action_controller.perform_caching = true
+    config.cache_store = :dalli_store,
+    { namespace: Bikeindex, expires_in: 0, compress: true }
+  else
+    config.action_controller.perform_caching = false
+
+    config.cache_store = :null_store
+  end
 
   config.action_mailer.raise_delivery_errors = true
   config.action_mailer.default_url_options = { host: "localhost", port: 3001 }

--- a/lib/tasks/dev_configuration.rake
+++ b/lib/tasks/dev_configuration.rake
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+# Pulling roughly from https://github.com/rails/rails/blob/master/railties/lib/rails/dev_caching.rb
+# Inspiration for spring from https://dev.to/evilmartians/living-in-sin-with-spring-48n8
+
+class RakeDevConfiguration
+  require "fileutils"
+  class << self
+    def toggle_dev_caching
+      file = "tmp/caching-dev.txt"
+      FileUtils.mkdir_p("tmp")
+
+      if File.exist?(file)
+        delete_cache_file(file)
+        puts "Development mode is no longer being cached."
+      else
+        create_cache_file(file)
+        puts "Development mode is now being cached."
+      end
+
+      FileUtils.touch "tmp/restart.txt"
+    end
+
+    def toggle_spring
+      file = "tmp/spring-off.txt"
+      FileUtils.mkdir_p("tmp")
+
+      if File.exist?(file)
+        delete_cache_file(file)
+        puts "Spring is now enabled."
+      else
+        create_cache_file(file)
+        puts "Spring is no longer enabled (you may need to manually kill the spring processes)"
+      end
+
+      FileUtils.touch "tmp/restart.txt" # Probably doesn't do anything right now, but whatever
+    end
+
+    def enable_by_argument(caching, file)
+      FileUtils.mkdir_p("tmp")
+
+      if caching
+        create_cache_file(file)
+      elsif caching == false && File.exist?(file)
+        delete_cache_file(file)
+      end
+    end
+
+    private
+      def create_cache_file(file)
+        FileUtils.touch(file)
+      end
+
+      def delete_cache_file(file)
+        File.delete(file)
+      end
+  end
+end
+
+namespace :dev do
+  task cache: :environment do
+    RakeDevConfiguration.toggle_dev_caching
+  end
+
+  task spring: :environment do
+    RakeDevConfiguration.toggle_spring
+  end
+end


### PR DESCRIPTION
I know people love spring!

I've spent a non-trivial chunk of time dealing with various Spring issues (previously in other projects), which makes me cautious. Spring also doesn't seem to speed up my personal development process of guard running tests for the files I'm changing (by much).

This PR adds a rake task to toggle spring disabled. I decided to do the same thing Rails 5 does for toggling caching in development, so I also added a rake task for `dev:cache` here as well, since it's nice to have, and why wait till rails 5!