### PR TITLE
Add directories statement to guardfiles

### DIFF
--- a/Guardfile
+++ b/Guardfile
@@ -1,3 +1,4 @@
+
 group :red_green_refactor, halt_on_fail: true do
   rspec_options = {
     cmd: "bin/rspec -f progress",

--- a/Guardfile
+++ b/Guardfile
@@ -1,3 +1,4 @@
+directories %w(app spec lib config)
 
 group :red_green_refactor, halt_on_fail: true do
   rspec_options = {

--- a/Guardfile_parallel
+++ b/Guardfile_parallel
@@ -1,3 +1,5 @@
+directories %w(app spec lib config)
+
 group :red_green_refactor, halt_on_fail: true do
   rspec_options = {
     cmd: "bin/parallel_rspec --test-options='-f documentation -o /dev/null -f progress",


### PR DESCRIPTION
Add `directories` statement to the Guardfiles (per [Guard's optimizing page](https://github.com/guard/guard/wiki/Optimizing-for-large-projects)) - this made a big difference for me. Enough of a difference that I'm no longer super concerned about this.