### PR TITLE
Fix admin/theft_alerts index typo

### DIFF
--- a/app/views/admin/theft_alerts/index.html.haml
+++ b/app/views/admin/theft_alerts/index.html.haml
@@ -24,7 +24,7 @@
           %td
             - if alert.bike.present?
               = link_to alert.bike.id, edit_admin_bike_path(alert.bike)
-            - if alert.bike_recovered?
+            - if alert.recovered?
               #{alert.bike.type} recovered
           %td
             = link_to alert.creator.email, edit_admin_user_path(alert.creator.email)

--- a/spec/requests/admin/theft_alerts_request_spec.rb
+++ b/spec/requests/admin/theft_alerts_request_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe Admin::TheftAlertsController, type: :request do
     include_context :request_spec_logged_in_as_superuser
 
     describe "GET /admin/theft_alerts" do
+      let!(:theft_alert) { FactoryBot.create(:theft_alert) }
       it "responds with 200 OK and renders the index template" do
         get "/admin/theft_alerts"
         expect(response).to be_ok


### PR DESCRIPTION
Oopsie, I'm a fool. Add a spec to make sure something like this doesn't slip through again.