### PR TITLE
Require accepting vendor terms for organization view

### DIFF
--- a/app/assets/stylesheets/revised/sections/legal.scss
+++ b/app/assets/stylesheets/revised/sections/legal.scss
@@ -56,6 +56,7 @@
     text-align: center;
     padding-top: $vertical-height;
     margin-bottom: 0;
+    cursor: pointer;
   }
 }
 

--- a/app/controllers/concerns/sessionable.rb
+++ b/app/controllers/concerns/sessionable.rb
@@ -10,7 +10,7 @@ module Sessionable
     if current_user.present?
       return if return_to_if_present # If this returns true, we're returning already
       flash[:success] = "You're already signed in!"
-      redirect_to user_home_url and return
+      redirect_to user_root_url and return
     end
   end
 

--- a/app/controllers/organized/base_controller.rb
+++ b/app/controllers/organized/base_controller.rb
@@ -15,10 +15,14 @@ module Organized
     end
 
     def ensure_member!
-      return true if current_user && current_user.member_of?(current_organization)
+      if current_user && current_user.member_of?(current_organization)
+        return true if current_user.accepted_vendor_terms_of_service?
+        flash[:success] = "Please accept the terms of service for organizations"
+        redirect_to accept_vendor_terms_path and return
+      end
       set_passive_organization(nil) # remove the active organization, because it failed so don't show it anymore
       flash[:error] = "You're not a member of that organization!"
-      redirect_to user_home_url(subdomain: false) and return
+      redirect_to user_root_url and return
     end
 
     def ensure_admin!

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -128,7 +128,7 @@ class UsersController < ApplicationController
         end
       elsif params[:user][:vendor_terms_of_service].present?
         if params[:user][:vendor_terms_of_service] == "1"
-          @user.accept_vendor_terms_of_service
+          @user.update_attributes(accepted_vendor_terms_of_service: true)
           if @user.memberships.any?
             flash[:success] = "Thanks! Now you can use Bike Index as #{@user.memberships.first.organization.name}"
           else
@@ -136,7 +136,7 @@ class UsersController < ApplicationController
           end
           redirect_to user_root_url and return
         else
-          redirect_to accept_vendor_terms_url, notice: "You have to accept the Terms of Service if you would like to use Bike Index through an organization" and return
+          redirect_to accept_vendor_terms_path, notice: "You have to accept the Terms of Service if you would like to use Bike Index through an organization" and return
         end
       end
       if params[:user][:password].present?

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -124,7 +124,7 @@ class UsersController < ApplicationController
           redirect_to user_home_url and return
         else
           flash[:notice] = "You have to accept the Terms of Service if you would like to use Bike Index"
-          redirect_to accept_vendor_terms_url and return
+          redirect_to accept_terms_url and return
         end
       elsif params[:user][:vendor_terms_of_service].present?
         if params[:user][:vendor_terms_of_service] == "1"
@@ -134,11 +134,9 @@ class UsersController < ApplicationController
           else
             flash[:success] = "Thanks for accepting the terms of service!"
           end
-          redirect_to user_home_url and return
-          # TODO: Redirect to the correct page, somehow this breaks things right now though.
-          # redirect_to organization_home and return
+          redirect_to user_root_url and return
         else
-          redirect_to accept_vendor_terms_url, notice: "You have to accept the Terms of Service if you would like to use Bike Index as through the organization" and return
+          redirect_to accept_vendor_terms_url, notice: "You have to accept the Terms of Service if you would like to use Bike Index through an organization" and return
         end
       end
       if params[:user][:password].present?

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -175,10 +175,16 @@ class User < ActiveRecord::Base
     self.save
   end
 
-  def accept_vendor_terms_of_service
-    self.vendor_terms_of_service = true
-    self.when_vendor_terms_of_service = DateTime.current
-    save
+  def accepted_vendor_terms_of_service?
+    vendor_terms_of_service
+  end
+
+  def accepted_vendor_terms_of_service=(val)
+    if ActiveRecord::Type::Boolean.new.type_cast_from_database(val)
+      self.vendor_terms_of_service = true
+      self.when_vendor_terms_of_service = Time.current
+    end
+    true
   end
 
   def send_password_reset_email

--- a/app/views/layouts/new_admin.html.haml
+++ b/app/views/layouts/new_admin.html.haml
@@ -37,6 +37,11 @@
                 = link_to "Customer", '/rails/mailers/customer_mailer' , role: "button", class: "btn btn-light dropdown-item"
         :ruby
           other_links = [
+                          { title: "Users", path: admin_users_path, match_controller: true },
+                          { title: "Bikes", path: admin_bikes_path, match_controller: true },
+                          { title: "Stolen Bikes", path: admin_stolen_bikes_path, match_controller: true },
+                          { title: "Organizations", path: admin_organizations_path, match_controller: true },
+                          { title: "News", path: admin_news_index_path, match_controller: true },
                           { title: "POS Integration", path: lightspeed_interface_path, match_controller: false },
                           { title: "Ambassador Activities", path: admin_ambassador_tasks_path, match_controller: true },
                           { title: "Completed Ambassador Activities", path: admin_ambassador_task_assignments_path, match_controller: true },
@@ -65,11 +70,6 @@
                           { title: "Bulk Imports", path: admin_bulk_imports_path, match_controller: true },
                           { title: "Partial Bikes", path: admin_partial_bikes_path, match_controller: true },
                           { title: "Duplicate Bikes", path: duplicates_admin_bikes_path, match_controller: false },
-                          { title: "Users", path: admin_users_path, match_controller: true },
-                          { title: "Bikes", path: admin_bikes_path, match_controller: true },
-                          { title: "Stolen Bikes", path: admin_stolen_bikes_path, match_controller: true },
-                          { title: "Organizations", path: admin_organizations_path, match_controller: true },
-                          { title: "News", path: admin_news_index_path, match_controller: true },
                           { title: "Exit Admin", path: root_path, match_controller: false },
                         ]
           other_link_active = other_links.detect { |l| current_page_active?(l[:path], l[:match_controller]) }

--- a/app/views/users/accept_terms.html.haml
+++ b/app/views/users/accept_terms.html.haml
@@ -10,7 +10,7 @@
     = form_for @user, html: { class: 'form' } do |f|
 
       .form-group
-        %label{ for: 'user_terms_of_service', class: 'center-accept-terms-text' }
+        = f.label :terms_of_service, class: "center-accept-terms-text" do
           = f.check_box :terms_of_service
           I agree to Bike Index
           %strong

--- a/app/views/users/accept_vendor_terms.html.haml
+++ b/app/views/users/accept_vendor_terms.html.haml
@@ -6,16 +6,13 @@
 .accept-vendor-terms
 
   = form_for @user do |f|
-    
-    .form-horizontal
+
+    .form-group
       .control-group
-        %label
-          .control-label
-            = f.check_box :vendor_terms_of_service
-          .controls
-            I agree to Bike Index 
-            %strong
-              Terms of Service for Vendors.
+        = f.label :vendor_terms_of_service, class: "center-accept-terms-text" do
+          = f.check_box :vendor_terms_of_service
+          I agree to Bike Index
+          %strong
+            Terms of Service for Organizations.
     .agree-action
-      .control-group
-        = f.submit "Submit", class: 'button-blue'
+      = f.submit "Submit", class: "btn btn-primary btn-lg center-accept-terms-button"

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -571,11 +571,14 @@ RSpec.describe UsersController, type: :controller do
     it "updates the vendor terms of service and emailable" do
       user = FactoryBot.create(:user_confirmed, terms_of_service: false, notification_newsletters: false)
       expect(user.notification_newsletters).to be_falsey
-      org = FactoryBot.create(:organization)
-      FactoryBot.create(:membership, organization: org, user: user)
+      organization = FactoryBot.create(:organization)
+      FactoryBot.create(:membership, organization: organization, user: user)
+      user.reload
+      expect(user.default_organization).to eq organization
       set_current_user(user)
       post :update, id: user.username, user: { vendor_terms_of_service: "1", notification_newsletters: true }
       expect(response.code).to eq("302")
+      expect(response).to redirect_to organization_root_url(organization_id: organization.to_param)
       expect(user.reload.vendor_terms_of_service).to be_truthy
       expect(user.notification_newsletters).to be_truthy
     end
@@ -587,7 +590,27 @@ RSpec.describe UsersController, type: :controller do
       end.to change(AfterUserChangeWorker.jobs, :size).by(1)
       expect(user.reload.name).to eq("Cool stuff")
     end
+
+    describe "submit without updating terms" do
+      it "redirects to accept the terms" do
+        set_current_user(user)
+        post :update, id: user.username, user: { terms_of_service: "0" }
+        expect(response).to redirect_to accept_terms_path
+        expect(user.reload.terms_of_service).to be_falsey
+      end
+      context "vendor_terms" do
+        let(:user) { FactoryBot.create(:user) }
+        it "redirects to accept the terms" do
+          expect(user.terms_of_service).to be_truthy
+          expect(user.vendor_terms_of_service).to be_truthy
+          set_current_user(user)
+          post :update, id: user.username, user: { vendor_terms_of_service: "0" }
+          expect(response).to redirect_to accept_vendor_terms_path
+        end
+      end
+    end
   end
+
   describe "unsubscribe" do
     context "subscribed unconfirmed user" do
       let(:user) { FactoryBot.create(:user, notification_newsletters: true) }

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -579,7 +579,8 @@ RSpec.describe UsersController, type: :controller do
       post :update, id: user.username, user: { vendor_terms_of_service: "1", notification_newsletters: true }
       expect(response.code).to eq("302")
       expect(response).to redirect_to organization_root_url(organization_id: organization.to_param)
-      expect(user.reload.vendor_terms_of_service).to be_truthy
+      expect(user.reload.accepted_vendor_terms_of_service?).to be_truthy
+      expect(user.when_vendor_terms_of_service).to be_within(1.second).of Time.current
       expect(user.notification_newsletters).to be_truthy
     end
 

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -600,13 +600,14 @@ RSpec.describe UsersController, type: :controller do
         expect(user.reload.terms_of_service).to be_falsey
       end
       context "vendor_terms" do
-        let(:user) { FactoryBot.create(:user) }
+        let(:user) { FactoryBot.create(:user_confirmed) }
         it "redirects to accept the terms" do
           expect(user.terms_of_service).to be_truthy
-          expect(user.vendor_terms_of_service).to be_truthy
+          expect(user.accepted_vendor_terms_of_service?).to be_falsey
           set_current_user(user)
           post :update, id: user.username, user: { vendor_terms_of_service: "0" }
           expect(response).to redirect_to accept_vendor_terms_path
+          expect(user.reload.vendor_terms_of_service).to be_falsey
         end
       end
     end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -11,6 +11,7 @@ FactoryBot.define do
         partner_data { { sign_up: "bikehub" } }
       end
       factory :admin do
+        accepted_vendor_terms_of_service { true }
         superuser { true }
         factory :admin_developer do
           developer { true }
@@ -25,6 +26,9 @@ FactoryBot.define do
         transient do
           organization { FactoryBot.create(:organization) }
         end
+
+        accepted_vendor_terms_of_service { true } # Necessary so everyone doesn't redirect back accept_vendor_terms
+
         factory :organization_member do
           after(:create) do |user, evaluator|
             FactoryBot.create(:membership, user: user, organization: evaluator.organization)

--- a/spec/requests/admin/invoices_request_spec.rb
+++ b/spec/requests/admin/invoices_request_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 RSpec.describe Admin::InvoicesController, type: :request do
   context "given a logged-in superuser" do
-    before { log_in_as_superuser }
+    include_context :request_spec_logged_in_as_superuser
 
     describe "GET /admin/invoices" do
       it "responds with 200 OK and renders the index template" do

--- a/spec/requests/admin/theft_alert_plans_request_spec.rb
+++ b/spec/requests/admin/theft_alert_plans_request_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 RSpec.describe Admin::TheftAlertPlansController, type: :request do
   context "given a logged-in superuser" do
-    before { log_in_as_superuser }
+    include_context :request_spec_logged_in_as_superuser
 
     describe "GET /admin/theft_alert_plans" do
       it "responds with 200 OK and renders the index template" do

--- a/spec/requests/admin/theft_alerts_request_spec.rb
+++ b/spec/requests/admin/theft_alerts_request_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 RSpec.describe Admin::TheftAlertsController, type: :request do
   context "given a logged-in superuser" do
-    before { log_in_as_superuser }
+    include_context :request_spec_logged_in_as_superuser
 
     describe "GET /admin/theft_alerts" do
       it "responds with 200 OK and renders the index template" do

--- a/spec/requests/organized/ambassador_dashboards_request_spec.rb
+++ b/spec/requests/organized/ambassador_dashboards_request_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Organized::AmbassadorDashboardsController, type: :request do
     describe "index" do
       it "redirects to the user homepage" do
         get organization_ambassador_dashboard_path(organization)
-        expect(response).to redirect_to(/user_home/)
+        expect(response).to redirect_to root_url
       end
     end
   end

--- a/spec/requests/organized/ambassador_dashboards_request_spec.rb
+++ b/spec/requests/organized/ambassador_dashboards_request_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Organized::AmbassadorDashboardsController, type: :request do
   context "given an unauthenticated user" do
     describe "index" do
       it "redirects to the user homepage" do
-        get organization_ambassador_dashboard_path(organization)
+        get organization_ambassador_dashboard_path(current_organization)
         expect(response).to redirect_to root_url
       end
     end
@@ -14,7 +14,7 @@ RSpec.describe Organized::AmbassadorDashboardsController, type: :request do
 
   context "given an authenticated non-ambassador" do
     include_context :request_spec_logged_in_as_user
-    let(:organization) { FactoryBot.create(:organization) }
+    let(:current_organization) { FactoryBot.create(:organization) }
     let(:current_user) { FactoryBot.create(:organization_member, organization: current_organization) }
     describe "index" do
       it "redirects to organization root path" do
@@ -33,7 +33,7 @@ RSpec.describe Organized::AmbassadorDashboardsController, type: :request do
         FactoryBot.create_list(:ambassador_task, 2)
         FactoryBot.create_list(:ambassador, 2, organization: current_organization)
 
-        get organization_ambassador_dashboard_path(organization)
+        get organization_ambassador_dashboard_path(current_organization)
 
         expect(response.status).to eq(200)
         expect(assigns(:ambassadors).count).to eq(3)

--- a/spec/requests/organized/ambassador_dashboards_request_spec.rb
+++ b/spec/requests/organized/ambassador_dashboards_request_spec.rb
@@ -1,9 +1,7 @@
 require "rails_helper"
 
 RSpec.describe Organized::AmbassadorDashboardsController, type: :request do
-  # Request specs don't have cookies so we need to stub stuff if we're in request specs
-  # This is suboptimal, but hey, it gets us to request specs for now
-  before { allow(User).to receive(:from_auth) { user } }
+  include_context :logged_in_as_ambassador
   let(:organization) { FactoryBot.create(:organization_ambassador) }
 
   context "given an unauthenticated user" do
@@ -41,6 +39,13 @@ RSpec.describe Organized::AmbassadorDashboardsController, type: :request do
         expect(response.status).to eq(200)
         expect(assigns(:ambassadors).count).to eq(3)
         expect(response).to render_template(:show)
+      end
+      context "has not accepted vendor terms" do
+        let(:user) { FactoryBot.create(:ambassador, accept_vendor_terms_of_service: false) }
+        it "redirects to accept the terms" do
+          get "/o/#{organization.slug}/ambassador_dashboard"
+          expect(response).to redirect_to accept_vendor_terms_path
+        end
       end
     end
 

--- a/spec/requests/organized/ambassador_dashboards_request_spec.rb
+++ b/spec/requests/organized/ambassador_dashboards_request_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 RSpec.describe Organized::AmbassadorDashboardsController, type: :request do
-  let(:organization) { FactoryBot.create(:organization_ambassador) }
+  let(:current_organization) { FactoryBot.create(:organization_ambassador) }
 
   context "given an unauthenticated user" do
     describe "index" do
@@ -15,13 +15,13 @@ RSpec.describe Organized::AmbassadorDashboardsController, type: :request do
   context "given an authenticated non-ambassador" do
     include_context :request_spec_logged_in_as_user
     let(:organization) { FactoryBot.create(:organization) }
-    let(:user) { FactoryBot.create(:organization_member, organization: organization) }
+    let(:current_user) { FactoryBot.create(:organization_member, organization: current_organization) }
     describe "index" do
       it "redirects to organization root path" do
-        user.reload
-        expect(user.default_organization).to be_present
-        get organization_ambassador_dashboard_path(organization)
-        expect(response).to redirect_to organization_root_path(organization_id: organization)
+        current_user.reload
+        expect(current_user.default_organization).to be_present
+        get organization_ambassador_dashboard_path(current_organization)
+        expect(response).to redirect_to organization_root_path(organization_id: current_organization)
       end
     end
   end
@@ -31,7 +31,7 @@ RSpec.describe Organized::AmbassadorDashboardsController, type: :request do
     describe "show" do
       it "renders the ambassador dashboard" do
         FactoryBot.create_list(:ambassador_task, 2)
-        FactoryBot.create_list(:ambassador, 2, organization: organization)
+        FactoryBot.create_list(:ambassador, 2, organization: current_organization)
 
         get organization_ambassador_dashboard_path(organization)
 
@@ -40,9 +40,9 @@ RSpec.describe Organized::AmbassadorDashboardsController, type: :request do
         expect(response).to render_template(:show)
       end
       context "has not accepted vendor terms" do
-        let(:user) { FactoryBot.create(:ambassador, vendor_terms_of_service: false, organization: organization) }
+        let(:current_user) { FactoryBot.create(:ambassador, vendor_terms_of_service: false, organization: current_organization) }
         it "redirects to accept the terms" do
-          get "/o/#{organization.slug}/ambassador_dashboard"
+          get "/o/#{current_organization.slug}/ambassador_dashboard"
           expect(response).to redirect_to accept_vendor_terms_path
         end
       end
@@ -50,7 +50,7 @@ RSpec.describe Organized::AmbassadorDashboardsController, type: :request do
 
     describe "resources" do
       it "renders the ambassador resources" do
-        get resources_organization_ambassador_dashboard_path(organization)
+        get resources_organization_ambassador_dashboard_path(current_organization)
         expect(response.status).to eq(200)
         expect(response).to render_template(:resources)
       end
@@ -58,7 +58,7 @@ RSpec.describe Organized::AmbassadorDashboardsController, type: :request do
 
     describe "getting_started" do
       it "renders the ambassador resources" do
-        get getting_started_organization_ambassador_dashboard_path(organization)
+        get getting_started_organization_ambassador_dashboard_path(current_organization)
         expect(response.status).to eq(200)
         expect(response).to render_template(:getting_started)
       end
@@ -71,9 +71,9 @@ RSpec.describe Organized::AmbassadorDashboardsController, type: :request do
     describe "show" do
       it "renders the ambassador dashboard with ambassadors list" do
         FactoryBot.create_list(:ambassador_task, 2)
-        FactoryBot.create_list(:ambassador, 2, organization: organization)
+        FactoryBot.create_list(:ambassador, 2, organization: current_organization)
 
-        get organization_ambassador_dashboard_path(organization)
+        get organization_ambassador_dashboard_path(current_organization)
 
         expect(response.status).to eq(200)
         expect(assigns(:ambassadors).count).to eq(2)
@@ -85,7 +85,7 @@ RSpec.describe Organized::AmbassadorDashboardsController, type: :request do
 
     describe "resources" do
       it "renders the ambassador resources template" do
-        get resources_organization_ambassador_dashboard_path(organization)
+        get resources_organization_ambassador_dashboard_path(current_organization)
         expect(response.status).to eq(200)
         expect(response).to render_template(:resources)
       end
@@ -93,7 +93,7 @@ RSpec.describe Organized::AmbassadorDashboardsController, type: :request do
 
     describe "getting_started" do
       it "renders the ambassador getting started template" do
-        get getting_started_organization_ambassador_dashboard_path(organization)
+        get getting_started_organization_ambassador_dashboard_path(current_organization)
         expect(response.status).to eq(200)
         expect(response).to render_template(:getting_started)
       end

--- a/spec/requests/theft_alerts_request_spec.rb
+++ b/spec/requests/theft_alerts_request_spec.rb
@@ -4,9 +4,10 @@ RSpec.describe TheftAlertsController, type: :request, vcr: true do
   describe "POST /bikes/:bike_id/theft_alerts" do
     let(:theft_alert_plan) { FactoryBot.create(:theft_alert_plan) }
     let(:bike) { FactoryBot.create(:ownership_stolen).bike }
+    let(:current_user) { bike.owner }
 
     before do
-      log_in bike.owner
+      log_in current_user
       expect(Payment.count).to eq(0)
       expect(TheftAlert.count).to eq(0)
     end

--- a/spec/support/controller_spec_helpers.rb
+++ b/spec/support/controller_spec_helpers.rb
@@ -17,24 +17,24 @@ module ControllerSpecHelpers
   end
 
   RSpec.shared_context :logged_in_as_organization_admin do
-    let(:user) { FactoryBot.create(:organization_admin) }
-    let(:organization) { user.organizations.first }
+    let(:user) { FactoryBot.create(:organization_admin, organization: organization) }
+    let(:organization) { FactoryBot.create(:organization) }
     before :each do
       set_current_user(user)
     end
   end
 
   RSpec.shared_context :logged_in_as_organization_member do
-    let(:user) { FactoryBot.create(:organization_member) }
-    let(:organization) { user.organizations.first }
+    let(:user) { FactoryBot.create(:organization_member, organization: organization) }
+    let(:organization) { FactoryBot.create(:organization) }
     before :each do
       set_current_user(user)
     end
   end
 
   RSpec.shared_context :logged_in_as_ambassador do
-    let(:user) { FactoryBot.create(:ambassador) }
-    let(:organization) { user.organizations.first }
+    let(:user) { FactoryBot.create(:ambassador, organization: organization) }
+    let(:organization) { FactoryBot.create(:organization_ambassador) }
     before { set_current_user(user) }
   end
 

--- a/spec/support/request_spec_helpers.rb
+++ b/spec/support/request_spec_helpers.rb
@@ -18,19 +18,19 @@ module RequestSpecHelpers
 
   RSpec.shared_context :request_spec_logged_in_as_organization_admin do
     let(:current_organization) { FactoryBot.create(:organization) }
-    let(:current_user) { FactoryBot.create(:organization_admin, organization: organization) }
+    let(:current_user) { FactoryBot.create(:organization_admin, organization: current_organization) }
     before { log_in(current_user) }
   end
 
   RSpec.shared_context :request_spec_logged_in_as_organization_member do
     let(:current_organization) { FactoryBot.create(:organization) }
-    let(:current_user) { FactoryBot.create(:organization_member, organization: organization) }
+    let(:current_user) { FactoryBot.create(:organization_member, organization: current_organization) }
     before { log_in(current_user) }
   end
 
   RSpec.shared_context :request_spec_logged_in_as_ambassador do
     let(:current_organization) { FactoryBot.create(:organization_ambassador) }
-    let(:current_user) { FactoryBot.create(:ambassador, organization: organization) }
+    let(:current_user) { FactoryBot.create(:ambassador, organization: current_organization) }
     before { log_in(current_user) }
   end
 end

--- a/spec/support/request_spec_helpers.rb
+++ b/spec/support/request_spec_helpers.rb
@@ -9,26 +9,26 @@ module RequestSpecHelpers
     allow(User).to receive(:from_auth) { user }
   end
 
-  def log_in_as_superuser
-    user = FactoryBot.create(:admin)
-    log_in user
+  RSpec.shared_context :request_spec_logged_in_as_superuser do
+    let(:user) { FactoryBot.create(:admin) }
+    before { log_in(user) }
   end
 
-  def log_in_as_organization_admin
-    user = FactoryBot.create(:organization_admin)
-    @current_organization ||= user.organizations.first
-    log_in user
+  RSpec.shared_context :request_spec_logged_in_as_organization_admin do
+    let(:user) { FactoryBot.create(:organization_admin) }
+    let(:organization) { user.organizations.first }
+    before { log_in(user) }
   end
 
-  def log_in_as_organization_member
-    user = FactoryBot.create(:organization_memebr)
-    @current_organization ||= user.organizations.first
-    log_in user
+  RSpec.shared_context :request_spec_logged_in_as_organization_member do
+    let(:user) { FactoryBot.create(:organization_member) }
+    let(:organization) { user.organizations.first }
+    before { log_in(user) }
   end
 
-  def log_in_as_ambassador
-    user = FactoryBot.create(:ambassador)
-    @current_organization ||= user.organizations.first
-    log_in user
+  RSpec.shared_context :request_spec_logged_in_as_ambassador do
+    let(:user) { FactoryBot.create(:ambassador) }
+    let(:organization) { user.organizations.first }
+    before { log_in(user) }
   end
 end

--- a/spec/support/request_spec_helpers.rb
+++ b/spec/support/request_spec_helpers.rb
@@ -1,39 +1,36 @@
 # Spec helpers that are included in all request specs
 # via Rspec.configure (rails_helper)
 module RequestSpecHelpers
-  attr_reader :current_user, :current_organization
-
-  def log_in(user = nil)
-    user ||= FactoryBot.create(:user_confirmed)
-    @current_user = user
-    allow(User).to receive(:from_auth) { user }
+  def log_in(current_user = nil)
+    current_user ||= FactoryBot.create(:user_confirmed)
+    allow(User).to receive(:from_auth) { current_user }
   end
 
   RSpec.shared_context :request_spec_logged_in_as_user do
-    let(:user) { FactoryBot.create(:user) }
-    before { log_in(user) }
+    let(:current_user) { FactoryBot.create(:user) }
+    before { log_in(current_user) }
   end
 
   RSpec.shared_context :request_spec_logged_in_as_superuser do
-    let(:user) { FactoryBot.create(:admin) }
-    before { log_in(user) }
+    let(:current_user) { FactoryBot.create(:admin) }
+    before { log_in(current_user) }
   end
 
   RSpec.shared_context :request_spec_logged_in_as_organization_admin do
-    let(:organization) { FactoryBot.create(:organization) }
-    let(:user) { FactoryBot.create(:organization_admin, organization: organization) }
-    before { log_in(user) }
+    let(:current_organization) { FactoryBot.create(:organization) }
+    let(:current_user) { FactoryBot.create(:organization_admin, organization: organization) }
+    before { log_in(current_user) }
   end
 
   RSpec.shared_context :request_spec_logged_in_as_organization_member do
-    let(:organization) { FactoryBot.create(:organization) }
-    let(:user) { FactoryBot.create(:organization_member, organization: organization) }
-    before { log_in(user) }
+    let(:current_organization) { FactoryBot.create(:organization) }
+    let(:current_user) { FactoryBot.create(:organization_member, organization: organization) }
+    before { log_in(current_user) }
   end
 
   RSpec.shared_context :request_spec_logged_in_as_ambassador do
-    let(:organization) { FactoryBot.create(:organization_ambassador) }
-    let(:user) { FactoryBot.create(:ambassador, organization: organization) }
-    before { log_in(user) }
+    let(:current_organization) { FactoryBot.create(:organization_ambassador) }
+    let(:current_user) { FactoryBot.create(:ambassador, organization: organization) }
+    before { log_in(current_user) }
   end
 end

--- a/spec/support/request_spec_helpers.rb
+++ b/spec/support/request_spec_helpers.rb
@@ -9,26 +9,31 @@ module RequestSpecHelpers
     allow(User).to receive(:from_auth) { user }
   end
 
+  RSpec.shared_context :request_spec_logged_in_as_user do
+    let(:user) { FactoryBot.create(:user) }
+    before { log_in(user) }
+  end
+
   RSpec.shared_context :request_spec_logged_in_as_superuser do
     let(:user) { FactoryBot.create(:admin) }
     before { log_in(user) }
   end
 
   RSpec.shared_context :request_spec_logged_in_as_organization_admin do
-    let(:user) { FactoryBot.create(:organization_admin) }
-    let(:organization) { user.organizations.first }
+    let(:organization) { FactoryBot.create(:organization) }
+    let(:user) { FactoryBot.create(:organization_admin, organization: organization) }
     before { log_in(user) }
   end
 
   RSpec.shared_context :request_spec_logged_in_as_organization_member do
-    let(:user) { FactoryBot.create(:organization_member) }
-    let(:organization) { user.organizations.first }
+    let(:organization) { FactoryBot.create(:organization) }
+    let(:user) { FactoryBot.create(:organization_member, organization: organization) }
     before { log_in(user) }
   end
 
   RSpec.shared_context :request_spec_logged_in_as_ambassador do
-    let(:user) { FactoryBot.create(:ambassador) }
-    let(:organization) { user.organizations.first }
+    let(:organization) { FactoryBot.create(:organization_ambassador) }
+    let(:user) { FactoryBot.create(:ambassador, organization: organization) }
     before { log_in(user) }
   end
 end


### PR DESCRIPTION
Also:

- Switch to using contexts rather than methods for the request spec `logged_in_as...`
- Make redirects to `user_root_url` more consistent