### PR TITLE
Fix incorrect interpolation arg

### DIFF
--- a/app/views/organized_mailer/finished_registration.text.haml
+++ b/app/views/organized_mailer/finished_registration.text.haml
@@ -26,7 +26,7 @@
   - if @bike.recovered?
     = t(".text.bike_found_at", address: stolen_record.address(skip_default_country: true))
   - else
-    = t(".text.bike_stolen_from", address:  stolen_record.address(skip_default_country: true))
+    = t(".text.bike_stolen_from", address: stolen_record.address(skip_default_country: true))
 
   = t(".text.bike_date", date: l(stolen_record.date_stolen, format: :dotted))
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3665,7 +3665,7 @@ en:
           can't be easily removed."
         bike_colors: 'Color(s): %{frame_colors}'
         bike_date: 'Date: %{date}'
-        bike_found_at: 'Found: %{country}'
+        bike_found_at: 'Found: %{address}'
         bike_make: 'Make: %{bike_mnfg_name}'
         bike_serial: 'Serial: %{bike_serial_number}'
         bike_stolen_from: 'Stolen from: %{address}'


### PR DESCRIPTION
Original:

```haml
- if @bike.stolen
  - stolen_record = @bike.current_stolen_record
  #{ @bike.recovered ? 'Found:' : 'Stolen from:' }#{ stolen_record.address(skip_default_country: true) }

  Date: #{ l stolen_record.date_stolen, format: :dotted }
```

Resolves https://app.honeybadger.io/projects/35931/faults/52572238