### PR TITLE
Access ip address in consistent manner

### DIFF
--- a/app/controllers/api/base.rb
+++ b/app/controllers/api/base.rb
@@ -3,14 +3,10 @@ require "grape_logging"
 module GrapeLogging
   module Loggers
     class BinxLogger < GrapeLogging::Loggers::Base
-      def forwarded_ip_address
-        return @forwarded_ip_address if defined?(@forwarded_ip_address)
-        @forwarded_ip_address = request.headers["CF-Connecting-IP"] if request.headers["CF-Connecting-IP"]
-        @forwarded_ip_address ||= request.headers["HTTP_X_FORWARDED_FOR"].split(",").last if request.headers["HTTP_X_FORWARDED_FOR"].present?
-        @forwarded_ip_address ||= request.headers["REMOTE_ADDR"] || request.headers["ip"]
-      end
-
       def parameters(request, _)
+        forwarded_ip_address ||= request.env["HTTP_CF_CONNECTING_IP"]
+        forwarded_ip_address ||= request.env["HTTP_X_FORWARDED_FOR"].split(",").last if request.env["HTTP_X_FORWARDED_FOR"].present?
+        forwarded_ip_address ||= request.env["REMOTE_ADDR"] || request.env["ip"]
         { remote_ip: forwarded_ip_address, format: "json" }
       end
     end

--- a/app/controllers/api/base.rb
+++ b/app/controllers/api/base.rb
@@ -4,10 +4,7 @@ module GrapeLogging
   module Loggers
     class BinxLogger < GrapeLogging::Loggers::Base
       def parameters(request, _)
-        forwarded_ip_address ||= request.env["HTTP_CF_CONNECTING_IP"]
-        forwarded_ip_address ||= request.env["HTTP_X_FORWARDED_FOR"].split(",").last if request.env["HTTP_X_FORWARDED_FOR"].present?
-        forwarded_ip_address ||= request.env["REMOTE_ADDR"] || request.env["ip"]
-        { remote_ip: forwarded_ip_address, format: "json" }
+        { remote_ip: ForwardedIpAddress.parse(request), format: "json" }
       end
     end
   end

--- a/app/controllers/api/base.rb
+++ b/app/controllers/api/base.rb
@@ -3,8 +3,15 @@ require "grape_logging"
 module GrapeLogging
   module Loggers
     class BinxLogger < GrapeLogging::Loggers::Base
+      def forwarded_ip_address
+        return @forwarded_ip_address if defined?(@forwarded_ip_address)
+        @forwarded_ip_address = request.headers["CF-Connecting-IP"] if request.headers["CF-Connecting-IP"]
+        @forwarded_ip_address ||= request.headers["HTTP_X_FORWARDED_FOR"].split(",").last if request.headers["HTTP_X_FORWARDED_FOR"].present?
+        @forwarded_ip_address ||= request.headers["REMOTE_ADDR"] || request.headers["ip"]
+      end
+
       def parameters(request, _)
-        { remote_ip: request.env["HTTP_CF_CONNECTING_IP"], format: "json" }
+        { remote_ip: forwarded_ip_address, format: "json" }
       end
     end
   end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -12,15 +12,6 @@ class ApplicationController < ActionController::Base
                           x_download_options: false,
                           x_permitted_cross_domain_policies: false)
 
-  def forwarded_ip_address
-    @forwarded_ip_address ||= request.env["HTTP_X_FORWARDED_FOR"].split(",")[0] if request.env["HTTP_X_FORWARDED_FOR"]
-  end
-
-  def append_info_to_payload(payload)
-    super
-    payload[:ip] = request.headers["CF-Connecting-IP"]
-  end
-
   def handle_unverified_request
     flash[:error] = "CSRF invalid. If you don't know why you're receiving this message, please contact us"
     redirect_to user_root_url

--- a/app/controllers/concerns/controller_helpers.rb
+++ b/app/controllers/concerns/controller_helpers.rb
@@ -17,10 +17,7 @@ module ControllerHelpers
   end
 
   def forwarded_ip_address
-    return @forwarded_ip_address if defined?(@forwarded_ip_address)
-    @forwarded_ip_address = request.env["HTTP_CF_CONNECTING_IP"]
-    @forwarded_ip_address ||= request.headers["HTTP_X_FORWARDED_FOR"].split(",").last if request.headers["HTTP_X_FORWARDED_FOR"].present?
-    @forwarded_ip_address ||= request.headers["REMOTE_ADDR"] || request.headers["ip"]
+    @forwarded_ip_address ||= ForwardedIpAddress.parse(request)
   end
 
   def enable_rack_profiler

--- a/app/controllers/concerns/controller_helpers.rb
+++ b/app/controllers/concerns/controller_helpers.rb
@@ -18,7 +18,7 @@ module ControllerHelpers
 
   def forwarded_ip_address
     return @forwarded_ip_address if defined?(@forwarded_ip_address)
-    @forwarded_ip_address = request.headers["CF-Connecting-IP"] if request.headers["CF-Connecting-IP"]
+    @forwarded_ip_address = request.env["HTTP_CF_CONNECTING_IP"]
     @forwarded_ip_address ||= request.headers["HTTP_X_FORWARDED_FOR"].split(",").last if request.headers["HTTP_X_FORWARDED_FOR"].present?
     @forwarded_ip_address ||= request.headers["REMOTE_ADDR"] || request.headers["ip"]
   end

--- a/app/controllers/concerns/controller_helpers.rb
+++ b/app/controllers/concerns/controller_helpers.rb
@@ -11,6 +11,19 @@ module ControllerHelpers
     before_filter :enable_rack_profiler
   end
 
+  def append_info_to_payload(payload)
+    super
+    payload[:ip] = forwarded_ip_address
+  end
+
+  def forwarded_ip_address
+    return @forwarded_ip_address if defined?(@forwarded_ip_address)
+    @forwarded_ip_address = request.headers["CF-Connecting-IP"] if request.headers["CF-Connecting-IP"]
+    @forwarded_ip_address ||= request.headers["HTTP_X_FORWARDED_FOR"].split(",").last if request.headers["HTTP_X_FORWARDED_FOR"].present?
+    @forwarded_ip_address ||= request.headers["REMOTE_ADDR"] || request.headers["ip"]
+    @forwarded_ip_address
+  end
+
   def enable_rack_profiler
     return false unless current_user&.developer?
     Rack::MiniProfiler.authorize_request unless Rails.env.test?

--- a/app/controllers/concerns/controller_helpers.rb
+++ b/app/controllers/concerns/controller_helpers.rb
@@ -21,7 +21,6 @@ module ControllerHelpers
     @forwarded_ip_address = request.headers["CF-Connecting-IP"] if request.headers["CF-Connecting-IP"]
     @forwarded_ip_address ||= request.headers["HTTP_X_FORWARDED_FOR"].split(",").last if request.headers["HTTP_X_FORWARDED_FOR"].present?
     @forwarded_ip_address ||= request.headers["REMOTE_ADDR"] || request.headers["ip"]
-    @forwarded_ip_address
   end
 
   def enable_rack_profiler

--- a/app/controllers/concerns/sessionable.rb
+++ b/app/controllers/concerns/sessionable.rb
@@ -18,7 +18,7 @@ module Sessionable
     session[:last_seen] = Time.current
     session[:render_donation_request] = user.render_donation_request if user&.render_donation_request
     set_passive_organization(user.default_organization) # Set that organization!
-    user.update_last_login(params[:remote_ip])
+    user.update_last_login(forwarded_ip_address)
     if ParamsNormalizer.boolean(params.dig(:session, :remember_me))
       cookies.permanent.signed[:auth] = cookie_options(user)
     else

--- a/config/initializers/forwarded_ip_address.rb
+++ b/config/initializers/forwarded_ip_address.rb
@@ -1,0 +1,7 @@
+class ForwardedIpAddress
+  def self.parse(request)
+    addy = request.env["HTTP_CF_CONNECTING_IP"]
+    addy ||= request.env["HTTP_X_FORWARDED_FOR"].split(",").last if request.env["HTTP_X_FORWARDED_FOR"].present?
+    addy ||= request.env["REMOTE_ADDR"] || request.env["ip"]
+  end
+end

--- a/spec/controllers/bikes_controller_spec.rb
+++ b/spec/controllers/bikes_controller_spec.rb
@@ -48,9 +48,9 @@ RSpec.describe BikesController, type: :controller do
       end
       context "ip proximity" do
         let(:query_params) { { location: "yoU", distance: 1, stolenness: "proximity" } }
+        before { request.env["HTTP_CF_CONNECTING_IP"] = ip_address }
         context "found location" do
           it "assigns passed parameters and close_serials" do
-            expect_any_instance_of(BikesController).to receive(:forwarded_ip_address) { ip_address }
             allow(Geocoder).to receive(:search) { legacy_production_ip_search_result }
             get :index, query_params
             expect(response.status).to eq 200
@@ -61,7 +61,6 @@ RSpec.describe BikesController, type: :controller do
         context "ip passed as parameter" do
           let(:ip_query_params) { query_params.merge(location: "IP") }
           it "assigns passed parameters and close_serials" do
-            expect_any_instance_of(BikesController).to receive(:forwarded_ip_address) { ip_address }
             allow(Geocoder).to receive(:search) { production_ip_search_result }
             get :index, ip_query_params
             expect(response.status).to eq 200
@@ -72,7 +71,6 @@ RSpec.describe BikesController, type: :controller do
         context "no location" do
           let(:ip_query_params) { query_params.merge(location: "   ") }
           it "assigns passed parameters and close_serials" do
-            expect_any_instance_of(BikesController).to receive(:forwarded_ip_address) { ip_address }
             allow(Geocoder).to receive(:search) { production_ip_search_result }
             get :index, ip_query_params
             expect(response.status).to eq 200
@@ -105,7 +103,7 @@ RSpec.describe BikesController, type: :controller do
           }.as_json
         end
         it "sends all the params we want to searchable_interpreted_params" do
-          expect_any_instance_of(BikesController).to receive(:forwarded_ip_address) { "special" }
+          request.env["HTTP_CF_CONNECTING_IP"] = "special"
           expect(Bike).to receive(:searchable_interpreted_params).with(query_params, ip: "special") { {} }
           get :index, query_params
           expect(response.status).to eq 200

--- a/spec/controllers/sessions_controller_spec.rb
+++ b/spec/controllers/sessions_controller_spec.rb
@@ -89,14 +89,18 @@ RSpec.describe SessionsController, type: :controller do
       describe "when authentication works" do
         it "authenticates and removes partner session" do
           expect(user.last_login_at).to be_blank
+          expect(user.last_login_ip).to be_blank
           session[:partner] = "bikehub"
           expect(user).to receive(:authenticate).and_return(true)
           request.env["HTTP_REFERER"] = user_home_url
+          request.env["HTTP_CF_CONNECTING_IP"] = "66.66.66.66"
           post :create, session: { password: "would be correct" }
           expect(cookies.signed[:auth][1]).to eq(user.auth_token)
           expect(response).to redirect_to "https://new.bikehub.com/account"
           expect(session[:partner]).to be_nil
+          user.reload
           expect(user.last_login_at).to be_within(1.second).of Time.now
+          expect(user.last_login_ip).to eq "66.66.66.66"
         end
 
         context "admin" do

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -127,9 +127,10 @@ RSpec.describe UsersController, type: :controller do
               expect(User.from_auth(cookies.signed[:auth])).to eq user
               bike.reload
               expect(bike.user).to eq user
+              expect(user.confirmed?).to be_truthy
+              expect(user.last_login_at).to be_within(3.seconds).of Time.current
+              expect(user.last_login_ip).to eq "99.99.99.9"
             end.to change(EmailWelcomeWorker.jobs, :count)
-            expect(user.last_login_at).to be_within(1.second).of Time.now
-            expect(user.last_login_ip).to eq "99.99.99.9"
           end
         end
         context "with membership, partner param" do

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -113,6 +113,7 @@ RSpec.describe UsersController, type: :controller do
             bike.reload
             expect(bike.user).to be_blank
             expect do
+              request.env["HTTP_CF_CONNECTING_IP"] = "99.99.99.9"
               post :create, user: user_attributes
               # TODO: Rails 5 update - this is an after_commit issue
               user = User.order(:created_at).last
@@ -127,6 +128,8 @@ RSpec.describe UsersController, type: :controller do
               bike.reload
               expect(bike.user).to eq user
             end.to change(EmailWelcomeWorker.jobs, :count)
+            expect(user.last_login_at).to be_within(1.second).of Time.now
+            expect(user.last_login_ip).to eq "99.99.99.9"
           end
         end
         context "with membership, partner param" do


### PR DESCRIPTION
Follow up to #1013

Things this does:

- Switch to using `forwarded_ip_address` for what is appended to our logging payload
- Always fallback in the same way, in all the places ip addresses are checked
- Move the `forwarded_ip_address` and ip appending to payload into controller helpers, which is included in controllers that don't inherit from `ApplicationController` (ie Doorkeeper controllers)
- Pass `forwarded_ip_address` to user and test that it is passed to user