### PR TITLE
Remove activerecord-import library

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,6 @@ ruby "2.5.1"
 gem "rails", "4.2.11"
 
 gem "active_model_serializers", "~> 0.9.3"
-gem "activerecord-import"
 gem "aws-sdk", "~> 1.33"
 gem "bcrypt", "~> 3.1.7"
 gem "jquery-rails"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -33,8 +33,6 @@ GEM
       activemodel (= 4.2.11)
       activesupport (= 4.2.11)
       arel (~> 6.0)
-    activerecord-import (1.0.2)
-      activerecord (>= 3.2)
     activesupport (4.2.11)
       i18n (~> 0.7)
       minitest (~> 5.1)
@@ -627,7 +625,6 @@ PLATFORMS
 
 DEPENDENCIES
   active_model_serializers (~> 0.9.3)
-  activerecord-import
   airborne
   api-pagination
   aws-sdk (~> 1.33)


### PR DESCRIPTION
No other current usage aside from the logic removed in #910.