### PR TITLE
Update Honeybadger Ruby client

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -230,7 +230,7 @@ GEM
     high_voltage (3.0.0)
     highline (2.0.2)
     hiredis (0.6.3)
-    honeybadger (4.3.1)
+    honeybadger (4.4.2)
     htmlentities (4.3.4)
     http (3.3.0)
       addressable (~> 2.3)


### PR DESCRIPTION
Bump for breadcrumbs 🥖🍞 

> Breadcrumbs are avaliable for our Honeybadger Ruby client, but it
> looks like you need to upgrade first.

> This notice was sent using version 4.3.1. We introduced Breadcrumbs
> in version 4.4.0. Be sure to upgrade and enable to send breadcrumb
> data along with your errors!