### PR TITLE
Move test-specific CarrierWave settings to rails_helper

### DIFF
--- a/config/initializers/carrierwave.rb
+++ b/config/initializers/carrierwave.rb
@@ -54,14 +54,3 @@ CarrierWave.configure do |config|
     config.enable_processing = false
   end
 end
-
-RSpec.configure do |config|
-  config.before(:all) do
-    FileUtils.mkdir_p(ApplicationUploader.cache_dir)
-  end
-
-  config.after(:all) do
-    FileUtils.rm_rf(ApplicationUploader.cache_dir)
-    FileUtils.mkdir_p(ApplicationUploader.cache_dir)
-  end
-end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -166,3 +166,16 @@ RSpec.configure do |config|
     DatabaseCleaner.clean
   end
 end
+
+# CarrierWave Settings
+# ====================
+RSpec.configure do |config|
+  config.before(:all) do
+    FileUtils.mkdir_p(ApplicationUploader.cache_dir)
+  end
+
+  config.after(:all) do
+    FileUtils.rm_rf(ApplicationUploader.cache_dir)
+    FileUtils.mkdir_p(ApplicationUploader.cache_dir)
+  end
+end


### PR DESCRIPTION
Hotfix -- `RSpec` isn't defined during deployment init, so this patch moves CarrierWave RSpec settings to rails_helper.