### PR TITLE
Forward locale param when provided, set locale in around_action

### DIFF
--- a/app/assets/javascripts/init.coffee
+++ b/app/assets/javascripts/init.coffee
@@ -160,9 +160,22 @@ window.updateSearchBikesHeaderLink = ->
       distance = null
     else
       localStorage.setItem('distance', distance)
+
   distance ||= 100
-  url = "/bikes?stolenness=proximity&location=#{location}&distance=#{distance}"
-  $('#search_bikes_header_link').attr('href', url)
+
+  # update search params, retaining any other query params
+  $bike_search_link = $("#search_bikes_header_link")
+
+  bike_search_query = $bike_search_link[0].search
+  params = Object.fromEntries(bike_search_query.replace("?", "").split("&").map((e) => e.split("=")))
+  params["stolenness"] = "proximity"
+  params["location"] = location
+  params["distance"] = distance
+
+  bike_search_path = $bike_search_link[0].pathname
+  query_string = Object.entries(params).map((e) => e.join("=")).join("&")
+  $bike_search_link.attr("href", "#{bike_search_path}?#{query_string}")
+
 
 $(document).ready ->
   window.updateSearchBikesHeaderLink()

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -58,6 +58,11 @@ class ApplicationController < ActionController::Base
     params.permit(*Bike.permitted_search_params).merge(stolenness: @stolenness)
   end
 
+  def default_url_options
+    # forward locale param when provided
+    params.slice(:locale)
+  end
+
   def locale_from_request_header
     request.env.fetch("HTTP_ACCEPT_LANGUAGE", "").scan(/^[a-z]{2}/).first
   end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -90,7 +90,7 @@ class ApplicationController < ActionController::Base
     requested_locale
   end
 
-  # TODO: Remove logging when feature flag is removed
+  # TODO: Remove logging in #requested_locale when feature flag is removed
   def set_locale
     if Flipper.enabled?(:localization, current_user)
       I18n.with_locale(requested_locale) { yield }

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,7 +1,8 @@
 class ApplicationController < ActionController::Base
   include ControllerHelpers
   protect_from_forgery
-  before_action :set_locale
+
+  around_action :set_locale
 
   ensure_security_headers(csp: false,
                           hsts: "max-age=#{20.years.to_i}",
@@ -66,24 +67,30 @@ class ApplicationController < ActionController::Base
     requested_locale if I18n.available_locales.include?(requested_locale)
   end
 
-  def set_locale
-    # Prevent leaking of I18n.locale between requests
-    I18n.locale = I18n.default_locale
+  def requested_locale
+    logger.info("* Current: '#{I18n.locale}'")
+    logger.info("* Params: '#{locale_from_request_params}'")
+    logger.info("* User profile:: '#{current_user&.preferred_language}'")
+    logger.info("* Request Headers: '#{locale_from_request_header}'")
+    logger.info("* Default: '#{I18n.default_locale}'")
 
-    return unless Flipper.enabled?(:localization, current_user)
-    # TODO: Remove debug logging when feature flag is removed
-
-    logger.debug("* Params: '#{locale_from_request_params}'")
-    logger.debug("* User profile:: '#{current_user&.preferred_language}'")
-    logger.debug("* Request Headers: '#{locale_from_request_header}'")
-    logger.debug("* Default: '#{I18n.default_locale}'")
-
-    I18n.locale =
+    requested_locale =
       locale_from_request_params ||
       current_user&.preferred_language.presence ||
       locale_from_request_header ||
       I18n.default_locale
 
-    logger.debug("* Locale set to '#{I18n.locale}'")
+    logger.info("* Locale set to '#{requested_locale}'")
+
+    requested_locale
+  end
+
+  # TODO: Remove logging when feature flag is removed
+  def set_locale
+    if Flipper.enabled?(:localization, current_user)
+      I18n.with_locale(requested_locale) { yield }
+    else
+      I18n.with_locale(I18n.default_locale) { yield }
+    end
   end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -217,9 +217,8 @@ module ApplicationHelper
   end
 
   def language_choices
-    @language_choices ||=
-      I18n
-        .available_locales
-        .map { |locale| [t("language", locale: locale), locale.to_s] }
+    @language_choices ||= I18n.available_locales.map do |locale|
+      [t("language", locale: locale), locale.to_s]
+    end
   end
 end

--- a/app/views/layouts/application_revised.html.haml
+++ b/app/views/layouts/application_revised.html.haml
@@ -12,7 +12,7 @@
       .container
         %a.primary-logo{ href: user_root_url }
           = image_tag "revised/logo.svg", class: "primary-nav", alt: "Bike Index home"
-        %a.nonprofit-subtitle{ href: "https://bikeindex.org/news/bike-index--now-a-nonprofit" }
+        = link_to news_path("bike-index--now-a-nonprofit"), class: "nonprofit-subtitle" do
           the non-profit
           %br
           bike registry

--- a/app/views/layouts/new_admin.html.haml
+++ b/app/views/layouts/new_admin.html.haml
@@ -70,6 +70,7 @@
                           { title: "Bulk Imports", path: admin_bulk_imports_path, match_controller: true },
                           { title: "Partial Bikes", path: admin_partial_bikes_path, match_controller: true },
                           { title: "Duplicate Bikes", path: duplicates_admin_bikes_path, match_controller: false },
+                          { title: "Feature Flags", path: admin_feature_flags_path, match_controller: false },
                           { title: "Exit Admin", path: root_path, match_controller: false },
                         ]
           other_link_active = other_links.detect { |l| current_page_active?(l[:path], l[:match_controller]) }

--- a/config/application.rb
+++ b/config/application.rb
@@ -39,6 +39,10 @@ module Bikeindex
     # Throttle stuff
     config.middleware.use Rack::Throttle::Minute, :max => ENV["MIN_MAX_RATE"].to_i, :cache => Redis.new, :key_prefix => :throttle
 
+    # Add middleware to make i18n configuration thread-safe
+    require_relative "../lib/i18n/middleware"
+    config.middleware.use I18n::Middleware
+
     config.to_prepare do
       Doorkeeper::ApplicationsController.layout "doorkeeper"
       Doorkeeper::AuthorizationsController.layout "doorkeeper"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -209,7 +209,9 @@ Bikeindex::Application.routes.draw do
     end
     resources :users, only: [:index, :show, :edit, :update, :destroy]
 
-    mount Flipper::UI.app(Flipper) => "/feature_flags", constraints: AdminRestriction
+    mount Flipper::UI.app(Flipper) => "/feature_flags",
+          constraints: AdminRestriction,
+          as: :feature_flags
   end
 
   namespace :api, defaults: { format: "json" } do

--- a/lib/i18n/middleware.rb
+++ b/lib/i18n/middleware.rb
@@ -1,0 +1,15 @@
+module I18n
+  # Taken from https://github.com/ruby-i18n/i18n
+  # Isolates i18n config by thread
+  class Middleware
+    def initialize(app)
+      @app = app
+    end
+
+    def call(env)
+      @app.call(env)
+    ensure
+      Thread.current[:i18n_config] = I18n::Config.new
+    end
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -80,9 +80,6 @@ RSpec.configure do |config|
     # Reset feature-flipping between examples
     # (Un-stub before each example as needed, overriding with specific args)
     allow(Flipper).to receive(:enabled?).with(any_args).and_call_original
-
-    # Reset default locale between examples
-    I18n.default_locale = :en
   end
 end
 

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -40,6 +40,9 @@ RSpec.configure do |config|
   config.use_transactional_fixtures = true
   config.render_views
 
+  # include translation / localization methods
+  config.include AbstractController::Translation
+
   # Add our request/controller spec helpers
   config.include RequestSpecHelpers, type: :request
   config.include ControllerSpecHelpers, type: :controller

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -78,7 +78,7 @@ end
 RSpec.configure do |config|
   config.before(:each) do
     # Reset feature-flipping between examples
-    # (Un-stub before each example as needed, overriding with specific args)
+    # (In test examples, stub Flipper as needed, passing specific args to #with)
     allow(Flipper).to receive(:enabled?).with(any_args).and_call_original
   end
 end

--- a/spec/requests/locale_detection_request_spec.rb
+++ b/spec/requests/locale_detection_request_spec.rb
@@ -30,10 +30,8 @@ RSpec.describe "Locale detection", type: :request do
       it "renders the homepage in the requested language" do
         get "/", locale: :en
         expect(response.body).to match(/bike registration/i)
-
         get "/", locale: :es
         expect(response.body).to match(/registro de bicicleta/i)
-
         get "/", locale: :nl
         expect(response.body).to match(/fietsregistratie/i)
       end
@@ -74,12 +72,8 @@ RSpec.describe "Locale detection", type: :request do
 
       it "gives highest precedence to query param" do
         current_user.update(preferred_language: :es)
-
-        get "/",
-            { locale: :nl },
-            { "HTTP_ACCEPT_LANGUAGE" => "en-US,en;q=0.9" }
-
-        expect(response.body).to match(/fietsregistratie/i), nil
+        get "/", { locale: :nl }, { "HTTP_ACCEPT_LANGUAGE" => "en-US,en;q=0.9" }
+        expect(response.body).to match(/fietsregistratie/i)
       end
 
       it "gives secondary precedence to user preference" do
@@ -95,10 +89,13 @@ RSpec.describe "Locale detection", type: :request do
       end
 
       it "falls back to the app default if no other locales are provided or recognized" do
-        I18n.default_locale = :es
+        allow(I18n).to receive(:default_locale).and_return(:es)
         current_user.update(preferred_language: nil)
+
         get "/", { locale: :klingon }, { "HTTP_ACCEPT_LANGUAGE" => "k3" }
+
         expect(response.body).to match(/registro de bicicleta/i)
+        allow(I18n).to receive(:default_locale).and_call_original
       end
     end
   end


### PR DESCRIPTION
- Adds [middleware](https://github.com/ruby-i18n/i18n/blob/master/lib/i18n/middleware.rb) from a more recent (but incompatible, alas) version of i18n to make i18n configuration thread-safe. This resolved the locale-leaking bug locally.
- Refactors locale setting to use an `around_action` to more cleanly isolate I18n locale per-request
- Implements `default_url_options` to set the current locale param, if one is provided, in any Rails-generated links
- Updates the coffeescript setting the bike search query params on the welcome page to not strip the locale param in the link
- Updates the blog post link on the home page logo so it retains the locale param
- Adds a link to the feature flag dashboard to the admin dashboard dropdown menu