### PR TITLE
Add Ownership#owner_email format validation

### DIFF
--- a/app/models/ownership.rb
+++ b/app/models/ownership.rb
@@ -4,6 +4,8 @@ class Ownership < ActiveRecord::Base
   validates_presence_of :owner_email
   validates_presence_of :creator_id
   validates_presence_of :bike_id
+  validates :owner_email,
+            format: { with: /\A.+@.+\..+\z/, message: "invalid format" }
 
   belongs_to :bike, touch: true
   belongs_to :user, touch: true

--- a/spec/models/ownership_spec.rb
+++ b/spec/models/ownership_spec.rb
@@ -13,6 +13,33 @@ RSpec.describe Ownership, type: :model do
     end
   end
 
+  describe "validate owner_email format" do
+    it "disallows owner_emails without an @ sign" do
+      ownership = FactoryBot.build_stubbed(:ownership, owner_email: "n/a")
+      expect(ownership).to_not be_valid
+      expect(ownership.errors.full_messages).to eq(["Owner email invalid format"])
+    end
+
+    it "disallows owner_emails without a tld" do
+      ownership = FactoryBot.build_stubbed(:ownership, owner_email: "name@email")
+      expect(ownership).to_not be_valid
+      expect(ownership.errors.full_messages).to eq(["Owner email invalid format"])
+    end
+
+    it "disallows owner_emails without a mailbox" do
+      ownership = FactoryBot.build_stubbed(:ownership, owner_email: "@email.com")
+      expect(ownership).to_not be_valid
+      expect(ownership.errors.full_messages).to eq(["Owner email invalid format"])
+    end
+
+    it "allows owner_emails with valid modifications" do
+      ownership = FactoryBot.build_stubbed(:ownership, owner_email: "name.1@email.com")
+      expect(ownership).to be_valid
+      ownership = FactoryBot.build_stubbed(:ownership, owner_email: "name+two@email.com")
+      expect(ownership).to be_valid
+    end
+  end
+
   describe "mark_claimed" do
     it "associates with a user" do
       ownership = FactoryBot.create(:ownership)


### PR DESCRIPTION
OwnerEmail can be persisted with an invalid owner_email, leading to exceptions
downstream when triggering `OrganizedMailer.finished_registration`:

https://app.honeybadger.io/projects/35931/faults/52974853

```
 Ownership.find(id).owner_email
 # => "a.b.c"
```

```rb
 Ownership.where("owner_email NOT LIKE '%@%'").count
 # => 113
```