### PR TITLE
Fix BParam handling of color values

### DIFF
--- a/app/models/b_param.rb
+++ b/app/models/b_param.rb
@@ -178,7 +178,7 @@ class BParam < ActiveRecord::Base
     bike["stolen"] = true if params["stolen_record"].present?
     set_wheel_size_key
     set_manufacturer_key
-    set_color_key unless bike["primary_frame_color_id"].present?
+    set_color_keys
     set_cycle_type_key
     set_rear_gear_type_slug if bike["rear_gear_type_slug"].present?
     set_front_gear_type_slug if bike["front_gear_type_slug"].present?
@@ -245,22 +245,34 @@ class BParam < ActiveRecord::Base
     params["bike"]["front_gear_type_id"] = gear && gear.id
   end
 
-  def set_color_key
-    paint = params.dig("bike", "color") || params.dig("bike", "primary_frame_color")
+  def set_color_keys
+    %w[primary_frame_color secondary_frame_color tertiary_frame_color].each { |key| set_color_key(key) }
+  end
+
+  def set_color_key(key = nil)
+    if bike["#{key}_id"].present?
+      params["bike"].delete(key)
+      return
+    end
+
+    paint = params.dig("bike", "color") || params.dig("bike", key)
     color = Color.friendly_find(paint.strip) if paint.present?
+
     if color.present?
-      params["bike"]["primary_frame_color_id"] = color.id
-      params["bike"].delete("primary_frame_color")
-      params["bike"].delete("color")
+      params["bike"]["#{key}_id"] = color.id
     else
       set_paint_key(paint)
     end
+
+    params["bike"].delete(key)
     params["bike"].delete("color")
   end
 
   def set_paint_key(paint_entry)
     return nil unless paint_entry.present?
+
     paint = Paint.friendly_find(paint_entry)
+
     if paint.present?
       params["bike"]["paint_id"] = paint.id
     else
@@ -270,6 +282,7 @@ class BParam < ActiveRecord::Base
       params["bike"]["paint_id"] = paint.id
       params["bike"]["paint_name"] = paint.name
     end
+
     unless bike["primary_frame_color_id"].present?
       if paint.color_id.present?
         params["bike"]["primary_frame_color_id"] = paint.color.id

--- a/app/models/b_param.rb
+++ b/app/models/b_param.rb
@@ -246,10 +246,12 @@ class BParam < ActiveRecord::Base
   end
 
   def set_color_key
-    paint = params["bike"]["color"]
+    paint = params.dig("bike", "color") || params.dig("bike", "primary_frame_color")
     color = Color.friendly_find(paint.strip) if paint.present?
     if color.present?
       params["bike"]["primary_frame_color_id"] = color.id
+      params["bike"].delete("primary_frame_color")
+      params["bike"].delete("color")
     else
       set_paint_key(paint)
     end

--- a/app/models/b_param.rb
+++ b/app/models/b_param.rb
@@ -246,7 +246,11 @@ class BParam < ActiveRecord::Base
   end
 
   def set_color_keys
-    %w[primary_frame_color secondary_frame_color tertiary_frame_color].each { |key| set_color_key(key) }
+    %w[
+      primary_frame_color
+      secondary_frame_color
+      tertiary_frame_color
+    ].each { |key| set_color_key(key) }
   end
 
   def set_color_key(key = nil)

--- a/app/services/bike_updator.rb
+++ b/app/services/bike_updator.rb
@@ -81,7 +81,8 @@ class BikeUpdator
     set_protected_attributes
     update_ownership
     update_api_components if @bike_params["components"].present?
-    update_stolen_record if @bike.update_attributes(@bike_params["bike"].except("stolen_records_attributes"))
+    update_attrs = @bike_params["bike"].except("stolen_records_attributes")
+    update_stolen_record if @bike.update_attributes(update_attrs)
     AfterBikeSaveWorker.perform_async(@bike.id) if @bike.present? # run immediately
     remove_blank_components
     @bike

--- a/config/initializers/grape_values.rb
+++ b/config/initializers/grape_values.rb
@@ -2,7 +2,7 @@ CYCLE_TYPE_NAMES = CycleType::NAMES.values.map(&:downcase) rescue ["bike"]
 
 if Rails.env.test?
   CTYPE_NAMES = ["wheel", "headset"]
-  COLOR_NAMES = ["black"]
+  COLOR_NAMES = ["black", "orange"]
   COUNTRY_ISOS = ["US"]
 else
   CTYPE_NAMES = !!Ctype && Ctype.pluck(:name).map(&:downcase) rescue []

--- a/spec/controllers/bikes_controller_spec.rb
+++ b/spec/controllers/bikes_controller_spec.rb
@@ -552,14 +552,20 @@ RSpec.describe BikesController, type: :controller do
         context "invalid" do
           it "renders the stolen form with all the attributes" do
             target_path = embed_organization_path(id: organization.slug, b_param_id_token: b_param.id_token)
+
             expect do
-              post :create, bike: bike_params.merge(stolen: "1", primary_frame_color: nil),
-                            stolen_record: stolen_params
+              post :create,
+                   bike: bike_params.merge(stolen: "1", serial_number: nil),
+                   stolen_record: stolen_params
+
               expect(assigns(:bike).errors&.full_messages).to be_present
-            end.to change(Ownership, :count).by 0
+            end.to change(Ownership, :count).by(0)
+
             expect(response).to redirect_to target_path
             bike = assigns(:bike)
-            testable_bike_params.except(:primary_frame_color_id).each { |k, v| expect(bike.send(k).to_s).to eq v.to_s }
+            testable_bike_params
+              .except(:serial_number)
+              .each { |k, v| expect(bike.send(k).to_s).to eq(v.to_s) }
             expect(bike.stolen).to be_truthy
             # we retain the stolen record attrs, it would be great to test that they are
             # assigned correctly, but I don't know how - it needs to completely

--- a/spec/models/b_param_spec.rb
+++ b/spec/models/b_param_spec.rb
@@ -126,7 +126,7 @@ RSpec.describe BParam, type: :model do
       }.as_json
       b_param = BParam.new(params: { bike: bike })
       expect(b_param).to receive(:set_manufacturer_key).and_return(true)
-      expect(b_param).to receive(:set_color_key).and_return(true)
+      expect(b_param).to receive(:set_color_keys).and_return(true)
       expect(b_param).to receive(:set_wheel_size_key).and_return(true)
       expect(b_param).to receive(:set_cycle_type_key).and_return(true)
       expect(b_param).to receive(:set_rear_gear_type_slug).and_return(true)
@@ -301,7 +301,7 @@ RSpec.describe BParam, type: :model do
       color = FactoryBot.create(:color)
       bike = { color: color.name }
       b_param = BParam.new(params: { bike: bike })
-      b_param.set_color_key
+      b_param.set_color_key("primary_frame_color")
       expect(b_param.params["bike"]["color"]).not_to be_present
       expect(b_param.params["bike"]["primary_frame_color_id"]).to eq(color.id)
     end

--- a/spec/requests/api/v3/bikes_request_spec.rb
+++ b/spec/requests/api/v3/bikes_request_spec.rb
@@ -681,7 +681,7 @@ RSpec.describe "Bikes API V3", type: :request do
       mfg1 = FactoryBot.create(:manufacturer, name: "old manufacturer")
       mfg2 = FactoryBot.create(:manufacturer, name: "new manufacturer")
       comp = FactoryBot.create(:component, manufacturer: mfg1, bike: bike, ctype: headsets)
-      comp2 = FactoryBot.create(:component, manufacturer: mfg1, bike: bike, ctype: wheels)
+      comp2 = FactoryBot.create(:component, manufacturer: mfg1, bike: bike, ctype: wheels, serial_number: "old-serial")
       FactoryBot.create(:component)
       bike.reload
       expect(bike.components.count).to eq(2)
@@ -692,7 +692,6 @@ RSpec.describe "Bikes API V3", type: :request do
           year: "1999",
           component_type: "headset",
           description: "C-2",
-          serial_number: "69",
           model: "Sram GXP Eagle",
         },
         {
@@ -708,6 +707,7 @@ RSpec.describe "Bikes API V3", type: :request do
           id: comp2.id,
           manufacturer: mfg2.id,
           year: "1999",
+          serial: "updated-serial",
           description: "C-1",
         },
       ]
@@ -733,6 +733,11 @@ RSpec.describe "Bikes API V3", type: :request do
       expect(manufacturers).to(match_array([["C-1", "new manufacturer"],
                                             ["C-2", "new manufacturer"],
                                             ["C-3", "Other"]]))
+
+      serials = components.map { |c| [c.description, c.serial_number] }.compact
+      expect(serials).to(match_array([["C-1", "updated-serial"],
+                                      ["C-2", nil],
+                                      ["C-3", nil]]))
     end
 
     it "doesn't remove components that aren't the bikes" do


### PR DESCRIPTION
Updates `BParam` so it doesn't choke on primary/secondary/tertiary frame color params.

This class and its specs could use some refactoring but this a minimal fix — more substantial changes would take more time to implement safely than is feasible at the moment.

Related: #955 