### PR TITLE
Use url helpers in token emails

### DIFF
--- a/app/mailers/customer_mailer.rb
+++ b/app/mailers/customer_mailer.rb
@@ -18,7 +18,7 @@ class CustomerMailer < ActionMailer::Base
 
   def password_reset_email(user)
     @user = user
-    @url = password_reset_url(token: @user.password_reset_token)
+    @url = password_reset_form_users_url(token: @user.password_reset_token)
     mail(to: @user.email)
   end
 

--- a/app/mailers/customer_mailer.rb
+++ b/app/mailers/customer_mailer.rb
@@ -18,13 +18,13 @@ class CustomerMailer < ActionMailer::Base
 
   def password_reset_email(user)
     @user = user
-    @url = "#{ENV["BASE_URL"]}/users/password_reset?token=#{@user.password_reset_token}"
+    @url = password_reset_url(token: @user.password_reset_token)
     mail(to: @user.email)
   end
 
   def magic_login_link_email(user)
     @user = user
-    @url = "#{ENV["BASE_URL"]}/session/magic_link?token=#{@user.magic_link_token}"
+    @url = magic_link_session_url(token: @user.password_reset_token)
     mail(to: @user.email, subject: "Sign in to Bike Index")
   end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -100,7 +100,7 @@ Bikeindex::Application.routes.draw do
       get "confirm" # Get because needs to be called from a link in an email
       get "request_password_reset"
       post "password_reset"
-      get "password_reset"
+      get "password_reset", as: :password_reset_form
       get "update_password"
       get "globalid"
     end


### PR DESCRIPTION
[@jmromer asked why we weren't using the url paths](https://github.com/bikeindex/bike_index/pull/1010#discussion_r303441100) for are token emails.

I said:

> I forget why I switched to doing this for the token emails, but I did, so I'm hesitant to switch back.

From PR #1010