### PR TITLE
Improve bike authorize_and_claim_for_user naming

### DIFF
--- a/app/controllers/api/v2/bikes.rb
+++ b/app/controllers/api/v2/bikes.rb
@@ -81,7 +81,7 @@ module API
         end
 
         def authorize_bike_for_user(addendum = "")
-          return true if @bike.authorize_for_user!(current_user)
+          return true if @bike.authorize_and_claim_for_user(current_user)
           error!("You do not own that #{@bike.type}#{addendum}", 403)
         end
       end

--- a/app/controllers/bikes_controller.rb
+++ b/app/controllers/bikes_controller.rb
@@ -308,7 +308,7 @@ class BikesController < ApplicationController
   def ensure_user_allowed_to_edit
     @current_ownership = @bike.current_ownership
     type = @bike && @bike.type || "bike"
-    return true if @bike.authorize_for_user!(current_user)
+    return true if @bike.authorize_and_claim_for_user(current_user)
     if current_user.present?
       error = "Oh no! It looks like you don't own that #{type}."
     else

--- a/app/controllers/theft_alerts_controller.rb
+++ b/app/controllers/theft_alerts_controller.rb
@@ -34,7 +34,7 @@ class TheftAlertsController < ApplicationController
   def ensure_user_allowed_to_create_theft_alert
     @bike = Bike.find_by(id: params[:bike_id])
     @current_ownership = @bike&.current_ownership
-    return true if @bike&.authorize_for_user!(current_user)
+    return true if @bike&.authorize_and_claim_for_user(current_user)
 
     flash[:error] = "You don't have permission to do that. Please contact support."
     redirect_to bikes_url and return

--- a/app/models/bike.rb
+++ b/app/models/bike.rb
@@ -272,7 +272,7 @@ class Bike < ActiveRecord::Base
     authorized_by_organization?(u: u)
   end
 
-  def authorize_for_user!(u)
+  def authorize_and_claim_for_user(u)
     return authorized_for_user?(u) unless claimable_by?(u)
     current_ownership.mark_claimed
     true

--- a/spec/models/bike_spec.rb
+++ b/spec/models/bike_spec.rb
@@ -283,7 +283,7 @@ RSpec.describe Bike, type: :model do
     end
   end
 
-  describe "authorize_for_user!, authorized_for_user?" do
+  describe "authorize_and_claim_for_user, authorized_for_user?" do
     let(:bike) { ownership.bike }
     let(:creator) { ownership.creator }
     let(:user) { FactoryBot.create(:user) }
@@ -293,19 +293,19 @@ RSpec.describe Bike, type: :model do
       context "no user" do
         it "returns false" do
           expect(bike.authorized_for_user?(nil)).to be_falsey
-          expect(bike.authorize_for_user!(nil)).to be_falsey
+          expect(bike.authorize_and_claim_for_user(nil)).to be_falsey
         end
       end
       context "unauthorized" do
         it "returns false" do
           expect(bike.authorized_for_user?(user)).to be_falsey
-          expect(bike.authorize_for_user!(user)).to be_falsey
+          expect(bike.authorize_and_claim_for_user(user)).to be_falsey
         end
       end
       context "creator" do
         it "returns true" do
           expect(bike.authorized_for_user?(creator)).to be_truthy
-          expect(bike.authorize_for_user!(creator)).to be_truthy
+          expect(bike.authorize_and_claim_for_user(creator)).to be_truthy
         end
       end
       context "claimed" do
@@ -315,8 +315,8 @@ RSpec.describe Bike, type: :model do
           expect(bike.claimed?).to be_truthy
           expect(bike.authorized_for_user?(creator)).to be_falsey
           expect(bike.authorized_for_user?(user)).to be_truthy
-          expect(bike.authorize_for_user!(creator)).to be_falsey
-          expect(bike.authorize_for_user!(user)).to be_truthy
+          expect(bike.authorize_and_claim_for_user(creator)).to be_falsey
+          expect(bike.authorize_and_claim_for_user(user)).to be_truthy
         end
       end
       context "claimable_by?" do
@@ -325,11 +325,11 @@ RSpec.describe Bike, type: :model do
           expect(ownership.claimed?).to be_falsey
           expect(bike.claimed?).to be_falsey
           expect(ownership.owner).to eq creator
-          expect(bike.authorize_for_user!(creator)).to be_truthy
+          expect(bike.authorize_and_claim_for_user(creator)).to be_truthy
           expect(bike.authorized_for_user?(user)).to be_truthy
-          expect(bike.authorize_for_user!(user)).to be_truthy
+          expect(bike.authorize_and_claim_for_user(user)).to be_truthy
           expect(bike.claimed?).to be_truthy
-          expect(bike.authorize_for_user!(creator)).to be_falsey
+          expect(bike.authorize_and_claim_for_user(creator)).to be_falsey
           ownership.reload
           expect(ownership.owner).to eq user
           expect(bike.ownerships.count).to eq 1
@@ -353,8 +353,8 @@ RSpec.describe Bike, type: :model do
         expect(bike.creation_organization).to eq organization
         expect(bike.editable_organizations.pluck(:id)).to eq([organization.id])
         expect(bike.claimed?).to be_falsey
-        expect(bike.authorize_for_user!(member)).to be_truthy
-        expect(bike.authorize_for_user!(member)).to be_truthy
+        expect(bike.authorize_and_claim_for_user(member)).to be_truthy
+        expect(bike.authorize_and_claim_for_user(member)).to be_truthy
         expect(bike.claimed?).to be_falsey
         # And test authorized_by_organization?
         expect(bike.authorized_by_organization?).to be_truthy
@@ -377,9 +377,9 @@ RSpec.describe Bike, type: :model do
         expect(bike.authorized_by_organization?(u: user, org: organization)).to be_falsey
         expect(bike.authorized_by_organization?(org: Organization.new)).to be_falsey
         expect(bike.authorized_for_user?(user)).to be_falsey
-        expect(bike.authorize_for_user!(user)).to be_falsey
+        expect(bike.authorize_and_claim_for_user(user)).to be_falsey
         # Also test the post-claim authorization
-        bike.authorize_for_user!(owner)
+        bike.authorize_and_claim_for_user(owner)
         expect(bike.authorized_for_user?(owner)).to be_truthy
         expect(bike.authorized_by_organization?(u: owner)).to be_falsey # Also doesn't work for user if bike is claimed
       end
@@ -423,7 +423,7 @@ RSpec.describe Bike, type: :model do
           expect(bike.ownerships.count).to eq 2
           expect(bike.authorized_by_organization?).to be_falsey
           expect(bike.authorized_for_user?(member)).to be_falsey
-          expect(bike.authorize_for_user!(member)).to be_falsey
+          expect(bike.authorize_and_claim_for_user(member)).to be_falsey
           expect(bike.claimed?).to be_falsey
         end
         context "can_edit_claimed true" do
@@ -436,7 +436,7 @@ RSpec.describe Bike, type: :model do
             expect(bike.authorized_by_organization?).to be_truthy
             expect(bike.authorized_by_organization?(org: organization)).to be_truthy
             expect(bike.authorized_for_user?(member)).to be_truthy
-            expect(bike.authorize_for_user!(member)).to be_truthy
+            expect(bike.authorize_and_claim_for_user(member)).to be_truthy
             expect(bike.claimed?).to be_falsey
           end
         end


### PR DESCRIPTION
Rename `Bike` method `authorize_for_user!` to `authorize_and_claim_for_user`, to follow Ruby conventions.

Reasoning: I just started to write another method in bike, and was about to make it a bang method, since it also modifies state - however, I feel like bang methods should raise errors if the fail, since that seems to be a convention.

historical context: I _think_ I originally made `authorize_for_user!` a bang method to distinguish it from the similarly named `authorized_for_user?` - but I think renaming does a better job explaining what is going on and distinguishing it.