### PR TITLE
Ensure bike is saved in BikeCreatorAssociator

### DIFF
--- a/app/services/bike_creator_associator.rb
+++ b/app/services/bike_creator_associator.rb
@@ -67,7 +67,7 @@ class BikeCreatorAssociator
       attach_photo(bike)
       attach_photos(bike)
       add_other_listings(bike)
-      bike.reload
+      bike.reload.save
     rescue => e
       bike.errors.add(:association_error, e.message)
     end


### PR DESCRIPTION
Ensures parent (bike) is saved before associated records are created:

```rb
# app/services/bike_creator.rb L70-75 (9aceeb76)

def save_bike(bike)
  bike.save
  @bike = create_associations(bike)
  validate_record(@bike)
  if @bike.present? && @bike.id.present?
    @bike.creation_states.create(creation_state_attributes)
```
<sup>[[source](https://github.com/bikeindex/bike_index/blob/9aceeb76/app/services/bike_creator.rb#L70-L75)]</sup>



```rb
# app/services/bike_creator.rb L45-47 (9aceeb76)

def create_associations(bike)
  @bike = BikeCreatorAssociator.new(@b_param).associate(bike)
end
```
<sup>[[source](https://github.com/bikeindex/bike_index/blob/9aceeb76/app/services/bike_creator.rb#L45-L47)]</sup>

```rb
# app/services/bike_creator_associator.rb L60-75 (c91dffa3)

def associate(bike)
  begin
    ownership = create_ownership(bike)
    create_components(bike)
    create_normalized_serial_segments(bike)
    assign_user_attributes(bike, ownership&.user)
    create_stolen_record(bike) if bike.stolen
    attach_photo(bike)
    attach_photos(bike)
    add_other_listings(bike)
    bike.reload.save
  rescue => e
    bike.errors.add(:association_error, e.message)
  end
  bike
end
```
<sup>[[source](https://github.com/bikeindex/bike_index/blob/c91dffa3/app/services/bike_creator_associator.rb#L60-L75)]</sup>




https://app.honeybadger.io/projects/35931/faults/53042917