### PR TITLE
Add translation sync build step

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,6 +9,7 @@ jobs:
       RACK_ENV: test
       COVERAGE: true
       DISABLE_SPRING: true
+      TRANSLATION_BRANCH: master
       TZ: /usr/share/zoneinfo/America/Chicago
 
     docker:
@@ -35,16 +36,48 @@ jobs:
           environment:
             DOCKERIZE_VERSION: v0.6.1
 
+      - restore_cache:
+          key: v2-git-2.22.0
+      - run:
+          name: Install Git
+          environment:
+            GIT_VERSION: 2.22.0
+          command: |
+            mkdir deps-git
+            cd    deps-git
+
+            sudo apt-get update
+            sudo apt-get install libcurl4-gnutls-dev libexpat1-dev gettext libz-dev libssl-dev
+
+            wget -O git.tgz https://mirrors.edge.kernel.org/pub/software/scm/git/git-${GIT_VERSION}.tar.gz
+            tar -xzf git.tgz
+            cd git-${GIT_VERSION}
+
+            sudo make prefix=/usr/local all
+            sudo cp ./git /usr/local/bin/git
+      - save_cache:
+          key: v2-git-2.22.0
+          paths:
+            - deps-git
+
+      - restore_cache:
+          key: v2-hub-2.12.3
       - run:
           name: Install Hub
-          command: |
-            command -v hub >/dev/null && exit 0
-            wget -O hub.tgz https://github.com/github/hub/releases/download/v${HUB_VERSION}/hub-linux-amd64-${HUB_VERSION}.tgz
-            tar -xzf hub.tgz
-            sudo mv hub-linux-amd64-${HUB_VERSION}/bin/hub /usr/bin/
-            rm -rf hub-linux-amd64-${HUB_VERSION} hub.tgz
           environment:
             HUB_VERSION: 2.12.3
+          command: |
+            mkdir deps-hub
+            cd    deps-hub
+
+            wget -O hub.tgz https://github.com/github/hub/releases/download/v${HUB_VERSION}/hub-linux-amd64-${HUB_VERSION}.tgz
+            tar -xzf hub.tgz
+
+            sudo cp ./hub-linux-amd64-${HUB_VERSION}/bin/hub /usr/local/bin/hub
+      - save_cache:
+          key: v2-hub-2.12.3
+          paths:
+            - deps-hub
 
       - run:
           name: Install system libraries
@@ -68,43 +101,7 @@ jobs:
 
       - run:
           name: Sync translations (only on master by default)
-          command: |
-            # Quit as success if not on the branch to be synced
-            if ! git branch --list | grep "^* ${TRANSLATION_BRANCH}$"; then
-              echo Skipping: Not on branch ${TRANSLATION_BRANCH}
-              exit 0
-            fi
-
-            # TODO: Delete test code
-            echo bundle exec rake translations:sync >> Gemfile
-            # bundle exec rake translations:sync
-
-            if [[ -n `git status --porcelain --short` ]]; then
-              echo ------------------------
-              echo Uncommitted translations:
-              echo ------------------------
-              git --no-pager diff
-
-              echo ------------------------
-              git config user.email "ci@bikeindex.org"
-              git config user.name "CircleCI"
-
-              BRANCH="translation-update-${CIRCLE_BUILD_NUM}"
-              git stash
-              git clean -df
-              git checkout -b ${BRANCH}
-              git reset --hard origin/master
-              git stash pop
-              git add .
-              git commit -m "Translation update [ci skip]"
-              git push -u origin ${BRANCH}
-              hub pull-request \
-              -m "[CircleCI] Translation update
-
-              Merge to Unblock CircleCI Job ${CIRCLE_BUILD_NUM}: ${CIRCLE_BUILD_URL}
-              Related: PR ${CIRCLE_PULL_REQUEST}"
-              exit 1
-            fi
+          command: bin/check_translations
 
       # Node dependencies
       - restore_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,33 +23,88 @@ jobs:
       - image: redis:4.0.9
 
     steps:
+      - add_ssh_keys:
+          fingerprints:
+            - "b7:01:89:de:d8:f8:77:cc:9e:5a:ca:ee:0c:24:57:13"
+
       - checkout
 
       - run:
-          name: install dockerize
+          name: Install Dockerize
           command: wget https://github.com/jwilder/dockerize/releases/download/$DOCKERIZE_VERSION/dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz && sudo tar -C /usr/local/bin -xzvf dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz && rm dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz
           environment:
             DOCKERIZE_VERSION: v0.6.1
 
       - run:
-          name: install system libraries
+          name: Install Hub
+          command: |
+            command -v hub >/dev/null && exit 0
+            wget -O hub.tgz https://github.com/github/hub/releases/download/v${HUB_VERSION}/hub-linux-amd64-${HUB_VERSION}.tgz
+            tar -xzf hub.tgz
+            sudo mv hub-linux-amd64-${HUB_VERSION}/bin/hub /usr/bin/
+            rm -rf hub-linux-amd64-${HUB_VERSION} hub.tgz
+          environment:
+            HUB_VERSION: 2.12.3
+
+      - run:
+          name: Install system libraries
           command: sudo apt-get update && sudo apt-get -y install imagemagick postgresql-client
 
       - run:
-          name: install bundler
+          name: Install Bundler
           command: gem install bundler
 
       # Ruby dependencies
       - restore_cache:
           key: v2-bundler-{{ checksum "Gemfile.lock" }}
       - run:
-          name: bundle gems
+          name: Bundle Gems
           command: bundle install --path=vendor/bundle --jobs=4 --retry=3
       - save_cache:
           key: v2-bundler-{{ checksum "Gemfile.lock" }}
           paths:
             - vendor/bundle
             - ~/.bundle
+
+      - run:
+          name: Sync translations (only on master by default)
+          command: |
+            # Quit as success if not on the branch to be synced
+            if ! git branch --list | grep "^* ${TRANSLATION_BRANCH}$"; then
+              echo Skipping: Not on branch ${TRANSLATION_BRANCH}
+              exit 0
+            fi
+
+            # TODO: Delete test code
+            echo bundle exec rake translations:sync >> Gemfile
+            # bundle exec rake translations:sync
+
+            if [[ -n `git status --porcelain --short` ]]; then
+              echo ------------------------
+              echo Uncommitted translations:
+              echo ------------------------
+              git --no-pager diff
+
+              echo ------------------------
+              git config user.email "ci@bikeindex.org"
+              git config user.name "CircleCI"
+
+              BRANCH="translation-update-${CIRCLE_BUILD_NUM}"
+              git stash
+              git clean -df
+              git checkout -b ${BRANCH}
+              git reset --hard origin/master
+              git stash pop
+              git add .
+              git commit -m "Translation update [ci skip]"
+              git push -u origin ${BRANCH}
+              hub pull-request \
+              -m "[CircleCI] Translation update
+
+              Merge to Unblock CircleCI Job ${CIRCLE_BUILD_NUM}: ${CIRCLE_BUILD_URL}
+              Related: PR ${CIRCLE_PULL_REQUEST}"
+              exit 1
+            fi
 
       # Node dependencies
       - restore_cache:
@@ -135,7 +190,7 @@ jobs:
 
   upload-coverage:
     docker:
-      - image: circleci/ruby:2.5.1-stretch-node
+      - image: circleci/ruby:2.5.5-stretch-node
     environment:
       CC_TEST_REPORTER_ID: 04daa6564351115dc1515504790cd379ad8dc25e7778f0641e0f8c63185f887c
     working_directory: ~/bikeindex/bike_index

--- a/README.markdown
+++ b/README.markdown
@@ -56,7 +56,8 @@ This explanation assumes you're familiar with developing Ruby on Rails applicati
 
 ## Translation
 
-We're using [translation.io](https://translation.io) to manage internationalization: [translation.io/bikeindex/bike_index](https://translation.io/bikeindex/bike_index)
+We're using [translation.io](https://translation.io) to manage internationalization:
+[translation.io/bikeindex/bike_index](https://translation.io/bikeindex/bike_index)
 
 To contribute, sign up for an account there and ask to be added to the project
 as a translator.
@@ -64,15 +65,25 @@ as a translator.
 **Non-English translation files should be treated as read-only.** We sync these
 with our translation.io project
 
-If you modify the English translation file [config/locales/en.yml](config/locales/en.yml), run:
+If you modify the English translation file
+[config/locales/en.yml](config/locales/en.yml), run:
 
-```
+```shell
 bin/rake prepare_translations
 ```
 
-before pushing to GitHub. This will normalize translation file formatting and check for missing or unused keys.
+before pushing to GitHub. This will normalize translation file formatting and
+check for missing or unused keys.
 
-To update the keys on translation.io, run `bin/rake translation:sync` (requires having an active API key locally).
+### Syncing Translations
+
+When building master, we check for un-synced translations and, if any are found,
+stop the build and open a PR to master with the translation updates. (See
+[#1100](https://github.com/bikeindex/bike_index/pull/1100) for details.)
+
+To update the keys on translation.io, run `bin/rake translation:sync` (requires
+having an active API key locally).
+
 
 ## Testing
 

--- a/bin/check_translations
+++ b/bin/check_translations
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+
+set -e
+
+CYAN="\033[0;36m"
+YELLOW="\033[0;33m"
+RED="\033[0;31m"
+GREEN="\033[0;32m"
+NONE="\033[0m"
+
+output() {
+  printf "\n${1}${2}${NONE}\n\n"
+}
+
+alias git=/usr/local/bin/git
+
+output "${CYAN}" "Checking Translations"
+
+# Quit as success if not on the branch to be synced
+if ! git branch --list | grep --silent "^* ${TRANSLATION_BRANCH}$"; then
+  output "${GREEN}" "Skipping: Not on TRANSLATION_BRANCH: ${TRANSLATION_BRANCH}"
+  exit 0
+fi
+
+echo bundle exec rake translation:sync
+bundle exec rake translation:sync
+
+output "${YELLOW}" "Stashing translation.io timestamp file"
+set -x
+git stash -- config/locales/.translation_io
+git status --short
+set +x
+
+if [[ -z "$(git --no-pager diff)" ]]; then
+  output "${GREEN}" "No uncommitted translations. Done."
+  exit 0
+else
+  output "${RED}" "Uncommitted Translations"
+  git --no-pager diff
+
+  git config user.email "ci@bikeindex.org"
+  git config user.name "CircleCI"
+
+  output "${YELLOW}" "Committing and pushing translation update"
+  BRANCH="translation-update-${CIRCLE_BUILD_NUM}"
+  set -x
+  git clean --quiet --force -d -x
+  git stash
+  git checkout -b ${BRANCH}
+  git reset --hard origin/master
+  git stash pop
+  git stash pop
+  git add .
+  git commit -m "Translation update [ci skip]"
+  git push -u origin ${BRANCH}
+  set +x
+
+  output "${YELLOW}" "Creating Update Pull Request"
+  hub pull-request \
+      -m "[i18n] Translation update
+
+          Merge to unblock CI job ${CIRCLE_BUILD_NUM}: ${CIRCLE_BUILD_URL}
+          Related: PR ${CIRCLE_PULL_REQUEST}"
+
+  output "${GREEN}" "Translation update PR Created."
+  exit 1
+fi


### PR DESCRIPTION
To automate translation syncing and updating, this patch adds a build step which checks for translation updates and, if any are found, stops the build and creates a PR for those changes. 

This is meant to be run on `master` in order to stop deployments, but can be customized (see below).

- Added a read-write SSH key to CircleCI and GitHub
Public: https://github.com/bikeindex/bike_index/settings/keys
Private: https://circleci.com/gh/bikeindex/bike_index/edit#ssh

- Added a [personal access token](https://github.com/settings/tokens) to CircleCI and exposed to builds as the `GITHUB_TOKEN` env variable. Used by [Hub](https://hub.github.com/) to create PRs on GitHub.

- Checks for un-synced translations only when building `master`. The branch is customizable by setting the `TRANSLATION_BRANCH` [env var](https://circleci.com/gh/bikeindex/bike_index/edit#env-vars) on CircleCI.

Reference:

https://circleci.com/docs/2.0/gh-bb-integration/#creating-a-github-user-key