### PR TITLE
Fix non-stolen bikes being called stolen in finished_registration email

### DIFF
--- a/app/views/organized_mailer/finished_registration.html.haml
+++ b/app/views/organized_mailer/finished_registration.html.haml
@@ -21,12 +21,14 @@
 
 %p
   - org_name = @creation_org&.name || @ownership&.creator&.display_name
-  - bike_type = @bike.stolen? && @bike.recovered? ? t(".html.recovered_biketype", biketype: @bike.type) : t(".html.stolen_biketype", biketype: @bike.type)
+  - if @bike.stolen?
+    - bike_type = @bike.recovered? ? t(".html.recovered_biketype", biketype: @bike.type) : t(".html.stolen_biketype", biketype: @bike.type)
+  - else
+    - bike_type = @bike.type
 
-  - case
-  - when @vars[:registered_by_owner]
+  - if @vars[:registered_by_owner]
     = t(".html.you_added_a_bike_type_on_bike_index", bike_type: bike_type)
-  - when @vars[:new_registration]
+  - elsif @vars[:new_registration]
     = t(".html.org_added_a_bike_html", org_name: org_name, bike_type: bike_type)
   - else
     = t(".html.org_sent_a_bike_html", org_name: org_name, bike_type: bike_type)


### PR DESCRIPTION
<img width="710" alt="Screen Shot 2019-07-24 at 4 57 48 PM" src="https://user-images.githubusercontent.com/1235441/61836418-f85eb700-ae34-11e9-80fe-687b530ecafd.png">

Fix so this doesn't say stolen