### PR TITLE
Error if token is blank for emails requiring token

### DIFF
--- a/app/mailers/customer_mailer.rb
+++ b/app/mailers/customer_mailer.rb
@@ -24,8 +24,8 @@ class CustomerMailer < ActionMailer::Base
 
   def magic_login_link_email(user)
     @user = user
-    @url = magic_link_session_url(token: @user.password_reset_token)
-    mail(to: @user.email, subject: "Sign in to Bike Index")
+    @url = magic_link_session_url(token: @user.magic_link_token)
+    mail(to: @user.email)
   end
 
   def additional_email_confirmation(user_email)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -343,6 +343,7 @@ class User < ActiveRecord::Base
   def update_auth_token(auth_token_type, time = nil)
     generate_auth_token(auth_token_type, time)
     save
+    reload
   end
 
   def generate_auth_token(auth_token_type, time = nil)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -343,7 +343,6 @@ class User < ActiveRecord::Base
   def update_auth_token(auth_token_type, time = nil)
     generate_auth_token(auth_token_type, time)
     save
-    reload
   end
 
   def generate_auth_token(auth_token_type, time = nil)

--- a/app/workers/email_magic_login_link_worker.rb
+++ b/app/workers/email_magic_login_link_worker.rb
@@ -5,6 +5,7 @@ class EmailMagicLoginLinkWorker
 
   def perform(user_id)
     user = User.find(user_id)
+    raise "Missing magic_link_token token for user: #{user_id}" unless user.magic_link_token.present?
     CustomerMailer.magic_login_link_email(user).deliver_now
   end
 end

--- a/app/workers/email_reset_password_worker.rb
+++ b/app/workers/email_reset_password_worker.rb
@@ -5,6 +5,7 @@ class EmailResetPasswordWorker
 
   def perform(user_id)
     user = User.find(user_id)
+    raise "Missing password_reset_token token for user: #{user_id}" unless user.password_reset_token.present?
     CustomerMailer.password_reset_email(user).deliver_now
   end
 end

--- a/config/locales/customer_mailer.en.yml
+++ b/config/locales/customer_mailer.en.yml
@@ -8,5 +8,7 @@ en:
       subject: Thank you for supporting Bike Index!
     password_reset_email:
       subject: Instructions to reset your password
+    magic_login_link_email:
+      subject: Sign in to Bike Index
     additional_email_confirmation:
       subject: Confirm your additional email

--- a/spec/mailers/customer_mailer_spec.rb
+++ b/spec/mailers/customer_mailer_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe CustomerMailer, type: :mailer do
   describe "magic_login_link_email" do
     it "renders email" do
       user.update_auth_token("magic_link_token")
-      mail = CustomerMailer.password_reset_email(user)
+      mail = CustomerMailer.magic_login_link_email(user)
       expect(mail.subject).to eq("Instructions to reset your password")
       expect(mail.from).to eq(["contact@bikeindex.org"])
       expect(mail.body.encoded).to match(user.magic_link_token)

--- a/spec/mailers/customer_mailer_spec.rb
+++ b/spec/mailers/customer_mailer_spec.rb
@@ -43,11 +43,11 @@ RSpec.describe CustomerMailer, type: :mailer do
 
   describe "magic_login_link_email" do
     it "renders email" do
-      user.update_auth_token("password_reset_token")
+      user.update_auth_token("magic_link_token")
       mail = CustomerMailer.password_reset_email(user)
       expect(mail.subject).to eq("Instructions to reset your password")
       expect(mail.from).to eq(["contact@bikeindex.org"])
-      expect(mail.body.encoded).to match(user.password_reset_token)
+      expect(mail.body.encoded).to match(user.magic_link_token)
     end
   end
 

--- a/spec/mailers/customer_mailer_spec.rb
+++ b/spec/mailers/customer_mailer_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe CustomerMailer, type: :mailer do
     it "renders email" do
       user.update_auth_token("magic_link_token")
       mail = CustomerMailer.magic_login_link_email(user)
-      expect(mail.subject).to eq("Instructions to reset your password")
+      expect(mail.subject).to eq("Sign in to Bike Index")
       expect(mail.from).to eq(["contact@bikeindex.org"])
       expect(mail.body.encoded).to match(user.magic_link_token)
     end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -348,7 +348,7 @@ RSpec.describe User, type: :model do
       end
       it "gets the time" do
         user = User.new
-        user.update_auth_token("magic_link_token")
+        user.generate_auth_token("magic_link_token")
         expect(user.auth_token_time("magic_link_token")).to be > Time.current - 2.seconds
       end
       it "uses input time" do

--- a/spec/workers/email_magic_link_worker_spec.rb
+++ b/spec/workers/email_magic_link_worker_spec.rb
@@ -2,9 +2,16 @@ require "rails_helper"
 
 RSpec.describe EmailMagicLoginLinkWorker, type: :job do
   it "sends an email" do
-    user = FactoryBot.create(:user)
+    user = FactoryBot.build(:user)
+    user.update_auth_token("magic_link_token")
     ActionMailer::Base.deliveries = []
-    EmailMagicLoginLinkWorker.new.perform(user.id)
+    described_class.new.perform(user.id)
     expect(ActionMailer::Base.deliveries.empty?).to be_falsey
+  end
+  context "user doesn't have token" do
+    it "raises an error" do
+      user = FactoryBot.create(:user)
+      expect { described_class.new.perform(user.id) }.to raise_error(/missing.*token/i)
+    end
   end
 end

--- a/spec/workers/email_reset_password_worker_spec.rb
+++ b/spec/workers/email_reset_password_worker_spec.rb
@@ -2,9 +2,16 @@ require "rails_helper"
 
 RSpec.describe EmailResetPasswordWorker, type: :job do
   it "sends a password_reset email" do
-    user = FactoryBot.create(:user)
+    user = FactoryBot.build(:user)
+    user.update_auth_token("password_reset_token")
     ActionMailer::Base.deliveries = []
     EmailResetPasswordWorker.new.perform(user.id)
     expect(ActionMailer::Base.deliveries.empty?).to be_falsey
+  end
+  context "user doesn't have token" do
+    it "raises an error" do
+      user = FactoryBot.create(:user)
+      expect { described_class.new.perform(user.id) }.to raise_error(/missing.*token/i)
+    end
   end
 end

--- a/spec/workers/process_membership_worker_spec.rb
+++ b/spec/workers/process_membership_worker_spec.rb
@@ -96,6 +96,9 @@ RSpec.describe ProcessMembershipWorker, type: :job do
         expect(EmailConfirmationWorker.jobs.count).to eq 0
         # We don't want to send users emails for organizations with passwordless users
         expect(ActionMailer::Base.deliveries.empty?).to be_truthy
+        # There was a bug where users weren't getting the magic link token when it was sent to them. So verify that we create the token
+        user.send_magic_link_email
+        expect(user.magic_link_token).to be_present
       end
       context "user already exists" do
         let!(:user) { FactoryBot.create(:user, email: email) }


### PR DESCRIPTION
Looks like https://github.com/bikeindex/bike_index/pull/1034#issuecomment-512509125 was a valid bug.

Investigating fixes - I believe it isn't the fault of the url helpers, but instead something to do with the database