### PR TITLE
Rescue unknown bike edit templates

### DIFF
--- a/spec/controllers/bikes_controller_spec.rb
+++ b/spec/controllers/bikes_controller_spec.rb
@@ -997,6 +997,15 @@ RSpec.describe BikesController, type: :controller do
               expect(response).to render_template "edit_theft_details"
             end
           end
+          context "unknown template" do
+            it "renders the bike_details template" do
+              get :edit, id: bike.id, page: "root_party"
+              expect(response.status).to eq(200)
+              expect(assigns(:edit_template)).to eq "bike_details"
+              expect(assigns(:edit_templates)).to eq non_stolen_edit_templates.as_json
+              expect(response).to render_template "edit_bike_details"
+            end
+          end
         end
         # Grab all the template keys from the controller so we can test that we
         # render all of them Both to ensure we get all of them and because we


### PR DESCRIPTION
Spec that shows that unknown edit templates fail ([Honeybadger error showing it](https://app.honeybadger.io/projects/35931/faults/51171400) - caused by a robot).

The `target_edit_template` method in BikesController returns a hash, to tell you if you requested a valid template or not - which is nice, but I don't think telling people whether the template is valid is actually important, because I don't think it's an error people run into unless they're trying to fuck around (or are robots). I think we could drop returning the hash and just return the template we're going to show (either the match for the parameter, or the default if there is no match), which would simplify the logic and make solving this easier.

Leaving resolving this up to you @jmromer. If you're still excited about the protection provided by `is_valid` just let me know why!