### PR TITLE
Prevent leaking of locale between requests

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -67,6 +67,9 @@ class ApplicationController < ActionController::Base
   end
 
   def set_locale
+    # Prevent leaking of I18n.locale between requests
+    I18n.locale = I18n.default_locale
+
     return unless Flipper.enabled?(:localization, current_user)
     # TODO: Remove debug logging when feature flag is removed
 

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -78,9 +78,8 @@ RSpec.configure do |config|
     # (Un-stub before each example as needed, overriding with specific args)
     allow(Flipper).to receive(:enabled?).with(any_args).and_call_original
 
-    # Reset locale settings to defaults
+    # Reset default locale between examples
     I18n.default_locale = :en
-    I18n.locale = I18n.default_locale
   end
 end
 


### PR DESCRIPTION
Setting I18n.locale is [not thread-safe](https://github.com/ruby-i18n/i18n/pull/382). This patch ensures per-request locale setting doesn't leak across threads.