### PR TITLE
Add TheftAlert, TheftAlertPlan models

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -164,7 +164,6 @@ group :test do
   gem "factory_bot_rails"
   gem "rspec-sidekiq"
   gem "simplecov", require: false
-  gem "timecop"
   gem "vcr" # Stub external HTTP requests
   gem "webmock" # mocking for VCR
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -569,7 +569,6 @@ GEM
     thor (0.19.1)
     thread_safe (0.3.6)
     tilt (2.0.8)
-    timecop (0.9.1)
     twitter (6.2.0)
       addressable (~> 2.3)
       buftok (~> 0.2.0)
@@ -739,7 +738,6 @@ DEPENDENCIES
   swagger-ui_rails
   therubyracer
   thor (= 0.19.1)
-  timecop
   twitter
   uglifier
   unicorn

--- a/app/controllers/admin/theft_alert_plans_controller.rb
+++ b/app/controllers/admin/theft_alert_plans_controller.rb
@@ -1,0 +1,45 @@
+class Admin::TheftAlertPlansController < Admin::BaseController
+  layout "new_admin"
+
+  def index
+    @theft_alert_plans = TheftAlertPlan.all
+  end
+
+  def new
+    @theft_alert_plan = TheftAlertPlan.new
+  end
+
+  def create
+    @theft_alert_plan = TheftAlertPlan.new(theft_alert_plan_params)
+
+    if @theft_alert_plan.save
+      redirect_to(edit_admin_theft_alert_plan_path(@theft_alert_plan))
+    else
+      flash[:errors] = @theft_alert_plan.errors.full_messages
+      render :new
+    end
+  end
+
+  def edit
+    @theft_alert_plan = TheftAlertPlan.find(params[:id])
+  end
+
+  def update
+    @theft_alert_plan = TheftAlertPlan.find(params[:id])
+
+    if @theft_alert_plan.update_attributes(theft_alert_plan_params)
+      redirect_to(admin_theft_alert_plans_path)
+    else
+      flash[:errors] = @theft_alert_plan.errors.full_messages
+      render :edit
+    end
+  end
+
+  private
+
+  def theft_alert_plan_params
+    params
+      .require(:theft_alert_plan)
+      .permit(:name, :amount_cents, :views, :duration_days, :description, :active)
+  end
+end

--- a/app/controllers/admin/theft_alerts_controller.rb
+++ b/app/controllers/admin/theft_alerts_controller.rb
@@ -1,0 +1,48 @@
+class Admin::TheftAlertsController < Admin::BaseController
+  layout "new_admin"
+
+  def index
+    @theft_alerts = TheftAlert.includes(:theft_alert_plan).all
+  end
+
+  def edit
+    @theft_alert = TheftAlert.find(params[:id])
+
+    case state_transition
+    when "begin"
+      render :edit
+    else
+      flash[:error] = "Invalid state transition."
+      redirect_to admin_theft_alerts_path
+    end
+  end
+
+  def update
+    @theft_alert = TheftAlert.find(params[:id])
+    @theft_alert.public_send("#{state_transition}!", theft_alert_params)
+
+    if @theft_alert.errors.present?
+      flash[:error] = @theft_alert.errors.full_messages.first
+      redirect_to edit_admin_theft_alert_path(@theft_alert, params: { state_transition: state_transition })
+    else
+      flash[:success] = "Success!"
+      redirect_to admin_theft_alerts_path
+    end
+  end
+
+  private
+
+  def theft_alert_params
+    params.require(:theft_alert).permit(:facebook_post_url)
+  end
+
+  def state_transition
+    return @state_transition if defined?(@state_transition)
+
+    valid_state_transitions = %w[begin end reset]
+    state_transition = params[:state_transition]
+    return unless state_transition.in?(valid_state_transitions)
+
+    @state_transition = state_transition
+  end
+end

--- a/app/controllers/admin/theft_alerts_controller.rb
+++ b/app/controllers/admin/theft_alerts_controller.rb
@@ -19,7 +19,13 @@ class Admin::TheftAlertsController < Admin::BaseController
 
   def update
     @theft_alert = TheftAlert.find(params[:id])
-    @theft_alert.public_send("#{state_transition}!", theft_alert_params)
+
+    case state_transition
+    when "begin"
+      @theft_alert.begin!(facebook_post_url: theft_alert_params[:facebook_post_url])
+    when "end", "reset"
+      @theft_alert.public_send("#{state_transition}!")
+    end
 
     if @theft_alert.errors.present?
       flash[:error] = @theft_alert.errors.to_a

--- a/app/controllers/admin/theft_alerts_controller.rb
+++ b/app/controllers/admin/theft_alerts_controller.rb
@@ -22,7 +22,7 @@ class Admin::TheftAlertsController < Admin::BaseController
     @theft_alert.public_send("#{state_transition}!", theft_alert_params)
 
     if @theft_alert.errors.present?
-      flash[:error] = @theft_alert.errors.full_messages.first
+      flash[:error] = @theft_alert.errors.to_a
       redirect_to edit_admin_theft_alert_path(@theft_alert, params: { state_transition: state_transition })
     else
       flash[:success] = "Success!"

--- a/app/models/theft_alert.rb
+++ b/app/models/theft_alert.rb
@@ -19,7 +19,7 @@ class TheftAlert < ActiveRecord::Base
   delegate :bike, to: :stolen_record
 
   def begin!(kwargs)
-    start_time = Time.current.beginning_of_day
+    start_time = Time.current
     end_time = start_time + theft_alert_plan&.duration_days&.days
 
     attrs = {

--- a/app/models/theft_alert.rb
+++ b/app/models/theft_alert.rb
@@ -18,39 +18,36 @@ class TheftAlert < ActiveRecord::Base
 
   delegate :bike, to: :stolen_record
 
-  def begin!(kwargs)
+  def begin!(facebook_post_url:)
     start_time = Time.current
     end_time = start_time + theft_alert_plan&.duration_days&.days
 
     attrs = {
       status: "active",
-      facebook_post_url: kwargs.fetch(:facebook_post_url, ""),
+      facebook_post_url: facebook_post_url,
       begin_at: start_time,
       end_at: end_time.end_of_day,
     }
-
     update(attrs) if valid_state?(attrs)
   end
 
-  def end!(*)
+  def end!
     attrs = {
       status: "inactive",
       facebook_post_url: facebook_post_url,
       begin_at: begin_at,
       end_at: end_at,
     }
-
     update(attrs) if valid_state?(attrs)
   end
 
-  def reset!(*)
+  def reset!
     attrs = {
       status: "pending",
       facebook_post_url: "",
       begin_at: nil,
       end_at: nil,
     }
-
     update(attrs) if valid_state?(attrs)
   end
 

--- a/app/models/theft_alert.rb
+++ b/app/models/theft_alert.rb
@@ -1,0 +1,79 @@
+class TheftAlert < ActiveRecord::Base
+  enum status: { pending: 0, active: 1, inactive: 2 }.freeze
+
+  validates :stolen_record,
+            :theft_alert_plan,
+            :status,
+            :creator,
+            presence: true
+
+  belongs_to :stolen_record
+  belongs_to :theft_alert_plan
+  belongs_to :payment
+  belongs_to :creator,
+             class_name: "User",
+             foreign_key: :user_id
+
+  scope :due_for_expiration, -> { active.where('"theft_alerts"."end_at" <= ?', Time.current) }
+
+  delegate :bike, to: :stolen_record
+
+  def begin!(kwargs)
+    start_time = Time.current.beginning_of_day
+    end_time = start_time + theft_alert_plan&.duration_days&.days
+
+    attrs = {
+      status: "active",
+      facebook_post_url: kwargs.fetch(:facebook_post_url, ""),
+      begin_at: start_time,
+      end_at: end_time.end_of_day,
+    }
+
+    update(attrs) if valid_state?(attrs)
+  end
+
+  def end!(*)
+    attrs = {
+      status: "inactive",
+      facebook_post_url: facebook_post_url,
+      begin_at: begin_at,
+      end_at: end_at,
+    }
+
+    update(attrs) if valid_state?(attrs)
+  end
+
+  def reset!(*)
+    attrs = {
+      status: "pending",
+      facebook_post_url: "",
+      begin_at: nil,
+      end_at: nil,
+    }
+
+    update(attrs) if valid_state?(attrs)
+  end
+
+  private
+
+  # Ensure fields have expected values for the target state's status
+  def valid_state?(target_state)
+    status = target_state[:status]
+    begin_at = target_state[:begin_at]
+    end_at = target_state[:end_at]
+    facebook_post_url = target_state[:facebook_post_url]
+
+    case status
+    when "pending"
+      errors.add(:facebook_post_url, "must be blank when pending") if facebook_post_url.present?
+      errors.add(:begin_at, "must be blank when pending") if begin_at.present?
+      errors.add(:end_at, "must be blank when pending") if end_at.present?
+    when "active", "inactive"
+      errors.add(:facebook_post_url, "must be a valid url") if facebook_post_url.blank?
+      errors.add(:begin_at, "must be present") if begin_at.blank?
+      errors.add(:end_at, "must be present") if end_at.blank?
+    end
+
+    errors.none?
+  end
+end

--- a/app/models/theft_alert_plan.rb
+++ b/app/models/theft_alert_plan.rb
@@ -1,0 +1,58 @@
+DESCRIPTION = <<~MD
+  - **5,000 Ad Campaign Views** from people within 10 miles
+  - **+10,000 Bonus Views** from people within 10 miles
+  - Ad campaign runs for **7 Days**
+  - **Priority Support** from the Bike Index Team
+MD
+
+PRICING_PLANS = [
+  {
+    views: 50_000,
+    duration_days: 7,
+    amount_cents: 6995,
+    name: "Maximum",
+    description: DESCRIPTION,
+  },
+  {
+    views: 25_000,
+    duration_days: 7,
+    amount_cents: 3995,
+    name: "Standard",
+    description: DESCRIPTION,
+  },
+  {
+    views: 10_000,
+    duration_days: 7,
+    amount_cents: 1995,
+    name: "Starter",
+    description: DESCRIPTION,
+  },
+]
+
+class TheftAlertPlan < ActiveRecord::Base
+  include Amountable
+
+  validates :name,
+            :amount_cents,
+            :views,
+            :duration_days,
+            presence: true
+
+  validates :amount_cents, :duration_days, :views, numericality: { greater_than: 0 }
+
+  has_many :theft_alerts, dependent: :destroy
+  has_many :stolen_records, through: :theft_alerts
+
+  scope :active, -> { where(active: true) }
+  scope :price_ordered_desc, -> { order(amount_cents: :desc) }
+  scope :price_ordered_asc, -> { order(amount_cents: :asc) }
+
+  def self.seed_plans
+    delete_all
+    PRICING_PLANS.map { |attr| create(attr) }
+  end
+
+  def description_html
+    Kramdown::Document.new(description).to_html
+  end
+end

--- a/app/views/admin/theft_alert_plans/_form.html.haml
+++ b/app/views/admin/theft_alert_plans/_form.html.haml
@@ -1,0 +1,30 @@
+= form_for record, url: action, method: method, html: { class: "form" } do |f|
+  = f.label :name, "Name", class: "form-label font-weight-bold mt-2 mb-0"
+  = f.text_field :name, class: "form-control"
+
+  = f.label :amount_cents, "Price (cents)", class: "form-label font-weight-bold mt-2 mb-0"
+  = f.number_field :amount_cents, class: "form-control"
+
+  = f.label :views, "Views Provided", class: "form-label font-weight-bold mt-2 mb-0"
+  = f.number_field :views, class: "form-control"
+
+  = f.label :duration_days, "Duration (days)", class: "form-label font-weight-bold mt-2 mb-0"
+  = f.number_field :duration_days, class: "form-control"
+
+  = f.label :active, "Active?", class: "form-label font-weight-bold mt-2 mb-0"
+  = f.check_box :active, class: "form-control"
+
+  = f.label :description, "Description", class: "form-label font-weight-bold mt-2 mb-0"
+  = f.text_area :description, class: "form-control", rows: "10"
+
+  .float-right
+    [
+    = link_to "Markdown",
+      "https://www.markdownguide.org/getting-started",
+      target: "_blank",
+      tabindex: -1
+    permitted
+    ]
+
+  %br
+  = submit_tag submit_label, class: "btn btn-success btn-lg"

--- a/app/views/admin/theft_alert_plans/edit.html.haml
+++ b/app/views/admin/theft_alert_plans/edit.html.haml
@@ -1,0 +1,8 @@
+.container
+  %h1 Edit Theft Alert Plan
+
+  = render "form",
+    record: @theft_alert_plan,
+    action: admin_theft_alert_plan_path(@theft_alert_plan),
+    method: :patch,
+    submit_label: "Save"

--- a/app/views/admin/theft_alert_plans/index.html.haml
+++ b/app/views/admin/theft_alert_plans/index.html.haml
@@ -1,0 +1,27 @@
+.admin-subnav
+  .col-md-4
+    %h1 Theft Alert Plans
+  .col-md-8
+    %ul
+      %li.nav-item
+        = link_to "New Theft Alert Plan", new_admin_theft_alert_plan_path
+
+.full-screen-table
+  %table.table.table-striped.table-bordered.ambassador-tasks-table
+    %thead.small-header
+      %tr
+        %th Name
+        %th Price
+        %th Views Provided
+        %th Duration (days)
+        %th Description
+        %th Active?
+    %tbody
+      - @theft_alert_plans.each do |plan|
+        %tr
+          %td= link_to plan.name , edit_admin_theft_alert_plan_path(plan)
+          %td= number_to_currency(plan.amount_cents / 100.0, unit: "$")
+          %td= plan.views
+          %td= plan.duration_days
+          %td= plan.description_html.html_safe
+          %td= plan.active?

--- a/app/views/admin/theft_alert_plans/new.html.haml
+++ b/app/views/admin/theft_alert_plans/new.html.haml
@@ -1,0 +1,8 @@
+.container
+  %h1 New Theft Alert Plan
+
+  = render "form",
+    record: @theft_alert_plan,
+    action: admin_theft_alert_plans_path,
+    method: :post,
+    submit_label: "Create"

--- a/app/views/admin/theft_alerts/edit.html.haml
+++ b/app/views/admin/theft_alerts/edit.html.haml
@@ -1,0 +1,12 @@
+.container
+  %h1 Activate Theft Alert
+
+  = form_for @theft_alert,
+    url: admin_theft_alert_path(@theft_alert),
+    method: :patch,
+    html: { class: "m-0" } do |f|
+    = hidden_field_tag :state_transition, "begin"
+    = f.label :facebook_post_url, class: "form-label font-weight-bold mt-2 mb-0"
+    = f.text_field :facebook_post_url, class: "form-control"
+    %br
+    = submit_tag "Begin", class: "btn btn-info"

--- a/app/views/admin/theft_alerts/index.html.haml
+++ b/app/views/admin/theft_alerts/index.html.haml
@@ -1,0 +1,61 @@
+.admin-subnav
+  .col-md-12
+    %h1 Theft Alerts
+
+.full-screen-table
+  %table.table.table-striped.table-bordered.ambassador-tasks-table
+    %thead.small-header
+      %tr
+        %th Created at
+        %th Bike
+        %th Creator
+        %th Plan
+        %th Status
+        %th Begins at
+        %th Ends at
+        %th Facebook post
+        %th
+    %tbody
+      - @theft_alerts.each do |alert|
+        %tr
+          %td
+            = link_to edit_admin_theft_alert_path(alert) do
+              .convertTime= l(alert.created_at, format: :convert_time)
+          %td
+            = link_to alert.bike.id, edit_admin_bike_path(alert.bike)
+          %td
+            = link_to alert.creator.email, edit_admin_user_path(alert.creator.email)
+          %td
+            - plan = alert.theft_alert_plan
+            = link_to "#{plan.name} (#{plan.duration_days} days)", edit_admin_theft_alert_plan_path(plan)
+          %td
+            = link_to alert.status, edit_admin_theft_alert_path(alert)
+          %td
+            = link_to edit_admin_theft_alert_path(alert) do
+              .convertTime= l(alert.begin_at, format: :convert_time) if alert.begin_at.present?
+          %td
+            = link_to edit_admin_theft_alert_path(alert) do
+              .convertTime= l(alert.end_at, format: :convert_time) if alert.end_at.present?
+          %td
+            = link_to "link", alert.facebook_post_url, target: "_blank" if alert.facebook_post_url.present?
+
+          %td
+            - case alert.status
+            - when "pending"
+              = form_tag edit_admin_theft_alert_path(alert), method: :get do |f|
+                = hidden_field_tag :state_transition, "begin"
+                = submit_tag "Begin Alert", class: "btn btn-success p-1"
+            - when "active"
+              = form_for alert,
+                url: admin_theft_alert_path(alert),
+                method: :patch do |f|
+                = hidden_field_tag :state_transition, "end"
+                = f.hidden_field :status
+                = submit_tag "End Alert", class: "btn btn-danger p-1", data: { confirm: "Are you sure?" }
+            - when "inactive"
+              = form_for alert,
+                url: admin_theft_alert_path(alert),
+                method: :patch do |f|
+                = hidden_field_tag :state_transition, "reset"
+                = f.hidden_field :status
+                = submit_tag "Reset Alert", class: "btn btn-warning p-1", data: { confirm: "Are you sure?" }

--- a/app/views/layouts/new_admin.html.haml
+++ b/app/views/layouts/new_admin.html.haml
@@ -44,6 +44,8 @@
                                 { title: "POS Integration", path: "https://posintegration.bikeindex.org", match_controller: false },
                                 { title: "Ambassador Activities", path: admin_ambassador_tasks_path, match_controller: true },
                                 { title: "Completed Ambassador Activities", path: admin_ambassador_task_assignments_path, match_controller: true },
+                                { title: "Theft Alerts", path: admin_theft_alerts_path, match_controller: true },
+                                { title: "Theft Alert Plans", path: admin_theft_alert_plans_path, match_controller: true },
                                 { title: "Payments", path: admin_payments_path, match_controller: true },
                                 { title: "Paid Features", path: admin_paid_features_path, match_controller: true },
                                 { title: "Invoices", path: admin_invoices_path, match_controller: true },

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -161,6 +161,10 @@ Bikeindex::Application.routes.draw do
     resources :memberships, :organization_invitations, :bulk_imports, :exports, :bike_codes,
               :paints, :ads, :recovery_displays, :mail_snippets, :paid_features, :payments,
               :partial_bikes
+
+    resources :theft_alerts, only: [:index, :edit, :update]
+    resources :theft_alert_plans, only: [:index, :edit, :update, :new, :create]
+
     resources :organizations do
       resources :custom_layouts, only: [:index, :edit, :update], controller: "organizations/custom_layouts"
       resources :invoices, controller: "organizations/invoices"

--- a/db/migrate/20190617193251_add_theft_alert_plans.rb
+++ b/db/migrate/20190617193251_add_theft_alert_plans.rb
@@ -1,0 +1,14 @@
+class AddTheftAlertPlans < ActiveRecord::Migration
+  def change
+    create_table :theft_alert_plans do |t|
+      t.string :name, null: false, default: ""
+      t.integer :amount_cents, null: false
+      t.integer :views, null: false
+      t.integer :duration_days, null: false
+      t.string :description, null: false, default: ""
+      t.boolean :active, null: false, default: true
+
+      t.timestamps null: false
+    end
+  end
+end

--- a/db/migrate/20190617193255_add_theft_alerts.rb
+++ b/db/migrate/20190617193255_add_theft_alerts.rb
@@ -1,0 +1,25 @@
+class AddTheftAlerts < ActiveRecord::Migration
+  def change
+    create_table :theft_alerts do |t|
+      t.belongs_to :stolen_record, index: true
+      t.foreign_key :stolen_records, on_delete: :cascade
+
+      t.belongs_to :theft_alert_plan, index: true
+      t.foreign_key :theft_alert_plans, on_delete: :cascade
+
+      t.belongs_to :payment, index: true
+      t.foreign_key :payments
+
+      t.belongs_to :user, index: true
+      t.foreign_key :users
+
+      t.integer :status, null: false, default: 0
+
+      t.string :facebook_post_url, null: false, default: ""
+      t.datetime :begin_at
+      t.datetime :end_at
+
+      t.timestamps null: false
+    end
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -1867,7 +1867,7 @@ ALTER SEQUENCE public.recovery_displays_id_seq OWNED BY public.recovery_displays
 --
 
 CREATE TABLE public.schema_migrations (
-    version character varying(255) NOT NULL
+    version character varying NOT NULL
 );
 
 
@@ -2011,6 +2011,82 @@ CREATE SEQUENCE public.stolen_records_id_seq
 --
 
 ALTER SEQUENCE public.stolen_records_id_seq OWNED BY public.stolen_records.id;
+
+
+--
+-- Name: theft_alert_plans; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.theft_alert_plans (
+    id integer NOT NULL,
+    name character varying DEFAULT ''::character varying NOT NULL,
+    amount_cents integer NOT NULL,
+    views integer NOT NULL,
+    duration_days integer NOT NULL,
+    description character varying DEFAULT ''::character varying NOT NULL,
+    active boolean DEFAULT true NOT NULL,
+    created_at timestamp without time zone NOT NULL,
+    updated_at timestamp without time zone NOT NULL
+);
+
+
+--
+-- Name: theft_alert_plans_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.theft_alert_plans_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: theft_alert_plans_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.theft_alert_plans_id_seq OWNED BY public.theft_alert_plans.id;
+
+
+--
+-- Name: theft_alerts; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.theft_alerts (
+    id integer NOT NULL,
+    stolen_record_id integer,
+    theft_alert_plan_id integer,
+    payment_id integer,
+    user_id integer,
+    status integer DEFAULT 0 NOT NULL,
+    facebook_post_url character varying DEFAULT ''::character varying NOT NULL,
+    begin_at timestamp without time zone,
+    end_at timestamp without time zone,
+    created_at timestamp without time zone NOT NULL,
+    updated_at timestamp without time zone NOT NULL
+);
+
+
+--
+-- Name: theft_alerts_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.theft_alerts_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: theft_alerts_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.theft_alerts_id_seq OWNED BY public.theft_alerts.id;
 
 
 --
@@ -2543,6 +2619,20 @@ ALTER TABLE ONLY public.stolen_records ALTER COLUMN id SET DEFAULT nextval('publ
 
 
 --
+-- Name: theft_alert_plans id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.theft_alert_plans ALTER COLUMN id SET DEFAULT nextval('public.theft_alert_plans_id_seq'::regclass);
+
+
+--
+-- Name: theft_alerts id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.theft_alerts ALTER COLUMN id SET DEFAULT nextval('public.theft_alerts_id_seq'::regclass);
+
+
+--
 -- Name: tweets id; Type: DEFAULT; Schema: public; Owner: -
 --
 
@@ -2976,6 +3066,22 @@ ALTER TABLE ONLY public.stolen_records
 
 ALTER TABLE ONLY public.stolen_notifications
     ADD CONSTRAINT stolen_notifications_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: theft_alert_plans theft_alert_plans_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.theft_alert_plans
+    ADD CONSTRAINT theft_alert_plans_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: theft_alerts theft_alerts_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.theft_alerts
+    ADD CONSTRAINT theft_alerts_pkey PRIMARY KEY (id);
 
 
 --
@@ -3473,6 +3579,34 @@ CREATE INDEX index_stolen_records_on_recovering_user_id ON public.stolen_records
 
 
 --
+-- Name: index_theft_alerts_on_payment_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_theft_alerts_on_payment_id ON public.theft_alerts USING btree (payment_id);
+
+
+--
+-- Name: index_theft_alerts_on_stolen_record_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_theft_alerts_on_stolen_record_id ON public.theft_alerts USING btree (stolen_record_id);
+
+
+--
+-- Name: index_theft_alerts_on_theft_alert_plan_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_theft_alerts_on_theft_alert_plan_id ON public.theft_alerts USING btree (theft_alert_plan_id);
+
+
+--
+-- Name: index_theft_alerts_on_user_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_theft_alerts_on_user_id ON public.theft_alerts USING btree (user_id);
+
+
+--
 -- Name: index_user_emails_on_user_id; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -3501,11 +3635,43 @@ CREATE UNIQUE INDEX unique_schema_migrations ON public.schema_migrations USING b
 
 
 --
+-- Name: theft_alerts fk_rails_3c23dcdc45; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.theft_alerts
+    ADD CONSTRAINT fk_rails_3c23dcdc45 FOREIGN KEY (stolen_record_id) REFERENCES public.stolen_records(id) ON DELETE CASCADE;
+
+
+--
+-- Name: theft_alerts fk_rails_4d1dc73022; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.theft_alerts
+    ADD CONSTRAINT fk_rails_4d1dc73022 FOREIGN KEY (theft_alert_plan_id) REFERENCES public.theft_alert_plans(id) ON DELETE CASCADE;
+
+
+--
+-- Name: theft_alerts fk_rails_58c070cc66; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.theft_alerts
+    ADD CONSTRAINT fk_rails_58c070cc66 FOREIGN KEY (user_id) REFERENCES public.users(id);
+
+
+--
 -- Name: ambassador_task_assignments fk_rails_6c31316b38; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.ambassador_task_assignments
     ADD CONSTRAINT fk_rails_6c31316b38 FOREIGN KEY (user_id) REFERENCES public.users(id) ON DELETE CASCADE;
+
+
+--
+-- Name: theft_alerts fk_rails_6dac5d87d9; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.theft_alerts
+    ADD CONSTRAINT fk_rails_6dac5d87d9 FOREIGN KEY (payment_id) REFERENCES public.payments(id);
 
 
 --
@@ -4239,4 +4405,8 @@ INSERT INTO schema_migrations (version) VALUES ('20190612183532');
 INSERT INTO schema_migrations (version) VALUES ('20190614223136');
 
 INSERT INTO schema_migrations (version) VALUES ('20190617174200');
+
+INSERT INTO schema_migrations (version) VALUES ('20190617193251');
+
+INSERT INTO schema_migrations (version) VALUES ('20190617193255');
 

--- a/spec/factories/theft_alert_plans.rb
+++ b/spec/factories/theft_alert_plans.rb
@@ -1,0 +1,9 @@
+FactoryBot.define do
+  factory :theft_alert_plan do
+    sequence(:name) { |n| "Theft Alert Plan #{n.to_s.rjust(3, "0")}" }
+    sequence(:amount_cents) { |n| n * 100 }
+    views { 50_000 }
+    duration_days { 7 }
+    active { true }
+  end
+end

--- a/spec/factories/theft_alerts.rb
+++ b/spec/factories/theft_alerts.rb
@@ -1,0 +1,56 @@
+FactoryBot.define do
+  factory :theft_alert do
+    stolen_record { create(:stolen_record) }
+    theft_alert_plan { create(:theft_alert_plan) }
+    creator { create(:user_confirmed) }
+    status { "pending" }
+
+    trait :paid do
+      after(:create) do |theft_alert, _evaluator|
+        payment = create(:payment, user: theft_alert.creator)
+        theft_alert.update_attributes(payment: payment)
+      end
+    end
+
+    trait :begun do
+      status { "active" }
+      begin_at { Time.current.beginning_of_day }
+      sequence(:facebook_post_url) do |n|
+        "https://facebook.com/user.#{creator.id}/posts/#{n}"
+      end
+      before(:create) do |theft_alert, _evaluator|
+        plan = create(:theft_alert_plan)
+
+        duration = plan.duration_days
+        end_at = theft_alert.begin_at + duration.days
+
+        theft_alert.theft_alert_plan = plan
+        theft_alert.end_at = end_at.end_of_day
+
+        theft_alert.save
+      end
+    end
+
+    trait :ended do
+      status { "inactive" }
+      end_at { Time.current.end_of_day }
+
+      before(:create) do |theft_alert, _evaluator|
+        plan = create(:theft_alert_plan)
+
+        duration = plan.duration_days
+        begin_at = theft_alert.end_at - duration.days
+
+        theft_alert.theft_alert_plan = plan
+        theft_alert.begin_at = begin_at.beginning_of_day
+
+        theft_alert.save
+      end
+    end
+
+    factory :theft_alert_pending
+    factory :theft_alert_paid, traits: [:paid]
+    factory :theft_alert_begun, traits: [:paid, :begun]
+    factory :theft_alert_ended, traits: [:paid, :begun, :ended]
+  end
+end

--- a/spec/factories/theft_alerts.rb
+++ b/spec/factories/theft_alerts.rb
@@ -1,17 +1,12 @@
 FactoryBot.define do
   factory :theft_alert do
     stolen_record { create(:stolen_record) }
-    theft_alert_plan { create(:theft_alert_plan) }
-    creator { create(:user_confirmed) }
+    theft_alert_plan { FactoryBot.create(:theft_alert_plan) }
+    creator { FactoryBot.create(:user_confirmed) }
     status { "pending" }
 
     trait :paid do
-      transient do
-        payment { create(:payment, user: creator) }
-      end
-      after(:create) do |theft_alert, evaluator|
-        theft_alert.update_attributes(payment: evaluator.payment)
-      end
+      payment { FactoryBot.create(:payment, user: creator) }
     end
 
     trait :begun do
@@ -20,31 +15,13 @@ FactoryBot.define do
       sequence(:facebook_post_url) do |n|
         "https://facebook.com/user.#{creator.id}/posts/#{n}"
       end
-      transient do
-        theft_alert_plan { create(:theft_alert_plan) }
-      end
-      before(:create) do |theft_alert, evaluator|
-        plan = evaluator.theft_alert_plan
-        theft_alert.theft_alert_plan = plan
-        theft_alert.end_at = theft_alert.begin_at + plan.duration_days.days
-        theft_alert.save
-      end
+      end_at { begin_at + theft_alert_plan.duration_days.days }
     end
 
     trait :ended do
       status { "inactive" }
       end_at { Time.current }
-
-      transient do
-        theft_alert_plan { create(:theft_alert_plan) }
-      end
-
-      before(:create) do |theft_alert, evaluator|
-        plan = evaluator.theft_alert_plan
-        theft_alert.theft_alert_plan = plan
-        theft_alert.begin_at = theft_alert.end_at - plan.duration_days.days
-        theft_alert.save
-      end
+      begin_at { end_at - theft_alert_plan.duration_days.days }
     end
 
     factory :theft_alert_pending

--- a/spec/models/theft_alert_plan_spec.rb
+++ b/spec/models/theft_alert_plan_spec.rb
@@ -1,0 +1,4 @@
+require "rails_helper"
+
+RSpec.describe TheftAlertPlan, type: :model do
+end

--- a/spec/models/theft_alert_spec.rb
+++ b/spec/models/theft_alert_spec.rb
@@ -1,0 +1,63 @@
+require "rails_helper"
+
+RSpec.describe TheftAlert, type: :model do
+  describe "#begin!" do
+    context "given no facebook post url" do
+      it "rejects the update, sets an error" do
+        theft_alert = FactoryBot.create(:theft_alert)
+
+        theft_alert.begin!(facebook_post_url: "")
+
+        expect(theft_alert.reload.status).to eq("pending")
+        expect(theft_alert.begin_at).to eq(nil)
+        expect(theft_alert.end_at).to eq(nil)
+        expect(theft_alert.errors.to_a).to eq(["Facebook post url must be a valid url"])
+      end
+    end
+
+    context "given a facebook post url" do
+      it "sets begin and end times, flips the status" do
+        theft_alert = FactoryBot.create(:theft_alert_paid)
+        duration = theft_alert.theft_alert_plan.duration_days
+        now = nil
+
+        Timecop.freeze do
+          now = Time.current
+          theft_alert.begin!(facebook_post_url: "https://facebook.com")
+        end
+
+        expect(theft_alert.begin_at).to eq(now.beginning_of_day)
+        expect(theft_alert.end_at).to eq(now.end_of_day + duration.days)
+        expect(theft_alert.status).to eq("active")
+      end
+    end
+  end
+
+  describe "#end!" do
+    it "sets the alert status, without changing other state values" do
+      theft_alert = FactoryBot.create(:theft_alert_begun)
+      begin_at = theft_alert.begin_at
+      end_at = theft_alert.end_at
+      fb_url = theft_alert.facebook_post_url
+
+      theft_alert.end!
+
+      expect(theft_alert.status).to eq("inactive")
+      expect(theft_alert.begin_at).to eq(begin_at)
+      expect(theft_alert.end_at).to eq(end_at)
+      expect(theft_alert.facebook_post_url).to eq(fb_url)
+    end
+  end
+
+  describe "#reset!" do
+    it "resets the alert state to pending" do
+      theft_alert = FactoryBot.create(:theft_alert_ended)
+      theft_alert.reset!
+
+      expect(theft_alert.status).to eq("pending")
+      expect(theft_alert.begin_at).to eq(nil)
+      expect(theft_alert.end_at).to eq(nil)
+      expect(theft_alert.facebook_post_url).to eq("")
+    end
+  end
+end

--- a/spec/models/theft_alert_spec.rb
+++ b/spec/models/theft_alert_spec.rb
@@ -19,12 +19,9 @@ RSpec.describe TheftAlert, type: :model do
       it "sets begin and end times, flips the status" do
         theft_alert = FactoryBot.create(:theft_alert_paid)
         duration = theft_alert.theft_alert_plan.duration_days
-        now = nil
+        now = Time.current
 
-        Timecop.freeze do
-          now = Time.current
-          theft_alert.begin!(facebook_post_url: "https://facebook.com")
-        end
+        theft_alert.begin!(facebook_post_url: "https://facebook.com")
 
         expect(theft_alert.begin_at).to eq(now.beginning_of_day)
         expect(theft_alert.end_at).to eq(now.end_of_day + duration.days)

--- a/spec/models/theft_alert_spec.rb
+++ b/spec/models/theft_alert_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe TheftAlert, type: :model do
 
         theft_alert.begin!(facebook_post_url: "https://facebook.com")
 
-        expect(theft_alert.begin_at).to eq(now.beginning_of_day)
+        expect(theft_alert.begin_at).to be_within(5.seconds).of(now)
         expect(theft_alert.end_at).to eq(now.end_of_day + duration.days)
         expect(theft_alert.status).to eq("active")
       end

--- a/spec/models/theft_alert_spec.rb
+++ b/spec/models/theft_alert_spec.rb
@@ -1,6 +1,25 @@
 require "rails_helper"
 
 RSpec.describe TheftAlert, type: :model do
+  describe "factory" do
+    let(:theft_alert) { FactoryBot.build(:theft_alert) }
+    it "is valid" do
+      expect(theft_alert.save).to be_truthy
+    end
+    context "begun" do
+      let(:theft_alert) { FactoryBot.build(:theft_alert_begun) }
+      it "is valid" do
+        expect(theft_alert.save).to be_truthy
+      end
+    end
+    context "paid" do
+      let(:theft_alert) { FactoryBot.build(:theft_alert_paid) }
+      it "is valid" do
+        expect(theft_alert.save).to be_truthy
+        expect(theft_alert.payment).to be_present
+      end
+    end
+  end
   describe "#begin!" do
     context "given no facebook post url" do
       it "rejects the update, sets an error" do

--- a/spec/requests/admin/theft_alert_plans_request_spec.rb
+++ b/spec/requests/admin/theft_alert_plans_request_spec.rb
@@ -1,0 +1,107 @@
+require "rails_helper"
+
+RSpec.describe Admin::TheftAlertPlansController, type: :request do
+  context "given a logged-in superuser" do
+    before { log_in_as_superuser }
+
+    describe "GET /admin/theft_alert_plans" do
+      it "responds with 200 OK and renders the index template" do
+        plans = FactoryBot.create_list(:theft_alert_plan, 3)
+
+        get "/admin/theft_alert_plans"
+
+        expect(response).to be_ok
+        expect(response).to render_template(:index)
+        plans.each do |plan|
+          expect(response.body).to include(plan.name)
+        end
+      end
+    end
+
+    describe "GET /admin/theft_alert_plans/new" do
+      it "responds with 200 OK and renders the new template" do
+        get "/admin/theft_alert_plans/new"
+        expect(response).to be_ok
+        expect(response).to render_template(:new)
+      end
+    end
+
+    describe "POST /admin/theft_alert_plans" do
+      it "redirects to the index route on update success" do
+        expect(TheftAlertPlan.count).to eq(0)
+
+        post "/admin/theft_alert_plans",
+             theft_alert_plan: {
+               name: "New Plan",
+               amount_cents: 22_00,
+               views: 5_000,
+               duration_days: 7,
+             }
+
+        expect(TheftAlertPlan.count).to eq(1)
+        new_plan = TheftAlertPlan.first
+        expect(response).to redirect_to(edit_admin_theft_alert_plan_path(new_plan))
+        expect(flash[:errors]).to be_blank
+      end
+
+      it "re-renders the edit template with a flash on update failure" do
+        post "/admin/theft_alert_plans", theft_alert_plan: { amount_cents: 22_00 }
+        expect(response).to render_template(:new)
+        expect(flash[:errors]).to include("Name can't be blank")
+      end
+    end
+
+    describe "GET /admin/theft_alert_plans/:id/edit" do
+      it "responds with 200 OK and renders the edit template" do
+        plan = FactoryBot.create(:theft_alert_plan)
+
+        get "/admin/theft_alert_plans/#{plan.id}/edit"
+
+        expect(response).to be_ok
+        expect(response).to render_template(:edit)
+        expect(response.body).to include(plan.name)
+      end
+    end
+
+    describe "PATCH /admin/theft_alert_plans/:id" do
+      it "redirects to the index route on update success" do
+        plan = FactoryBot.create(:theft_alert_plan, name: "Old Name")
+
+        patch "/admin/theft_alert_plans/#{plan.id}",
+              theft_alert_plan: { name: "New Name" }
+
+        expect(response).to redirect_to(admin_theft_alert_plans_path)
+        expect(flash[:errors]).to be_blank
+        expect(plan.reload.name).to eq("New Name")
+      end
+
+      it "re-renders the edit template with a flash on update failure" do
+        plan = FactoryBot.create(:theft_alert_plan)
+
+        patch "/admin/theft_alert_plans/#{plan.id}",
+              theft_alert_plan: { name: "" }
+
+        expect(response).to be_ok
+        expect(response).to render_template(:edit)
+        expect(flash[:errors]).to include("Name can't be blank")
+      end
+    end
+  end
+
+  context "given a logged-in non-superuser" do
+    before { log_in }
+    it { expect(get("/admin/theft_alert_plans")).to eq(302) }
+    it { expect(get("/admin/theft_alert_plans/new")).to eq(302) }
+    it { expect(post("/admin/theft_alert_plans")).to eq(302) }
+    it { expect(get("/admin/theft_alert_plans/0/edit")).to eq(302) }
+    it { expect(patch("/admin/theft_alert_plans/0")).to eq(302) }
+  end
+
+  context "given a unauthenticated user" do
+    it { expect(get("/admin/theft_alert_plans")).to eq(302) }
+    it { expect(get("/admin/theft_alert_plans/new")).to eq(302) }
+    it { expect(post("/admin/theft_alert_plans")).to eq(302) }
+    it { expect(get("/admin/theft_alert_plans/0/edit")).to eq(302) }
+    it { expect(patch("/admin/theft_alert_plans/0")).to eq(302) }
+  end
+end

--- a/spec/requests/admin/theft_alerts_request_spec.rb
+++ b/spec/requests/admin/theft_alerts_request_spec.rb
@@ -1,0 +1,96 @@
+require "rails_helper"
+
+RSpec.describe Admin::TheftAlertsController, type: :request do
+  context "given a logged-in superuser" do
+    before { log_in_as_superuser }
+
+    describe "GET /admin/theft_alerts" do
+      it "responds with 200 OK and renders the index template" do
+        get "/admin/theft_alerts"
+        expect(response).to be_ok
+        expect(response).to render_template(:index)
+      end
+    end
+
+    describe "GET /admin/theft_alerts/:id/edit" do
+      context "given a valid state transition param" do
+        it "responds with 200 OK and renders the edit template" do
+          alert = FactoryBot.create(:theft_alert)
+
+          get "/admin/theft_alerts/#{alert.id}/edit", state_transition: :begin
+
+          expect(response.status).to eq(200)
+          expect(response).to render_template(:edit)
+        end
+      end
+
+      context "given no state transition param" do
+        it "redirects to the theft alert index page" do
+          alert = FactoryBot.create(:theft_alert)
+
+          get "/admin/theft_alerts/#{alert.id}/edit"
+
+          expect(response).to redirect_to(admin_theft_alerts_path)
+          expect(flash[:error]).to match(/invalid state/i)
+        end
+      end
+    end
+
+    describe "PATCH /admin/theft_alerts/:id" do
+      it "redirects to the index route on state transition success" do
+        alert = FactoryBot.create(:theft_alert)
+        expect(alert.status).to eq("pending")
+
+        patch "/admin/theft_alerts/#{alert.id}",
+              state_transition: "begin",
+              theft_alert: { facebook_post_url: "https://facebook.com/example/post/1" }
+
+        expect(response).to redirect_to(admin_theft_alerts_path)
+        expect(flash[:errors]).to be_blank
+        expect(alert.reload.status).to eq("active")
+
+        patch "/admin/theft_alerts/#{alert.id}",
+              state_transition: "end",
+              theft_alert: { status: true }
+
+        expect(response).to redirect_to(admin_theft_alerts_path)
+        expect(flash[:errors]).to be_blank
+        expect(alert.reload.status).to eq("inactive")
+
+        patch "/admin/theft_alerts/#{alert.id}",
+              state_transition: "reset",
+              theft_alert: { status: true }
+
+        expect(response).to redirect_to(admin_theft_alerts_path)
+        expect(flash[:errors]).to be_blank
+        expect(alert.reload.status).to eq("pending")
+      end
+
+      it "redirects to the edit template on update failure" do
+        alert = FactoryBot.create(:theft_alert, status: "pending")
+
+        patch "/admin/theft_alerts/#{alert.id}",
+              state_transition: "begin",
+              theft_alert: { facebook_post_url: "" }
+
+        expect(flash[:success]).to be_blank
+        expect(flash[:error]).to match(/must be a valid url/)
+        expect(response).to redirect_to(edit_admin_theft_alert_path(alert, params: { state_transition: :begin }))
+        expect(alert.reload.status).to eq("pending")
+      end
+    end
+  end
+
+  context "given a logged-in non-superuser" do
+    before { log_in }
+    it { expect(get("/admin/theft_alerts")).to eq(302) }
+    it { expect(get("/admin/theft_alerts/0/edit")).to eq(302) }
+    it { expect(patch("/admin/theft_alerts/0")).to eq(302) }
+  end
+
+  context "given a unauthenticated user" do
+    it { expect(get("/admin/theft_alerts")).to eq(302) }
+    it { expect(get("/admin/theft_alerts/0/edit")).to eq(302) }
+    it { expect(patch("/admin/theft_alerts/0")).to eq(302) }
+  end
+end

--- a/spec/requests/admin/theft_alerts_request_spec.rb
+++ b/spec/requests/admin/theft_alerts_request_spec.rb
@@ -74,7 +74,7 @@ RSpec.describe Admin::TheftAlertsController, type: :request do
               theft_alert: { facebook_post_url: "" }
 
         expect(flash[:success]).to be_blank
-        expect(flash[:error]).to match(/must be a valid url/)
+        expect(flash[:error]).to include("Facebook post url must be a valid url")
         expect(response).to redirect_to(edit_admin_theft_alert_path(alert, params: { state_transition: :begin }))
         expect(alert.reload.status).to eq("pending")
       end


### PR DESCRIPTION
- Adds `TheftAlert` and `TheftAlertPlan` models (with a temporary seed method on the latter)
- Adds admin pages to manage these

<img width="1265" alt="Screen Shot 2019-06-19 at 12 24 38 PM" src="https://user-images.githubusercontent.com/4433943/59784201-e3b85d80-928f-11e9-9df4-54d27620f3f4.png">
<img width="1264" alt="Screen Shot 2019-06-19 at 12 24 50 PM" src="https://user-images.githubusercontent.com/4433943/59784202-e3b85d80-928f-11e9-97fc-b7cf7eca0d5d.png">


Extracted from #915 to reduce diff size