### PR TITLE
Make Message kinds variable plural

### DIFF
--- a/app/controllers/organized/messages_controller.rb
+++ b/app/controllers/organized/messages_controller.rb
@@ -38,9 +38,10 @@ module Organized
     end
 
     def ensure_permitted_message_kind!
-      @kind = params[:organization_message].present? ? params[:organization_message][:kind_slug] : params[:kind]
-      @kind ||= current_organization.message_kinds
-      return true if current_organization.paid_for?(@kind)
+      kind = params[:organization_message].present? ? params[:organization_message][:kind_slug] : params[:kind]
+      @kinds =  Array(kind).flatten if kind.present?
+      @kinds ||= current_organization.message_kinds
+      return true if current_organization.paid_for?(@kinds)
       flash[:error] = "Your organization doesn't have access to that, please contact Bike Index support"
       if current_organization.message_kinds.any?
         redirect_to organization_messages_path(organization_id: current_organization.to_param, kind: current_organization.message_kinds.first)
@@ -56,7 +57,7 @@ module Organized
     end
 
     def redirect_back
-      redirect_kind = @kind || current_organization.message_kinds.first
+      redirect_kind = @kinds || current_organization.message_kinds.first
       redirect_to organization_messages_path(organization_id: current_organization.to_param, kind: redirect_kind)
       return
     end

--- a/app/controllers/organized/messages_controller.rb
+++ b/app/controllers/organized/messages_controller.rb
@@ -39,7 +39,7 @@ module Organized
 
     def ensure_permitted_message_kind!
       kind = params[:organization_message].present? ? params[:organization_message][:kind_slug] : params[:kind]
-      @kinds =  Array(kind).flatten if kind.present?
+      @kinds = Array(kind).flatten if kind.present?
       @kinds ||= current_organization.message_kinds
       return true if current_organization.paid_for?(@kinds)
       flash[:error] = "Your organization doesn't have access to that, please contact Bike Index support"

--- a/app/controllers/organized/messages_controller.rb
+++ b/app/controllers/organized/messages_controller.rb
@@ -38,9 +38,8 @@ module Organized
     end
 
     def ensure_permitted_message_kind!
-      kind = params[:organization_message].present? ? params[:organization_message][:kind_slug] : params[:kind]
-      @kinds = Array(kind).flatten if kind.present?
-      @kinds ||= current_organization.message_kinds
+      @kinds = Array(params.dig(:organization_message, :kind_slug) || params[:kind])
+      @kinds = current_organization.message_kinds unless @kinds.any?
       return true if current_organization.paid_for?(@kinds)
       flash[:error] = "Your organization doesn't have access to that, please contact Bike Index support"
       if current_organization.message_kinds.any?

--- a/app/views/organized/messages/index.html.haml
+++ b/app/views/organized/messages/index.html.haml
@@ -1,6 +1,6 @@
 .organized-page-header
   %h1
-    #{[@kinds].flatten.map(&:titleize).join(", ")}
+    #{@kinds.flatten.map(&:titleize).join(", ")}
 
 .organized-messages
   #map

--- a/app/views/organized/messages/index.html.haml
+++ b/app/views/organized/messages/index.html.haml
@@ -1,6 +1,6 @@
 .organized-page-header
   %h1
-    #{[@kind].flatten.map(&:titleize).join(", ")}
+    #{[@kinds].flatten.map(&:titleize).join(", ")}
 
 .organized-messages
   #map

--- a/app/views/organized/messages/index.html.haml
+++ b/app/views/organized/messages/index.html.haml
@@ -1,6 +1,6 @@
 .organized-page-header
   %h1
-    #{@kinds.flatten.map(&:titleize).join(", ")}
+    #{@kinds.map(&:titleize).join(", ")}
 
 .organized-messages
   #map

--- a/spec/controllers/organized/messages_controller_spec.rb
+++ b/spec/controllers/organized/messages_controller_spec.rb
@@ -67,7 +67,7 @@ RSpec.describe Organized::MessagesController, type: :controller do
           expect(organization.paid_for?(kind_slug)).to be_truthy
           expect do
             post :create, organization_id: organization.to_param, organization_message: message_params
-            expect(response).to redirect_to root_path
+            expect(response).to redirect_to organization_messages_path(organization_id: organization.to_param, kind: [kind_slug])
             expect(flash[:success]).to be_present
           end.to change(EmailOrganizationMessageWorker.jobs, :count).by(1)
           organization_message = OrganizationMessage.last


### PR DESCRIPTION
Follow up to #868 - specifically to [my message about plural variables](https://github.com/bikeindex/bike_index/pull/868/files#r292229758)

I thought, from a cursory look around the code, that we were only passing singular paid features to `paid_for?` - however, this `@kind` was actually an array some of the time.

This refactors it to _always_ be an array, which makes more sense to me.