### PR TITLE
remove sync from prepare translations

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -72,6 +72,8 @@ bin/rake prepare_translations
 
 before pushing to GitHub. This will normalize translation file formatting and check for missing or unused keys.
 
+To update the keys on translation.io, run `bin/rake translation:sync` (requires having an active API key locally).
+
 ## Testing
 
 We use [RSpec](https://github.com/rspec/rspec) and

--- a/lib/tasks/rake_tasks.rake
+++ b/lib/tasks/rake_tasks.rake
@@ -24,8 +24,4 @@ task prepare_translations: :environment do
   i18n_tasks = I18n::Tasks::CLI.new
   i18n_tasks.start(["normalize"])
   i18n_tasks.start(["health"])
-  if ENV["TRANSLATION_IO_API_KEY"] != "something"
-    puts "Syncing translations"
-    `bin/rake translation:sync`
-  end
 end


### PR DESCRIPTION
We don't want to sync branches, we only want to sync master, so this isn't a good thing to run all the time.

Reverts some of #1073 - but we still want to skip adding the missing translation keys, because when we do sync that will be managed.