### PR TITLE
Feedbacks hash migration

### DIFF
--- a/app/controllers/admin/bikes_controller.rb
+++ b/app/controllers/admin/bikes_controller.rb
@@ -142,7 +142,7 @@ class Admin::BikesController < Admin::BaseController
   def matching_bikes
     return @matching_bikes if defined?(@matching_bikes)
     if params[:search_user_id].present?
-      @user = User.friendly_username_find(params[:search_user_id])
+      @user = User.username_friendly_find(params[:search_user_id])
       if @user.rough_approx_bikes.count > 25
         bikes = @user.rough_approx_bikes
       else

--- a/app/controllers/admin/bikes_controller.rb
+++ b/app/controllers/admin/bikes_controller.rb
@@ -142,7 +142,7 @@ class Admin::BikesController < Admin::BaseController
   def matching_bikes
     return @matching_bikes if defined?(@matching_bikes)
     if params[:search_user_id].present?
-      @user = User.find(params[:search_user_id])
+      @user = User.friendly_username_find(params[:search_user_id])
       if @user.rough_approx_bikes.count > 25
         bikes = @user.rough_approx_bikes
       else

--- a/app/controllers/admin/feedbacks_controller.rb
+++ b/app/controllers/admin/feedbacks_controller.rb
@@ -28,7 +28,7 @@ class Admin::FeedbacksController < Admin::BaseController
       feedbacks = feedbacks.where(feedback_type: params[:search_type] == "msg" ? nil : params[:search_type])
     end
     if params[:search_user_id].present?
-      @user = User.friendly_username_find(params[:search_user_id])
+      @user = User.username_friendly_find(params[:search_user_id])
       feedbacks = feedbacks.where(user_id: @user.id) if @user.present?
     end
     if params[:search_bike_id].present?

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -55,11 +55,7 @@ class Admin::UsersController < Admin::BaseController
   end
 
   def find_user
-    user_id = params[:id]
-    if user_id.is_a?(Integer) || user_id.match(/\A\d*\z/).present?
-      @user = User.where(id: user_id).first
-    end
-    @user ||= User.find_by_username(user_id)
+    @user = User.friendly_username_find(params[:id])
     raise ActiveRecord::RecordNotFound unless @user.present?
   end
 

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -55,7 +55,7 @@ class Admin::UsersController < Admin::BaseController
   end
 
   def find_user
-    @user = User.friendly_username_find(params[:id])
+    @user = User.username_friendly_find(params[:id])
     raise ActiveRecord::RecordNotFound unless @user.present?
   end
 

--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -48,6 +48,7 @@ module Api
             elsif feedback_type.match("bike_recovery")
               recover_bike(bike, feedback)
             end
+            feedback.user_id = current_user&.id
             feedback.save
             success = { success: "submitted request" }
             render json: success and return

--- a/app/models/feedback.rb
+++ b/app/models/feedback.rb
@@ -25,7 +25,7 @@ class Feedback < ActiveRecord::Base
   end
 
   def phone_number=(val)
-    feedback_hash = (feedback_hash || {}).merge(phone_number: val)
+    self.feedback_hash = (feedback_hash || {}).merge(phone_number: val)
   end
 
   def notify_admins

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -84,7 +84,7 @@ class User < ActiveRecord::Base
       fuzzy_email_find(email) || fuzzy_unconfirmed_primary_email_find(email)
     end
 
-    def friendly_username_find(n)
+    def username_friendly_find(n)
       if n.is_a?(Integer) || n.match(/\A\d*\z/).present?
         where(id: n).first
       else

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -84,6 +84,14 @@ class User < ActiveRecord::Base
       fuzzy_email_find(email) || fuzzy_unconfirmed_primary_email_find(email)
     end
 
+    def friendly_username_find(n)
+      if n.is_a?(Integer) || n.match(/\A\d*\z/).present?
+        where(id: n).first
+      else
+        find_by_username(n)
+      end
+    end
+
     def friendly_id_find(n)
       u = self.fuzzy_email_find(n)
       u && u.id

--- a/app/views/admin/bikes/edit.html.haml
+++ b/app/views/admin/bikes/edit.html.haml
@@ -164,8 +164,14 @@
       .form-group
         = f.label :owner_email
         = f.text_field :owner_email, :required =>true, class: "form-control"
-  = submit_tag "Update the bike", class: "btn btn-success mb-4"
-  = link_to "Delete bike", admin_bike_url(@bike), method: :delete, confirm: "Are you sure?", class: "btn btn-danger mb-4"
+
+  .row.mb-4
+    .col-4
+      = submit_tag "Update the bike", class: "btn btn-success"
+    .col-8.text-right
+      = link_to "Bike messages", admin_feedbacks_path(search_bike_id: @bike.to_param), class: "btn btn-outline-primary"
+      = link_to "Delete bike", admin_bike_url(@bike), method: :delete, confirm: "Are you sure?", class: "btn btn-danger ml-4"
+
   - if @bike.stolen and @bike.find_current_stolen_record.present?
     %hr
     = f.fields_for :stolen_records do |s|

--- a/app/views/admin/bikes/edit.html.haml
+++ b/app/views/admin/bikes/edit.html.haml
@@ -74,6 +74,12 @@
           %small.convertTimezone
       %tr
         %td
+          Updated
+        %td
+          %span.convertTime
+            = l @bike.updated_at, format: :convert_time
+      %tr
+        %td
           Cached Data
         %td
           %em.less-strong

--- a/app/views/admin/feedbacks/index.html.haml
+++ b/app/views/admin/feedbacks/index.html.haml
@@ -3,25 +3,30 @@
     %h1
       #{link_to 'Feedback and messages', admin_feedbacks_path}
   .col-12.mt-4
-    = line_chart graphs_admin_feedbacks_path(params.merge(start_at: params[:start_at]).except(:controller, :action))
-  .col-12.mt-2
-    .d-flex
-      %ul.list-inline.mx-auto.justify-content-center
-        - %w(all_time past_year past_month past_week).each do |start_at|
-          %li.list-inline-item
-            = link_to start_at.humanize, admin_feedbacks_path(params.merge(start_at: start_at).except(:controller, :action))
+    = line_chart available_feedbacks.send(group_by_method(@time_range), "feedbacks.created_at").count, curve: false, thousands: ",", defer: true
+  .col-12.mb-2.mt-2
+    .row.justify-content-end
+      .col-2
+        %p
+          %em.small.less-strong
+            = number_with_delimiter(available_feedbacks.count)
+            charted
+      = render partial: "/shared/period_select"
 
 
 %p
-  - if @matching_count.present?
-    = number_with_delimiter(@matching_count)
+  = number_with_delimiter(@feedbacks.total_count)
+  - if params[:search_type].present?
     %strong
-      = params[:type]
-    messages
-  - else
-    = number_with_delimiter(@feedbacks.total_count)
-    total messages
+      = params[:search_type]
 
+  - if params[:search_bike_id].present?
+    for #{link_to "bike##{params[:search_bike_id]}", admin_bike_path(params[:search_bike_id])}
+
+  - if @user.present?
+    From #{link_to @user.display_name, admin_user_path(@user)}
+
+  = "message".pluralize(@feedbacks.count)
 
 = paginate @feedbacks, views_prefix: 'admin'
 
@@ -29,11 +34,18 @@
   %table.table.table-bordered.table-striped
     %thead.thead-light
       %tr
-        %th.w-25{:scope => "col"} Created
-        %th{:scope => "col"} User
-        %th{:scope => "col"} Type
-        %th{:scope => "col"} Name
-        %th.w-25{:scope => "col"} Body
+        %th
+          = sortable "created_at"
+        %th
+          User
+        %th
+          Bike
+        %th
+          = sortable "feedback_type", "Type"
+        %th
+          Name
+        %th.w-25
+          Body
     %tbody
       - @feedbacks.each do |feedback|
         %tr
@@ -41,13 +53,22 @@
             %a.convertTime{ href: admin_feedback_url(feedback) }
               = l feedback.created_at, format: :convert_time
           %td
-            - if feedback.user
-              = link_to feedback.user.display_name, edit_admin_user_path(feedback.user)
+            - if feedback.user_id.present?
+              = link_to feedback.user.display_name, admin_user_path(feedback.user)
+              - unless params[:search_user_id].present?
+                %small
+                  = link_to "matching messages", admin_feedbacks_path(sortable_search_params.merge(search_user_id: feedback.user_id)), class: "gray-link"
             - else
               = link_to feedback.email, admin_users_path(user_query: feedback.email)
           %td
-            - feedback_type = feedback.feedback_type || 'msg'
+            - feedback_type = (feedback.feedback_type || 'msg').humanize
             = link_to feedback_type, admin_feedbacks_path(type: feedback_type)
+          %td
+            - if feedback.bike_id.present?
+              = link_to "#{feedback.bike_id}", admin_bike_path(feedback.bike_id), class: "less-strong"
+              - unless params[:search_bike_id].present?
+                %small
+                  = link_to "matching messages", admin_feedbacks_path(sortable_search_params.merge(search_bike_id: feedback.bike_id)), class: "gray-link"
           %td
             = feedback.name
           %td

--- a/app/views/admin_mailer/feedback_notification_email.html.haml
+++ b/app/views/admin_mailer/feedback_notification_email.html.haml
@@ -14,10 +14,10 @@
     = feedback_body
   %p
     Old serial:
-    = @feedback.feedback_hash[:old_serial]
+    = @feedback.feedback_hash["old_serial"]
   %p
     New serial:
-    = @feedback.feedback_hash[:new_serial]
+    = @feedback.feedback_hash["new_serial"]
   %p
     = link_to edit_admin_bike_url(@feedback.bike), edit_admin_bike_url(@feedback.bike)
 - if @feedback.feedback_type == 'manufacturer_update_request'
@@ -34,10 +34,10 @@
     = feedback_body
   %p
     Old manufacturer:
-    = @feedback.feedback_hash[:old_manufacturer]
+    = @feedback.feedback_hash["old_manufacturer"]
   %p
     New manufacturer:
-    = @feedback.feedback_hash[:new_manufacturer]
+    = @feedback.feedback_hash["new_manufacturer"]
   %p
     = link_to edit_admin_bike_url(@feedback.bike), edit_admin_bike_url(@feedback.bike)
 - elsif @feedback.feedback_type == 'bike_delete_request'
@@ -64,13 +64,13 @@
   %p
     Did we help?
     %strong
-      = @feedback.feedback_hash[:index_helped_recovery]
-  - if @feedback.feedback_hash[:index_helped_recovery]
+      = @feedback.feedback_hash["index_helped_recovery"]
+  - if @feedback.feedback_hash["index_helped_recovery"]
     %p
       Can we share?
       %strong
-        = @feedback.feedback_hash[:can_share_recovery]
-    - if @feedback.feedback_hash[:can_share_recovery]
+        = @feedback.feedback_hash["can_share_recovery"]
+    - if @feedback.feedback_hash["can_share_recovery"]
       %h3{ :style => "font-weight: 400px;" }
         = link_to "Approve sharing this recovery!", admin_recoveries_url
   %p
@@ -90,7 +90,7 @@
     = feedback_body
 
 - elsif @feedback.feedback_type.present? && @feedback.feedback_type.match(/organization_/i)
-  - organization = Organization.find(@feedback.feedback_hash[:organization_id])
+  - organization = Organization.find(@feedback.feedback_hash["organization_id"])
   %h1
     = feedback_body
   %p

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -189,9 +189,7 @@ Bikeindex::Application.routes.draw do
       end
     end
     resources :failed_bikes, only: [:index, :show]
-    resources :feedbacks, only: [:index, :show] do
-      collection { get :graphs }
-    end
+    resources :feedbacks, only: [:index, :show]
     resources :ownerships, only: [:edit, :update]
     resources :tweets
     get "blog", to: redirect("/news")

--- a/db/migrate/20190611203612_migrate_feedback_hash_to_jsonb.rb
+++ b/db/migrate/20190611203612_migrate_feedback_hash_to_jsonb.rb
@@ -1,0 +1,6 @@
+class MigrateFeedbackHashToJsonb < ActiveRecord::Migration
+  def change
+    rename_column :feedbacks, :feedback_hash, :feedback_hash_text
+    add_column :feedbacks, :feedback_hash, :jsonb
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -802,8 +802,9 @@ CREATE TABLE public.feedbacks (
     created_at timestamp without time zone NOT NULL,
     updated_at timestamp without time zone NOT NULL,
     feedback_type character varying(255),
-    feedback_hash text,
-    user_id integer
+    feedback_hash_text text,
+    user_id integer,
+    feedback_hash jsonb
 );
 
 
@@ -4168,4 +4169,6 @@ INSERT INTO schema_migrations (version) VALUES ('20190524191139');
 INSERT INTO schema_migrations (version) VALUES ('20190529024835');
 
 INSERT INTO schema_migrations (version) VALUES ('20190607174104');
+
+INSERT INTO schema_migrations (version) VALUES ('20190611203612');
 

--- a/spec/controllers/admin/feedbacks_controller_spec.rb
+++ b/spec/controllers/admin/feedbacks_controller_spec.rb
@@ -19,14 +19,4 @@ RSpec.describe Admin::FeedbacksController, type: :controller do
       expect(response).to render_template(:show)
     end
   end
-
-  describe "graphs" do
-    it "returns json" do
-      expect(subject).to be_present
-      get :graphs
-      expect(response.status).to eq(200)
-      result = JSON.parse(response.body)
-      expect(result.keys.count).to be > 0
-    end
-  end
 end

--- a/spec/controllers/api/v1/users_controller_spec.rb
+++ b/spec/controllers/api/v1/users_controller_spec.rb
@@ -190,7 +190,8 @@ RSpec.describe Api::V1::UsersController, type: :controller do
         expect(bike.stolen).to be_falsey
         expect(feedback.body).to eq recovery_request[:request_reason]
         expect(feedback.feedback_hash).to eq recovery_request
-                                               .slice(:index_helped_recovery, :can_share_recovery).merge(bike_id: bike.id.to_s)
+                                               .slice(:index_helped_recovery, :can_share_recovery)
+                                               .merge(bike_id: bike.id.to_s).as_json
         expect(stolen_record.current).to be_falsey
         expect(stolen_record.bike).to eq(bike)
         expect(stolen_record.recovered?).to be_truthy

--- a/spec/controllers/feedbacks_controller_spec.rb
+++ b/spec/controllers/feedbacks_controller_spec.rb
@@ -72,7 +72,7 @@ RSpec.describe FeedbacksController, type: :controller do
         expect(feedback.title).to eq "New School lead: Cool School"
         expect(feedback.email).to eq "example@example.com"
         expect(feedback.body).to eq "ffff"
-        expect(feedback.feedback_hash[:package_size]).to eq "small"
+        expect(feedback.feedback_hash["package_size"]).to eq "small"
       end
       context "with a phone number and no package_size" do
         it "creates a feedback" do

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -104,13 +104,6 @@ FactoryBot.define do
     sequence(:title) { |n| "Blog title #{n}" }
   end
 
-  factory :feedback do
-    email { "foo@boy.com" }
-    body { "This is a test email." }
-    title { "New Feedback Submitted" }
-    name { "Bobby Joe" }
-  end
-
   factory :stolen_notification do
     sender { FactoryBot.create(:user) }
     receiver { FactoryBot.create(:user) }

--- a/spec/factories/feedbacks.rb
+++ b/spec/factories/feedbacks.rb
@@ -1,0 +1,15 @@
+FactoryBot.define do
+  factory :feedback do
+    email { "foo@boy.com" }
+    body { "This is a test email." }
+    title { "New Feedback Submitted" }
+    name { "Bobby Joe" }
+    factory :feedback_serial_update_request do
+      transient do
+        bike { FactoryBot.create(:bike) }
+      end
+      feedback_type { "serial_update_request" }
+      feedback_hash { { bike_id: bike.id } }
+    end
+  end
+end

--- a/spec/models/feedback_spec.rb
+++ b/spec/models/feedback_spec.rb
@@ -1,6 +1,15 @@
 require "rails_helper"
 
 RSpec.describe Feedback, type: :model do
+  describe "bike" do
+    let(:bike) { FactoryBot.create(:bike) }
+    let!(:feedback) { FactoryBot.create(:feedback_serial_update_request, bike: bike) }
+    it "finds it, returns bike" do
+      expect(Feedback.for_bike.pluck(:id)).to eq([feedback.id])
+      expect(Feedback.for_bike(bike).pluck(:id)).to eq([feedback.id])
+      expect(feedback.bike).to eq bike
+    end
+  end
   describe "create" do
     it "enqueues an email job" do
       expect do
@@ -32,7 +41,7 @@ RSpec.describe Feedback, type: :model do
       expect(feedback.errors.full_messages).to_not be_present
       expect(feedback.errors.count).to eq 0
       expect(feedback.id).to be_present
-      expect(feedback.feedback_hash).to eq(package_size: "small")
+      expect(feedback.feedback_hash).to eq("package_size" => "small")
     end
   end
 

--- a/spec/models/feedback_spec.rb
+++ b/spec/models/feedback_spec.rb
@@ -2,11 +2,13 @@ require "rails_helper"
 
 RSpec.describe Feedback, type: :model do
   describe "bike" do
+    let(:_bike) { FactoryBot.create(:bike) }
     let(:bike) { FactoryBot.create(:bike) }
     let!(:feedback) { FactoryBot.create(:feedback_serial_update_request, bike: bike) }
     it "finds it, returns bike" do
-      expect(Feedback.for_bike.pluck(:id)).to eq([feedback.id])
-      expect(Feedback.for_bike(bike).pluck(:id)).to eq([feedback.id])
+      expect(Feedback.bike.pluck(:id)).to eq([feedback.id])
+      expect(Feedback.bike(bike).pluck(:id)).to eq([feedback.id])
+      expect(Feedback.bike(bike.id).pluck(:id)).to eq([feedback.id])
       expect(feedback.bike).to eq bike
     end
   end


### PR DESCRIPTION
Add some stuff to make it easier to view messages about bikes

After shipping, need to migrate the existing records with:

```ruby
Feedback.find_each { |f| f.update_column :feedback_hash, f.feedback_hash_text }
```

And then create a separate PR that drops the legacy column
