### PR TITLE
Fix bikes_controller#target_edit_template

### DIFF
--- a/app/controllers/bikes_controller.rb
+++ b/app/controllers/bikes_controller.rb
@@ -227,7 +227,7 @@ class BikesController < ApplicationController
     when requested_page.blank?
       result[:is_valid] = true
       result[:template] = default_page.to_s
-    when edit_templates.has_key?(requested_page), :alert_purchase
+    when edit_templates.has_key?(requested_page), requested_page == :alert_purchase
       result[:is_valid] = true
       result[:template] = requested_page.to_s
     else

--- a/app/controllers/bikes_controller.rb
+++ b/app/controllers/bikes_controller.rb
@@ -221,13 +221,14 @@ class BikesController < ApplicationController
   # Return a Hash with keys :is_valid (boolean), :template (string)
   def target_edit_template(requested_page:)
     result = {}
+    valid_pages = [*edit_templates.keys, "alert_purchase"]
     default_page = @bike.stolen? ? :theft_details : :bike_details
 
     case
     when requested_page.blank?
       result[:is_valid] = true
       result[:template] = default_page.to_s
-    when edit_templates.has_key?(requested_page), requested_page == :alert_purchase
+    when requested_page.in?(valid_pages)
       result[:is_valid] = true
       result[:template] = requested_page.to_s
     else

--- a/spec/controllers/bikes_controller_spec.rb
+++ b/spec/controllers/bikes_controller_spec.rb
@@ -1015,7 +1015,7 @@ RSpec.describe BikesController, type: :controller do
           context "with query param ?page=#{template}" do
             it "renders the #{template} template" do
               get :edit, id: bike.id, page: template
-              expect(response).to be_success
+              expect(response.status).to eq(200)
               expect(response).to render_template("edit_#{template}")
               expect(assigns(:edit_template)).to eq(template)
               expect(assigns(:private_images)).to eq([]) if template == "photos"

--- a/spec/controllers/bikes_controller_spec.rb
+++ b/spec/controllers/bikes_controller_spec.rb
@@ -997,6 +997,14 @@ RSpec.describe BikesController, type: :controller do
               expect(response).to render_template "edit_theft_details"
             end
           end
+          context "unknown template" do
+            it "renders the bike_details template" do
+              get :edit, id: bike.id, page: "root_party"
+              expect(response).to redirect_to(edit_bike_url(bike, params: { page: :bike_details }))
+              expect(assigns(:edit_template)).to eq "bike_details"
+              expect(assigns(:edit_templates)).to eq non_stolen_edit_templates.as_json
+            end
+          end
         end
         # Grab all the template keys from the controller so we can test that we
         # render all of them Both to ensure we get all of them and because we


### PR DESCRIPTION
Fixes a case statement clause allowing invalid templates to be returned
from #target_edit_template

https://app.honeybadger.io/projects/35931/faults/51171400