### PR TITLE
Add additional lookups for bike codes

### DIFF
--- a/app/models/bike_code.rb
+++ b/app/models/bike_code.rb
@@ -97,7 +97,7 @@ class BikeCode < ActiveRecord::Base
   end
 
   def pretty_code
-    [code_prefix, code_integer.to_s.scan(/.{1,3}/)]
+    [code_prefix, code_number_string.scan(/.{1,3}/)]
       .flatten.compact.join(" ")
   end
 
@@ -154,5 +154,13 @@ class BikeCode < ActiveRecord::Base
     self.code = self.class.normalize_code(code)
     self.code_integer = self.class.calculated_code_integer(code)
     self.code_prefix = self.class.calculated_code_prefix(code)
+  end
+
+  private
+
+  def code_number_string
+    str = code_integer.to_s
+    return str unless bike_code_batch&.code_number_length.present?
+    str.rjust(bike_code_batch.code_number_length, "0")
   end
 end

--- a/app/models/bike_code.rb
+++ b/app/models/bike_code.rb
@@ -29,6 +29,10 @@ class BikeCode < ActiveRecord::Base
     code.gsub(/\A0*/, "") # Strip leading 0s, because we don't care about them
   end
 
+  def self.calculated_code_integer(str); str.present? ? str.gsub(/\A\D+/, "").to_i : nil end
+
+  def self.calculated_code_prefix(str); str.present? ? str.gsub(/\d+\z/, "") : nil end
+
   # organization_id can be any organization identifier (name, slug, id)
   # generally don't pass in normalized_code
   def self.lookup(str, organization_id: nil)
@@ -78,6 +82,11 @@ class BikeCode < ActiveRecord::Base
 
   def next_unclaimed_code
     BikeCode.where(organization_id: organization_id).next_unclaimed_code(id)
+  end
+
+  def pretty_code
+    [code_prefix, code_integer.to_s.scan(/.{1,3}/)]
+      .flatten.compact.join(" ")
   end
 
   def claimable_by?(user)
@@ -131,5 +140,7 @@ class BikeCode < ActiveRecord::Base
 
   def set_calculated_attributes
     self.code = self.class.normalize_code(code)
+    self.code_integer = self.class.calculated_code_integer(code)
+    self.code_prefix = self.class.calculated_code_prefix(code)
   end
 end

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -72,6 +72,7 @@ class Organization < ActiveRecord::Base
 
   def self.friendly_find(n)
     return nil unless n.present?
+    return n if n.is_a?(Organization)
     return find(n) if integer_slug?(n)
     slug = Slugifyer.slugify(n)
     # First try slug, then previous slug, and finally, just give finding by name a shot

--- a/db/migrate/20190620203854_add_code_integer_and_prefix_to_bike_codes.rb
+++ b/db/migrate/20190620203854_add_code_integer_and_prefix_to_bike_codes.rb
@@ -2,5 +2,6 @@ class AddCodeIntegerAndPrefixToBikeCodes < ActiveRecord::Migration
   def change
     add_column :bike_codes, :code_integer, :integer
     add_column :bike_codes, :code_prefix, :string
+    add_column :bike_code_batches, :code_number_length, :integer
   end
 end

--- a/db/migrate/20190620203854_add_code_integer_and_prefix_to_bike_codes.rb
+++ b/db/migrate/20190620203854_add_code_integer_and_prefix_to_bike_codes.rb
@@ -1,0 +1,6 @@
+class AddCodeIntegerAndPrefixToBikeCodes < ActiveRecord::Migration
+  def change
+    add_column :bike_codes, :code_integer, :integer
+    add_column :bike_codes, :code_prefix, :string
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -201,7 +201,8 @@ CREATE TABLE public.bike_code_batches (
     organization_id integer,
     notes text,
     created_at timestamp without time zone NOT NULL,
-    updated_at timestamp without time zone NOT NULL
+    updated_at timestamp without time zone NOT NULL,
+    code_number_length integer
 );
 
 

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -2,8 +2,8 @@
 -- PostgreSQL database dump
 --
 
--- Dumped from database version 11.3
--- Dumped by pg_dump version 11.3
+-- Dumped from database version 10.3
+-- Dumped by pg_dump version 10.3
 
 SET statement_timeout = 0;
 SET lock_timeout = 0;
@@ -12,9 +12,22 @@ SET client_encoding = 'UTF8';
 SET standard_conforming_strings = on;
 SELECT pg_catalog.set_config('search_path', '', false);
 SET check_function_bodies = false;
-SET xmloption = content;
 SET client_min_messages = warning;
 SET row_security = off;
+
+--
+-- Name: plpgsql; Type: EXTENSION; Schema: -; Owner: -
+--
+
+CREATE EXTENSION IF NOT EXISTS plpgsql WITH SCHEMA pg_catalog;
+
+
+--
+-- Name: EXTENSION plpgsql; Type: COMMENT; Schema: -; Owner: -
+--
+
+COMMENT ON EXTENSION plpgsql IS 'PL/pgSQL procedural language';
+
 
 --
 -- Name: fuzzystrmatch; Type: EXTENSION; Schema: -; Owner: -
@@ -226,7 +239,9 @@ CREATE TABLE public.bike_codes (
     updated_at timestamp without time zone NOT NULL,
     claimed_at timestamp without time zone,
     previous_bike_id integer,
-    bike_code_batch_id integer
+    bike_code_batch_id integer,
+    code_integer integer,
+    code_prefix character varying
 );
 
 
@@ -259,7 +274,8 @@ CREATE TABLE public.bike_organizations (
     organization_id integer,
     created_at timestamp without time zone NOT NULL,
     updated_at timestamp without time zone NOT NULL,
-    deleted_at timestamp without time zone
+    deleted_at timestamp without time zone,
+    unable_to_edit_claimed boolean DEFAULT false NOT NULL
 );
 
 
@@ -830,7 +846,6 @@ CREATE TABLE public.flipper_features (
 --
 
 CREATE SEQUENCE public.flipper_features_id_seq
-    AS integer
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -864,7 +879,6 @@ CREATE TABLE public.flipper_gates (
 --
 
 CREATE SEQUENCE public.flipper_gates_id_seq
-    AS integer
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -1867,7 +1881,7 @@ ALTER SEQUENCE public.recovery_displays_id_seq OWNED BY public.recovery_displays
 --
 
 CREATE TABLE public.schema_migrations (
-    version character varying NOT NULL
+    version character varying(255) NOT NULL
 );
 
 
@@ -4409,4 +4423,8 @@ INSERT INTO schema_migrations (version) VALUES ('20190617174200');
 INSERT INTO schema_migrations (version) VALUES ('20190617193251');
 
 INSERT INTO schema_migrations (version) VALUES ('20190617193255');
+
+INSERT INTO schema_migrations (version) VALUES ('20190619202656');
+
+INSERT INTO schema_migrations (version) VALUES ('20190620203854');
 

--- a/spec/controllers/bikes_controller_spec.rb
+++ b/spec/controllers/bikes_controller_spec.rb
@@ -265,10 +265,10 @@ RSpec.describe BikesController, type: :controller do
 
   describe "scanned" do
     let(:bike) { FactoryBot.create(:bike) }
-    let!(:bike_code) { FactoryBot.create(:bike_code, bike: bike, code: 900) }
+    let!(:bike_code) { FactoryBot.create(:bike_code, bike: bike, code: "D900") }
     let(:organization) { FactoryBot.create(:organization) }
     context "organized no bike" do
-      let!(:bike_code2) { FactoryBot.create(:bike_code, organization: organization, code: "0900") }
+      let!(:bike_code2) { FactoryBot.create(:bike_code, organization: organization, code: "D0900") }
       let!(:user) { FactoryBot.create(:user_confirmed) }
       before { set_current_user(user) }
       it "renders the scanned page" do
@@ -282,7 +282,7 @@ RSpec.describe BikesController, type: :controller do
       context "user part of organization" do
         let!(:user) { FactoryBot.create(:organization_member, organization: organization) }
         it "makes current_organization the organization" do
-          get :scanned, id: "000#{bike_code2.code}", organization_id: organization.to_param
+          get :scanned, id: "D0900", organization_id: organization.to_param
           expect(assigns(:bike_code)).to eq bike_code2
           expect(session[:passive_organization_id]).to eq organization.id
           expect(response).to redirect_to organization_bikes_path(organization_id: organization.to_param, bike_code: bike_code2.code)
@@ -292,7 +292,7 @@ RSpec.describe BikesController, type: :controller do
           it "makes current_organization the organization" do
             expect(user.memberships&.pluck(:organization_id)).to eq([organization.id])
             expect(bike_code2.organization).to eq organization
-            get :scanned, id: "000#{bike_code2.code}", organization_id: "BikeIndex"
+            get :scanned, id: "D900", organization_id: "BikeIndex"
             expect(assigns(:bike_code)).to eq bike_code2
             expect(session[:passive_organization_id]).to eq organization.id
             expect(response).to redirect_to organization_bikes_path(organization_id: organization.to_param, bike_code: bike_code2.code)

--- a/spec/models/bike_code_spec.rb
+++ b/spec/models/bike_code_spec.rb
@@ -62,6 +62,18 @@ RSpec.describe BikeCode, type: :model do
     end
   end
 
+  describe "lookup with split ups" do
+    let!(:bike_code1) { FactoryBot.create(:bike_code, code: "A0010") }
+    let!(:bike_code2) { FactoryBot.create(:bike_code, code: "A00100") }
+    it "finds the expected bike_codes" do
+      expect(BikeCode.lookup_with_fallback("A10")).to eq bike_code1
+      expect(BikeCode.lookup_with_fallback("A 00 10")).to eq bike_code1
+      expect(BikeCode.lookup_with_fallback("A 000 10")).to eq bike_code1
+      expect(BikeCode.lookup_with_fallback("A0 00 100")).to eq bike_code2
+      expect(BikeCode.lookup_with_fallback("A 100")).to eq bike_code2
+    end
+  end
+
   describe "duplication and integers" do
     let(:organization) { FactoryBot.create(:organization) }
     let!(:sticker) { FactoryBot.create(:bike_code, kind: "sticker", code: 12, organization_id: organization.id) }

--- a/spec/models/bike_code_spec.rb
+++ b/spec/models/bike_code_spec.rb
@@ -60,6 +60,15 @@ RSpec.describe BikeCode, type: :model do
         expect(bike_code.pretty_code).to eq("A 0")
       end
     end
+    context "bike_code_batch has a set length" do
+      let(:bike_code) { BikeCode.new(code: "A001", bike_code_batch_id: bike_code_batch.id) }
+      let(:bike_code2) { FactoryBot.create(:bike_code, code: "A102", bike_code_batch_id: bike_code_batch.id) }
+      let(:bike_code_batch) { FactoryBot.create(:bike_code_batch, code_number_length: 5) }
+      it "renders the pretty print from the batch length" do
+        expect(bike_code.pretty_code).to eq "A 000 01"
+        expect(bike_code2.pretty_code).to eq "A 001 02"
+      end
+    end
   end
 
   describe "lookup_with_fallback" do

--- a/spec/models/bike_code_spec.rb
+++ b/spec/models/bike_code_spec.rb
@@ -68,7 +68,7 @@ RSpec.describe BikeCode, type: :model do
     let!(:bike_code) { FactoryBot.create(:bike_code, code: "a0010", organization: organization2) }
     let(:bike_code_duplicate) { FactoryBot.create(:bike_code, code: "a0010", organization: organization1) }
     let!(:user) { FactoryBot.create(:organization_member, organization: organization2) }
-    xit "looks up, falling back to the orgs for the user, falling back to any org" do
+    it "looks up, falling back to the orgs for the user, falling back to any org" do
       expect(BikeCode.lookup_with_fallback("a0010", organization_id: "bikeindex")).to eq bike_code
       expect(BikeCode.lookup_with_fallback("0010", organization_id: "bikeindex")).to eq bike_code
       # It finds the bike_code that exists, even though it doesn't match the organization passed

--- a/spec/models/organization_spec.rb
+++ b/spec/models/organization_spec.rb
@@ -117,6 +117,7 @@ RSpec.describe Organization, type: :model do
       expect(Organization.friendly_find("bike shop")).to eq organization2
       expect(Organization.friendly_find("trek store of SANTA CRUZ")).to eq organization2
       expect(Organization.friendly_find("bikeeastbay")).to eq organization3
+      expect(Organization.friendly_find(organization)).to eq organization
     end
   end
 


### PR DESCRIPTION
After shipping this and updating all the existing stickers, we're going to remove the `code` column (or calculate it from `pretty_code`)