### PR TITLE
Add uniqueness constraint on organization names

### DIFF
--- a/app/controllers/organized/manage_controller.rb
+++ b/app/controllers/organized/manage_controller.rb
@@ -48,8 +48,8 @@ module Organized
     end
 
     def permitted_parameters
-      params.require(:organization).permit(:name, :website, show_on_map_if_permitted, permitted_kind,
-                                           :embedable_user_email, paid_attributes,
+      params.require(:organization).permit(:name, :website, :embedable_user_email, :short_name,
+                                           show_on_map_if_permitted, permitted_kind, paid_attributes,
                                            locations_attributes: permitted_locations_params)
     end
 

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -50,7 +50,8 @@ class Organization < ActiveRecord::Base
   enum pos_kind: POS_KIND_ENUM
 
   validates_presence_of :name
-  validates_uniqueness_of :slug, message: "Slug error. You shouldn't see this - please contact admin@bikeindex.org"
+  validates_uniqueness_of :short_name, message: "Another organization already has this short name - if you don't think that should be the case, contact support@bikeindex.org"
+  validates_uniqueness_of :slug, message: "Slug error. You shouldn't see this - please contact support@bikeindex.org"
 
   default_scope { order(:name) }
   scope :shown_on_map, -> { where(show_on_map: true, approved: true) }

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -50,7 +50,7 @@ class Organization < ActiveRecord::Base
   enum pos_kind: POS_KIND_ENUM
 
   validates_presence_of :name
-  validates_uniqueness_of :short_name, message: "Another organization already has this short name - if you don't think that should be the case, contact support@bikeindex.org"
+  validates_uniqueness_of :short_name, case_sensitive: false, message: "another organization has this abbreviation - if you don't think that should be the case, contact support@bikeindex.org"
   validates_uniqueness_of :slug, message: "Slug error. You shouldn't see this - please contact support@bikeindex.org"
 
   default_scope { order(:name) }

--- a/spec/controllers/organized/manage_controller_spec.rb
+++ b/spec/controllers/organized/manage_controller_spec.rb
@@ -143,6 +143,7 @@ RSpec.describe Organized::ManageController, type: :controller do
           {
             name: organization.name,
             show_on_map: true,
+            short_name: "Something cool",
             kind: "ambassador",
             locations_attributes: {
               "0" => {
@@ -217,6 +218,21 @@ RSpec.describe Organized::ManageController, type: :controller do
           end
         end
 
+        context "matching short_name" do
+          let!(:organization2) { FactoryBot.create(:organization, short_name: "cool short name") }
+          it "doesn't update" do
+            put :update,
+                organization_id: organization.to_param,
+                id: organization.to_param,
+                organization: { kind: "property_management", short_name: "cool short name" }
+
+            expect(assigns[:page_errors]).to be_present
+            organization.reload
+            expect(organization.short_name).to_not eq "cool short name"
+            expect(organization.kind).to_not eq "property_management"
+          end
+        end
+
         context "removing a location" do
           it "removes the location" do
             update_attributes[:locations_attributes]["0"][:_destroy] = 1
@@ -225,11 +241,12 @@ RSpec.describe Organized::ManageController, type: :controller do
               put :update,
                   organization_id: organization.to_param,
                   id: organization.to_param,
-                  organization: update_attributes.merge(kind: "bike_shop")
+                  organization: update_attributes.merge(kind: "bike_shop", short_name: "cool other name")
             end.to change(Location, :count).by 0
 
             organization.reload
             expect(Location.where(id: location_1.id).count).to eq 0
+            expect(organization.short_name).to eq "cool other name"
           end
         end
       end


### PR DESCRIPTION
I think there might need to be more interface around this, eventually.

We ran into a problem where people from an organization had independently created two organizations and weren't able to figure out why they couldn't see each other. This should be harder to do than it is right now.