### PR TITLE
Externalize dev_and_design templates

### DIFF
--- a/app/views/info/dev_and_design.html.haml
+++ b/app/views/info/dev_and_design.html.haml
@@ -1,37 +1,39 @@
-%h5 Bike Index is meant to be usable and expandable by everyone. We're way into the open source.
+- bikeindex_github_root_url = "https://github.com/bikeindex"
+- bikeindex_github_url = "#{bikeindex_github_root_url}/bike_index"
+- stolen_bikes_widget_url = "#{bikeindex_github_root_url}/stolen_bikes_widget_html"
 
-%h3.mt-4 Design resources
+%h5= t(".meant_to_be_usable")
+
+%h3.mt-4= t(".design_resources")
 
 %ul
   %li
-    = image_assets_link = link_to "Image assets", image_resources_path
-    = "#{image_assets_link} - vector and png Bike Index logos".html_safe
+    - image_assets_link = link_to t(".image_assets"), image_resources_path
+    = t(".bike_index_logos_html", link: image_assets_link)
   %li
-    - flyer_pdf_url =  "https://files.bikeindex.org/stored/Bike-Index-TriFold.pdf"
-    - trifold_flyer_link = link_to "Trifold Flyer", flyer_pdf_url
-    = "#{trifold_flyer_link} - Print color & double-sided (<em>do not</em> rescale, have printer print as close to the edges as it can)".html_safe
+    - trifold_flyer_link = link_to t(".trifold_flyer"), t(".trifold_flyer_pdf_url")
+    = t(".flyers_html", link: trifold_flyer_link)
   %li
-    - bike_shop_card_url = "https://files.bikeindex.org/stored/Bike-Index-Shop-Card.pdf"
-    = bike_shop_card_link = link_to "Bike shop card", bike_shop_card_url
-    = "#{bike_shop_card_link} - design is for notecard size (5.5\" x 4.25\")"
+    - bike_shop_card_link = link_to(t(".bike_shop_card"), t(".bike_shop_card_pdf_url"))
+    = t(".bike_shop_cards_html", link: bike_shop_card_link)
 
-%h3.mt-4 Development resources
+%h3.mt-4= t(".development_resources")
 %ul
   %li
-    - github_link = link_to "on GitHub", "https://github.com/bikeindex/bike_index"
-    = "Bike Index itself is open source - check it out #{github_link}."
+    - github_link = link_to t(".on_github"), bikeindex_github_url
+    = t(".open_source_html", link: github_link)
   %li
-    = link_to "Our API documentation", documentation_index_path
+    = link_to t(".our_api_documentation"), documentation_index_path
   %li
-    - nearby_stolen_widget_link = link_to "Nearby stolen widget", "https://github.com/bikeindex/stolen_bikes_widget_html"
-    = "#{nearby_stolen_widget_link} (on GitHub)".html_safe
+    - nearby_stolen_widget_link = link_to t(".nearby_stolen_widget"), stolen_bikes_widget_url
+    = t(".nearby_stolen_widget_html", link: nearby_stolen_widget_link)
   %li
     - url_for_embed = current_user ? user_embed_path(current_user) : new_user_url(return_to: dev_and_design_path)
     - display_widget_link = link_to "Personal bike display widget", url_for_embed
-    = "#{display_widget_link} (must be logged in - also, has no usage instructions...)".html_safe
+    = t(".display_widget_html", link: display_widget_link)
   %li
     - oauth_apps_link = link_to "OAuth Applications you've made", oauth_applications_path
-    = "#{oauth_apps_link} (must be logged in)".html_safe
+    = t(".oauth_apps_html", link: oauth_apps_link).html_safe
   %li
     - oauth_authorized_apps_link = link_to "OAuth Applications you've authorized", oauth_authorized_applications_path
-    = "#{oauth_authorized_apps_link} (must be logged in)".html_safe
+    = t(".oauth_authorized_apps_html", link: oauth_authorized_apps_link).html_safe

--- a/app/views/info/dev_and_design.html.haml
+++ b/app/views/info/dev_and_design.html.haml
@@ -1,28 +1,37 @@
-%h5
-  Bike Index is meant to be usable and expandable by everyone. We're way into the open source.
+%h5 Bike Index is meant to be usable and expandable by everyone. We're way into the open source.
 
-%h3.mt-4
-  Design resources
+%h3.mt-4 Design resources
+
 %ul
   %li
-    #{link_to "Image assets", image_resources_path} - vector and png Bike Index logos
+    = image_assets_link = link_to "Image assets", image_resources_path
+    = "#{image_assets_link} - vector and png Bike Index logos".html_safe
   %li
-    #{link_to "Trifold Flyer", "https://files.bikeindex.org/stored/Bike-Index-TriFold.pdf"} - Print color & double-sided (<em>do not</em> rescale, have printer print as close to the edges as it can)
+    - flyer_pdf_url =  "https://files.bikeindex.org/stored/Bike-Index-TriFold.pdf"
+    - trifold_flyer_link = link_to "Trifold Flyer", flyer_pdf_url
+    = "#{trifold_flyer_link} - Print color & double-sided (<em>do not</em> rescale, have printer print as close to the edges as it can)".html_safe
   %li
-    #{link_to "Bike shop card", "https://files.bikeindex.org/stored/Bike-Index-Shop-Card.pdf"} - design is for notecard size (5.5" x 4.25")
+    - bike_shop_card_url = "https://files.bikeindex.org/stored/Bike-Index-Shop-Card.pdf"
+    = bike_shop_card_link = link_to "Bike shop card", bike_shop_card_url
+    = "#{bike_shop_card_link} - design is for notecard size (5.5\" x 4.25\")"
 
 %h3.mt-4 Development resources
 %ul
   %li
-    Bike Index itself is open source - check it out #{ link_to "on GitHub", "https://github.com/bikeindex/bike_index" }.
+    - github_link = link_to "on GitHub", "https://github.com/bikeindex/bike_index"
+    = "Bike Index itself is open source - check it out #{github_link}."
   %li
     = link_to "Our API documentation", documentation_index_path
   %li
-    #{ link_to "Nearby stolen widget", "https://github.com/bikeindex/stolen_bikes_widget_html" } (on GitHub)
+    - nearby_stolen_widget_link = link_to "Nearby stolen widget", "https://github.com/bikeindex/stolen_bikes_widget_html"
+    = "#{nearby_stolen_widget_link} (on GitHub)".html_safe
   %li
     - url_for_embed = current_user ? user_embed_path(current_user) : new_user_url(return_to: dev_and_design_path)
-    #{link_to "Personal bike display widget", url_for_embed} (must be logged in - also, has no usage instructions...)
+    - display_widget_link = link_to "Personal bike display widget", url_for_embed
+    = "#{display_widget_link} (must be logged in - also, has no usage instructions...)".html_safe
   %li
-    #{link_to "OAuth Applications you've made", oauth_applications_path} (must be logged in)
+    - oauth_apps_link = link_to "OAuth Applications you've made", oauth_applications_path
+    = "#{oauth_apps_link} (must be logged in)".html_safe
   %li
-    #{link_to "OAuth Applications you've authorized", oauth_authorized_applications_path} (must be logged in)
+    - oauth_authorized_apps_link = link_to "OAuth Applications you've authorized", oauth_authorized_applications_path
+    = "#{oauth_authorized_apps_link} (must be logged in)".html_safe

--- a/app/views/info/image_resources.html.haml
+++ b/app/views/info/image_resources.html.haml
@@ -1,6 +1,4 @@
-%h1
-  Bike Index image assets
-
+%h1 Bike Index image assets
 
 %ul.serial-pictures
   %li

--- a/app/views/info/protect_your_bike.html.haml
+++ b/app/views/info/protect_your_bike.html.haml
@@ -6,7 +6,6 @@
     %a.footnote-ref{ href: "#fn-bike-theft-estimate" }
       1
 
-
   %br
   %strong
     Make sure your bike isn't one of them

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2347,3 +2347,23 @@ en:
         <strong>Mike Oleon</strong> does the graphic design and illustration for the Index. If
         anything looks good, it's probably his fault.
       alumni: Alumni
+    dev_and_design:
+      meant_to_be_usable: Bike Index is meant to be usable and expandable by everyone. We're way into the open source.
+      design_resources: Design resources
+      image_assets: Image assets
+      bike_index_logos_html: "%{link} - vector and png Bike Index logos"
+      trifold_flyer: Trifold Flyer
+      trifold_flyer_pdf_url: 'https://files.bikeindex.org/stored/Bike-Index-TriFold.pdf'
+      flyers_html: "%{link} - Print color & double-sided (<em>do not</em> rescale, have printer print as close to the edges as it can)"
+      bike_shop_card: Bike shop card
+      bike_shop_card_pdf_url: 'https://files.bikeindex.org/stored/Bike-Index-Shop-Card.pdf'
+      bike_shop_cards_html: '%{link} - design is for notecard size (5.5" x 4.25")'
+      development_resources: Development resources
+      on_github: on GitHub
+      open_source_html: Bike Index itself is open source - check it out %{link}.
+      our_api_documentation: Our API documentation
+      nearby_stolen_widget: Nearby stolen widget
+      nearby_stolen_widget_html: "%{link} (on GitHub)"
+      display_widget_html: "%{link} (must be logged in - also, has no usage instructions...)"
+      oauth_apps_html: "%{link} (must be logged in)"
+      oauth_authorized_apps_html: "%{link} (must be logged in)"


### PR DESCRIPTION
Externalizes strings from `info/dev_and_design.html.haml`.

The high-priority templates are all done at this point, so I'm pivoting toward model attributes and translation service setup. 