### PR TITLE
Add rake task to seed Redis with Counts figures

### DIFF
--- a/bin/setup
+++ b/bin/setup
@@ -18,6 +18,7 @@ Dir.chdir APP_ROOT do
   puts "\n== Preparing and seeding database =="
   system "bin/rake db:setup"
   system "bin/rake seed_test_users_and_bikes"
+  system "bin/rake dev:seed_counts"
 
   puts "\n== Preparing test database (including parallelism) =="
   system "bin/rake parallel:prepare"

--- a/lib/tasks/dev_configuration.rake
+++ b/lib/tasks/dev_configuration.rake
@@ -64,14 +64,17 @@ class RakeDevConfiguration
 end
 
 namespace :dev do
+  desc "Toggle caching"
   task cache: :environment do
     RakeDevConfiguration.toggle_dev_caching
   end
 
+  desc "Toggle Spring (application pre-loader)"
   task spring: :environment do
     RakeDevConfiguration.toggle_spring
   end
 
+  desc "Toggle letter_opener gem, which automatically opens sent emails in a browser window"
   task letter_opener: :environment do
     RakeDevConfiguration.toggle_letter_opener
   end

--- a/lib/tasks/seed_tasks.rake
+++ b/lib/tasks/seed_tasks.rake
@@ -93,3 +93,32 @@ task seed_dup_bikes: :environment do
     end
   end
 end
+
+namespace :dev do
+  desc "Seed Redis with dummy values retrieved by Counts module"
+  task seed_counts: :environment do
+    next unless Rails.env.development?
+
+    entries = {
+      stolen_bikes: 66_406,
+      total_bikes: 241_945,
+      organizations: 724,
+      recoveries: 5_734,
+      recoveries_value: 8_188_294,
+      week_creation_chart: {
+        "2019-06-21": 261,
+        "2019-06-22": 323,
+        "2019-06-23": 313,
+        "2019-06-24": 228,
+        "2019-06-25": 226,
+        "2019-06-26": 259,
+        "2019-06-27": 127,
+      }.to_json,
+    }
+
+    printf "Assigning Counts values... "
+    entries.each_pair { |key, value| Counts.assign_for(key, value) }
+    printf "done.\n\n"
+    entries.keys.each { |key| puts "Counts.#{key}: #{Counts.public_send(key)}" }
+  end
+end


### PR DESCRIPTION
- Populates the counts on bike stats visualization on the home page
- Adds descriptions for other dev-namespaced tasks so they show up in
  `rake -T`