### PR TITLE
Add user-configurable preferred language, locale detection

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,6 +17,10 @@ gem "flipper"
 gem "flipper-active_record"
 gem "flipper-ui"
 
+# I18n
+gem "i18n_generators"
+gem "rails-i18n"
+
 # Redis and redis dependents
 gem "hiredis"
 gem "redis", ">= 3.2.0", require: ["redis", "redis/connection/hiredis"]
@@ -34,7 +38,6 @@ gem "geocoder"
 gem "hamlit"
 gem "high_voltage"
 gem "httparty"
-gem "i18n"
 gem "journey", "~> 1.0.3"
 gem "kaminari" # pagination
 gem "kramdown" # Markdown
@@ -44,8 +47,8 @@ gem "money-rails"
 gem "nokogiri", "~> 1.8.1"
 gem "omniauth", "~> 1.6"
 gem "omniauth-facebook"
-gem "omniauth-strava"
 gem "omniauth-globalid"
+gem "omniauth-strava"
 gem "paranoia"
 gem "pg_search"
 gem "rack-contrib"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -244,6 +244,9 @@ GEM
       json (~> 1.8)
       multi_xml (>= 0.5.2)
     i18n (0.7.0)
+    i18n_generators (2.2.1)
+      activerecord (>= 3.0.0)
+      railties (>= 3.0.0)
     ice_nine (0.11.2)
     ipaddress (0.8.3)
     jaro_winkler (1.5.2)
@@ -437,6 +440,9 @@ GEM
       rails-deprecated_sanitizer (>= 1.0.1)
     rails-html-sanitizer (1.0.4)
       loofah (~> 2.2, >= 2.2.2)
+    rails-i18n (4.0.9)
+      i18n (~> 0.7)
+      railties (~> 4.0)
     railties (4.2.11)
       actionpack (= 4.2.11)
       activesupport (= 4.2.11)
@@ -670,7 +676,7 @@ DEPENDENCIES
   hiredis
   honeybadger
   httparty
-  i18n
+  i18n_generators
   jazz_fingers
   journey (~> 1.0.3)
   jquery-datatables-rails (~> 3.4.0)
@@ -711,6 +717,7 @@ DEPENDENCIES
   rails-assets-selectize (~> 0.12.1)!
   rails-assets-tether (~> 1.1.0)!
   rails-assets-waypoints (~> 3.1.1)!
+  rails-i18n
   rb-fsevent (~> 0.10.3)
   redcarpet
   redis (>= 3.2.0)

--- a/app/assets/stylesheets/revised/sections/primary_footer.scss
+++ b/app/assets/stylesheets/revised/sections/primary_footer.scss
@@ -30,6 +30,13 @@ $primary-footer-top-margin: 6 * $vertical-height;
     }
   }
 
+  .locale-form {
+    font-size: 12px;
+    label {
+      margin-right: 5px;
+    }
+  }
+
   .primary-footer-nav {
     background: $gray-dark;
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -68,6 +68,7 @@ class ApplicationController < ActionController::Base
 
   def set_locale
     return unless Flipper.enabled?(:localization, current_user)
+    # TODO: Remove debug logging when feature flag is removed
 
     logger.debug("* Params: '#{locale_from_request_params}'")
     logger.debug("* User profile:: '#{current_user&.preferred_language}'")

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -67,6 +67,8 @@ class ApplicationController < ActionController::Base
   end
 
   def set_locale
+    return unless Flipper.enabled?(:localization, current_user)
+
     logger.debug("* Params: '#{locale_from_request_params}'")
     logger.debug("* User profile:: '#{current_user&.preferred_language}'")
     logger.debug("* Request Headers: '#{locale_from_request_header}'")

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,6 +1,7 @@
 class ApplicationController < ActionController::Base
   include ControllerHelpers
   protect_from_forgery
+  before_action :set_locale
 
   ensure_security_headers(csp: false,
                           hsts: "max-age=#{20.years.to_i}",
@@ -54,5 +55,29 @@ class ApplicationController < ActionController::Base
   def permitted_org_bike_search_params
     @stolenness ||= params["stolenness"].present? ? params["stolenness"] : "all"
     params.permit(*Bike.permitted_search_params).merge(stolenness: @stolenness)
+  end
+
+  def locale_from_request_header
+    request.env.fetch("HTTP_ACCEPT_LANGUAGE", "").scan(/^[a-z]{2}/).first
+  end
+
+  def locale_from_request_params
+    requested_locale = params.fetch(:locale, "").strip.to_sym
+    requested_locale if I18n.available_locales.include?(requested_locale)
+  end
+
+  def set_locale
+    logger.debug("* Params: '#{locale_from_request_params}'")
+    logger.debug("* User profile:: '#{current_user&.preferred_language}'")
+    logger.debug("* Request Headers: '#{locale_from_request_header}'")
+    logger.debug("* Default: '#{I18n.default_locale}'")
+
+    I18n.locale =
+      locale_from_request_params ||
+      current_user&.preferred_language.presence ||
+      locale_from_request_header ||
+      I18n.default_locale
+
+    logger.debug("* Locale set to '#{I18n.locale}'")
   end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -184,7 +184,8 @@ class UsersController < ApplicationController
           .permit(:name, :username, :email, :notification_newsletters, :notification_unstolen, :terms_of_service,
                   :additional_emails, :title, :description, :phone, :street, :city, :zipcode, :country_id,
                   :state_id, :avatar, :avatar_cache, :twitter, :show_twitter, :website, :show_website,
-                  :show_bikes, :show_phone, :my_bikes_link_target, :my_bikes_link_title, :password, :password_confirmation)
+                  :show_bikes, :show_phone, :my_bikes_link_target, :my_bikes_link_title, :password,
+                  :password_confirmation, :preferred_language)
           .merge(sign_in_partner.present? ? { partner_data: { sign_up: sign_in_partner } } : {})
   end
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -215,4 +215,11 @@ module ApplicationHelper
       html.html_safe
     end
   end
+
+  def language_choices
+    @language_choices ||=
+      I18n
+        .available_locales
+        .map { |locale| [t("language", locale: locale), locale.to_s] }
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -58,6 +58,8 @@ class User < ActiveRecord::Base
     on: :update
   validates_format_of :password, with: /\A.*(?=.*[a-z]).*\Z/i, message: "must contain at least one letter", on: :update, allow_blank: true
 
+  validate :preferred_language_is_an_available_locale
+
   validates_presence_of :email
   validates_uniqueness_of :email, case_sensitive: false
 
@@ -361,5 +363,13 @@ class User < ActiveRecord::Base
   def geocodeable_attributes_changed?
     return false unless city.present? || zipcode.present? || street.present?
     city_changed? || zipcode_changed? || street_changed?
+  end
+
+  private
+
+  def preferred_language_is_an_available_locale
+    return if preferred_language.blank?
+    return if I18n.available_locales.include?(preferred_language.to_sym)
+    errors.add(:preferred_language, "not an available language")
   end
 end

--- a/app/views/shared/_footer_revised.html.haml
+++ b/app/views/shared/_footer_revised.html.haml
@@ -70,18 +70,32 @@
                     </g>
                   </svg>
 
-
   %nav.terms-and-stuff
     .container
-      %p
-        - if current_user.present? && current_user.has_membership?
-          #{link_to "Privacy policy", privacy_path}, #{link_to "vendor terms", vendor_terms_path}
-        - else
-          #{link_to "Privacy policy", privacy_path}
-        and #{link_to "terms and conditions", terms_path}.
-      %p
-        %span{data: {license: "https://github.com/bikeindex/bike_index/blob/master/LICENSE"}}
-          #{Time.current.year} &copy; Bike Index, a 501(c)(3) nonprofit - EIN 81-4296194
+      .row
+        .col-md-6.text-left
+          - if Flipper.enabled?(:localization, current_user)
+            = form_tag nil, method: :get, class: "locale-form" do
+              .row
+                .form-group
+                  = label_tag(:locale, "Language")
+                  = select_tag(:locale,
+                  options_for_select(language_choices, selected: I18n.locale),
+                  class: "form-control-sm",
+                  onchange: "this.form.submit()")
+          - else
+            &nbsp;
+        .col-md-6.text-right
+          %p
+            - if current_user.present? && current_user.has_membership?
+              #{link_to "Privacy policy", privacy_path}, #{link_to "vendor terms", vendor_terms_path}
+            - else
+              #{link_to "Privacy policy", privacy_path}
+            and #{link_to "terms and conditions", terms_path}.
+          %p
+            %span{data: {license: "https://github.com/bikeindex/bike_index/blob/master/LICENSE"}}
+              #{Time.current.year} &copy; Bike Index, a 501(c)(3) nonprofit - EIN 81-4296194
+
 - cache 'facebook_pixel' do
   = render '/shared/facebook_pixel'
 

--- a/app/views/users/_edit_root.html.haml
+++ b/app/views/users/_edit_root.html.haml
@@ -50,6 +50,17 @@
     %label.form-well-label
     .form-well-input
       = f.text_field :zipcode, placeholder: "zipcode", class: "form-control"
+
+  - if Flipper.enabled?(:localization, current_user)
+    .form-group.row.fancy-select.unfancy
+      = f.label :country_id, class: "form-well-label" do
+        Preferred language
+      .form-well-input
+        = f.select(:preferred_language,
+        options_for_select(language_choices, selected: current_user.preferred_language),
+        { prompt: "Choose language", include_blank: true },
+        { class: "language-select-input form-control" } )
+
   .col-xs-12
     %p
       Have multiple emails? Consolidate them into one account here

--- a/app/views/welcome/index.html.haml
+++ b/app/views/welcome/index.html.haml
@@ -4,8 +4,7 @@
       .root-landing-header-text
         %h2
           Over $#{number_with_delimiter(Counts.recoveries_value)} Worth of Bikes Recovered
-        %h1.upcase
-          Bike registration that works
+        %h1.upcase= t(".hero")
         %h2
           = link_to new_bike_path do
             Register Now
@@ -155,4 +154,3 @@
               Partner Organizations
               %span.count-display
                 = number_with_delimiter(Counts.organizations)
-

--- a/config/application.rb
+++ b/config/application.rb
@@ -30,6 +30,7 @@ module Bikeindex
     # The default locale is :en and all translations from config/locales/*.rb,yml are auto loaded.
     config.i18n.load_path += Dir[Rails.root.join("config", "locales", "**", "*.{rb,yml}").to_s]
     config.i18n.default_locale = :en
+    config.i18n.available_locales = %i[en es nl]
     config.i18n.enforce_available_locales = false
 
     # Do not swallow errors in after_commit/after_rollback callbacks.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,6 +1,213 @@
 ---
 en:
   language: English
+  date:
+    abbr_day_names:
+    - Sun
+    - Mon
+    - Tue
+    - Wed
+    - Thu
+    - Fri
+    - Sat
+    abbr_month_names:
+    -
+    - Jan
+    - Feb
+    - Mar
+    - Apr
+    - May
+    - Jun
+    - Jul
+    - Aug
+    - Sep
+    - Oct
+    - Nov
+    - Dec
+    day_names:
+    - Sunday
+    - Monday
+    - Tuesday
+    - Wednesday
+    - Thursday
+    - Friday
+    - Saturday
+    formats:
+      default: "%Y-%m-%d"
+      long: "%B %d, %Y"
+      short: "%b %d"
+    month_names:
+    -
+    - January
+    - February
+    - March
+    - April
+    - May
+    - June
+    - July
+    - August
+    - September
+    - October
+    - November
+    - December
+    order:
+    - :year
+    - :month
+    - :day
+  datetime:
+    distance_in_words:
+      about_x_hours:
+        one: about 1 hour
+        other: about %{count} hours
+      about_x_months:
+        one: about 1 month
+        other: about %{count} months
+      about_x_years:
+        one: about 1 year
+        other: about %{count} years
+      almost_x_years:
+        one: almost 1 year
+        other: almost %{count} years
+      half_a_minute: half a minute
+      less_than_x_seconds:
+        one: less than 1 second
+        other: less than %{count} seconds
+      less_than_x_minutes:
+        one: less than a minute
+        other: less than %{count} minutes
+      over_x_years:
+        one: over 1 year
+        other: over %{count} years
+      x_seconds:
+        one: 1 second
+        other: "%{count} seconds"
+      x_minutes:
+        one: 1 minute
+        other: "%{count} minutes"
+      x_days:
+        one: 1 day
+        other: "%{count} days"
+      x_months:
+        one: 1 month
+        other: "%{count} months"
+      x_years:
+        one: 1 year
+        other: "%{count} years"
+    prompts:
+      second: Seconds
+      minute: Minute
+      hour: Hour
+      day: Day
+      month: Month
+      year: Year
+  errors:
+    format: "%{attribute} %{message}"
+    messages:
+      accepted: must be accepted
+      blank: can't be blank
+      confirmation: doesn't match %{attribute}
+      empty: can't be empty
+      equal_to: must be equal to %{count}
+      even: must be even
+      exclusion: is reserved
+      greater_than: must be greater than %{count}
+      greater_than_or_equal_to: must be greater than or equal to %{count}
+      inclusion: is not included in the list
+      invalid: is invalid
+      less_than: must be less than %{count}
+      less_than_or_equal_to: must be less than or equal to %{count}
+      model_invalid: 'Validation failed: %{errors}'
+      not_a_number: is not a number
+      not_an_integer: must be an integer
+      odd: must be odd
+      other_than: must be other than %{count}
+      present: must be blank
+      required: must exist
+      taken: has already been taken
+      too_long:
+        one: is too long (maximum is 1 character)
+        other: is too long (maximum is %{count} characters)
+      too_short:
+        one: is too short (minimum is 1 character)
+        other: is too short (minimum is %{count} characters)
+      wrong_length:
+        one: is the wrong length (should be 1 character)
+        other: is the wrong length (should be %{count} characters)
+    template:
+      body: 'There were problems with the following fields:'
+      header:
+        one: 1 error prohibited this %{model} from being saved
+        other: "%{count} errors prohibited this %{model} from being saved"
+  helpers:
+    select:
+      prompt: Please select
+    submit:
+      create: Create %{model}
+      submit: Save %{model}
+      update: Update %{model}
+  number:
+    currency:
+      format:
+        delimiter: ","
+        format: "%u%n"
+        precision: 2
+        separator: "."
+        significant: false
+        strip_insignificant_zeros: false
+        unit: "$"
+    format:
+      delimiter: ","
+      precision: 3
+      separator: "."
+      significant: false
+      strip_insignificant_zeros: false
+    human:
+      decimal_units:
+        format: "%n %u"
+        units:
+          billion: Billion
+          million: Million
+          quadrillion: Quadrillion
+          thousand: Thousand
+          trillion: Trillion
+          unit: ''
+      format:
+        delimiter: ''
+        precision: 3
+        significant: true
+        strip_insignificant_zeros: true
+      storage_units:
+        format: "%n %u"
+        units:
+          byte:
+            one: Byte
+            other: Bytes
+          eb: EB
+          gb: GB
+          kb: KB
+          mb: MB
+          pb: PB
+          tb: TB
+    percentage:
+      format:
+        delimiter: ''
+        format: "%n%"
+    precision:
+      format:
+        delimiter: ''
+  support:
+    array:
+      last_word_connector: ", and "
+      two_words_connector: " and "
+      words_connector: ", "
+  time:
+    am: am
+    formats:
+      default: "%a, %d %b %Y %H:%M:%S %z"
+      long: "%B %d, %Y %H:%M"
+      short: "%d %b %H:%M"
+    pm: pm
+
   meta_titles:
     welcome_index: "Bike Index - Bike registration that works"
     welcome_goodbye: "Logged out"
@@ -140,6 +347,14 @@ en:
           other: "Displaying <b>all %{count}</b> %{entry_name}"
       more_pages:
         display_entries: "Displaying %{entry_name} <b>%{first}&nbsp;-&nbsp;%{last}</b> of <b>%{total}</b> in total"
+
+  activerecord:
+    errors:
+      messages:
+        record_invalid: 'Validation failed: %{errors}'
+        restrict_dependent_destroy:
+          has_one: Cannot delete record because a dependent %{record} exists
+          has_many: Cannot delete record because dependent %{record} exist
 
   welcome:
     index:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,4 +1,6 @@
+---
 en:
+  language: English
   meta_titles:
     welcome_index: "Bike Index - Bike registration that works"
     welcome_goodbye: "Logged out"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -140,3 +140,7 @@ en:
           other: "Displaying <b>all %{count}</b> %{entry_name}"
       more_pages:
         display_entries: "Displaying %{entry_name} <b>%{first}&nbsp;-&nbsp;%{last}</b> of <b>%{total}</b> in total"
+
+  welcome:
+    index:
+      hero: Bike registration that works

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -1,0 +1,1057 @@
+---
+es:
+  language: Español
+  date:
+    abbr_day_names:
+    - dom
+    - lun
+    - mar
+    - mié
+    - jue
+    - vie
+    - sáb
+    abbr_month_names:
+    -
+    - ene
+    - feb
+    - mar
+    - abr
+    - may
+    - jun
+    - jul
+    - ago
+    - sep
+    - oct
+    - nov
+    - dic
+    day_names:
+    - domingo
+    - lunes
+    - martes
+    - miércoles
+    - jueves
+    - viernes
+    - sábado
+    formats:
+      default: "%-d/%-m/%Y"
+      long: "%-d de %B de %Y"
+      short: "%-d de %b"
+    month_names:
+    -
+    - enero
+    - febrero
+    - marzo
+    - abril
+    - mayo
+    - junio
+    - julio
+    - agosto
+    - septiembre
+    - octubre
+    - noviembre
+    - diciembre
+    order:
+    - :day
+    - :month
+    - :year
+  datetime:
+    distance_in_words:
+      about_x_hours:
+        one: alrededor de 1 hora
+        other: alrededor de %{count} horas
+      about_x_months:
+        one: alrededor de 1 mes
+        other: alrededor de %{count} meses
+      about_x_years:
+        one: alrededor de 1 año
+        other: alrededor de %{count} años
+      almost_x_years:
+        one: casi 1 año
+        other: casi %{count} años
+      half_a_minute: medio minuto
+      less_than_x_seconds:
+        one: menos de 1 segundo
+        other: menos de %{count} segundos
+      less_than_x_minutes:
+        one: menos de 1 minuto
+        other: menos de %{count} minutos
+      over_x_years:
+        one: más de 1 año
+        other: más de %{count} años
+      x_seconds:
+        one: 1 segundo
+        other: "%{count} segundos"
+      x_minutes:
+        one: 1 minuto
+        other: "%{count} minutos"
+      x_days:
+        one: 1 día
+        other: "%{count} días"
+      x_months:
+        one: 1 mes
+        other: "%{count} meses"
+      x_years:
+        one: 1 año
+        other: "%{count} años"
+    prompts:
+      second: Segundos
+      minute: Minutos
+      hour: Hora
+      day: Día
+      month: Mes
+      year: Año
+  errors:
+    format: "%{attribute} %{message}"
+    messages:
+      accepted: debe ser aceptado
+      blank: no puede estar en blanco
+      confirmation: no coincide
+      empty: no puede estar vacío
+      equal_to: debe ser igual a %{count}
+      even: debe ser par
+      exclusion: está reservado
+      greater_than: debe ser mayor que %{count}
+      greater_than_or_equal_to: debe ser mayor que o igual a %{count}
+      inclusion: no está incluido en la lista
+      invalid: no es válido
+      less_than: debe ser menor que %{count}
+      less_than_or_equal_to: debe ser menor que o igual a %{count}
+      model_invalid: 'La validación falló: %{errors}'
+      not_a_number: no es un número
+      not_an_integer: debe ser un entero
+      odd: debe ser impar
+      other_than: debe ser distinto de %{count}
+      present: debe estar en blanco
+      required: debe existir
+      taken: ya está en uso
+      too_long:
+        one: es demasiado largo (1 carácter máximo)
+        other: es demasiado largo (%{count} caracteres máximo)
+      too_short:
+        one: es demasiado corto (1 carácter mínimo)
+        other: es demasiado corto (%{count} caracteres mínimo)
+      wrong_length:
+        one: no tiene la longitud correcta (1 carácter exactos)
+        other: no tiene la longitud correcta (%{count} caracteres exactos)
+    template:
+      body: 'Se encontraron problemas con los siguientes campos:'
+      header:
+        one: No se pudo guardar este/a %{model} porque se encontró 1 error
+        other: No se pudo guardar este/a %{model} porque se encontraron %{count} errores
+  helpers:
+    select:
+      prompt: Por favor seleccione
+    submit:
+      create: Crear %{model}
+      submit: Guardar %{model}
+      update: Actualizar %{model}
+  number:
+    currency:
+      format:
+        delimiter: "."
+        format: "%n %u"
+        precision: 2
+        separator: ","
+        significant: false
+        strip_insignificant_zeros: false
+        unit: "€"
+    format:
+      delimiter: "."
+      precision: 3
+      separator: ","
+      significant: false
+      strip_insignificant_zeros: false
+    human:
+      decimal_units:
+        format: "%n %u"
+        units:
+          billion: mil millones
+          million:
+            one: millón
+            other: millones
+          quadrillion: mil billones
+          thousand: mil
+          trillion:
+            one: billón
+            other: billones
+          unit: ''
+      format:
+        delimiter: ''
+        precision: 1
+        significant: true
+        strip_insignificant_zeros: true
+      storage_units:
+        format: "%n %u"
+        units:
+          byte:
+            one: Byte
+            other: Bytes
+          eb: EB
+          gb: GB
+          kb: KB
+          mb: MB
+          pb: PB
+          tb: TB
+    percentage:
+      format:
+        delimiter: ''
+        format: "%n %"
+    precision:
+      format:
+        delimiter: ''
+  support:
+    array:
+      last_word_connector: " y "
+      two_words_connector: " y "
+      words_connector: ", "
+  time:
+    am: am
+    formats:
+      default: "%A, %-d de %B de %Y %H:%M:%S %z"
+      long: "%-d de %B de %Y %H:%M"
+      short: "%-d de %b %H:%M"
+    pm: pm
+
+  activerecord:
+    errors:
+      messages:
+        record_invalid: 'La validación falló: %{errors}'
+        restrict_dependent_destroy:
+          has_one: No se puede eliminar el registro porque existe un %{record} dependiente
+          has_many: No se puede eliminar el registro porque existen %{record} dependientes
+    models:
+      ad: Anuncio  #g
+      ambassador: Embajador  #g
+      ambassador_task: Tarea de embajador  #g
+      ambassador_task_assignment: Tarea de embajador  #g
+      b_param: B param  #g
+      bike: Bicicleta  #g
+      bike_code: Código de bicicleta  #g
+      bike_code_batch: Lote de codigo de bicicleta  #g
+      bike_organization: Organización de bicicletas  #g
+      blog: Blog  #g
+      bulk_import: Importación a granel  #g
+      cgroup: Grupo  #g
+      color: Color  #g
+      component: Componente  #g
+      country: País  #g
+      creation_state: Estado de creacion  #g
+      ctype: Ctype  #g
+      customer_contact: Contacto con el cliente  #g
+      doorkeeper/access_grant: Portero / beca de acceso  #g
+      doorkeeper/access_token: Portero / token de acceso  #g
+      doorkeeper/application: Portero / aplicación  #g
+      duplicate_bike_group: Grupo de bicicletas duplicadas  #g
+      export: Exportar  #g
+      feedback: Realimentación  #g
+      flipper/adapters/active_record/feature: Flipper / adaptadores / registro activo / característica  #g
+      flipper/adapters/active_record/gate: Flipper / adaptadores / registro activo / puerta  #g
+      front_gear_type: Tipo de engranaje delantero  #g
+      integration: Integración  #g
+      invoice: Factura  #g
+      invoice_paid_feature: Factura de facturas pagadas  #g
+      listicle: Lista  #g
+      location: Ubicación  #g
+      lock: Bloquear  #g
+      lock_type: Tipo de bloqueo  #g
+      mail_snippet: Fragmento de correo  #g
+      manufacturer: Fabricante  #g
+      membership: Afiliación  #g
+      normalized_serial_segment: Segmento serial normalizado  #g
+      organization: Organización  #g
+      organization_invitation: Invitación a la organización  #g
+      organization_message: Mensaje de organizacion  #g
+      other_listing: Otro listado  #g
+      ownership: Propiedad  #g
+      paid_feature: Característica de pago  #g
+      paint: Pintar  #g
+      payment: Pago  #g
+      public_image: Imagen pública  #g
+      rear_gear_type: Tipo de engranaje trasero  #g
+      recovery_display: Pantalla de recuperación  #g
+      state: Estado  #g
+      stolen_notification: Notificación robada  #g
+      stolen_record: Registro robado  #g
+      theft_alert: Alerta de robo  #g
+      theft_alert_plan: Plan de alerta de robo  #g
+      tweet: Pío  #g
+      user: Usuario  #g
+      user_email: Email del usuario  #g
+      wheel_size: Tamaño de la rueda  #g
+
+    attributes:
+      ad:
+        body: Cuerpo  #g
+        image: Imagen  #g
+        live: Vivir  #g
+        organization: :activerecord.models.organization  #g
+        target_url: URL de destino  #g
+        title: Título  #g
+
+      ambassador:
+        ambassador_task_assignments: Tareas de embajador  #g
+        ambassador_tasks: Tareas de embajador  #g
+        auth_token: Token de autor  #g
+        avatar: Avatar  #g
+        banned: Prohibido  #g
+        can_send_many_stolen_notifications: Puede enviar muchas notificaciones robadas  #g
+        city: Ciudad  #g
+        confirmation_token: Ficha de confirmación  #g
+        confirmed: Confirmado  #g
+        country: :activerecord.models.country  #g
+        created_bikes: Bicicletas creadas  #g
+        created_ownerships: Propiedades creadas  #g
+        creation_states: Estados de creacion  #g
+        current_ownerships: Propiedades actuales  #g
+        currently_owned_bikes: Bicicletas de propiedad actual.  #g
+        description: Descripción  #g
+        developer: Desarrollador  #g
+        email: Email  #g
+        integrations: Integraciones  #g
+        last_login: Último acceso  #g
+        latitude: Latitud  #g
+        locks: Cabellos  #g
+        longitude: Longitud  #g
+        memberships: Membresías  #g
+        my_bikes_hash: Mis bicicletas hash  #g
+        name: Nombre  #g
+        notification_newsletters: Boletines de notificaciones  #g
+        notification_unstolen: Notificación no robada  #g
+        oauth_applications: Aplicaciones de Oauth  #g
+        organization_embeds: Organización encaja  #g
+        organization_invitations: Invitaciones de organización  #g
+        organizations: Organizaciones  #g
+        owned_bikes: Bicicletas propias  #g
+        ownerships: Propiedades  #g
+        partner_data: Datos de pareja  #g
+        password: Contraseña  #g
+        password_digest: Resumen de contraseña  #g
+        password_reset_token: token para cambiar la contraseña  #g
+        payments: Pagos  #g
+        phone: Teléfono  #g
+        preferred_language: Idioma preferido  #g
+        received_stolen_notifications: Recibió notificaciones robadas  #g
+        sent_stolen_notifications: Enviado notificaciones robadas  #g
+        show_bikes: Mostrar bicicletas  #g
+        show_phone: Mostrar telefono  #g
+        show_twitter: Mostrar twitter  #g
+        show_website: Mostrar sitio web  #g
+        state: :activerecord.models.state  #g
+        street: Calle  #g
+        subscriptions: Suscripciones  #g
+        superuser: Superusuario  #g
+        terms_of_service: Términos de servicio  #g
+        title: Título  #g
+        twitter: Gorjeo  #g
+        user_emails: Correos electrónicos del usuario  #g
+        username: Nombre de usuario  #g
+        vendor_terms_of_service: Términos del servicio del vendedor  #g
+        website: Sitio web  #g
+        when_vendor_terms_of_service: Cuando los términos de servicio del vendedor  #g
+        zipcode: Código postal  #g
+
+      ambassador_task:
+        ambassador_task_assignments: Tareas de embajador  #g
+        ambassadors: Embajadores  #g
+        description: Descripción  #g
+        title: Título  #g
+
+      ambassador_task_assignment:
+        ambassador: :activerecord.models.ambassador  #g
+        ambassador_task: :activerecord.models.ambassador_task  #g
+        completed_at: Completado en  #g
+
+      b_param:
+        bike_errors: Errores de bicicleta  #g
+        bike_title: Título de bicicleta  #g
+        created_bike: :activerecord.models.created_bike  #g
+        creator: :activerecord.models.creator  #g
+        email: Email  #g
+        id_token: Token de identificación  #g
+        image: Imagen  #g
+        image_processed: Imagen procesada  #g
+        image_tmp: Imagen tmp  #g
+        old_params: Viejos params  #g
+        organization: :activerecord.models.organization  #g
+        origin: Origen  #g
+        params: Parámetros  #g
+
+      bike:
+        additional_registration: Registro adicional  #g
+        all_description: Todas las descripciones  #g
+        approved_stolen: Aprobado robado  #g
+        b_params: B params  #g
+        belt_drive: Cinturón de conducir  #g
+        bike_codes: Códigos de bicicleta  #g
+        bike_organizations: Organizaciones de bicicletas  #g
+        cached_data: Datos en caché  #g
+        can_edit_claimed_bike_organizations: Puede editar organizaciones de bicicletas reclamadas  #g
+        can_edit_claimed_organizations: Puede editar organizaciones reclamadas  #g
+        coaster_brake: Freno de pedal  #g
+        components: Componentes  #g
+        creation_organization: :activerecord.models.creation_organization  #g
+        creation_states: Estados de creacion  #g
+        creator: :activerecord.models.creator  #g
+        current_stolen_record: :activerecord.models.current_stolen_record  #g
+        cycle_type: Tipo de ciclo  #g
+        description: Descripción  #g
+        duplicate_bike_groups: Grupos duplicados de bicicletas.  #g
+        example: Ejemplo  #g
+        frame_material: Material del marco  #g
+        frame_model: Modelo de marco  #g
+        frame_size: Tamaño del marco  #g
+        frame_size_number: Número de tamaño de marco  #g
+        frame_size_unit: Unidad de tamaño de marco  #g
+        front_gear_type: :activerecord.models.front_gear_type  #g
+        front_tire_narrow: Neumático delantero estrecho  #g
+        front_wheel_size: :activerecord.models.front_wheel_size  #g
+        handlebar_type: Tipo de manillar  #g
+        handlebar_type_other: Manillar tipo otro  #g
+        has_no_serial: No tiene serial  #g
+        hidden: Oculto  #g
+        invoice: :activerecord.models.invoice  #g
+        is_for_sale: Está a la venta  #g
+        listing_order: Orden de listado  #g
+        location: :activerecord.models.location  #g
+        made_without_serial: Hecho sin serial  #g
+        manufacturer: :activerecord.models.manufacturer  #g
+        manufacturer_other: Fabricante otro  #g
+        mnfg_name: Nombre Mnfg  #g
+        name: Nombre  #g
+        normalized_serial_segments: Segmentos seriales normalizados  #g
+        number_of_seats: Numero de asientos  #g
+        organizations: Organizaciones  #g
+        other_listings: Otros listados  #g
+        owner_email: Email del propietario  #g
+        ownerships: Propiedades  #g
+        paint: :activerecord.models.paint  #g
+        pdf: Pdf  #g
+        primary_frame_color: :activerecord.models.primary_frame_color  #g
+        propulsion_type: Tipo de propulsion  #g
+        propulsion_type_other: Propulsión tipo otro.  #g
+        public_images: Imagenes publicas  #g
+        rear_gear_type: :activerecord.models.rear_gear_type  #g
+        rear_tire_narrow: Neumático trasero estrecho  #g
+        rear_wheel_size: :activerecord.models.rear_wheel_size  #g
+        recovered: Recuperado  #g
+        recovered_records: Registros recuperados  #g
+        registered_new: Nuevo registrado  #g
+        secondary_frame_color: :activerecord.models.secondary_frame_color  #g
+        serial_normalized: Serial normalizado  #g
+        serial_number: Número de serie  #g
+        stock_photo_url: Stock foto url  #g
+        stolen: Robado  #g
+        stolen_lat: Lat robado  #g
+        stolen_long: Robado largo  #g
+        stolen_notifications: Notificaciones robadas  #g
+        stolen_records: Registros robados  #g
+        tertiary_frame_color: :activerecord.models.tertiary_frame_color  #g
+        thumb_path: Camino del pulgar  #g
+        updator: :activerecord.models.updator  #g
+        video_embed: Video incrustado  #g
+        year: Año  #g
+        zipcode: Código postal  #g
+
+      bike_code:
+        bike: :activerecord.models.bike  #g
+        bike_code_batch: :activerecord.models.bike_code_batch  #g
+        claimed_at: Reclamado en  #g
+        code: Código  #g
+        code_integer: Código entero  #g
+        code_prefix: Prefijo de código  #g
+        kind: Tipo  #g
+        organization: :activerecord.models.organization  #g
+        user: :activerecord.models.user  #g
+
+      bike_code_batch:
+        bike_codes: Códigos de bicicleta  #g
+        code_number_length: Longitud del número de código  #g
+        notes: Notas  #g
+        organization: :activerecord.models.organization  #g
+        user: :activerecord.models.user  #g
+
+      bike_organization:
+        bike: :activerecord.models.bike  #g
+        can_not_edit_claimed: No se puede editar reclamado  #g
+        deleted_at: Eliminado en  #g
+        organization: :activerecord.models.organization  #g
+
+      blog:
+        body: Cuerpo  #g
+        body_abbr: Cuerpo abbr  #g
+        description_abbr: Descripción abbr  #g
+        index_image: Imagen de índice  #g
+        index_image_lg: Imagen de índice lg  #g
+        is_listicle: Es listicle  #g
+        listicles: Listicles  #g
+        old_title_slug: Babosa del título antiguo  #g
+        public_images: Imagenes publicas  #g
+        published: Publicado  #g
+        published_at: Publicado en  #g
+        tags: Etiquetas  #g
+        title: Título  #g
+        title_slug: Título babosa  #g
+        user: :activerecord.models.user  #g
+
+      bulk_import:
+        bikes: Bicicletas  #g
+        creation_states: Estados de creacion  #g
+        file: Expediente  #g
+        import_errors: Errores de importación  #g
+        is_ascend: Es ascender  #g
+        no_notify: No notificar  #g
+        organization: :activerecord.models.organization  #g
+        progress: Progreso  #g
+        user: :activerecord.models.user  #g
+
+      cgroup:
+        ctypes: Ctypes  #g
+        description: Descripción  #g
+        name: Nombre  #g
+        slug: Babosa  #g
+
+      color:
+        bikes: Bicicletas  #g
+        display: Monitor  #g
+        name: Nombre  #g
+        paints: Las pinturas  #g
+        priority: Prioridad  #g
+
+      component:
+        bike: :activerecord.models.bike  #g
+        cmodel_name: Nombre del modelo  #g
+        ctype: :activerecord.models.ctype  #g
+        ctype_other: Otro tipo de ctype  #g
+        description: Descripción  #g
+        front: Frente  #g
+        is_stock: Es stock  #g
+        manufacturer: :activerecord.models.manufacturer  #g
+        manufacturer_other: Fabricante otro  #g
+        rear: Posterior  #g
+        serial_number: Número de serie  #g
+        year: Año  #g
+
+      country:
+        iso: Yo asi  #g
+        locations: Ubicaciones  #g
+        name: Nombre  #g
+        stolen_records: Registros robados  #g
+
+      creation_state:
+        bike: :activerecord.models.bike  #g
+        bulk_import: :activerecord.models.bulk_import  #g
+        creator: :activerecord.models.creator  #g
+        is_bulk: Es a granel  #g
+        is_new: Es nuevo  #g
+        is_pos: Es pos  #g
+        organization: :activerecord.models.organization  #g
+        origin: Origen  #g
+        pos_kind: Pos amable  #g
+
+      ctype:
+        cgroup: :activerecord.models.cgroup  #g
+        components: Componentes  #g
+        has_multiple: Tiene multiples  #g
+        image: Imagen  #g
+        name: Nombre  #g
+        secondary_name: Nombre secundario  #g
+        slug: Babosa  #g
+
+      customer_contact:
+        bike: :activerecord.models.bike  #g
+        body: Cuerpo  #g
+        contact_type: Tipo de Contacto  #g
+        creator: :activerecord.models.creator  #g
+        creator_email: Email del creador  #g
+        info_hash: Información de resumen criptográfico  #g
+        title: Título  #g
+        user: :activerecord.models.user  #g
+        user_email: Email del usuario  #g
+
+      doorkeeper/access_grant:
+        application: :activerecord.models.application  #g
+        expires_in: Expira en  #g
+        redirect_uri: Redirigir uri  #g
+        revoked_at: Revocado en  #g
+        scopes: Alcances  #g
+        token: Simbólico  #g
+
+      doorkeeper/access_token:
+        application: :activerecord.models.application  #g
+        expires_in: Expira en  #g
+        refresh_token: Actualizar token  #g
+        revoked_at: Revocado en  #g
+        scopes: Alcances  #g
+        token: Simbólico  #g
+
+      doorkeeper/application:
+        access_grants: Becas de acceso  #g
+        access_tokens: Tokens de acceso  #g
+        authorized_applications: Aplicaciones autorizadas  #g
+        authorized_tokens: Tokens autorizados  #g
+        can_send_stolen_notifications: Puede enviar notificaciones robadas  #g
+        is_internal: Es interno  #g
+        name: Nombre  #g
+        owner: :activerecord.models.owner  #g
+        owner_type: Tipo de propietario  #g
+        redirect_uri: Redirigir uri  #g
+        scopes: Alcances  #g
+        secret: Secreto  #g
+        uid: Uid  #g
+
+      duplicate_bike_group:
+        added_bike_at: Bicicleta añadida en  #g
+        bikes: Bicicletas  #g
+        ignore: Ignorar  #g
+        normalized_serial_segments: Segmentos seriales normalizados  #g
+
+      export:
+        file: Expediente  #g
+        file_format: Formato de archivo  #g
+        kind: Tipo  #g
+        options: Opciones  #g
+        organization: :activerecord.models.organization  #g
+        progress: Progreso  #g
+        rows: Filas  #g
+        user: :activerecord.models.user  #g
+
+      feedback:
+        body: Cuerpo  #g
+        email: Email  #g
+        feedback_hash: Hash de retroalimentación  #g
+        feedback_type: Tipo de Comentarios  #g
+        name: Nombre  #g
+        title: Título  #g
+        user: :activerecord.models.user  #g
+
+      flipper/adapters/active_record/feature:
+        key: Llave  #g
+
+      flipper/adapters/active_record/gate:
+        feature_key: Tecla de función  #g
+        key: Llave  #g
+        value: Valor  #g
+
+      front_gear_type:
+        bikes: Bicicletas  #g
+        count: Contar  #g
+        internal: Interno  #g
+        name: Nombre  #g
+        slug: Babosa  #g
+        standard: Estándar  #g
+
+      integration:
+        access_token: Token de acceso  #g
+        information: Información  #g
+        provider_name: Nombre del proveedor  #g
+        user: :activerecord.models.user  #g
+
+      invoice:
+        amount_due_cents: Cantidad debida centavos  #g
+        amount_paid_cents: Cantidad pagada centavos  #g
+        first_invoice: :activerecord.models.first_invoice  #g
+        force_active: Fuerza activa  #g
+        invoice_paid_features: Facturas de pago facturadas.  #g
+        is_active: Está activo  #g
+        notes: Notas  #g
+        organization: :activerecord.models.organization  #g
+        paid_features: Características de pago  #g
+        payments: Pagos  #g
+        subscription_end_at: Suscripción finaliza en  #g
+        subscription_start_at: La suscripción comienza en  #g
+
+      invoice_paid_feature:
+        invoice: :activerecord.models.invoice  #g
+        paid_feature: :activerecord.models.paid_feature  #g
+
+      listicle:
+        blog: :activerecord.models.blog  #g
+        body: Cuerpo  #g
+        body_html: Cuerpo html  #g
+        crop_top_offset: Crop top offset  #g
+        image: Imagen  #g
+        image_credits: Creditos de la imagen  #g
+        image_credits_html: Créditos de la imagen html  #g
+        image_height: Altura de imagen  #g
+        image_width: Ancho de la imagen  #g
+        list_order: Orden de la lista  #g
+        title: Título  #g
+
+      location:
+        bikes: Bicicletas  #g
+        city: Ciudad  #g
+        country: :activerecord.models.country  #g
+        deleted_at: Eliminado en  #g
+        email: Email  #g
+        latitude: Latitud  #g
+        longitude: Longitud  #g
+        name: Nombre  #g
+        organization: :activerecord.models.organization  #g
+        phone: Teléfono  #g
+        shown: Mostrado  #g
+        state: :activerecord.models.state  #g
+        street: Calle  #g
+        zipcode: Código postal  #g
+
+      lock:
+        combination: Combinación  #g
+        has_combination: Tiene combinacion  #g
+        has_key: Tiene llave  #g
+        key_serial: Serie de clave  #g
+        lock_model: Modelo de bloqueo  #g
+        lock_type: :activerecord.models.lock_type  #g
+        manufacturer: :activerecord.models.manufacturer  #g
+        manufacturer_other: Fabricante otro  #g
+        notes: Notas  #g
+        user: :activerecord.models.user  #g
+
+      lock_type:
+        name: Nombre  #g
+        slug: Babosa  #g
+
+      mail_snippet:
+        address: Dirección  #g
+        body: Cuerpo  #g
+        is_enabled: Está habilitado  #g
+        is_location_triggered: Se dispara la ubicación  #g
+        kind: Tipo  #g
+        latitude: Latitud  #g
+        longitude: Longitud  #g
+        name: Nombre  #g
+        organization: :activerecord.models.organization  #g
+        proximity_radius: Radio de proximidad  #g
+        public_images: Imagenes publicas  #g
+
+      manufacturer:
+        bikes: Bicicletas  #g
+        close_year: Año de cierre  #g
+        components: Componentes  #g
+        description: Descripción  #g
+        frame_maker: Fabricante de marcos  #g
+        locks: Cabellos  #g
+        logo: Logo  #g
+        logo_source: Fuente de logo  #g
+        name: Nombre  #g
+        notes: Notas  #g
+        open_year: Año abierto  #g
+        paints: Las pinturas  #g
+        slug: Babosa  #g
+        total_years_active: Total años activos  #g
+        website: Sitio web  #g
+
+      membership:
+        deleted_at: Eliminado en  #g
+        invited_email: Email invitado  #g
+        organization: :activerecord.models.organization  #g
+        role: Papel  #g
+        user: :activerecord.models.user  #g
+
+      normalized_serial_segment:
+        bike: :activerecord.models.bike  #g
+        duplicate_bike_group: :activerecord.models.duplicate_bike_group  #g
+        segment: Segmento  #g
+
+      organization:
+        access_token: Token de acceso  #g
+        api_access_approved: Api acceso aprobado  #g
+        approved: Aprobado  #g
+        ascend_name: Ascender nombre  #g
+        auto_user: :activerecord.models.auto_user  #g
+        avatar: Avatar  #g
+        b_params: B params  #g
+        bike_codes: Códigos de bicicleta  #g
+        bike_organizations: Organizaciones de bicicletas  #g
+        bikes: Bicicletas  #g
+        child_organizations: Organizaciones infantiles  #g
+        created_bikes: Bicicletas creadas  #g
+        creation_states: Estados de creacion  #g
+        deleted_at: Eliminado en  #g
+        invoices: Facturas  #g
+        is_paid: Está pagado  #g
+        is_suspended: Está suspendido  #g
+        kind: Tipo  #g
+        landing_html: Html de aterrizaje  #g
+        locations: Ubicaciones  #g
+        lock_show_on_map: Bloquear mostrar en el mapa  #g
+        mail_snippets: Fragmentos de correo  #g
+        memberships: Membresías  #g
+        name: Nombre  #g
+        organization_invitations: Invitaciones de organización  #g
+        organization_messages: Mensajes de organizacion  #g
+        paid_feature_slugs: Slugs pagados  #g
+        parent_organization: :activerecord.models.parent_organization  #g
+        payments: Pagos  #g
+        pos_kind: Pos amable  #g
+        previous_slug: Babosa anterior  #g
+        public_images: Imagenes publicas  #g
+        recovered_records: Registros recuperados  #g
+        registration_field_labels: Etiquetas de campo de registro  #g
+        short_name: Nombre corto  #g
+        show_on_map: Mostrar en el mapa  #g
+        slug: Babosa  #g
+        users: Usuarios  #g
+        website: Sitio web  #g
+
+      organization_invitation:
+        deleted_at: Eliminado en  #g
+        invitee: :activerecord.models.invitee  #g
+        invitee_email: Email del invitado  #g
+        invitee_name: Nombre del invitado  #g
+        inviter: :activerecord.models.inviter  #g
+        membership_role: Rol de membresía  #g
+        organization: :activerecord.models.organization  #g
+        redeemed: Redimidos  #g
+
+      organization_message:
+        accuracy: Exactitud  #g
+        address: Dirección  #g
+        bike: :activerecord.models.bike  #g
+        body: Cuerpo  #g
+        delivery_status: Estado de entrega  #g
+        email: Email  #g
+        kind: Tipo  #g
+        latitude: Latitud  #g
+        longitude: Longitud  #g
+        organization: :activerecord.models.organization  #g
+        sender: :activerecord.models.sender  #g
+
+      other_listing:
+        bike: :activerecord.models.bike  #g
+        listing_type: Tipo de listado  #g
+        url: Url  #g
+
+      ownership:
+        bike: :activerecord.models.bike  #g
+        claimed: Reclamado  #g
+        creator: :activerecord.models.creator  #g
+        current: Corriente  #g
+        example: Ejemplo  #g
+        owner_email: Email del propietario  #g
+        send_email: Enviar correo electrónico  #g
+        user: :activerecord.models.user  #g
+        user_hidden: Usuario oculto  #g
+
+      paid_feature:
+        amount_cents: Cantidad de centavos  #g
+        description: Descripción  #g
+        details_link: Enlace de detalles  #g
+        feature_slugs: Barras de características  #g
+        invoice_paid_features: Facturas de pago facturadas.  #g
+        invoices: Facturas  #g
+        kind: Tipo  #g
+        name: Nombre  #g
+
+      paint:
+        bikes: Bicicletas  #g
+        color: :activerecord.models.color  #g
+        manufacturer: :activerecord.models.manufacturer  #g
+        name: Nombre  #g
+        secondary_color: :activerecord.models.secondary_color  #g
+        tertiary_color: :activerecord.models.tertiary_color  #g
+
+      payment:
+        amount_cents: Cantidad de centavos  #g
+        email: Email  #g
+        first_payment_date: Primera fecha de pago  #g
+        invoice: :activerecord.models.invoice  #g
+        is_current: Es actual  #g
+        is_payment: Es pago  #g
+        is_recurring: Es recurrente  #g
+        kind: Tipo  #g
+        last_payment_date: Última Fecha de Pago  #g
+        organization: :activerecord.models.organization  #g
+        user: :activerecord.models.user  #g
+
+      public_image:
+        external_image_url: URL de imagen externa  #g
+        image: Imagen  #g
+        imageable: :activerecord.models.imageable  #g
+        imageable_type: Tipo imaginable  #g
+        is_private: Es privado  #g
+        listing_order: Orden de listado  #g
+        name: Nombre  #g
+
+      rear_gear_type:
+        bikes: Bicicletas  #g
+        count: Contar  #g
+        internal: Interno  #g
+        name: Nombre  #g
+        slug: Babosa  #g
+        standard: Estándar  #g
+
+      recovery_display:
+        date_recovered: Fecha de recuperación  #g
+        image: Imagen  #g
+        link: Enlazar  #g
+        quote: Citar  #g
+        quote_by: Citar por  #g
+        stolen_record: :activerecord.models.stolen_record  #g
+
+      state:
+        abbreviation: Abreviatura  #g
+        country: :activerecord.models.country  #g
+        locations: Ubicaciones  #g
+        name: Nombre  #g
+        stolen_records: Registros robados  #g
+
+      stolen_notification:
+        bike: :activerecord.models.bike  #g
+        message: Mensaje  #g
+        receiver: :activerecord.models.receiver  #g
+        receiver_email: Email del receptor  #g
+        reference_url: URL de referencia  #g
+        send_dates: Enviar fechas  #g
+        sender: :activerecord.models.sender  #g
+        subject: Tema  #g
+
+      stolen_record:
+        approved: Aprobado  #g
+        bike: :activerecord.models.bike  #g
+        can_share_recovery: Puede compartir recuperacion  #g
+        city: Ciudad  #g
+        country: :activerecord.models.country  #g
+        create_open311: Crear open311  #g
+        creation_organization: :activerecord.models.creation_organization  #g
+        current: Corriente  #g
+        current_bike: :activerecord.models.current_bike  #g
+        date_recovered: Fecha de recuperación  #g
+        date_stolen: Fecha robada  #g
+        estimated_value: Valor estimado  #g
+        index_helped_recovery: Índice ayudó a la recuperación  #g
+        latitude: Latitud  #g
+        lock_defeat_description: Descripción de la derrota de bloqueo  #g
+        locking_description: Descripción de bloqueo  #g
+        longitude: Longitud  #g
+        phone: Teléfono  #g
+        phone_for_everyone: Telefono para todos  #g
+        phone_for_police: Telefono para policia  #g
+        phone_for_shops: Teléfono para tiendas  #g
+        phone_for_users: Teléfono para usuarios.  #g
+        police_report_department: Departamento de denuncia policial  #g
+        police_report_number: Número de denuncia policial  #g
+        proof_of_ownership: Prueba de la propiedad  #g
+        receive_notifications: Recibir notificaciones  #g
+        recovered_description: Descripción recuperada  #g
+        recovering_user: :activerecord.models.recovering_user  #g
+        recovery_display: :activerecord.models.recovery_display  #g
+        recovery_display_status: Estado de visualización de recuperación  #g
+        recovery_link_token: Token de enlace de recuperación  #g
+        recovery_posted: Recuperación publicado  #g
+        recovery_share: Cuota de recuperación  #g
+        recovery_tweet: Tweet de recuperación  #g
+        secondary_phone: Teléfono secundario  #g
+        show_address: Mostrar direccion  #g
+        state: :activerecord.models.state  #g
+        street: Calle  #g
+        theft_alerts: Alertas de robo  #g
+        theft_description: Descripción de robo  #g
+        time: Hora  #g
+        tsved_at: Tsved en  #g
+        zipcode: Código postal  #g
+
+      theft_alert:
+        begin_at: Comenzar en  #g
+        creator: :activerecord.models.creator  #g
+        end_at: Termina en  #g
+        facebook_post_url: La url de publicación de Facebook #g
+        notes: Notas  #g
+        payment: :activerecord.models.payment  #g
+        status: Estado  #g
+        stolen_record: :activerecord.models.stolen_record  #g
+        theft_alert_plan: :activerecord.models.theft_alert_plan  #g
+
+      theft_alert_plan:
+        active: Activo  #g
+        amount_cents: Cantidad de centavos  #g
+        description: Descripción  #g
+        duration_days: Duración (Días  #g
+        name: Nombre  #g
+        stolen_records: Registros robados  #g
+        theft_alerts: Alertas de robo  #g
+        views: Puntos de vista  #g
+
+      tweet:
+        alignment: Alineación  #g
+        body_html: Cuerpo html  #g
+        image: Imagen  #g
+        public_images: Imagenes publicas  #g
+        twitter_response: Respuesta de Twitter  #g
+
+      user:
+        ambassador_task_assignments: Tareas de embajador  #g
+        ambassador_tasks: Tareas de embajador  #g
+        auth_token: Token de autor  #g
+        avatar: Avatar  #g
+        banned: Prohibido  #g
+        can_send_many_stolen_notifications: Puede enviar muchas notificaciones robadas  #g
+        city: Ciudad  #g
+        confirmation_token: Ficha de confirmación  #g
+        confirmed: Confirmado  #g
+        country: :activerecord.models.country  #g
+        created_bikes: Bicicletas creadas  #g
+        created_ownerships: Propiedades creadas  #g
+        creation_states: Estados de creacion  #g
+        current_ownerships: Propiedades actuales  #g
+        currently_owned_bikes: Bicicletas de propiedad actual.  #g
+        description: Descripción  #g
+        developer: Desarrollador  #g
+        email: Email  #g
+        integrations: Integraciones  #g
+        last_login: Último acceso  #g
+        latitude: Latitud  #g
+        locks: Cabellos  #g
+        longitude: Longitud  #g
+        memberships: Membresías  #g
+        my_bikes_hash: Mis bicicletas hash  #g
+        name: Nombre  #g
+        notification_newsletters: Boletines de notificaciones  #g
+        notification_unstolen: Notificación no robada  #g
+        oauth_applications: Aplicaciones de Oauth  #g
+        organization_embeds: Organización encaja  #g
+        organization_invitations: Invitaciones de organización  #g
+        organizations: Organizaciones  #g
+        owned_bikes: Bicicletas propias  #g
+        ownerships: Propiedades  #g
+        partner_data: Datos de pareja  #g
+        password: Contraseña  #g
+        password_digest: Resumen de contraseña  #g
+        password_reset_token: token para cambiar la contraseña  #g
+        payments: Pagos  #g
+        phone: Teléfono  #g
+        preferred_language: Idioma preferido  #g
+        received_stolen_notifications: Recibió notificaciones robadas  #g
+        sent_stolen_notifications: Enviado notificaciones robadas  #g
+        show_bikes: Mostrar bicicletas  #g
+        show_phone: Mostrar telefono  #g
+        show_twitter: Mostrar twitter  #g
+        show_website: Mostrar sitio web  #g
+        state: :activerecord.models.state  #g
+        street: Calle  #g
+        subscriptions: Suscripciones  #g
+        superuser: Superusuario  #g
+        terms_of_service: Términos de servicio  #g
+        title: Título  #g
+        twitter: Gorjeo  #g
+        user_emails: Correos electrónicos del usuario  #g
+        username: Nombre de usuario  #g
+        vendor_terms_of_service: Términos del servicio del vendedor  #g
+        website: Sitio web  #g
+        when_vendor_terms_of_service: Cuando los términos de servicio del vendedor  #g
+        zipcode: Código postal  #g
+
+      user_email:
+        confirmation_token: Ficha de confirmación  #g
+        email: Email  #g
+        old_user: :activerecord.models.old_user  #g
+        user: :activerecord.models.user  #g
+
+      wheel_size:
+        bikes: Bicicletas  #g
+        description: Descripción  #g
+        iso_bsd: Isa bsd  #g
+        name: Nombre  #g
+        priority: Prioridad  #g
+
+  welcome:
+    index:
+      hero: Registro de bicicleta que funciona

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -1,0 +1,839 @@
+nl:
+  language: Dutch
+  activerecord:
+    models:
+      ad: Advertentie  #g
+      ambassador: Ambassadeur  #g
+      ambassador_task: Ambassador-taak  #g
+      ambassador_task_assignment: Taaktoewijzing ambassadeur  #g
+      b_param: B param  #g
+      bike: Fiets  #g
+      bike_code: Fiets code  #g
+      bike_code_batch: Fietscodebatch  #g
+      bike_organization: Fiets organisatie  #g
+      blog: blog  #g
+      bulk_import: Bulkimport  #g
+      cgroup: CGroup  #g
+      color: Kleur  #g
+      component: bestanddeel  #g
+      country: land  #g
+      creation_state: Creatie staat  #g
+      ctype: Ctype  #g
+      customer_contact: Klantencontact  #g
+      doorkeeper/access_grant: Doorkeeper / toegangssubsidie  #g
+      doorkeeper/access_token: Doorkeeper / toegangstoken  #g
+      doorkeeper/application: Portier / applicatie  #g
+      duplicate_bike_group: Dubbele fietsgroep  #g
+      export: Exporteren  #g
+      feedback: terugkoppeling  #g
+      flipper/adapters/active_record/feature: Flipper / adapters / actief record / functie  #g
+      flipper/adapters/active_record/gate: Flipper / adapters / actief record / poort  #g
+      front_gear_type: Voorste versnelling type  #g
+      integration: integratie  #g
+      invoice: Factuur  #g
+      invoice_paid_feature: Factuur betaald functie  #g
+      listicle: Listicle  #g
+      location: Plaats  #g
+      lock: Slot  #g
+      lock_type: Type vergrendelen  #g
+      mail_snippet: E-mailfragment  #g
+      manufacturer: Fabrikant  #g
+      membership: Lidmaatschap  #g
+      normalized_serial_segment: Genormaliseerd serieel segment  #g
+      organization: Organisatie  #g
+      organization_invitation: Organisatie uitnodiging  #g
+      organization_message: Organisatie bericht  #g
+      other_listing: Andere aanbieding  #g
+      ownership: Eigendom  #g
+      paid_feature: Betaalde functie  #g
+      paint: Verf  #g
+      payment: Betaling  #g
+      public_image: Publiek imago  #g
+      rear_gear_type: Achter versnelling type  #g
+      recovery_display: Herstelscherm  #g
+      state: Staat  #g
+      stolen_notification: Gestolen melding  #g
+      stolen_record: Gestolen record  #g
+      theft_alert: Diefstalwaarschuwing  #g
+      theft_alert_plan: Diefstal-alarmplan  #g
+      tweet: gekwetter  #g
+      user: Gebruiker  #g
+      user_email: E-mailadres gebruiker  #g
+      wheel_size: Wielgrootte  #g
+
+    attributes:
+      ad:
+        body: Lichaam  #g
+        image: Beeld  #g
+        live: Leven  #g
+        organization: :activerecord.models.organization  #g
+        target_url: Doel-URL  #g
+        title: Titel  #g
+
+      ambassador:
+        ambassador_task_assignments: Ambassador taakopdrachten  #g
+        ambassador_tasks: Ambassador-taken  #g
+        auth_token: auth_token  #g
+        avatar: avatar  #g
+        banned: banned  #g
+        can_send_many_stolen_notifications: can_send_many_stolen_notifications  #g
+        city: city  #g
+        confirmation_token: confirmation_token  #g
+        confirmed: confirmed  #g
+        country: :activerecord.models.country  #g
+        created_bikes: Gemaakt fietsen  #g
+        created_ownerships: Gemaakte eigendommen  #g
+        creation_states: Creatie staten  #g
+        current_ownerships: Huidige eigendommen  #g
+        currently_owned_bikes: Momenteel fietsen in eigendom  #g
+        description: description  #g
+        developer: developer  #g
+        email: email  #g
+        integrations: integraties  #g
+        last_login: last_login  #g
+        latitude: latitude  #g
+        locks: sloten  #g
+        longitude: longitude  #g
+        memberships: lidmaatschappen  #g
+        my_bikes_hash: my_bikes_hash  #g
+        name: name  #g
+        notification_newsletters: notification_newsletters  #g
+        notification_unstolen: notification_unstolen  #g
+        oauth_applications: OAuth-applicaties  #g
+        organization_embeds: Organisatie instort  #g
+        organization_invitations: Organisatie-uitnodigingen  #g
+        organizations: organisaties  #g
+        owned_bikes: Eigen fietsen  #g
+        ownerships: eigendommen  #g
+        partner_data: partner_data  #g
+        password: password  #g
+        password_digest: password_digest  #g
+        password_reset_token: password_reset_token  #g
+        payments: betalingen  #g
+        phone: phone  #g
+        preferred_language: preferred_language  #g
+        received_stolen_notifications: Gestolen meldingen ontvangen  #g
+        sent_stolen_notifications: Verzonden gestolen meldingen  #g
+        show_bikes: show_bikes  #g
+        show_phone: show_phone  #g
+        show_twitter: show_twitter  #g
+        show_website: show_website  #g
+        state: :activerecord.models.state  #g
+        street: street  #g
+        subscriptions: abonnementen  #g
+        superuser: superuser  #g
+        terms_of_service: terms_of_service  #g
+        title: title  #g
+        twitter: twitter  #g
+        user_emails: Gebruikersmails  #g
+        username: username  #g
+        vendor_terms_of_service: vendor_terms_of_service  #g
+        website: website  #g
+        when_vendor_terms_of_service: when_vendor_terms_of_service  #g
+        zipcode: zipcode  #g
+
+      ambassador_task:
+        ambassador_task_assignments: Ambassador taakopdrachten  #g
+        ambassadors: Ambassadors  #g
+        description: Omschrijving  #g
+        title: Titel  #g
+
+      ambassador_task_assignment:
+        ambassador: :activerecord.models.ambassador  #g
+        ambassador_task: :activerecord.models.ambassador_task  #g
+        completed_at: Voltooid op  #g
+
+      b_param:
+        bike_errors: Fietsfouten  #g
+        bike_title: Titel van de fiets  #g
+        created_bike: :activerecord.models.created_bike  #g
+        creator: :activerecord.models.creator  #g
+        email: E-mail  #g
+        id_token: Id-token  #g
+        image: Beeld  #g
+        image_processed: Afbeelding verwerkt  #g
+        image_tmp: Afbeelding tmp  #g
+        old_params: Oude params  #g
+        organization: :activerecord.models.organization  #g
+        origin: Oorsprong  #g
+        params: params  #g
+
+      bike:
+        additional_registration: Aanvullende registratie  #g
+        all_description: Alle beschrijving  #g
+        approved_stolen: Goedgekeurd gestolen  #g
+        b_params: B params  #g
+        belt_drive: Riemaandrijving  #g
+        bike_codes: Fietscodes  #g
+        bike_organizations: Fietsorganisaties  #g
+        cached_data: Gegevens in cache  #g
+        can_edit_claimed_bike_organizations: Kan geclaimde fietsorganisaties bewerken  #g
+        can_edit_claimed_organizations: Kan geclaimde organisaties bewerken  #g
+        coaster_brake: Terugtraprem  #g
+        components: Components  #g
+        creation_organization: :activerecord.models.creation_organization  #g
+        creation_states: Creatie staten  #g
+        creator: :activerecord.models.creator  #g
+        current_stolen_record: :activerecord.models.current_stolen_record  #g
+        cycle_type: Cyclustype  #g
+        description: Omschrijving  #g
+        duplicate_bike_groups: Dubbele fietsgroepen  #g
+        example: Voorbeeld  #g
+        frame_material: Frame materiaal  #g
+        frame_model: Frame model  #g
+        frame_size: Kadergrootte  #g
+        frame_size_number: Framegrootte nummer  #g
+        frame_size_unit: Framegrootte-eenheid  #g
+        front_gear_type: :activerecord.models.front_gear_type  #g
+        front_tire_narrow: Voorband smal  #g
+        front_wheel_size: :activerecord.models.front_wheel_size  #g
+        handlebar_type: Stuur type  #g
+        handlebar_type_other: Stuur type anders  #g
+        has_no_serial: Heeft geen serie  #g
+        hidden: Verborgen  #g
+        invoice: :activerecord.models.invoice  #g
+        is_for_sale: Is te koop  #g
+        listing_order: Listing order  #g
+        location: :activerecord.models.location  #g
+        made_without_serial: Gemaakt zonder serienummer  #g
+        manufacturer: :activerecord.models.manufacturer  #g
+        manufacturer_other: Fabrikant anders  #g
+        mnfg_name: Mnfg-naam  #g
+        name: Naam  #g
+        normalized_serial_segments: Genormaliseerde seriële segmenten  #g
+        number_of_seats: aantal zitplaatsen  #g
+        organizations: organisaties  #g
+        other_listings: Andere aanbiedingen  #g
+        owner_email: Eigenaar e-mail  #g
+        ownerships: eigendommen  #g
+        paint: :activerecord.models.paint  #g
+        pdf: pdf  #g
+        primary_frame_color: :activerecord.models.primary_frame_color  #g
+        propulsion_type: Voortstuwingstype  #g
+        propulsion_type_other: Voortstuwingstype overig  #g
+        public_images: Openbare afbeeldingen  #g
+        rear_gear_type: :activerecord.models.rear_gear_type  #g
+        rear_tire_narrow: Achterband smal  #g
+        rear_wheel_size: :activerecord.models.rear_wheel_size  #g
+        recovered: hersteld  #g
+        recovered_records: Herstelde records  #g
+        registered_new: Geregistreerd nieuw  #g
+        secondary_frame_color: :activerecord.models.secondary_frame_color  #g
+        serial_normalized: Serieel genormaliseerd  #g
+        serial_number: Serienummer  #g
+        stock_photo_url: URL voor stockfoto  #g
+        stolen: Gestolen  #g
+        stolen_lat: Gestolen lat  #g
+        stolen_long: Lang gestolen  #g
+        stolen_notifications: Gestolen meldingen  #g
+        stolen_records: Gestolen records  #g
+        tertiary_frame_color: :activerecord.models.tertiary_frame_color  #g
+        thumb_path: Duim pad  #g
+        updator: :activerecord.models.updator  #g
+        video_embed: Video insluiten  #g
+        year: Jaar  #g
+        zipcode: Postcode  #g
+
+      bike_code:
+        bike: :activerecord.models.bike  #g
+        bike_code_batch: :activerecord.models.bike_code_batch  #g
+        claimed_at: claimed_at  #g
+        code: Code  #g
+        code_integer: code_integer  #g
+        code_prefix: Codevoorvoegsel  #g
+        kind: kind  #g
+        organization: :activerecord.models.organization  #g
+        user: :activerecord.models.user  #g
+
+      bike_code_batch:
+        bike_codes: Fietscodes  #g
+        code_number_length: Codenummer lengte  #g
+        notes: Notes  #g
+        organization: :activerecord.models.organization  #g
+        user: :activerecord.models.user  #g
+
+      bike_organization:
+        bike: :activerecord.models.bike  #g
+        can_not_edit_claimed: Kan geclaimd niet bewerken  #g
+        deleted_at: Verwijderd om  #g
+        organization: :activerecord.models.organization  #g
+
+      blog:
+        body: Lichaam  #g
+        body_abbr: Lichaam abbr  #g
+        description_abbr: Beschrijving abbr  #g
+        index_image: Index afbeelding  #g
+        index_image_lg: Index afbeelding lg  #g
+        is_listicle: Is listicle  #g
+        listicles: Listicles  #g
+        old_title_slug: Oude titelslak  #g
+        public_images: Openbare afbeeldingen  #g
+        published: Gepubliceerd  #g
+        published_at: Gepubliceerd op  #g
+        tags: Tags  #g
+        title: Titel  #g
+        title_slug: Titel naaktslak  #g
+        user: :activerecord.models.user  #g
+
+      bulk_import:
+        bikes: Bikes  #g
+        creation_states: Creatie staten  #g
+        file: het dossier  #g
+        import_errors: Fouten importeren  #g
+        is_ascend: Is ascend  #g
+        no_notify: Geen melding  #g
+        organization: :activerecord.models.organization  #g
+        progress: Vooruitgang  #g
+        user: :activerecord.models.user  #g
+
+      cgroup:
+        ctypes: ctypes  #g
+        description: Omschrijving  #g
+        name: Naam  #g
+        slug: Naaktslak  #g
+
+      color:
+        bikes: Bikes  #g
+        display: tonen  #g
+        name: Naam  #g
+        paints: verven  #g
+        priority: Prioriteit  #g
+
+      component:
+        bike: :activerecord.models.bike  #g
+        cmodel_name: Cmodel naam  #g
+        ctype: :activerecord.models.ctype  #g
+        ctype_other: Ctype anders  #g
+        description: Omschrijving  #g
+        front: Voorkant  #g
+        is_stock: Is voorraad  #g
+        manufacturer: :activerecord.models.manufacturer  #g
+        manufacturer_other: Fabrikant anders  #g
+        rear: achterkant  #g
+        serial_number: Serienummer  #g
+        year: Jaar  #g
+
+      country:
+        iso: Iso  #g
+        locations: locaties  #g
+        name: Naam  #g
+        stolen_records: Gestolen records  #g
+
+      creation_state:
+        bike: :activerecord.models.bike  #g
+        bulk_import: :activerecord.models.bulk_import  #g
+        creator: :activerecord.models.creator  #g
+        is_bulk: Is bulk  #g
+        is_new: Is nieuw  #g
+        is_pos: Is pos  #g
+        organization: :activerecord.models.organization  #g
+        origin: Oorsprong  #g
+        pos_kind: Pos soort  #g
+
+      ctype:
+        cgroup: :activerecord.models.cgroup  #g
+        components: Components  #g
+        has_multiple: Heeft meerdere  #g
+        image: Beeld  #g
+        name: Naam  #g
+        secondary_name: Secundaire naam  #g
+        slug: Naaktslak  #g
+
+      customer_contact:
+        bike: :activerecord.models.bike  #g
+        body: Lichaam  #g
+        contact_type: Contact type  #g
+        creator: :activerecord.models.creator  #g
+        creator_email: E-mail van maker  #g
+        info_hash: Info Hash  #g
+        title: Titel  #g
+        user: :activerecord.models.user  #g
+        user_email: E-mailadres gebruiker  #g
+
+      doorkeeper/access_grant:
+        application: :activerecord.models.application  #g
+        expires_in: expires_in  #g
+        redirect_uri: Stuur uri door  #g
+        revoked_at: Ingetrokken om  #g
+        scopes: scopes  #g
+        token: blijk  #g
+
+      doorkeeper/access_token:
+        application: :activerecord.models.application  #g
+        expires_in: Verloopt in  #g
+        refresh_token: Token vernieuwen  #g
+        revoked_at: Ingetrokken om  #g
+        scopes: scopes  #g
+        token: blijk  #g
+
+      doorkeeper/application:
+        access_grants: Toegangssubsidies  #g
+        access_tokens: Toegangstokens  #g
+        authorized_applications: Geautoriseerde applicaties  #g
+        authorized_tokens: Geautoriseerde tokens  #g
+        can_send_stolen_notifications: Kan gestolen meldingen verzenden  #g
+        is_internal: Is intern  #g
+        name: Naam  #g
+        owner: :activerecord.models.owner  #g
+        owner_type: Eigenaar type  #g
+        redirect_uri: Stuur uri door  #g
+        scopes: scopes  #g
+        secret: Geheim  #g
+        uid: uid  #g
+
+      duplicate_bike_group:
+        added_bike_at: Fiets toegevoegd bij  #g
+        bikes: Bikes  #g
+        ignore: Negeren  #g
+        normalized_serial_segments: Genormaliseerde seriële segmenten  #g
+
+      export:
+        file: het dossier  #g
+        file_format: Bestandsformaat  #g
+        kind: Soort  #g
+        options: opties  #g
+        organization: :activerecord.models.organization  #g
+        progress: Vooruitgang  #g
+        rows: rijen  #g
+        user: :activerecord.models.user  #g
+
+      feedback:
+        body: Lichaam  #g
+        email: E-mail  #g
+        feedback_hash: Feedbackhash  #g
+        feedback_type: Soort feedback  #g
+        name: Naam  #g
+        title: Titel  #g
+        user: :activerecord.models.user  #g
+
+      flipper/adapters/active_record/feature:
+        key: Sleutel  #g
+
+      flipper/adapters/active_record/gate:
+        feature_key: feature_key  #g
+        key: Sleutel  #g
+        value: Waarde  #g
+
+      front_gear_type:
+        bikes: Bikes  #g
+        count: tellen  #g
+        internal: intern  #g
+        name: Naam  #g
+        slug: Naaktslak  #g
+        standard: Standaard  #g
+
+      integration:
+        access_token: Toegangstoken  #g
+        information: Informatie  #g
+        provider_name: Provider naam  #g
+        user: :activerecord.models.user  #g
+
+      invoice:
+        amount_due_cents: amount_due_cents  #g
+        amount_paid_cents: amount_paid_cents  #g
+        first_invoice: :activerecord.models.first_invoice  #g
+        force_active: Forceer actief  #g
+        invoice_paid_features: Factuur betaalde functies  #g
+        is_active: Is actief  #g
+        notes: notes  #g
+        organization: :activerecord.models.organization  #g
+        paid_features: Betaalde functies  #g
+        payments: betalingen  #g
+        subscription_end_at: subscription_end_at  #g
+        subscription_start_at: subscription_start_at  #g
+
+      invoice_paid_feature:
+        invoice: :activerecord.models.invoice  #g
+        paid_feature: :activerecord.models.paid_feature  #g
+
+      listicle:
+        blog: :activerecord.models.blog  #g
+        body: body  #g
+        body_html: body_html  #g
+        crop_top_offset: crop_top_offset  #g
+        image: image  #g
+        image_credits: image_credits  #g
+        image_credits_html: image_credits_html  #g
+        image_height: image_height  #g
+        image_width: image_width  #g
+        list_order: list_order  #g
+        title: title  #g
+
+      location:
+        bikes: Bikes  #g
+        city: stad  #g
+        country: :activerecord.models.country  #g
+        deleted_at: deleted_at  #g
+        email: email  #g
+        latitude: latitude  #g
+        longitude: longitude  #g
+        name: name  #g
+        organization: :activerecord.models.organization  #g
+        phone: phone  #g
+        shown: shown  #g
+        state: :activerecord.models.state  #g
+        street: street  #g
+        zipcode: Postcode  #g
+
+      lock:
+        combination: Combinatie  #g
+        has_combination: Heeft combinatie  #g
+        has_key: Heeft sleutel  #g
+        key_serial: Key serial  #g
+        lock_model: Lock-model  #g
+        lock_type: :activerecord.models.lock_type  #g
+        manufacturer: :activerecord.models.manufacturer  #g
+        manufacturer_other: Fabrikant anders  #g
+        notes: Notes  #g
+        user: :activerecord.models.user  #g
+
+      lock_type:
+        name: name  #g
+        slug: slug  #g
+
+      mail_snippet:
+        address: address  #g
+        body: body  #g
+        is_enabled: is_enabled  #g
+        is_location_triggered: is_location_triggered  #g
+        kind: kind  #g
+        latitude: latitude  #g
+        longitude: longitude  #g
+        name: name  #g
+        organization: :activerecord.models.organization  #g
+        proximity_radius: proximity_radius  #g
+        public_images: Openbare afbeeldingen  #g
+
+      manufacturer:
+        bikes: Bikes  #g
+        close_year: close_year  #g
+        components: Components  #g
+        description: description  #g
+        frame_maker: frame_maker  #g
+        locks: sloten  #g
+        logo: logo  #g
+        logo_source: logo_source  #g
+        name: name  #g
+        notes: notes  #g
+        open_year: open_year  #g
+        paints: verven  #g
+        slug: slug  #g
+        total_years_active: total_years_active  #g
+        website: website  #g
+
+      membership:
+        deleted_at: deleted_at  #g
+        invited_email: invited_email  #g
+        organization: :activerecord.models.organization  #g
+        role: role  #g
+        user: :activerecord.models.user  #g
+
+      normalized_serial_segment:
+        bike: :activerecord.models.bike  #g
+        duplicate_bike_group: :activerecord.models.duplicate_bike_group  #g
+        segment: segment  #g
+
+      organization:
+        access_token: Toegangstoken  #g
+        api_access_approved: Api-toegang goedgekeurd  #g
+        approved: aangenomen  #g
+        ascend_name: Ga naar de naam  #g
+        auto_user: :activerecord.models.auto_user  #g
+        avatar: avatar  #g
+        b_params: B params  #g
+        bike_codes: Fietscodes  #g
+        bike_organizations: Fietsorganisaties  #g
+        bikes: Bikes  #g
+        child_organizations: Kinderorganisaties  #g
+        created_bikes: Gemaakt fietsen  #g
+        creation_states: Creatie staten  #g
+        deleted_at: Verwijderd om  #g
+        invoices: facturen  #g
+        is_paid: Is betaald  #g
+        is_suspended: Is geschorst  #g
+        kind: Soort  #g
+        landing_html: Bestemmings-html  #g
+        locations: locaties  #g
+        lock_show_on_map: Lock show op kaart  #g
+        mail_snippets: E-mailfragmenten  #g
+        memberships: lidmaatschappen  #g
+        name: Naam  #g
+        organization_invitations: Organisatie-uitnodigingen  #g
+        organization_messages: Organisatie berichten  #g
+        paid_feature_slugs: Betaalde kenmerkslakken  #g
+        parent_organization: :activerecord.models.parent_organization  #g
+        payments: betalingen  #g
+        pos_kind: Pos soort  #g
+        previous_slug: Vorige slak  #g
+        public_images: Openbare afbeeldingen  #g
+        recovered_records: Herstelde records  #g
+        registration_field_labels: Registratie veldlabels  #g
+        short_name: Korte naam  #g
+        show_on_map: Toon op kaart  #g
+        slug: Naaktslak  #g
+        users: gebruikers  #g
+        website: Website  #g
+
+      organization_invitation:
+        deleted_at: deleted_at  #g
+        invitee: :activerecord.models.invitee  #g
+        invitee_email: invitee_email  #g
+        invitee_name: invitee_name  #g
+        inviter: :activerecord.models.inviter  #g
+        membership_role: membership_role  #g
+        organization: :activerecord.models.organization  #g
+        redeemed: redeemed  #g
+
+      organization_message:
+        accuracy: accuracy  #g
+        address: address  #g
+        bike: :activerecord.models.bike  #g
+        body: body  #g
+        delivery_status: delivery_status  #g
+        email: email  #g
+        kind: kind  #g
+        latitude: latitude  #g
+        longitude: longitude  #g
+        organization: :activerecord.models.organization  #g
+        sender: :activerecord.models.sender  #g
+
+      other_listing:
+        bike: :activerecord.models.bike  #g
+        listing_type: listing_type  #g
+        url: url  #g
+
+      ownership:
+        bike: :activerecord.models.bike  #g
+        claimed: claimed  #g
+        creator: :activerecord.models.creator  #g
+        current: current  #g
+        example: example  #g
+        owner_email: owner_email  #g
+        send_email: send_email  #g
+        user: :activerecord.models.user  #g
+        user_hidden: user_hidden  #g
+
+      paid_feature:
+        amount_cents: amount_cents  #g
+        description: description  #g
+        details_link: details_link  #g
+        feature_slugs: feature_slugs  #g
+        invoice_paid_features: Factuur betaalde functies  #g
+        invoices: facturen  #g
+        kind: kind  #g
+        name: name  #g
+
+      paint:
+        bikes: Bikes  #g
+        color: :activerecord.models.color  #g
+        manufacturer: :activerecord.models.manufacturer  #g
+        name: Naam  #g
+        secondary_color: :activerecord.models.secondary_color  #g
+        tertiary_color: :activerecord.models.tertiary_color  #g
+
+      payment:
+        amount_cents: amount_cents  #g
+        email: email  #g
+        first_payment_date: first_payment_date  #g
+        invoice: :activerecord.models.invoice  #g
+        is_current: is_current  #g
+        is_payment: is_payment  #g
+        is_recurring: is_recurring  #g
+        kind: kind  #g
+        last_payment_date: last_payment_date  #g
+        organization: :activerecord.models.organization  #g
+        user: :activerecord.models.user  #g
+
+      public_image:
+        external_image_url: external_image_url  #g
+        image: image  #g
+        imageable: :activerecord.models.imageable  #g
+        imageable_type: imageable_type  #g
+        is_private: is_private  #g
+        listing_order: listing_order  #g
+        name: name  #g
+
+      rear_gear_type:
+        bikes: Bikes  #g
+        count: count  #g
+        internal: internal  #g
+        name: name  #g
+        slug: slug  #g
+        standard: standard  #g
+
+      recovery_display:
+        date_recovered: date_recovered  #g
+        image: image  #g
+        link: link  #g
+        quote: quote  #g
+        quote_by: quote_by  #g
+        stolen_record: :activerecord.models.stolen_record  #g
+
+      state:
+        abbreviation: Afkorting  #g
+        country: :activerecord.models.country  #g
+        locations: locaties  #g
+        name: Naam  #g
+        stolen_records: Gestolen records  #g
+
+      stolen_notification:
+        bike: :activerecord.models.bike  #g
+        message: message  #g
+        receiver: :activerecord.models.receiver  #g
+        receiver_email: receiver_email  #g
+        reference_url: reference_url  #g
+        send_dates: send_dates  #g
+        sender: :activerecord.models.sender  #g
+        subject: subject  #g
+
+      stolen_record:
+        approved: approved  #g
+        bike: :activerecord.models.bike  #g
+        can_share_recovery: can_share_recovery  #g
+        city: city  #g
+        country: :activerecord.models.country  #g
+        create_open311: create_open311  #g
+        creation_organization: :activerecord.models.creation_organization  #g
+        current: current  #g
+        current_bike: :activerecord.models.current_bike  #g
+        date_recovered: date_recovered  #g
+        date_stolen: date_stolen  #g
+        estimated_value: estimated_value  #g
+        index_helped_recovery: index_helped_recovery  #g
+        latitude: latitude  #g
+        lock_defeat_description: lock_defeat_description  #g
+        locking_description: locking_description  #g
+        longitude: longitude  #g
+        phone: phone  #g
+        phone_for_everyone: phone_for_everyone  #g
+        phone_for_police: phone_for_police  #g
+        phone_for_shops: phone_for_shops  #g
+        phone_for_users: phone_for_users  #g
+        police_report_department: police_report_department  #g
+        police_report_number: police_report_number  #g
+        proof_of_ownership: proof_of_ownership  #g
+        receive_notifications: receive_notifications  #g
+        recovered_description: recovered_description  #g
+        recovering_user: :activerecord.models.recovering_user  #g
+        recovery_display: :activerecord.models.recovery_display  #g
+        recovery_display_status: recovery_display_status  #g
+        recovery_link_token: recovery_link_token  #g
+        recovery_posted: recovery_posted  #g
+        recovery_share: recovery_share  #g
+        recovery_tweet: recovery_tweet  #g
+        secondary_phone: secondary_phone  #g
+        show_address: show_address  #g
+        state: :activerecord.models.state  #g
+        street: street  #g
+        theft_alerts: Diefstalwaarschuwingen  #g
+        theft_description: theft_description  #g
+        time: time  #g
+        tsved_at: tsved_at  #g
+        zipcode: zipcode  #g
+
+      theft_alert:
+        begin_at: begin_at  #g
+        creator: :activerecord.models.creator  #g
+        end_at: end_at  #g
+        facebook_post_url: facebook_post_url  #g
+        notes: notes  #g
+        payment: :activerecord.models.payment  #g
+        status: status  #g
+        stolen_record: :activerecord.models.stolen_record  #g
+        theft_alert_plan: :activerecord.models.theft_alert_plan  #g
+
+      theft_alert_plan:
+        active: active  #g
+        amount_cents: amount_cents  #g
+        description: description  #g
+        duration_days: duration_days  #g
+        name: name  #g
+        stolen_records: Gestolen records  #g
+        theft_alerts: Diefstalwaarschuwingen  #g
+        views: views  #g
+
+      tweet:
+        alignment: alignment  #g
+        body_html: body_html  #g
+        image: image  #g
+        public_images: Openbare afbeeldingen  #g
+        twitter_response: twitter_response  #g
+
+      user:
+        ambassador_task_assignments: Ambassador taakopdrachten  #g
+        ambassador_tasks: Ambassador-taken  #g
+        auth_token: Auth token  #g
+        avatar: avatar  #g
+        banned: verboden  #g
+        can_send_many_stolen_notifications: Kan veel gestolen meldingen verzenden  #g
+        city: stad  #g
+        confirmation_token: Bevestigingstoken  #g
+        confirmed: bevestigd  #g
+        country: :activerecord.models.country  #g
+        created_bikes: Gemaakt fietsen  #g
+        created_ownerships: Gemaakte eigendommen  #g
+        creation_states: Creatie staten  #g
+        current_ownerships: Huidige eigendommen  #g
+        currently_owned_bikes: Momenteel fietsen in eigendom  #g
+        description: Omschrijving  #g
+        developer: Ontwikkelaar  #g
+        email: E-mail  #g
+        integrations: integraties  #g
+        last_login: Laatste aanmelding  #g
+        latitude: Breedtegraad  #g
+        locks: sloten  #g
+        longitude: Lengtegraad  #g
+        memberships: lidmaatschappen  #g
+        my_bikes_hash: Mijn fietsen hasj  #g
+        name: Naam  #g
+        notification_newsletters: Meldingsnieuwsbrieven  #g
+        notification_unstolen: Melding ongedaan gemaakt  #g
+        oauth_applications: OAuth-applicaties  #g
+        organization_embeds: Organisatie instort  #g
+        organization_invitations: Organisatie-uitnodigingen  #g
+        organizations: organisaties  #g
+        owned_bikes: Eigen fietsen  #g
+        ownerships: eigendommen  #g
+        partner_data: Partner gegevens  #g
+        password: Wachtwoord  #g
+        password_digest: Wachtwoordoverzicht  #g
+        password_reset_token: Wachtwoordherstel-token  #g
+        payments: betalingen  #g
+        phone: Telefoon  #g
+        preferred_language: Voorkeurstaal  #g
+        received_stolen_notifications: Gestolen meldingen ontvangen  #g
+        sent_stolen_notifications: Verzonden gestolen meldingen  #g
+        show_bikes: Toon fietsen  #g
+        show_phone: Toon telefoon  #g
+        show_twitter: Laat twitter zien  #g
+        show_website: Toon website  #g
+        state: :activerecord.models.state  #g
+        street: Straat  #g
+        subscriptions: abonnementen  #g
+        superuser: Super gebruiker  #g
+        terms_of_service: Servicevoorwaarden  #g
+        title: Titel  #g
+        twitter: tjilpen  #g
+        user_emails: Gebruikersmails  #g
+        username: Gebruikersnaam  #g
+        vendor_terms_of_service: Servicevoorwaarden van de leverancier  #g
+        website: Website  #g
+        when_vendor_terms_of_service: Wanneer de servicevoorwaarden van de leverancier  #g
+        zipcode: Postcode  #g
+
+      user_email:
+        confirmation_token: confirmation_token  #g
+        email: email  #g
+        old_user: :activerecord.models.old_user  #g
+        user: :activerecord.models.user  #g
+
+      wheel_size:
+        bikes: Bikes  #g
+        description: Omschrijving  #g
+        iso_bsd: Iso bsd  #g
+        name: Naam  #g
+        priority: Prioriteit  #g
+
+  welcome:
+    index:
+      hero: Fietsregistratie die werkt

--- a/db/migrate/20190625151428_add_preferred_language_to_user.rb
+++ b/db/migrate/20190625151428_add_preferred_language_to_user.rb
@@ -1,0 +1,5 @@
+class AddPreferredLanguageToUser < ActiveRecord::Migration
+  def change
+    add_column :users, :preferred_language, :string
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -2218,7 +2218,8 @@ CREATE TABLE public.users (
     country_id integer,
     state_id integer,
     notification_unstolen boolean DEFAULT true,
-    my_bikes_hash jsonb
+    my_bikes_hash jsonb,
+    preferred_language character varying
 );
 
 
@@ -4429,4 +4430,6 @@ INSERT INTO schema_migrations (version) VALUES ('20190620203854');
 INSERT INTO schema_migrations (version) VALUES ('20190621183811');
 
 INSERT INTO schema_migrations (version) VALUES ('20190624171627');
+
+INSERT INTO schema_migrations (version) VALUES ('20190625151428');
 

--- a/spec/controllers/bikes_controller_spec.rb
+++ b/spec/controllers/bikes_controller_spec.rb
@@ -968,11 +968,14 @@ RSpec.describe BikesController, type: :controller do
             end
           end
           context "stolen bike" do
+            before do
+              allow(Flipper).to receive(:enabled?).with(:premium_listings, user).and_return(true)
+            end
+
             it "renders with stolen as first template, different description" do
               bike.update_attribute(:stolen, true)
               bike.reload
               expect(bike.stolen).to be_truthy
-              allow(Flipper).to receive(:enabled?).and_return(true)
 
               get :edit, id: bike.id
 
@@ -983,11 +986,13 @@ RSpec.describe BikesController, type: :controller do
             end
           end
           context "recovered bike" do
+            before do
+              allow(Flipper).to receive(:enabled?).with(:premium_listings, user).and_return(true)
+            end
             it "renders with recovered as first template, different description" do
               bike.update_attributes(stolen: true, recovered: true)
               bike.reload
               expect(bike.recovered).to be_truthy
-              allow(Flipper).to receive(:enabled?).and_return(true)
 
               get :edit, id: bike.id
 

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -559,6 +559,24 @@ RSpec.describe UsersController, type: :controller do
       expect(user.reload.terms_of_service).to be_truthy
     end
 
+    it "updates the preferred_language if valid" do
+      expect(user.preferred_language).to eq(nil)
+      set_current_user(user)
+      patch :update, id: user.username, user: { preferred_language: "en" }
+      expect(flash[:success]).to match(/successfully updated/i)
+      expect(response).to redirect_to(my_account_url)
+      expect(user.reload.preferred_language).to eq("en")
+    end
+
+    it "does not update the preferred_language if invalid" do
+      expect(user.preferred_language).to eq(nil)
+      set_current_user(user)
+      patch :update, id: user.username, user: { preferred_language: "klingon" }
+      expect(flash[:success]).to be_blank
+      expect(response).to render_template(:edit)
+      expect(user.reload.preferred_language).to eq(nil)
+    end
+
     it "updates notification" do
       set_current_user(user)
       expect(user.notification_unstolen).to be_truthy # Because it's set to true by default

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -38,48 +38,57 @@ RSpec.describe User, type: :model do
 
   describe "validate" do
     describe "create" do
+      subject { User.new(FactoryBot.attributes_for(:user)) }
       before :each do
-        @user = User.new(FactoryBot.attributes_for(:user))
-        expect(@user.valid?).to be_truthy
+        expect(subject.valid?).to be_truthy
       end
 
       it "requires password on create" do
-        @user.password = nil
-        @user.password_confirmation = nil
-        expect(@user.valid?).to be_falsey
-        expect(@user.errors.messages[:password].include?("can't be blank")).to be_truthy
+        subject.password = nil
+        subject.password_confirmation = nil
+        expect(subject.valid?).to be_falsey
+        expect(subject.errors.messages[:password].include?("can't be blank")).to be_truthy
       end
 
       it "requires password and confirmation to match" do
-        @user.password_confirmation = "wtf"
-        expect(@user.valid?).to be_falsey
-        expect(@user.errors.messages[:password_confirmation].include?("doesn't match confirmation")).to be_truthy
+        subject.password_confirmation = "wtf"
+        expect(subject.valid?).to be_falsey
+        expect(subject.errors.messages[:password_confirmation].include?("doesn't match confirmation")).to be_truthy
       end
 
       it "requires at least 8 characters for the password" do
-        @user.password = "hi"
-        @user.password_confirmation = "hi"
-        expect(@user.valid?).to be_falsey
-        expect(@user.errors.messages[:password].include?("is too short (minimum is 6 characters)")).to be_truthy
+        subject.password = "hi"
+        subject.password_confirmation = "hi"
+        expect(subject.valid?).to be_falsey
+        expect(subject.errors.messages[:password].include?("is too short (minimum is 6 characters)")).to be_truthy
       end
 
       it "makes sure there is at least one letter" do
-        @user.password = "1234567890"
-        @user.password_confirmation = "1234567890"
-        expect(@user.valid?).to be_falsey
-        expect(@user.errors.messages[:password].include?("must contain at least one letter")).to be_truthy
+        subject.password = "1234567890"
+        subject.password_confirmation = "1234567890"
+        expect(subject.valid?).to be_falsey
+        expect(subject.errors.messages[:password].include?("must contain at least one letter")).to be_truthy
       end
 
       it "doesn't let unconfirmed users have the same password" do
-        FactoryBot.create(:user, email: @user.email)
-        expect(@user.valid?).to be_falsey
-        expect(@user.errors.messages[:email]).to be_present
+        FactoryBot.create(:user, email: subject.email)
+        expect(subject.valid?).to be_falsey
+        expect(subject.errors.messages[:email]).to be_present
       end
 
       it "doesn't let confirmed users have the same password" do
-        FactoryBot.create(:user_confirmed, email: @user.email)
-        expect(@user.valid?).to be_falsey
-        expect(@user.errors.messages[:email]).to be_present
+        FactoryBot.create(:user_confirmed, email: subject.email)
+        expect(subject.valid?).to be_falsey
+        expect(subject.errors.messages[:email]).to be_present
+      end
+
+      it "validates preferred_language" do
+        subject.preferred_language = nil
+        expect(subject.valid?).to eq(true)
+        subject.preferred_language = "en"
+        expect(subject.valid?).to eq(true)
+        subject.preferred_language = "klingon"
+        expect(subject.valid?).to eq(false)
       end
     end
 

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -72,6 +72,18 @@ RSpec::Sidekiq.configure do |config|
   config.warn_when_jobs_not_processed_by_sidekiq = false
 end
 
+RSpec.configure do |config|
+  config.before(:each) do
+    # Reset feature-flipping between examples
+    # (Un-stub before each example as needed, overriding with specific args)
+    allow(Flipper).to receive(:enabled?).with(any_args).and_call_original
+
+    # Reset locale settings to defaults
+    I18n.default_locale = :en
+    I18n.locale = I18n.default_locale
+  end
+end
+
 # DB Cleaner metadata tags
 # ========================
 #

--- a/spec/requests/locale_detection_request_spec.rb
+++ b/spec/requests/locale_detection_request_spec.rb
@@ -1,0 +1,105 @@
+require "rails_helper"
+
+RSpec.describe "Locale detection", type: :request do
+  before do
+    allow(Flipper).to receive(:enabled?).with(:localization, nil).and_return(true)
+  end
+
+  describe "requesting the root path" do
+    context "given a user preference" do
+      include_context :request_spec_logged_in_as_user
+      before do
+        allow(Flipper).to receive(:enabled?).with(:localization, current_user).and_return(true)
+      end
+
+      it "renders the homepage in the requested language" do
+        get "/"
+        expect(response.body).to match(/bike registration/i)
+
+        current_user.update(preferred_language: :es)
+        get "/"
+        expect(response.body).to match(/registro de bicicleta/i)
+
+        current_user.update(preferred_language: :nl)
+        get "/"
+        expect(response.body).to match(/fietsregistratie/i)
+      end
+    end
+
+    context "given a valid locale query param" do
+      it "renders the homepage in the requested language" do
+        get "/", locale: :en
+        expect(response.body).to match(/bike registration/i)
+
+        get "/", locale: :es
+        expect(response.body).to match(/registro de bicicleta/i)
+
+        get "/", locale: :nl
+        expect(response.body).to match(/fietsregistratie/i)
+      end
+    end
+
+    context "given an invalid locale query param" do
+      it "renders the homepage in the default language" do
+        get "/", locale: :klingon
+        expect(response.body).to match(/bike registration/i)
+      end
+    end
+
+    context "given a valid ACCEPT_LANGUAGE header" do
+      it "renders the homepage in the requested language" do
+        get "/", {}, { "HTTP_ACCEPT_LANGUAGE" => "en-US,en;q=0.9" }
+        expect(response.body).to match(/bike registration/i)
+
+        get "/", {}, { "HTTP_ACCEPT_LANGUAGE" => "es,en;q=0.9" }
+        expect(response.body).to match(/registro de bicicleta/i)
+
+        get "/", {}, { "HTTP_ACCEPT_LANGUAGE" => "nl,en;q=0.9" }
+        expect(response.body).to match(/fietsregistratie/i)
+      end
+    end
+
+    context "given an unrecognized ACCEPT_LANGUAGE header" do
+      it "renders the homepage in the default language" do
+        get "/", {}, { "HTTP_ACCEPT_LANGUAGE" => "es-ES;q=0.8,nl-NL;q=0.7" }
+        expect(response.body).to match(/bike registration/i)
+      end
+    end
+
+    context "given multiple detected locales" do
+      include_context :request_spec_logged_in_as_user
+      before do
+        allow(Flipper).to receive(:enabled?).with(:localization, current_user).and_return(true)
+      end
+
+      it "gives highest precedence to query param" do
+        current_user.update(preferred_language: :es)
+
+        get "/",
+            { locale: :nl },
+            { "HTTP_ACCEPT_LANGUAGE" => "en-US,en;q=0.9" }
+
+        expect(response.body).to match(/fietsregistratie/i), nil
+      end
+
+      it "gives secondary precedence to user preference" do
+        current_user.update(preferred_language: :es)
+        get "/", {}, { "HTTP_ACCEPT_LANGUAGE" => "en-US,en;q=0.9" }
+        expect(response.body).to match(/registro de bicicleta/i)
+      end
+
+      it "gives lowest precedence to request headers" do
+        current_user.update(preferred_language: nil)
+        get "/", {}, { "HTTP_ACCEPT_LANGUAGE" => "nl,en;q=0.9" }
+        expect(response.body).to match(/fietsregistratie/i)
+      end
+
+      it "falls back to the app default if no other locales are provided or recognized" do
+        I18n.default_locale = :es
+        current_user.update(preferred_language: nil)
+        get "/", { locale: :klingon }, { "HTTP_ACCEPT_LANGUAGE" => "k3" }
+        expect(response.body).to match(/registro de bicicleta/i)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Provides localization toggling via, in order of precedence:

1. Query param (settable via the footer UI)
2. User preference (settable via the user#edit?root form)
3. The `ACCEPT_LANGUAGE` header (minimally. settable via browser options)

Adds stub localization files for Spanish (for testing) and Dutch with generated translations of models and attributes

#### Next steps

- Externalize template strings to English localization files
- Set up a translation service (PhraseApp, CrowdIn, Transifex, Locale)

#### Screenshots

`/my_account` 

<img width="660" alt="Screen Shot 2019-06-26 at 11 24 11 AM" src="https://user-images.githubusercontent.com/4433943/60193116-1bca1e00-9805-11e9-9dea-6a7082d15cd1.png">

site footer

<img width="257" alt="Screen Shot 2019-06-26 at 11 24 24 AM" src="https://user-images.githubusercontent.com/4433943/60193134-22589580-9805-11e9-905f-aa23f1b514c1.png">

via browser preferences

<img width="1101" alt="Screen Shot 2019-06-26 at 11 25 11 AM" src="https://user-images.githubusercontent.com/4433943/60193155-2c7a9400-9805-11e9-8003-5dd9f740bdaa.png">


