### PR TITLE
Minor admin blog edits

### DIFF
--- a/app/controllers/admin/news_controller.rb
+++ b/app/controllers/admin/news_controller.rb
@@ -74,6 +74,6 @@ class Admin::NewsController < Admin::BaseController
   end
 
   def find_blog
-    @blog = Blog.find_by_title_slug(params[:id])
+    @blog = Blog.friendly_find(params[:id])
   end
 end

--- a/app/javascript/packs/application_css.scss
+++ b/app/javascript/packs/application_css.scss
@@ -9,6 +9,11 @@
   line-height: 1.5;
 }
 
+// Hide overflowing file names
+.custom-file-label {
+  overflow: hidden;
+}
+
 // General styles
 @import "../stylesheets/utils";
 @import "../stylesheets/table_extensions";

--- a/app/models/blog.rb
+++ b/app/models/blog.rb
@@ -34,7 +34,8 @@ class Blog < ActiveRecord::Base
     return nil unless str.present?
     return find(str) if integer_slug?(str)
     slug = slugify_title(str)
-    find_by_title_slug(slug) || find_by_old_title_slug(slug)
+    find_by_title_slug(slug) || find_by_old_title_slug(slug) ||
+      find_by_title_slug(str) || find_by_title(str)
   end
 
   def to_param

--- a/app/views/admin/news/index.html.haml
+++ b/app/views/admin/news/index.html.haml
@@ -8,7 +8,7 @@
 .full-screen-table
   %table.table.table-striped.table-bordered.table-sm
     %thead.thead-light
-      %th.d-none.d-lg-table-cell
+      %th
         Date&nbsp;<small class="convertTimezone"></small>
       %th.d-none.d-lg-table-cell
         Creator
@@ -21,9 +21,12 @@
     %tbody
       - @blogs.each do |blog|
         %tr
-          %td.d-none.d-lg-table-cell
+          .less-strong-hold
             %span.convertTime
               = l blog.published_at, format: :convert_time
+            - if current_user.developer?
+              %small.less-strong-right
+                = blog.id
           %td.d-none.d-lg-table-cell
             = blog.user&.name || blog.user&.email
           %td

--- a/spec/models/blog_spec.rb
+++ b/spec/models/blog_spec.rb
@@ -25,6 +25,20 @@ RSpec.describe Blog, type: :model do
       blog.save
       expect(blog.title_slug).to eq("a-really-really-really-really-loooooooooooooooooooooooooooooooooooong")
     end
+    context "long title" do
+      let(:title) { "We made it all the way to Oregon and back without one dysentery scare" }
+      let(:target) { "we-made-it-all-the-way-to-oregon-and-back-without-one-dysentery-scare" }
+      let(:legacy_slug) { "we-made-it-all-the-way-to-oregon-and-back-without-" }
+      let(:blog) { FactoryBot.create(:blog, title: title, body: "text about making it to Oregon") }
+      it "doesn't break things" do
+        blog.reload
+        expect(blog.title_slug).to eq target
+        expect(Blog.friendly_find(target)).to eq blog
+        # legacy issue where we chopped stuff down
+        blog.update_attribute :title_slug, legacy_slug
+        expect(Blog.friendly_find(legacy_slug)).to eq blog
+      end
+    end
   end
 
   describe "update_title_save" do


### PR DESCRIPTION
Currently the URL to one of our Blog posts "WE MADE IT ALL THE WAY TO OREGON AND BACK WITHOUT ONE DYSENTERY SCARE", https://bikeindex.org/news/we-made-it-all-the-way-to-oregon-and-back-without- 404s

This fixes that