### PR TITLE
Externalize legal, about pages

### DIFF
--- a/app/assets/stylesheets/revised/pages/info/about.scss
+++ b/app/assets/stylesheets/revised/pages/info/about.scss
@@ -60,14 +60,6 @@ $hover-about-social-color: lighten($gray-light, 15%);
     }
   }
 
-  .the-alumni {
-    display: none;
-  }
-
-  .about-alumni-list {
-    display: none;
-  }
-
   .about-list {
     @include clearfix;
 
@@ -86,10 +78,6 @@ $hover-about-social-color: lighten($gray-light, 15%);
       margin: 0 0 0 2%;
       position: relative;
 
-      &:first-of-type {
-        margin-left: 0;
-      }
-
       img {
         display: block;
         width: 100%;
@@ -101,5 +89,15 @@ $hover-about-social-color: lighten($gray-light, 15%);
         margin-left: 16%;
       }
     }
+  }
+
+  .about-alumni-list {
+    list-style-position: outside;
+
+    li {
+      margin: 0;
+      margin-right: 5px;
+    }
+
   }
 }

--- a/app/assets/stylesheets/revised/pages/info/about.scss
+++ b/app/assets/stylesheets/revised/pages/info/about.scss
@@ -20,35 +20,23 @@ $hover-about-social-color: lighten($gray-light, 15%);
       width: 8 * $vertical-height;
     }
 
-    svg {
-      display: inline-block;
-      max-height: 6 * $vertical-height;
-    }
-
-    span.social-link-text {
-      display: block;
-      margin-top: -0.5em;
+    .social-link-text {
       color: $initial-about-social-color;
-    }
-
-    .svgpath,
-    span.social-link-text {
+      display: block;
       fill: $initial-about-social-color;
+      margin-top: -0.5em;
       transition: all 0.05s linear;
     }
 
     a {
       display: block;
       position: relative;
+      color: inherit;
 
       &:hover,
       &:active {
         text-decoration: none;
         color: $hover-about-social-color;
-
-        .svgpath {
-          fill: $hover-about-social-color;
-        }
       }
     }
   }

--- a/app/views/info/_terms_text.html.erb
+++ b/app/views/info/_terms_text.html.erb
@@ -1,5 +1,8 @@
 <% file_path = @view_renderer.lookup_context.find_template(@virtual_path).identifier.gsub(/\A.*\/app\//i, 'app/') %>
 <%- change_history_url = "https://github.com/bikeindex/bike_index/tree/master/#{file_path}" %>
+<%- terms_link = link_to("bikeindex.org/terms", terms_path) %>
+<%- contact_email_link = link_to("contact@bikeindex.org", "mailto:contact@bikeindex.org") %>
+<%- contact_link = link_to("contact us", contact_us_path) %>
 
 <header>
   <h1>
@@ -23,7 +26,7 @@
 
 <p><%= t('.welcome_to_bike_index_html') %></p>
 
-<p><%= t('.by_giving_bike_shops_html', contact_link: link_to("contact us", contact_us_path)) %></p>
+<p><%= t('.by_giving_bike_shops_html', contact_link: contact_link) %></p>
 
 <h1 id="section_a">
   <a name="section-a-acceptance-of-terms" class="anchor" href="#section-a-acceptance-of-terms"><span class="mini-icon mini-icon-link"></span></a>
@@ -36,7 +39,6 @@
   </li>
   <li>
     <p>
-    <%- terms_link = link_to("bikeindex.org/terms", terms_path) %>
     <%= t('.if_bike_index_html', terms_link: terms_link) %>
     </p>
   </li>
@@ -190,7 +192,6 @@
   </li>
   <li>
     <p>
-    <%- contact_email_link = link_to("contact@bikeindex.org", "mailto:contact@bikeindex.org") %>
     <%= t('.questions_html', contact_email_link: contact_email_link) %>
     </p>
   </li>

--- a/app/views/info/_vendor_terms_text.html.erb
+++ b/app/views/info/_vendor_terms_text.html.erb
@@ -1,249 +1,469 @@
 <% file_path = @view_renderer.lookup_context.find_template(@virtual_path).identifier.gsub(/\A.*\/app\//i, 'app/') %>
+<%- change_history_url = "https://github.com/bikeindex/bike_index/tree/master/#{file_path}" %>
+<%- terms_link = link_to("bikeindex.org/terms", terms_path) %>
+<%- contact_email_link = link_to("contact@bikeindex.org", "mailto:contact@bikeindex.org") %>
+<%- contact_link = link_to("contact us", contact_us_path) %>
+
 <header>
-<h1>
-<a name="terms-of-service-for-vendors" class="anchor" href="#terms-of-service-for-vendors"><span class="mini-icon mini-icon-link"></span></a>Terms of Service for Vendors</h1>
+  <h1>
+    <a name="terms-of-service-for-vendors" class="anchor" href="#terms-of-service-for-vendors">
+      <span class="mini-icon mini-icon-link"></span></a>
+    <%= t('.terms_of_service_for_vendors') %>
+  </h1>
 
-<p>Last updated July 29th, 2017. Previous versions and the change history is <a href="https://github.com/bikeindex/bike_index/tree/master/<%= file_path %>">available here</a>.</p>
+  <p>
+  <%= t('.last_updated_html', link: link_to(t('.available_here'), change_history_url)) %>
+  </p>
 
-<hr>
+  <hr>
 </header>
 
 <h2>
-<a name="about-our-terms-of-service-for-vendors" class="anchor" href="#about-our-terms-of-service-for-vendors"><span class="mini-icon mini-icon-link"></span></a>About our terms of service for vendors</h2>
+  <a name="about-our-terms-of-service-for-vendors"
+     class="anchor"
+     href="#about-our-terms-of-service-for-vendors">
+    <span class="mini-icon mini-icon-link"></span></a>
+  <%= t('.about_terms_of_service_for_vendors') %>
+</h2>
 
-<p><strong>Welcome to Bike Index</strong>, a 501(c)(3) nonprofit. We developed a publicly-accessible bike registration service (the "Service") that gives organizations registered on Bike Index ("Vendors", "you") the ability to quickly and easily register bikes for their "Customers" - patrons of their services - using Vendor "Accounts." We believe that such a service that the Service deters bike theft and helps Customers recover stolen bikes.
+<p>
+<%= t('.welcome_to_bike_index_html') %>
 </p>
 
-<p>By giving bike shop employees and bike advocacy organizations - Vendors - the ability to add bikes to the Service for free, we aim to encourage registration and to fight procrastination of bike registrations. We have additionally developed a Lightspeed integration that allows shops that use Lightspeed as your point of sale to register bikes immediately upon sale. We discuss this in detail later in this document. If you have any questions or concerns, or simply want to better understand how we do things at Bike Index, please do not hesitate to <a href="https://www.bikeindex.org/contact_us">contact us</a>.</p>
+<p>
+<%= t('.by_giving_bike_shop_employees_html', contact_link: contact_link) %>
+</p>
 
-<p>With the following brief descriptions of the parts of this "Agreement", we attempt to explain the important parts of our Service. But there are significant details in the whole document that make it worth reading.</p>
-
-<h2>
-<a name="bike-index-vendor-service" class="anchor" href="#bike-index-vendor-service"><span class="mini-icon mini-icon-link"></span></a>Bike Index Vendor Service</h2>
-
-<p>We provide you with a service to register the bikes you interact with; we will respect and protect your and your Customers' privacy, data and personal information. You run your business, service your Customers, and observe all laws, rules, and regulations. <a href="#section_a">Complete details</a></p>
-
-<h2>
-<a name="becoming-a-vendor-on-the-bike-index" class="anchor" href="#becoming-a-vendor-on-the-bike-index"><span class="mini-icon mini-icon-link"></span></a>Becoming a Vendor on Bike Index</h2>
-
-<p>Because Bike Index relies on partnering with bike organizations, we may need to verify your status as a bike organization. You provide us with basic information about your organization and we will seek to verify your information (we may work with third parties to do so) and approve your Vendor Account unless deemed risky (by us or our friends). You give us permission to do all this, and to periodically update the information or we otherwise must decline to offer you the Service. <a href="#section_c">Complete details</a></p>
+<p>
+<%= t('.with_the_following_brief_descriptions') %>
+</p>
 
 <h2>
-<a name="termination-and-other-legal-terms" class="anchor" href="#termination-and-other-legal-terms"><span class="mini-icon mini-icon-link"></span></a>Termination and Other Legal Terms</h2>
+  <a name="bike-index-vendor-service" class="anchor" href="#bike-index-vendor-service">
+    <span class="mini-icon mini-icon-link"></span></a>
+  <%= t('.bike_index_vendor_service') %>
+</h2>
 
-<p>We can deactivate your ability to register new bikes or terminate this "Agreement" at any time (especially if you do something bad). You can also terminate anytime. Termination is effective immediately. Termination does not alter your previously registered bikes. This section also includes all the extra legal stuff they make us add (e.g. indemnification, warranties, assignment). <a href="#section_d">Complete details</a></p>
+<p>
+<%= t('.we_provide_you_with_html') %>
+</p>
 
 <h2>
-<a name="bike-index-vendor-terms-of-service" class="anchor" href="#bike-index-vendor-terms-of-service"><span class="mini-icon mini-icon-link"></span></a>Bike Index Vendor Terms of Service</h2>
+  <a name="becoming-a-vendor-on-the-bike-index" class="anchor" href="#becoming-a-vendor-on-the-bike-index">
+    <span class="mini-icon mini-icon-link"></span></a>
+  <%= t('.becoming_a_vendor') %>
+</h2>
 
-<p>The Terms and Conditions described here constitute a legal "Agreement" between the sole proprietor or business organization listed as the "Vendor" on the Service registration page (sometimes referred to as "you," "your", "merchant"), and Bike Index, NFP. ("Bike Index").</p>
+<p>
+<%= t('.because_bike_index_html') %>
+</p>
+
+<h2>
+  <a name="termination-and-other-legal-terms" class="anchor" href="#termination-and-other-legal-terms">
+    <span class="mini-icon mini-icon-link"></span></a>
+  <%= t('.termination_and_other_legal_terms') %>
+</h2>
+
+<p>
+<%= t('.we_can_deactivate_html') %>
+</p>
+
+<h2>
+  <a name="bike-index-vendor-terms-of-service" class="anchor" href="#bike-index-vendor-terms-of-service">
+    <span class="mini-icon mini-icon-link"></span></a>
+  <%= t('.bike_index_vendor_tos') %>
+</h2>
+
+<p>
+<%= t('.tos_agreement') %>
+</p>
 
 <h1 id="section_a">
-<a name="section-a-the-bike-index-service" class="anchor" href="#section-a-the-bike-index-service"><span class="mini-icon mini-icon-link"></span></a>Section A: The Bike Index Service</h1>
+  <a name="section-a-the-bike-index-service" class="anchor" href="#section-a-the-bike-index-service">
+    <span class="mini-icon mini-icon-link"></span></a>
+  <%= t('.section_a') %>
+</h1>
 
 <ol>
-<li>
-<h3>
-<a name="our-role" class="anchor" href="#our-role"><span class="mini-icon mini-icon-link"></span></a>Our Role</h3>
+  <li>
+    <h3>
+      <a name="our-role" class="anchor" href="#our-role">
+        <span class="mini-icon mini-icon-link"></span></a>
+      <%= t('.our_role') %>
+    </h3>
 
-<p>Our Service helps you quickly and easily register bikes for your Customers, and gives Customers the ability to modify most aspects of their registrations. You will be required to register with Bike Index to use Bike Index Vendor Service (see Becoming a Bike Index Vendor). In addition, we do not assume any liability for bicycles, tricycles or other types of crafts (collectively "Bikes") registered through our Service.</p>
-</li>
-<li>
-<h3>
-<a name="customer-service" class="anchor" href="#customer-service"><span class="mini-icon mini-icon-link"></span></a>Customer Service</h3>
+    <p>
+    <%= t('.our_role_body') %>
+    </p>
+  </li>
+  <li>
+    <h3>
+      <a name="customer-service" class="anchor" href="#customer-service">
+        <span class="mini-icon mini-icon-link"></span></a>
+      <%= t('.customer_service') %>
+    </h3>
 
-<p>We will provide you with customer service to resolve any issues relating to your Bike Index Account, the registration of bikes through our service, and use of our software.</p>
-</li>
-<li>
-<h3>
-<a name="security" class="anchor" href="#security"><span class="mini-icon mini-icon-link"></span></a>Security</h3>
+    <p>
+    <%= t('.customer_service_body') %>
+    </p>
+  </li>
+  <li>
+    <h3>
+      <a name="security" class="anchor" href="#security">
+        <span class="mini-icon mini-icon-link"></span></a>
+      <%= t('.security') %>
+    </h3>
 
-<p>Bike Index is responsible for protecting the security of Customer data in our possession from unauthorized access and accidental loss or modification. We will maintain commercially reasonable administrative, technical and physical procedures to protect all the personal information regarding you and your Customers that is stored in our servers. However, we cannot guarantee that unauthorized third parties will never be able to defeat those measures or use such personal information for improper purposes. You acknowledge that you provide this personal information regarding you and your Customers at your own risk. We recommend you review our <a href="https://bikeindex.org/privacy">Privacy Policy</a>, which will help you understand how we collect, use and safeguard the information you provide to us.</p>
-</li>
-<li>
-<h3>
-<a name="your-privacy" class="anchor" href="#your-privacy"><span class="mini-icon mini-icon-link"></span></a>Your Privacy</h3>
+    <p>
+    <%= t('.security_body_html') %>
+    </p>
+  </li>
+  <li>
+    <h3>
+      <a name="your-privacy" class="anchor" href="#your-privacy">
+        <span class="mini-icon mini-icon-link"></span></a>
+      <%= t('.your_privacy') %>
+    </h3>
 
-<p>Your privacy and the protection of your data are very important to us. You acknowledge that you have received, read in full and agree with the terms of our <a href="https://bikeindex.org/privacy">Privacy Policy</a> linked to and incorporated into this Agreement by reference, which contains your consent to our collection, use, retention and disclosure of personal information as well as other matters set forth therein and which explains how and for what purposes we collect, use, retain, disclose and safeguard the information you provide to us.</p>
-</li>
-<li>
-<h3>
-<a name="privacy-of-others" class="anchor" href="#privacy-of-others"><span class="mini-icon mini-icon-link"></span></a>Privacy of Others</h3>
+    <p>
+    <%= t('.your_privacy_body_html') %>
+    </p>
+  </li>
+  <li>
+    <h3>
+      <a name="privacy-of-others" class="anchor" href="#privacy-of-others">
+        <span class="mini-icon mini-icon-link"></span></a>
+      <%= t('.privacy_of_others') %>
+    </h3>
 
-<p>You represent to Bike Index that you are in compliance with all applicable privacy laws, you have obtained all necessary rights and consents under applicable law to disclose to Bike Index, or allow Bike Index to collect, use, retain and disclose any Customer data that you provide to us or authorize us to collect. You are solely responsible for disclosing to your Customers that accessing our service will require their acceptance of our <a href="https://bikeindex.org/terms">Terms of Service</a> and <a href="https://bikeindex.org/privacy">Privacy Policy</a></p>
+    <p>
+    <%= t('.privacy_of_others_p1_html') %>
+    </p>
 
-<p>If you receive information about others, including Bike Index Users, through the use of the Service, you must keep such information confidential and only use it in connection with the Service. You may not disclose or distribute any such information to a third party or use any such information for marketing purposes unless you receive the express consent of the user to do so.</p>
+    <p>
+    <%= t('.privacy_of_others_p2_html') %>
+    </p>
 
-<p>We will never sell, trade, or give out information about your Customers. If Bike Index is acquired by another organization, we will notify all users via the primary e-mail address on file that their information is being transferred and may be subject to a different privacy policy.</p>
+    <p>
+    <%= t('.privacy_of_others_p4_html') %>
+    </p>
 
-<p>Customer data you have collected prior to this partnership but that you want Bike Index to incorporate into the Service will be protected by all of the terms listed in this Agreement.</p>      
-</li>
-<li>
-<h3>
-<a name="lightspeed-integration" class="anchor" href="#lightspeed-integration"><span class="mini-icon mini-icon-link"></span></a>Lightspeed Integration</h3>
+    <p>
+    <%= t('.privacy_of_others_p5_html') %>
+    </p>
+  </li>
+  <li>
+    <h3>
+      <a name="lightspeed-integration" class="anchor" href="#lightspeed-integration">
+        <span class="mini-icon mini-icon-link"></span></a>
+      <%= t('.lightspeed_integration') %>
+    </h3>
 
-<p>To register a customer’s bicycle directly from your shop, you must collect the customer’s bike serial number and the customer’s e-mail address. If your shop uses Lightspeed Retail and you use the Bike Index Lightspeed integration, Lightspeed will collect and send to us all information in Lightspeed at the time of the sale. This information could include, but is not limited to, customer phone number, customer address, bike color and bike size. We only collect the information necessary to effectively register the bicycle for your Customer.</p>
+    <p>
+    <%= t('.lightspeed_integration_p1') %>
+    </p>
 
-<p>We are committed to keeping customer information private. We do not store any of the information transmitted from Lightspeed other than the information needed to create the Bike Index registration. All communication between Lightspeed and our Service is encrypted and covered under our Terms and the applicable terms and agreements set by Lightspeed.</p>
-</li>
-<li>
-<h3>
-<a name="restricted-use" class="anchor" href="#restricted-use"><span class="mini-icon mini-icon-link"></span></a>Restricted Use</h3>
+    <p>
+    <%= t('.lightspeed_integration_p2') %>
+    </p>
+  </li>
+  <li>
+    <h3>
+      <a name="restricted-use" class="anchor" href="#restricted-use">
+        <span class="mini-icon mini-icon-link"></span></a>
+      <%= t('.restricted_use') %>
+    </h3>
 
-<p>You are required to obey all laws, rules, and regulations applicable to your use of the Service (for example, those governing stolen property, consumer protections, unfair competition, anti-discrimination or false advertising). In addition to any other requirements or restrictions set forth in this Agreement, you agree not to, nor to permit any third party to, do any of the following: (i) access or attempt to access Bike Index systems, programs or data that are not made available for public use; (ii) permit any third party to use and benefit from the Service via a rental, lease, timesharing, service bureau or other arrangement; (iii) transfer any rights granted to you under this Agreement; (iv) work around any of the technical limitations of the Service, use any tool to enable features or functionalities that are otherwise disabled in the Service, or decompile, disassemble or otherwise reverse engineer the Service, except to the extent that such restriction is expressly prohibited by law; (v) perform or attempt to perform any actions that would interfere with the proper working of the Service, prevent access to or use of the Service by our other users, or impose an unreasonable or disproportionately large load on our infrastructure; or (vi) otherwise use the Service except as expressly allowed under this section.</p>
-</li>
-<li>
-<h3>
-<a name="suspicion-of-unauthorized-or-illegal-use" class="anchor" href="#suspicion-of-unauthorized-or-illegal-use"><span class="mini-icon mini-icon-link"></span></a>Suspicion of Unauthorized or Illegal Use</h3>
+    <p>
+    <%= t('.restricted_use_p1') %>
+    </p>
+  </li>
+  <li>
+    <h3>
+      <a name="suspicion-of-unauthorized-or-illegal-use" class="anchor" href="#suspicion-of-unauthorized-or-illegal-use">
+        <span class="mini-icon mini-icon-link"></span></a>
+      <%= t('.illegal_use') %>
+    </h3>
 
-<p>We reserve the right to not authorize or settle any transaction you submit which we believe is in violation of this Agreement, any other Bike Index agreement, or exposes you, other Bike Index users, our processors or Bike Index to harm, including but not limited to fraud and other criminal acts. You are hereby granting us authorization to share information with law enforcement about you, your transactions, or your Bike Index Service Account if we reasonably suspect that your use of Bike Index has been for an unauthorized, illegal, or criminal purpose.</p>
-</li>
-<li>
-<h3>
-<a name="disclosures-and-notices" class="anchor" href="#disclosures-and-notices"><span class="mini-icon mini-icon-link"></span></a>Disclosures and Notices</h3>
+    <p>
+    <%= t('.illegal_use_p1') %>
+    </p>
+  </li>
+  <li>
+    <h3>
+      <a name="disclosures-and-notices" class="anchor" href="#disclosures-and-notices">
+        <span class="mini-icon mini-icon-link"></span></a>
+      <%= t('.disclosures_and_notices') %>
+    </h3>
 
-<p>You agree that Bike Index can provide disclosures and notices regarding the Service to you by posting such disclosures and notices on our website, emailing them to the email address listed in your Bike Index account, or mailing them to the address listed in your Bike Index Vendor Account. You also agree that electronic disclosures and notices have the same meaning and effect as if we had provided you with a paper copy. Such disclosures and notices shall be considered to be received by you within 24 hours of the time it is posted to our website or emailed to you unless we receive notice that the email was not delivered.</p>
-</li>
-<li>
-<h3>
-<a name="references-to-our-relationship" class="anchor" href="#references-to-our-relationship"><span class="mini-icon mini-icon-link"></span></a>References to Our Relationship</h3>
+    <p>
+    <%= t('.disclosures_and_notices_p1') %>
+    </p>
+  </li>
+  <li>
+    <h3>
+      <a name="references-to-our-relationship" class="anchor" href="#references-to-our-relationship">
+        <span class="mini-icon mini-icon-link"></span></a>
+      <%= t('.references_to_relationship') %>
+    </h3>
 
-<p>You agree, from the time that you accept this Agreement with Bike Index until you terminate your account with us, that we may identify you as a Vendor of Bike Index. Neither you nor we will imply any untrue sponsorship, endorsement or affiliation between you and Bike Index. You give us permission to post information on our website regarding your business including but not limited to it's name, location, and phone number.</p>
-</li>
+    <p>
+    <%= t('.references_to_relationship_p1') %>
+    </p>
+  </li>
 </ol>
 
 <h1 id="section_c">
-<a name="section-c-registering-for-bike-index-vendor-status" class="anchor" href="#section-c-registering-for-bike-index-vendor-status"><span class="mini-icon mini-icon-link"></span></a>Section C: Registering for Bike Index Vendor Status</h1>
+  <a name="section-c-registering-for-bike-index-vendor-status" class="anchor" href="#section-c-registering-for-bike-index-vendor-status">
+    <span class="mini-icon mini-icon-link"></span></a>
+  <%= t('.section_c') %>
+</h1>
 
 <ol>
-<li>
-<h3>
-<a name="vendor-registration" class="anchor" href="#vendor-registration"><span class="mini-icon mini-icon-link"></span></a>Vendor Registration</h3>
+  <li>
+    <h3>
+      <a name="vendor-registration" class="anchor" href="#vendor-registration">
+        <span class="mini-icon mini-icon-link"></span></a>
+      <%= t('.vendor_registration') %>
+    </h3>
 
-<p>The Bike Index Vendor Service is only made available under this Agreement to persons that operate a business selling goods or services, or operate cycling related organizations. To use Bike Index to register bikes, you will first have to register for a "Vendor Account." When you register for a Bike Index Vendor Account, we will collect basic information including your name, company name, location, email address, and phone number. If you have not already done so, you will also be required to provide an email address and password for your Bike Index account.</p>
+    <p>
+    <%= t('.vendor_registration_p1') %>
+    </p>
 
-<p>When you register as a Vendor, you must also provide information about an owner or principal of the business or organization and you must be authorized to act on behalf of the business and have the authority to bind the business to this Agreement. To sign up a business to use the Service, you must agree to this Agreement on behalf of the business. If you have so agreed, the term "you" will mean you, the natural person, as well as the business organization that you represent.</p>
-</li>
-<li>
-<h3>
-<a name="verification" class="anchor" href="#verification"><span class="mini-icon mini-icon-link"></span></a>Verification</h3>
+    <p>
+    <%= t('.vendor_registration_p2') %>
+    </p>
+  </li>
+  <li>
+    <h3>
+      <a name="verification" class="anchor" href="#verification">
+        <span class="mini-icon mini-icon-link"></span></a>
+      <%= t('.verification') %>
+    </h3>
 
-<p>We may ask for information to help verify your identity including a driver’s license or other government issued identification, or a business license. We may request your permission to do a physical inspection at your place of business and to examine bicycles that pertain to your compliance with this Agreement. Your failure to comply with any of these requests within five (5) days may result in deactivation or termination of your Bike Index account. You authorize us to retrieve additional information about you from third parties and other identification services.</p>
+    <p>
+    <%= t('.verification_p1') %>
+    </p>
 
-<p>After we have collected and verified all your information, Bike Index will review your Account and determine if you are eligible to use the Service. Bike Index will notify you once your account has been either approved or deemed ineligible for use of the Service.</p>
+    <p>
+    <%= t('.verification_p2') %>
+    </p>
 
-<p>By accepting the terms of this Agreement, you are providing us with authorization to retrieve information about you by using third parties, including bike industry wholesalers, distributors, and other information providers. You acknowledge that such information retrieved may include your name, address history, business history, and other data about you. Bike Index may periodically update this information to determine whether you continue to meet our eligibility requirements.</p>
+    <p>
+    <%= t('.verification_p3') %>
+    </p>
 
-<p>You agree that Bike Index is permitted to contact and share information about you and your application (including whether you are approved or declined), as well as your use of Bike Index with our friends.</p>
-</li>
-<li>
-<h3>
-<a name="prohibited-businesses" class="anchor" href="#prohibited-businesses"><span class="mini-icon mini-icon-link"></span></a>Prohibited Businesses</h3>
+    <p>
+    <%= t('.verification_p4') %>
+    </p>
+  </li>
+  <li>
+    <h3>
+      <a name="prohibited-businesses" class="anchor" href="#prohibited-businesses">
+        <span class="mini-icon mini-icon-link"></span></a>
+      <%= t('.prohibited_businesses') %>
+    </h3>
 
-<p>By registering for Bike Index Vendor Service, you are confirming that you will not use the Service to register bikes in connection with the following businesses, business activities or business practices: (1) knowingly selling stolen bikes, (2) stealing bikes.</p>
+    <p>
+    <%= t('.prohibited_businesses_p1') %>
+    </p>
 
-<p>By accepting this Agreement you confirm that you will satisfy these requirements.</p>
-</li>
-</ol><h1 id="section_d">
-<a name="section-d-termination-and-other-legal-matters" class="anchor" href="#section-d-termination-and-other-legal-matters"><span class="mini-icon mini-icon-link"></span></a>Section D: Termination and Other Legal Matters</h1>
+    <p>
+    <%= t('.prohibited_businesses_p2') %>
+    </p>
+  </li>
+</ol>
+
+<h1 id="section_d">
+  <a name="section-d-termination-and-other-legal-matters" class="anchor" href="#section-d-termination-and-other-legal-matters">
+    <span class="mini-icon mini-icon-link"></span></a>
+  <%= t('.section_d') %>
+</h1>
 
 <ol>
-<li>
-<h3>
-<a name="term" class="anchor" href="#term"><span class="mini-icon mini-icon-link"></span></a>Term</h3>
+  <li>
+    <h3>
+      <a name="term" class="anchor" href="#term">
+        <span class="mini-icon mini-icon-link"></span></a>
+      <%= t('.term') %>
+    </h3>
 
-<p>The Agreement is effective upon the date you agree to it (by electronically indicating acceptance) and continues so long as you use the Service or until terminated by Bike Index.</p>
-</li>
-<li>
-<h3>
-<a name="termination" class="anchor" href="#termination"><span class="mini-icon mini-icon-link"></span></a>Termination</h3>
+    <p>
+    <%= t('.term_p1') %>
+    </p>
+  </li>
+  <li>
+    <h3>
+      <a name="termination" class="anchor" href="#termination">
+        <span class="mini-icon mini-icon-link"></span></a>
+      <%= t('.termination') %>
+    </h3>
 
-<p>You may terminate this Agreement by closing your Bike Index account at any time by following the instructions on our website in your organization’s Vendor Account profile. We may terminate this Agreement and close your Bike Index Vendor Account at any time for any reason effective upon providing you notice in accordance with Section A10(references to our relationships) above. We may suspend your Bike Index account and your access to the Service, or terminate this Agreement, if (i) we determine in our sole discretion that you are ineligible for the Service for reasons, including without limitation customer complaints about your use of the service, or for any other reason; or (ii) you do not comply with any of the provisions of this Agreement.</p>
-</li>
-<li>
-<h3>
-<a name="effects-of-deactivation" class="anchor" href="#effects-of-deactivation"><span class="mini-icon mini-icon-link"></span></a>Effects of Deactivation</h3>
+    <p>
+    <%= t('.termination_p1') %>
+    </p>
+  </li>
+  <li>
+    <h3>
+      <a name="effects-of-deactivation" class="anchor" href="#effects-of-deactivation">
+        <span class="mini-icon mini-icon-link"></span></a>
+      <%= t('.effects_of_deactivation') %>
+    </h3>
 
-<p>Upon deactivation of your Bike Index Vendor Account, we will immediately discontinue your ability to add bikes through the Service. You will still be able to access the rest of the service.</p>
-</li>
-<li>
-<h3>
-<a name="effects-of-termination" class="anchor" href="#effects-of-termination"><span class="mini-icon mini-icon-link"></span></a>Effects of Termination</h3>
+    <p>
+    <%= t('.effects_of_deactivation_p1') %>
+    </p>
+  </li>
+  <li>
+    <h3>
+      <a name="effects-of-termination" class="anchor" href="#effects-of-termination">
+        <span class="mini-icon mini-icon-link"></span></a>
+      <%= t('.effects_of_termination') %>
+    </h3>
 
-<p>Upon termination and closing of your Bike Index Account, we will immediately discontinue your access to the Vendor Service. You agree to stop accepting new registrations through the Service. You will not be refunded the remainder of any fees that you have paid for the Service if your access to or use of the Service is terminated or suspended. Any funds in our custody will be retained by Bike Index.</p>
+    <p>
+    <%= t('.effects_of_termination_p1') %>
+    </p>
 
-<p>Upon termination you agree: (i) to immediately cease your use of the Service (ii) to discontinue use of any Bike Index trademarks and to immediately remove any Bike Index references and logos from your business (iii) to continue to be bound by this Agreement (iv) that the license granted under this Agreement shall end, (v) that we reserve the right (but have no obligation) to delete all of your information and account data stored on our servers, and (e) we will not be liable to you for compensation, reimbursement, or damages in connection with your use of the Service, or any termination or suspension of the Service or deletion of your information or account data.</p>
-</li>
-<li>
-<h3>
-<a name="your-license-our-trademarks" class="anchor" href="#your-license-our-trademarks"><span class="mini-icon mini-icon-link"></span></a>Your License; Our Trademarks</h3>
+    <p>
+    <%= t('.effects_of_termination_p2') %>
+    </p>
+  </li>
+  <li>
+    <h3>
+      <a name="your-license-our-trademarks" class="anchor" href="#your-license-our-trademarks">
+        <span class="mini-icon mini-icon-link"></span></a>
+      <%= t('.license_trademarks') %>
+    </h3>
 
-<p>Bike Index grants you a personal, limited, non-exclusive, revocable, non-transferable license, without the right to sublicense, to electronically access and use the Service solely to register, to manage the bicycles records you so create, and to contact stolen bike owners if you encounter their bike. The Service includes our website, any software, programs, documentation, tools, internet-based services, components, and any updates (including software maintenance, service information, help content, bug fixes or maintenance releases) thereto provided to you by Bike Index. You will be entitled to download updates to the Service, subject to any additional terms made known to you at that time, when Bike Index makes these updates available.</p>
+    <p>
+    <%= t('.license_trademarks_p1') %>
+    </p>
 
-<p>We may also periodically make available certain Bike Index logos, trademarks or other identifiers for your use. You are not required to use them and may use them in the way you desire.</p>
-</li>
-<li>
-<h3>
-<a name="ownership" class="anchor" href="#ownership"><span class="mini-icon mini-icon-link"></span></a>Ownership</h3>
+    <p>
+    <%= t('.license_trademarks_p2') %>
+    </p>
+  </li>
+  <li>
+    <h3>
+      <a name="ownership" class="anchor" href="#ownership">
+        <span class="mini-icon mini-icon-link"></span></a>
+      <%= t('.ownership') %>
+    </h3>
 
-<p>The Service is licensed and not sold. We reserve all rights not expressly granted to you in this Agreement. The Service is protected by copyright, trade secret and other intellectual property laws. We own the title, copyright and other worldwide Intellectual Property Rights (as defined below) in the Service and all copies of the Service. This Agreement does not grant you any rights to our trademarks or service marks.</p>
+    <p>
+    <%= t('.ownership_p1') %>
+    </p>
 
-<p>For the purposes of this Agreement, "Intellectual Property Rights" means all patent rights, copyright rights, mask work rights, moral rights, rights of publicity, trademark, trade dress and service mark rights, goodwill, trade secret rights and other intellectual property rights as may now exist or hereafter come into existence, and all applications therefore and registrations, renewals and extensions thereof, under the laws of any state, country, territory or other jurisdiction.</p>
+    <p>
+    <%= t('.ownership_p2') %>
+    </p>
 
-<p>You may choose to or we may invite you to submit comments or ideas about the Service, including without limitation about how to improve the Service or our products ("Ideas"). By submitting any Idea, you agree that your disclosure is gratuitous, unsolicited and without restriction and will not place Bike Index under any fiduciary or other obligation, and that we are free to use the Idea without any additional compensation to you, and/or to disclose the Idea on a non-confidential basis or otherwise to anyone. You further acknowledge that, by acceptance of your submission, Bike Index does not waive any rights to use similar or related ideas previously known to Bike Index, or developed by its employees, or obtained from sources other than you.</p>
-</li>
-<li>
-<h3>
-<a name="your-liability" class="anchor" href="#your-liability"><span class="mini-icon mini-icon-link"></span></a>Your Liability</h3>
+    <p>
+    <%= t('.ownership_p3') %>
+    </p>
+  </li>
+  <li>
+    <h3>
+      <a name="your-liability" class="anchor" href="#your-liability">
+        <span class="mini-icon mini-icon-link"></span></a>
+      <%= t('.your_liability') %>
+    </h3>
 
-<p>You are responsible for all claims, fines, fees, penalties and other liability arising out of or relating to your breach of this Agreement, and/or your use of the Service. Bike Index will have the final decision-making authority with respect to claims. You will be required to reimburse Bike Index for your liability. You will not receive a refund of any fees paid to Bike Index.</p>
+    <p>
+    <%= t('.your_liability_p1') %>
+    </p>
 
-<p>Without limiting the foregoing, you agree to defend, indemnify, and hold harmless Bike Index and its respective employees and agents (collectively "Disclaiming Entities") from and against any claim, suit, demand, loss, liability, damage, action or proceeding arising out of or relating to (i) your breach of any provision of this Agreement, and/or (ii) your use of the Service, including without limitation any reversals, claims, fines, fees, penalties and attorneys’ fees; (iii) your, or your employee’s or agent’s, negligence or willful misconduct; or (iv) third party indemnity obligations we incur as a direct or indirect result of your acts or omissions.</p>
-</li>
-<li>
-<h3>
-<a name="representation-and-warranties" class="anchor" href="#representation-and-warranties"><span class="mini-icon mini-icon-link"></span></a>Representation and Warranties</h3>
+    <p>
+    <%= t('.your_liability_p2') %>
+    </p>
+  </li>
+  <li>
+    <h3>
+      <a name="representation-and-warranties" class="anchor" href="#representation-and-warranties">
+        <span class="mini-icon mini-icon-link"></span></a>
+      <%= t('.representation_and_warranties') %>
+    </h3>
 
-<p>You represent and warrant to us that: (a) you are a natural person at least eighteen (18) years of age or, if you are under eighteen (18) years of age have obtained the consent of your parent or legal guardian to your execution of this Agreement and use of Bike Index Vendor Services in the manner prescribed by Bike Index; (b) you are eligible to register and use the Service and have the right, power, and ability to enter into and perform under this Agreement; (c) the name identified by you when you registered is the business name under which you sell goods and services; (d) any registration submitted by you will represent a bona fide sale by you; (e) you will fulfill all of your obligations to each customer for which you submit a registration and will resolve any Customer dispute or complaint directly with the Customer; (f) you and all registrations initiated by you will comply with all federal, state, and local laws, rules, and regulations applicable to your business, including any applicable tax laws and regulations; (g) you will not use the Service, directly or indirectly, for any fraudulent undertaking or in any manner so as to interfere with the use of the Service.</p>
-</li>
-<li>
-<h3>
-<a name="no-warranties" class="anchor" href="#no-warranties"><span class="mini-icon mini-icon-link"></span></a>No Warranties</h3>
+    <p>
+    <%= t('.representation_and_warranties_p1') %>
+    </p>
+  </li>
+  <li>
+    <h3>
+      <a name="no-warranties" class="anchor" href="#no-warranties">
+        <span class="mini-icon mini-icon-link"></span></a>
+      <%= t('.no_warranties') %>
+    </h3>
 
-<p>THE SERVICE AND ALL ACCOMPANYING DOCUMENTATION ARE PROVIDED ON AN "AS IS" AND "AS AVAILABLE" BASIS, WITHOUT ANY WARRANTIES, EITHER EXPRESS, IMPLIED, OR STATUTORY, INCLUDING WITHOUT LIMITATION ANY IMPLIED WARRANTIES OF TITLE, MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, AND NON-INFRINGEMENT. USE OF THE SERVICE IS AT YOUR OWN RISK.</p>
+    <p>
+    <%= t('.no_warranties_p1') %>
+    </p>
 
-<p>NO ADVICE OR INFORMATION, WHETHER ORAL OR WRITTEN, OBTAINED BY YOU FROM OR THROUGH THE SERVICE OR FROM (I) BIKE INDEX; OR (II) ANY OF THE RESPECTIVE AFFILIATES, AGENTS, DIRECTORS AND EMPLOYEES OF ANY OF THE ENTITIES LISTED IN (I) ABOVE (COLLECTIVELY, THE "DISCLAIMING ENTITIES" AND INDIVIDUALLY A "DISCLAIMING ENTITY"), WILL CREATE ANY WARRANTY. YOU SPECIFICALLY ACKNOWLEDGE THAT BIKE INDEX CAN NOT ENSURE THAT YOUR CUSTOMERS WILL COMPLETE A REGISTRATION OR ARE AUTHORIZED TO DO SO.</p>
+    <p>
+    <%= t('.no_warranties_p2') %>
+    </p>
 
-<p>WITHOUT LIMITING THE FOREGOING, THE DISCLAIMING ENTITIES DO NOT WARRANT THAT THE INFORMATION THEY PROVIDE OR THAT IS PROVIDED THROUGH THE SERVICE IS ACCURATE, RELIABLE OR CORRECT; THAT THE SERVICE WILL MEET YOUR REQUIREMENTS; THAT THE SERVICE WILL BE AVAILABLE AT ANY PARTICULAR TIME OR LOCATION, THAT THE SERVICE WILL FUNCTION IN AN UNINTERRUPTED MANNER OR BE SECURE; THAT ANY DEFECTS OR ERRORS WILL BE CORRECTED; OR THAT THE SERVICE IS FREE OF VIRUSES OR OTHER HARMFUL COMPONENTS. ANY SUBJECT MATTER DOWNLOADED OR OTHERWISE OBTAINED THROUGH THE USE OF THE SERVICE IS DOWNLOADED AT YOUR OWN RISK AND YOU WILL BE SOLELY RESPONSIBLE FOR ANY DAMAGE TO YOUR PROPERTY OR LOSS OF DATA THAT RESULTS FROM SUCH DOWNLOAD. THE DISCLAIMING ENTITIES MAKE NO REPRESENTATIONS OR WARRANTIES ABOUT HOW LONG WILL BE NEEDED TO COMPLETE THE PROCESSING OF A TRANSACTION.</p>
+    <p>
+    <%= t('.no_warranties_p3') %>
+    </p>
 
-<p>THE DISCLAIMING ENTITIES DO NOT WARRANT, ENDORSE, GUARANTEE, OR ASSUME RESPONSIBILITY FOR ANY PRODUCT OR SERVICE ADVERTISED OR OFFERED BY A THIRD PARTY THROUGH THE SERVICE OR ANY HYPERLINKED WEBSITE OR SERVICE, OR FEATURED IN ANY BANNER OR OTHER ADVERTISING, AND BIKE INDEX WILL NOT BE A PARTY TO OR IN ANY WAY MONITOR ANY TRANSACTION BETWEEN YOU AND THIRD-PARTY PROVIDERS OF PRODUCTS OR SERVICES.</p>
-</li>
-<li>
-<h3>
-<a name="limitation-of-liability-and-damages" class="anchor" href="#limitation-of-liability-and-damages"><span class="mini-icon mini-icon-link"></span></a>Limitation of Liability and Damages</h3>
+    <p>
+    <%= t('.no_warranties_p4') %>
+    </p>
+  </li>
+  <li>
+    <h3>
+      <a name="limitation-of-liability-and-damages" class="anchor" href="#limitation-of-liability-and-damages">
+        <span class="mini-icon mini-icon-link"></span></a>
+      <%= t('.limitation_of_liability') %>
+    </h3>
 
-<p>IN NO EVENT SHALL A DISCLAIMING ENTITY (AS DEFINED IN SECTION 7 ABOVE) BE LIABLE FOR ANY LOST PROFITS, LOSS OF DATA, OR ANY INDIRECT, PUNITIVE, INCIDENTAL, SPECIAL, CONSEQUENTIAL OR EXEMPLARY DAMAGES ARISING OUT OF, IN CONNECTION WITH OR RELATING TO THIS AGREEMENT OR THE SERVICES, INCLUDING WITHOUT LIMITATION THE USE OF, INABILITY TO USE, OR UNAVAILABILITY OF THE SERVICE. UNDER NO CIRCUMSTANCES WILL ANY OF THE DISCLAIMING ENTITIES (AS DEFINED IN SECTION 12 ABOVE) BE RESPONSIBLE FOR ANY DAMAGE, LOSS OR INJURY RESULTING FROM HACKING, TAMPERING OR OTHER UNAUTHORIZED ACCESS OR USE OF THE SERVICE OR YOUR BIKE INDEX ACCOUNT OR THE INFORMATION CONTAINED THEREIN.</p>
+    <p>
+    <%= t('.limitation_of_liability_p1') %>
+    </p>
 
-<p>THE DISCLAIMING ENTITIES ASSUME NO LIABILITY OR RESPONSIBILITY FOR (A) ANY PERSONAL INJURY OR PROPERTY DAMAGE, OF ANY NATURE WHATSOEVER, RESULTING FROM YOUR ACCESS TO OR USE OF THE SERVICE; (B) ANY UNAUTHORIZED ACCESS TO OR USE OF SERVERS USED IN CONNECTION WITH THE SERVICES AND/OR ANY AND ALL PERSONAL INFORMATION STORED THEREIN; (C) ANY INTERRUPTION OR CESSATION OF TRANSMISSION TO OR FROM THE SERVICE; (D) ANY SOFTWARE BUGS, VIRUSES, TROJAN HORSES, OR OTHER HARMFUL CODE THAT MAY BE TRANSMITTED TO OR THROUGH THE SERVICE; (E) ANY ERRORS, INACCURACIES OR OMISSIONS IN ANY CONTENT OR INFORMATION, FOR ANY LOSS OR DAMAGE INCURRED AS A RESULT OF THE USE OF ANY CONTENT OR INFORMATION, IN EACH CASE POSTED, EMAILED, STORED, TRANSMITTED, OR OTHERWISE MADE AVAILABLE THROUGH THE SERVICE; AND/OR (F) USER CONTENT OR THE DEFAMATORY, OFFENSIVE, OR ILLEGAL CONDUCT OF ANY THIRD PARTY.</p>
+    <p>
+    <%= t('.limitation_of_liability_p2') %>
+    </p>
 
-<p>WITHOUT LIMITING THE FOREGOING PROVISIONS OF THIS SECTION 10, THE DISCLAIMING ENTITIES’ CUMULATIVE LIABILITY TO YOU SHALL BE LIMITED TO DIRECT DAMAGES AND IN ALL EVENTS SHALL NOT EXCEED IN THE AGGREGATE THE AMOUNT OF FEES PAID BY YOU TO BIKE INDEX DURING THE TWELVE (12) MONTH PERIOD IMMEDIATELY PRECEDING THE EVENT GIVING RISE TO THE CLAIM FOR LIABILITY.</p>
+    <p>
+    <%= t('.limitation_of_liability_p3') %>
+    </p>
 
-<p>THIS LIMITATION OF LIABILITY SECTION APPLIES REGARDLESS OF THE LEGAL THEORY ON WHICH THE CLAIM IS BASED, INCLUDING WITHOUT LIMITATION CONTRACT, TORT (INCLUDING NEGLIGENCE), STRICT LIABILITY, OR ANY OTHER BASIS. THE LIMITATIONS APPLY EVEN IF BIKE INDEX HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.</p>
+    <p>
+    <%= t('.limitation_of_liability_p4') %>
+    </p>
 
-<p>THE PROVISIONS OF THIS SECTION 10 SHALL APPLY TO THE FULLEST EXTENT PERMITTED BY LAW IN THE APPLICABLE JURISDICTION.</p>
+    <p>
+    <%= t('.limitation_of_liability_p5') %>
+    </p>
 
-<p>The Service is controlled and operated from its facilities in the United States. Bike Index makes no representations that the Service is appropriate or available for use in other locations. Those who access or use the Service from other jurisdictions do so at their own volition and are entirely responsible for compliance with all applicable United States, foreign and local laws and regulations, including but not limited to export and import regulations. Unless otherwise explicitly stated, all materials found on the Service are solely directed to individuals, companies, or other entities located in the United States.</p>
-</li>
-<li>
-<h3>
-<a name="binding-arbitration" class="anchor" href="#binding-arbitration"><span class="mini-icon mini-icon-link"></span></a>Binding Arbitration</h3>
+    <p>
+    <%= t('.limitation_of_liability_p6') %>
+    </p>
+  </li>
+  <li>
+    <h3>
+      <a name="binding-arbitration" class="anchor" href="#binding-arbitration">
+        <span class="mini-icon mini-icon-link"></span></a>
+      <%= t('.binding_arbitration') %>
+    </h3>
 
-<p>Any controversy or claim arising out of or relating to these Terms of Service, or any breach thereof, shall be settled by arbitration administered by the American Arbitration Association in accordance with its Commercial Arbitration Rules and judgment on the award rendered by the arbitrator(s) may be entered in any court having jurisdiction thereof.</p>
-</li>
-<li>
-<h3>
-<a name="governing-law" class="anchor" href="#governing-law"><span class="mini-icon mini-icon-link"></span></a>Governing Law</h3>
+    <p>
+    <%= t('.binding_arbitration_p1') %>
+    </p>
+  </li>
+  <li>
+    <h3>
+      <a name="governing-law" class="anchor" href="#governing-law">
+        <span class="mini-icon mini-icon-link"></span></a>
+      <%= t('.governing_law') %>
+    </h3>
 
-<p>The terms of these Terms of Service for Vendors shall be interpreted and enforced according to the laws of the State of Illinois. All parties consent to the personal jurisdiction and venue of any court located in Cook County, Illinois, and each waives any objections based on improper jurisdiction, on venue, on the inconvenience of the judicial forum, or on any other grounds.</p>
-</li>
+    <p>
+    <%= t('.governing_law_p1') %>
+    </p>
+  </li>
 </ol>

--- a/app/views/info/about.html.haml
+++ b/app/views/info/about.html.haml
@@ -1,24 +1,21 @@
-%h1
-  About Bike Index
+- bikes_count = number_with_precision(Bike.count.round(-3), precision: 0, delimiter: ',')
+- partners_count = number_with_precision(Organization.count.round(-1), precision: 0, delimiter: ',')
+- nonprofit_blog_link = link_to(t(".nonprofit_status"), news_path("bike-index--now-a-nonprofit"))
+
+%h1= t(".about_bike_index")
 
 - cache('about_counts', expires_in: 24.hours) do
-  %p
-    Cofounded by Seth Herr and Bryan Hance in 2013, Bike Index is a #{link_to '501(c)(3) nonprofit', 'https://bikeindex.org/news/bike-index--now-a-nonprofit'}.
-  %p
-    It is the most widely used and successful bicycle registration service in the world with over #{number_with_precision(Bike.count.round(-3), precision: 0, delimiter: ',')} cataloged bikes, #{number_with_precision(Organization.count.round(-1), precision: 0, delimiter: ',')} community partners and tens of thousands of daily searches.
+  %p= t(".cofounded_by_html", description_link: nonprofit_blog_link)
+  %p= t(".widely_used", bikes_count: bikes_count, partners_count: partners_count)
+
+%p= t(".seth_built")
+
+%p= t(".merging_the_services")
+
+%p= t(".simple_efficient_effective")
 
 %p
-  Seth built Bike Index when he was a bike mechanic because he wanted to be able to register bikes for his customers. Bryan developed and ran a community driven bicycle recovery service (StolenBikeRegistry.com) that recovered bikes from the first week it was created in 2004.
-
-%p
-  Merging the two services Seth and Bryan created the universal bike registration service they both dreamed of&mdash;a database used and searched by individuals, bike shops, police departments and other apps. A bike registry that gives everyone the ability to register and recover bicycles.
-
-%p
-  Simple. Efficient. Effective.
-
-%p
-  %strong
-    Bike registration that works.
+  %strong= t(".bike_registration_that_works")
 
 .about-social
   %ul
@@ -35,78 +32,57 @@
         %i.fab.fa-instagram.fa-5x
         %span.social-link-text Instagram
 
-%h2
-  The team
+%h2= t(".the_team")
 
 %ul.about-people
   %li
     %p
-      = image_tag "who/seth-herr2.jpg", alt: 'Seth Herr', title: "Those are not official Bike Index arm warmers, we don't have Bike Index arm warmers"
-      %strong
-        Seth Herr
-      learned to program so that he could build Bike Index, because he was a bike mechanic and was frustrated that something like it didn't exist.
+      = image_tag "who/seth-herr2.jpg", alt: 'Seth Herr', title: t(".seth_herr_image_title")
+      = t(".seth_herr_bio_html")
   %li
     %p
       = image_tag "who/bryan-hance.jpg", alt: 'Bryan Hance'
-      %strong
-        Bryan Hance
-      created StolenBicycleRegistry.com in 2004 because 5 of his bikes were stolen in 9 years&mdash;and realized recovering bikes was really fun. He lives in Portland and recovers lots of bikes.
+      = t(".bryan_hance_bio_html")
   %li
     %p
       = image_tag 'who/craig-dalton1.jpg', alt: 'Craig Dalton'
-      %strong
-        Craig Dalton
-      thought he had the bike industry out of his system until Bike Index came knocking. Craig is bringing his entrepreneurial experience to the business side of Bike Index.
+      = t(".craig_dalton_bio_html")
   %li
     %p
       = image_tag 'who/lily-williams.jpg', alt: 'Lily Williams'
-      %strong
-        Lily Williams
-      has a master's degree from Medill School of Journalism but realized along the way that bikes are the most deserving recipients of words. She writes and communicates for Bike Index.
+      = t(".lily_williams_bio_html")
   %li
     %p
       = image_tag "who/jan-pecnik.jpg", alt: "Jan Pecnik"
-      %strong
-        Jan Pecnik
-      fell in love with bikes while studying his masters in the Netherlands, focusing on social entrepreneurship. After a couple of years of solo riding, he now helps Bike Index expand across Europe and beyond.
+      = t(".jan_pecnik_bio_html")
   %li
     %p
       = image_tag 'who/mike-oleon.jpg', alt: 'Mike Oleon'
-      %strong
-        Mike Oleon
-      does the graphic design and illustration for the Index. If anything looks good, it's probably his fault.
+      = t(".mike_oleon_bio_html")
 
 
-%h2.the-alumni
-  Alumni
+%h2.the-alumni.d-none
+  = t(".alumni")
 
-%ul.about-list.about-alumni-list
+%ul.about-list.about-alumni-list.d-none
   %li
     = image_tag "who/will-barrett.jpg", alt: 'Will Barrett'
-    %h4
-      Will Barrett
+    %h4 Will Barrett
   %li
     = image_tag "who/erin-vogel.jpg", alt: 'Erin Vogel'
-    %h4
-      Erin Vogel
+    %h4 Erin Vogel
   %li
     = image_tag "who/andrew-herr.jpg", alt: 'Andrew Herr'
-    %h4
-      Andrew Herr
+    %h4 Andrew Herr
   %li
     = image_tag "who/laura-nash.jpg", alt: 'Laura Nash'
-    %h4
-      Laura Nash
-%ul.about-list.final-list.about-alumni-list
+    %h4 Laura Nash
   %li
     = image_tag 'who/michael-catano.jpg', alt: 'Michael Catano'
-    %h4
-      Michael Catano
+    %h4 Michael Catano
   %li
     = image_tag "who/stephanie-scheurich1.jpg", alt: 'Stephanie Scheurich'
-    %h4
-      Stephanie Scheurich
+    %h4 Stephanie Scheurich
   %li
     = image_tag "who/bike-mike.jpg", alt: 'Mike Pickerd'
-    %h4
-      Mike Pickerd
+    %h4 Mike Pickerd

--- a/app/views/info/about.html.haml
+++ b/app/views/info/about.html.haml
@@ -23,39 +23,17 @@
 .about-social
   %ul
     %li
-      %a.footer-facebook{ href: 'https://facebook.com/bikeindex', alt: 'Bike Index Facebook' }
-        :plain
-          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 40.09 40.09">
-            <g>
-              <path class="svgpath" d="M2987.81,2564.42a20,20,0,1,1,20-20A20.07,20.07,0,0,1,2987.81,2564.42Zm0-38.57a18.52,18.52,0,1,0,18.52,18.52A18.54,18.54,0,0,0,2987.81,2525.85Z" transform="translate(-2967.76 -2524.33)"/>
-              <path class="svgpath" d="M2997,2552.31a1,1,0,0,1-1,1h-4.75v-7.22h2.42l0.36-2.81h-2.79v-1.8a1.17,1.17,0,0,1,1.39-1.37h1.49v-2.52a19.91,19.91,0,0,0-2.17-.11,3.39,3.39,0,0,0-3.62,3.72v2.08h-2.43v2.81h2.43v7.22h-8.93a1,1,0,0,1-1-1v-16.59a1,1,0,0,1,1-1H2996a1,1,0,0,1,1,1v16.59Z" transform="translate(-2967.76 -2524.33)"/>
-            </g>
-          </svg>
-        %span.social-link-text
-          Facebook
-
+      = link_to "https://facebook.com/BikeIndex", alt: "Bike Index Facebook" do
+        %i.fab.fa-facebook-square.fa-5x
+        %span.social-link-text Facebook
     %li
-      %a{ href: 'https://twitter.com/BikeIndex', alt: 'Bike Index Twitter' }
-        :plain
-          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 40.09 40.09">
-            <g>
-              <path class="svgpath" d="M2806.61,2590.64a7.69,7.69,0,0,1-2.48,1,3.85,3.85,0,0,0-2.85-1.26,4,4,0,0,0-3.9,4,4.08,4.08,0,0,0,.1.91,11,11,0,0,1-8-4.18,4.07,4.07,0,0,0-.53,2,4,4,0,0,0,1.74,3.33,3.83,3.83,0,0,1-1.77-.5v0a4,4,0,0,0,3.13,3.92,3.72,3.72,0,0,1-1,.14,3.79,3.79,0,0,1-.73-0.07,3.92,3.92,0,0,0,3.65,2.78,7.71,7.71,0,0,1-4.85,1.71,7.81,7.81,0,0,1-.93-0.05,10.87,10.87,0,0,0,6,1.8c7.18,0,11.1-6.1,11.1-11.39,0-.17,0-0.35,0-0.52a8,8,0,0,0,1.95-2.07,7.62,7.62,0,0,1-2.24.63A4,4,0,0,0,2806.61,2590.64Z" transform="translate(-2777.81 -2578.33)"/>
-              <path class="svgpath" d="M2797.85,2618.42a20,20,0,1,1,20-20A20.07,20.07,0,0,1,2797.85,2618.42Zm0-38.57a18.52,18.52,0,1,0,18.52,18.52A18.54,18.54,0,0,0,2797.85,2579.85Z" transform="translate(-2777.81 -2578.33)"/>
-            </g>
-          </svg>
-        %span.social-link-text
-          Twitter
+      = link_to "https://twitter.com/BikeIndex", alt: "Bike Index Twitter" do
+        %i.fab.fa-twitter.fa-5x
+        %span.social-link-text Twitter
     %li
-      %a{ href:  'https://instagram.com/bikeindex', alt: 'Bike Index Instagram' }
-        :plain
-          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 40.09 40.09">
-            <g>
-              <path class="svgpath" d="M2868.16,2589H2854a2.21,2.21,0,0,0-2.21,2.21v14.2a2.21,2.21,0,0,0,2.21,2.21h14.19a2.21,2.21,0,0,0,2.21-2.21v-14.2A2.21,2.21,0,0,0,2868.16,2589Zm-3,2.91a0.58,0.58,0,0,1,.58-0.58h1.75a0.58,0.58,0,0,1,.58.58v1.75a0.58,0.58,0,0,1-.58.58h-1.75a0.58,0.58,0,0,1-.58-0.58v-1.75Zm-4.05,2.85a3.57,3.57,0,1,1-3.58,3.57A3.58,3.58,0,0,1,2861.09,2594.78Zm7.54,10.53a0.58,0.58,0,0,1-.58.58h-14a0.58,0.58,0,0,1-.58-0.58v-8.73h2.33a3.55,3.55,0,0,0-.41,1.77,5.66,5.66,0,0,0,11.33,0,3,3,0,0,0-.45-1.77h2.33v8.73Z" transform="translate(-2840.54 -2578.33)"/>
-              <path class="svgpath" d="M2860.58,2618.42a20,20,0,1,1,20-20A20.07,20.07,0,0,1,2860.58,2618.42Zm0-38.57a18.52,18.52,0,1,0,18.52,18.52A18.54,18.54,0,0,0,2860.58,2579.85Z" transform="translate(-2840.54 -2578.33)"/>
-            </g>
-          </svg>
-        %span.social-link-text
-          Instagram
+      = link_to "https://instagram.com/bikeindex", alt: "Bike Index Instagram" do
+        %i.fab.fa-instagram.fa-5x
+        %span.social-link-text Instagram
 
 %h2
   The team

--- a/app/views/info/privacy.html.erb
+++ b/app/views/info/privacy.html.erb
@@ -1,79 +1,113 @@
 <% file_path = @view_renderer.lookup_context.find_template(@virtual_path).identifier.gsub(/\A.*\/app\//i, 'app/') %>
+<%- change_history_url = "https://github.com/bikeindex/bike_index/tree/master/#{file_path}" %>
+<%- terms_link = link_to(t(".terms_of_service"), terms_path) %>
+
 <div id="legal-terms" class="inner-recep legal-content">
   <header>
-  <h1>
-    <a name="privacy-policy" class="anchor" href="#privacy-policy"><span class="mini-icon mini-icon-link"></span></a>
-    Privacy Policy
-  </h1>
-  <p>Last updated July 29th, 2017. Previous versions and the change history is <a href="https://github.com/bikeindex/bike_index/tree/master/<%= file_path %>">available here</a>.</p>
+    <h1>
+      <a name="privacy-policy" class="anchor" href="#privacy-policy">
+        <span class="mini-icon mini-icon-link"></span></a>
+      Privacy Policy
+    </h1>
 
-  <hr>
+    <p>
+    <%= t('.last_updated_html', link: link_to(t('.available_here'), change_history_url)) %>
+    </p>
+
+    <hr>
   </header>
 
   <h2>
     <a name="privacy-general-information" class="anchor" href="#privacy-general-information"><span class="mini-icon mini-icon-link"></span></a>
-    General Information
+    <%= t('.general_information') %>
   </h2>
-  
-  <p>Please see the <%= link_to 'Terms of Service', terms_path %> for definitions of terms.</p>
-  
-  <p>We collect the e-mail addresses and other shared personal information of those who communicate with us, aggregate information on the pages Users access or visit and the functions Users perform on pages, and information volunteered by Users (such as survey information and/or site registrations). The information we collect is used to improve the content of our Web pages and the quality of our Service, and is not shared with or sold to other organizations for commercial purposes, except to provide products or services you've requested, when we have your permission, or under the following circumstances:</p>
 
-  <p>It is necessary to share information in order to investigate, prevent, or take action regarding illegal activities, suspected fraud, situations involving potential threats to the physical safety of any person, violations of Terms of Service of the specific application, or as otherwise required by law.</p>
+  <p>
+  <%= t('.see_terms_link_html', terms_link: terms_link) %>
+  </p>
 
-  <p>We transfer information about you if Bike Index is acquired by or merged with another company. In this unlikely event, Bike Index will notify you via e-mail before information about you is transferred and becomes subject to a different privacy policy.</p>
+  <p>
+  <%= t('.general_information_p1') %>
+  </p>
+
+  <p>
+  <%= t('.general_information_p2') %>
+  </p>
+
+  <p>
+  <%= t('.general_information_p3') %>
+  </p>
 
   <h2>
     <a name="privacy-information-gathering-and-usage" class="anchor" href="#information-gathering-and-usage"><span class="mini-icon mini-icon-link"></span></a>
-    Information Gathering and Usage
+    <%= t('.information_gathering') %>
   </h2>
 
-  <p>When you register for Bike Index we may ask for information such as your name, email address, billing address, or phone number. The only required field is e-mail. Whatever you choose to share, You can either show or hide from the public on your Bike Index Account.</p>
+  <p>
+  <%= t('.information_gathering_p1') %>
+  </p>
 
-  <p>Bike Index uses collected information for the following general purposes: provision of products and services, identification and authentication, services improvement, contact, and research.</p>
+  <p>
+  <%= t('.information_gathering_p2') %>
+  </p>
 
   <h2>
     <a name="cookies" class="anchor" href="#cookies"><span class="mini-icon mini-icon-link"></span></a>
-    Cookies
+    <%= t('.cookies') %>
   </h2>
 
-  <p>A cookie is a small amount of data, which often includes an anonymous unique identifier, that is sent to your browser from a web site's computers and is stored on your computer's hard drive. The stored information helps you connect more quickly to sites you’ve previously visited.</p>
+  <p>
+  <%= t('.cookies_p1') %>
+  </p>
 
-  <p>Cookies are required to use Bike Index Service.</p>
+  <p>
+  <%= t('.cookies_p2') %>
+  </p>
 
-  <p>We use cookies to record current session information, but do not use permanent cookies. For example, you are required to re-login to your Bike Index account after a certain period of time has elapsed to protect you against others accidentally or intentionally accessing your Account contents.</p>
+  <p>
+  <%= t('.cookies_p3') %>
+  </p>
 
 
   <h2>
     <a name="data-storage" class="anchor" href="#data-storage"><span class="mini-icon mini-icon-link"></span></a>
-    Data Storage
-  </h2>
-
-  <p>Bike Index uses third party vendors and hosting partners to provide the necessary hardware, software, networking, storage, and related technology required to run Bike Index. Although Bike Index does own the code, databases, and all rights to Bike Index application, you retain all rights to your data.</p>
-
-  <h2>
-    <a name="disclosure" class="anchor" href="#disclosure"><span class="mini-icon mini-icon-link"></span></a>
-    Disclosure
+    <%= t('.data_storage') %>
   </h2>
 
   <p>
-    Bike Index may disclose personally identifiable information under special circumstances, such as to comply with subpoenas or when your actions violate the <a href="https://bikeindex.org/terms">Terms of Service</a>.
+  <%= t('.data_storage_p1') %>
+  </p>
+
+  <h2>
+    <a name="disclosure" class="anchor" href="#disclosure"><span class="mini-icon mini-icon-link"></span></a>
+    <%= t('.disclosure') %>
+  </h2>
+
+  <p>
+  <%= t('.disclosure_p1_html') %>
   </p>
 
   <h2>
     <a name="changes" class="anchor" href="#changes"><span class="mini-icon mini-icon-link"></span></a>
-    Changes
+    <%= t('.changes') %>
   </h2>
 
-  <p>Bike Index may periodically update this policy. We will notify you about significant changes by sending a notice to the primary email address specified in your Bike Index Service Account or by placing a prominent notice on our site. Such notices shall be considered to be received by you within 24 hours of the time it is posted to our website or emailed to you unless we receive notice that the email was not delivered.</p>
+  <p>
+  <%= t('.changes_p1') %>
+  </p>
 
-  <p>You retain the right to access, amend, correct or delete your personal information where it is inaccurate at any time. To do so, please contact <a href="mailto:contact@bikeindex.org">contact@bikeindex.org</a>.</p> 
+  <p>
+  <%= t('.changes_p2_html') %>
+  </p>
 
 
   <h2>
     <a name="questions" class="anchor" href="#questions"><span class="mini-icon mini-icon-link"></span></a>
-    Questions
+    <%= t('.questions') %>
   </h2>
 
-  <p>Any questions about this Privacy Policy should be addressed to <a href="mailto:contact@bikeindex.org">contact@bikeindex.org</a></p>
+  <p>
+  <%= t('.questions_p1_html') %>
+  </p>
+
 </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1702,3 +1702,415 @@ en:
         assistance, at your expense.'
       your_use_of_the_service: 'Your use of the Service is at your sole risk. The
         service is provided on an "as is" and "as available" basis.'
+    vendor_terms_text:
+      about_terms_of_service_for_vendors: About our terms of service for vendors
+      available_here: available here
+      because_bike_index_html: |
+        Because Bike Index relies on partnering with bike organizations, we may need to
+        verify your status as a bike organization. You provide us with basic information
+        about your organization and we will seek to verify your information (we may work
+        with third parties to do so) and approve your Vendor Account unless deemed risky
+        (by us or our friends). You give us permission to do all this, and to
+        periodically update the information or we otherwise must decline to offer you
+        the Service. <a href="#section_c">Complete details</a>
+      becoming_a_vendor: Becoming a Vendor on Bike Index
+      bike_index_vendor_service: Bike Index Vendor Service
+      bike_index_vendor_tos: Bike Index Vendor Terms of Service
+      binding_arbitration: Binding Arbitration
+      binding_arbitration_p1: Any controversy or claim arising out of or relating
+        to these Terms of Service, or any breach thereof, shall be settled by arbitration
+        administered by the American Arbitration Association in accordance with its
+        Commercial Arbitration Rules and judgment on the award rendered by the arbitrator(s)
+        may be entered in any court having jurisdiction thereof.
+      by_giving_bike_shop_employees_html: |
+        By giving bike shop employees and bike advocacy organizations - Vendors - the
+        ability to add bikes to the Service for free, we aim to encourage registration
+        and to fight procrastination of bike registrations. We have additionally
+        developed a Lightspeed integration that allows shops that use Lightspeed as your
+        point of sale to register bikes immediately upon sale. We discuss this in detail
+        later in this document. If you have any questions or concerns, or simply want to
+        better understand how we do things at Bike Index, please do not hesitate to
+        %{contact_link}.
+      customer_service: Customer Service
+      customer_service_body: We will provide you with customer service to resolve
+        any issues relating to your Bike Index Account, the registration of bikes
+        through our service, and use of our software.
+      disclosures_and_notices: Disclosures and Notices
+      disclosures_and_notices_p1: You agree that Bike Index can provide disclosures
+        and notices regarding the Service to you by posting such disclosures and notices
+        on our website, emailing them to the email address listed in your Bike Index
+        account, or mailing them to the address listed in your Bike Index Vendor Account.
+        You also agree that electronic disclosures and notices have the same meaning
+        and effect as if we had provided you with a paper copy. Such disclosures and
+        notices shall be considered to be received by you within 24 hours of the time
+        it is posted to our website or emailed to you unless we receive notice that
+        the email was not delivered.
+      effects_of_deactivation: Effects of Deactivation
+      effects_of_deactivation_p1: Upon deactivation of your Bike Index Vendor Account,
+        we will immediately discontinue your ability to add bikes through the Service.
+        You will still be able to access the rest of the service.
+      effects_of_termination: Effects of Termination
+      effects_of_termination_p1: Upon termination and closing of your Bike Index Account,
+        we will immediately discontinue your access to the Vendor Service. You agree
+        to stop accepting new registrations through the Service. You will not be refunded
+        the remainder of any fees that you have paid for the Service if your access
+        to or use of the Service is terminated or suspended. Any funds in our custody
+        will be retained by Bike Index.
+      effects_of_termination_p2: 'Upon termination you agree: (i) to immediately cease
+        your use of the Service (ii) to discontinue use of any Bike Index trademarks
+        and to immediately remove any Bike Index references and logos from your business
+        (iii) to continue to be bound by this Agreement (iv) that the license granted
+        under this Agreement shall end, (v) that we reserve the right (but have no
+        obligation) to delete all of your information and account data stored on our
+        servers, and (e) we will not be liable to you for compensation, reimbursement,
+        or damages in connection with your use of the Service, or any termination
+        or suspension of the Service or deletion of your information or account data.'
+      governing_law: Governing Law
+      governing_law_p1: The terms of these Terms of Service for Vendors shall be interpreted
+        and enforced according to the laws of the State of Illinois. All parties consent
+        to the personal jurisdiction and venue of any court located in Cook County,
+        Illinois, and each waives any objections based on improper jurisdiction, on
+        venue, on the inconvenience of the judicial forum, or on any other grounds.
+      illegal_use: Suspicion of Unauthorized or Illegal Use
+      illegal_use_p1: We reserve the right to not authorize or settle any transaction
+        you submit which we believe is in violation of this Agreement, any other Bike
+        Index agreement, or exposes you, other Bike Index users, our processors or
+        Bike Index to harm, including but not limited to fraud and other criminal
+        acts. You are hereby granting us authorization to share information with law
+        enforcement about you, your transactions, or your Bike Index Service Account
+        if we reasonably suspect that your use of Bike Index has been for an unauthorized,
+        illegal, or criminal purpose.
+      last_updated_html: Last updated July 29th, 2017. Previous versions and the change
+        history is %{link}.
+      license_trademarks: Your License; Our Trademarks
+      license_trademarks_p1: Bike Index grants you a personal, limited, non-exclusive,
+        revocable, non-transferable license, without the right to sublicense, to electronically
+        access and use the Service solely to register, to manage the bicycles records
+        you so create, and to contact stolen bike owners if you encounter their bike.
+        The Service includes our website, any software, programs, documentation, tools,
+        internet-based services, components, and any updates (including software maintenance,
+        service information, help content, bug fixes or maintenance releases) thereto
+        provided to you by Bike Index. You will be entitled to download updates to
+        the Service, subject to any additional terms made known to you at that time,
+        when Bike Index makes these updates available.
+      license_trademarks_p2: We may also periodically make available certain Bike
+        Index logos, trademarks or other identifiers for your use. You are not required
+        to use them and may use them in the way you desire.
+      lightspeed_integration: Lightspeed Integration
+      lightspeed_integration_p1: To register a customer’s bicycle directly from your
+        shop, you must collect the customer’s bike serial number and the customer’s
+        e-mail address. If your shop uses Lightspeed Retail and you use the Bike Index
+        Lightspeed integration, Lightspeed will collect and send to us all information
+        in Lightspeed at the time of the sale. This information could include, but
+        is not limited to, customer phone number, customer address, bike color and
+        bike size. We only collect the information necessary to effectively register
+        the bicycle for your Customer.
+      lightspeed_integration_p2: We are committed to keeping customer information
+        private. We do not store any of the information transmitted from Lightspeed
+        other than the information needed to create the Bike Index registration. All
+        communication between Lightspeed and our Service is encrypted and covered
+        under our Terms and the applicable terms and agreements set by Lightspeed.
+      limitation_of_liability: Limitation of Liability and Damages
+      limitation_of_liability_p1: IN NO EVENT SHALL A DISCLAIMING ENTITY (AS DEFINED
+        IN SECTION 7 ABOVE) BE LIABLE FOR ANY LOST PROFITS, LOSS OF DATA, OR ANY INDIRECT,
+        PUNITIVE, INCIDENTAL, SPECIAL, CONSEQUENTIAL OR EXEMPLARY DAMAGES ARISING
+        OUT OF, IN CONNECTION WITH OR RELATING TO THIS AGREEMENT OR THE SERVICES,
+        INCLUDING WITHOUT LIMITATION THE USE OF, INABILITY TO USE, OR UNAVAILABILITY
+        OF THE SERVICE. UNDER NO CIRCUMSTANCES WILL ANY OF THE DISCLAIMING ENTITIES
+        (AS DEFINED IN SECTION 12 ABOVE) BE RESPONSIBLE FOR ANY DAMAGE, LOSS OR INJURY
+        RESULTING FROM HACKING, TAMPERING OR OTHER UNAUTHORIZED ACCESS OR USE OF THE
+        SERVICE OR YOUR BIKE INDEX ACCOUNT OR THE INFORMATION CONTAINED THEREIN.
+      limitation_of_liability_p2: THE DISCLAIMING ENTITIES ASSUME NO LIABILITY OR
+        RESPONSIBILITY FOR (A) ANY PERSONAL INJURY OR PROPERTY DAMAGE, OF ANY NATURE
+        WHATSOEVER, RESULTING FROM YOUR ACCESS TO OR USE OF THE SERVICE; (B) ANY UNAUTHORIZED
+        ACCESS TO OR USE OF SERVERS USED IN CONNECTION WITH THE SERVICES AND/OR ANY
+        AND ALL PERSONAL INFORMATION STORED THEREIN; (C) ANY INTERRUPTION OR CESSATION
+        OF TRANSMISSION TO OR FROM THE SERVICE; (D) ANY SOFTWARE BUGS, VIRUSES, TROJAN
+        HORSES, OR OTHER HARMFUL CODE THAT MAY BE TRANSMITTED TO OR THROUGH THE SERVICE;
+        (E) ANY ERRORS, INACCURACIES OR OMISSIONS IN ANY CONTENT OR INFORMATION, FOR
+        ANY LOSS OR DAMAGE INCURRED AS A RESULT OF THE USE OF ANY CONTENT OR INFORMATION,
+        IN EACH CASE POSTED, EMAILED, STORED, TRANSMITTED, OR OTHERWISE MADE AVAILABLE
+        THROUGH THE SERVICE; AND/OR (F) USER CONTENT OR THE DEFAMATORY, OFFENSIVE,
+        OR ILLEGAL CONDUCT OF ANY THIRD PARTY.
+      limitation_of_liability_p3: WITHOUT LIMITING THE FOREGOING PROVISIONS OF THIS
+        SECTION 10, THE DISCLAIMING ENTITIES’ CUMULATIVE LIABILITY TO YOU SHALL BE
+        LIMITED TO DIRECT DAMAGES AND IN ALL EVENTS SHALL NOT EXCEED IN THE AGGREGATE
+        THE AMOUNT OF FEES PAID BY YOU TO BIKE INDEX DURING THE TWELVE (12) MONTH
+        PERIOD IMMEDIATELY PRECEDING THE EVENT GIVING RISE TO THE CLAIM FOR LIABILITY.
+      limitation_of_liability_p4: THIS LIMITATION OF LIABILITY SECTION APPLIES REGARDLESS
+        OF THE LEGAL THEORY ON WHICH THE CLAIM IS BASED, INCLUDING WITHOUT LIMITATION
+        CONTRACT, TORT (INCLUDING NEGLIGENCE), STRICT LIABILITY, OR ANY OTHER BASIS.
+        THE LIMITATIONS APPLY EVEN IF BIKE INDEX HAS BEEN ADVISED OF THE POSSIBILITY
+        OF SUCH DAMAGE.
+      limitation_of_liability_p5: THE PROVISIONS OF THIS SECTION 10 SHALL APPLY TO
+        THE FULLEST EXTENT PERMITTED BY LAW IN THE APPLICABLE JURISDICTION.
+      limitation_of_liability_p6: The Service is controlled and operated from its
+        facilities in the United States. Bike Index makes no representations that
+        the Service is appropriate or available for use in other locations. Those
+        who access or use the Service from other jurisdictions do so at their own
+        volition and are entirely responsible for compliance with all applicable United
+        States, foreign and local laws and regulations, including but not limited
+        to export and import regulations. Unless otherwise explicitly stated, all
+        materials found on the Service are solely directed to individuals, companies,
+        or other entities located in the United States.
+      no_warranties: No Warranties
+      no_warranties_p1: THE SERVICE AND ALL ACCOMPANYING DOCUMENTATION ARE PROVIDED
+        ON AN "AS IS" AND "AS AVAILABLE" BASIS, WITHOUT ANY WARRANTIES, EITHER EXPRESS,
+        IMPLIED, OR STATUTORY, INCLUDING WITHOUT LIMITATION ANY IMPLIED WARRANTIES
+        OF TITLE, MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, AND NON-INFRINGEMENT.
+        USE OF THE SERVICE IS AT YOUR OWN RISK.
+      no_warranties_p2: NO ADVICE OR INFORMATION, WHETHER ORAL OR WRITTEN, OBTAINED
+        BY YOU FROM OR THROUGH THE SERVICE OR FROM (I) BIKE INDEX; OR (II) ANY OF
+        THE RESPECTIVE AFFILIATES, AGENTS, DIRECTORS AND EMPLOYEES OF ANY OF THE ENTITIES
+        LISTED IN (I) ABOVE (COLLECTIVELY, THE "DISCLAIMING ENTITIES" AND INDIVIDUALLY
+        A "DISCLAIMING ENTITY"), WILL CREATE ANY WARRANTY. YOU SPECIFICALLY ACKNOWLEDGE
+        THAT BIKE INDEX CAN NOT ENSURE THAT YOUR CUSTOMERS WILL COMPLETE A REGISTRATION
+        OR ARE AUTHORIZED TO DO SO.
+      no_warranties_p3: WITHOUT LIMITING THE FOREGOING, THE DISCLAIMING ENTITIES DO
+        NOT WARRANT THAT THE INFORMATION THEY PROVIDE OR THAT IS PROVIDED THROUGH
+        THE SERVICE IS ACCURATE, RELIABLE OR CORRECT; THAT THE SERVICE WILL MEET YOUR
+        REQUIREMENTS; THAT THE SERVICE WILL BE AVAILABLE AT ANY PARTICULAR TIME OR
+        LOCATION, THAT THE SERVICE WILL FUNCTION IN AN UNINTERRUPTED MANNER OR BE
+        SECURE; THAT ANY DEFECTS OR ERRORS WILL BE CORRECTED; OR THAT THE SERVICE
+        IS FREE OF VIRUSES OR OTHER HARMFUL COMPONENTS. ANY SUBJECT MATTER DOWNLOADED
+        OR OTHERWISE OBTAINED THROUGH THE USE OF THE SERVICE IS DOWNLOADED AT YOUR
+        OWN RISK AND YOU WILL BE SOLELY RESPONSIBLE FOR ANY DAMAGE TO YOUR PROPERTY
+        OR LOSS OF DATA THAT RESULTS FROM SUCH DOWNLOAD. THE DISCLAIMING ENTITIES
+        MAKE NO REPRESENTATIONS OR WARRANTIES ABOUT HOW LONG WILL BE NEEDED TO COMPLETE
+        THE PROCESSING OF A TRANSACTION.
+      no_warranties_p4: THE DISCLAIMING ENTITIES DO NOT WARRANT, ENDORSE, GUARANTEE,
+        OR ASSUME RESPONSIBILITY FOR ANY PRODUCT OR SERVICE ADVERTISED OR OFFERED
+        BY A THIRD PARTY THROUGH THE SERVICE OR ANY HYPERLINKED WEBSITE OR SERVICE,
+        OR FEATURED IN ANY BANNER OR OTHER ADVERTISING, AND BIKE INDEX WILL NOT BE
+        A PARTY TO OR IN ANY WAY MONITOR ANY TRANSACTION BETWEEN YOU AND THIRD-PARTY
+        PROVIDERS OF PRODUCTS OR SERVICES.
+      our_role: Our Role
+      our_role_body: Our Service helps you quickly and easily register bikes for your
+        Customers, and gives Customers the ability to modify most aspects of their
+        registrations. You will be required to register with Bike Index to use Bike
+        Index Vendor Service (see Becoming a Bike Index Vendor). In addition, we do
+        not assume any liability for bicycles, tricycles or other types of crafts
+        (collectively "Bikes") registered through our Service.
+      ownership: Ownership
+      ownership_p1: The Service is licensed and not sold. We reserve all rights not
+        expressly granted to you in this Agreement. The Service is protected by copyright,
+        trade secret and other intellectual property laws. We own the title, copyright
+        and other worldwide Intellectual Property Rights (as defined below) in the
+        Service and all copies of the Service. This Agreement does not grant you any
+        rights to our trademarks or service marks.
+      ownership_p2: For the purposes of this Agreement, "Intellectual Property Rights"
+        means all patent rights, copyright rights, mask work rights, moral rights,
+        rights of publicity, trademark, trade dress and service mark rights, goodwill,
+        trade secret rights and other intellectual property rights as may now exist
+        or hereafter come into existence, and all applications therefore and registrations,
+        renewals and extensions thereof, under the laws of any state, country, territory
+        or other jurisdiction.
+      ownership_p3: You may choose to or we may invite you to submit comments or ideas
+        about the Service, including without limitation about how to improve the Service
+        or our products ("Ideas"). By submitting any Idea, you agree that your disclosure
+        is gratuitous, unsolicited and without restriction and will not place Bike
+        Index under any fiduciary or other obligation, and that we are free to use
+        the Idea without any additional compensation to you, and/or to disclose the
+        Idea on a non-confidential basis or otherwise to anyone. You further acknowledge
+        that, by acceptance of your submission, Bike Index does not waive any rights
+        to use similar or related ideas previously known to Bike Index, or developed
+        by its employees, or obtained from sources other than you.
+      privacy_of_others: Privacy of Others
+      privacy_of_others_p1_html: You represent to Bike Index that you are in compliance
+        with all applicable privacy laws, you have obtained all necessary rights and
+        consents under applicable law to disclose to Bike Index, or allow Bike Index
+        to collect, use, retain and disclose any Customer data that you provide to
+        us or authorize us to collect. You are solely responsible for disclosing to
+        your Customers that accessing our service will require their acceptance of
+        our <a href="https://bikeindex.org/terms">Terms of Service</a> and <a href="https://bikeindex.org/privacy">Privacy
+        Policy</a>
+      privacy_of_others_p2_html: If you receive information about others, including
+        Bike Index Users, through the use of the Service, you must keep such information
+        confidential and only use it in connection with the Service. You may not disclose
+        or distribute any such information to a third party or use any such information
+        for marketing purposes unless you receive the express consent of the user
+        to do so.
+      privacy_of_others_p3_html: We will never sell, trade, or give out information
+        about your Customers. If Bike Index is acquired by another organization, we
+        will notify all users via the primary e-mail address on file that their information
+        is being transferred and may be subject to a different privacy policy.
+      privacy_of_others_p4_html: We will never sell, trade, or give out information
+        about your Customers. If Bike Index is acquired by another organization, we
+        will notify all users via the primary e-mail address on file that their information
+        is being transferred and may be subject to a different privacy policy.
+      privacy_of_others_p5_html: Customer data you have collected prior to this partnership
+        but that you want Bike Index to incorporate into the Service will be protected
+        by all of the terms listed in this Agreement.
+      prohibited_businesses: Prohibited Businesses
+      prohibited_businesses_p1: 'By registering for Bike Index Vendor Service, you
+        are confirming that you will not use the Service to register bikes in connection
+        with the following businesses, business activities or business practices:
+        (1) knowingly selling stolen bikes, (2) stealing bikes.'
+      prohibited_businesses_p2: By accepting this Agreement you confirm that you will
+        satisfy these requirements.
+      references_to_relationship: References to Our Relationship
+      references_to_relationship_p1: You agree, from the time that you accept this
+        Agreement with Bike Index until you terminate your account with us, that we
+        may identify you as a Vendor of Bike Index. Neither you nor we will imply
+        any untrue sponsorship, endorsement or affiliation between you and Bike Index.
+        You give us permission to post information on our website regarding your business
+        including but not limited to it's name, location, and phone number.
+      representation_and_warranties: Representation and Warranties
+      representation_and_warranties_p1: 'You represent and warrant to us that: (a)
+        you are a natural person at least eighteen (18) years of age or, if you are
+        under eighteen (18) years of age have obtained the consent of your parent
+        or legal guardian to your execution of this Agreement and use of Bike Index
+        Vendor Services in the manner prescribed by Bike Index; (b) you are eligible
+        to register and use the Service and have the right, power, and ability to
+        enter into and perform under this Agreement; (c) the name identified by you
+        when you registered is the business name under which you sell goods and services;
+        (d) any registration submitted by you will represent a bona fide sale by you;
+        (e) you will fulfill all of your obligations to each customer for which you
+        submit a registration and will resolve any Customer dispute or complaint directly
+        with the Customer; (f) you and all registrations initiated by you will comply
+        with all federal, state, and local laws, rules, and regulations applicable
+        to your business, including any applicable tax laws and regulations; (g) you
+        will not use the Service, directly or indirectly, for any fraudulent undertaking
+        or in any manner so as to interfere with the use of the Service.'
+      restricted_use: Restricted Use
+      restricted_use_p1: 'You are required to obey all laws, rules, and regulations
+        applicable to your use of the Service (for example, those governing stolen
+        property, consumer protections, unfair competition, anti-discrimination or
+        false advertising). In addition to any other requirements or restrictions
+        set forth in this Agreement, you agree not to, nor to permit any third party
+        to, do any of the following: (i) access or attempt to access Bike Index systems,
+        programs or data that are not made available for public use; (ii) permit any
+        third party to use and benefit from the Service via a rental, lease, timesharing,
+        service bureau or other arrangement; (iii) transfer any rights granted to
+        you under this Agreement; (iv) work around any of the technical limitations
+        of the Service, use any tool to enable features or functionalities that are
+        otherwise disabled in the Service, or decompile, disassemble or otherwise
+        reverse engineer the Service, except to the extent that such restriction is
+        expressly prohibited by law; (v) perform or attempt to perform any actions
+        that would interfere with the proper working of the Service, prevent access
+        to or use of the Service by our other users, or impose an unreasonable or
+        disproportionately large load on our infrastructure; or (vi) otherwise use
+        the Service except as expressly allowed under this section.'
+      section_a: 'Section A: The Bike Index Service'
+      section_c: 'Section C: Registering for Bike Index Vendor Status'
+      section_d: 'Section D: Termination and Other Legal Matters'
+      security: Security
+      security_body_html: Bike Index is responsible for protecting the security of
+        Customer data in our possession from unauthorized access and accidental loss
+        or modification. We will maintain commercially reasonable administrative,
+        technical and physical procedures to protect all the personal information
+        regarding you and your Customers that is stored in our servers. However, we
+        cannot guarantee that unauthorized third parties will never be able to defeat
+        those measures or use such personal information for improper purposes. You
+        acknowledge that you provide this personal information regarding you and your
+        Customers at your own risk. We recommend you review our <a href="https://bikeindex.org/privacy">Privacy
+        Policy</a>, which will help you understand how we collect, use and safeguard
+        the information you provide to us.
+      term: Term
+      term_p1: The Agreement is effective upon the date you agree to it (by electronically
+        indicating acceptance) and continues so long as you use the Service or until
+        terminated by Bike Index.
+      termination: Termination
+      termination_and_other_legal_terms: Termination and Other Legal Terms
+      termination_p1: You may terminate this Agreement by closing your Bike Index
+        account at any time by following the instructions on our website in your organization’s
+        Vendor Account profile. We may terminate this Agreement and close your Bike
+        Index Vendor Account at any time for any reason effective upon providing you
+        notice in accordance with Section A10(references to our relationships) above.
+        We may suspend your Bike Index account and your access to the Service, or
+        terminate this Agreement, if (i) we determine in our sole discretion that
+        you are ineligible for the Service for reasons, including without limitation
+        customer complaints about your use of the service, or for any other reason;
+        or (ii) you do not comply with any of the provisions of this Agreement.
+      terms_of_service_for_vendors: Terms of Service for Vendors
+      tos_agreement: The Terms and Conditions described here constitute a legal "Agreement"
+        between the sole proprietor or business organization listed as the "Vendor"
+        on the Service registration page (sometimes referred to as "you," "your",
+        "merchant"), and Bike Index, NFP. ("Bike Index").
+      vendor_registration: Vendor Registration
+      vendor_registration_p1: The Bike Index Vendor Service is only made available
+        under this Agreement to persons that operate a business selling goods or services,
+        or operate cycling related organizations. To use Bike Index to register bikes,
+        you will first have to register for a "Vendor Account." When you register
+        for a Bike Index Vendor Account, we will collect basic information including
+        your name, company name, location, email address, and phone number. If you
+        have not already done so, you will also be required to provide an email address
+        and password for your Bike Index account.
+      vendor_registration_p2: When you register as a Vendor, you must also provide
+        information about an owner or principal of the business or organization and
+        you must be authorized to act on behalf of the business and have the authority
+        to bind the business to this Agreement. To sign up a business to use the Service,
+        you must agree to this Agreement on behalf of the business. If you have so
+        agreed, the term "you" will mean you, the natural person, as well as the business
+        organization that you represent.
+      verification: Verification
+      verification_p1: We may ask for information to help verify your identity including
+        a driver’s license or other government issued identification, or a business
+        license. We may request your permission to do a physical inspection at your
+        place of business and to examine bicycles that pertain to your compliance
+        with this Agreement. Your failure to comply with any of these requests within
+        five (5) days may result in deactivation or termination of your Bike Index
+        account. You authorize us to retrieve additional information about you from
+        third parties and other identification services.
+      verification_p2: After we have collected and verified all your information,
+        Bike Index will review your Account and determine if you are eligible to use
+        the Service. Bike Index will notify you once your account has been either
+        approved or deemed ineligible for use of the Service.
+      verification_p3: By accepting the terms of this Agreement, you are providing
+        us with authorization to retrieve information about you by using third parties,
+        including bike industry wholesalers, distributors, and other information providers.
+        You acknowledge that such information retrieved may include your name, address
+        history, business history, and other data about you. Bike Index may periodically
+        update this information to determine whether you continue to meet our eligibility
+        requirements.
+      verification_p4: You agree that Bike Index is permitted to contact and share
+        information about you and your application (including whether you are approved
+        or declined), as well as your use of Bike Index with our friends.
+      we_can_deactivate_html: |
+        We can deactivate your ability to register new bikes or terminate this
+        "Agreement" at any time (especially if you do something bad). You can also
+        terminate anytime. Termination is effective immediately. Termination does not
+        alter your previously registered bikes. This section also includes all the extra
+        legal stuff they make us add (e.g. indemnification, warranties, assignment).
+        <a href="#section_d">Complete details</a>
+      we_provide_you_with_html: |
+        We provide you with a service to register the bikes you interact with; we will
+        respect and protect your and your Customers' privacy, data and personal
+        information. You run your business, service your Customers, and observe all
+        laws, rules, and regulations. <a href="#section_a">Complete details</a>
+      welcome_to_bike_index_html: |
+        <strong>Welcome to Bike Index</strong>, a 501(c)(3) nonprofit. We developed a
+        publicly-accessible bike registration service (the "Service") that gives
+        organizations registered on Bike Index ("Vendors", "you") the ability to quickly
+        and easily register bikes for their "Customers" - patrons of their services -
+        using Vendor "Accounts." We believe that such a service that the Service deters
+        bike theft and helps Customers recover stolen bikes.
+      with_the_following_brief_descriptions: With the following brief descriptions
+        of the parts of this "Agreement", we attempt to explain the important parts
+        of our Service. But there are significant details in the whole document that
+        make it worth reading.
+      your_liability: Your Liability
+      your_liability_p1: You are responsible for all claims, fines, fees, penalties
+        and other liability arising out of or relating to your breach of this Agreement,
+        and/or your use of the Service. Bike Index will have the final decision-making
+        authority with respect to claims. You will be required to reimburse Bike Index
+        for your liability. You will not receive a refund of any fees paid to Bike
+        Index.
+      your_liability_p2: Without limiting the foregoing, you agree to defend, indemnify,
+        and hold harmless Bike Index and its respective employees and agents (collectively
+        "Disclaiming Entities") from and against any claim, suit, demand, loss, liability,
+        damage, action or proceeding arising out of or relating to (i) your breach
+        of any provision of this Agreement, and/or (ii) your use of the Service, including
+        without limitation any reversals, claims, fines, fees, penalties and attorneys’
+        fees; (iii) your, or your employee’s or agent’s, negligence or willful misconduct;
+        or (iv) third party indemnity obligations we incur as a direct or indirect
+        result of your acts or omissions.
+      your_privacy: Your Privacy
+      your_privacy_body_html: Your privacy and the protection of your data are very
+        important to us. You acknowledge that you have received, read in full and
+        agree with the terms of our <a href="https://bikeindex.org/privacy">Privacy
+        Policy</a> linked to and incorporated into this Agreement by reference, which
+        contains your consent to our collection, use, retention and disclosure of
+        personal information as well as other matters set forth therein and which
+        explains how and for what purposes we collect, use, retain, disclose and safeguard
+        the information you provide to us.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2114,3 +2114,198 @@ en:
         personal information as well as other matters set forth therein and which
         explains how and for what purposes we collect, use, retain, disclose and safeguard
         the information you provide to us.
+    privacy:
+      available_here: available here
+      changes: Changes
+      changes_p1: Bike Index may periodically update this policy. We will notify you
+        about significant changes by sending a notice to the primary email address
+        specified in your Bike Index Service Account or by placing a prominent notice
+        on our site.  Such notices shall be considered to be received by you within
+        24 hours of the time it is posted to our website or emailed to you unless
+        we receive notice that the email was not delivered.
+      changes_p2_html: You retain the right to access, amend, correct or delete your
+        personal information where it is inaccurate at any time. To do so, please
+        contact <a href="mailto:contact@bikeindex.org">contact@bikeindex.org</a>.
+      cookies: Cookies
+      cookies_p1: A cookie is a small amount of data, which often includes an anonymous
+        unique identifier, that is sent to your browser from a web site's computers
+        and is stored on your computer's hard drive. The stored information helps
+        you connect more quickly to sites you’ve previously visited.
+      cookies_p2: Cookies are required to use Bike Index Service.
+      cookies_p3: We use cookies to record current session information, but do not
+        use permanent cookies. For example, you are required to re-login to your Bike
+        Index account after a certain period of time has elapsed to protect you against
+        others accidentally or intentionally accessing your Account contents.
+      data_storage: Data Storage
+      data_storage_p1: 'Bike Index uses third party vendors and hosting partners to
+        provide the necessary hardware, software, networking, storage, and related
+        technology required to run Bike Index. Although Bike Index does own the code,
+        databases, and all rights to Bike Index application, you retain all rights
+        to your data.  '
+      disclosure: Disclosure
+      disclosure_p1_html: Bike Index may disclose personally identifiable information
+        under special circumstances, such as to comply with subpoenas or when your
+        actions violate the <a href="https://bikeindex.org/terms">Terms of Service</a>.
+      general_information: General Information
+      general_information_p1: 'We collect the e-mail addresses and other shared personal
+        information of those who communicate with us, aggregate information on the
+        pages Users access or visit and the functions Users perform on pages, and
+        information volunteered by Users (such as survey information and/or site registrations).
+        The information we collect is used to improve the content of our Web pages
+        and the quality of our Service, and is not shared with or sold to other organizations
+        for commercial purposes, except to provide products or services you''ve requested,
+        when we have your permission, or under the following circumstances:'
+      general_information_p2: It is necessary to share information in order to investigate,
+        prevent, or take action regarding illegal activities, suspected fraud, situations
+        involving potential threats to the physical safety of any person, violations
+        of Terms of Service of the specific application, or as otherwise required
+        by law.
+      general_information_p3: We transfer information about you if Bike Index is acquired
+        by or merged with another company. In this unlikely event, Bike Index will
+        notify you via e-mail before information about you is transferred and becomes
+        subject to a different privacy policy.
+      information_gathering: Information Gathering and Usage
+      information_gathering_p1: When you register for Bike Index we may ask for information
+        such as your name, email address, billing address, or phone number. The only
+        required field is e-mail. Whatever you choose to share, You can either show
+        or hide from the public on your Bike Index Account.
+      information_gathering_p2: 'Bike Index uses collected information for the following
+        general purposes: provision of products and services, identification and authentication,
+        services improvement, contact, and research.'
+      last_updated_html: Last updated July 29th, 2017. Previous versions and the change
+        history is %{link}.
+      questions: Questions
+      questions_p1_html: Any questions about this Privacy Policy should be addressed
+        to <a href="mailto:contact@bikeindex.org">contact@bikeindex.org</a>
+      see_terms_link_html: Please see the %{terms_link} for definitions of terms.
+      terms_of_service: Terms of Service
+    terms_text:
+      about_our_terms_of_service: About our Terms of Service
+      available_here: available here
+      best_effort: Bike Index does not warrant that (i) the service will meet your
+        specific requirements, (ii) the service will be uninterrupted, timely, secure,
+        or error-free, (iii) the results that may be obtained from the use of the
+        service will be accurate or reliable, (iv) the quality of any products, services,
+        information, or other material purchased or obtained by you through the service
+        will meet your expectations, and (v) any errors in the Service will be corrected.
+      bike_index_reserves: Bike Index reserves the right at any time and from time
+        to time to modify or discontinue, temporarily or permanently, the Service
+        (or any part thereof) with or without notice.
+      bike_index_shall_not_be_liable: Bike Index shall not be liable to you or to
+        any third party for any modification, suspension or discontinuance of the
+        Service.
+      by_creating_account: By creating an "Account" and using the BikeIndex.org web
+        site ("Service"), or any services of Bike Index, NFP ("Bike Index"), you are
+        agreeing to be bound by the following terms and conditions ("Terms of Service").
+        IF YOU ARE ENTERING INTO THIS AGREEMENT ON BEHALF OF A COMPANY OR OTHER LEGAL
+        ENTITY, YOU REPRESENT THAT YOU HAVE THE AUTHORITY TO BIND SUCH ENTITY, ITS
+        AFFILIATES AND ALL USERS WHO ACCESS OUR SERVICES THROUGH YOUR ACCOUNT TO THESE
+        TERMS AND CONDITIONS, IN WHICH CASE THE TERMS "YOU" OR "YOUR" SHALL REFER
+        TO SUCH ENTITY, ITS AFFILIATES AND USERS ASSOCIATED WITH IT. IF YOU DO NOT
+        HAVE SUCH AUTHORITY, OR IF YOU DO NOT AGREE WITH THESE TERMS AND CONDITIONS,
+        YOU MUST NOT ACCEPT THIS AGREEMENT AND MAY NOT USE THE SERVICES.
+      by_giving_bike_shops_html: By giving bike shops, biking organizations and police
+        departments the ability to register bikes directly for their constituents
+        we aim to incentivize bike registration, support local cycling culture and
+        ensure accurate registrations. We have tried to draft this Terms of Service
+        to be as simple and comprehensible as possible. Unfortunately, the realities
+        of the legal world make that a very difficult task. So, should you have any
+        questions or concerns, or simply want to better understand how we do things
+        at Bike Index, please do not hesitate to %{contact_link}.
+      content_on_the_service: Content" on the Service is defined by any information
+        Users input into the service. Users are defined as those who utilize the Bike
+        Index Service and agree to the Terms of Service. While Bike Index prohibits
+        some conduct and Content on the Service, you understand and agree that Bike
+        Index cannot be responsible for the Content posted on the Service and you
+        nonetheless may be exposed to such materials. you agree to use the Service
+        at your own risk. Violation of any of the terms below will result in the termination
+        of your Account.
+      if_bike_index_html: 'If Bike Index makes material changes to these Terms, we
+        will notify you by email or by posting a notice on our site before the changes
+        are effective. Any new features that augment or enhance the current Service,
+        including the release of new tools and resources, shall be subject to the
+        Terms of Service. Continued use of the Service after any such changes shall
+        constitute your consent to such changes. You can review the most current version
+        of the Terms of Service at any time at: %{terms_link}.'
+      last_updated_html: Last updated July 29th, 2017. Previous versions and the change
+        history is %{link}.
+      may_be_terminated: You understand that the technical processing and transmission
+        of the Service, including your Content, may be transfered unencrypted and
+        involve (a) transmissions over various networks; and (b) changes to conform
+        and adapt to technical requirements of connecting networks or devices.
+      no_abuse: Verbal, physical, written or other abuse (including threats of abuse
+        or retribution) of any Bike Index customer, employee, member, or officer will
+        result in immediate account termination.
+      no_spam: You must not upload, post, host, or transmit unsolicited email, SMSs,
+        or "spam" messages.
+      no_waiver: The failure of Bike Index to exercise or enforce any right or provision
+        of the Terms of Service shall not constitute a waiver of such right or provision.
+        The Terms of Service constitutes the entire agreement between you and Bike
+        Index and govern your use of the Service, superseding any prior agreements
+        between you and Bike Index (including, but not limited to, any prior versions
+        of the Terms of Service). You agree that these Terms of Service and your use
+        of the Service are governed under Illinois law.
+      questions_html: Questions about the Terms of Service should be sent to %{contact_email_link}.
+      section_a_header: 'Section A: User''s Acknowledgment and Acceptance of Terms'
+      section_b_header: 'Section B: Account Terms'
+      section_c_header: 'Section C: Modifications to the service'
+      section_d_header: 'Section D: Copyright and content ownership'
+      section_e_header: 'Section E: General Conditions'
+      support_for_bike_index_services: Support for Bike Index services is currently
+        only available in English, via email.
+      terms_of_service: Terms of Service
+      third_party_vendors: You understand that Bike Index uses third party vendors
+        and hosting partners to provide the necessary hardware, software, networking,
+        storage, and related technology required to run the Service.
+      we_claim_no_ip: We claim no intellectual property rights over the material you
+        provide to the Service. Your profile and materials uploaded remain yours.
+        However, Content that you upload about your bikes can be viewed publicly,
+        and setting your profile to be public will allow information you add to it
+        to be viewed publicly. You agree to allow others to view this Content.
+      we_dont_prescreen_content: Bike Index does not pre-screen Content, but Bike
+        Index and its designee have the right (but not the obligation) in their sole
+        discretion to refuse or remove any Content that is available via the Service.
+      we_may_remove_content: We may, but have no obligation to, remove Content and
+        Accounts containing Content that we determine in our sole discretion are unlawful,
+        offensive, threatening, libelous, defamatory, pornographic, obscene or otherwise
+        objectionable or violates any party's intellectual property or these Terms
+        of Service.
+      welcome_to_bike_index_html: <strong>Welcome to Bike Index</strong>, a 501(c)(3)
+        nonprofit. We've developed a publicly-accessible bike registration service
+        (the "Service") that gives you the ability to save and share your bikes on
+        the internet.
+      you_agree_not_to_resell: You agree not to sell, resell or exploit any portion
+        of the Service, use of the Service, or access to the Service without the express
+        written permission by Bike Index.
+      you_are_responsible_for_content: You are responsible for all Content posted
+        and activity that occurs under your account (even when Content is posted by
+        others who have accounts under your account or access to your account).
+      you_are_responsible_for_security: You are responsible for maintaining the security
+        of your account and password. Bike Index cannot and will not be liable for
+        any loss or damage from your failure to comply with this security obligation.
+      you_may_not_use_for_illegal: You may not use the Service for any illegal or
+        unauthorized purpose. You must not, in the use of the Service, violate any
+        laws in your jurisdiction (including but not limited to copyright or trademark
+        laws).
+      you_must_be_human: You must be a human. Accounts registered by "bots" or other
+        automated methods are not permitted.
+      you_must_notify: You must not modify, adapt or hack the Service or modify another
+        website so as to falsely imply that it is associated with the Service, Bike
+        Index, or any other Bike Index service.
+      you_must_provide_email: You must provide a valid email address in order to complete
+        the signup process.
+      you_shall_defend_bike_index: You shall defend Bike Index against any claim,
+        demand, suit or proceeding made or brought against Bike Index by a third party
+        alleging that your Content, or your use of the Service in violation of this
+        Agreement, infringes or misappropriates the intellectual property rights of
+        a third party or violates applicable law, and shall indemnify Bike Index for
+        any damages finally awarded against, and for reasonable attorney’s fees incurred
+        by, Bike Index in connection with any such claim, demand, suit or proceeding;
+        provided, that Bike Index (a) promptly gives you written notice of the claim,
+        demand, suit or proceeding; (b) gives you sole control of the defense and
+        settlement of the claim, demand, suit or proceeding (provided that tou may
+        not settle any claim, demand, suit or proceeding unless the settlement unconditionally
+        releases Bike Index of all liability); and (c) provides to you all reasonable
+        assistance, at your expense.
+      your_use_of_the_service: Your use of the Service is at your sole risk. The service
+        is provided on an "as is" and "as available" basis.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2309,3 +2309,41 @@ en:
         assistance, at your expense.
       your_use_of_the_service: Your use of the Service is at your sole risk. The service
         is provided on an "as is" and "as available" basis.
+    about:
+      about_bike_index: About Bike Index
+      nonprofit_status: 501(c)(3) nonprofit
+      cofounded_by_html: Cofounded by Seth Herr and Bryan Hance in 2013, Bike Index is a %{description_link}.
+      widely_used: It is the most widely used and successful bicycle registration service in the world with over %{bikes_count} cataloged bikes, %{partners_count} community partners and tens of thousands of daily searches.
+      seth_built: Seth built Bike Index when he was a bike mechanic because he wanted to be able to register bikes for his customers. Bryan developed and ran a community driven bicycle recovery service (StolenBikeRegistry.com) that recovered bikes from the first week it was created in 2004.
+      merging_the_services: Merging the two services Seth and Bryan created the universal bike registration service they both dreamed of — a database used and searched by individuals, bike shops, police departments and other apps. A bike registry that gives everyone the ability to register and recover bicycles.
+      simple_efficient_effective: Simple. Efficient. Effective.
+      bike_registration_that_works: Bike registration that works.
+      the_team: The team
+      seth_herr_image_title: Those are not official Bike Index arm warmers, we don't have Bike Index arm warmers
+      seth_herr_bio_html: |
+        <strong>Seth Herr</strong> learned to program so that he could build
+        Bike Index, because he was a bike mechanic and was frustrated that
+        something like it didn't exist.
+      bryan_hance_bio_html: |
+        <strong>Bryan Hance</strong> created StolenBicycleRegistry.com in 2004
+        because 5 of his bikes were stolen in 9 years&mdash;and realized
+        recovering bikes was really fun. He lives in Portland and recovers lots
+        of bikes.
+      craig_dalton_bio_html: |
+        <strong>Craig Dalton</strong> thought he had the bike industry out of
+        his system until Bike Index came knocking. Craig is bringing his
+        entrepreneurial experience to the business side of Bike Index.
+      lily_williams_bio_html: |
+        <strong>Lily Williams</strong> has a master's degree from Medill School
+        of Journalism but realized along the way that bikes are the most
+        deserving recipients of words. She writes and communicates for Bike
+        Index.
+      jan_pecnik_bio_html: |
+        <strong>Jan Pecnik</strong> fell in love with bikes while studying his masters in the
+        Netherlands, focusing on social entrepreneurship. After a couple of
+        years of solo riding, he now helps Bike Index expand across Europe and
+        beyond.
+      mike_oleon_bio_html: |
+        <strong>Mike Oleon</strong> does the graphic design and illustration for the Index. If
+        anything looks good, it's probably his fault.
+      alumni: Alumni


### PR DESCRIPTION
Externalizes strings from the following templates:

-  app/views/info/_terms_text.html.erb
-  app/views/info/_vendor_terms_text.html.erb
-  app/views/info/privacy.html.erb
-  app/views/info/about.html.haml

Related: https://github.com/bikeindex/bike_index/issues/963