### PR TITLE
Add honeybadger.yml, enable breadcrumbs

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -37,6 +37,7 @@ gem "fog-aws"
 gem "geocoder"
 gem "hamlit"
 gem "high_voltage"
+gem "honeybadger"
 gem "httparty"
 gem "journey", "~> 1.0.3"
 gem "kaminari" # pagination
@@ -131,7 +132,6 @@ gem "logstash-event" # Use logstash format for logging data
 
 group :production do
   gem "skylight" # Performance monitoring
-  gem "honeybadger"
 end
 
 group :development do

--- a/app/controllers/concerns/controller_helpers.rb
+++ b/app/controllers/concerns/controller_helpers.rb
@@ -9,6 +9,12 @@ module ControllerHelpers
                   :user_root_bike_search?, :current_organization, :passive_organization, :controller_namespace, :page_id,
                   :default_bike_search_path
     before_filter :enable_rack_profiler
+
+    before_action do
+      if current_user.present?
+        Honeybadger.context(user_id: current_user.id, user_email: current_user.email)
+      end
+    end
   end
 
   def append_info_to_payload(payload)

--- a/config/honeybadger.yml
+++ b/config/honeybadger.yml
@@ -1,0 +1,3 @@
+---
+breadcrumbs:
+  enabled: true


### PR DESCRIPTION
Adds honeybadger.yml to enable breadcrumbs:

> You currently have Breadcrumbs disabled in your Honeybadger Ruby client.

> If you would like to send Breadcrumbs to Honeybadger you must update your configuration to enable Breadcrumbs.

> Consult our documentation to learn more about Breadcrumbs and specifically [how to enable them](http://docs.honeybadger.io/lib/ruby/getting-started/breadcrumbs.html#enabling-breadcrumbs).