### PR TITLE
Add generate_alert_image!, alert image to admin UI

### DIFF
--- a/app/controllers/admin/stolen_bikes_controller.rb
+++ b/app/controllers/admin/stolen_bikes_controller.rb
@@ -1,5 +1,5 @@
 class Admin::StolenBikesController < Admin::BaseController
-  before_filter :find_bike, only: [:edit, :destroy, :approve, :update]
+  before_filter :find_bike, only: [:edit, :destroy, :approve, :update, :regenerate_alert_image]
 
   def index
     if params[:unapproved]
@@ -18,6 +18,11 @@ class Admin::StolenBikesController < Admin::BaseController
     @bike.update_attribute :approved_stolen, true
     ApproveStolenListingWorker.perform_async(@bike.id)
     redirect_to edit_admin_stolen_bike_url(@bike), notice: "Bike was approved."
+  end
+
+  def regenerate_alert_image
+    @bike.current_stolen_record.generate_alert_image!
+    redirect_to edit_admin_stolen_bike_url(@bike), notice: "Premium alert images regenerated."
   end
 
   def show

--- a/app/views/admin/stolen_bikes/edit.html.haml
+++ b/app/views/admin/stolen_bikes/edit.html.haml
@@ -1,10 +1,27 @@
 = render partial: "admin/bikes/bike", locals: { bike: @bike, target: "show", stolen_record: @stolen_record }
 
+%h3 Public Images
+
 .row.mt-2.mb-4
   - @bike.public_images.each_with_index do |img, index|
     - next if index == 1
     .col-3.mb-2.col-lg-2
       = image_tag img.image_url(:small), class: "ml-auto mr-auto", style: "display: block; max-width: 150px; height: auto;"
+
+%h3 Premium Alert Images
+
+= link_to "Regenerate",
+  regenerate_alert_image_admin_stolen_bike_path(@bike),
+  method: :patch,
+  data: { confirm: "Are you sure you want to regenerate premium alert images?" },
+  class: "btn btn-danger mb-4"
+
+.row.mt-2.mb-4
+  .col-3.mb-2.col-lg-2
+    = link_to @bike.alert_image_url, target: "_blank" do
+      = image_tag @bike.alert_image_url,
+        class: "ml-auto mr-auto",
+        style: "display: block; max-width: 150px; height: auto;"
 
 - if @stolen_record.blank?
   %h1.mt-4

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -185,6 +185,7 @@ Bikeindex::Application.routes.draw do
 
     resources :stolen_bikes do
       member { post :approve }
+      member { patch :regenerate_alert_image }
     end
     resources :customer_contacts, only: [:create]
     resources :recoveries do

--- a/spec/models/stolen_record_spec.rb
+++ b/spec/models/stolen_record_spec.rb
@@ -46,11 +46,12 @@ RSpec.describe StolenRecord, type: :model do
     end
 
     context "given multiple bike images" do
-      it "uses the most recently created one for the alert image" do
+      it "uses the first bike image for the alert image" do
         bike = FactoryBot.create(:bike)
-        image1 = FactoryBot.create(:public_image, imageable: bike)
-        image2 = FactoryBot.create(:public_image, imageable: bike)
         stolen_record = FactoryBot.create(:stolen_record, alert_image: nil, bike: bike)
+
+        image1 = FactoryBot.create(:public_image, imageable: bike)
+        FactoryBot.create(:public_image, imageable: bike)
         expect(stolen_record.alert_image).to be_blank
 
         stolen_record.generate_alert_image
@@ -58,9 +59,7 @@ RSpec.describe StolenRecord, type: :model do
 
         alert_image_name = File.basename(stolen_record.alert_image.path, ".*")
         image1_name = File.basename(image1.image.path, ".*")
-        image2_name = File.basename(image2.image.path, ".*")
-        expect(alert_image_name).to_not eq("#{image1_name}-alert")
-        expect(alert_image_name).to eq("#{image2_name}-alert")
+        expect(alert_image_name).to eq("#{image1_name}-alert")
       end
     end
 


### PR DESCRIPTION
- Adds `StolenRecord#generate_alert_image!` to force regenerating the alert image
- Adds the premium alert image to the stolen bike UI with a button to trigger regenerating

<img width="403" alt="Screen Shot 2019-08-02 at 9 01 19 AM" src="https://user-images.githubusercontent.com/4433943/62371947-206cab00-b504-11e9-8fb6-afa48f8176cf.png">


<img width="621" alt="Screen Shot 2019-08-02 at 8 59 10 AM" src="https://user-images.githubusercontent.com/4433943/62371837-d08de400-b503-11e9-92d4-306c3daa5865.png">
