### PR TITLE
Fall back to empty collection if Bike.search_close_serials returns nil

### DIFF
--- a/app/controllers/api/v3/search.rb
+++ b/app/controllers/api/v3/search.rb
@@ -37,7 +37,7 @@ module API
             `location` is ignored unless `stolenness` is "**proximity**"
 
             `location` can be an address, zipcode, city, or latitude,longitude. e.g. "**210 NW 11th Ave, Portland, OR**", "**60647**", "**Chicago, IL**", or "**45.521728,-122.67326**"
-            
+
             If `location` is "**IP**" (the default), the location is determined via geolocation of your IP address.
           NOTE
         }
@@ -95,7 +95,8 @@ module API
           optional :per_page, type: Integer, default: 25, desc: "Bikes per page (max 100)"
         end
         get "/close_serials" do
-          serialized_bikes_results(paginate Bike.search_close_serials(interpreted_params))
+          close_serials = Bike.search_close_serials(interpreted_params)
+          serialized_bikes_results(paginate(close_serials))
         end
       end
     end

--- a/app/models/concerns/bike_searchable.rb
+++ b/app/models/concerns/bike_searchable.rb
@@ -28,7 +28,7 @@ module BikeSearchable
     end
 
     def search_close_serials(interpreted_params)
-      return nil unless interpreted_params[:serial]
+      return Bike.none unless interpreted_params[:serial]
       # Skip the exact match ids
       where.not(id: search(interpreted_params).pluck(:id))
         .non_serial_matches(interpreted_params)

--- a/spec/support/shared_examples/bike_searchable.rb
+++ b/spec/support/shared_examples/bike_searchable.rb
@@ -359,7 +359,7 @@ RSpec.shared_examples "bike_searchable" do
     context "no serial param" do
       let(:query_params) { { query_items: [manufacturer.search_id], stolenness: "non" } }
       it "returns nil" do
-        expect(Bike.search_close_serials(interpreted_params)).to be_nil
+        expect(Bike.search_close_serials(interpreted_params)).to be_blank
       end
     end
     context "exact normalized serial" do


### PR DESCRIPTION
Ensures chained ActiveRecord calls and pagination work as expected:

```rb
# app/controllers/api/v3/search.rb L97-100 (fad36f08)

get "/close_serials" do
  close_serials = Bike.search_close_serials(interpreted_params)
  serialized_bikes_results(paginate(close_serials))
end
```
<sup>[[source](https://github.com/bikeindex/bike_index/blob/fad36f08/app/controllers/api/v3/search.rb#L97-L100)]</sup>

```rb
# app/controllers/bikes_controller.rb L24 (f3c38a9d)

@close_serials = Bike.search_close_serials(@interpreted_params).limit(10).decorate
```
<sup>[[source](https://github.com/bikeindex/bike_index/blob/f3c38a9d/app/controllers/bikes_controller.rb#L24-L24)]</sup>


### After

```js
// 20190802093507
// http://localhost:3001/api/v3/search/close_serials?page=1&per_page=25&serial=

{
  "bikes": []
}
```

Resolves https://app.honeybadger.io/projects/35931/faults/52862785