### PR TITLE
Fix missing translation argument in mobile header

### DIFF
--- a/app/views/layouts/application_revised.html.haml
+++ b/app/views/layouts/application_revised.html.haml
@@ -112,7 +112,7 @@
                 %li
                   = active_link t(".your_bikes"), user_home_path, class: 'nav-link'
                 %li
-                  = active_link t(".settings", user_email: current_user_or_unconfirmed_user.email), my_account_path, class: 'nav-link'
+                  = active_link t(".user_settings", user_email: current_user_or_unconfirmed_user.email), my_account_path, class: 'nav-link'
                 %li
                   = link_to t(".logout"), goodbye_path, class: 'nav-link'
             %li.divider-nav-item

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -501,7 +501,8 @@ en:
       registration_stickers: Registration stickers
       resources: Resources
       search_bikes: Search bikes
-      settings: "%{user_email} settings"
+      settings: Settings
+      user_settings: "%{user_email} settings"
       sign_up: Sign up
       super_admin_view: Super Admin view %{org_name}
       the_nonprofit_bike_registry: the non-profit bike registry


### PR DESCRIPTION
Fixes a clobbered translation key:

Before:

<img width="500" alt="Screen Shot 2019-07-05 at 8 36 38 AM" src="https://user-images.githubusercontent.com/4433943/60722857-1012e180-9f00-11e9-9709-32ff034e8e38.png">

After:

<img width="500" alt="Screen Shot 2019-07-05 at 8 36 30 AM" src="https://user-images.githubusercontent.com/4433943/60722862-14d79580-9f00-11e9-96f3-b33098a25dcd.png">
