### PR TITLE
Include sync in prepare_translations task

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,14 +17,10 @@ gem "flipper"
 gem "flipper-active_record"
 gem "flipper-ui"
 
-# I18n
+# I18n - localization/translation
 gem "i18n-country-translations"
 gem "rails-i18n"
 gem "translation"
-group :development, :test do
-  gem "i18n-tasks"
-  gem "i18n_generators"
-end
 
 # Redis and redis dependents
 gem "hiredis"
@@ -166,6 +162,9 @@ group :development, :test do
   gem "rubocop-daemon", "~> 0.3.1", require: false
   gem "rubocop-performance", "~> 1.1.0", require: false
   gem "rufo", "~> 0.7.0", require: false
+  # I18n - localization/translation
+  gem "i18n-tasks"
+  gem "i18n_generators"
 end
 
 group :test do

--- a/README.markdown
+++ b/README.markdown
@@ -63,13 +63,17 @@ We're using [translation.io](https://translation.io) to manage internationalizat
 To contribute, sign up for an account there and ask to be added to the project
 as a translator.
 
-If you modify any English translation files locally (e.g.
-`config/locales/en.yml`), run `bin/rake prepare_translations` before pushing to
-GitHub. This will normalize translation file formatting and check for missing or
-unused keys.
+**Non-English translation files should be treated as read-only.** We sync these
+with our translation.io project
 
-Non-English translation files should be treated as read-only. We sync these
-with our translation.io project during prepare_translations if the project API key is set.
+If you modify the English translation file [config/locales/en.yml], run:
+
+```
+bin/rake prepare_translations
+```
+
+before pushing to GitHub. This will normalize translation file formatting and check for missing or
+unused keys.
 
 ## Testing
 

--- a/README.markdown
+++ b/README.markdown
@@ -68,9 +68,8 @@ If you modify any English translation files locally (e.g.
 GitHub. This will normalize translation file formatting and check for missing or
 unused keys.
 
-Non-English translation files should be treated as read-only. We can sync these
-with our translation.io project by issuing `bin/rake translation:sync` see the
-[Rails client docs](https://github.com/translation/rails) for details.
+Non-English translation files should be treated as read-only. We sync these
+with our translation.io project during prepare_translations if the project API key is set.
 
 ## Testing
 

--- a/lib/tasks/rake_tasks.rake
+++ b/lib/tasks/rake_tasks.rake
@@ -25,4 +25,8 @@ task prepare_translations: :environment do
   i18n_tasks.start(["add-missing", "-v", "'TRME %{value}'"])
   i18n_tasks.start(["normalize"])
   i18n_tasks.start(["health"])
+  if ENV["TRANSLATION_IO_API_KEY"] != "something"
+    puts "Syncing translations"
+    `bin/rake translation:sync`
+  end
 end

--- a/lib/tasks/rake_tasks.rake
+++ b/lib/tasks/rake_tasks.rake
@@ -22,7 +22,6 @@ desc "Prepare translations for committing to master"
 task prepare_translations: :environment do
   require "i18n/tasks/cli"
   i18n_tasks = I18n::Tasks::CLI.new
-  i18n_tasks.start(["add-missing", "-v", "'TRME %{value}'"])
   i18n_tasks.start(["normalize"])
   i18n_tasks.start(["health"])
   if ENV["TRANSLATION_IO_API_KEY"] != "something"


### PR DESCRIPTION
Include `translation:sync` in `bin/rake prepare_translations` task.

I think this is useful because running `translation:sync` radically alters the normalized output (since it overrides any changes the normalization makes to non-english translations) - so I think it should be run any time you run the prepare_translation task. Is there a time when we wouldn't want prepare_translations to include sync (provided the API key is available?)