### PR TITLE
Bike Manufacturer fix

### DIFF
--- a/app/views/bikes/show.html.haml
+++ b/app/views/bikes/show.html.haml
@@ -84,7 +84,7 @@
 
           %li
             %span.attr-title #{t(".manufacturer")}:
-            / We want to display the whole manufacturer name here, not just the simple name. So only use mnfg_name if it's other (which sanitizes)
+            -# We want to display the whole manufacturer name here, not just the simple name. So only use mnfg_name if it's other (which sanitizes)
             - if @bike.manufacturer.name == "Other"
               = @bike.mnfg_name
             - else

--- a/app/views/bikes/show.html.haml
+++ b/app/views/bikes/show.html.haml
@@ -82,7 +82,13 @@
           - unless @bike.type == 'bike'
             = @bike.attr_list_item(@bike.type.titleize, t(".cycle_type"), with_colon: true)
 
-          = @bike.attr_list_item(@bike.mnfg_name, t(".manufacturer"), with_colon: true)
+          %li
+            %span.attr-title #{t(".manufacturer")}:
+            / We want to display the whole manufacturer name here, not just the simple name. So only use mnfg_name if it's other (which sanitizes)
+            - if @bike.manufacturer.name == "Other"
+              = @bike.mnfg_name
+            - else
+              = @bike.manufacturer.name
           = @bike.attr_list_item(@bike.name, t(".name"), with_colon: true)
           = @bike.attr_list_item(@bike.frame_model, t(".model"), with_colon: true)
           = @bike.attr_list_item(@bike.year.to_s, t(".year"), with_colon: true)


### PR DESCRIPTION
When displaying manufacturers, we default to the Simple name - which, for "Pure Cycles (Pure Fix)" is just "Pure Cycles".

We include _Pure Fix_ in parentheses to make the manufacturer easier to find if the manufacturer goes by other names - e.g. Pure Cycles [changed its name from Pure Fix](https://www.purecycles.com/).

While displaying the detailed view of the bike, we should display the full manufacturer name.

<img width="720" alt="Screen Shot 2019-07-17 at 9 19 51 AM" src="https://user-images.githubusercontent.com/1235441/61392638-1b58fc00-a874-11e9-84b4-691574f6242e.png">
