### PR TITLE
Fix TZ bug in counts_spec

### DIFF
--- a/spec/models/counts_spec.rb
+++ b/spec/models/counts_spec.rb
@@ -13,6 +13,7 @@ RSpec.describe Counts, type: :model do
   end
 
   context "week_creation_chart" do
+    # TODO: This is failing locally
     let!(:bike) { FactoryBot.create(:bike) }
     let!(:bike_first) { FactoryBot.create(:bike, created_at: (Time.current - 6.days).beginning_of_day + 1.minute) }
     let(:target) do

--- a/spec/models/counts_spec.rb
+++ b/spec/models/counts_spec.rb
@@ -13,18 +13,17 @@ RSpec.describe Counts, type: :model do
   end
 
   context "week_creation_chart" do
-    # TODO: This is failing locally
     let!(:bike) { FactoryBot.create(:bike) }
     let!(:bike_first) { FactoryBot.create(:bike, created_at: (Time.current - 6.days).beginning_of_day + 1.minute) }
     let(:target) do
       {
-        (Date.today - 6.days).to_s => 1,
-        (Date.today - 5.days).to_s => 0,
-        (Date.today - 4.days).to_s => 0,
-        (Date.today - 3.days).to_s => 0,
-        (Date.today - 2.days).to_s => 0,
-        (Date.today - 1.days).to_s => 0,
-        Date.today.to_s => 1,
+        (Date.current - 6.days).to_s => 1,
+        (Date.current - 5.days).to_s => 0,
+        (Date.current - 4.days).to_s => 0,
+        (Date.current - 3.days).to_s => 0,
+        (Date.current - 2.days).to_s => 0,
+        (Date.current - 1.days).to_s => 0,
+        Date.current.to_s => 1,
       }
     end
     it "saves the thing" do


### PR DESCRIPTION
```
1) Counts week_creation_chart saves the thing
   Failure/Error: expect(Counts.week_creation_chart).to eq target

     expected: {"2019-06-14"=>1, "2019-06-15"=>0, "2019-06-16"=>0, "2019-06-17"=>0, "2019-06-18"=>0, "2019-06-19"=>0, "2019-06-20"=>1}
          got: {"2019-06-13"=>1, "2019-06-14"=>0, "2019-06-15"=>0, "2019-06-16"=>0, "2019-06-17"=>0, "2019-06-18"=>0, "2019-06-19"=>1}

     (compared using ==)

     Diff:

       @@ -1,8 +1,8 @@
       -"2019-06-14" => 1,
       +"2019-06-13" => 1,
       +"2019-06-14" => 0,
        "2019-06-15" => 0,
        "2019-06-16" => 0,
        "2019-06-17" => 0,
        "2019-06-18" => 0,
       -"2019-06-19" => 0,
       -"2019-06-20" => 1,
       +"2019-06-19" => 1,

   # ./spec/models/counts_spec.rb:33:in `block (3 levels) in <top (required)>'
   # -e:1:in `<main>'
```