### PR TITLE
Handle theft_alerts in MergeAdditionalEmailWorker

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -34,6 +34,7 @@ class User < ActiveRecord::Base
 
   has_many :sent_stolen_notifications, class_name: "StolenNotification", foreign_key: :sender_id
   has_many :received_stolen_notifications, class_name: "StolenNotification", foreign_key: :receiver_id
+  has_many :theft_alerts
 
   belongs_to :state
   belongs_to :country

--- a/app/workers/merge_additional_email_worker.rb
+++ b/app/workers/merge_additional_email_worker.rb
@@ -22,6 +22,7 @@ class MergeAdditionalEmailWorker
     old_user.integrations.each { |i| i.update_attribute :user_id, user_email.user_id }
     old_user.sent_stolen_notifications.each { |i| i.update_attribute :sender_id, user_email.user_id }
     old_user.received_stolen_notifications.each { |i| i.update_attribute :receiver_id, user_email.user_id }
+    old_user.theft_alerts.each { |i| i.update_attribute :user_id, user_email.user_id }
     Doorkeeper::Application.where(owner_id: old_user.id).each { |i| i.update_attribute :owner_id, user_email.user_id }
     CustomerContact.where(user_id: old_user.id).each { |i| i.update_attribute :user_id, user_email.user_id }
     CustomerContact.where(creator_id: old_user.id).each { |i| i.update_attribute :creator_id, user_email.user_id }

--- a/spec/workers/merge_additional_email_worker_spec.rb
+++ b/spec/workers/merge_additional_email_worker_spec.rb
@@ -19,6 +19,7 @@ RSpec.describe MergeAdditionalEmailWorker, type: :job do
       let(:old_user) { FactoryBot.create(:user_confirmed, email: email) }
       let(:pre_created_ownership) { FactoryBot.create(:ownership, creator_id: old_user.id) }
       let(:old_user_ownership) { FactoryBot.create(:ownership, owner_email: email) }
+      let(:theft_alert) { FactoryBot.create(:theft_alert, creator: old_user) }
 
       let(:organization) { membership.organization }
       let(:membership) { FactoryBot.create(:membership_claimed, user: old_user) }
@@ -55,6 +56,7 @@ RSpec.describe MergeAdditionalEmailWorker, type: :job do
         expect(payment).to be_present
         expect(customer_contact).to be_present
         expect(stolen_notification).to be_present
+        expect(theft_alert).to be_present
       end
 
       it "merges bikes and memberships and deletes user" do


### PR DESCRIPTION
Resolves the foreign key constraint violation that occurs when attempting to destroy a user record in `MergeAdditionalEmailWorker` without reassigning dependent theft alerts.

Fixes https://app.honeybadger.io/projects/35931/faults/52295768