### PR TITLE
Fix alert image exceptions

### DIFF
--- a/app/models/stolen_record.rb
+++ b/app/models/stolen_record.rb
@@ -277,6 +277,8 @@ class StolenRecord < ActiveRecord::Base
 
   # If the bike has been recovered, remove the alert_image
   def remove_outdated_alert_image
-    alert_image.remove! unless bike.reload.stolen?
+    if bike.blank? || !bike.stolen?
+      alert_image.remove!
+    end
   end
 end

--- a/app/services/alert_image_generator.rb
+++ b/app/services/alert_image_generator.rb
@@ -46,7 +46,8 @@ module AlertImageGenerator
       i.gravity "Northeast"
       i.pointsize 110
       i.size [nil, HEADER_HEIGHT].join("x")
-      i.draw "text 30,30 '#{bike_location}'"
+      sanitized_bike_location = bike_location.gsub("'", "\\'")
+      i.draw "text 30,30 '#{sanitized_bike_location}'"
     end
 
     alert_image.write(output_path)

--- a/app/uploaders/alert_image_uploader.rb
+++ b/app/uploaders/alert_image_uploader.rb
@@ -12,7 +12,7 @@ class AlertImageUploader < ApplicationUploader
 
   def filename
     return if stolen_record.alert_image.blank?
-    file, _ = File.basename(stolen_record.alert_image.path, ".*").split("-alert")
+    file = File.basename(stolen_record.alert_image.path, ".*").chomp("-alert")
     "#{file}-alert.jpg"
   end
 

--- a/spec/services/alert_image_generator_spec.rb
+++ b/spec/services/alert_image_generator_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe AlertImageGenerator do
       AlertImageGenerator.generate_image(
         bike_image_path: Rails.root.join("spec/fixtures/bike.jpg"),
         bike_url: "bikeindex.org/bikes/1",
-        bike_location: "New City, OR",
+        bike_location: "Coeur d'Alene, ID",
         output_path: output_location,
       )
 

--- a/spec/uploaders/alert_image_uploader_spec.rb
+++ b/spec/uploaders/alert_image_uploader_spec.rb
@@ -4,6 +4,38 @@ require "carrierwave/test/matchers"
 RSpec.describe AlertImageUploader do
   include CarrierWave::Test::Matchers
 
+  describe "#filename" do
+    it "returns nil if no alert image" do
+      stolen_record = FactoryBot.create(:stolen_record, alert_image: nil)
+      uploader = described_class.new(stolen_record, :theft_alert_image)
+      expect(uploader.filename).to be_nil
+    end
+
+    it "ignores -alert suffix" do
+      image = double(:image, path: "/path/name-alert.jpg")
+      stolen_record = FactoryBot.create(:stolen_record)
+      allow(stolen_record).to receive(:alert_image).and_return(image)
+      uploader = described_class.new(stolen_record, :theft_alert_image)
+      expect(uploader.filename).to eq("name-alert.jpg")
+    end
+
+    it "appends -alert suffix if none present" do
+      image = double(:image, path: "/path/name.jpg")
+      stolen_record = FactoryBot.create(:stolen_record)
+      allow(stolen_record).to receive(:alert_image).and_return(image)
+      uploader = described_class.new(stolen_record, :theft_alert_image)
+      expect(uploader.filename).to eq("name-alert.jpg")
+    end
+
+    it "correctly handles punctuation-filled filenames" do
+      image = double(:image, path: "/path/2019-07-06T18-alert_16_05_078Z.bike.jpg")
+      stolen_record = FactoryBot.create(:stolen_record)
+      allow(stolen_record).to receive(:alert_image).and_return(image)
+      uploader = described_class.new(stolen_record, :theft_alert_image)
+      expect(uploader.filename).to eq("2019-07-06T18-alert_16_05_078Z.bike-alert.jpg")
+    end
+  end
+
   describe "#bike_url" do
     it "returns a simplified url string to the given bike" do
       stolen_record = FactoryBot.create(:stolen_record)


### PR DESCRIPTION
Fixes https://app.honeybadger.io/projects/35931/faults/52866327, stemming from a stolen record that no longer has an associated bike

Fixes https://app.honeybadger.io/projects/35931/faults/52866677, from an apostrophe in a bike location string

Makes filename parsing more robust (the current method assumes `-alert` may be present in the bike image filename only as a suffix)