### PR TITLE
Fix redirect to org bikes path

### DIFF
--- a/app/controllers/concerns/controller_helpers.rb
+++ b/app/controllers/concerns/controller_helpers.rb
@@ -48,7 +48,7 @@ module ControllerHelpers
     return root_url unless current_user.present?
     return admin_root_url if current_user.superuser
     return user_home_url(subdomain: false) unless current_user.default_organization.present?
-    organization_bikes_path(organization_id: current_user.default_organization.to_param)
+    organization_root_url(organization_id: current_user.default_organization.to_param)
   end
 
   def default_bike_search_path

--- a/spec/controllers/admin/dashboard_controller_spec.rb
+++ b/spec/controllers/admin/dashboard_controller_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Admin::DashboardController, type: :controller do
       it "redirects" do
         get :index
         expect(response.code).to eq("302")
-        expect(response).to redirect_to organization_bikes_path(organization_id: user.default_organization.to_param)
+        expect(response).to redirect_to organization_root_path(organization_id: user.default_organization.to_param)
       end
     end
   end

--- a/spec/controllers/sessions_controller_spec.rb
+++ b/spec/controllers/sessions_controller_spec.rb
@@ -170,7 +170,7 @@ RSpec.describe SessionsController, type: :controller do
           post :create, session: { password: "would be correct" }
           expect(cookies.signed[:auth][1]).to eq(user.auth_token)
           expect(session[:render_donation_request]).to be_falsey
-          expect(response).to redirect_to organization_bikes_path(organization_id: organization.to_param)
+          expect(response).to redirect_to organization_root_path(organization_id: organization.to_param)
         end
         context "organization is police" do
           let(:organization_kind) { "law_enforcement" }
@@ -180,7 +180,7 @@ RSpec.describe SessionsController, type: :controller do
             post :create, session: { password: "would be correct" }
             expect(cookies.signed[:auth][1]).to eq(user.auth_token)
             expect(session[:render_donation_request]).to eq "law_enforcement"
-            expect(response).to redirect_to organization_bikes_path(organization_id: organization.to_param)
+            expect(response).to redirect_to organization_root_path(organization_id: organization.to_param)
           end
         end
       end

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -115,7 +115,7 @@ RSpec.describe UsersController, type: :controller do
             expect do
               post :create, user: user_attributes
             end.to change(EmailWelcomeWorker.jobs, :count)
-            expect(response).to redirect_to organization_bikes_path(organization_id: organization.to_param)
+            expect(response).to redirect_to organization_root_path(organization_id: organization.to_param)
             user = User.order(:created_at).last
             expect(user.email).to eq email
             expect(User.from_auth(cookies.signed[:auth])).to eq user

--- a/spec/requests/organized/ambassador_dashboards_request_spec.rb
+++ b/spec/requests/organized/ambassador_dashboards_request_spec.rb
@@ -21,9 +21,9 @@ RSpec.describe Organized::AmbassadorDashboardsController, type: :request do
     let(:organization) { FactoryBot.create(:organization) }
     let(:user) { FactoryBot.create(:organization_member, organization: organization) }
     describe "index" do
-      it "redirects the user's homepage" do
+      it "redirects to organization root path" do
         get organization_ambassador_dashboard_path(organization)
-        expect(response).to redirect_to organization_bikes_path(organization_id: organization)
+        expect(response).to redirect_to organization_root_path(organization_id: organization)
       end
     end
   end


### PR DESCRIPTION
With #787 we replaced redirects to `organization_bikes_url` with `organization_root_url` in order to dispatch to the ambassador dashboard when in ambassador view or the organization bikes page otherwise. 

This patch updates `user_root_url` to do likewise:

```rb
# app/controllers/concerns/controller_helpers.rb L47-52 (ec8a5f9f)

def user_root_url
  return root_url unless current_user.present?
  return admin_root_url if current_user.superuser
  return user_home_url(subdomain: false) unless current_user.default_organization.present?
  organization_root_url(organization_id: current_user.default_organization.to_param)
end
```


```rb
# app/controllers/organized/base_controller.rb L9-15 (5c8bf746)

def root
  if current_organization.ambassador?
    redirect_to organization_ambassador_dashboard_path
  else
    redirect_to organization_bikes_path
  end
end
```
