### PR TITLE
Filter file params out everywhere

### DIFF
--- a/app/controllers/api/base.rb
+++ b/app/controllers/api/base.rb
@@ -8,15 +8,13 @@ module GrapeLogging
       end
     end
   end
-  # Need to add file parameters to this so it doesn't try (and fail) to make images json
-  FILTERED_PARAMS = Rails.application.config.filter_parameters + [:file]
 end
 
 module API
   class Base < Grape::API
     use GrapeLogging::Middleware::RequestLogger, instrumentation_key: "grape_key",
                                                  include: [GrapeLogging::Loggers::BinxLogger.new,
-                                                           GrapeLogging::Loggers::FilterParameters.new(GrapeLogging::FILTERED_PARAMS)]
+                                                           GrapeLogging::Loggers::FilterParameters.new]
     mount API::V3::RootV3
     mount API::V2::RootV2
 

--- a/config/initializers/filter_parameter_logging.rb
+++ b/config/initializers/filter_parameter_logging.rb
@@ -1,4 +1,4 @@
 # Be sure to restart your server when you modify this file.
 
 # Configure sensitive parameters which will be filtered from the log file.
-Rails.application.config.filter_parameters += [:password]
+Rails.application.config.filter_parameters += [:password, :file]


### PR DESCRIPTION
In #979 we started filtering out image params from the API, because attempting to stringify images for JSON logging was causing the server to 500.

Let's filter them out in a more consistent way.

From my own local tests, this appears to work