### PR TITLE
Fix missing interpolation argument in bikes/show

### DIFF
--- a/app/views/bikes/show.html.haml
+++ b/app/views/bikes/show.html.haml
@@ -84,7 +84,8 @@
 
           %li
             %span.attr-title #{t(".manufacturer")}:
-            -# We want to display the whole manufacturer name here, not just the simple name. So only use mnfg_name if it's other (which sanitizes)
+            -# We want to display the whole manufacturer name here, not just the
+            -# simple name. So only use mnfg_name if it's other (which sanitizes)
             - if @bike.manufacturer.name == "Other"
               = @bike.mnfg_name
             - else

--- a/app/views/bikes/show.html.haml
+++ b/app/views/bikes/show.html.haml
@@ -86,10 +86,10 @@
             %span.attr-title #{t(".manufacturer")}:
             -# We want to display the whole manufacturer name here, not just the
             -# simple name. So only use mnfg_name if it's other (which sanitizes)
-            - if @bike.manufacturer.name == "Other"
+            - if @bike.manufacturer&.name == "Other"
               = @bike.mnfg_name
             - else
-              = @bike.manufacturer.name
+              = @bike.manufacturer&.name
           = @bike.attr_list_item(@bike.name, t(".name"), with_colon: true)
           = @bike.attr_list_item(@bike.frame_model, t(".model"), with_colon: true)
           = @bike.attr_list_item(@bike.year.to_s, t(".year"), with_colon: true)

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1281,8 +1281,8 @@ en:
       or_click_html: >-
         Or, click <em>link it</em> on of your bikes to connect it to this %{bike_code_kind}:
       please_email_support_html: >-
-        Please email %{support_email} if you don't understand why you're seeing this
-        message or if you need an exception made.
+        Please email %{support_email_link} if you don't understand why you're seeing
+        this message or if you need an exception made.
       please_sign_in: please sign in
       to_link_that_card_with_a_bike: To link that card with a bike,
       update: Update


### PR DESCRIPTION
Fixes an exception from a missing interpolation key.

```yml
# config/locales/en.yml L1283-1285 (0e96aa29)

please_email_support_html: >-
  Please email %{support_email_link} if you don't understand why you're seeing
  this message or if you need an exception made.
```
<sup>[[source](https://github.com/bikeindex/bike_index/blob/0e96aa29/config/locales/en.yml#L1283-L1285)]</sup>


Resolves https://app.honeybadger.io/projects/35931/faults/52442699


Also fixes a NoMethodError from `.manufacturer` returning `nil':

https://app.honeybadger.io/projects/35931/faults/52395156