### PR TITLE
Move Sidekiq options to ApplicationWorker

### DIFF
--- a/app/workers/additional_email_confirmation_worker.rb
+++ b/app/workers/additional_email_confirmation_worker.rb
@@ -1,7 +1,5 @@
-class AdditionalEmailConfirmationWorker
-  include Sidekiq::Worker
+class AdditionalEmailConfirmationWorker < ApplicationWorker
   sidekiq_options queue: "notify"
-  sidekiq_options backtrace: true
 
   def perform(user_email_id)
     user_email = UserEmail.find(user_email_id)

--- a/app/workers/after_bike_save_worker.rb
+++ b/app/workers/after_bike_save_worker.rb
@@ -1,9 +1,9 @@
 # This will replace WebhookRunner - which is brittle and not flexible enough for what I'm looking for now
 # I need to refactor that, but I don't want to right now because I don't want to break existing stuff yet
 
-class AfterBikeSaveWorker
-  include Sidekiq::Worker
-  sidekiq_options queue: "low_priority", backtrace: true, retry: false
+class AfterBikeSaveWorker < ApplicationWorker
+  sidekiq_options retry: false
+
   POST_URL = ENV["BIKE_WEBHOOK_URL"]
   AUTH_TOKEN = ENV["BIKE_WEBHOOK_AUTH_TOKEN"]
 

--- a/app/workers/after_user_change_worker.rb
+++ b/app/workers/after_user_change_worker.rb
@@ -1,6 +1,6 @@
-class AfterUserChangeWorker
-  include Sidekiq::Worker
-  sidekiq_options queue: "low_priority", backtrace: true, retry: false
+class AfterUserChangeWorker < ApplicationWorker
+  sidekiq_options retry: false
+
   # This is called when a user is updated
   # Or when a bike a user owns is updated
 

--- a/app/workers/after_user_create_worker.rb
+++ b/app/workers/after_user_create_worker.rb
@@ -1,7 +1,7 @@
 # TODO: eventually this should merge with after_user_change_worker.rb, or something
-class AfterUserCreateWorker
-  include Sidekiq::Worker
-  sidekiq_options queue: "high_priority", backtrace: true
+class AfterUserCreateWorker < ApplicationWorker
+
+  sidekiq_options queue: "high_priority"
 
   # Generally, this is called inline - so it makes sense to pass in the user rather than just the user_id
   def perform(user_id, user_state, user: nil, email: nil)

--- a/app/workers/ambassador_task_after_create_worker.rb
+++ b/app/workers/ambassador_task_after_create_worker.rb
@@ -1,6 +1,5 @@
-class AmbassadorTaskAfterCreateWorker
-  include Sidekiq::Worker
-  sidekiq_options queue: "high_priority", backtrace: true
+class AmbassadorTaskAfterCreateWorker < ApplicationWorker
+  sidekiq_options queue: "high_priority"
 
   def perform(ambassador_task_id)
     ambassador_task = AmbassadorTask.find(ambassador_task_id)

--- a/app/workers/application_worker.rb
+++ b/app/workers/application_worker.rb
@@ -1,0 +1,6 @@
+class ApplicationWorker
+  include Sidekiq::Worker
+  sidekiq_options queue: "low_priority"
+  sidekiq_options backtrace: true
+  sidekiq_options retry: true
+end

--- a/app/workers/approve_stolen_listing_worker.rb
+++ b/app/workers/approve_stolen_listing_worker.rb
@@ -1,7 +1,5 @@
-class ApproveStolenListingWorker
-  include Sidekiq::Worker
+class ApproveStolenListingWorker < ApplicationWorker
   sidekiq_options queue: "notify"
-  sidekiq_options backtrace: true
 
   def perform(bike_id)
     StolenTwitterbotIntegration.new.send_tweet(bike_id)

--- a/app/workers/autocomplete_loader_worker.rb
+++ b/app/workers/autocomplete_loader_worker.rb
@@ -1,6 +1,5 @@
-class AutocompleteLoaderWorker
-  include Sidekiq::Worker
-  sidekiq_options queue: "high_priority", backtrace: true
+class AutocompleteLoaderWorker < ApplicationWorker
+  sidekiq_options queue: "high_priority"
 
   def perform(loader_method)
     AutocompleteLoader.new.send(loader_method)

--- a/app/workers/averyable_bike_worker.rb
+++ b/app/workers/averyable_bike_worker.rb
@@ -1,10 +1,7 @@
-# Useful because of looking at PSU errors. Checkout https://github.com/bikeindex/bike_index/pull/1042
+# Useful because of looking at PSU errors.
+# Checkout https://github.com/bikeindex/bike_index/pull/1042
 
-class AveryableBikeWorker
-  include Sidekiq::Worker
-  sidekiq_options queue: "low_priority"
-  sidekiq_options backtrace: true
-
+class AveryableBikeWorker < ApplicationWorker
   def perform(filename, bike_id)
     bike = Bike.unscoped.find_by_id(bike_id)
     return true if Export.avery_export_bike?(bike)

--- a/app/workers/bike_book_update_worker.rb
+++ b/app/workers/bike_book_update_worker.rb
@@ -1,6 +1,5 @@
-class BikeBookUpdateWorker
-  include Sidekiq::Worker
-  sidekiq_options queue: "high_priority", backtrace: true
+class BikeBookUpdateWorker < ApplicationWorker
+  sidekiq_options queue: "high_priority"
 
   def perform(bike_id)
     bike = Bike.unscoped.where(id: bike_id).first

--- a/app/workers/bike_deleter_worker.rb
+++ b/app/workers/bike_deleter_worker.rb
@@ -1,8 +1,4 @@
-class BikeDeleterWorker
-  include Sidekiq::Worker
-  sidekiq_options queue: "low_priority"
-  sidekiq_options backtrace: true
-
+class BikeDeleterWorker < ApplicationWorker
   def perform(bike_id)
     Bike.where(id: bike_id).first&.destroy
   end

--- a/app/workers/bulk_import_worker.rb
+++ b/app/workers/bulk_import_worker.rb
@@ -1,9 +1,7 @@
 require "csv"
 
-class BulkImportWorker
-  include Sidekiq::Worker
-  sidekiq_options queue: "low_priority" # Because it's low priority!
-  sidekiq_options backtrace: true, retry: false
+class BulkImportWorker < ApplicationWorker
+  sidekiq_options retry: false
 
   attr_accessor :bulk_import, :line_errors # Only necessary for testing
 

--- a/app/workers/duplicate_bike_finder_worker.rb
+++ b/app/workers/duplicate_bike_finder_worker.rb
@@ -1,6 +1,5 @@
-class DuplicateBikeFinderWorker
-  include Sidekiq::Worker
-  sidekiq_options queue: "low_priority", backtrace: true, :retry => false
+class DuplicateBikeFinderWorker < ApplicationWorker
+  sidekiq_options retry: false
 
   def perform(bike_id)
     serial_segments = Bike.find(bike_id).normalized_serial_segments

--- a/app/workers/email_admin_contact_stolen_worker.rb
+++ b/app/workers/email_admin_contact_stolen_worker.rb
@@ -1,7 +1,6 @@
-class EmailAdminContactStolenWorker
-  include Sidekiq::Worker
+class EmailAdminContactStolenWorker < ApplicationWorker
+
   sidekiq_options queue: "notify"
-  sidekiq_options backtrace: true
 
   def perform(customer_contact_id)
     customer_contact = CustomerContact.find(customer_contact_id)

--- a/app/workers/email_confirmation_worker.rb
+++ b/app/workers/email_confirmation_worker.rb
@@ -1,7 +1,6 @@
-class EmailConfirmationWorker
-  include Sidekiq::Worker
+class EmailConfirmationWorker < ApplicationWorker
+
   sidekiq_options queue: "notify"
-  sidekiq_options backtrace: true
 
   def perform(user_id)
     user = User.find(user_id)

--- a/app/workers/email_feedback_notification_worker.rb
+++ b/app/workers/email_feedback_notification_worker.rb
@@ -1,6 +1,6 @@
-class EmailFeedbackNotificationWorker
-  include Sidekiq::Worker
-  sidekiq_options queue: "notify", backtrace: true, retry: 1
+class EmailFeedbackNotificationWorker < ApplicationWorker
+
+  sidekiq_options queue: "notify", retry: 1
 
   def perform(feedback_id)
     @feedback = Feedback.find(feedback_id)

--- a/app/workers/email_invoice_worker.rb
+++ b/app/workers/email_invoice_worker.rb
@@ -1,7 +1,6 @@
-class EmailInvoiceWorker
-  include Sidekiq::Worker
+class EmailInvoiceWorker < ApplicationWorker
+
   sidekiq_options queue: "notify"
-  sidekiq_options backtrace: true
 
   def perform(id)
     @payment = Payment.find(id)

--- a/app/workers/email_lightspeed_notification_worker.rb
+++ b/app/workers/email_lightspeed_notification_worker.rb
@@ -1,7 +1,6 @@
-class EmailLightspeedNotificationWorker
-  include Sidekiq::Worker
+class EmailLightspeedNotificationWorker < ApplicationWorker
+
   sidekiq_options queue: "notify"
-  sidekiq_options backtrace: true
 
   def perform(organization_id, api_key)
     @api_key = api_key

--- a/app/workers/email_magic_login_link_worker.rb
+++ b/app/workers/email_magic_login_link_worker.rb
@@ -1,7 +1,6 @@
-class EmailMagicLoginLinkWorker
-  include Sidekiq::Worker
+class EmailMagicLoginLinkWorker < ApplicationWorker
+
   sidekiq_options queue: "notify"
-  sidekiq_options backtrace: true
 
   def perform(user_id)
     user = User.find(user_id)

--- a/app/workers/email_no_admins_notification_worker.rb
+++ b/app/workers/email_no_admins_notification_worker.rb
@@ -1,7 +1,6 @@
-class EmailNoAdminsNotificationWorker
-  include Sidekiq::Worker
+class EmailNoAdminsNotificationWorker < ApplicationWorker
+
   sidekiq_options queue: "notify"
-  sidekiq_options backtrace: true
 
   def perform(organization_id)
     @organization = Organization.find(organization_id)

--- a/app/workers/email_organization_message_worker.rb
+++ b/app/workers/email_organization_message_worker.rb
@@ -1,6 +1,6 @@
-class EmailOrganizationMessageWorker
-  include Sidekiq::Worker
-  sidekiq_options queue: "notify", backtrace: true
+class EmailOrganizationMessageWorker < ApplicationWorker
+
+  sidekiq_options queue: "notify"
 
   def perform(organization_message_id)
     organization_message = OrganizationMessage.find(organization_message_id)

--- a/app/workers/email_ownership_invitation_worker.rb
+++ b/app/workers/email_ownership_invitation_worker.rb
@@ -1,7 +1,6 @@
-class EmailOwnershipInvitationWorker
-  include Sidekiq::Worker
+class EmailOwnershipInvitationWorker < ApplicationWorker
+
   sidekiq_options queue: "notify"
-  sidekiq_options backtrace: true
 
   def perform(ownership_id)
     ownership = Ownership.where(id: ownership_id).first

--- a/app/workers/email_partial_registration_worker.rb
+++ b/app/workers/email_partial_registration_worker.rb
@@ -1,7 +1,6 @@
-class EmailPartialRegistrationWorker
-  include Sidekiq::Worker
+class EmailPartialRegistrationWorker < ApplicationWorker
+
   sidekiq_options queue: "notify"
-  sidekiq_options backtrace: true
 
   def perform(b_param_id)
     b_param = BParam.find(b_param_id)

--- a/app/workers/email_recovered_from_link_worker.rb
+++ b/app/workers/email_recovered_from_link_worker.rb
@@ -1,7 +1,6 @@
-class EmailRecoveredFromLinkWorker
-  include Sidekiq::Worker
+class EmailRecoveredFromLinkWorker < ApplicationWorker
+
   sidekiq_options queue: "notify"
-  sidekiq_options backtrace: true
 
   def perform(stolen_record_id)
     stolen_record = StolenRecord.unscoped.find(stolen_record_id)

--- a/app/workers/email_reset_password_worker.rb
+++ b/app/workers/email_reset_password_worker.rb
@@ -1,7 +1,6 @@
-class EmailResetPasswordWorker
-  include Sidekiq::Worker
+class EmailResetPasswordWorker < ApplicationWorker
+
   sidekiq_options queue: "notify"
-  sidekiq_options backtrace: true
 
   def perform(user_id)
     user = User.find(user_id)

--- a/app/workers/email_stolen_bike_alert_worker.rb
+++ b/app/workers/email_stolen_bike_alert_worker.rb
@@ -1,7 +1,6 @@
-class EmailStolenBikeAlertWorker
-  include Sidekiq::Worker
+class EmailStolenBikeAlertWorker < ApplicationWorker
+
   sidekiq_options queue: "notify"
-  sidekiq_options backtrace: true
 
   def perform(customer_contact_id)
     customer_contact = CustomerContact.find(customer_contact_id)

--- a/app/workers/email_stolen_notification_worker.rb
+++ b/app/workers/email_stolen_notification_worker.rb
@@ -1,6 +1,6 @@
-class EmailStolenNotificationWorker
-  include Sidekiq::Worker
-  sidekiq_options queue: "notify", backtrace: true
+class EmailStolenNotificationWorker < ApplicationWorker
+
+  sidekiq_options queue: "notify"
 
   def perform(stolen_notification_id)
     stolen_notification = StolenNotification.find(stolen_notification_id)

--- a/app/workers/email_updated_terms_worker.rb
+++ b/app/workers/email_updated_terms_worker.rb
@@ -1,7 +1,6 @@
-class EmailUpdatedTermsWorker
-  include Sidekiq::Worker
+class EmailUpdatedTermsWorker < ApplicationWorker
+
   sidekiq_options queue: "low_priority"
-  sidekiq_options backtrace: true
   sidekiq_options retry: false
 
   def perform

--- a/app/workers/email_welcome_worker.rb
+++ b/app/workers/email_welcome_worker.rb
@@ -1,7 +1,6 @@
-class EmailWelcomeWorker
-  include Sidekiq::Worker
+class EmailWelcomeWorker < ApplicationWorker
+
   sidekiq_options queue: "notify"
-  sidekiq_options backtrace: true
 
   def perform(user_id)
     user = User.find(user_id)

--- a/app/workers/external_image_url_store_worker.rb
+++ b/app/workers/external_image_url_store_worker.rb
@@ -1,6 +1,5 @@
-class ExternalImageUrlStoreWorker
-  include Sidekiq::Worker
-  sidekiq_options queue: "carrierwave", backtrace: true
+class ExternalImageUrlStoreWorker < ApplicationWorker
+  sidekiq_options queue: "carrierwave"
 
   def perform(public_image_id)
     public_image = PublicImage.find(public_image_id)

--- a/app/workers/image_associator_worker.rb
+++ b/app/workers/image_associator_worker.rb
@@ -1,6 +1,5 @@
-class ImageAssociatorWorker
-  include Sidekiq::Worker
-  sidekiq_options queue: "high_priority", backtrace: true
+class ImageAssociatorWorker < ApplicationWorker
+  sidekiq_options queue: "high_priority"
 
   def perform
     BParam.where(image_processed: false).where("image IS NOT NULL").each do |b_param|

--- a/app/workers/listicle_image_size_worker.rb
+++ b/app/workers/listicle_image_size_worker.rb
@@ -1,7 +1,5 @@
-class ListicleImageSizeWorker
-  include Sidekiq::Worker
+class ListicleImageSizeWorker < ApplicationWorker
   sidekiq_options queue: "carrierwave"
-  sidekiq_options backtrace: true
 
   def perform(id)
     listicle = Listicle.find(id)

--- a/app/workers/merge_additional_email_worker.rb
+++ b/app/workers/merge_additional_email_worker.rb
@@ -1,6 +1,6 @@
-class MergeAdditionalEmailWorker
-  include Sidekiq::Worker
-  sidekiq_options queue: "high_priority", backtrace: true
+class MergeAdditionalEmailWorker < ApplicationWorker
+
+  sidekiq_options queue: "high_priority"
 
   def perform(user_email_id)
     user_email = UserEmail.find(user_email_id)

--- a/app/workers/organization_export_worker.rb
+++ b/app/workers/organization_export_worker.rb
@@ -1,8 +1,7 @@
-class OrganizationExportWorker
-  include Sidekiq::Worker
-  sidekiq_options queue: "low_priority", backtrace: true, retry: false
+class OrganizationExportWorker < ApplicationWorker
   LINK_BASE = "#{ENV["BASE_URL"]}/bikes/".freeze
 
+  sidekiq_options retry: false
   attr_accessor :export # Only necessary for testing
 
   def perform(export_id)

--- a/app/workers/process_membership_worker.rb
+++ b/app/workers/process_membership_worker.rb
@@ -1,6 +1,5 @@
-class ProcessMembershipWorker
-  include Sidekiq::Worker
-  sidekiq_options queue: "high_priority", backtrace: true
+class ProcessMembershipWorker < ApplicationWorker
+  sidekiq_options queue: "high_priority"
 
   def perform(membership_id, user_id = nil)
     membership = Membership.find(membership_id)

--- a/app/workers/scheduled_worker.rb
+++ b/app/workers/scheduled_worker.rb
@@ -1,6 +1,5 @@
-class ScheduledWorker
-  include Sidekiq::Worker
-  sidekiq_options queue: "low_priority", backtrace: true, retry: false
+class ScheduledWorker < ApplicationWorker
+  sidekiq_options retry: false
 
   def self.frequency
     30.seconds

--- a/app/workers/send_newsletter_worker.rb
+++ b/app/workers/send_newsletter_worker.rb
@@ -1,6 +1,5 @@
-class SendNewsletterWorker
-  include Sidekiq::Worker
-  sidekiq_options queue: "notify", backtrace: true, retry: false
+class SendNewsletterWorker < ApplicationWorker
+  sidekiq_options queue: "notify", retry: false
   API_KEY = ENV["SPARKPOST_API_KEY"]
 
   def client; @client ||= SimpleSpark::Client.new(api_key: API_KEY) end

--- a/app/workers/theft_alert_purchase_notification_worker.rb
+++ b/app/workers/theft_alert_purchase_notification_worker.rb
@@ -1,7 +1,5 @@
-class TheftAlertPurchaseNotificationWorker
-  include Sidekiq::Worker
+class TheftAlertPurchaseNotificationWorker < ApplicationWorker
   sidekiq_options queue: "notify"
-  sidekiq_options backtrace: true
 
   def perform(theft_alert_id)
     theft_alert = TheftAlert.find(theft_alert_id)

--- a/app/workers/unknown_organization_for_ascend_import_worker.rb
+++ b/app/workers/unknown_organization_for_ascend_import_worker.rb
@@ -1,7 +1,5 @@
-class UnknownOrganizationForAscendImportWorker
-  include Sidekiq::Worker
+class UnknownOrganizationForAscendImportWorker < ApplicationWorker
   sidekiq_options queue: "notify"
-  sidekiq_options backtrace: true
 
   def perform(id)
     AdminMailer.unknown_organization_for_ascend_import(BulkImport.find(id)).deliver_now

--- a/app/workers/update_auth_token_worker.rb
+++ b/app/workers/update_auth_token_worker.rb
@@ -1,7 +1,6 @@
 # Not called in the code, only called if manually expiring
-class UpdateAuthTokenWorker
-  include Sidekiq::Worker
-  sidekiq_options queue: "high_priority", backtrace: true
+class UpdateAuthTokenWorker < ApplicationWorker
+  sidekiq_options queue: "high_priority"
 
   def perform(id)
     user = User.find(id)


### PR DESCRIPTION
- Adds `ApplicationWorker` to set default sidekiq options
- Extracted from #1056. Taking a different approach to locale-setting there but we may want to keep this patch since this was suggested on a past PR.
