### PR TITLE
Move purchased theft alert table above purchasing new alerts

### DIFF
--- a/app/assets/stylesheets/revised/sections/form_well_header.scss
+++ b/app/assets/stylesheets/revised/sections/form_well_header.scss
@@ -20,27 +20,29 @@
 }
 
 // Per page header on bikes and users
-.form-well-form-header {
+.form-well-form-header,
+.form-well-form-header-always-visible {
   h3,
   h5 {
     padding: 0 $vertical-height;
     margin-bottom: 2 * $vertical-height;
+
+    @include media-breakpoint-down(md) {
+      padding: 0;
+    }
+  }
+
+  @include media-breakpoint-up(lg) {
+    margin-top: -2 * $vertical-height;
   }
 }
 
-.primary-edit-bike-form {
-  // On bike pages, per page header is hidden except on large screens
-  // It's  always visible on user edit
-  .form-well-form-header {
-    display: none;
-
-    // Hidden on sm screens, shown via mediaquery
-    @include media-breakpoint-up(lg) {
-      margin-top: -2 * $vertical-height;
-    }
-
-    @include media-breakpoint-up(md) {
-      display: block;
-    }
+// On bike pages, per page header is generally hidden except on large screens
+// It's  always visible on user edit
+.form-well-form-header {
+  display: none;
+  // Hidden on sm screens, shown via mediaquery
+  @include media-breakpoint-up(md) {
+    display: block;
   }
 }

--- a/app/views/bikes/_theft_alerts_table.html.haml
+++ b/app/views/bikes/_theft_alerts_table.html.haml
@@ -1,20 +1,28 @@
-%h3 Past Bike Index Alerts
-%table.table.table-bordered
-  %thead.small-header
-    %tr
-      %th Created
-      %th Plan
-      %th Status
-      %th Start
-      %th End
-      %th Post
+- first_form_well ||= false
 
-  %tbody
-    - theft_alerts.each do |alert|
-      %tr
-        %td= alert.created_at.to_date.to_s(:long)
-        %td= alert.theft_alert_plan.name
-        %td= alert.status
-        %td.convertTime= l(alert.begin_at, format: :convert_time) if alert.begin_at.present?
-        %td.convertTime= l(alert.end_at, format: :convert_time) if alert.end_at.present?
-        %td= link_to "link", alert.facebook_post_url, target: "_blank" if alert.facebook_post_url.present?
+- if theft_alerts.present?
+  .form-wrap{ class: first_form_well ? "" : "secondary-form-wrap" }
+    .form-well-form-header-always-visible
+      %h3
+        Existing Theft Alerts
+    .row
+      .col-md-12
+        %table.table.table-bordered{ style: "background: #fff;" }
+          %thead.small-header
+            %tr
+              %th Created
+              %th Plan
+              %th Status
+              %th Start
+              %th End
+              %th Post
+
+          %tbody
+            - theft_alerts.each do |alert|
+              %tr
+                %td= alert.created_at.to_date.to_s(:long)
+                %td= alert.theft_alert_plan.name
+                %td= alert.status
+                %td.convertTime= l(alert.begin_at, format: :convert_time) if alert.begin_at.present?
+                %td.convertTime= l(alert.end_at, format: :convert_time) if alert.end_at.present?
+                %td= link_to "link", alert.facebook_post_url, target: "_blank" if alert.facebook_post_url.present?

--- a/app/views/bikes/edit_alert.html.haml
+++ b/app/views/bikes/edit_alert.html.haml
@@ -2,9 +2,13 @@
   .form-well-container.container{ class: "edit-bike-page-#{@edit_template}" }
     .row
       = render partial: "/bikes/edit_primary_menu", locals: { is_disabled: true }
-
       .col-md-8.form-well
         .form-wrap{style: "padding-bottom: 20px;"}
+          - if @theft_alerts.present?
+            .row &nbsp;
+            .row
+              .col-md-12
+                = render partial: "theft_alerts_table", locals: { theft_alerts: @theft_alerts }
           .form-well-form-header
             / Activate Bike Index Alert
             %h3.text-center.w-100
@@ -22,9 +26,3 @@
             .row
               .text-center.w-100.mt-2
                 %button.btn.btn-lg.btn-primary Select Plan
-
-        - if @theft_alerts.present?
-          .row &nbsp;
-          .row
-            .col-md-12
-              = render partial: "theft_alerts_table", locals: { theft_alerts: @theft_alerts }

--- a/app/views/bikes/edit_alert.html.haml
+++ b/app/views/bikes/edit_alert.html.haml
@@ -3,13 +3,11 @@
     .row
       = render partial: "/bikes/edit_primary_menu", locals: { is_disabled: true }
       .col-md-8.form-well
-        .form-wrap{style: "padding-bottom: 20px;"}
-          - if @theft_alerts.present?
-            .row &nbsp;
-            .row
-              .col-md-12
-                = render partial: "theft_alerts_table", locals: { theft_alerts: @theft_alerts }
-          .form-well-form-header
+
+        = render partial: "theft_alerts_table", locals: { theft_alerts: @theft_alerts, first_form_well: true }
+
+        .form-wrap{ class: @theft_alerts.present? ? "secondary-form-wrap" : "" }
+          .form-well-form-header-always-visible
             / Activate Bike Index Alert
             %h3.text-center.w-100
               = @edit_templates[@edit_template]

--- a/app/views/bikes/edit_alert_purchase.html.haml
+++ b/app/views/bikes/edit_alert_purchase.html.haml
@@ -4,7 +4,7 @@
       = render partial: "/bikes/edit_primary_menu", locals: { is_disabled: true }
 
       .col-md-8.form-well
-        .form-wrap{style: "padding-bottom: 15px;"}
+        .form-wrap
           .form-well-form-header
             %h3.text-center.w-100
               / 'alert'-prefixed templates should all have the same header and
@@ -50,10 +50,6 @@
                     %span.times &times;
                     Cancel
 
-        - if @theft_alerts.present?
-          .row &nbsp;
-          .row
-            .col-md-12
-              = render partial: "theft_alerts_table", locals: { theft_alerts: @theft_alerts }
+        = render partial: "theft_alerts_table", locals: { theft_alerts: @theft_alerts }
 
 %script{ src: "https://checkout.stripe.com/checkout.js", async: true }

--- a/app/views/bikes/edit_alert_purchase_confirmation.html.haml
+++ b/app/views/bikes/edit_alert_purchase_confirmation.html.haml
@@ -4,7 +4,7 @@
       = render partial: "/bikes/edit_primary_menu", locals: { is_disabled: true }
 
       .col-md-8.form-well
-        .form-wrap{style: "padding-bottom: 15px;"}
+        .form-wrap
           .form-well-form-header
             %h3.text-center.w-100
               / 'alert'-prefixed templates should all have the same header and
@@ -21,8 +21,4 @@
                 .copy.text-center
                   Stay tuned for an update once we've processed your alert.
 
-        - if @theft_alerts.present?
-          .row &nbsp;
-          .row
-            .col-md-12
-              = render partial: "theft_alerts_table", locals: { theft_alerts: @theft_alerts }
+        = render partial: "theft_alerts_table", locals: { theft_alerts: @theft_alerts }

--- a/app/views/bikes/edit_drivetrain.html.haml
+++ b/app/views/bikes/edit_drivetrain.html.haml
@@ -4,7 +4,7 @@
       = render partial: '/bikes/edit_primary_menu'
       .col-md-8.form-well
         .form-wrap
-          .form-well-form-header
+          .form-well-form-header-always-visible
             %h3
               Wheels
 
@@ -54,7 +54,7 @@
                   Wide
 
         .form-wrap.secondary-form-wrap#edit_drivetrain
-          .form-well-form-header
+          .form-well-form-header-always-visible
             %h3
               Drivetrain
           - rear_fixed = RearGearType.fixed.id

--- a/app/views/bikes/edit_publicize.html.haml
+++ b/app/views/bikes/edit_publicize.html.haml
@@ -3,7 +3,7 @@
 
   .form-well-container.container{ class: "edit-bike-page-#{@edit_template}" }
     .row
-      = render partial: "/bikes/edit_primary_menu"
+      = render partial: "/bikes/edit_primary_menu", locals: { is_disabled: true }
 
       .col-md-8.form-well#form_well_wrap
         .form-wrap

--- a/app/views/bikes/edit_remove.html.haml
+++ b/app/views/bikes/edit_remove.html.haml
@@ -1,7 +1,7 @@
 = form_for @bike, multipart: true, html: { class: 'primary-edit-bike-form' } do |f|
   .form-well-container.container{ class: "edit-bike-page-#{@edit_template}" }
     .row
-      = render partial: '/bikes/edit_primary_menu'
+      = render partial: '/bikes/edit_primary_menu', locals: { is_disabled: true }
       .col-md-8.form-well
         .form-wrap
           .form-well-form-header

--- a/app/views/bikes/edit_report_recovered.html.haml
+++ b/app/views/bikes/edit_report_recovered.html.haml
@@ -4,7 +4,7 @@
 
   .form-well-container.container{ class: "edit-bike-page-#{@edit_template}" }
     .row
-      = render partial: "/bikes/edit_primary_menu"
+      = render partial: "/bikes/edit_primary_menu", locals: { is_disabled: true }
 
       - if @bike.stolen? && @bike.find_current_stolen_record.present? && !@bike.recovered?
         .col-md-8.form-well#form_well_wrap

--- a/app/views/users/_edit_password.html.haml
+++ b/app/views/users/_edit_password.html.haml
@@ -1,5 +1,5 @@
 .form-wrap
-  .form-well-form-header
+  .form-well-form-header-always-visible
     %h3
       Reset password
   .form-group.row.unnested-field

--- a/app/views/users/_edit_root.html.haml
+++ b/app/views/users/_edit_root.html.haml
@@ -1,5 +1,5 @@
 .form-wrap
-  .form-well-form-header
+  .form-well-form-header-always-visible
     %h3
       Personal Information for
       = @user.display_name

--- a/app/views/users/_edit_sharing.html.haml
+++ b/app/views/users/_edit_sharing.html.haml
@@ -1,5 +1,5 @@
 .form-wrap
-  .form-well-form-header
+  .form-well-form-header-always-visible
     %h3
       Sharing and Personal page settings
 


### PR DESCRIPTION
I worry people will miss it, because it's below the fold, and then buy a new alert because they think it didn't work.

Also, add the `is_disabled` local variable to the primary edit menus on pages where it should be added because it's super slick 😍 @jmromer 

<img width="1179" alt="Screen Shot 2019-06-22 at 5 09 33 PM" src="https://user-images.githubusercontent.com/1235441/59970011-8b43c300-9510-11e9-86db-46e8fdbc927c.png">

(on the other pages "existing theft alerts" is still below the main section)