### PR TITLE
Bump Ruby to 2.5.5

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,7 @@ jobs:
       TZ: /usr/share/zoneinfo/America/Chicago
 
     docker:
-      - image: circleci/ruby:2.5.1-stretch-node
+      - image: circleci/ruby:2.5.5-stretch-node
         environment:
           PGHOST: 127.0.0.1
           PGUSER: root

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source "https://rubygems.org"
 # If you bump the Ruby version, make sure to update the Vagrantfile appropriately
-ruby "2.5.1"
+ruby "2.5.5"
 gem "rails", "4.2.11"
 
 gem "active_model_serializers", "~> 0.9.3"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -778,7 +778,7 @@ DEPENDENCIES
   wkhtmltopdf-binary
 
 RUBY VERSION
-   ruby 2.5.1p57
+   ruby 2.5.5p157
 
 BUNDLED WITH
    1.17.3


### PR DESCRIPTION
- Bumps the patch version to silence warnings from i18n-tasks.
~- Kills `FILTERED_PARAMS` setting in `Api::Base` to silence a warning~
