### PR TITLE
Replace Time.now with Time.current

### DIFF
--- a/app/controllers/admin/base_controller.rb
+++ b/app/controllers/admin/base_controller.rb
@@ -6,13 +6,13 @@ class Admin::BaseController < ApplicationController
     @period = params[:period]
     case @period
     when "hour"
-      @start_time = Time.now - 1.hour
+      @start_time = Time.current - 1.hour
     when "day"
-      @start_time = Time.now - 1.day
+      @start_time = Time.current - 1.day
     when "month"
-      @start_time = Time.now - 30.days
+      @start_time = Time.current - 30.days
     when "year"
-      @start_time = Time.now - 1.year
+      @start_time = Time.current - 1.year
     when "all"
       if current_organization.present?
         @start_time = current_organization.created_at
@@ -21,8 +21,8 @@ class Admin::BaseController < ApplicationController
       end
     else
       @period = "week"
-      @start_time = Time.now - 7.days
+      @start_time = Time.current - 7.days
     end
-    @time_range = @start_time..Time.now
+    @time_range = @start_time..Time.current
   end
 end

--- a/app/controllers/admin/graphs_controller.rb
+++ b/app/controllers/admin/graphs_controller.rb
@@ -62,9 +62,9 @@ class Admin::GraphsController < Admin::BaseController
     bikes = Bike.unscoped
     case params[:start_at]
     when "past_year"
-      range = 1.year.ago.midnight..Time.now
+      range = 1.year.ago.midnight..Time.current
     else
-      range ||= bike_index_start..Time.now
+      range ||= bike_index_start..Time.current
     end
     bgraph = [
       { name: "Registrations", data: bikes.group_by_month(:created_at, range: range).count },
@@ -113,7 +113,7 @@ class Admin::GraphsController < Admin::BaseController
   def set_variable_graphing_timing
     @timezone = TimeParser.parse_timezone(params[:timezone] || "America/Los_Angeles")
     @start_at = params[:start_at].present? ? TimeParser.parse(params[:start_at], @timezone) : bike_index_start
-    @end_at = params[:end_at].present? ? TimeParser.parse(params[:end_at], @timezone) : Time.now
+    @end_at = params[:end_at].present? ? TimeParser.parse(params[:end_at], @timezone) : Time.current
     @group_period = calculated_group_period(@start_at, @end_at)
   end
 

--- a/app/controllers/admin/news_controller.rb
+++ b/app/controllers/admin/news_controller.rb
@@ -7,7 +7,7 @@ class Admin::NewsController < Admin::BaseController
   end
 
   def new
-    @blog = Blog.new(published_at: Time.now, user_id: current_user.id)
+    @blog = Blog.new(published_at: Time.current, user_id: current_user.id)
   end
 
   def image_edit
@@ -43,7 +43,7 @@ class Admin::NewsController < Admin::BaseController
       title: params[:blog][:title],
       user_id: current_user.id,
       body: "No content yet, write some now!",
-      published_at: Time.now,
+      published_at: Time.current,
       is_listicle: false,
     })
     if @blog.save

--- a/app/controllers/concerns/sessionable.rb
+++ b/app/controllers/concerns/sessionable.rb
@@ -15,7 +15,7 @@ module Sessionable
   end
 
   def sign_in_and_redirect(user)
-    session[:last_seen] = Time.now
+    session[:last_seen] = Time.current
     session[:render_donation_request] = user.render_donation_request if user&.render_donation_request
     set_passive_organization(user.default_organization) # Set that organization!
     if ActiveRecord::Type::Boolean.new.type_cast_from_database(params.dig(:session, :remember_me))

--- a/app/controllers/organizations_controller.rb
+++ b/app/controllers/organizations_controller.rb
@@ -89,7 +89,7 @@ class OrganizationsController < ApplicationController
     if @b_param.params && @b_param.params["stolen_record"].present?
       stolen_attrs = @b_param.params["stolen_record"].except("phone_no_show")
     else
-      stolen_attrs = { country_id: Country.united_states.id, date_stolen: Time.zone.now }
+      stolen_attrs = { country_id: Country.united_states.id, date_stolen: Time.current }
     end
     @bike.stolen_records.build(stolen_attrs)
   end
@@ -97,7 +97,7 @@ class OrganizationsController < ApplicationController
   def built_stolen_record_date(str)
     DateTime.strptime("#{str} 06", "%m-%d-%Y %H") if str.present?
   rescue ArgumentError
-    Time.zone.now
+    Time.current
   end
 
   def permitted_create_params

--- a/app/mailers/customer_mailer.rb
+++ b/app/mailers/customer_mailer.rb
@@ -53,7 +53,7 @@ class CustomerMailer < ActionMailer::Base
          cc: ["bryan@bikeindex.org", "lily@bikeindex.org"],
          reply_to: @stolen_notification.sender.email,
          from: "bryan@bikeindex.org", subject: @stolen_notification.display_subject)
-    dates = stolen_notification.send_dates_parsed + [Time.now.to_i]
+    dates = stolen_notification.send_dates_parsed + [Time.current.to_i]
     stolen_notification.update_attribute :send_dates, dates
   end
 

--- a/app/models/ambassador_task_assignment.rb
+++ b/app/models/ambassador_task_assignment.rb
@@ -11,8 +11,8 @@ class AmbassadorTaskAssignment < ActiveRecord::Base
 
   scope :completed, -> { where.not(completed_at: nil) }
   scope :incomplete, -> { where(completed_at: nil) }
-  scope :pending_completion, -> { incomplete.or(where("completed_at > ?", Time.now - 2.hours)) }
-  scope :locked_completed, -> { completed.where("completed_at < ?", Time.now - 2.hours) }
+  scope :pending_completion, -> { incomplete.or(where("completed_at > ?", Time.current - 2.hours)) }
+  scope :locked_completed, -> { completed.where("completed_at < ?", Time.current - 2.hours) }
   scope :task_ordered, -> { order(ambassador_task_id: :asc) }
 
   after_commit :update_associated_user
@@ -103,6 +103,6 @@ class AmbassadorTaskAssignment < ActiveRecord::Base
   end
 
   def update_associated_user
-    ambassador.update_attributes(updated_at: Time.now)
+    ambassador.update_attributes(updated_at: Time.current)
   end
 end

--- a/app/models/b_param.rb
+++ b/app/models/b_param.rb
@@ -55,7 +55,7 @@ class BParam < ActiveRecord::Base
   end
 
   def self.with_organization_or_no_creator(toke) # Because organization embed bikes might not match the creator
-    without_bike.where("created_at >= ?", Time.now - 1.month).where(id_token: toke)
+    without_bike.where("created_at >= ?", Time.current - 1.month).where(id_token: toke)
       .detect { |b| b.creator_id.blank? || b.creation_organization_id.present? || b.params["creation_organization_id"].present? }
   end
 

--- a/app/models/bike.rb
+++ b/app/models/bike.rb
@@ -164,7 +164,7 @@ class Bike < ActiveRecord::Base
 
   def get_listing_order
     return current_stolen_record.date_stolen.to_time.to_i.abs if stolen && current_stolen_record.present?
-    t = (updated_at || Time.now).to_i / 10000
+    t = (updated_at || Time.current).to_i / 10000
     stock_photo_url.present? || public_images.present? ? t : t / 100
   end
 

--- a/app/models/bike_code.rb
+++ b/app/models/bike_code.rb
@@ -110,7 +110,7 @@ class BikeCode < ActiveRecord::Base
       unclaim!
     elsif claiming_bike.present?
       self.previous_bike_id = bike_id || previous_bike_id # Don't erase previous_bike_id if double unclaiming
-      update(bike_id: claiming_bike.id, user_id: user.id, claimed_at: Time.now) unless errors.any?
+      update(bike_id: claiming_bike.id, user_id: user.id, claimed_at: Time.current) unless errors.any?
     else
       errors.add(:bike, "\"#{bike_str}\" not found")
     end
@@ -121,11 +121,11 @@ class BikeCode < ActiveRecord::Base
   def update_associations
     if bike_id.present?
       found_b = Bike.where(id: bike_id).first
-      found_b&.update_attributes(updated_at: Time.now)
+      found_b&.update_attributes(updated_at: Time.current)
     end
     if previous_bike_id.present?
       found_previous_b = Bike.where(id: previous_bike_id).first
-      found_previous_b&.update_attributes(updated_at: Time.now)
+      found_previous_b&.update_attributes(updated_at: Time.current)
     end
   end
 

--- a/app/models/blog.rb
+++ b/app/models/blog.rb
@@ -42,7 +42,7 @@ class Blog < ActiveRecord::Base
   end
 
   def set_calculated_attributes
-    self.published_at ||= Time.now # We need to have a published time...
+    self.published_at ||= Time.current # We need to have a published time...
     set_published_at_and_published
     update_title_save
     create_abbreviation
@@ -53,7 +53,7 @@ class Blog < ActiveRecord::Base
     if self.post_date.present?
       self.published_at = TimeParser.parse(post_date, timezone)
     end
-    self.published_at = Time.now if self.post_now == "1"
+    self.published_at = Time.current if self.post_now == "1"
     if self.user_email.present?
       u = User.fuzzy_email_find(user_email)
       self.user_id = u.id if u.present?

--- a/app/models/bulk_import.rb
+++ b/app/models/bulk_import.rb
@@ -35,7 +35,7 @@ class BulkImport < ActiveRecord::Base
 
   def import_errors?; line_import_errors.present? || file_import_errors.present? end
 
-  def blocking_error?; file_import_errors.present? || pending? && created_at && created_at < Time.now - 5.minutes end
+  def blocking_error?; file_import_errors.present? || pending? && created_at && created_at < Time.current - 5.minutes end
 
   def no_bikes?; import_errors["bikes"] == "none_imported" end
 

--- a/app/models/counts.rb
+++ b/app/models/counts.rb
@@ -49,7 +49,7 @@ class Counts
     end
 
     def assign_week_creation_chart
-      assign_for("week_creation_chart", Bike.unscoped.where(created_at: beginning_of_week..Time.now).group_by_day(:created_at).count.to_json)
+      assign_for("week_creation_chart", Bike.unscoped.where(created_at: beginning_of_week..Time.current).group_by_day(:created_at).count.to_json)
     end
 
     def recoveries; retrieve_for("recoveries") end

--- a/app/models/counts.rb
+++ b/app/models/counts.rb
@@ -55,7 +55,7 @@ class Counts
     def recoveries; retrieve_for("recoveries") end
 
     def assign_recoveries_value
-      valued = StolenRecord.recovered.where("date_recovered < ?", Time.zone.now.beginning_of_day).pluck(:estimated_value).reject(&:blank?)
+      valued = StolenRecord.recovered.where("date_recovered < ?", Time.current.beginning_of_day).pluck(:estimated_value).reject(&:blank?)
       # Sum of the recovered bikes with estimated_values + recovery_average_value * the number of bikes without an estimated_value
       assign_for("recoveries_value", valued.sum + (recoveries - valued.count) * recovery_average_value)
     end

--- a/app/models/duplicate_bike_group.rb
+++ b/app/models/duplicate_bike_group.rb
@@ -7,7 +7,7 @@ class DuplicateBikeGroup < ActiveRecord::Base
   before_save :update_added_bike_at
 
   def update_added_bike_at
-    self.added_bike_at ||= Time.now
+    self.added_bike_at ||= Time.current
   end
 
   def segment

--- a/app/models/export.rb
+++ b/app/models/export.rb
@@ -190,7 +190,7 @@ class Export < ActiveRecord::Base
   # Generally, use calculated_progress rather than progress directly for display
   def calculated_progress
     return progress unless pending? || ongoing?
-    (created_at || Time.now) < Time.now - 10.minutes ? "errored" : progress
+    (created_at || Time.current) < Time.current - 10.minutes ? "errored" : progress
   end
 
   def validated_options(opts)

--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -47,7 +47,7 @@ class Location < ActiveRecord::Base
   def update_organization
     # Because we need to update the organization and make sure it is shown on the map correctly
     # Manually update to ensure that it runs the before save stuff
-    organization && organization.update_attributes(updated_at: Time.now)
+    organization && organization.update_attributes(updated_at: Time.current)
   end
 
   def display_name

--- a/app/models/mail_snippet.rb
+++ b/app/models/mail_snippet.rb
@@ -48,6 +48,6 @@ class MailSnippet < ActiveRecord::Base
   def update_organization
     # Because we need to update the organization and make sure mail snippet calculations are included
     # Manually update to ensure that it runs the before save stuff
-    organization && organization.update_attributes(updated_at: Time.now)
+    organization && organization.update_attributes(updated_at: Time.current)
   end
 end

--- a/app/models/membership.rb
+++ b/app/models/membership.rb
@@ -28,8 +28,8 @@ class Membership < ActiveRecord::Base
   end
 
   def update_relationships
-    user&.update_attributes(updated_at: Time.now)
-    organization&.update_attributes(updated_at: Time.now)
+    user&.update_attributes(updated_at: Time.current)
+    organization&.update_attributes(updated_at: Time.current)
   end
 
   def ensure_ambassador_tasks_assigned!

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -241,7 +241,7 @@ class Organization < ActiveRecord::Base
   end
 
   def calculated_pos_kind
-    recent_bikes = bikes.where(created_at: (Time.now - 1.week)..Time.now)
+    recent_bikes = bikes.where(created_at: (Time.current - 1.week)..Time.current)
     return "lightspeed_pos" if recent_bikes.lightspeed_pos.count > 0
     return "ascend_pos" if recent_bikes.ascend_pos.count > 0
     return "other_pos" if recent_bikes.any_pos.count > 0

--- a/app/models/paid_feature.rb
+++ b/app/models/paid_feature.rb
@@ -54,6 +54,6 @@ class PaidFeature < ActiveRecord::Base
 
   # Trigger an update to invoices which will, in turn, update the associated organizations
   def update_invoices
-    invoices.each { |i| i.update_attributes(updated_at: Time.now) }
+    invoices.each { |i| i.update_attributes(updated_at: Time.current) }
   end
 end

--- a/app/models/payment.rb
+++ b/app/models/payment.rb
@@ -45,6 +45,6 @@ class Payment < ActiveRecord::Base
 
   def update_invoice
     return true unless invoice.present?
-    invoice.update_attributes(updated_at: Time.now) # Manually trigger invoice update
+    invoice.update_attributes(updated_at: Time.current) # Manually trigger invoice update
   end
 end

--- a/app/models/public_image.rb
+++ b/app/models/public_image.rb
@@ -26,7 +26,7 @@ class PublicImage < ActiveRecord::Base
     if external_image_url.present? && image.blank?
       return ExternalImageUrlStoreWorker.perform_async(id)
     end
-    imageable&.update_attributes(updated_at: Time.now)
+    imageable&.update_attributes(updated_at: Time.current)
     return true unless imageable_type == "Bike"
     AfterBikeSaveWorker.perform_async(imageable_id)
   end

--- a/app/models/recovery_display.rb
+++ b/app/models/recovery_display.rb
@@ -14,7 +14,7 @@ class RecoveryDisplay < ActiveRecord::Base
     if date_input.present?
       self.date_recovered = DateTime.strptime("#{date_input} 06", "%m-%d-%Y %H")
     end
-    self.date_recovered = Time.now unless date_recovered.present?
+    self.date_recovered = Time.current unless date_recovered.present?
   end
 
   validate :quote_not_too_long

--- a/app/models/stolen_record.rb
+++ b/app/models/stolen_record.rb
@@ -38,7 +38,7 @@ class StolenRecord < ActiveRecord::Base
   scope :approveds, -> { where(approved: true) }
   scope :approveds_with_reports, -> { approveds.where("police_report_number IS NOT NULL").where("police_report_department IS NOT NULL") }
   scope :not_tsved, -> { where("tsved_at IS NULL") }
-  scope :tsv_today, -> { where("tsved_at IS NULL OR tsved_at >= '#{Time.now.beginning_of_day}'") }
+  scope :tsv_today, -> { where("tsved_at IS NULL OR tsved_at >= '#{Time.current.beginning_of_day}'") }
 
   scope :recovered, -> { unscoped.where(current: false).order("date_recovered desc") }
   scope :displayable, -> { recovered.where(can_share_recovery: true) }
@@ -126,13 +126,13 @@ class StolenRecord < ActiveRecord::Base
 
   def fix_date
     year = date_stolen.year
-    if date_stolen.year < (Time.now - 100.years).year
+    if date_stolen.year < (Time.current - 100.years).year
       decade = year.to_s.chars.last(2).join("")
       corrected = date_stolen.change(year: "20#{decade}".to_i)
       self.date_stolen = corrected
     end
-    if date_stolen > Time.now + 2.days
-      corrected = date_stolen.change(year: Time.now.year - 1)
+    if date_stolen > Time.current + 2.days
+      corrected = date_stolen.change(year: Time.current.year - 1)
       self.date_stolen = corrected
     end
   end
@@ -198,7 +198,7 @@ class StolenRecord < ActiveRecord::Base
 
   def add_recovery_information(info = {})
     info = ActiveSupport::HashWithIndifferentAccess.new(info)
-    self.date_recovered = TimeParser.parse(info[:date_recovered], info[:timezone]) || Time.now
+    self.date_recovered = TimeParser.parse(info[:date_recovered], info[:timezone]) || Time.current
     update_attributes(current: false,
                       recovered_description: info[:recovered_description],
                       recovering_user_id: info[:recovering_user_id],

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -166,22 +166,22 @@ class User < ActiveRecord::Base
   end
 
   def reset_token_expired?
-    reset_token_time < (Time.now - 1.hours)
+    reset_token_time < (Time.current - 1.hours)
   end
 
-  def set_password_reset_token(t = Time.now.to_i)
-    self.password_reset_token = "#{t}-" + Digest::MD5.hexdigest("#{SecureRandom.hex(10)}-#{DateTime.now}")
+  def set_password_reset_token(t = Time.current.to_i)
+    self.password_reset_token = "#{t}-" + Digest::MD5.hexdigest("#{SecureRandom.hex(10)}-#{DateTime.current}")
     self.save
   end
 
   def accept_vendor_terms_of_service
     self.vendor_terms_of_service = true
-    self.when_vendor_terms_of_service = DateTime.now
+    self.when_vendor_terms_of_service = DateTime.current
     save
   end
 
   def send_password_reset_email
-    unless reset_token_time > Time.now - 2.minutes
+    unless reset_token_time > Time.current - 2.minutes
       set_password_reset_token
       EmailResetPasswordWorker.perform_async(id)
     end
@@ -328,7 +328,7 @@ class User < ActiveRecord::Base
 
   def generate_auth_token
     begin
-      self.auth_token = SecureRandom.urlsafe_base64 + "t#{Time.now.to_i}"
+      self.auth_token = SecureRandom.urlsafe_base64 + "t#{Time.current.to_i}"
     end while User.where(auth_token: auth_token).exists?
   end
 
@@ -345,7 +345,7 @@ class User < ActiveRecord::Base
     end
     self.username = usrname
     if !confirmed
-      self.confirmation_token = (Digest::MD5.hexdigest "#{SecureRandom.hex(10)}-#{DateTime.now.to_s}")
+      self.confirmation_token = (Digest::MD5.hexdigest "#{SecureRandom.hex(10)}-#{DateTime.current.to_s}")
     end
     generate_auth_token
     true

--- a/app/models/user_email.rb
+++ b/app/models/user_email.rb
@@ -81,6 +81,6 @@ class UserEmail < ActiveRecord::Base
   end
 
   def generate_confirmation
-    self.update_attribute :confirmation_token, (Digest::MD5.hexdigest "#{SecureRandom.hex(10)}-#{DateTime.now.to_s}")
+    self.update_attribute :confirmation_token, (Digest::MD5.hexdigest "#{SecureRandom.hex(10)}-#{DateTime.current.to_s}")
   end
 end

--- a/app/models/user_email.rb
+++ b/app/models/user_email.rb
@@ -56,7 +56,7 @@ class UserEmail < ActiveRecord::Base
   end
 
   def expired
-    created_at > Time.zone.now - 2.hours
+    created_at > Time.current - 2.hours
   end
 
   def make_primary

--- a/app/services/stolen_record_updator.rb
+++ b/app/services/stolen_record_updator.rb
@@ -48,7 +48,7 @@ class StolenRecordUpdator
 
     stolen_record.attributes = permitted_attributes(sr)
 
-    stolen_record.date_stolen = TimeParser.parse(sr["date_stolen"], sr["timezone"]) || Time.now unless @date_stolen.present?
+    stolen_record.date_stolen = TimeParser.parse(sr["date_stolen"], sr["timezone"]) || Time.current unless @date_stolen.present?
 
     if sr["country"].present?
       country = Country.fuzzy_iso_find(sr["country"])
@@ -68,7 +68,7 @@ class StolenRecordUpdator
 
   def create_new_record
     mark_records_not_current
-    new_stolen_record = StolenRecord.new(bike: @bike, current: true, date_stolen: @date_stolen || Time.now)
+    new_stolen_record = StolenRecord.new(bike: @bike, current: true, date_stolen: @date_stolen || Time.current)
     new_stolen_record.phone = @bike.phone
     new_stolen_record.country_id = Country.united_states&.id
     stolen_record = update_with_params(new_stolen_record)

--- a/app/views/admin/bikes/index.html.haml
+++ b/app/views/admin/bikes/index.html.haml
@@ -66,13 +66,13 @@
   %p
     There are currently #{number_with_delimiter(PublicImage.count)} bike images
     %em
-      (#{PublicImage.where("created_at >= ?", Time.zone.now.beginning_of_day).count} today)
+      (#{PublicImage.where("created_at >= ?", Time.current.beginning_of_day).count} today)
 
   %p
     = number_with_delimiter(Bike.count)
     publicly registered,
     %em
-      (#{Bike.where("created_at >= ?", Time.zone.now.beginning_of_day).count} today)
+      (#{Bike.where("created_at >= ?", Time.current.beginning_of_day).count} today)
     = number_with_delimiter(Ownership.where(current: true).where(claimed: true).count)
     are claimed
 

--- a/app/views/admin/bulk_imports/index.html.haml
+++ b/app/views/admin/bulk_imports/index.html.haml
@@ -19,7 +19,7 @@
       %small
         = link_to "orgs view", organization_bulk_imports_path(organization_id: current_organization.to_param), class: "less-strong"
 
-= line_chart matching_bulk_imports.group_by_day(:created_at, range: 1.month.ago.midnight..Time.now).count
+= line_chart matching_bulk_imports.group_by_day(:created_at, range: 1.month.ago.midnight..Time.current).count
 
 %p
   = number_with_delimiter(@bulk_imports.total_count)

--- a/app/views/admin/dashboard/index.html.haml
+++ b/app/views/admin/dashboard/index.html.haml
@@ -14,8 +14,8 @@
       = number_with_delimiter(Bike.count)
       bikes total
       %em
-        - today = Bike.where("created_at >= ?", Time.zone.now.beginning_of_day).count
-        - yesterday = (Bike.where("created_at >= ?", Time.zone.now.beginning_of_day - 1.day).count) - today
+        - today = Bike.where("created_at >= ?", Time.current.beginning_of_day).count
+        - yesterday = (Bike.where("created_at >= ?", Time.current.beginning_of_day - 1.day).count) - today
         (#{number_with_delimiter(today)} today, #{number_with_delimiter(yesterday)} yesterday)
     - bikes = [ { name: 'Registrations', data: Bike.unscoped.group_by_day(:created_at, range: 1.weeks.ago.midnight..Time.current).count }, { name: 'Stolen', data: Bike.unscoped.where(stolen: true).group_by_day(:created_at, range: 1.weeks.ago.midnight..Time.current).count }]
 
@@ -32,8 +32,8 @@
     %p
       = number_with_delimiter(User.count)
       users total
-      - today = User.where("created_at >= ?", Time.zone.now.beginning_of_day).count
-      - yesterday = (User.where("created_at >= ?", Time.zone.now.beginning_of_day - 1.day).count) - today
+      - today = User.where("created_at >= ?", Time.current.beginning_of_day).count
+      - yesterday = (User.where("created_at >= ?", Time.current.beginning_of_day - 1.day).count) - today
       %em
         (#{number_with_delimiter(today)} today, #{number_with_delimiter(yesterday)} yesterday)
 
@@ -48,7 +48,7 @@
     %p
       = number_with_delimiter(Organization.count)
       Organizations total
-      - today = Organization.where("created_at >= ?", Time.zone.now.beginning_of_day).count
-      - yesterday = (Organization.where("created_at >= ?", Time.zone.now.beginning_of_day - 1.day).count) - today
+      - today = Organization.where("created_at >= ?", Time.current.beginning_of_day).count
+      - yesterday = (Organization.where("created_at >= ?", Time.current.beginning_of_day - 1.day).count) - today
       %em
         (#{number_with_delimiter(today)} today, #{number_with_delimiter(yesterday)} yesterday)

--- a/app/views/admin/dashboard/index.html.haml
+++ b/app/views/admin/dashboard/index.html.haml
@@ -17,7 +17,7 @@
         - today = Bike.where("created_at >= ?", Time.zone.now.beginning_of_day).count
         - yesterday = (Bike.where("created_at >= ?", Time.zone.now.beginning_of_day - 1.day).count) - today
         (#{number_with_delimiter(today)} today, #{number_with_delimiter(yesterday)} yesterday)
-    - bikes = [ { name: 'Registrations', data: Bike.unscoped.group_by_day(:created_at, range: 1.weeks.ago.midnight..Time.now).count }, { name: 'Stolen', data: Bike.unscoped.where(stolen: true).group_by_day(:created_at, range: 1.weeks.ago.midnight..Time.now).count }]
+    - bikes = [ { name: 'Registrations', data: Bike.unscoped.group_by_day(:created_at, range: 1.weeks.ago.midnight..Time.current).count }, { name: 'Stolen', data: Bike.unscoped.where(stolen: true).group_by_day(:created_at, range: 1.weeks.ago.midnight..Time.current).count }]
 
 = line_chart bikes
 

--- a/app/views/admin/graphs/index.html.haml
+++ b/app/views/admin/graphs/index.html.haml
@@ -2,7 +2,7 @@
 - if @kind == "general"
 
   %h2 Users past week
-  = line_chart User.group_by_day(:created_at, range: 1.weeks.ago.midnight..Time.now).count
+  = line_chart User.group_by_day(:created_at, range: 1.weeks.ago.midnight..Time.current).count
 
   %h2
     Users since start

--- a/app/views/admin/graphs/tables.html.haml
+++ b/app/views/admin/graphs/tables.html.haml
@@ -7,8 +7,8 @@
     = submit_tag 'Load', name: 'search', class: 'btn btn-primary'
 - years = Array(2013..Time.current.year)
 - dates = years.map { |y| Date.civil(y, 6, 6) }
-- yday = Time.zone.now.yday
-- days_left = Time.zone.now.end_of_year.yday - yday
+- yday = Time.current.yday
+- days_left = Time.current.end_of_year.yday - yday
 
 %h2
   Records everywhere
@@ -41,32 +41,32 @@
               = StolenRecord.unscoped.where(date_stolen: date.all_year).count
             - else
               = count = StolenRecord.unscoped.where(created_at: date.all_year).count
-              - if year == Time.zone.now.year
+              - if year == Time.current.year
                 %span.less-strong
                   = s_project = count + (BigDecimal.new(count) / yday * days_left).to_i
           %td
             = count = StolenRecord.unscoped.where('created_at < ?', date.end_of_year).count
-            - if year == Time.zone.now.year
+            - if year == Time.current.year
               %span.less-strong
                 = s_project + count
           %td
             = count = StolenRecord.unscoped.where(date_recovered: date.all_year).count
-            - if year == Time.zone.now.year
+            - if year == Time.current.year
               %span.less-strong
                 = count + (BigDecimal.new(count) / yday * days_left).to_i
           %td
             = count = Bike.unscoped.where(created_at: date.all_year).count
-            - if year == Time.zone.now.year
+            - if year == Time.current.year
               %span.less-strong
                 = a_project = count + (BigDecimal.new(count) / yday * days_left).to_i
           %td
             = count = Bike.unscoped.where('created_at < ?', date.all_year.last).count
-            - if year == Time.zone.now.year
+            - if year == Time.current.year
               %span.less-strong
                 = a_project + count
           %td
             = count = User.unscoped.where(created_at: date.all_year).count
-            - if year == Time.zone.now.year
+            - if year == Time.current.year
               %span.less-strong
                 = count + (BigDecimal.new(count) / yday * days_left).to_i
 .mt-4
@@ -102,19 +102,19 @@
               = StolenRecord.unscoped.where(date_stolen: date.all_year).within_bounding_box(box).count
             - else
               = count = StolenRecord.unscoped.where(created_at: date.all_year).within_bounding_box(box).count
-              - if year == Time.zone.now.year
+              - if year == Time.current.year
                 %span.less-strong
                   = s_project = count + (BigDecimal.new(count) / yday * days_left).to_i
           %td
             / To calculate for a specific time period:
             / StolenRecord.unscoped.where(created_at: Time.current.beginning_of_month..Time.current).within_bounding_box(Geocoder::Calculations.bounding_box('Seattle', 25)).count
             = count = StolenRecord.unscoped.where('created_at < ?', date.end_of_year).within_bounding_box(box).count
-            - if year == Time.zone.now.year
+            - if year == Time.current.year
               %span.less-strong
                 = s_project + count
           %td
             = count = StolenRecord.unscoped.where(date_recovered: date.all_year).within_bounding_box(box).count
-            - if year == Time.zone.now.year
+            - if year == Time.current.year
               %span.less-strong
                 = count + (BigDecimal.new(count) / yday * days_left).to_i
           %td

--- a/app/views/admin/graphs/tables.html.haml
+++ b/app/views/admin/graphs/tables.html.haml
@@ -5,7 +5,7 @@
     = text_field_tag :location_radius, params[:location_radius], placeholder: 'Proximity in miles', class: "form-control mr-2"
     = hidden_field_tag :tables, true
     = submit_tag 'Load', name: 'search', class: 'btn btn-primary'
-- years = Array(2013..Time.now.year)
+- years = Array(2013..Time.current.year)
 - dates = years.map { |y| Date.civil(y, 6, 6) }
 - yday = Time.zone.now.yday
 - days_left = Time.zone.now.end_of_year.yday - yday
@@ -107,7 +107,7 @@
                   = s_project = count + (BigDecimal.new(count) / yday * days_left).to_i
           %td
             / To calculate for a specific time period:
-            / StolenRecord.unscoped.where(created_at: Time.now.beginning_of_month..Time.now).within_bounding_box(Geocoder::Calculations.bounding_box('Seattle', 25)).count
+            / StolenRecord.unscoped.where(created_at: Time.current.beginning_of_month..Time.current).within_bounding_box(Geocoder::Calculations.bounding_box('Seattle', 25)).count
             = count = StolenRecord.unscoped.where('created_at < ?', date.end_of_year).within_bounding_box(box).count
             - if year == Time.zone.now.year
               %span.less-strong

--- a/app/views/admin/news/edit.html.haml
+++ b/app/views/admin/news/edit.html.haml
@@ -10,7 +10,7 @@
         - images = @blog.listicles.map(&:image_url)
       - else
         - images = @blog.public_images.map(&:image_url)
-      - images.each do |i| 
+      - images.each do |i|
         %br
         = link_to i, i
       - images.each do |i|
@@ -28,7 +28,7 @@
         #alert-block
           .alert.alert-error
             %h4
-              Please fix the following 
+              Please fix the following
               = pluralize(@blog.errors.count, "error")
             %ul
               - @blog.errors.full_messages.each do |msg|
@@ -47,14 +47,14 @@
             .span6
               .control-group
                 %label.control-label
-                  Published date 
+                  Published date
                 .controls.radio-controls
                   %label.checkbox
                     = f.check_box :post_now
                     Publish now
                 .controls.extra-field
                   = @blog.published_at.strftime("%m-%d-%Y")
-                  
+
                   %a#change_published_date{ href: "#", data: {date: "#{@blog.published_at.strftime("%m-%d-%Y")}" }}
                     edit
 
@@ -62,9 +62,9 @@
                 = label :post_date, "Post date", class: "control-label"
                 .controls
                   #post-date-field
-                    - @blog.post_date = TimeParser.round(@blog.published_at || Time.now, "seconds")
+                    - @blog.post_date = TimeParser.round(@blog.published_at || Time.current, "seconds")
                     = f.hidden_field :timezone, value: "", class: "hiddenFieldTimezone"
-                    = f.datetime_local_field :post_date, max: Time.now + 1.week, step: 60, required: true, class: 'form-control'
+                    = f.datetime_local_field :post_date, max: Time.current + 1.week, step: 60, required: true, class: 'form-control'
 
               .control-group
                 = f.label :published, "Published", class: "control-label"
@@ -95,7 +95,7 @@
                   %label.index-image-select
                     <input type="radio" name="index_image_id" value="0" class="index_image_0">
                     No primary image
-          
+
           .blog-field
             = f.text_field :title, placeholder: "Blog title"
           .blog-field
@@ -125,4 +125,3 @@
   .padded.clearfix
     = link_to "Delete post", admin_news_url(@blog), method: :delete, confirm: "Are you sure?", class: "button-red"
 
-    

--- a/app/views/admin/organizations/index.html.haml
+++ b/app/views/admin/organizations/index.html.haml
@@ -46,7 +46,7 @@
           matching
       organizations
       %em
-        (#{matching_organizations.where("organizations.created_at >= ?", Time.zone.now.beginning_of_day).count} today)
+        (#{matching_organizations.where("organizations.created_at >= ?", Time.current.beginning_of_day).count} today)
   .col-md-7
     = form_tag admin_organizations_path, method: :get, class: "form-inline" do
       = hidden_field_tag :sort, sort_column

--- a/app/views/admin/organizations/invoices/_form.html.haml
+++ b/app/views/admin/organizations/invoices/_form.html.haml
@@ -72,13 +72,13 @@
       .col-md-6
         .form-group
           = f.label :start_at, "Coverage starts"
-          - @invoice.subscription_start_at = TimeParser.round(@invoice.subscription_start_at || Time.now, "seconds")
+          - @invoice.subscription_start_at = TimeParser.round(@invoice.subscription_start_at || Time.current, "seconds")
           = f.hidden_field :timezone, value: "", class: "hiddenFieldTimezone"
           = f.datetime_local_field :start_at, step: 60, required: true, class: "form-control"
       .col-md-6
         .form-group
           = f.label :end_at, "Coverage ends"
-          - @invoice.subscription_end_at = TimeParser.round(@invoice.subscription_end_at || Time.now + 1.year, "seconds")
+          - @invoice.subscription_end_at = TimeParser.round(@invoice.subscription_end_at || Time.current + 1.year, "seconds")
           = f.datetime_local_field :end_at, step: 60, required: true, class: "form-control"
     .row
       .col-md-6

--- a/app/views/admin/organizations/invoices/_table.html.haml
+++ b/app/views/admin/organizations/invoices/_table.html.haml
@@ -64,7 +64,7 @@
                 = l invoice.subscription_start_at, format: :convert_time
           %td
             - if invoice.subscription_end_at.present?
-              %span.convertTime{ class: invoice.subscription_end_at < Time.now ? "text-danger" : "" }
+              %span.convertTime{ class: invoice.subscription_end_at < Time.current ? "text-danger" : "" }
                 = l invoice.subscription_end_at, format: :convert_time
           %td
             = invoice.amount_due_formatted

--- a/app/views/admin/organizations/show.html.haml
+++ b/app/views/admin/organizations/show.html.haml
@@ -11,7 +11,7 @@
 
 - if @organization.law_enforcement_missing_verified_features?
   .alert.alert-info
-    This is a law enforcement organization without unstolen notifications. To enable unstolen notifications, #{link_to "add an invoice for this organization", new_admin_organization_invoice_path(organization_id: @organization.to_param, end_at: (Time.now + 10.years).to_i)} and enable "unstolen notifications" in it
+    This is a law enforcement organization without unstolen notifications. To enable unstolen notifications, #{link_to "add an invoice for this organization", new_admin_organization_invoice_path(organization_id: @organization.to_param, end_at: (Time.current + 10.years).to_i)} and enable "unstolen notifications" in it
 .row
   .col-md-6
     %table.table-list

--- a/app/views/admin/paints/index.html.haml
+++ b/app/views/admin/paints/index.html.haml
@@ -6,7 +6,7 @@
   = Paint.count
   indexed,
   %em
-    (#{Paint.where("created_at >= ?", Time.zone.now.beginning_of_day).count} today)
+    (#{Paint.where("created_at >= ?", Time.current.beginning_of_day).count} today)
   = Paint.where('color_id IS NULL').count
   are unlinked
 

--- a/app/views/admin/payments/new.html.haml
+++ b/app/views/admin/payments/new.html.haml
@@ -13,11 +13,11 @@
         = f.select :kind, Payment.admin_creatable_kinds.map { |k| [k.humanize, k] }
 
     .control-group.padded
-      - f.object.created_at = TimeParser.round(f.object.created_at || Time.now)
+      - f.object.created_at = TimeParser.round(f.object.created_at || Time.current)
       .control-label
         = f.label :created_at, "Time of payment"
       .controls
-        = f.datetime_local_field :created_at, max: Time.now + 1.week, step: 60, required: true, class: 'form-control'
+        = f.datetime_local_field :created_at, max: Time.current + 1.week, step: 60, required: true, class: 'form-control'
 
     .control-group.padded
       .control-label

--- a/app/views/admin/recovery_displays/_form.html.haml
+++ b/app/views/admin/recovery_displays/_form.html.haml
@@ -18,8 +18,8 @@
         .col-lg-6
           .form-group
             = f.label :date_recovered
-            - f.object.date_recovered ||= Time.now
-            = f.datetime_local_field :date_recovered, max: Time.now + 1.day, step: 60, required: true, class: 'form-control dateInputUpdateZone', "data-initialtime" => l(f.object.date_recovered, format: :convert_time)
+            - f.object.date_recovered ||= Time.current
+            = f.datetime_local_field :date_recovered, max: Time.current + 1.day, step: 60, required: true, class: 'form-control dateInputUpdateZone', "data-initialtime" => l(f.object.date_recovered, format: :convert_time)
         .col-lg-6
           - if @bike.present?
             .form-group

--- a/app/views/admin/stolen_bikes/index.html.haml
+++ b/app/views/admin/stolen_bikes/index.html.haml
@@ -16,7 +16,7 @@
   = Bike.where(stolen: true).count
   Stolen Bikes indexed,
   %em
-    (#{Bike.where(stolen: true).where("created_at >= ?", Time.zone.now.beginning_of_day).count} today)
+    (#{Bike.where(stolen: true).where("created_at >= ?", Time.current.beginning_of_day).count} today)
 %h4
   - if StolenRecord.where(approved: false).count == 0
     %h4.text-success

--- a/app/views/admin/stolen_notifications/index.html.haml
+++ b/app/views/admin/stolen_notifications/index.html.haml
@@ -6,7 +6,7 @@
   = StolenNotification.count
   Stolen Notifications created,
   %em
-    (#{StolenNotification.where("created_at >= ?", Time.zone.now.beginning_of_day).count} today)
+    (#{StolenNotification.where("created_at >= ?", Time.current.beginning_of_day).count} today)
 
 
 = paginate @stolen_notifications, views_prefix: "admin"

--- a/app/views/bikes/_bike_show_overlays.html.haml
+++ b/app/views/bikes/_bike_show_overlays.html.haml
@@ -17,9 +17,9 @@
             = f.text_area :recovered_description, class: 'form-control'
           .form-group
             = f.label :date_recovered, 'When did you recover it?', class: 'form-well-label'
-            - f.object.date_recovered = TimeParser.round(f.object.date_recovered || Time.now)
+            - f.object.date_recovered = TimeParser.round(f.object.date_recovered || Time.current)
             = f.hidden_field :timezone, value: "", class: "hiddenFieldTimezone"
-            = f.datetime_local_field :date_recovered, max: Time.now.end_of_day, step: 3600, required: true, class: 'form-control'
+            = f.datetime_local_field :date_recovered, max: Time.current.end_of_day, step: 3600, required: true, class: 'form-control'
           .checkbox
             %label
               = f.check_box :index_helped_recovery

--- a/app/views/bikes/edit_bike_details.html.haml
+++ b/app/views/bikes/edit_bike_details.html.haml
@@ -28,7 +28,7 @@
           .form-group.row.fancy-select-placeholder.unfancy.unnested-field
             = f.label :year, 'Model year', class: 'form-well-label'
             .form-well-input
-              - years = (1900..Time.now.year+1).to_a.reverse.map { |i| [i,i] }
+              - years = (1900..Time.current.year+1).to_a.reverse.map { |i| [i,i] }
               = f.select :year, years, prompt: 'Unsure or unknown', allow_blank: true
             .right-input-help
               %label

--- a/app/views/bikes/edit_theft_details.html.haml
+++ b/app/views/bikes/edit_theft_details.html.haml
@@ -20,8 +20,8 @@
               = srecord.hidden_field :timezone, value: "", class: "hiddenFieldTimezone"
               = srecord.label :date_stolen, "When was it #{stolen_type}", class: 'form-well-label'
               .form-well-input
-                - srecord.object.date_stolen = TimeParser.round(srecord.object.date_stolen || Time.now)
-                = srecord.datetime_local_field :date_stolen, max: Time.now + 1.day, step: 60, required: true, class: 'form-control dateInputUpdateZone', "data-initialtime" => l(srecord.object.date_stolen, format: :convert_time)
+                - srecord.object.date_stolen = TimeParser.round(srecord.object.date_stolen || Time.current)
+                = srecord.datetime_local_field :date_stolen, max: Time.current + 1.day, step: 60, required: true, class: 'form-control dateInputUpdateZone', "data-initialtime" => l(srecord.object.date_stolen, format: :convert_time)
 
             .form-group.row.unnested-field
               = srecord.label :phone, class: 'form-well-label'

--- a/app/views/bikes/new.html.haml
+++ b/app/views/bikes/new.html.haml
@@ -58,8 +58,8 @@
           .form-group.row.fancy-select.unfancy.unnested-field
             = f.label :year, 'Model year', class: 'form-well-label'
             .form-well-input
-              - years = (1900..Time.now.year+1).to_a.reverse.map { |i| [i,i] }
-              = f.select :year, years, prompt: "Unsure or unknown", selected: @bike.year || Time.now.year
+              - years = (1900..Time.current.year+1).to_a.reverse.map { |i| [i,i] }
+              = f.select :year, years, prompt: "Unsure or unknown", selected: @bike.year || Time.current.year
             .right-input-help
               %label
                 %input#bike_unknown_year{ type: 'checkbox', tabindex: -1 }

--- a/app/views/customer_mailer/stolen_bike_alert_email.html.erb
+++ b/app/views/customer_mailer/stolen_bike_alert_email.html.erb
@@ -18,7 +18,7 @@
       <%= @info[:tweet_string].split('https://bikeindex.org')[0] %>
       <a href="https://bikeindex.org/bikes/<%= @bike.id %>" style="border:none;color:#0084b4;text-decoration:none">Bike Index link</a>
     </p>
-    <a href="https://twitter.com/<%= @info[:tweet_account_screen_name] %>/status/<%= @info[:tweet_id] %>" style="display:block;border:none;color:#0084b4;text-decoration:none;color:#999999;font-size: 12px; margin-top: 5px;" target="_blank"><%= Time.now.strftime("%I:%M %P - %d %b %y") %></a>
+    <a href="https://twitter.com/<%= @info[:tweet_account_screen_name] %>/status/<%= @info[:tweet_id] %>" style="display:block;border:none;color:#0084b4;text-decoration:none;color:#999999;font-size: 12px; margin-top: 5px;" target="_blank"><%= Time.current.strftime("%I:%M %P - %d %b %y") %></a>
   </div>
 </div>
 <% if @info[:retweet_screen_names].present? %>

--- a/app/views/layouts/email.html.haml
+++ b/app/views/layouts/email.html.haml
@@ -31,6 +31,6 @@
 
       .binx-footer
         %h5
-          #{Time.zone.now.year} &copy; Bike Index.
+          #{Time.current.year} &copy; Bike Index.
           - unless @organization.present? && controller_path == 'organized_mailer' && @organization.is_paid
             Help prevent bike theft, #{ link_to 'make a donation.', support_the_index_url }

--- a/app/views/news/show.html.haml
+++ b/app/views/news/show.html.haml
@@ -8,7 +8,7 @@
         %a.blog-poster{href: @blogger.userlink}
           = @blogger.name if @blogger.name
       %h4.pub-date
-        - if @blog.published_at > Time.now - 1.week
+        - if @blog.published_at > Time.current - 1.week
           #{l @blog.published_at, format: :standard_display}
         - else
           #{l @blog.published_at, format: :no_day_with_year}

--- a/app/views/organizations/embed.html.haml
+++ b/app/views/organizations/embed.html.haml
@@ -46,8 +46,8 @@
     .control-group.special-select-single
       = f.label :year, "Model year", class: "control-label"
       .controls
-        - years = (1900..Time.now.year+1).to_a.reverse.map {|i| [i,i] }
-        = f.select :year, years, selected: Time.now.year, prompt: "Unsure or unknown"
+        - years = (1900..Time.current.year+1).to_a.reverse.map {|i| [i,i] }
+        = f.select :year, years, selected: Time.current.year, prompt: "Unsure or unknown"
     .unknown-year.optional-block
       %label
         %input#bike_unknown_year{ type: 'checkbox', tabindex: -1 }
@@ -99,9 +99,9 @@
         .input-group#stolenDisplay
           .control-group{ style: "width: 300px; max-width: 100%;" }
             = builder.label :date_stolen, "When was it stolen?", class: "control-label"
-            - builder.object.date_stolen = TimeParser.round(builder.object.date_stolen || Time.now)
+            - builder.object.date_stolen = TimeParser.round(builder.object.date_stolen || Time.current)
             = builder.hidden_field :timezone, value: "", class: "hiddenFieldTimezone"
-            = builder.datetime_local_field :date_stolen, max: Time.now + 1.day, step: 3600, required: true, class: 'form-control', style: "font-size: 90%; width: 100%;"
+            = builder.datetime_local_field :date_stolen, max: Time.current + 1.day, step: 3600, required: true, class: 'form-control', style: "font-size: 90%; width: 100%;"
         #stolen-bike-location.input-group
           .control-group.special-select-single
             = builder.label :street, 'Where was it stolen?', class: 'control-label'

--- a/app/views/organizations/embed_extended.html.haml
+++ b/app/views/organizations/embed_extended.html.haml
@@ -36,8 +36,8 @@
     .control-group.special-select-single
       = f.label :year, "Model year", class: "control-label"
       .controls
-        - years = (1900..Time.now.year+1).to_a.reverse.map {|i| [i,i] }
-        = f.select :year, years, selected: Time.now.year, prompt: "Unsure or unknown"
+        - years = (1900..Time.current.year+1).to_a.reverse.map {|i| [i,i] }
+        = f.select :year, years, selected: Time.current.year, prompt: "Unsure or unknown"
     .unknown-year.optional-block
       %label
         %input#bike_unknown_year{ type: 'checkbox', tabindex: -1 }

--- a/app/views/shared/_footer.html.haml
+++ b/app/views/shared/_footer.html.haml
@@ -34,7 +34,7 @@
 
       %p
         %span{data: {license: "https://github.com/bikeindex/bike_index/blob/master/LICENSE"}}
-          #{Time.zone.now.year} &copy; Bike Index.
+          #{Time.current.year} &copy; Bike Index.
         - if current_user.present? && current_user.has_membership?
           #{link_to "Privacy policy", privacy_url}, #{link_to "vendor terms", vendor_terms_url}
         - else

--- a/app/views/shared/_footer_revised.html.haml
+++ b/app/views/shared/_footer_revised.html.haml
@@ -81,7 +81,7 @@
         and #{link_to "terms and conditions", terms_path}.
       %p
         %span{data: {license: "https://github.com/bikeindex/bike_index/blob/master/LICENSE"}}
-          #{Time.zone.now.year} &copy; Bike Index, a 501(c)(3) nonprofit - EIN 81-4296194
+          #{Time.current.year} &copy; Bike Index, a 501(c)(3) nonprofit - EIN 81-4296194
 - cache 'facebook_pixel' do
   = render '/shared/facebook_pixel'
 

--- a/app/views/shared/_footer_updated.html.haml
+++ b/app/views/shared/_footer_updated.html.haml
@@ -38,7 +38,7 @@
 
     %p
       %span{data: {license: "https://github.com/bikeindex/bike_index/blob/master/LICENSE"}}
-        #{Time.zone.now.year} &copy; Bike Index.
+        #{Time.current.year} &copy; Bike Index.
       - if current_user.present? && current_user.has_membership?
         #{link_to "Privacy policy", privacy_path}, #{link_to "vendor terms", vendor_terms_path}
       - else

--- a/app/workers/after_bike_save_worker.rb
+++ b/app/workers/after_bike_save_worker.rb
@@ -31,12 +31,12 @@ class AfterBikeSaveWorker
     {
       auth_token: AUTH_TOKEN,
       bike: BikeV2ShowSerializer.new(bike, root: false).as_json,
-      update: bike.created_at > Time.now - 30.seconds,
+      update: bike.created_at > Time.current - 30.seconds,
     }
   end
 
   def update_matching_partial_registrations(bike)
-    return true unless bike.created_at > Time.now - 5.minutes # skip unless new bike
+    return true unless bike.created_at > Time.current - 5.minutes # skip unless new bike
     matches = BParam.partial_registrations.without_bike.where("email ilike ?", "%#{bike.owner_email}%")
     if matches.count > 1
       # Try to make it a little more accurate lookup

--- a/app/workers/cache_all_stolen_worker.rb
+++ b/app/workers/cache_all_stolen_worker.rb
@@ -22,7 +22,7 @@ class CacheAllStolenWorker
   end
 
   def filename
-    @filename ||= "#{file_prefix}#{Time.now.to_i}_all_stolen_cache.json"
+    @filename ||= "#{file_prefix}#{Time.current.to_i}_all_stolen_cache.json"
   end
 
   def tmp_path

--- a/app/workers/duplicate_bike_finder_worker.rb
+++ b/app/workers/duplicate_bike_finder_worker.rb
@@ -10,7 +10,7 @@ class DuplicateBikeFinderWorker
         where(normalized_serial_segments: { segment: serial_segment.segment }).first
       if existing_duplicate.present?
         serial_segment.update_attribute :duplicate_bike_group_id, existing_duplicate.id
-        existing_duplicate.update_attribute :added_bike_at, Time.now
+        existing_duplicate.update_attribute :added_bike_at, Time.current
       else
         duplicate_segments = NormalizedSerialSegment.where(segment: serial_segment.segment)
         if duplicate_segments.count > 1

--- a/app/workers/remove_expired_file_cache_worker.rb
+++ b/app/workers/remove_expired_file_cache_worker.rb
@@ -7,7 +7,7 @@ class RemoveExpiredFileCacheWorker
   end
 
   def expired_file_hashes
-    expiration = (Time.now - 2.days).to_i
+    expiration = (Time.current - 2.days).to_i
     FileCacheMaintainer.files.select do |file|
       file["updated_at"].to_i < expiration
     end

--- a/app/workers/scheduled_worker.rb
+++ b/app/workers/scheduled_worker.rb
@@ -38,7 +38,7 @@ class ScheduledWorker
 
   def self.should_enqueue?
     return false if enqueued?
-    last_started.blank? || Time.parse(last_started) + frequency < Time.now
+    last_started.blank? || Time.parse(last_started) + frequency < Time.current
   end
 
   # Should be the new cannonical way of using redis

--- a/app/workers/scheduled_worker_runner.rb
+++ b/app/workers/scheduled_worker_runner.rb
@@ -28,7 +28,7 @@ class ScheduledWorkerRunner < ScheduledWorker
     redis { |r| r.hget HISTORY_KEY, record_key(worker_string, record) }
   end
 
-  def self.write_worker_history(worker_string, record, value = Time.now)
+  def self.write_worker_history(worker_string, record, value = Time.current)
     redis { |r| r.hset HISTORY_KEY, record_key(worker_string, record), value }
   end
 

--- a/app/workers/update_expired_invoice_worker.rb
+++ b/app/workers/update_expired_invoice_worker.rb
@@ -5,7 +5,7 @@ class UpdateExpiredInvoiceWorker < ScheduledWorker
 
   def perform
     record_scheduler_started
-    Invoice.should_expire.each { |invoice| invoice.update_attributes(updated_at: Time.now) }
+    Invoice.should_expire.each { |invoice| invoice.update_attributes(updated_at: Time.current) }
     record_scheduler_finished
   end
 end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -71,7 +71,7 @@ Rails.application.configure do
   # config.action_view.raise_on_missing_translations = true
 
   # Make sure we reload the API after every request!
-  @last_api_change = Time.now
+  @last_api_change = Time.current
   api_reloader = ActiveSupport::FileUpdateChecker.new(Dir["#{Rails.root}/app/controllers/api/v2/**/*.rb"]) do |reloader|
     times = Dir["#{Rails.root}/app/api/**/*.rb"].map { |f| File.mtime(f) }
     files = Dir["#{Rails.root}/app/api/**/*.rb"].map { |f| f }

--- a/lib/integrations/file_cache_maintainer.rb
+++ b/lib/integrations/file_cache_maintainer.rb
@@ -32,7 +32,7 @@ class FileCacheMaintainer
     end
 
     def update_file_info(filename, updated_at = nil)
-      updated_at ||= Time.now
+      updated_at ||= Time.current
       begin
         redis.hset info_id, filename, updated_at.to_i
       rescue

--- a/lib/integrations/tsv_creator.rb
+++ b/lib/integrations/tsv_creator.rb
@@ -57,7 +57,7 @@ class TsvCreator
   end
 
   def create_org_count(organization, start_date = nil)
-    start_date ||= Time.now.beginning_of_year
+    start_date ||= Time.current.beginning_of_year
     obikes = organization.bikes.where("bikes.created_at >= ?", start_date)
     out_file = File.join(Rails.root, "#{@file_prefix}org_count_bikes.tsv")
     output = File.open(out_file, "w")
@@ -69,7 +69,7 @@ class TsvCreator
   # Not tested. Needs to be tested and made useful before use
   # def create_org_total_count(organization, start_date=nil)
   #   return "organization has no location" unless organization.locations.present?
-  #   start_date ||= Time.now.beginning_of_year
+  #   start_date ||= Time.current.beginning_of_year
   #   obikes = organization.bikes.where("created_at >= ?", start_date)
   #   organization_bikes = obikes.count
   #   box = Geocoder::Calculations.bounding_box(organization.locations.first, 50)
@@ -125,10 +125,10 @@ class TsvCreator
   end
 
   def create_daily_tsvs
-    @file_prefix = "#{@file_prefix}#{Time.now.strftime("%Y_%-m_%-d")}_"
+    @file_prefix = "#{@file_prefix}#{Time.current.strftime("%Y_%-m_%-d")}_"
     create_stolen(true, stolen_records: StolenRecord.approveds.tsv_today)
     create_stolen_with_reports(true, stolen_records: StolenRecord.approveds_with_reports.tsv_today)
-    t = Time.now
+    t = Time.current
     StolenRecord.tsv_today.map { |sr| sr.update_attribute :tsved_at, t }
   end
 end

--- a/spec/controllers/admin/dashboard_controller_spec.rb
+++ b/spec/controllers/admin/dashboard_controller_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe Admin::DashboardController, type: :controller do
       it "renders and assigns tsvs" do
         user = FactoryBot.create(:admin)
         set_current_user(user)
-        t = Time.now
+        t = Time.current
         FileCacheMaintainer.reset_file_info("current_stolen_bikes.tsv", t)
         # tsvs = [{ filename: 'current_stolen_bikes.tsv', updated_at: t.to_i.to_s, description: 'Approved Stolen bikes' }]
         blacklist = %w(1010101 2 4 6)

--- a/spec/controllers/admin/graphs_controller_spec.rb
+++ b/spec/controllers/admin/graphs_controller_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe Admin::GraphsController, type: :controller do
         expect(response.status).to eq(200)
         expect(json_result.is_a?(Array)).to be_truthy
         expect(assigns(:start_at)).to be_within(1.day).of Time.parse("2007-01-01 1:00")
-        expect(assigns(:end_at)).to be_within(1.minute).of Time.now
+        expect(assigns(:end_at)).to be_within(1.minute).of Time.current
         expect(assigns(:group_period)).to eq "month"
       end
       context "passed date and time" do
@@ -73,7 +73,7 @@ RSpec.describe Admin::GraphsController, type: :controller do
             expect(data_group["error"]).to_not be_present
           end
           expect(assigns(:start_at)).to be_within(1.day).of Time.parse("2007-01-01 1:00")
-          expect(assigns(:end_at)).to be_within(1.minute).of Time.now
+          expect(assigns(:end_at)).to be_within(1.minute).of Time.current
           expect(assigns(:group_period)).to eq "month"
         end
         context "passed date and time" do

--- a/spec/controllers/admin/organizations/invoices_controller_spec.rb
+++ b/spec/controllers/admin/organizations/invoices_controller_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe Admin::Organizations::InvoicesController, type: :controller do
         expect(response).to render_template(:new)
       end
       context "passed end_at" do
-        let(:end_at) { Time.now + 10.years }
+        let(:end_at) { Time.current + 10.years }
         it "renders, includes end_at" do
           get :new, organization_id: organization.to_param, end_at: end_at.to_i
           expect(response.status).to eq(200)
@@ -56,7 +56,7 @@ RSpec.describe Admin::Organizations::InvoicesController, type: :controller do
           post :create, organization_id: organization.to_param, invoice: params
         end.to change(Invoice, :count).by 1
         # TODO: Rails 5 update
-        organization.update_attributes(updated_at: Time.now)
+        organization.update_attributes(updated_at: Time.current)
         invoice = organization.invoices.last
         expect(invoice.active?).to be_falsey
         expect(organization.is_paid).to be_falsey
@@ -73,7 +73,7 @@ RSpec.describe Admin::Organizations::InvoicesController, type: :controller do
             post :create, organization_id: organization.to_param, invoice: params.merge(amount_due: "0", end_at: "2020-09-05T23:00:00")
           end.to change(Invoice, :count).by 1
           # TODO: Rails 5 update
-          organization.update_attributes(updated_at: Time.now)
+          organization.update_attributes(updated_at: Time.current)
           invoice = organization.invoices.last
           expect(invoice.active?).to be_truthy
           expect(organization.is_paid).to be_truthy
@@ -105,7 +105,7 @@ RSpec.describe Admin::Organizations::InvoicesController, type: :controller do
         expect(invoice.notes).to eq params[:notes]
       end
       context "create_following_invoice" do
-        let!(:invoice) { FactoryBot.create(:invoice, organization: organization, subscription_start_at: Time.now - 2.years, force_active: true) }
+        let!(:invoice) { FactoryBot.create(:invoice, organization: organization, subscription_start_at: Time.current - 2.years, force_active: true) }
         it "creates following invoice" do
           expect do
             put :update, organization_id: organization.to_param, id: invoice.to_param, create_following_invoice: true

--- a/spec/controllers/admin/organizations_controller_spec.rb
+++ b/spec/controllers/admin/organizations_controller_spec.rb
@@ -74,8 +74,8 @@ RSpec.describe Admin::OrganizationsController, type: :controller do
             shown: false,
             _destroy: 0,
           },
-          Time.zone.now.to_i.to_s => {
-            created_at: Time.zone.now.to_f.to_s,
+          Time.current.to_i.to_s => {
+            created_at: Time.current.to_f.to_s,
             name: "Second shop",
             zipcode: "12243444",
             city: "cool city",

--- a/spec/controllers/admin/payments_controller_spec.rb
+++ b/spec/controllers/admin/payments_controller_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Admin::PaymentsController, type: :controller do
   let(:organization) { FactoryBot.create(:organization) }
   let(:invoice) { FactoryBot.create(:invoice, organization: organization) }
   let(:user2) { FactoryBot.create(:user) }
-  let(:create_time) { Time.now - 2.weeks }
+  let(:create_time) { Time.current - 2.weeks }
   let(:params) { { organization_id: organization.id, invoice_id: invoice.id, email: user2.email, amount: 222.22, kind: "stripe", created_at: create_time.strftime("%FT%T%:z") } }
 
   describe "index" do
@@ -43,7 +43,7 @@ RSpec.describe Admin::PaymentsController, type: :controller do
 
   describe "update" do
     context "stripe payment" do
-      let(:og_time) { Time.now - 3.hours }
+      let(:og_time) { Time.current - 3.hours }
       let(:invoice) { FactoryBot.create(:invoice, organization: organization, updated_at: og_time) }
       it "updates available attributes" do
         expect(subject.invoice).to be_nil
@@ -53,12 +53,12 @@ RSpec.describe Admin::PaymentsController, type: :controller do
         expect(subject.invoice).to eq invoice
         # Not changed attrs:
         expect(subject.kind).to eq "stripe"
-        expect(subject.created_at).to be_within(1.minute).of Time.now
+        expect(subject.created_at).to be_within(1.minute).of Time.current
         expect(subject.user).to eq user
         expect(subject.amount_cents).to_not eq 22_222
         expect(subject.is_payment).to be_truthy
         # invoice.reload
-        # expect(invoice.updated_at).to be_within(1.second).of Time.now # TODO: Rails 5 update - enable this, rspec doesn't correctly manage after_commit right now
+        # expect(invoice.updated_at).to be_within(1.second).of Time.current # TODO: Rails 5 update - enable this, rspec doesn't correctly manage after_commit right now
       end
     end
     context "check payment" do
@@ -70,7 +70,7 @@ RSpec.describe Admin::PaymentsController, type: :controller do
         expect(subject.invoice).to eq invoice
         # Not changed attrs:
         expect(subject.kind).to eq "check"
-        expect(subject.created_at).to be_within(1.minute).of Time.now
+        expect(subject.created_at).to be_within(1.minute).of Time.current
         expect(subject.user).to eq user
         expect(subject.email).to eq user.email
         expect(subject.amount_cents).to eq 55555
@@ -83,7 +83,7 @@ RSpec.describe Admin::PaymentsController, type: :controller do
           expect(subject.invoice).to be_nil
           # Not changed attrs:
           expect(subject.kind).to eq "check"
-          expect(subject.created_at).to be_within(1.minute).of Time.now
+          expect(subject.created_at).to be_within(1.minute).of Time.current
           expect(subject.user).to eq user
           expect(subject.email).to eq user.email
           expect(subject.amount_cents).to eq 55555

--- a/spec/controllers/admin/recoveries_controller_spec.rb
+++ b/spec/controllers/admin/recoveries_controller_spec.rb
@@ -31,8 +31,8 @@ RSpec.describe Admin::RecoveriesController, type: :controller do
       it "updates not_displayed to waiting_on_decision" do
         user = FactoryBot.create(:admin)
         set_current_user(user)
-        bike.reload.update_attributes(updated_at: Time.now)
-        stolen_record.reload.update_attributes(updated_at: Time.now)
+        bike.reload.update_attributes(updated_at: Time.current)
+        stolen_record.reload.update_attributes(updated_at: Time.current)
         put :update, params
         stolen_record.reload
         expect(stolen_record.recovery_display_status).to eq "waiting_on_decision"

--- a/spec/controllers/api/v1/users_controller_spec.rb
+++ b/spec/controllers/api/v1/users_controller_spec.rb
@@ -135,7 +135,7 @@ RSpec.describe Api::V1::UsersController, type: :controller do
     end
 
     it "it untsvs a bike" do
-      t = Time.now - 1.minute
+      t = Time.current - 1.minute
       stolen_record = FactoryBot.create(:stolen_record, tsved_at: t)
       o = FactoryBot.create(:ownership, bike: stolen_record.bike)
       user = o.creator

--- a/spec/controllers/bikes_controller_spec.rb
+++ b/spec/controllers/bikes_controller_spec.rb
@@ -1068,7 +1068,7 @@ RSpec.describe BikesController, type: :controller do
                 "_destroy" => "1",
                 id: component1.id.to_s,
               },
-              Time.zone.now.to_i.to_s => component2_attrs,
+              Time.current.to_i.to_s => component2_attrs,
             },
           }
           expect do

--- a/spec/controllers/bikes_controller_spec.rb
+++ b/spec/controllers/bikes_controller_spec.rb
@@ -504,8 +504,8 @@ RSpec.describe BikesController, type: :controller do
         end
       end
       context "stolen" do
-        let(:target_time) { Time.now.to_i }
-        let(:stolen_params) { chicago_stolen_params.merge(date_stolen: (Time.now - 1.day).utc, timezone: "UTC") }
+        let(:target_time) { Time.current.to_i }
+        let(:stolen_params) { chicago_stolen_params.merge(date_stolen: (Time.current - 1.day).utc, timezone: "UTC") }
         context "valid" do
           include_context :geocoder_real
           context "with old style date input" do
@@ -523,7 +523,7 @@ RSpec.describe BikesController, type: :controller do
                 testable_bike_params.each { |k, v| expect(bike.send(k).to_s).to eq v.to_s }
                 stolen_record = bike.current_stolen_record
                 stolen_params.except(:date_stolen, :timezone).each { |k, v| expect(stolen_record.send(k).to_s).to eq v.to_s }
-                expect(stolen_record.date_stolen.to_i).to be_within(1).of(Time.now.yesterday.to_i)
+                expect(stolen_record.date_stolen.to_i).to be_within(1).of(Time.current.yesterday.to_i)
                 expect(stolen_record.show_address).to be_falsey
               end
             end

--- a/spec/controllers/organized/manage_controller_spec.rb
+++ b/spec/controllers/organized/manage_controller_spec.rb
@@ -162,8 +162,8 @@ RSpec.describe Organized::ManageController, type: :controller do
                 shown: false,
                 _destroy: 0,
               },
-              Time.zone.now.to_i.to_s => {
-                created_at: Time.zone.now.to_f.to_s,
+              Time.current.to_i.to_s => {
+                created_at: Time.current.to_f.to_s,
                 name: "Second shop",
                 zipcode: "12243444",
                 city: "cool city",

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -312,7 +312,7 @@ RSpec.describe UsersController, type: :controller do
 
       context "token expired" do
         it "redirects to request password reset" do
-          user.set_password_reset_token((Time.now - 61.minutes).to_i)
+          user.set_password_reset_token((Time.current - 61.minutes).to_i)
           post :password_reset, token: user.password_reset_token
           expect(flash[:error]).to be_present
           expect(cookies.signed[:auth]).to_not be_present
@@ -436,7 +436,7 @@ RSpec.describe UsersController, type: :controller do
     end
 
     it "Updates user if there is a reset_pass token" do
-      user.set_password_reset_token((Time.now - 30.minutes).to_i)
+      user.set_password_reset_token((Time.current - 30.minutes).to_i)
       user.reload
       auth = user.auth_token
       email = user.email
@@ -476,7 +476,7 @@ RSpec.describe UsersController, type: :controller do
     end
 
     it "Doesn't update user if reset_pass token is more than an hour old" do
-      user.set_password_reset_token((Time.now - 61.minutes).to_i)
+      user.set_password_reset_token((Time.current - 61.minutes).to_i)
       auth = user.auth_token
       user.email
       set_current_user(user)

--- a/spec/factories/bike_codes.rb
+++ b/spec/factories/bike_codes.rb
@@ -2,7 +2,7 @@ FactoryBot.define do
   factory :bike_code do
     sequence(:code) { |n| "999#{n}" }
     factory :bike_code_claimed do
-      claimed_at { Time.now }
+      claimed_at { Time.current }
       user { FactoryBot.create(:user) }
       bike { FactoryBot.create(:bike) }
     end

--- a/spec/factories/invoices.rb
+++ b/spec/factories/invoices.rb
@@ -4,7 +4,7 @@ FactoryBot.define do
     amount_due_cents { 100_000 }
     factory :invoice_paid do
       amount_due { 0 }
-      start_at { Time.now - 1.week }
+      start_at { Time.current - 1.week }
     end
   end
 end

--- a/spec/factories/stolen_records.rb
+++ b/spec/factories/stolen_records.rb
@@ -1,9 +1,9 @@
 FactoryBot.define do
   factory :stolen_record do
     bike { FactoryBot.create(:bike) }
-    date_stolen { Time.now }
+    date_stolen { Time.current }
     factory :stolen_record_recovered do
-      date_recovered { Time.now }
+      date_recovered { Time.current }
       recovered_description { "Awesome help by Bike Index" }
       current { false }
     end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -379,27 +379,27 @@ RSpec.describe ApplicationHelper, type: :helper do
   describe "group_by_method" do
     context "hourly" do
       it "returns group_by_minute" do
-        expect(group_by_method((Time.now - 1.hour)..Time.now)).to eq :group_by_minute
+        expect(group_by_method((Time.current - 1.hour)..Time.current)).to eq :group_by_minute
       end
     end
     context "daily" do
       it "returns group_by_hour" do
-        expect(group_by_method((Time.now - 1.day)..Time.now)).to eq :group_by_hour
+        expect(group_by_method((Time.current - 1.day)..Time.current)).to eq :group_by_hour
       end
     end
     context "weekly" do
       it "returns group_by_day" do
-        expect(group_by_method((Time.now - 6.days)..Time.now)).to eq :group_by_day
+        expect(group_by_method((Time.current - 6.days)..Time.current)).to eq :group_by_day
       end
     end
     context "6 months" do
       it "returns group_by_week" do
-        expect(group_by_method((Time.now - 6.months)..Time.now)).to eq :group_by_week
+        expect(group_by_method((Time.current - 6.months)..Time.current)).to eq :group_by_week
       end
     end
     context "2 years" do
       it "returns group_by_month" do
-        expect(group_by_method((Time.now - 2.years)..Time.now)).to eq :group_by_month
+        expect(group_by_method((Time.current - 2.years)..Time.current)).to eq :group_by_month
       end
     end
   end

--- a/spec/helpers/header_tag_helper_spec.rb
+++ b/spec/helpers/header_tag_helper_spec.rb
@@ -338,7 +338,7 @@ RSpec.describe HeaderTagHelper, type: :helper do
     end
     describe "show" do
       let(:action_name) { "show" }
-      let(:target_time) { (Time.now - 1.hour).utc }
+      let(:target_time) { (Time.current - 1.hour).utc }
       # Have to create user so it creates a path for the user
       let(:user) { FactoryBot.create(:user, name: "John", twitter: "stolenbikereg") }
       let(:blog) do

--- a/spec/lib/file_cache_maintainer_spec.rb
+++ b/spec/lib/file_cache_maintainer_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe FileCacheMaintainer do
   describe "cached_all_stolen" do
     it "returns the most recent all_stolen" do
       FileCacheMaintainer.update_file_info("1456863086_all_stolen_cache.json", 1456863086)
-      t = Time.now.to_i
+      t = Time.current.to_i
       FileCacheMaintainer.update_file_info("#{t}_all_stolen_cache.json", t)
       target = {
         "path" => "#{t}_all_stolen_cache.json",
@@ -38,7 +38,7 @@ RSpec.describe FileCacheMaintainer do
 
   describe "tsv info" do
     it "updates tsv info and returns with indifferent access" do
-      t = Time.now
+      t = Time.current
       FileCacheMaintainer.reset_file_info("current_stolen_bikes.tsv", t)
       tsv = FileCacheMaintainer.files[0]
       expect(tsv[:updated_at]).to eq(t.to_i.to_s)
@@ -48,16 +48,16 @@ RSpec.describe FileCacheMaintainer do
     end
 
     it "returns the way we want - dailys after non daily" do
-      t = Time.now
+      t = Time.current
       FileCacheMaintainer.reset_file_info("https://files.bikeindex.org/uploads/tsvs/approved_current_stolen_bikes.tsv", t)
       FileCacheMaintainer.update_file_info("https://files.bikeindex.org/uploads/tsvs/current_stolen_bikes.tsv")
-      FileCacheMaintainer.update_file_info("https://files.bikeindex.org/uploads/tsvs/#{Time.now.strftime("%Y_%-m_%-d")}_approved_current_stolen_bikes.tsv")
-      FileCacheMaintainer.update_file_info("https://files.bikeindex.org/uploads/tsvs/#{Time.now.strftime("%Y_%-m_%-d")}_current_stolen_bikes.tsv")
+      FileCacheMaintainer.update_file_info("https://files.bikeindex.org/uploads/tsvs/#{Time.current.strftime("%Y_%-m_%-d")}_approved_current_stolen_bikes.tsv")
+      FileCacheMaintainer.update_file_info("https://files.bikeindex.org/uploads/tsvs/#{Time.current.strftime("%Y_%-m_%-d")}_current_stolen_bikes.tsv")
       FileCacheMaintainer.files.each_with_index do |file, index|
         if index < 2
           expect(["approved_current_stolen_bikes.tsv", "current_stolen_bikes.tsv"].include?(file[:filename])).to be_truthy
         else
-          expect(["#{Time.now.strftime("%Y_%-m_%-d")}_approved_current_stolen_bikes.tsv", "#{Time.now.strftime("%Y_%-m_%-d")}_current_stolen_bikes.tsv"].include?(file[:filename])).to be_truthy
+          expect(["#{Time.current.strftime("%Y_%-m_%-d")}_approved_current_stolen_bikes.tsv", "#{Time.current.strftime("%Y_%-m_%-d")}_current_stolen_bikes.tsv"].include?(file[:filename])).to be_truthy
         end
       end
     end

--- a/spec/lib/tsv_creator_spec.rb
+++ b/spec/lib/tsv_creator_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe TsvCreator do
       expect(tsv_creator).to receive(:create_stolen).with(true, stolen_records: StolenRecord.approveds.tsv_today)
 
       tsv_creator.create_daily_tsvs
-      expect(tsv_creator.file_prefix).to eq("/spec/fixtures/tsv_creation/#{Time.now.year}_#{Time.now.month}_#{Time.now.day}_")
+      expect(tsv_creator.file_prefix).to eq("/spec/fixtures/tsv_creation/#{Time.current.year}_#{Time.current.month}_#{Time.current.day}_")
       stolen_record.reload
       expect(stolen_record.tsved_at).to be_present
     end

--- a/spec/mailers/organized_mailer_spec.rb
+++ b/spec/mailers/organized_mailer_spec.rb
@@ -138,7 +138,7 @@ RSpec.describe OrganizedMailer, type: :mailer do
       end
       context "non-new (pre-existing ownership)" do
         let(:bike) { FactoryBot.create(:bike, creation_organization: organization) }
-        let(:pre_existing_ownership) { FactoryBot.create(:ownership, bike: bike, created_at: Time.now - 1.minute) }
+        let(:pre_existing_ownership) { FactoryBot.create(:ownership, bike: bike, created_at: Time.current - 1.minute) }
         before do
           expect(pre_existing_ownership).to be_present
         end

--- a/spec/models/b_param_spec.rb
+++ b/spec/models/b_param_spec.rb
@@ -363,7 +363,7 @@ RSpec.describe BParam, type: :model do
     #
     # Because for now we aren't updating the factory, use this let for b_params factory
     let(:b_param) { BParam.create }
-    let(:expire_b_param) { b_param.update_attribute :created_at, Time.zone.now - 5.weeks }
+    let(:expire_b_param) { b_param.update_attribute :created_at, Time.current - 5.weeks }
     context "with user_id passed" do
       context "without token" do
         it "returns a new b_param, with creator of user_id" do

--- a/spec/models/bike_code_spec.rb
+++ b/spec/models/bike_code_spec.rb
@@ -170,7 +170,7 @@ RSpec.describe BikeCode, type: :model do
       bike_code.claim(user, "https://bikeindex.org/bikes?per_page=200")
       expect(bike_code.errors.full_messages).to be_present
       expect(bike_code.bike).to eq bike
-      expect(bike_code.claimed_at).to be_within(1.second).of Time.now
+      expect(bike_code.claimed_at).to be_within(1.second).of Time.current
       expect(bike_code.previous_bike_id).to be_nil
       reloaded_code = BikeCode.find bike_code.id # Hard reload, it wasn't resetting errors
       expect(reloaded_code.unclaimable_by?(user)).to be_falsey

--- a/spec/models/bike_spec.rb
+++ b/spec/models/bike_spec.rb
@@ -900,20 +900,20 @@ RSpec.describe Bike, type: :model do
   describe "get_listing_order" do
     let(:bike) { Bike.new }
     it "is 1/1000 of the current timestamp" do
-      expect(bike.get_listing_order).to eq(Time.now.to_i / 1000000)
+      expect(bike.get_listing_order).to eq(Time.current.to_i / 1000000)
     end
 
     it "is the current stolen record date stolen * 1000" do
       allow(bike).to receive(:stolen).and_return(true)
       stolen_record = StolenRecord.new
-      yesterday = Time.now - 1.days
+      yesterday = Time.current - 1.days
       allow(stolen_record).to receive(:date_stolen).and_return(yesterday)
       allow(bike).to receive(:current_stolen_record).and_return(stolen_record)
       expect(bike.get_listing_order).to eq(yesterday.to_time.to_i)
     end
 
     it "is the updated_at" do
-      last_week = Time.now - 7.days
+      last_week = Time.current - 7.days
       bike.updated_at = last_week
       allow(bike).to receive(:stock_photo_url).and_return("https://some_photo.cum")
       expect(bike.get_listing_order).to eq(last_week.to_time.to_i / 10000)
@@ -921,8 +921,8 @@ RSpec.describe Bike, type: :model do
 
     context "problem date" do
       let(:problem_date) do
-        digits = (Time.now.year - 1).to_s[2, 3] # last two digits of last year
-        problem_date = Date.strptime("#{Time.now.month}-22-00#{digits}", "%m-%d-%Y")
+        digits = (Time.current.year - 1).to_s[2, 3] # last two digits of last year
+        problem_date = Date.strptime("#{Time.current.month}-22-00#{digits}", "%m-%d-%Y")
       end
       let(:bike) { FactoryBot.create(:stolen_bike) }
       it "does not get out of integer errors" do
@@ -932,8 +932,8 @@ RSpec.describe Bike, type: :model do
         # TODO: Rails 5 update - enable this, rspec doesn't correctly manage after_commit right now -
         # but stolen records don't actually have an after_commit hook to update bikes (they probably should though)
         # This is just checking this is called correctly on save
-        bike.update_attributes(updated_at: Time.now)
-        expect(bike.listing_order).to be > (Time.now - 13.months).to_i
+        bike.update_attributes(updated_at: Time.current)
+        expect(bike.listing_order).to be > (Time.current - 13.months).to_i
       end
     end
   end
@@ -990,7 +990,7 @@ RSpec.describe Bike, type: :model do
         bike.bike_organization_ids = ""
         # Acts as paranoid
         bike_organization.reload
-        expect(bike_organization.deleted_at).to be_within(1.second).of Time.now
+        expect(bike_organization.deleted_at).to be_within(1.second).of Time.current
         expect(bike.bike_organization_ids).to eq([])
         bike.bike_organization_ids = [organization.id]
         bike.reload

--- a/spec/models/blog_spec.rb
+++ b/spec/models/blog_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe Blog, type: :model do
   describe "set_title_slug" do
     it "makes the title 70 char long and character safe for params" do
       @user = FactoryBot.create(:user)
-      blog = Blog.new(title: "A really really really really loooooooooooooooooooooooooooooooooooong title that absolutely rocks so hard", body: "some things", user_id: @user.id, published_at: Time.now)
+      blog = Blog.new(title: "A really really really really loooooooooooooooooooooooooooooooooooong title that absolutely rocks so hard", body: "some things", user_id: @user.id, published_at: Time.current)
       blog.save
       expect(blog.title_slug).to eq("a-really-really-really-really-loooooooooooooooooooooooooooooooooooong")
     end
@@ -30,7 +30,7 @@ RSpec.describe Blog, type: :model do
   describe "update_title_save" do
     it "makes the title 70 char long and character safe for params" do
       @user = FactoryBot.create(:user)
-      blog = Blog.new(title: "A really really really really loooooooooooooooooooooooooooooooooooong title that absolutely rocks so hard", body: "some things", user_id: @user.id, published_at: Time.now)
+      blog = Blog.new(title: "A really really really really loooooooooooooooooooooooooooooooooooong title that absolutely rocks so hard", body: "some things", user_id: @user.id, published_at: Time.current)
       blog.save
       blog.title = "New Title"
       blog.update_title = "1"
@@ -43,7 +43,7 @@ RSpec.describe Blog, type: :model do
   describe "create_abbreviation" do
     it "makes the text 200 char long or less and remove any new lines" do
       @user = FactoryBot.create(:user)
-      blog = Blog.new(title: "Blog title", user_id: @user.id, published_at: Time.now)
+      blog = Blog.new(title: "Blog title", user_id: @user.id, published_at: Time.current)
       blog.body = "" "
       Lorem ipsum dolor sit amet! Consectetur adipisicing elit, sed do eiusmod
 
@@ -64,7 +64,7 @@ RSpec.describe Blog, type: :model do
 
     it "creates the body abbr from a listicle" do
       @user = FactoryBot.create(:user)
-      blog = Blog.create(title: "Blog title", user_id: @user.id, published_at: Time.now, body: "stuff", is_listicle: true)
+      blog = Blog.create(title: "Blog title", user_id: @user.id, published_at: Time.current, body: "stuff", is_listicle: true)
       Listicle.create(blog_id: blog.id, body: "View the link\n[here](http://something)\n\n<img class='post-image' src='https://files.bikeindex.org/uploads/Pu/1003/large_photo__6_.JPG' alt='Bike Index shirt and stickers'>\n![PBR, a bike bag and drawings](http://imgur.com/e4zzEjP.jpg) and also this")
       blog.reload.save
       expect(blog.reload.body_abbr).to eq("View the link here and also this")
@@ -74,7 +74,7 @@ RSpec.describe Blog, type: :model do
       # TODO: remove markdown images
       # Also, it would be cool if we could end on a word instead of in the middle of one...
       @user = FactoryBot.create(:user)
-      blog = Blog.new(title: "Blog title", user_id: @user.id, published_at: Time.now)
+      blog = Blog.new(title: "Blog title", user_id: @user.id, published_at: Time.current)
       blog.body = "View the link\n[here](http://something)\n\n<img class='post-image' src='https://files.bikeindex.org/uploads/Pu/1003/large_photo__6_.JPG' alt='Bike Index shirt and stickers'>\n![PBR, a bike bag and drawings](http://imgur.com/e4zzEjP.jpg) and also this"
       blog.save
       expect(blog.body_abbr).to eq("View the link here and also this")

--- a/spec/models/bulk_import_spec.rb
+++ b/spec/models/bulk_import_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe BulkImport, type: :model do
   end
 
   describe "blocking_error?" do
-    let(:bulk_import) { BulkImport.new(import_errors: { line: [2, "dddd"] }.as_json, progress: "finished", created_at: Time.now - 1.month) }
+    let(:bulk_import) { BulkImport.new(import_errors: { line: [2, "dddd"] }.as_json, progress: "finished", created_at: Time.current - 1.month) }
     it "is be_falsey" do
       expect(bulk_import.blocking_error?).to be_falsey
     end
@@ -45,7 +45,7 @@ RSpec.describe BulkImport, type: :model do
       end
     end
     context "pending and more than a minute old" do
-      let(:bulk_import) { BulkImport.new(created_at: Time.now - 10.minutes, progress: "pending") }
+      let(:bulk_import) { BulkImport.new(created_at: Time.current - 10.minutes, progress: "pending") }
       it "is truthy" do
         # Fallback because we failed to parse it
         expect(bulk_import.blocking_error?).to be_truthy

--- a/spec/models/counts_spec.rb
+++ b/spec/models/counts_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Counts, type: :model do
 
   context "week_creation_chart" do
     let!(:bike) { FactoryBot.create(:bike) }
-    let!(:bike_first) { FactoryBot.create(:bike, created_at: (Time.now - 6.days).beginning_of_day + 1.minute) }
+    let!(:bike_first) { FactoryBot.create(:bike, created_at: (Time.current - 6.days).beginning_of_day + 1.minute) }
     let(:target) do
       {
         (Date.today - 6.days).to_s => 1,
@@ -35,7 +35,7 @@ RSpec.describe Counts, type: :model do
   end
 
   context "recoveries" do
-    let!(:recovered_bike) { FactoryBot.create(:stolen_record_recovered, date_recovered: Time.now - 1.day) }
+    let!(:recovered_bike) { FactoryBot.create(:stolen_record_recovered, date_recovered: Time.current - 1.day) }
     it "returns constant" do
       expect(StolenRecord.recovered.count).to eq 1
       expect(Counts.assign_recoveries).to eq 2042

--- a/spec/models/export_spec.rb
+++ b/spec/models/export_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe Export, type: :model do
   end
 
   describe "calculated_progress" do
-    let(:export) { Export.new(created_at: Time.now, progress: "pending") }
+    let(:export) { Export.new(created_at: Time.current, progress: "pending") }
     it "returns the progress it is given" do
       expect(export.pending?).to be_truthy
       expect(export.calculated_progress).to eq "pending"
@@ -45,7 +45,7 @@ RSpec.describe Export, type: :model do
       expect(export.calculated_progress).to eq "errored"
     end
     context "export created a lil bit ago" do
-      let(:export) { Export.new(created_at: Time.now - 10.minutes, progress: "pending") }
+      let(:export) { Export.new(created_at: Time.current - 10.minutes, progress: "pending") }
       it "returns what it's given, unless incomplete" do
         expect(export.pending?).to be_truthy
         expect(export.calculated_progress).to eq "errored"
@@ -87,10 +87,10 @@ RSpec.describe Export, type: :model do
 
   describe "custom_bike_ids=" do
     let(:organization) { FactoryBot.create(:organization) }
-    let!(:bike1) { FactoryBot.create(:bike_organized, organization: organization, created_at: Time.now - 1.day) }
+    let!(:bike1) { FactoryBot.create(:bike_organized, organization: organization, created_at: Time.current - 1.day) }
     let!(:bike2) { FactoryBot.create(:bike_organized, organization: organization) }
     let!(:bike3) { FactoryBot.create(:bike) }
-    let(:export) { FactoryBot.build(:export_organization, organization: organization, end_at: Time.now - 1.hour) }
+    let(:export) { FactoryBot.build(:export_organization, organization: organization, end_at: Time.current - 1.hour) }
     it "assigns the bike ids" do
       bike1.reload
       expect(bike1.created_at).to be < export.end_at
@@ -145,8 +145,8 @@ RSpec.describe Export, type: :model do
     # end
     context "organization" do
       let(:export) { FactoryBot.create(:export_organization, file: nil) }
-      let(:start_time) { Time.now - 20.hours }
-      let(:end_time) { Time.now - 5.minutes }
+      let(:start_time) { Time.current - 20.hours }
+      let(:end_time) { Time.current - 5.minutes }
       it "has the scopes we expect" do
         expect(export.bikes_scoped.to_sql).to eq organization.bikes.to_sql
         export.options = export.options.merge("start_at" => start_time)

--- a/spec/models/invoice_spec.rb
+++ b/spec/models/invoice_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Invoice, type: :model do
 
   describe "set_calculated_attributes" do
     context "expired paid_in_full" do
-      let(:invoice) { Invoice.new(subscription_start_at: Time.now.yesterday - 1.year, amount_due: 0) }
+      let(:invoice) { Invoice.new(subscription_start_at: Time.current.yesterday - 1.year, amount_due: 0) }
       it "is not active" do
         invoice.set_calculated_attributes
         expect(invoice.expired?).to be_truthy
@@ -25,7 +25,7 @@ RSpec.describe Invoice, type: :model do
   end
 
   describe "previous_invoice" do
-    let(:invoice) { FactoryBot.create(:invoice, start_at: Time.now - 4.years, force_active: true) }
+    let(:invoice) { FactoryBot.create(:invoice, start_at: Time.current - 4.years, force_active: true) }
     let(:invoice2) { invoice.create_following_invoice }
     let(:invoice3) { invoice2.create_following_invoice }
     it "returns correct invoices" do
@@ -36,10 +36,10 @@ RSpec.describe Invoice, type: :model do
       expect(invoice2.active?).to be_falsey
       expect(invoice2.was_active?).to be_truthy
       expect(invoice3.subscription_first_invoice).to eq invoice
-      expect(invoice2.subscription_start_at).to be_within(1.minute).of Time.now - 3.years
+      expect(invoice2.subscription_start_at).to be_within(1.minute).of Time.current - 3.years
       expect(invoice2.renewal_invoice?).to be_truthy
       expect(invoice2.previous_invoice).to eq invoice
-      expect(invoice3.subscription_start_at).to be_within(1.minute).of Time.now - 2.years
+      expect(invoice3.subscription_start_at).to be_within(1.minute).of Time.current - 2.years
       expect(invoice3.previous_invoice).to eq invoice2
     end
   end
@@ -54,7 +54,7 @@ RSpec.describe Invoice, type: :model do
       end
     end
     context "with active invoice" do
-      let(:invoice) { FactoryBot.create(:invoice, subscription_start_at: Time.now - 4.years, force_active: true) }
+      let(:invoice) { FactoryBot.create(:invoice, subscription_start_at: Time.current - 4.years, force_active: true) }
       let(:paid_feature) { FactoryBot.create(:paid_feature, kind: "standard") }
       let(:paid_feature_one_time) { FactoryBot.create(:paid_feature_one_time) }
       it "returns invoice" do
@@ -75,7 +75,7 @@ RSpec.describe Invoice, type: :model do
   end
 
   describe "paid_feature_ids" do
-    let(:invoice) { FactoryBot.create(:invoice, amount_due_cents: nil, subscription_start_at: Time.now - 1.week) }
+    let(:invoice) { FactoryBot.create(:invoice, amount_due_cents: nil, subscription_start_at: Time.current - 1.week) }
     let(:paid_feature) { FactoryBot.create(:paid_feature, amount_cents: 100_000) }
     let(:paid_feature2) { FactoryBot.create(:paid_feature) }
     let(:paid_feature_one_time) { FactoryBot.create(:paid_feature_one_time, name: "one Time Feature") }
@@ -94,7 +94,7 @@ RSpec.describe Invoice, type: :model do
       invoice.reload
       expect(invoice.paid_features.pluck(:id)).to match_array([paid_feature2.id, paid_feature_one_time.id])
       # TODO: Rails 5 update - Have to manually deal with updating because rspec doesn't correctly manage after_commit
-      organization.update_attributes(updated_at: Time.now)
+      organization.update_attributes(updated_at: Time.current)
       organization.reload
       expect(organization.paid_feature_slugs).to eq([])
     end
@@ -103,17 +103,17 @@ RSpec.describe Invoice, type: :model do
   describe "two invoices" do
     let(:paid_feature1) { FactoryBot.create(:paid_feature, feature_slugs: ["bike_search"]) }
     let(:paid_feature2) { FactoryBot.create(:paid_feature, feature_slugs: ["reg_secondary_serial"]) }
-    let(:invoice1) { FactoryBot.create(:invoice, amount_due_cents: 0, subscription_start_at: Time.now - 1.week) }
+    let(:invoice1) { FactoryBot.create(:invoice, amount_due_cents: 0, subscription_start_at: Time.current - 1.week) }
     let(:organization) { invoice1.organization }
-    let(:invoice2) { FactoryBot.build(:invoice, amount_due_cents: 0, subscription_start_at: Time.now - 1.day, organization: organization) }
+    let(:invoice2) { FactoryBot.build(:invoice, amount_due_cents: 0, subscription_start_at: Time.current - 1.day, organization: organization) }
     it "adds the paid features" do
       invoice1.update_attributes(paid_feature_ids: [paid_feature1.id])
       # TODO: Rails 5 update
-      organization.update_attributes(updated_at: Time.now)
+      organization.update_attributes(updated_at: Time.current)
       expect(organization.paid_feature_slugs).to eq(["bike_search"])
       invoice2.save
       invoice2.update_attributes(paid_feature_ids: [paid_feature2.id])
-      organization.update_attributes(updated_at: Time.now)
+      organization.update_attributes(updated_at: Time.current)
       expect(organization.paid_feature_slugs).to match_array %w[bike_search reg_secondary_serial]
     end
   end

--- a/spec/models/organization_spec.rb
+++ b/spec/models/organization_spec.rb
@@ -165,11 +165,11 @@ RSpec.describe Organization, type: :model do
       expect(organization.paid_for?("csv_exports")).to be_falsey
       invoice.update_attributes(paid_feature_ids: [paid_feature.id])
       expect(invoice.feature_slugs).to eq(["csv_exports"])
-      organization.update_attributes(updated_at: Time.now) # TODO: Rails 5 update - after_commit
+      organization.update_attributes(updated_at: Time.current) # TODO: Rails 5 update - after_commit
       expect(organization.is_paid).to be_truthy
       expect(organization.paid_feature_slugs).to eq(["csv_exports"])
       expect(organization.paid_for?("csv_exports")).to be_truthy
-      organization_child.update_attributes(updated_at: Time.now) # TODO: Rails 5 update - after_commit
+      organization_child.update_attributes(updated_at: Time.current) # TODO: Rails 5 update - after_commit
       expect(organization_child.is_paid).to be_falsey
       organization_child.update_attributes(parent_organization: organization)
       organization_child.reload
@@ -189,7 +189,7 @@ RSpec.describe Organization, type: :model do
         expect(organization.paid_for?("geolocated_messages")).to be_falsey
         expect(user.send_unstolen_notifications?).to be_falsey
         invoice.update_attributes(paid_feature_ids: [paid_feature.id, paid_feature2.id])
-        organization.update_attributes(updated_at: Time.now) # TODO: Rails 5 update - after_commit
+        organization.update_attributes(updated_at: Time.current) # TODO: Rails 5 update - after_commit
         expect(organization.paid_for?("messages")).to be_truthy
         expect(organization.paid_for?("geolocated_messages")).to be_falsey
         expect(organization.paid_for?("abandoned_bike_messages")).to be_truthy
@@ -441,7 +441,7 @@ RSpec.describe Organization, type: :model do
         expect(organization.pos_kind).to eq "not_pos"
         expect(organization.calculated_pos_kind).to eq "lightspeed_pos"
         # And if bike is created before cut-of for pos kind, it returns broken
-        bike_pos.update_attribute :created_at, Time.now - 2.weeks
+        bike_pos.update_attribute :created_at, Time.current - 2.weeks
         expect(organization.calculated_pos_kind).to eq "broken_pos"
       end
     end

--- a/spec/models/recovery_display_spec.rb
+++ b/spec/models/recovery_display_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe RecoveryDisplay, type: :model do
     it "sets time if no time" do
       recovery_display = RecoveryDisplay.new
       recovery_display.set_time
-      expect(recovery_display.date_recovered).to be > Time.now - 5.seconds
+      expect(recovery_display.date_recovered).to be > Time.current - 5.seconds
     end
     it "has before_validation_callback_method defined" do
       expect(RecoveryDisplay._validation_callbacks.select { |cb| cb.kind.eql?(:before) }.map(&:raw_filter).include?(:set_time)).to eq(true)
@@ -24,12 +24,12 @@ RSpec.describe RecoveryDisplay, type: :model do
       expect(recovery_display.errors).not_to be_present
     end
     it "sets attrs from stolen record" do
-      t = Time.now
+      t = Time.current
       stolen_record = FactoryBot.create(:stolen_record_recovered, date_recovered: t, recovered_description: "stuff", current: false)
       recovery_display = RecoveryDisplay.new
       recovery_display.from_stolen_record(stolen_record.id)
       expect(recovery_display.quote).to eq("stuff")
-      expect(recovery_display.date_recovered).to be > Time.now - 5.seconds
+      expect(recovery_display.date_recovered).to be > Time.current - 5.seconds
       expect(recovery_display.stolen_record_id).to eq(stolen_record.id)
     end
     it "sets name from stolen record" do

--- a/spec/models/stolen_record_spec.rb
+++ b/spec/models/stolen_record_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe StolenRecord, type: :model do
       expect(StolenRecord.recovery_unposted.to_sql).to eq(StolenRecord.unscoped.where(current: false, recovery_posted: false).to_sql)
     end
     it "scopes tsv_today" do
-      stolen1 = FactoryBot.create(:stolen_record, current: true, tsved_at: Time.now)
+      stolen1 = FactoryBot.create(:stolen_record, current: true, tsved_at: Time.current)
       stolen2 = FactoryBot.create(:stolen_record, current: true, tsved_at: nil)
 
       expect(StolenRecord.tsv_today.pluck(:id)).to eq([stolen1.id, stolen2.id])
@@ -131,8 +131,8 @@ RSpec.describe StolenRecord, type: :model do
       let(:stolen_record) { FactoryBot.create(:stolen_record_recovered, can_share_recovery: true) }
       let(:bike) { stolen_record.bike }
       it "is waiting on decision when user marks that we can share" do
-        bike.reload.update_attributes(updated_at: Time.now)
-        stolen_record.reload.update_attributes(updated_at: Time.now)
+        bike.reload.update_attributes(updated_at: Time.current)
+        stolen_record.reload.update_attributes(updated_at: Time.current)
         expect(stolen_record.bike.thumb_path).to be_present
         expect(stolen_record.can_share_recovery).to be_truthy
         expect(stolen_record.recovery_display_status).to eq "waiting_on_decision"
@@ -149,14 +149,14 @@ RSpec.describe StolenRecord, type: :model do
       let(:recovery_display) { FactoryBot.create(:recovery_display) }
       let(:stolen_record) { FactoryBot.create(:stolen_record_recovered, can_share_recovery: true, recovery_display: recovery_display) }
       it "is displayed" do
-        stolen_record.reload.update_attributes(updated_at: Time.now)
+        stolen_record.reload.update_attributes(updated_at: Time.current)
         expect(stolen_record.recovery_display_status).to eq "displayed"
       end
     end
     context "stolen_record is not_displayed" do
       let(:stolen_record) { FactoryBot.create(:stolen_record_recovered, recovery_display_status: "not_displayed", can_share_recovery: true) }
       it "is not_displayed" do
-        stolen_record.reload.update_attributes(updated_at: Time.now)
+        stolen_record.reload.update_attributes(updated_at: Time.current)
         expect(stolen_record.recovery_display_status).to eq "not_displayed"
       end
     end
@@ -220,30 +220,30 @@ RSpec.describe StolenRecord, type: :model do
     end
     it "it should set the year to the past year if the date hasn't happened yet" do
       stolen_record = FactoryBot.create(:stolen_record)
-      next_year = (Time.now + 2.months)
+      next_year = (Time.current + 2.months)
       stolen_record.date_stolen = next_year
       stolen_record.fix_date
-      expect(stolen_record.date_stolen.year).to eq(Time.now.year - 1)
+      expect(stolen_record.date_stolen.year).to eq(Time.current.year - 1)
     end
   end
 
   describe "update_tsved_at" do
     it "does not reset on save" do
-      t = Time.now - 1.minute
+      t = Time.current - 1.minute
       stolen_record = FactoryBot.create(:stolen_record, tsved_at: t)
       stolen_record.update_attributes(theft_description: "Something new description wise")
       stolen_record.reload
       expect(stolen_record.tsved_at.to_i).to eq(t.to_i)
     end
     it "resets from an update to police report" do
-      t = Time.now - 1.minute
+      t = Time.current - 1.minute
       stolen_record = FactoryBot.create(:stolen_record, tsved_at: t)
       stolen_record.update_attributes(police_report_number: "89dasf89dasf")
       stolen_record.reload
       expect(stolen_record.tsved_at).to be_nil
     end
     it "resets from an update to police report department" do
-      t = Time.now - 1.minute
+      t = Time.current - 1.minute
       stolen_record = FactoryBot.create(:stolen_record, tsved_at: t)
       stolen_record.update_attributes(police_report_department: "CPD")
       stolen_record.reload
@@ -270,7 +270,7 @@ RSpec.describe StolenRecord, type: :model do
       let(:bike) { stolen_record.bike }
       it "returns waiting_on_decision" do
         bike.reload
-        bike.update_attributes(updated_at: Time.now)
+        bike.update_attributes(updated_at: Time.current)
         expect(stolen_record.calculated_recovery_display_status).to eq "waiting_on_decision"
       end
     end
@@ -322,7 +322,7 @@ RSpec.describe StolenRecord, type: :model do
     context "no date_recovered, no user" do
       let(:recovery_request) { recovery_info.except(:can_share_recovery) }
       it "updates recovered bike" do
-        expect(stolen_record.date_recovered).to be_within(1.second).of Time.now
+        expect(stolen_record.date_recovered).to be_within(1.second).of Time.current
         expect(stolen_record.recovering_user).to be_blank
         expect(stolen_record.recovering_user_owner?).to be_falsey
       end
@@ -333,7 +333,7 @@ RSpec.describe StolenRecord, type: :model do
       let(:user_id) { ownership.user_id }
       it "updates recovered bike and assigns recovering_user" do
         expect(stolen_record.recovering_user).to eq ownership.user
-        expect(stolen_record.date_recovered).to be_within(1.second).of Time.now
+        expect(stolen_record.date_recovered).to be_within(1.second).of Time.current
         expect(stolen_record.recovering_user_owner?).to be_truthy
         expect(stolen_record.pre_recovering_user?).to be_falsey
       end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -282,7 +282,7 @@ RSpec.describe User, type: :model do
       expect(user.username).to be_present
       expect(user.confirmation_token).to be_present
       time = Time.at(user.auth_token.match(/\d*\z/)[0].to_i)
-      expect(time).to be > Time.now - 1.minutes
+      expect(time).to be > Time.current - 1.minutes
     end
     it "haves before create callback" do
       expect(User._create_callbacks.select { |cb| cb.kind.eql?(:before) }.map(&:raw_filter).include?(:generate_username_confirmation_and_auth)).to eq(true)
@@ -320,12 +320,12 @@ RSpec.describe User, type: :model do
     it "gets the time" do
       user = User.new
       user.set_password_reset_token
-      expect(user.reset_token_time).to be > Time.now - 2.seconds
+      expect(user.reset_token_time).to be > Time.current - 2.seconds
     end
     it "uses input time" do
       user = FactoryBot.create(:user)
-      user.set_password_reset_token((Time.now - 61.minutes).to_i)
-      expect(user.reload.reset_token_time).to be < (Time.now - 1.hours)
+      user.set_password_reset_token((Time.current - 61.minutes).to_i)
+      expect(user.reload.reset_token_time).to be < (Time.current - 1.hours)
     end
   end
 
@@ -380,11 +380,11 @@ RSpec.describe User, type: :model do
         expect(user.render_donation_request).to be_nil
         expect(user.send_unstolen_notifications?).to be_falsey
         invoice.update_attributes(paid_feature_ids: [paid_feature.id])
-        organization.update_attributes(updated_at: Time.now) # TODO: Rails 5 update, after_commit
+        organization.update_attributes(updated_at: Time.current) # TODO: Rails 5 update, after_commit
         expect(organization.bike_actions?).to be_truthy
         expect(Organization.bike_actions.pluck(:id)).to eq([organization.id])
         # Also, it bubbles up. BUT TODO: Rails 5 update - Have to manually deal with updating because rspec doesn't correctly manage after_commit
-        user.update_attributes(updated_at: Time.now)
+        user.update_attributes(updated_at: Time.current)
         user.reload
         expect(user.send_unstolen_notifications?).to be_truthy
       end

--- a/spec/requests/api/v2/bikes_request_spec.rb
+++ b/spec/requests/api/v2/bikes_request_spec.rb
@@ -361,7 +361,7 @@ RSpec.describe "Bikes API V2", type: :request do
       expect(bike.reload.year).to eq(params[:year])
       expect(bike.serial_number).to eq(serial)
       expect(bike.stolen).to be_truthy
-      expect(bike.current_stolen_record.date_stolen.to_i).to be > Time.now.to_i - 10
+      expect(bike.current_stolen_record.date_stolen.to_i).to be > Time.current.to_i - 10
       expect(bike.current_stolen_record.police_report_number).to eq("999999")
     end
 

--- a/spec/requests/api/v2/bikes_search_request_spec.rb
+++ b/spec/requests/api/v2/bikes_search_request_spec.rb
@@ -79,7 +79,7 @@ RSpec.describe "Bikes API V2", type: :request do
   describe "all_stolen" do
     it "returns the cached file" do
       FactoryBot.create(:stolen_bike)
-      t = Time.now.to_i
+      t = Time.current.to_i
       CacheAllStolenWorker.new.perform
       cached_all_stolen = FileCacheMaintainer.cached_all_stolen
       expect(cached_all_stolen["updated_at"].to_i).to be >= t

--- a/spec/requests/api/v3/bikes_request_spec.rb
+++ b/spec/requests/api/v3/bikes_request_spec.rb
@@ -619,7 +619,7 @@ RSpec.describe "Bikes API V3", type: :request do
       expect(bike.reload.year).to eq(params[:year])
       expect(bike.serial_number).to eq(serial)
       expect(bike.stolen).to be_truthy
-      expect(bike.current_stolen_record.date_stolen.to_i).to be > Time.now.to_i - 10
+      expect(bike.current_stolen_record.date_stolen.to_i).to be > Time.current.to_i - 10
       expect(bike.current_stolen_record.police_report_number).to eq("999999")
       expect(bike.current_stolen_record.show_address).to be_truthy
     end

--- a/spec/requests/api/v3/me_request_spec.rb
+++ b/spec/requests/api/v3/me_request_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe "Me API V3", type: :request do
     end
 
     context "unconfirmed user" do
-      let(:time) { Time.now - 1.month }
+      let(:time) { Time.current - 1.month }
       let(:user) { FactoryBot.create(:user, created_at: time) }
       it "responds with unauthorized" do
         user.reload

--- a/spec/requests/organized/messages_request_spec.rb
+++ b/spec/requests/organized/messages_request_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe Organized::MessagesController, type: :request do
         expect(response.headers["Access-Control-Request-Method"]).not_to be_present
       end
       context "with a message" do
-        let!(:organization_message_1) { FactoryBot.create(:organization_message, organization: organization, kind: "geolocated", created_at: Time.now - 1.hour) }
+        let!(:organization_message_1) { FactoryBot.create(:organization_message, organization: organization, kind: "geolocated", created_at: Time.current - 1.hour) }
         let(:bike) { organization_message_1.bike }
         let(:target) do
           {

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -68,18 +68,18 @@ end
 class DeferredGarbageCollection
   DEFERRED_GC_THRESHOLD = (ENV["DEFER_GC"] || 10.0).to_f
 
-  @@last_gc_run = Time.current
+  @@last_gc_run = Time.now
 
   def self.start
     GC.disable if DEFERRED_GC_THRESHOLD > 0
   end
 
   def self.reconsider
-    if DEFERRED_GC_THRESHOLD > 0 && Time.current - @@last_gc_run >= DEFERRED_GC_THRESHOLD
+    if DEFERRED_GC_THRESHOLD > 0 && Time.now - @@last_gc_run >= DEFERRED_GC_THRESHOLD
       GC.enable
       GC.start
       GC.disable
-      @@last_gc_run = Time.current
+      @@last_gc_run = Time.now
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -68,18 +68,18 @@ end
 class DeferredGarbageCollection
   DEFERRED_GC_THRESHOLD = (ENV["DEFER_GC"] || 10.0).to_f
 
-  @@last_gc_run = Time.now
+  @@last_gc_run = Time.current
 
   def self.start
     GC.disable if DEFERRED_GC_THRESHOLD > 0
   end
 
   def self.reconsider
-    if DEFERRED_GC_THRESHOLD > 0 && Time.now - @@last_gc_run >= DEFERRED_GC_THRESHOLD
+    if DEFERRED_GC_THRESHOLD > 0 && Time.current - @@last_gc_run >= DEFERRED_GC_THRESHOLD
       GC.enable
       GC.start
       GC.disable
-      @@last_gc_run = Time.now
+      @@last_gc_run = Time.current
     end
   end
 end

--- a/spec/support/paid_organizations.rb
+++ b/spec/support/paid_organizations.rb
@@ -3,7 +3,7 @@ RSpec.shared_context :organization_with_geolocated_messages do
   let!(:invoice) do
     inv = FactoryBot.create(:invoice_paid, organization: organization)
     inv.update_attributes(paid_feature_ids: [paid_feature&.id]) # Because we have to create the invoice first
-    organization.update_attributes(updated_at: Time.now) # TODO: Rails 5 update - after_commit
+    organization.update_attributes(updated_at: Time.current) # TODO: Rails 5 update - after_commit
     inv
   end
   let(:organization) { FactoryBot.create(:organization) }

--- a/spec/workers/organization_export_worker_spec.rb
+++ b/spec/workers/organization_export_worker_spec.rb
@@ -92,7 +92,7 @@ RSpec.describe OrganizationExportWorker, type: :job do
           expect(bike_code.claimed?).to be_truthy
           expect(bike_code.bike).to eq bike_for_avery
           expect(bike_code.user).to eq export.user
-          expect(bike_code.claimed_at).to be_within(1.second).of Time.now
+          expect(bike_code.claimed_at).to be_within(1.second).of Time.current
         end
       end
     end
@@ -106,7 +106,7 @@ RSpec.describe OrganizationExportWorker, type: :job do
     end
     context "no bikes" do
       let(:csv_lines) { [export.headers] }
-      let(:export) { FactoryBot.create(:export_organization, progress: "pending", file: nil, end_at: Time.now - 1.week) }
+      let(:export) { FactoryBot.create(:export_organization, progress: "pending", file: nil, end_at: Time.current - 1.week) }
       it "finishes export" do
         expect(bike.organizations.pluck(:id)).to eq([organization.id])
         instance.perform(export.id)

--- a/spec/workers/remove_expired_file_cache_worker_spec.rb
+++ b/spec/workers/remove_expired_file_cache_worker_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 RSpec.describe RemoveExpiredFileCacheWorker, type: :job do
   describe "perform" do
     it "removes expired files" do
-      t = (Time.now - 3.days).to_i
+      t = (Time.current - 3.days).to_i
       FileCacheMaintainer.reset_file_info("#{t}_all_stolen_cache.json", t)
       FileCacheMaintainer.update_file_info("current_stolen_bikes.tsv")
       expect(FileCacheMaintainer.files.count).to eq 2


### PR DESCRIPTION
Fix #841 

> in general it takes some cognitive load off to not have to reason through it every time

@jmromer is right, we should default to `Time.current` - and since it's easy, remove all the `Time.now` calls so that they aren't confusing.