### PR TITLE
Social media logo UI fixes, Slick slider improvement

### DIFF
--- a/app/assets/javascripts/revised/pages/welcome/index.coffee
+++ b/app/assets/javascripts/revised/pages/welcome/index.coffee
@@ -4,5 +4,7 @@ class BikeIndex.WelcomeIndex extends BikeIndex
     $('#recovery-stories-container').slick
       infinite: false
       lazyLoad: 'ondemand'
+      prevArrow: '<i class="fas fa-chevron-left slick-prev"></i>'
+      nextArrow: '<i class="fas fa-chevron-right slick-next"></i>'
     $(window).scroll ->
       $('.root-landing-who').addClass('scrolled')

--- a/app/assets/javascripts/views/welcome/home.js.coffee
+++ b/app/assets/javascripts/views/welcome/home.js.coffee
@@ -15,6 +15,8 @@ class BikeIndex.Views.Home extends Backbone.View
     $('.testimonial-container').slick
       infinite: false
       lazyLoad: 'ondemand'
+      prevArrow: '<i class="fas fa-chevron-left slick-prev"></i>'
+      nextArrow: '<i class="fas fa-chevron-right slick-next"></i>'
 
   spaceWheelHolder: (only_if_overlap=false) ->
     active_quote = $('.testimonial-block.active .testimonial-quote')
@@ -31,4 +33,3 @@ class BikeIndex.Views.Home extends Backbone.View
       # console.log(wheel_margin)
       # console.log(target)
       $('.wheeled').css('margin-top', "#{target + wheel_margin}px")
-

--- a/app/assets/stylesheets/legacy_includes/slick.scss
+++ b/app/assets/stylesheets/legacy_includes/slick.scss
@@ -8,8 +8,6 @@ $slick-loader-path: "/assets/" !default;
 $slick-arrow-color: white !default;
 $slick-dot-color: black !default;
 $slick-dot-color-active: $slick-dot-color !default;
-$slick-prev-character: "<" !default;
-$slick-next-character: ">" !default;
 $slick-dot-character: "•" !default;
 $slick-dot-size: 6px !default;
 $slick-opacity-default: 0.75 !default;
@@ -187,15 +185,14 @@ $slick-opacity-not-active: 0.25 !default;
   }
 }
 
-.slick-prev:before,
-.slick-next:before {
-  font-family: $slick-font-family;
-  font-size: 40px;
-  line-height: 1;
+.slick-prev::before,
+.slick-next::before {
   color: $slick-arrow-color;
-  opacity: $slick-opacity-default;
-  -webkit-font-smoothing: antialiased;
+  font-size: 40px;
   -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+  line-height: 1;
+  opacity: $slick-opacity-default;
 }
 
 .slick-prev {
@@ -205,14 +202,6 @@ $slick-opacity-not-active: 0.25 !default;
     left: auto;
     right: -25px;
   }
-
-  &:before {
-    content: $slick-prev-character;
-
-    [dir="rtl"] & {
-      content: $slick-next-character;
-    }
-  }
 }
 
 .slick-next {
@@ -221,14 +210,6 @@ $slick-opacity-not-active: 0.25 !default;
   [dir="rtl"] & {
     left: -25px;
     right: auto;
-  }
-
-  &:before {
-    content: $slick-next-character;
-
-    [dir="rtl"] & {
-      content: $slick-prev-character;
-    }
   }
 }
 

--- a/app/assets/stylesheets/revised/pages/landing/_recoveries.scss
+++ b/app/assets/stylesheets/revised/pages/landing/_recoveries.scss
@@ -25,9 +25,8 @@
   .slick-next {
     &:before {
       color: $gray;
-      font-weight: 600;
       font-size: 30px;
-      font-family: sans-serif;
+      font-weight: 600;
     }
   }
 

--- a/app/assets/stylesheets/revised/sections/primary_footer.scss
+++ b/app/assets/stylesheets/revised/sections/primary_footer.scss
@@ -105,6 +105,16 @@ $primary-footer-top-margin: 6 * $vertical-height;
 }
 
 //
+// Large Screen Styles
+@media (max-width: $grid-breakpoint-lg - 1px) and (min-width: $grid-breakpoint-md) {
+  .social-nav {
+    li {
+      margin: auto 10px;
+    }
+  }
+}
+
+//
 // Small Screen Styles
 @media (max-width: $grid-breakpoint-lg - 1px) {
   .primary-footer-nav nav {

--- a/app/assets/stylesheets/revised/sections/primary_footer.scss
+++ b/app/assets/stylesheets/revised/sections/primary_footer.scss
@@ -32,6 +32,7 @@ $primary-footer-top-margin: 6 * $vertical-height;
 
   .locale-form {
     font-size: 12px;
+
     label {
       margin-right: 5px;
     }
@@ -48,7 +49,7 @@ $primary-footer-top-margin: 6 * $vertical-height;
       color: #fff;
       font-size: 14px;
       font-weight: 600;
-      margin-bottom: 0.5 * $vertical-height;
+      margin-bottom: .5 * $vertical-height;
     }
 
     ul {
@@ -67,24 +68,14 @@ $primary-footer-top-margin: 6 * $vertical-height;
         width: 33.33%;
       }
 
-      svg {
-        display: inline-block;
-        max-height: 4 * $vertical-height;
-      }
-
-      .svgpath {
-        fill: $gray-light;
-        transition: color 0.05s linear;
-      }
-
       a {
         display: block;
         position: relative;
 
         &:hover,
         &:active {
-          .svgpath {
-            fill: lighten($gray-light, 15%);
+          .fab {
+            color: lighten($gray-light, 15%);
           }
         }
       }


### PR DESCRIPTION
- Restore "highlight on hover" behavior to footer social media logos
- Fix social media logo crowding at intermediate breakpoint

#### Before

<img width="222" alt="resize at intermediate breakpoints" src="https://user-images.githubusercontent.com/4433943/60728914-7b17e480-9f0f-11e9-87fc-72e358b9781d.png">

#### After

<img width="412" alt="Screen Shot 2019-07-05 at 10 28 55 AM" src="https://user-images.githubusercontent.com/4433943/60729028-b6b2ae80-9f0f-11e9-8eca-6a0a05b1a4f5.png">

- Replace angled brackets in Slick sliders with chevron glyphs


#### Before

<img width="491" alt="Screen Shot 2019-07-05 at 10 00 04 AM" src="https://user-images.githubusercontent.com/4433943/60728954-95ea5900-9f0f-11e9-9c3a-24a223406474.png">


#### After

<img width="500" alt="Screen Shot 2019-07-05 at 9 59 39 AM" src="https://user-images.githubusercontent.com/4433943/60728963-9b47a380-9f0f-11e9-9bcf-0875bf9798fc.png">
