### PR TITLE
Add db-level uniqueness constraint for task assignments

### DIFF
--- a/db/migrate/20190617174200_add_unique_index_to_ambassador_task_assignments.rb
+++ b/db/migrate/20190617174200_add_unique_index_to_ambassador_task_assignments.rb
@@ -1,0 +1,8 @@
+class AddUniqueIndexToAmbassadorTaskAssignments < ActiveRecord::Migration
+  def change
+    add_index :ambassador_task_assignments,
+              [:user_id, :ambassador_task_id],
+              unique: true,
+              name: "unique_assignment_to_ambassador"
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -3487,6 +3487,13 @@ CREATE INDEX index_users_on_password_reset_token ON public.users USING btree (pa
 
 
 --
+-- Name: unique_assignment_to_ambassador; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX unique_assignment_to_ambassador ON public.ambassador_task_assignments USING btree (user_id, ambassador_task_id);
+
+
+--
 -- Name: unique_schema_migrations; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -4230,4 +4237,6 @@ INSERT INTO schema_migrations (version) VALUES ('20190611223723');
 INSERT INTO schema_migrations (version) VALUES ('20190612183532');
 
 INSERT INTO schema_migrations (version) VALUES ('20190614223136');
+
+INSERT INTO schema_migrations (version) VALUES ('20190617174200');
 

--- a/spec/models/ambassador_task_assignment_spec.rb
+++ b/spec/models/ambassador_task_assignment_spec.rb
@@ -55,6 +55,16 @@ RSpec.describe AmbassadorTaskAssignment, type: :model do
       expect(assignment2).to be_invalid
       expect(assignment2.errors[:ambassador_task]).to eq(["has already been taken"])
     end
+
+    it "raises if the task assignment is non-unique per-user" do
+      assignment1 = FactoryBot.create(:ambassador_task_assignment)
+      ambassador = assignment1.ambassador
+      task = assignment1.ambassador_task
+
+      assignment2 = described_class.new(ambassador: ambassador, ambassador_task: task)
+
+      expect { assignment2.save(validate: false) }.to raise_error(ActiveRecord::RecordNotUnique)
+    end
   end
 
   describe ".completed_assignments" do


### PR DESCRIPTION
Adds a database-level uniqueness constraint to task assignments. Working on determining why dupes are being created, I'll add a fix for that in a follow-up PR.

Related: #908 