### PR TITLE
Automate Bike Code creation

### DIFF
--- a/app/controllers/admin/bike_codes_controller.rb
+++ b/app/controllers/admin/bike_codes_controller.rb
@@ -14,7 +14,7 @@ class Admin::BikeCodesController < Admin::BaseController
   private
 
   def sortable_columns
-    %w[created_at code organization_id bike_code_batch_id]
+    %w[created_at code_integer organization_id bike_code_batch_id]
   end
 
   def matching_bike_codes

--- a/app/models/bike_code_batch.rb
+++ b/app/models/bike_code_batch.rb
@@ -2,4 +2,25 @@ class BikeCodeBatch < ActiveRecord::Base
   belongs_to :user # Creator of the batch
   belongs_to :organization
   has_many :bike_codes
+
+  def max_code_integer; bike_codes.maximum(:code_integer) || 0 end
+
+  def create_codes(number_to_create, initial_code_integer: nil, kind: "sticker")
+    raise "Prefix required to create sequential codes!" unless prefix.present?
+    initial_code_integer ||= max_code_integer
+    initial_code_integer += 1 if bike_codes.where(code_integer: initial_code_integer).present?
+    clength = code_number_length_or_default # Assign so it isn't recalculated in loop
+    number_to_create.times do |i|
+      code_integer_with_padding = (i + initial_code_integer).to_s.rjust(clength, "0")
+      bike_codes.create!(organization: organization,
+                         kind: kind,
+                         code: prefix + code_integer_with_padding)
+    end
+  end
+
+  def code_number_length_or_default
+    return code_number_length if code_number_length.present?
+    # minimum of 4. Return a larger number if there's a larger code in the batch
+    max_code_integer.to_s.length > 4 ? max_code_integer.to_s.length : 4
+  end
 end

--- a/app/models/bike_code_batch.rb
+++ b/app/models/bike_code_batch.rb
@@ -3,6 +3,8 @@ class BikeCodeBatch < ActiveRecord::Base
   belongs_to :organization
   has_many :bike_codes
 
+  def min_code_integer; bike_codes.minimum(:code_integer) || 0 end
+
   def max_code_integer; bike_codes.maximum(:code_integer) || 0 end
 
   def create_codes(number_to_create, initial_code_integer: nil, kind: "sticker")
@@ -16,6 +18,7 @@ class BikeCodeBatch < ActiveRecord::Base
                          kind: kind,
                          code: prefix + code_integer_with_padding)
     end
+    update_attributes(updated_at: Time.current) # Bump
   end
 
   def code_number_length_or_default

--- a/app/models/bike_code_batch.rb
+++ b/app/models/bike_code_batch.rb
@@ -18,7 +18,7 @@ class BikeCodeBatch < ActiveRecord::Base
                          kind: kind,
                          code: prefix + code_integer_with_padding)
     end
-    update_attributes(updated_at: Time.current) # Bump
+    touch # Bump
   end
 
   def code_number_length_or_default

--- a/app/views/admin/bike_codes/index.html.haml
+++ b/app/views/admin/bike_codes/index.html.haml
@@ -14,22 +14,21 @@
       .full-screen-table
         %table.table.table-striped.table-bordered.table-sm
           %thead
+            %th Batch
+            %th Created
+            %th Updated
+            %th Creator
+            %th Organization
             %th
-              Batch
+              %small count
             %th
-              Created
+              %small claimed
+            %th Prefix
             %th
-              Creator
+              %small Min
             %th
-              Organization
-            %th
-              %small
-                count
-            %th
-              %small
-                claimed
-            %th
-              Notes
+              %small Max
+            %th Notes
           %tbody
             - bike_code_batches.each do |bike_code_batch|
               %tr
@@ -39,12 +38,11 @@
                   %span.convertTime
                     = l bike_code_batch.created_at, format: :convert_time
                 %td
-                  .less-strong-hold
-                    - if bike_code_batch.user.present?
-                      = bike_code_batch.user.display_name
-                      - if current_user.developer
-                        %small.less-strong-right
-                          = bike_code_batch.user_id
+                  %small.convertTime
+                    = l bike_code_batch.updated_at, format: :convert_time
+                %td
+                  %small
+                    = bike_code_batch.user&.display_name
                 %td
                   - if bike_code_batch.organization.present?
                     = link_to bike_code_batch.organization.name, admin_bike_codes_path(organization_id: bike_code_batch.organization_id)
@@ -55,7 +53,17 @@
                   %small
                     = number_with_delimiter(bike_code_batch.bike_codes.claimed.count)
                 %td
-                  = bike_code_batch.notes
+                  %small
+                    = bike_code_batch.prefix
+                %td
+                  %small
+                    = number_with_delimiter(bike_code_batch.min_code_integer)
+                %td
+                  %small
+                    = number_with_delimiter(bike_code_batch.max_code_integer)
+                %td
+                  %small
+                    = bike_code_batch.notes
 
 .row
   .col-md-6

--- a/app/views/admin/bike_codes/index.html.haml
+++ b/app/views/admin/bike_codes/index.html.haml
@@ -47,23 +47,17 @@
                   - if bike_code_batch.organization.present?
                     = link_to bike_code_batch.organization.name, admin_bike_codes_path(organization_id: bike_code_batch.organization_id)
                 %td
-                  %small
-                    = number_with_delimiter(bike_code_batch.bike_codes.count)
+                  %small= number_with_delimiter(bike_code_batch.bike_codes.count)
                 %td
-                  %small
-                    = number_with_delimiter(bike_code_batch.bike_codes.claimed.count)
+                  %small= number_with_delimiter(bike_code_batch.bike_codes.claimed.count)
                 %td
-                  %small
-                    = bike_code_batch.prefix
+                  %small= bike_code_batch.prefix
                 %td
-                  %small
-                    = number_with_delimiter(bike_code_batch.min_code_integer)
+                  %small= number_with_delimiter(bike_code_batch.min_code_integer)
                 %td
-                  %small
-                    = number_with_delimiter(bike_code_batch.max_code_integer)
+                  %small= number_with_delimiter(bike_code_batch.max_code_integer)
                 %td
-                  %small
-                    = bike_code_batch.notes
+                  %small= bike_code_batch.notes
 
 .row
   .col-md-6
@@ -112,18 +106,12 @@
 .full-screen-table
   %table.table.table-striped.table-bordered.table-sm.without-exterior-border
     %thead.small-header
-      %th
-        = sortable "created_at"
-      %th
-        = sortable "organization_id"
-      %th
-        = sortable "bike_code_batch_id", "Batch"
-      %th
-        Linked
-      %th
-        Bike
-      %th
-        = sortable "code_integer", "Code #"
+      %th= sortable "created_at"
+      %th= sortable "organization_id"
+      %th= sortable "bike_code_batch_id", "Batch"
+      %th Linked
+      %th Bike
+      %th= sortable "code_integer", "Code #"
     %tbody
       - @bike_codes.each do |bike_code|
         %tr

--- a/app/views/admin/bike_codes/index.html.haml
+++ b/app/views/admin/bike_codes/index.html.haml
@@ -115,7 +115,7 @@
       %th
         Bike
       %th
-        = sortable "code"
+        = sortable "code_integer", "Code #"
     %tbody
       - @bike_codes.each do |bike_code|
         %tr

--- a/db/migrate/20190725172835_add_prefix_to_bike_code_batch.rb
+++ b/db/migrate/20190725172835_add_prefix_to_bike_code_batch.rb
@@ -1,0 +1,5 @@
+class AddPrefixToBikeCodeBatch < ActiveRecord::Migration
+  def change
+    add_column :bike_code_batches, :prefix, :string
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -202,7 +202,8 @@ CREATE TABLE public.bike_code_batches (
     notes text,
     created_at timestamp without time zone NOT NULL,
     updated_at timestamp without time zone NOT NULL,
-    code_number_length integer
+    code_number_length integer,
+    prefix character varying
 );
 
 
@@ -925,6 +926,41 @@ CREATE SEQUENCE public.front_gear_types_id_seq
 --
 
 ALTER SEQUENCE public.front_gear_types_id_seq OWNED BY public.front_gear_types.id;
+
+
+--
+-- Name: impound_records; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.impound_records (
+    id integer NOT NULL,
+    bike_id integer,
+    user_id integer,
+    organization_id integer,
+    retrieved_at timestamp without time zone,
+    created_at timestamp without time zone NOT NULL,
+    updated_at timestamp without time zone NOT NULL
+);
+
+
+--
+-- Name: impound_records_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.impound_records_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: impound_records_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.impound_records_id_seq OWNED BY public.impound_records.id;
 
 
 --
@@ -2402,6 +2438,13 @@ ALTER TABLE ONLY public.front_gear_types ALTER COLUMN id SET DEFAULT nextval('pu
 
 
 --
+-- Name: impound_records id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.impound_records ALTER COLUMN id SET DEFAULT nextval('public.impound_records_id_seq'::regclass);
+
+
+--
 -- Name: integrations id; Type: DEFAULT; Schema: public; Owner: -
 --
 
@@ -2814,6 +2857,14 @@ ALTER TABLE ONLY public.flipper_gates
 
 ALTER TABLE ONLY public.front_gear_types
     ADD CONSTRAINT front_gear_types_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: impound_records impound_records_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.impound_records
+    ADD CONSTRAINT impound_records_pkey PRIMARY KEY (id);
 
 
 --
@@ -4386,4 +4437,8 @@ INSERT INTO schema_migrations (version) VALUES ('20190709011902');
 INSERT INTO schema_migrations (version) VALUES ('20190710203715');
 
 INSERT INTO schema_migrations (version) VALUES ('20190710230727');
+
+INSERT INTO schema_migrations (version) VALUES ('20190725141309');
+
+INSERT INTO schema_migrations (version) VALUES ('20190725172835');
 

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -929,41 +929,6 @@ ALTER SEQUENCE public.front_gear_types_id_seq OWNED BY public.front_gear_types.i
 
 
 --
--- Name: impound_records; Type: TABLE; Schema: public; Owner: -
---
-
-CREATE TABLE public.impound_records (
-    id integer NOT NULL,
-    bike_id integer,
-    user_id integer,
-    organization_id integer,
-    retrieved_at timestamp without time zone,
-    created_at timestamp without time zone NOT NULL,
-    updated_at timestamp without time zone NOT NULL
-);
-
-
---
--- Name: impound_records_id_seq; Type: SEQUENCE; Schema: public; Owner: -
---
-
-CREATE SEQUENCE public.impound_records_id_seq
-    AS integer
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
-
-
---
--- Name: impound_records_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
---
-
-ALTER SEQUENCE public.impound_records_id_seq OWNED BY public.impound_records.id;
-
-
---
 -- Name: integrations; Type: TABLE; Schema: public; Owner: -
 --
 
@@ -2438,13 +2403,6 @@ ALTER TABLE ONLY public.front_gear_types ALTER COLUMN id SET DEFAULT nextval('pu
 
 
 --
--- Name: impound_records id; Type: DEFAULT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.impound_records ALTER COLUMN id SET DEFAULT nextval('public.impound_records_id_seq'::regclass);
-
-
---
 -- Name: integrations id; Type: DEFAULT; Schema: public; Owner: -
 --
 
@@ -2857,14 +2815,6 @@ ALTER TABLE ONLY public.flipper_gates
 
 ALTER TABLE ONLY public.front_gear_types
     ADD CONSTRAINT front_gear_types_pkey PRIMARY KEY (id);
-
-
---
--- Name: impound_records impound_records_pkey; Type: CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.impound_records
-    ADD CONSTRAINT impound_records_pkey PRIMARY KEY (id);
 
 
 --
@@ -4437,8 +4387,6 @@ INSERT INTO schema_migrations (version) VALUES ('20190709011902');
 INSERT INTO schema_migrations (version) VALUES ('20190710203715');
 
 INSERT INTO schema_migrations (version) VALUES ('20190710230727');
-
-INSERT INTO schema_migrations (version) VALUES ('20190725141309');
 
 INSERT INTO schema_migrations (version) VALUES ('20190725172835');
 

--- a/spec/factories/bike_code_batches.rb
+++ b/spec/factories/bike_code_batches.rb
@@ -1,5 +1,6 @@
 FactoryBot.define do
   factory :bike_code_batch do
     user { FactoryBot.create(:admin) }
+    sequence(:prefix) { |n| "G#{n}" }
   end
 end

--- a/spec/models/bike_code_batch_spec.rb
+++ b/spec/models/bike_code_batch_spec.rb
@@ -15,12 +15,15 @@ RSpec.describe BikeCodeBatch, type: :model do
     let(:bike_code_batch) { FactoryBot.create(:bike_code_batch, prefix: "XD", code_number_length: nil, organization: organization) }
     let(:target_codes) { %w[XD9999 XD10000 XD10001] }
     it "create_codes works and derives last code" do
+      bike_code_batch.update_column :updated_at, Time.current - 1.hour
+      expect(bike_code_batch.updated_at).to be < Time.current - 50.minutes
       expect(bike_code_batch.code_number_length_or_default).to eq 4
       expect(bike_code_batch.bike_codes.count).to eq 0
       expect do
         bike_code_batch.create_codes(3, initial_code_integer: 9999)
       end.to change(BikeCode, :count).by 3
       bike_code_batch.reload
+      expect(bike_code_batch.updated_at).to be_within(1.second).of Time.current
       expect(bike_code_batch.bike_codes.count).to eq 3
       expect(bike_code_batch.bike_codes.sticker.count).to eq 3
       expect(organization.bike_codes.count).to eq 3

--- a/spec/models/bike_code_batch_spec.rb
+++ b/spec/models/bike_code_batch_spec.rb
@@ -9,4 +9,49 @@ RSpec.describe BikeCodeBatch, type: :model do
       expect(bike_code.bike_code_batch).to eq bike_code_batch
     end
   end
+
+  describe "create_codes" do
+    let(:organization) { FactoryBot.create(:organization) }
+    let(:bike_code_batch) { FactoryBot.create(:bike_code_batch, prefix: "XD", code_number_length: nil, organization: organization) }
+    let(:target_codes) { %w[XD9999 XD10000 XD10001] }
+    it "create_codes works and derives last code" do
+      expect(bike_code_batch.code_number_length_or_default).to eq 4
+      expect(bike_code_batch.bike_codes.count).to eq 0
+      expect do
+        bike_code_batch.create_codes(3, initial_code_integer: 9999)
+      end.to change(BikeCode, :count).by 3
+      bike_code_batch.reload
+      expect(bike_code_batch.bike_codes.count).to eq 3
+      expect(bike_code_batch.bike_codes.sticker.count).to eq 3
+      expect(organization.bike_codes.count).to eq 3
+      expect(bike_code_batch.bike_codes.pluck(:code)).to match_array target_codes
+      expect(bike_code_batch.bike_codes.pluck(:code_integer)).to match_array([9999, 10_000, 10_001])
+      expect(bike_code_batch.code_number_length_or_default).to eq 5
+
+      expect do
+        bike_code_batch.create_codes(1)
+      end.to change(BikeCode, :count).by 1
+      expect(bike_code_batch.bike_codes.pluck(:code)).to match_array(target_codes + ["XD10002"])
+
+      # If passed a code number that already exists, it creates the following one
+      expect do
+        bike_code_batch.create_codes(1, initial_code_integer: 10_002)
+      end.to change(BikeCode, :count).by 1
+      expect(bike_code_batch.bike_codes.pluck(:code)).to match_array(target_codes + %w[XD10002 XD10003])
+
+      # It can do earlier numbers too. If doing so, it left pads accordingly
+      expect do
+        bike_code_batch.create_codes(1, initial_code_integer: 12)
+      end.to change(BikeCode, :count).by 1
+      expect(bike_code_batch.bike_codes.pluck(:code)).to match_array(target_codes + %w[XD10002 XD10003 XD00012])
+    end
+    context "without a prefix" do
+      let(:bike_code_batch) { FactoryBot.create(:bike_code_batch, prefix: nil) }
+      it "errors" do
+        expect do
+          bike_code_batch.create_codes(100)
+        end.to raise_error(/prefix/i)
+      end
+    end
+  end
 end

--- a/spec/models/bike_code_batch_spec.rb
+++ b/spec/models/bike_code_batch_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe BikeCodeBatch, type: :model do
       end.to change(BikeCode, :count).by 1
       expect(bike_code_batch.bike_codes.pluck(:code)).to match_array(target_codes + %w[XD10002 XD10003])
 
-      # It can do earlier numbers too. If doing so, it left pads accordingly
+      # It can do earlier numbers too. If doing so, it pads accordingly
       expect do
         bike_code_batch.create_codes(1, initial_code_integer: 12)
       end.to change(BikeCode, :count).by 1


### PR DESCRIPTION
I made a mistake adding codes manually - so I decided it was time to add some more automation to bike code creation.

Now if you have a `BikeCodeBatch`, you can create the next bike_codes by specifying how many you want to create.

```ruby
BikeCodeBatch.find(9).create_codes(500)
```

n.b. BikeCodes are actually stickers, see #1080