### PR TITLE
Upgrade fog

### DIFF
--- a/.env
+++ b/.env
@@ -13,6 +13,7 @@ STRIPE_SECRET_KEY: sk_test_tQGLxDke5HeZD6iTD1QyVZvV
 S3_BUCKET: absent
 S3_ACCESS_KEY: absent
 S3_SECRET_KEY: absent
+ASSET_HOST: https://files.bikeindex.org
 SPARKPOST_USERNAME: absent
 SPARKPOST_PASSWORD: absent
 SPARKPOST_PORT: absent

--- a/.env
+++ b/.env
@@ -13,7 +13,7 @@ STRIPE_SECRET_KEY: sk_test_tQGLxDke5HeZD6iTD1QyVZvV
 S3_BUCKET: absent
 S3_ACCESS_KEY: absent
 S3_SECRET_KEY: absent
-ASSET_HOST: https://files.bikeindex.org
+S3_ASSET_HOST: https://files.bikeindex.org
 SPARKPOST_USERNAME: absent
 SPARKPOST_PASSWORD: absent
 SPARKPOST_PORT: absent

--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,6 @@ ruby "2.5.5"
 gem "rails", "4.2.11"
 
 gem "active_model_serializers", "~> 0.9.3"
-gem "aws-sdk", "~> 1.33"
 gem "bcrypt", "~> 3.1.7"
 gem "jquery-rails"
 gem "pg"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -51,11 +51,6 @@ GEM
     autoprefixer-rails (6.5.0.2)
       execjs
     awesome_print (1.8.0)
-    aws-sdk (1.66.0)
-      aws-sdk-v1 (= 1.66.0)
-    aws-sdk-v1 (1.66.0)
-      json (~> 1.4)
-      nokogiri (>= 1.4.4)
     axiom-types (0.1.1)
       descendants_tracker (~> 0.0.4)
       ice_nine (~> 0.11.0)
@@ -137,7 +132,7 @@ GEM
     erubi (1.8.0)
     erubis (2.7.0)
     eventmachine (1.2.0.1)
-    excon (0.62.0)
+    excon (0.65.0)
     execjs (2.7.0)
     factory_bot (4.11.1)
       activesupport (>= 3.0.0)
@@ -158,12 +153,12 @@ GEM
       flipper (~> 0.16.2)
       rack (>= 1.4, < 3)
       rack-protection (>= 1.5.3, < 2.1.0)
-    fog-aws (3.0.0)
+    fog-aws (3.5.2)
       fog-core (~> 2.1)
       fog-json (~> 1.1)
       fog-xml (~> 0.1)
       ipaddress (~> 0.8)
-    fog-core (2.1.0)
+    fog-core (2.1.2)
       builder
       excon (~> 0.58)
       formatador (~> 0.2)
@@ -661,7 +656,6 @@ DEPENDENCIES
   active_model_serializers (~> 0.9.3)
   airborne
   api-pagination
-  aws-sdk (~> 1.33)
   axlsx
   backbone-on-rails (~> 0.9.10.0)
   bcrypt (~> 3.1.7)

--- a/app/uploaders/application_uploader.rb
+++ b/app/uploaders/application_uploader.rb
@@ -1,0 +1,17 @@
+class ApplicationUploader < CarrierWave::Uploader::Base
+  after :remove, :delete_empty_upstream_dirs
+
+  def delete_empty_upstream_dirs
+    path = ::File.expand_path(store_dir, root)
+    Dir.delete(path) # fails if path not empty dir
+
+    path = ::File.expand_path(base_store_dir, root)
+    Dir.delete(path) # fails if path not empty dir
+  rescue SystemCallError
+    true # nothing, the dir is not empty
+  end
+
+  def cache_dir
+    Rails.root.join("tmp", "cache")
+  end
+end

--- a/app/uploaders/avatar_uploader.rb
+++ b/app/uploaders/avatar_uploader.rb
@@ -1,27 +1,9 @@
-# encoding: utf-8
-
-class AvatarUploader < CarrierWave::Uploader::Base
+class AvatarUploader < ApplicationUploader
   include CarrierWave::MiniMagick
-
-  after :remove, :delete_empty_upstream_dirs
-
-  def delete_empty_upstream_dirs
-    path = ::File.expand_path(store_dir, root)
-    Dir.delete(path) # fails if path not empty dir
-
-    path = ::File.expand_path(base_store_dir, root)
-    Dir.delete(path) # fails if path not empty dir
-  rescue SystemCallError
-    true # nothing, the dir is not empty
-  end
 
   # Fallback so the page doesn't break if the image isn't there
   def default_url
     "https://files.bikeindex.org/blank.png"
-  end
-
-  def cache_dir
-    Rails.root.join("tmp", "cache")
   end
 
   def store_dir

--- a/app/uploaders/avatar_uploader.rb
+++ b/app/uploaders/avatar_uploader.rb
@@ -2,16 +2,6 @@
 
 class AvatarUploader < CarrierWave::Uploader::Base
   include CarrierWave::MiniMagick
-  # include Sprockets::Helpers::RailsHelper # Deprecated. Should be removed
-  # include Sprockets::Helpers::IsolatedHelper # Deprecated. Should be removed
-
-  if Rails.env.test?
-    storage :file
-  elsif Rails.env.development?
-    storage :file
-  else
-    storage :fog
-  end
 
   after :remove, :delete_empty_upstream_dirs
 

--- a/app/uploaders/bulk_import_uploader.rb
+++ b/app/uploaders/bulk_import_uploader.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 class BulkImportUploader < ExportUploader
   def store_dir
     "#{base_store_dir}imports/#{model.id}"

--- a/app/uploaders/circular_image_uploader.rb
+++ b/app/uploaders/circular_image_uploader.rb
@@ -1,27 +1,9 @@
-# encoding: utf-8
-
-class CircularImageUploader < CarrierWave::Uploader::Base
+class CircularImageUploader < ApplicationUploader
   include CarrierWave::MiniMagick
   include ::CarrierWave::Backgrounder::Delay
 
-  after :remove, :delete_empty_upstream_dirs
-
-  def delete_empty_upstream_dirs
-    path = ::File.expand_path(store_dir, root)
-    Dir.delete(path) # fails if path not empty dir
-
-    path = ::File.expand_path(base_store_dir, root)
-    Dir.delete(path) # fails if path not empty dir
-  rescue SystemCallError
-    true # nothing, the dir is not empty
-  end
-
   def store_dir
     "#{base_store_dir}/#{model.id}"
-  end
-
-  def cache_dir
-    Rails.root.join("tmp", "cache")
   end
 
   def base_store_dir

--- a/app/uploaders/circular_image_uploader.rb
+++ b/app/uploaders/circular_image_uploader.rb
@@ -4,12 +4,6 @@ class CircularImageUploader < CarrierWave::Uploader::Base
   include CarrierWave::MiniMagick
   include ::CarrierWave::Backgrounder::Delay
 
-  if Rails.env.production?
-    storage :fog
-  else
-    storage :file
-  end
-
   after :remove, :delete_empty_upstream_dirs
 
   def delete_empty_upstream_dirs

--- a/app/uploaders/export_uploader.rb
+++ b/app/uploaders/export_uploader.rb
@@ -2,14 +2,6 @@
 
 # We really should obfuscate the filename, for this and bulk imports
 class ExportUploader < CarrierWave::Uploader::Base
-  if Rails.env.test?
-    storage :file
-  elsif Rails.env.development?
-    storage :file
-  else
-    storage :fog
-  end
-
   def cache_dir
     Rails.root.join("tmp", "cache")
   end

--- a/app/uploaders/export_uploader.rb
+++ b/app/uploaders/export_uploader.rb
@@ -1,11 +1,5 @@
-# encoding: utf-8
-
 # We really should obfuscate the filename, for this and bulk imports
-class ExportUploader < CarrierWave::Uploader::Base
-  def cache_dir
-    Rails.root.join("tmp", "cache")
-  end
-
+class ExportUploader < ApplicationUploader
   def store_dir
     "#{base_store_dir}exports/#{model.id}"
   end

--- a/app/uploaders/image_uploader.rb
+++ b/app/uploaders/image_uploader.rb
@@ -1,12 +1,6 @@
 class ImageUploader < CarrierWave::Uploader::Base
   include CarrierWave::MiniMagick
 
-  if Rails.env.production?
-    storage :fog
-  else
-    storage :file
-  end
-
   after :remove, :delete_empty_upstream_dirs
 
   def delete_empty_upstream_dirs

--- a/app/uploaders/image_uploader.rb
+++ b/app/uploaders/image_uploader.rb
@@ -1,21 +1,5 @@
-class ImageUploader < CarrierWave::Uploader::Base
+class ImageUploader < ApplicationUploader
   include CarrierWave::MiniMagick
-
-  after :remove, :delete_empty_upstream_dirs
-
-  def delete_empty_upstream_dirs
-    path = ::File.expand_path(store_dir, root)
-    Dir.delete(path) # fails if path not empty dir
-
-    path = ::File.expand_path(base_store_dir, root)
-    Dir.delete(path) # fails if path not empty dir
-  rescue SystemCallError
-    true # nothing, the dir is not empty
-  end
-
-  def cache_dir
-    Rails.root.join("tmp", "cache")
-  end
 
   def store_dir
     "#{base_store_dir}/#{model.id}"

--- a/app/uploaders/json_uploader.rb
+++ b/app/uploaders/json_uploader.rb
@@ -1,16 +1,5 @@
 # encoding: utf-8
 class JsonUploader < CarrierWave::Uploader::Base
-  # include Sprockets::Helpers::RailsHelper # Deprecated. Should be removed
-  # include Sprockets::Helpers::IsolatedHelper # Deprecated. Should be removed
-
-  if Rails.env.test?
-    storage :file
-  elsif Rails.env.development?
-    storage :file
-  else
-    storage :fog
-  end
-
   def cache_dir
     Rails.root.join("tmp", "cache")
   end

--- a/app/uploaders/json_uploader.rb
+++ b/app/uploaders/json_uploader.rb
@@ -1,9 +1,4 @@
-# encoding: utf-8
-class JsonUploader < CarrierWave::Uploader::Base
-  def cache_dir
-    Rails.root.join("tmp", "cache")
-  end
-
+class JsonUploader < ApplicationUploader
   def store_dir
     "#{base_store_dir}json"
   end

--- a/app/uploaders/listicle_image_uploader.rb
+++ b/app/uploaders/listicle_image_uploader.rb
@@ -3,12 +3,6 @@
 class ListicleImageUploader < CarrierWave::Uploader::Base
   include CarrierWave::MiniMagick
 
-  if Rails.env.production?
-    storage :fog
-  else
-    storage :file
-  end
-
   after :remove, :delete_empty_upstream_dirs
 
   def delete_empty_upstream_dirs

--- a/app/uploaders/listicle_image_uploader.rb
+++ b/app/uploaders/listicle_image_uploader.rb
@@ -1,23 +1,5 @@
-# encoding: utf-8
-
-class ListicleImageUploader < CarrierWave::Uploader::Base
+class ListicleImageUploader < ApplicationUploader
   include CarrierWave::MiniMagick
-
-  after :remove, :delete_empty_upstream_dirs
-
-  def delete_empty_upstream_dirs
-    path = ::File.expand_path(store_dir, root)
-    Dir.delete(path) # fails if path not empty dir
-
-    path = ::File.expand_path(base_store_dir, root)
-    Dir.delete(path) # fails if path not empty dir
-  rescue SystemCallError
-    true # nothing, the dir is not empty
-  end
-
-  def cache_dir
-    Rails.root.join("tmp", "cache")
-  end
 
   def store_dir
     "#{base_store_dir}/#{model.id}"

--- a/app/uploaders/partner_uploader.rb
+++ b/app/uploaders/partner_uploader.rb
@@ -1,23 +1,5 @@
-# encoding: utf-8
-
-class PartnerUploader < CarrierWave::Uploader::Base
+class PartnerUploader < ApplicationUploader
   include CarrierWave::MiniMagick
-
-  after :remove, :delete_empty_upstream_dirs
-
-  def delete_empty_upstream_dirs
-    path = ::File.expand_path(store_dir, root)
-    Dir.delete(path) # fails if path not empty dir
-
-    path = ::File.expand_path(base_store_dir, root)
-    Dir.delete(path) # fails if path not empty dir
-  rescue SystemCallError
-    true # nothing, the dir is not empty
-  end
-
-  def cache_dir
-    Rails.root.join("tmp", "cache")
-  end
 
   def store_dir
     "#{base_store_dir}/#{model.id}"

--- a/app/uploaders/partner_uploader.rb
+++ b/app/uploaders/partner_uploader.rb
@@ -3,12 +3,6 @@
 class PartnerUploader < CarrierWave::Uploader::Base
   include CarrierWave::MiniMagick
 
-  if Rails.env.production?
-    storage :fog
-  else
-    storage :file
-  end
-
   after :remove, :delete_empty_upstream_dirs
 
   def delete_empty_upstream_dirs

--- a/app/uploaders/pdf_uploader.rb
+++ b/app/uploaders/pdf_uploader.rb
@@ -1,26 +1,8 @@
-# encoding: utf-8
-
-class PdfUploader < CarrierWave::Uploader::Base
+class PdfUploader < ApplicationUploader
   include ::CarrierWave::Backgrounder::Delay
   include CarrierWave::MimeTypes
 
   process :set_content_type
-
-  after :remove, :delete_empty_upstream_dirs
-
-  def delete_empty_upstream_dirs
-    path = ::File.expand_path(store_dir, root)
-    Dir.delete(path) # fails if path not empty dir
-
-    path = ::File.expand_path(base_store_dir, root)
-    Dir.delete(path) # fails if path not empty dir
-  rescue SystemCallError
-    true # nothing, the dir is not empty
-  end
-
-  def cache_dir
-    Rails.root.join("tmp", "cache")
-  end
 
   def store_dir
     "#{base_store_dir}/#{model.id}"

--- a/app/uploaders/pdf_uploader.rb
+++ b/app/uploaders/pdf_uploader.rb
@@ -5,16 +5,6 @@ class PdfUploader < CarrierWave::Uploader::Base
   include CarrierWave::MimeTypes
 
   process :set_content_type
-  # include Sprockets::Helpers::RailsHelper # Deprecated. Should be removed
-  # include Sprockets::Helpers::IsolatedHelper # Deprecated. Should be removed
-
-  if Rails.env.test?
-    storage :file
-  elsif Rails.env.development?
-    storage :file
-  else
-    storage :fog
-  end
 
   after :remove, :delete_empty_upstream_dirs
 

--- a/app/uploaders/tsv_uploader.rb
+++ b/app/uploaders/tsv_uploader.rb
@@ -1,16 +1,5 @@
 # encoding: utf-8
 class TsvUploader < CarrierWave::Uploader::Base
-  # include Sprockets::Helpers::RailsHelper # Deprecated. Should be removed
-  # include Sprockets::Helpers::IsolatedHelper # Deprecated. Should be removed
-
-  if Rails.env.test?
-    storage :file
-  elsif Rails.env.development?
-    storage :file
-  else
-    storage :fog
-  end
-
   def cache_dir
     Rails.root.join("tmp", "cache")
   end

--- a/app/uploaders/tsv_uploader.rb
+++ b/app/uploaders/tsv_uploader.rb
@@ -1,9 +1,4 @@
-# encoding: utf-8
-class TsvUploader < CarrierWave::Uploader::Base
-  def cache_dir
-    Rails.root.join("tmp", "cache")
-  end
-
+class TsvUploader < ApplicationUploader
   def store_dir
     "#{base_store_dir}tsvs"
   end

--- a/config/initializers/carrierwave.rb
+++ b/config/initializers/carrierwave.rb
@@ -37,7 +37,7 @@ CarrierWave.configure do |config|
 
   if Rails.env.production?
     config.fog_provider "fog/aws"
-    config.asset_host = "https://files.bikeindex.org" if Rails.env.production?
+    config.asset_host = "https://files.bikeindex.org"
     config.fog_credentials = {
       provider: "AWS",
       aws_access_key_id: ENV["S3_ACCESS_KEY"],

--- a/config/initializers/carrierwave.rb
+++ b/config/initializers/carrierwave.rb
@@ -37,7 +37,7 @@ CarrierWave.configure do |config|
 
   if Rails.env.production?
     config.fog_provider "fog/aws"
-    config.asset_host = ENV["ASSET_HOST"]
+    config.asset_host = ENV["S3_ASSET_HOST"]
     config.fog_credentials = {
       provider: "AWS",
       aws_access_key_id: ENV["S3_ACCESS_KEY"],

--- a/config/initializers/carrierwave.rb
+++ b/config/initializers/carrierwave.rb
@@ -1,20 +1,3 @@
-# Configure carrierwave
-
-CarrierWave.configure do |config|
-  config.cache_dir = "#{Rails.root}/tmp/uploads"
-  config.storage = :fog # For some reason, uploading sitemap doesn't work unless this is included.
-  config.asset_host = "https://files.bikeindex.org" if Rails.env.production?
-  config.fog_credentials = {
-    provider: "AWS",
-    aws_access_key_id: ENV["S3_ACCESS_KEY"],
-    aws_secret_access_key: ENV["S3_SECRET_KEY"],
-    region: "us-east-1",
-
-  }
-  config.fog_directory = ENV["S3_BUCKET"]
-  config.fog_attributes = { "Cache-Control" => "max-age=315576000" }
-end
-
 # Monkey Patch carrierwave
 module CarrierWave
   module MiniMagick
@@ -45,5 +28,26 @@ module CarrierWave
         img
       end
     end
+  end
+end
+
+# Additional carrierwave configurations
+CarrierWave.configure do |config|
+  config.cache_dir = "#{Rails.root}/tmp/uploads"
+
+  if Rails.env.production?
+    config.fog_provider "fog/aws"
+    config.asset_host = "https://files.bikeindex.org" if Rails.env.production?
+    config.fog_credentials = {
+      provider: "AWS",
+      aws_access_key_id: ENV["S3_ACCESS_KEY"],
+      aws_secret_access_key: ENV["S3_SECRET_KEY"],
+      region: "us-east-1",
+    }
+    config.fog_directory = ENV["S3_BUCKET"]
+    config.fog_attributes = { "Cache-Control" => "max-age=315576000" }
+    config.storage :fog
+  else
+    config.storage :file
   end
 end

--- a/config/initializers/carrierwave.rb
+++ b/config/initializers/carrierwave.rb
@@ -37,7 +37,7 @@ CarrierWave.configure do |config|
 
   if Rails.env.production?
     config.fog_provider "fog/aws"
-    config.asset_host = "https://files.bikeindex.org"
+    config.asset_host = ENV["ASSET_HOST"]
     config.fog_credentials = {
       provider: "AWS",
       aws_access_key_id: ENV["S3_ACCESS_KEY"],

--- a/spec/services/phonifyer_spec.rb
+++ b/spec/services/phonifyer_spec.rb
@@ -1,4 +1,3 @@
-# encoding: utf-8
 require "rails_helper"
 
 RSpec.describe Phonifyer do

--- a/spec/services/slugify_spec.rb
+++ b/spec/services/slugify_spec.rb
@@ -1,4 +1,3 @@
-# encoding: utf-8
 require "rails_helper"
 
 RSpec.describe Slugifyer do

--- a/spec/services/urlifyer_spec.rb
+++ b/spec/services/urlifyer_spec.rb
@@ -1,4 +1,3 @@
-# encoding: utf-8
 require "rails_helper"
 
 RSpec.describe Urlifyer do


### PR DESCRIPTION
- Upgrade `fog-aws` (unblocking nokogiri upgrade for Rails 5 upgrade)
- Add an `ApplicationUploader` for all the other uploaders to inherit from (cleaning up some of the carrierwave stuff)
- remove legacy utf magic comments because Ruby 2 made them unnecessary