### PR TITLE
Disable backtraces in EmailConfirmationWorker, EmailFeedbackNotificationWorker

### DIFF
--- a/app/workers/additional_email_confirmation_worker.rb
+++ b/app/workers/additional_email_confirmation_worker.rb
@@ -1,7 +1,7 @@
 class AdditionalEmailConfirmationWorker
   include Sidekiq::Worker
   sidekiq_options queue: "notify"
-  sidekiq_options backtrace: true
+  sidekiq_options backtrace: false
 
   def perform(user_email_id)
     user_email = UserEmail.find(user_email_id)

--- a/app/workers/email_confirmation_worker.rb
+++ b/app/workers/email_confirmation_worker.rb
@@ -1,7 +1,7 @@
 class EmailConfirmationWorker
   include Sidekiq::Worker
   sidekiq_options queue: "notify"
-  sidekiq_options backtrace: true
+  sidekiq_options backtrace: false
 
   def perform(user_id)
     user = User.find(user_id)

--- a/app/workers/email_feedback_notification_worker.rb
+++ b/app/workers/email_feedback_notification_worker.rb
@@ -1,6 +1,6 @@
 class EmailFeedbackNotificationWorker
   include Sidekiq::Worker
-  sidekiq_options queue: "notify", backtrace: true, retry: 1
+  sidekiq_options queue: "notify", backtrace: false
 
   def perform(feedback_id)
     @feedback = Feedback.find(feedback_id)


### PR DESCRIPTION
This patch disables backtraces in `EmailConfirmationWorker`, `EmailFeedbackNotificationWorker`, and `AdditionalEmailConfirmationWorker`.

When user lookups in these jobs fail (likely a race condition?) they clutter logs with the backtrace. Retries are [handled automatically](https://github.com/mperham/sidekiq/wiki/Error-Handling#automatic-job-retry). Spot-checking previous failures, it looks like the retries are succeeding eventually.

```json
{
  "context":"Job raised exception",
  "job":{
    "class":"EmailConfirmationWorker",
    "args":[163700],
    "retry":true,
    "queue":"notify",
    "backtrace":true,
    "jid":"66827b64f0cb8169dd8c64bd",
    "created_at":1562606655.1983092,
    "enqueued_at":1562606655.198338,
    "error_message":"Couldn't find User with 'id'=163700",
    "error_class":"ActiveRecord::RecordNotFound",
    "processor":"hawk:20665",
    "failed_at":1562606655.1993432,
    "error_backtrace":["..."]
  },
  "jobstr":"{...}"
}
```

```json
{
  "context": "Job raised exception",
  "job": {
    "class": "EmailFeedbackNotificationWorker",
    "args": [20783],
    "retry": 1,
    "queue": "notify",
    "backtrace": true,
    "jid": "5014d5bdc727555099e35a4a",
    "created_at": 1562097730.2670848,
    "enqueued_at": 1562097730.2671213,
    "error_message": "Couldn't find Feedback with 'id'=20783",
    "error_class": "ActiveRecord::RecordNotFound",
    "processor": "hawk:18338",
    "failed_at": 1562097730.2683673,
    "error_backtrace": ["..."]
  },
  "jobstr": "..."
}
```