### PR TITLE
Externalize error, info/terms pages

### DIFF
--- a/app/views/errors/not_found.html.erb
+++ b/app/views/errors/not_found.html.erb
@@ -1,7 +1,11 @@
 <div id="error-page-wrap">
   <h1 class="error-text">404</h1>
-  <p class="error-explanation">We're sorry, the page you were looking for wasn't there.</p>
+  <p class="error-explanation">
+    <%= t(".explanation") %>
+  </p>
   <h4 class="go-back">
-    <a class="back-link" onClick="history.go(-1);return true;">Send me back from whence I came!</a>
+    <a class="back-link" onClick="history.go(-1);return true;">
+      <%= t(".send_me_back") %>
+    </a>
   </h4>
 </div>

--- a/app/views/errors/server_error.html
+++ b/app/views/errors/server_error.html
@@ -1,7 +1,0 @@
-<div id="error-page-wrap">
-  <h1 class="error-text">500</h1>
-  <p class="error-explanation">We're sorry, there was a server error and we can't show you that page.</p>
-  <h4 class="go-back">
-    <a class="back-link" onClick="history.go(-1);return true;">Send me back from whence I came!</a>
-  </h4>
-</div>

--- a/app/views/errors/server_error.html.erb
+++ b/app/views/errors/server_error.html.erb
@@ -1,5 +1,5 @@
 <div id="error-page-wrap">
-  <h1 class="error-text">400</h1>
+  <h1 class="error-text">500</h1>
   <p class="error-explanation">
     <%= t(".explanation") %>
   </p>

--- a/app/views/errors/unauthorized.html.erb
+++ b/app/views/errors/unauthorized.html.erb
@@ -1,7 +1,11 @@
 <div id="error-page-wrap">
   <h1 class="error-text">401</h1>
-  <p class="error-explanation">We're sorry, you aren't allowed to do that.</p>
+  <p class="error-explanation">
+    <%= t(".explanation") %>
+  </p>
   <h4 class="go-back">
-    <a class="back-link" onClick="history.go(-1);return true;">Send me back from whence I came!</a>
+    <a class="back-link" onClick="history.go(-1);return true;">
+      <%= t(".send_me_back") %>
+    </a>
   </h4>
 </div>

--- a/app/views/errors/unprocessable_entity.html.erb
+++ b/app/views/errors/unprocessable_entity.html.erb
@@ -1,7 +1,12 @@
 <div id="error-page-wrap">
   <h1 class="error-text">422</h1>
-  <p class="error-explanation">We're sorry, We can't do what you just asked. Think you ought to be able to? Email us <a href="mailto:contact@bikeindex.org">Contact</a>.</p>
+  <p class="error-explanation">
+    <%- email_link = link_to t(".contact"), "mailto:#{t('.contact_email')}"  %>
+    <%= t(".explanation_html", email_link: email_link) %>
+  </p>
   <h4 class="go-back">
-    <a class="back-link" onClick="history.go(-1);return true;">Send me back from whence I came!</a>
+    <a class="back-link" onClick="history.go(-1);return true;">
+      <%= t(".send_me_back") %>
+    </a>
   </h4>
 </div>

--- a/app/views/info/_terms_text.html.erb
+++ b/app/views/info/_terms_text.html.erb
@@ -1,137 +1,197 @@
 <% file_path = @view_renderer.lookup_context.find_template(@virtual_path).identifier.gsub(/\A.*\/app\//i, 'app/') %>
+<%- change_history_url = "https://github.com/bikeindex/bike_index/tree/master/#{file_path}" %>
+
 <header>
-<h1>
-<a name="terms-of-service" class="anchor" href="#terms-of-service"><span class="mini-icon mini-icon-link"></span></a>Terms of Service</h1>
+  <h1>
+    <a name="terms-of-service" class="anchor" href="#terms-of-service">
+      <span class="mini-icon mini-icon-link">
+      </span></a>
+      <%= t('.terms_of_service') %>
+  </h1>
 
-<p>Last updated July 29th, 2017. Previous versions and the change history is <a href="https://github.com/bikeindex/bike_index/tree/master/<%= file_path %>">available here</a>.</p>
-
-<hr>
+  <p>
+  <%= t('.last_updated_html', link: link_to(t('.available_here'), change_history_url)) %>
+  </p>
+  <hr>
 </header>
 
 
 <h2>
   <a name="about-our-terms-of-service" class="anchor" href="#about-our-terms-of-service"><span class="mini-icon mini-icon-link"></span></a>
-  About our Terms of Service
+  <%= t('.about_our_terms_of_service') %>
 </h2>
 
-<p><strong>Welcome to Bike Index</strong>, a 501(c)(3) nonprofit. We've developed a publicly-accessible bike registration service (the "Service") that gives you the ability to save and share your bikes on the internet.</p>
+<p><%= t('.welcome_to_bike_index_html') %></p>
 
-<p>By giving bike shops, biking organizations and police departments the ability to register bikes directly for their constituents we aim to incentivize bike registration, support local cycling culture and ensure accurate registrations. We have tried to draft this Terms of Service to be as simple and comprehensible as possible. Unfortunately, the realities of the legal world make that a very difficult task. So, should you have any questions or concerns, or simply want to better understand how we do things at Bike Index, please do not hesitate to <a href="https://www.bikeindex.org/contact_us">contact us</a>.</p>
+<p><%= t('.by_giving_bike_shops_html', contact_link: link_to("contact us", contact_us_path)) %></p>
 
 <h1 id="section_a">
   <a name="section-a-acceptance-of-terms" class="anchor" href="#section-a-acceptance-of-terms"><span class="mini-icon mini-icon-link"></span></a>
-  Section A: User's Acknowledgment and Acceptance of Terms
+  <%= t('.section_a_header') %>
 </h1>
 
 <ol>
   <li>
-    <p>By creating an "Account" and using the BikeIndex.org web site ("Service"), or any services of Bike Index, NFP ("Bike Index"), you are agreeing to be bound by the following terms and conditions ("Terms of Service"). IF YOU ARE ENTERING INTO THIS AGREEMENT ON BEHALF OF A COMPANY OR OTHER LEGAL ENTITY, YOU REPRESENT THAT YOU HAVE THE AUTHORITY TO BIND SUCH ENTITY, ITS AFFILIATES AND ALL USERS WHO ACCESS OUR SERVICES THROUGH YOUR ACCOUNT TO THESE TERMS AND CONDITIONS, IN WHICH CASE THE TERMS "YOU" OR "YOUR" SHALL REFER TO SUCH ENTITY, ITS AFFILIATES AND USERS ASSOCIATED WITH IT. IF YOU DO NOT HAVE SUCH AUTHORITY, OR IF YOU DO NOT AGREE WITH THESE TERMS AND CONDITIONS, YOU MUST NOT ACCEPT THIS AGREEMENT AND MAY NOT USE THE SERVICES.</p>
+    <p><%= t('.by_creating_account') %></p>
   </li>
   <li>
     <p>
-      If Bike Index makes material changes to these Terms, we will notify you by email or by posting a notice on our site before the changes are effective. Any new features that augment or enhance the current Service, including the release of new tools and resources, shall be subject to the Terms of Service. Continued use of the Service after any such changes shall constitute your consent to such changes. You can review the most current version of the Terms of Service at any time at: <a href="https://www.bikeindex.org/terms">bikeindex.org/terms</a>
+    <%- terms_link = link_to("bikeindex.org/terms", terms_path) %>
+    <%= t('.if_bike_index_html', terms_link: terms_link) %>
     </p>
   </li>
   <li>
-    <p>"Content" on the Service is defined by any information Users input into the service. Users are defined as those who utilize the Bike Index Service and agree to the Terms of Service. While Bike Index prohibits some conduct and Content on the Service, you understand and agree that Bike Index cannot be responsible for the Content posted on the Service and you nonetheless may be exposed to such materials. you agree to use the Service at your own risk. Violation of any of the terms below will result in the termination of your Account.</p>
+    <p>
+    <%= t('.content_on_the_service') %>
+    </p>
   </li>
 </ol>
 
 
 <h1 id="section_b">
   <a name="section-b-account-terms" class="anchor" href="#section-b-account-terms"><span class="mini-icon mini-icon-link"></span></a>
-  Section B: Account Terms
+  <%= t('.section_b_header') %>
 </h1>
 
 <ol>
   <li>
-    <p>You must be a human. Accounts registered by "bots" or other automated methods are not permitted.</p>
+    <p>
+    <%= t('.you_must_be_human') %>
+    </p>
   </li>
   <li>
-    <p>You must provide a valid email address in order to complete the signup process.</p>
+    <p>
+    <%= t('.you_must_provide_email') %>
+    </p>
   </li>
   <li>
-    <p>You are responsible for maintaining the security of your account and password. Bike Index cannot and will not be liable for any loss or damage from your failure to comply with this security obligation.</p>
+    <p>
+    <%= t('.you_are_responsible_for_security') %>
+    </p>
   </li>
   <li>
-    <p>You are responsible for all Content posted and activity that occurs under your account (even when Content is posted by others who have accounts under your account or access to your account).</p>
+    <p>
+    <%= t('.you_are_responsible_for_content') %>
+    </p>
   </li>
   <li>
-    <p>You may not use the Service for any illegal or unauthorized purpose. You must not, in the use of the Service, violate any laws in your jurisdiction (including but not limited to copyright or trademark laws).</p>
+    <p>
+    <%= t('.you_may_not_use_for_illegal') %>
+    </p>
   </li>
 </ol>
 
 
 <h1 id="section_c">
   <a name="section-c-modifications-to-the-service" class="anchor" href="#section-c-modifications-to-the-service"><span class="mini-icon mini-icon-link"></span></a>
-  Section C: Modifications to the service
+  <%= t('.section_c_header') %>
 </h1>
 
 <ol>
   <li>
-    <p>Bike Index reserves the right at any time and from time to time to modify or discontinue, temporarily or permanently, the Service (or any part thereof) with or without notice.</p>
+    <p>
+    <%= t('.bike_index_reserves') %>
+    </p>
   </li>
   <li>
-    <p>Bike Index shall not be liable to you or to any third party for any modification, suspension or discontinuance of the Service.</p>
+    <p>
+    <%= t('.bike_index_shall_not_be_liable') %>
+    </p>
   </li>
 </ol>
 
 <h1 id="section_d">
   <a name="section-d-copyright-and-content-ownership" class="anchor" href="#section-d-copyright-and-content-ownership"><span class="mini-icon mini-icon-link"></span></a>
-  Section D: Copyright and content ownership
+  <%= t('.section_d_header') %>
 </h1>
 
 <ol>
   <li>
-    <p>We claim no intellectual property rights over the material you provide to the Service. Your profile and materials uploaded remain yours. However, Content that you upload about your bikes can be viewed publicly, and setting your profile to be public will allow information you add to it to be viewed publicly. You agree to allow others to view this Content.</p>
+    <p>
+    <%= t('.we_claim_no_ip') %>
+    </p>
   </li>
   <li>
-    <p>Bike Index does not pre-screen Content, but Bike Index and its designee have the right (but not the obligation) in their sole discretion to refuse or remove any Content that is available via the Service.</p>
+    <p>
+    <%= t('.we_dont_prescreen_content') %>
+    </p>
   </li>
   <li>
-    <p>You shall defend Bike Index against any claim, demand, suit or proceeding made or brought against Bike Index by a third party alleging that your Content, or your use of the Service in violation of this Agreement, infringes or misappropriates the intellectual property rights of a third party or violates applicable law, and shall indemnify Bike Index for any damages finally awarded against, and for reasonable attorney’s fees incurred by, Bike Index in connection with any such claim, demand, suit or proceeding; provided, that Bike Index (a) promptly gives you written notice of the claim, demand, suit or proceeding; (b) gives you sole control of the defense and settlement of the claim, demand, suit or proceeding (provided that tou may not settle any claim, demand, suit or proceeding unless the settlement unconditionally releases Bike Index of all liability); and (c) provides to you all reasonable assistance, at your expense.</p>
+    <p>
+    <%= t('.you_shall_defend_bike_index') %>
+    </p>
   </li>
 </ol>
 
 
 <h1 id="section_e">
-  <a name="section-e-general-conditions" class="anchor" href="#section-e-general-conditions"><span class="mini-icon mini-icon-link"></span></a>
-  Section E: General Conditions
+  <a name="section-e-general-conditions" class="anchor" href="#section-e-general-conditions">
+    <span class="mini-icon mini-icon-link">
+    </span>
+  </a>
+  <%= t('.section_e_header') %>
 </h1>
 
 <ol>
   <li>
-    <p>Your use of the Service is at your sole risk. The service is provided on an "as is" and "as available" basis.</p>
+    <p>
+    <%= t('.your_use_of_the_service') %>
+    </p>
   </li>
   <li>
-    <p>Support for Bike Index services is currently only available in English, via email.</p>
+    <p>
+    <%= t('.support_for_bike_index_services') %>
+    </p>
   </li>
   <li>
-    <p>You understand that Bike Index uses third party vendors and hosting partners to provide the necessary hardware, software, networking, storage, and related technology required to run the Service.</p>
+    <p>
+    <%= t('.third_party_vendors') %>
+    </p>
   </li>
   <li>
-    <p>You must not modify, adapt or hack the Service or modify another website so as to falsely imply that it is associated with the Service, Bike Index, or any other Bike Index service.</p>
+    <p>
+    <%= t('.you_must_notify') %>
+    </p>
   </li>
   <li>
-    <p>You agree not to sell, resell or exploit any portion of the Service, use of the Service, or access to the Service without the express written permission by Bike Index.</p>
+    <p>
+    <%= t('.you_agree_not_to_resell') %>
+    </p>
   </li>
   <li>
-    <p>We may, but have no obligation to, remove Content and Accounts containing Content that we determine in our sole discretion are unlawful, offensive, threatening, libelous, defamatory, pornographic, obscene or otherwise objectionable or violates any party's intellectual property or these Terms of Service.</p>
+    <p>
+    <%= t('.we_may_remove_content') %>
+    </p>
   </li>
   <li>
-    <p>Verbal, physical, written or other abuse (including threats of abuse or retribution) of any Bike Index customer, employee, member, or officer will result in immediate account termination.</p>
+    <p>
+    <%= t('.no_abuse') %>
+    </p>
   </li>
   <li>
-    <p>You understand that the technical processing and transmission of the Service, including your Content, may be transfered unencrypted and involve (a) transmissions over various networks; and (b) changes to conform and adapt to technical requirements of connecting networks or devices.</p>
+    <p>
+    <%= t('.may_be_terminated') %>
+    </p>
   </li>
   <li>
-    <p>You must not upload, post, host, or transmit unsolicited email, SMSs, or "spam" messages.</p>
+    <p>
+    <%= t('.no_spam') %>
+    </p>
   </li>
   <li>
-    <p>Bike Index does not warrant that (i) the service will meet your specific requirements, (ii) the service will be uninterrupted, timely, secure, or error-free, (iii) the results that may be obtained from the use of the service will be accurate or reliable, (iv) the quality of any products, services, information, or other material purchased or obtained by you through the service will meet your expectations, and (v) any errors in the Service will be corrected.</p>
+    <p>
+    <%= t('.best_effort') %>
+    </p>
   </li>
   <li>
-    <p>The failure of Bike Index to exercise or enforce any right or provision of the Terms of Service shall not constitute a waiver of such right or provision. The Terms of Service constitutes the entire agreement between you and Bike Index and govern your use of the Service, superseding any prior agreements between you and Bike Index (including, but not limited to, any prior versions of the Terms of Service). You agree that these Terms of Service and your use of the Service are governed under Illinois law.</p>
+    <p>
+    <%= t('.no_waiver') %>
+    </p>
   </li>
-  <li><p>Questions about the Terms of Service should be sent to <a href="mailto:contact@bikeindex.org">contact@bikeindex.org</a>.</p></li>
+  <li>
+    <p>
+    <%- contact_email_link = link_to("contact@bikeindex.org", "mailto:contact@bikeindex.org") %>
+    <%= t('.questions_html', contact_email_link: contact_email_link) %>
+    </p>
+  </li>
 </ol>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -101,41 +101,6 @@ en:
       day: Day
       month: Month
       year: Year
-  errors:
-    format: "%{attribute} %{message}"
-    messages:
-      accepted: must be accepted
-      blank: can't be blank
-      confirmation: doesn't match confirmation
-      empty: can't be empty
-      equal_to: must be equal to %{count}
-      even: must be even
-      exclusion: is reserved
-      greater_than: must be greater than %{count}
-      greater_than_or_equal_to: must be greater than or equal to %{count}
-      inclusion: is not included in the list
-      invalid: is invalid
-      less_than: must be less than %{count}
-      less_than_or_equal_to: must be less than or equal to %{count}
-      not_a_number: is not a number
-      not_an_integer: must be an integer
-      odd: must be odd
-      record_invalid: "Validation failed: %{errors}"
-      taken: has already been taken
-      too_long:
-        one: is too long (maximum is 1 character)
-        other: is too long (maximum is %{count} characters)
-      too_short:
-        one: is too short (minimum is 1 character)
-        other: is too short (minimum is %{count} characters)
-      wrong_length:
-        one: is the wrong length (should be 1 character)
-        other: is the wrong length (should be %{count} characters)
-    template:
-      body: "There were problems with the following fields:"
-      header:
-        one: 1 error prohibited this %{model} from being saved
-        other: "%{count} errors prohibited this %{model} from being saved"
   helpers:
     page_entries_info:
       one_page:
@@ -287,6 +252,58 @@ en:
   doorkeeper:
     scopes:
       public: Authenticate with you, view public information
+  errors:
+    format: "%{attribute} %{message}"
+    messages:
+      accepted: must be accepted
+      blank: can't be blank
+      confirmation: doesn't match confirmation
+      empty: can't be empty
+      equal_to: must be equal to %{count}
+      even: must be even
+      exclusion: is reserved
+      greater_than: must be greater than %{count}
+      greater_than_or_equal_to: must be greater than or equal to %{count}
+      inclusion: is not included in the list
+      invalid: is invalid
+      less_than: must be less than %{count}
+      less_than_or_equal_to: must be less than or equal to %{count}
+      not_a_number: is not a number
+      not_an_integer: must be an integer
+      odd: must be odd
+      record_invalid: "Validation failed: %{errors}"
+      taken: has already been taken
+      too_long:
+        one: is too long (maximum is 1 character)
+        other: is too long (maximum is %{count} characters)
+      too_short:
+        one: is too short (minimum is 1 character)
+        other: is too short (minimum is %{count} characters)
+      wrong_length:
+        one: is the wrong length (should be 1 character)
+        other: is the wrong length (should be %{count} characters)
+    template:
+      body: "There were problems with the following fields:"
+      header:
+        one: 1 error prohibited this %{model} from being saved
+        other: "%{count} errors prohibited this %{model} from being saved"
+    bad_request:
+      explanation: We're sorry, we didn't understand what you just asked. Why don't you try again?
+      send_me_back: Send me back from whence I came!
+    not_found:
+      explanation: We're sorry, the page you were looking for wasn't there.
+      send_me_back: Send me back from whence I came!
+    server_error:
+      explanation: We're sorry, there was a server error and we can't show you that page.
+      send_me_back: Send me back from whence I came!
+    unauthorized:
+      explanation: We're sorry, you aren't allowed to do that.
+      send_me_back: Send me back from whence I came!
+    unprocessable_entity:
+      contact: Contact
+      contact_email: contact@bikeindex.org
+      explanation_html: "We're sorry, We can't do what you just asked. Think you ought to be able to? Email us: %{email_link}."
+      send_me_back: Send me back from whence I came!
   controllers:
     bikes:
       bike_details: Bike Details

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1571,3 +1571,134 @@ en:
       reason_modal_body: Please fill in the reason for the %{bike_type} deletion
       reason_modal_title: We want to know why!
       modal_title: Are you sure you want to delete this %{bike_type}?
+  info:
+    terms_text:
+      about_our_terms_of_service: About our Terms of Service
+      available_here: available here
+      best_effort: 'Bike Index does not warrant that (i) the service will meet your
+        specific requirements, (ii) the service will be uninterrupted, timely, secure,
+        or error-free, (iii) the results that may be obtained from the use of the
+        service will be accurate or reliable, (iv) the quality of any products, services,
+        information, or other material purchased or obtained by you through the service
+        will meet your expectations, and (v) any errors in the Service will be corrected.'
+      bike_index_reserves: 'Bike Index reserves the right at any time and from time
+        to time to modify or discontinue, temporarily or permanently, the Service
+        (or any part thereof) with or without notice.'
+      bike_index_shall_not_be_liable: 'Bike Index shall not be liable to you or to
+        any third party for any modification, suspension or discontinuance of the
+        Service.'
+      by_creating_account: By creating an "Account" and using the BikeIndex.org web
+        site ("Service"), or any services of Bike Index, NFP ("Bike Index"), you are
+        agreeing to be bound by the following terms and conditions ("Terms of Service").
+        IF YOU ARE ENTERING INTO THIS AGREEMENT ON BEHALF OF A COMPANY OR OTHER LEGAL
+        ENTITY, YOU REPRESENT THAT YOU HAVE THE AUTHORITY TO BIND SUCH ENTITY, ITS
+        AFFILIATES AND ALL USERS WHO ACCESS OUR SERVICES THROUGH YOUR ACCOUNT TO THESE
+        TERMS AND CONDITIONS, IN WHICH CASE THE TERMS "YOU" OR "YOUR" SHALL REFER
+        TO SUCH ENTITY, ITS AFFILIATES AND USERS ASSOCIATED WITH IT. IF YOU DO NOT
+        HAVE SUCH AUTHORITY, OR IF YOU DO NOT AGREE WITH THESE TERMS AND CONDITIONS,
+        YOU MUST NOT ACCEPT THIS AGREEMENT AND MAY NOT USE THE SERVICES.
+      by_giving_bike_shops_html: By giving bike shops, biking organizations and police
+        departments the ability to register bikes directly for their constituents
+        we aim to incentivize bike registration, support local cycling culture and
+        ensure accurate registrations. We have tried to draft this Terms of Service
+        to be as simple and comprehensible as possible. Unfortunately, the realities
+        of the legal world make that a very difficult task. So, should you have any
+        questions or concerns, or simply want to better understand how we do things
+        at Bike Index, please do not hesitate to %{contact_link}.
+      content_on_the_service: Content" on the Service is defined by any information
+        Users input into the service. Users are defined as those who utilize the Bike
+        Index Service and agree to the Terms of Service. While Bike Index prohibits
+        some conduct and Content on the Service, you understand and agree that Bike
+        Index cannot be responsible for the Content posted on the Service and you
+        nonetheless may be exposed to such materials. you agree to use the Service
+        at your own risk. Violation of any of the terms below will result in the termination
+        of your Account.
+      if_bike_index_html: 'If Bike Index makes material changes to these Terms, we
+        will notify you by email or by posting a notice on our site before the changes
+        are effective. Any new features that augment or enhance the current Service,
+        including the release of new tools and resources, shall be subject to the
+        Terms of Service. Continued use of the Service after any such changes shall
+        constitute your consent to such changes. You can review the most current version
+        of the Terms of Service at any time at: %{terms_link}.'
+      last_updated_html: Last updated July 29th, 2017. Previous versions and the change
+        history is %{link}.
+      may_be_terminated: 'You understand that the technical processing and transmission
+        of the Service, including your Content, may be transfered unencrypted and
+        involve (a) transmissions over various networks; and (b) changes to conform
+        and adapt to technical requirements of connecting networks or devices.'
+      no_abuse: 'Verbal, physical, written or other abuse (including threats of abuse
+        or retribution) of any Bike Index customer, employee, member, or officer will
+        result in immediate account termination.'
+      no_spam: 'You must not upload, post, host, or transmit unsolicited email, SMSs,
+        or "spam" messages.'
+      no_waiver: 'The failure of Bike Index to exercise or enforce any right or provision
+        of the Terms of Service shall not constitute a waiver of such right or provision.
+        The Terms of Service constitutes the entire agreement between you and Bike
+        Index and govern your use of the Service, superseding any prior agreements
+        between you and Bike Index (including, but not limited to, any prior versions
+        of the Terms of Service). You agree that these Terms of Service and your use
+        of the Service are governed under Illinois law.'
+      questions_html: 'Questions about the Terms of Service should be sent to %{contact_email_link}.'
+      section_a_header: 'Section A: User''s Acknowledgment and Acceptance of Terms'
+      section_b_header: 'Section B: Account Terms'
+      section_c_header: 'Section C: Modifications to the service'
+      section_d_header: 'Section D: Copyright and content ownership'
+      section_e_header: 'Section E: General Conditions'
+      support_for_bike_index_services: 'Support for Bike Index services is currently
+        only available in English, via email.'
+      terms_of_service: Terms of Service
+      third_party_vendors: 'You understand that Bike Index uses third party vendors
+        and hosting partners to provide the necessary hardware, software, networking,
+        storage, and related technology required to run the Service.'
+      we_claim_no_ip: We claim no intellectual property rights over the material you
+        provide to the Service. Your profile and materials uploaded remain yours.
+        However, Content that you upload about your bikes can be viewed publicly,
+        and setting your profile to be public will allow information you add to it
+        to be viewed publicly. You agree to allow others to view this Content.
+      we_dont_prescreen_content: Bike Index does not pre-screen Content, but Bike
+        Index and its designee have the right (but not the obligation) in their sole
+        discretion to refuse or remove any Content that is available via the Service.
+      we_may_remove_content: 'We may, but have no obligation to, remove Content and
+        Accounts containing Content that we determine in our sole discretion are unlawful,
+        offensive, threatening, libelous, defamatory, pornographic, obscene or otherwise
+        objectionable or violates any party''s intellectual property or these Terms
+        of Service.'
+      welcome_to_bike_index_html: <strong>Welcome to Bike Index</strong>, a 501(c)(3)
+        nonprofit. We've developed a publicly-accessible bike registration service
+        (the "Service") that gives you the ability to save and share your bikes on
+        the internet.
+      you_agree_not_to_resell: 'You agree not to sell, resell or exploit any portion
+        of the Service, use of the Service, or access to the Service without the express
+        written permission by Bike Index.'
+      you_are_responsible_for_content: You are responsible for all Content posted
+        and activity that occurs under your account (even when Content is posted by
+        others who have accounts under your account or access to your account).
+      you_are_responsible_for_security: You are responsible for maintaining the security
+        of your account and password. Bike Index cannot and will not be liable for
+        any loss or damage from your failure to comply with this security obligation.
+      you_may_not_use_for_illegal: You may not use the Service for any illegal or
+        unauthorized purpose. You must not, in the use of the Service, violate any
+        laws in your jurisdiction (including but not limited to copyright or trademark
+        laws).
+      you_must_be_human: You must be a human. Accounts registered by "bots" or other
+        automated methods are not permitted.
+      you_must_notify: 'You must not modify, adapt or hack the Service or modify another
+        website so as to falsely imply that it is associated with the Service, Bike
+        Index, or any other Bike Index service.'
+      you_must_provide_email: You must provide a valid email address in order to complete
+        the signup process.
+      you_shall_defend_bike_index: 'You shall defend Bike Index against any claim,
+        demand, suit or proceeding made or brought against Bike Index by a third party
+        alleging that your Content, or your use of the Service in violation of this
+        Agreement, infringes or misappropriates the intellectual property rights of
+        a third party or violates applicable law, and shall indemnify Bike Index for
+        any damages finally awarded against, and for reasonable attorney’s fees incurred
+        by, Bike Index in connection with any such claim, demand, suit or proceeding;
+        provided, that Bike Index (a) promptly gives you written notice of the claim,
+        demand, suit or proceeding; (b) gives you sole control of the defense and
+        settlement of the claim, demand, suit or proceeding (provided that tou may
+        not settle any claim, demand, suit or proceeding unless the settlement unconditionally
+        releases Bike Index of all liability); and (c) provides to you all reasonable
+        assistance, at your expense.'
+      your_use_of_the_service: 'Your use of the Service is at your sole risk. The
+        service is provided on an "as is" and "as available" basis.'


### PR DESCRIPTION
Externalizes errors and TOS templates:

errors
  bad_request.html.erb
  not_found.html.erb
  unauthorized.html.erb
  unprocessable_entity.html.erb

info
  _terms_text.html.erb

Related: https://github.com/bikeindex/bike_index/issues/963
