### PR TITLE
Introduce MoneyHelper view helper module

### DIFF
--- a/app/helpers/money_helper.rb
+++ b/app/helpers/money_helper.rb
@@ -1,6 +1,7 @@
 module MoneyHelper
   include MoneyRails::ActionViewExtension
 
+  # TODO: Add a bank implementation that fetches conversion rate values
   Money.default_bank.add_rate(:USD, :EUR, 0.88)
 
   def default_currency

--- a/app/helpers/money_helper.rb
+++ b/app/helpers/money_helper.rb
@@ -1,0 +1,17 @@
+module MoneyHelper
+  include MoneyRails::ActionViewExtension
+
+  Money.default_bank.add_rate(:USD, :EUR, 0.88)
+
+  def default_currency
+    t("number.currency.alphabetic_code")
+  end
+
+  def money_usd(dollars, exchange_to: default_currency)
+    Money.new(dollars * 100, :USD).exchange_to(exchange_to)
+  end
+
+  def as_currency(dollars_usd, exchange_to: default_currency)
+    money_without_cents_and_with_symbol(money_usd(dollars_usd, exchange_to: exchange_to))
+  end
+end

--- a/app/models/counts.rb
+++ b/app/models/counts.rb
@@ -29,9 +29,6 @@ class Counts
 
     def organizations; retrieve_for("organizations") end
 
-    # TODO: Dupe method definition
-    def week_creation_chart; retrieve_for("week_creation_chart") end
-
     def week_creation_chart
       chart_data = redis { |r| r.hget STOREAGE_KEY, "week_creation_chart" }
       chart_data.present? ? JSON.parse(chart_data) : chart_data
@@ -62,22 +59,20 @@ class Counts
     end
 
     def recoveries_value; retrieve_for("recoveries_value") end
-  end
 
-  # TODO: This `protected` has no effect. Do we want to move the methods below
-  # into the class << self?
-  protected
+    protected
 
-  # Should be the new canonical way of using redis
-  def self.redis
-    # Basically, crib what is done in sidekiq
-    raise ArgumentError, "requires a block" unless block_given?
-    redis_pool.with { |conn| yield conn }
-  end
+    # Should be the new canonical way of using redis
+    def redis
+      # Basically, crib what is done in sidekiq
+      raise ArgumentError, "requires a block" unless block_given?
+      redis_pool.with { |conn| yield conn }
+    end
 
-  def self.redis_pool
-    @redis ||= ConnectionPool.new(timeout: 1, size: 2) do
-      Redis.new
+    def redis_pool
+      @redis ||= ConnectionPool.new(timeout: 1, size: 2) do
+        Redis.new
+      end
     end
   end
 end

--- a/app/models/counts.rb
+++ b/app/models/counts.rb
@@ -27,11 +27,12 @@ class Counts
 
     def stolen_bikes; retrieve_for("stolen_bikes") end
 
-    def week_creation_chart; retrieve_for("week_creation_chart") end
-
     def organizations; retrieve_for("organizations") end
 
-    def week_creation_chart;
+    # TODO: Dupe method definition
+    def week_creation_chart; retrieve_for("week_creation_chart") end
+
+    def week_creation_chart
       chart_data = redis { |r| r.hget STOREAGE_KEY, "week_creation_chart" }
       chart_data.present? ? JSON.parse(chart_data) : chart_data
     end
@@ -63,6 +64,8 @@ class Counts
     def recoveries_value; retrieve_for("recoveries_value") end
   end
 
+  # TODO: This `protected` has no effect. Do we want to move the methods below
+  # into the class << self?
   protected
 
   # Should be the new canonical way of using redis

--- a/config/application.rb
+++ b/config/application.rb
@@ -29,9 +29,10 @@ module Bikeindex
 
     # The default locale is :en and all translations from config/locales/*.rb,yml are auto loaded.
     config.i18n.load_path += Dir[Rails.root.join("config", "locales", "**", "*.{rb,yml}").to_s]
+    config.i18n.enforce_available_locales = false
     config.i18n.default_locale = :en
     config.i18n.available_locales = %i[en es nl]
-    config.i18n.enforce_available_locales = false
+    config.i18n.fallbacks = { "en-US": :en, "en-GB": :en }
 
     # Do not swallow errors in after_commit/after_rollback callbacks.
     config.active_record.raise_in_transactional_callbacks = true

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -147,6 +147,7 @@ en:
       update: Update %{model}
   number:
     currency:
+      alphabetic_code: USD
       format:
         delimiter: ","
         format: "%u%n"

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -1,5 +1,8 @@
 nl:
   language: Dutch
+  number:
+    currency:
+      alphabetic_code: EUR
   activerecord:
     models:
       ad: Advertentie  #g
@@ -836,4 +839,6 @@ nl:
 
   welcome:
     index:
+      value_of_bikes_recovered: Meer dan %{value} aan fietsen teruggevonden
       hero: Fietsregistratie die werkt
+      register_now: Registreer nu!

--- a/spec/helpers/money_helper_spec.rb
+++ b/spec/helpers/money_helper_spec.rb
@@ -1,0 +1,83 @@
+# coding: utf-8
+require "rails_helper"
+
+RSpec.describe MoneyHelper, type: :helper do
+  describe "#default_currency" do
+    context "given the current locale is set to the default_locale (en)" do
+      it "returns the alphabetic_code USD" do
+        expect(default_currency).to eq("USD")
+      end
+    end
+
+    context "given the current locale is set to an available locale" do
+      it "returns the alphabetic_code for the locale's currency" do
+        I18n.with_locale(:nl) do
+          expect(default_currency).to eq("EUR")
+        end
+      end
+    end
+
+    context "given the current locale is set to a locale with a fallback" do
+      it "returns the alphabetic_code for the fallback locale's currency" do
+        I18n.with_locale(:"en-GB") do
+          expect(default_currency).to eq("USD")
+        end
+      end
+    end
+
+    context "given the current locale is set to an unavailable locale" do
+      it "returns the alphabetic_code for the default locale's currency" do
+        I18n.with_locale(:"unavailable") do
+          expect(default_currency).to eq("USD")
+        end
+      end
+    end
+  end
+
+  describe "#money_usd" do
+    context "given a valid target currency" do
+      it "returns a Money object converting to the target currency" do
+        conversion_rate = Money.default_bank.get_rate(:USD, :EUR)
+        currency = money_usd(1.00, exchange_to: :EUR)
+        expect(currency).to be_an_instance_of(Money)
+        expect(currency.fractional).to eq(conversion_rate * 100)
+        expect(currency.currency).to eq(:EUR)
+      end
+    end
+
+    context "given an invalid target currency" do
+      it "raises UnknownCurrency" do
+        expect { money_usd(1.00, exchange_to: :ERR) }.to raise_error(Money::Currency::UnknownCurrency)
+      end
+    end
+
+    context "given no target currency" do
+      it "returns a Money object converting to the default currency" do
+        currency = money_usd(1.00)
+        expect(currency).to be_an_instance_of(Money)
+        expect(currency.fractional).to eq(100)
+        expect(currency.currency).to eq(:USD)
+      end
+    end
+  end
+
+  describe "#as_currency" do
+    context "given a valid target currency" do
+      it "returns a Money object converting to the default currency" do
+        expect(as_currency(100, exchange_to: :EUR)).to eq("€88")
+      end
+    end
+
+    context "given an invalid target currency" do
+      it "raises UnknownCurrency" do
+        expect { as_currency(100, exchange_to: :ERR) }.to raise_error(Money::Currency::UnknownCurrency)
+      end
+    end
+
+    context "given no target currency" do
+      it "returns a Money object converting to the default currency" do
+        expect(as_currency(100)).to eq("$100")
+      end
+    end
+  end
+end


### PR DESCRIPTION
Introduces `MoneyHelper` to format currency values and convert between localized currencies, to enable currency conversion in addition to localized currency formatting (see below).

#### TODO

- `Counts.week_creation_chart` seems to have a dupe definition, should we delete one?
- The `protected` access control in `Counts` is a no-op. Is the intent for it to apply to the methods defined below it? If so, I'll move those into the `class << self`.


<img width="1086" alt="Screen Shot 2019-06-27 at 1 12 00 PM" src="https://user-images.githubusercontent.com/4433943/60286218-49829600-98dd-11e9-879e-b16f2a69b27b.png">
<img width="1014" alt="Screen Shot 2019-06-27 at 1 12 09 PM" src="https://user-images.githubusercontent.com/4433943/60286219-49829600-98dd-11e9-9e0b-010f28b254fa.png">
