### PR TITLE
Fix prod assets host config

### DIFF
--- a/app/services/stolen_record_updator.rb
+++ b/app/services/stolen_record_updator.rb
@@ -17,8 +17,7 @@ class StolenRecordUpdator
         s.save
       end
     end
-    @bike.reload
-    @bike.update_attribute :current_stolen_record_id, nil
+    @bike.reload.update_attribute :current_stolen_record_id, nil
   end
 
   def update_records

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -54,9 +54,6 @@ Rails.application.configure do
   # Raises helpful error messages.
   config.assets.raise_runtime_errors = true
 
-  # Enable serving of images, stylesheets, and JavaScripts from an asset server.
-  config.action_controller.asset_host = ENV["BASE_URL"]
-
   config.lograge.enabled = true
   config.log_level = :debug
   config.lograge.formatter = Lograge::Formatters::Logstash.new # Use logstash format

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -65,7 +65,7 @@ Rails.application.configure do
   # config.cache_store = :mem_cache_store
 
   # Enable serving of images, stylesheets, and JavaScripts from an asset server.
-  config.action_controller.asset_host = ENV["S3_ASSET_HOST"]
+  # config.action_controller.asset_host = 'http://assets.example.com'
 
   # Ignore bad email addresses and do not raise email delivery errors.
   # Set this to true and configure the email server for immediate delivery to raise delivery errors.

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -46,7 +46,4 @@ Rails.application.configure do
   config.action_mailer.default_url_options = { host: ENV["BASE_URL"] }
 
   config.cache_store = :file_store, Rails.root.join("tmp", "cache", "test#{ENV["TEST_ENV_NUMBER"]}")
-
-  # Enable serving of images, stylesheets, and JavaScripts from an asset server.
-  config.action_controller.asset_host = ENV["BASE_URL"]
 end

--- a/config/initializers/carrierwave.rb
+++ b/config/initializers/carrierwave.rb
@@ -33,13 +33,14 @@ end
 
 # Additional carrierwave configurations
 CarrierWave.configure do |config|
-  config.asset_host = ActionController::Base.asset_host
   config.cache_dir = Rails.root.join("tmp", "uploads")
   config.storage :file
+  config.asset_host = ENV["BASE_URL"]
 
   if Rails.env.production?
     # config.fog_provider "fog/aws" # Once carrierwave is updated
     config.storage = :fog
+    config.asset_host = ENV["S3_ASSET_HOST"]
     config.fog_credentials = {
       provider: "AWS",
       aws_access_key_id: ENV["S3_ACCESS_KEY"],

--- a/spec/decorators/bike_decorator_spec.rb
+++ b/spec/decorators/bike_decorator_spec.rb
@@ -83,7 +83,7 @@ RSpec.describe BikeDecorator do
         decorator = BikeDecorator.new(bike)
         allow(decorator).to receive(:title_string).and_return("Title")
         expect(decorator.thumb_image).to match(%r{img alt="Title"})
-        expect(decorator.thumb_image).to match(%r{src=".+/images/pathy"})
+        expect(decorator.thumb_image).to match(%r{src=".+images/pathy"})
       end
     end
     context "bike photo does not exist" do


### PR DESCRIPTION
#1091 Breaks asset loading -- the changes to the app asset_host were overkill. This patch reverts those changes and instead sets `config.asset_host = ENV["BASE_URL"]` for CarrierWave specifically.