### PR TITLE
Set locale to English when requesting admin pages

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -92,7 +92,7 @@ class ApplicationController < ActionController::Base
 
   # TODO: Remove logging in #requested_locale when feature flag is removed
   def set_locale
-    if !Flipper.enabled?(:localization, current_user)
+    unless Flipper.enabled?(:localization, current_user)
       return I18n.with_locale(I18n.default_locale) { yield }
     end
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -92,10 +92,14 @@ class ApplicationController < ActionController::Base
 
   # TODO: Remove logging in #requested_locale when feature flag is removed
   def set_locale
-    if Flipper.enabled?(:localization, current_user)
-      I18n.with_locale(requested_locale) { yield }
-    else
+    if !Flipper.enabled?(:localization, current_user)
+      return I18n.with_locale(I18n.default_locale) { yield }
+    end
+
+    if controller_namespace == "admin"
       I18n.with_locale(I18n.default_locale) { yield }
+    else
+      I18n.with_locale(requested_locale) { yield }
     end
   end
 end

--- a/spec/requests/locale_detection_request_spec.rb
+++ b/spec/requests/locale_detection_request_spec.rb
@@ -99,4 +99,39 @@ RSpec.describe "Locale detection", type: :request do
       end
     end
   end
+
+  describe "requesting an admin path" do
+    include_context :request_spec_logged_in_as_superuser
+    before do
+      allow(Flipper).to receive(:enabled?).with(:localization, current_user).and_return(true)
+    end
+
+    context "given a user preference" do
+      it "renders the admin dashboard in English" do
+        current_user.update(preferred_language: :nl)
+        get "/admin"
+        expect(response.body).to match(/The best bike registry/i)
+        get "/admin/bikes"
+        expect(response.body).to match(/The best bike registry/i)
+      end
+    end
+
+    context "given a valid locale query param" do
+      it "renders the admin dashboard in English" do
+        get "/admin", locale: :nl
+        expect(response.body).to match(/The best bike registry/i)
+        get "/admin/bikes", locale: :nl
+        expect(response.body).to match(/The best bike registry/i)
+      end
+    end
+
+    context "given a valid ACCEPT_LANGUAGE header" do
+      it "renders the homepage in English" do
+        get "/admin", {}, { "HTTP_ACCEPT_LANGUAGE" => "nl,en;q=0.9" }
+        expect(response.body).to match(/The best bike registry/i)
+        get "/admin/users", {}, { "HTTP_ACCEPT_LANGUAGE" => "nl,en;q=0.9" }
+        expect(response.body).to match(/The best bike registry/i)
+      end
+    end
+  end
 end


### PR DESCRIPTION
Sets locale to english when requesting admin pages, since these will not be localized.

Resolves #968