### PR TITLE
Move time parsing to utils

### DIFF
--- a/app/javascript/packs/pages/initializer.js
+++ b/app/javascript/packs/pages/initializer.js
@@ -1,5 +1,5 @@
 import log from "../utils/log";
-import moment from "moment-timezone";
+import TimeParser from "../utils/time_parser";
 import BinxMapping from "./binx_mapping.js";
 import BinxAdmin from "./admin/binx_admin.js";
 import BinxAppOrgExport from "./binx_org_export.js";
@@ -8,80 +8,6 @@ import BinxAppOrgBikes from "./binx_org_bikes.js";
 import BinxAppOrgUserForm from "./binx_org_user_form";
 
 window.binxApp || (window.binxApp = {});
-
-binxApp.displayLocalDate = function(time, preciseTime) {
-  // Ensure we return if it's a big future day
-  if (preciseTime == null) {
-    preciseTime = false;
-  }
-  if (time < window.tomorrow) {
-    if (time > window.today) {
-      return time.format("h:mma");
-    } else if (time > window.yesterday) {
-      return `Yesterday ${time.format("h:mma")}`;
-    }
-  }
-  if (time.year() === moment().year()) {
-    if (preciseTime) {
-      return time.format("MMM Do[,] h:mma");
-    } else {
-      return time.format("MMM Do[,] ha");
-    }
-  } else {
-    if (preciseTime) {
-      return time.format("YYYY-MM-DD h:mma");
-    } else {
-      return time.format("YYYY-MM-DD");
-    }
-  }
-};
-
-binxApp.preciseTimeSeconds = function(time) {
-  return time.format("YYYY-MM-DD h:mm:ssa");
-};
-
-binxApp.localizeTimes = function() {
-  if (!window.userTimezone) {
-    window.userTimezone = moment.tz.guess();
-  }
-  moment.tz.setDefault(window.userTimezone);
-  window.yesterday = moment()
-    .subtract(1, "day")
-    .startOf("day");
-  window.today = moment().startOf("day");
-  window.tomorrow = moment().endOf("day");
-
-  // Write local time
-  $(".convertTime").each(function() {
-    const $this = $(this);
-    $this.removeClass("convertTime");
-    const text = $this.text().trim();
-    if (!(text.length > 0)) {
-      return;
-    }
-    let time = "";
-    if (isNaN(text)) {
-      time = moment(text, moment.ISO_8601);
-    } else {
-      // it's a timestamp!
-      time = moment.unix(text);
-    }
-
-    if (!time.isValid) {
-      return;
-    }
-    $this
-      .text(binxApp.displayLocalDate(time, $this.hasClass("preciseTime")))
-      .attr("title", binxApp.preciseTimeSeconds(time));
-  });
-
-  // Write timezone
-  return $(".convertTimezone").each(function() {
-    const $this = $(this);
-    $this.text(moment().format("z"));
-    return $this.removeClass("convertTimezone");
-  });
-};
 
 binxApp.enableFilenameForUploads = function() {
   $("input.custom-file-input[type=file]").on("change", function(e) {
@@ -103,7 +29,8 @@ binxApp.enableFilenameForUploads = function() {
 // and make the instance of class (which I'm storing on window) the same name without the first letter capitalized
 // I'm absolutely sure there is a best practice that I'm ignoring, but just doing it for now.
 $(document).ready(function() {
-  binxApp.localizeTimes();
+  const timeUtils = TimeParser();
+  timeParser.localize();
   // Load admin, whatever
   if ($("#admin-content").length > 0) {
     const binxAdmin = BinxAdmin();

--- a/app/javascript/packs/utils/time_parser.js
+++ b/app/javascript/packs/utils/time_parser.js
@@ -1,0 +1,77 @@
+import moment from "moment-timezone";
+
+const TimeParser = () => {
+  return {
+    displayLocalDate(time, preciseTime) {
+      // Ensure we return if it's a big future day
+      if (preciseTime == null) {
+        preciseTime = false;
+      }
+      if (time < window.tomorrow) {
+        if (time > window.today) {
+          return time.format("h:mma");
+        } else if (time > window.yesterday) {
+          return `Yesterday ${time.format("h:mma")}`;
+        }
+      }
+      if (time.year() === moment().year()) {
+        if (preciseTime) {
+          return time.format("MMM Do[,] h:mma");
+        } else {
+          return time.format("MMM Do[,] ha");
+        }
+      } else {
+        if (preciseTime) {
+          return time.format("YYYY-MM-DD h:mma");
+        } else {
+          return time.format("YYYY-MM-DD");
+        }
+      }
+    },
+
+    preciseTimeSeconds(time) {
+      return time.format("YYYY-MM-DD h:mm:ss a");
+    },
+
+    localize() {
+      if (!window.timezone) {
+        window.timezone = moment.tz.guess();
+      }
+      moment.tz.setDefault(window.timezone);
+      window.yesterday = moment()
+        .subtract(1, "day")
+        .startOf("day");
+      window.today = moment().startOf("day");
+      window.tomorrow = moment().endOf("day");
+
+      let displayLocalDate = this.displayLocalDate;
+      let preciseTimeSeconds = this.preciseTimeSeconds;
+      // Write local time
+      $(".convertTime").each(function() {
+        let $this = $(this);
+        $this.removeClass("convertTime");
+        $this.addClass("convertedTime"); // Because we style it sometimes
+        let text = $this.text().trim();
+        if (!(text.length > 0)) {
+          return;
+        }
+        let time = moment(text, moment.ISO_8601);
+        if (!time.isValid) {
+          return;
+        }
+        $this
+          .text(displayLocalDate(time, $this.hasClass("preciseTime")))
+          .attr("title", preciseTimeSeconds(time));
+      });
+
+      // Write timezone
+      $(".convertTimezone").each(function() {
+        let $this = $(this);
+        $this.text(moment().format("z"));
+        return $this.removeClass("convertTimezone");
+      });
+    }
+  };
+};
+
+export default TimeParser;


### PR DESCRIPTION
This is also written in coffeescript in [init.coffee](https://github.com/bikeindex/bike_index/blob/master/app/assets/javascripts/init.coffee) - but we've deprecated the coffeescript, so I'm not touching that.

This can absolutely, 100% be refactored and improved. Just looking at it I see glaring ugliness. But when refactoring, I would like to add tests for it, and I don't think that's a priority right now.