### PR TITLE
Fix premature image removal bug

### DIFF
--- a/app/models/stolen_record.rb
+++ b/app/models/stolen_record.rb
@@ -277,6 +277,6 @@ class StolenRecord < ActiveRecord::Base
 
   # If the bike has been recovered, remove the alert_image
   def remove_outdated_alert_image
-    alert_image.remove! if date_recovered.present?
+    alert_image.remove! unless bike.reload.stolen?
   end
 end

--- a/app/uploaders/alert_image_uploader.rb
+++ b/app/uploaders/alert_image_uploader.rb
@@ -12,7 +12,7 @@ class AlertImageUploader < ApplicationUploader
 
   def filename
     return if stolen_record.alert_image.blank?
-    file, _ = File.basename(stolen_record.alert_image.path, ".*").split("-")
+    file, _ = File.basename(stolen_record.alert_image.path, ".*").split("-alert")
     "#{file}-alert.jpg"
   end
 

--- a/app/workers/email_stolen_bike_alert_worker.rb
+++ b/app/workers/email_stolen_bike_alert_worker.rb
@@ -1,5 +1,4 @@
 class EmailStolenBikeAlertWorker < ApplicationWorker
-
   sidekiq_options queue: "notify"
 
   def perform(customer_contact_id)

--- a/config/initializers/carrierwave.rb
+++ b/config/initializers/carrierwave.rb
@@ -50,8 +50,5 @@ CarrierWave.configure do |config|
     config.fog_directory = ENV["S3_BUCKET"]
     config.fog_attributes = { "Cache-Control" => "max-age=315576000" }
     config.storage :fog
-  elsif Rails.env.test?
-    config.cache_dir = Rails.root.join("tmp", "cache", "carrierwave#{ENV["TEST_ENV_NUMBER"]}")
-    config.enable_processing = false
   end
 end

--- a/spec/factories/public_images.rb
+++ b/spec/factories/public_images.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :public_image do
-    sequence(:image) { |i| File.open(ApplicationUploader.cache_dir.join("bike#{i}.jpg"), "w+") }
+    sequence(:image) { |i| File.open(ApplicationUploader.cache_dir.join("bike-#{i}.jpg"), "w+") }
     imageable { FactoryBot.create(:bike) }
   end
 end

--- a/spec/factories/stolen_records.rb
+++ b/spec/factories/stolen_records.rb
@@ -5,6 +5,7 @@ FactoryBot.define do
     sequence(:alert_image) { |i| File.open(ApplicationUploader.cache_dir.join("alert_image-#{i}-alert.jpg"), "w+") }
 
     factory :stolen_record_recovered do
+      bike { FactoryBot.create(:bike, :with_image) }
       date_recovered { Time.current }
       recovered_description { "Awesome help by Bike Index" }
       current { false }

--- a/spec/factories/stolen_records.rb
+++ b/spec/factories/stolen_records.rb
@@ -2,7 +2,7 @@ FactoryBot.define do
   factory :stolen_record do
     bike { FactoryBot.create(:bike, :with_image) }
     date_stolen { Time.current }
-    sequence(:alert_image) { |i| File.open(ApplicationUploader.cache_dir.join("alert_image#{i}-alert.jpg"), "w+") }
+    sequence(:alert_image) { |i| File.open(ApplicationUploader.cache_dir.join("alert_image-#{i}-alert.jpg"), "w+") }
 
     factory :stolen_record_recovered do
       date_recovered { Time.current }

--- a/spec/models/stolen_record_spec.rb
+++ b/spec/models/stolen_record_spec.rb
@@ -7,7 +7,8 @@ RSpec.describe StolenRecord, type: :model do
         stolen_record = FactoryBot.create(:stolen_record)
         expect(stolen_record.alert_image).to be_present
 
-        stolen_record.update(date_recovered: Time.current)
+        stolen_record.add_recovery_information
+        stolen_record.save
         stolen_record.run_callbacks(:commit)
 
         expect(stolen_record.alert_image).to be_blank
@@ -16,10 +17,10 @@ RSpec.describe StolenRecord, type: :model do
 
     context "if not being marked as recovered" do
       it "does not removes alert_image" do
-        stolen_record = FactoryBot.create(:stolen_record)
+        stolen_bike = FactoryBot.create(:stolen_bike)
+        stolen_record = stolen_bike.current_stolen_record
         expect(stolen_record.alert_image).to be_present
 
-        stolen_record.update(date_recovered: nil)
         stolen_record.run_callbacks(:commit)
 
         expect(stolen_record.alert_image).to be_present

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -179,3 +179,8 @@ RSpec.configure do |config|
     FileUtils.mkdir_p(ApplicationUploader.cache_dir)
   end
 end
+
+CarrierWave.configure do |config|
+  config.cache_dir = Rails.root.join("tmp", "cache", "carrierwave#{ENV["TEST_ENV_NUMBER"]}")
+  config.enable_processing = false
+end


### PR DESCRIPTION
Fixes a bug whereby alert images are removed prematurely because a bike's `current_stolen record` has `date_recovered` set.

```rb
irb(main):006:0> bike.current_stolen_record.date_recovered
=> Wed, 31 Jul 2019 20:00:00 CDT -05:00

irb(main):007:0> bike.current_stolen_record.current
=> true

irb(main):008:0> bike.stolen?
=> true

irb(main):009:0> bike.recovered?
=> false
```

Also fixes filename generation for alert images, which currently doesn't correctly handle bike images with hyphens in the name.

Resolves https://app.honeybadger.io/projects/35931/faults/52782138