### PR TITLE
Show language selection to everyone

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -72,16 +72,8 @@ class ApplicationController < ActionController::Base
   end
 
   def set_locale
-    unless Flipper.enabled?(:localization, current_user)
-      return I18n.with_locale(I18n.default_locale) { yield }
-    end
-
     if controller_namespace == "admin"
       return I18n.with_locale(I18n.default_locale) { yield }
-    end
-
-    if current_user&.preferred_language != requested_locale
-      current_user&.update_attributes(preferred_language: requested_locale)
     end
 
     I18n.with_locale(requested_locale) { yield }

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -187,7 +187,6 @@ class UsersController < ApplicationController
                   :show_bikes, :show_phone, :my_bikes_link_target, :my_bikes_link_title, :password,
                   :password_confirmation, :preferred_language)
           .merge(sign_in_partner.present? ? { partner_data: { sign_up: sign_in_partner } } : {})
-          .merge({ preferred_language: params.dig(:user, :preferred_language) || nil })
   end
 
   def permitted_update_parameters

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -14,6 +14,7 @@ class UsersController < ApplicationController
 
   def create
     @user = User.new(permitted_parameters)
+    # Set the user's preferred locale if they have a locale we recognize
     if params[:locale].present? && I18n.available_locales.include?(params[:locale].to_sym)
       @user.preferred_language = params[:locale]
     end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -14,6 +14,9 @@ class UsersController < ApplicationController
 
   def create
     @user = User.new(permitted_parameters)
+    if params[:locale].present? && I18n.available_locales.include?(params[:locale].to_sym)
+      @user.preferred_language = params[:locale]
+    end
     if @user.save
       sign_in_and_redirect(@user)
     else

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -187,7 +187,7 @@ class UsersController < ApplicationController
                   :show_bikes, :show_phone, :my_bikes_link_target, :my_bikes_link_title, :password,
                   :password_confirmation, :preferred_language)
           .merge(sign_in_partner.present? ? { partner_data: { sign_up: sign_in_partner } } : {})
-          .merge({ preferred_language: params.dig(:user, :preferred_language) || I18n.locale })
+          .merge({ preferred_language: params.dig(:user, :preferred_language) || nil })
   end
 
   def permitted_update_parameters

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -15,8 +15,8 @@ class UsersController < ApplicationController
   def create
     @user = User.new(permitted_parameters)
     # Set the user's preferred locale if they have a locale we recognize
-    if params[:locale].present? && I18n.available_locales.include?(params[:locale].to_sym)
-      @user.preferred_language = params[:locale]
+    if requested_locale != I18n.default_locale
+      @user.preferred_language = requested_locale
     end
     if @user.save
       sign_in_and_redirect(@user)

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -220,6 +220,6 @@ module ApplicationHelper
   def language_choices
     @language_choices ||= I18n.available_locales.map do |locale|
       [t(locale, scope: [:locales]), locale.to_s]
-    end
+    end.sort { |a, b| a[0].downcase <=> b[0].downcase }
   end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -219,7 +219,6 @@ module ApplicationHelper
 
   def language_choices
     @language_choices ||= I18n.available_locales.map do |locale|
-      pp locale
       [t(locale, scope: [:locales]), locale.to_s]
     end
   end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -219,6 +219,7 @@ module ApplicationHelper
 
   def language_choices
     @language_choices ||= I18n.available_locales.map do |locale|
+      pp locale
       [t(locale, scope: [:locales]), locale.to_s]
     end
   end

--- a/app/views/shared/_footer_revised.html.haml
+++ b/app/views/shared/_footer_revised.html.haml
@@ -55,21 +55,20 @@
     .container
       .row
         .col-md-6.text-left
-          - if Flipper.enabled?(:localization, current_user)
-            = form_tag nil, method: :get, class: "locale-form" do
-              .row
-                .form-group
-                  = label_tag(:locale, t(".language"))
-                  = select_tag(:locale,
+          = form_tag nil, method: :get, class: "locale-form" do
+            .row
+              .form-group
+                = label_tag(:locale, t(".language"))
+                = select_tag(:locale,
                   options_for_select(language_choices, selected: I18n.locale),
                   class: "form-control-sm",
                   onchange: "this.form.submit()")
-          - else
-            &nbsp;
+                - if current_user.present? && current_user.preferred_language != I18n.locale
+                  = link_to t(".change_preferred_language"), my_account_path
         .col-md-6.text-right
           %p
             = [link_to(t(".privacy_policy"), privacy_url),
-            (current_user&.has_membership? ? link_to(t(".vendor_terms"), vendor_terms_url) : nil),
+              (current_user&.has_membership? ? link_to(t(".vendor_terms"), vendor_terms_url) : nil),
             link_to(t(".terms_and_conditions"), terms_url)].compact.to_sentence.html_safe
 
           %p

--- a/app/views/shared/_footer_revised.html.haml
+++ b/app/views/shared/_footer_revised.html.haml
@@ -64,7 +64,8 @@
                   class: "form-control-sm",
                   onchange: "this.form.submit()")
                 - if current_user.present? && current_user.preferred_language != I18n.locale
-                  = link_to t(".change_preferred_language"), my_account_path
+                  %em.below-input-help.text-right
+                    = link_to t(".change_preferred_language"), my_account_path
         .col-md-6.text-right
           %p
             = [link_to(t(".privacy_policy"), privacy_url),

--- a/app/views/users/_edit_root.html.haml
+++ b/app/views/users/_edit_root.html.haml
@@ -17,7 +17,7 @@
     %label.form-well-label
     %label.form-well-input{ style: "line-height: 1.5em;" }
       = f.check_box :notification_unstolen
-      - why_you_should_link = link_to("Read why you should", "https://bikeindex.org/news/recovering-bikes-before-they-are-marked-stolen")
+      - why_you_should_link = link_to(t(".why_you_should_text"), "https://bikeindex.org/news/recovering-bikes-before-they-are-marked-stolen")
       = t(".give_us_permission_html", why_you_should_link: why_you_should_link)
   .form-group.row
     = f.label :phone, class: "form-well-label"
@@ -57,7 +57,7 @@
         { prompt: t(".choose_language"), include_blank: true },
         { class: "language-select-input form-control" } )
 
-  .col-xs-12
+  .col-xs-12.mt-4
     %p
       = t(".have_multiple_emails")
   .form-group.row.unnested-field.no-divider-row

--- a/app/views/users/_edit_root.html.haml
+++ b/app/views/users/_edit_root.html.haml
@@ -48,12 +48,11 @@
       .form-well-input
         = f.text_field :zipcode, placeholder: t(".zipcode"), class: "form-control"
 
-  - if Flipper.enabled?(:localization, current_user)
-    .form-group.row.fancy-select.unfancy
-      = f.label :country_id, class: "form-well-label" do
-        = t(".preferred_language")
-      .form-well-input
-        = f.select(:preferred_language,
+  .form-group.row.fancy-select.unfancy
+    = f.label :country_id, class: "form-well-label" do
+      = t(".preferred_language")
+    .form-well-input
+      = f.select(:preferred_language,
         options_for_select(language_choices, selected: current_user.preferred_language),
         { prompt: t(".choose_language"), include_blank: true },
         { class: "language-select-input form-control" } )

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1669,7 +1669,7 @@ en:
     - Fri
     - Sat
     abbr_month_names:
-    -
+    - 
     - Jan
     - Feb
     - Mar
@@ -1695,7 +1695,7 @@ en:
       long: "%B %d, %Y"
       short: "%b %d"
     month_names:
-    -
+    - 
     - January
     - February
     - March

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3939,6 +3939,7 @@ en:
       bike_manufacturer_list: Bike Manufacturer List
       bike_shops: Bike Shops
       blog: Blog
+      change_preferred_language: change preferred language
       cities: Cities
       community_groups: Community Groups
       copyright_html: "%{current_year} &copy; Bike Index, a 501(c)(3) nonprofit -

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3058,7 +3058,7 @@ en:
       please_fix_the_following: Please fix the following %{errors}
   locales:
     en: English
-    nl: Dutch
+    nl: Dutch (Nederlands)
   meta_descriptions:
     bikes_index: Search for bikes that have been registered on Bike Index
     bikes_new: >-

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -4043,6 +4043,7 @@ en:
       resend_confirmation: Resend confirmation
       state: State
       unconfirmed_emails: Unconfirmed emails
+      why_you_should_text: Read why you should
       zipcode: Postal code
     edit_sharing:
       additional_link: Additional Link

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1669,7 +1669,7 @@ en:
     - Fri
     - Sat
     abbr_month_names:
-    - 
+    -
     - Jan
     - Feb
     - Mar
@@ -1695,7 +1695,7 @@ en:
       long: "%B %d, %Y"
       short: "%b %d"
     month_names:
-    - 
+    -
     - January
     - February
     - March
@@ -3058,7 +3058,7 @@ en:
       please_fix_the_following: Please fix the following %{errors}
   locales:
     en: English
-    nl: Dutch (Nederlands)
+    nl: Nederlands (Dutch)
   meta_descriptions:
     bikes_index: Search for bikes that have been registered on Bike Index
     bikes_new: >-

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -574,22 +574,33 @@ RSpec.describe UsersController, type: :controller do
       expect(user.reload.terms_of_service).to be_truthy
     end
 
-    it "updates the preferred_language if valid" do
-      expect(user.preferred_language).to eq(nil)
-      set_current_user(user)
-      patch :update, id: user.username, user: { preferred_language: "en" }
-      expect(flash[:success]).to match(/successfully updated/i)
-      expect(response).to redirect_to(my_account_url)
-      expect(user.reload.preferred_language).to eq("en")
-    end
+    describe "preferred_language" do
+      it "updates if valid" do
+        expect(user.preferred_language).to eq(nil)
+        set_current_user(user)
+        patch :update, id: user.username, locale: "nl", user: { preferred_language: "en" }
+        expect(flash[:success]).to match(/successfully updated/i)
+        expect(response).to redirect_to(my_account_url)
+        expect(user.reload.preferred_language).to eq("en")
+      end
 
-    it "does not update the preferred_language if invalid" do
-      expect(user.preferred_language).to eq(nil)
-      set_current_user(user)
-      patch :update, id: user.username, user: { preferred_language: "klingon" }
-      expect(flash[:success]).to be_blank
-      expect(response).to render_template(:edit)
-      expect(user.reload.preferred_language).to eq(nil)
+      it "changes from previous if valid" do
+        user.update_attribute :preferred_language, "en"
+        set_current_user(user)
+        patch :update, id: user.username, locale: "en", user: { preferred_language: "nl" }
+        expect(flash[:success]).to match(/successfully updated/i)
+        expect(response).to redirect_to(my_account_url)
+        expect(user.reload.preferred_language).to eq("nl")
+      end
+
+      it "does not update the preferred_language if invalid" do
+        expect(user.preferred_language).to eq(nil)
+        set_current_user(user)
+        patch :update, id: user.username, user: { preferred_language: "klingon" }
+        expect(flash[:success]).to be_blank
+        expect(response).to render_template(:edit)
+        expect(user.reload.preferred_language).to eq(nil)
+      end
     end
 
     it "updates notification" do

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -358,6 +358,29 @@ RSpec.describe ApplicationHelper, type: :helper do
     end
   end
 
+  describe "language_choices" do
+    let(:target) do
+      [
+        ["English", "en"],
+        ["Nederlands (Dutch)", "nl"],
+      ]
+    end
+    it "returns the language choices with english included" do
+      expect(language_choices).to eq target
+    end
+    context "in dutch" do
+      let(:target) do
+        [
+          ["English (Engels)", "en"],
+          ["Nederlands", "nl"],
+        ]
+      end
+      xit "returns with dutch included" do
+        expect(language_choices).to eq target
+      end
+    end
+  end
+
   describe "group_by_method" do
     context "hourly" do
       it "returns group_by_minute" do

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -361,8 +361,8 @@ RSpec.describe ApplicationHelper, type: :helper do
   describe "language_choices" do
     let(:target) do
       [
-        ["Dutch (Nederlands)", "nl"],
         ["English", "en"],
+        ["Nederlands (Dutch)", "nl"],
       ]
     end
     it "returns the language choices with english included" do

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -361,8 +361,8 @@ RSpec.describe ApplicationHelper, type: :helper do
   describe "language_choices" do
     let(:target) do
       [
+        ["Dutch (Nederlands)", "nl"],
         ["English", "en"],
-        ["Nederlands (Dutch)", "nl"],
       ]
     end
     it "returns the language choices with english included" do

--- a/spec/requests/locale_detection_request_spec.rb
+++ b/spec/requests/locale_detection_request_spec.rb
@@ -1,16 +1,9 @@
 require "rails_helper"
 
 RSpec.describe "Locale detection", type: :request do
-  before do
-    allow(Flipper).to receive(:enabled?).with(:localization, nil).and_return(true)
-  end
-
   describe "requesting the root path" do
     context "given a user preference" do
       include_context :request_spec_logged_in_as_user
-      before do
-        allow(Flipper).to receive(:enabled?).with(:localization, current_user).and_return(true)
-      end
 
       it "renders the homepage in the requested language" do
         get "/"
@@ -62,9 +55,11 @@ RSpec.describe "Locale detection", type: :request do
       end
 
       it "gives highest precedence to query param" do
-        current_user.update(preferred_language: :es)
+        current_user.update_attribute :preferred_language, :es
         get "/", { locale: :nl }, { "HTTP_ACCEPT_LANGUAGE" => "en-US,en;q=0.9" }
         expect(response.body).to match(/fietsregistratie/i)
+        # It doesn't reset users preferences based on request
+        expect(current_user.reload.preferred_language).to eq "es"
       end
 
       it "gives secondary precedence to user preference" do

--- a/spec/requests/locale_detection_request_spec.rb
+++ b/spec/requests/locale_detection_request_spec.rb
@@ -50,9 +50,6 @@ RSpec.describe "Locale detection", type: :request do
 
     context "given multiple detected locales" do
       include_context :request_spec_logged_in_as_user
-      before do
-        allow(Flipper).to receive(:enabled?).with(:localization, current_user).and_return(true)
-      end
 
       it "gives highest precedence to query param" do
         current_user.update_attribute :preferred_language, :es
@@ -63,15 +60,19 @@ RSpec.describe "Locale detection", type: :request do
       end
 
       it "gives secondary precedence to user preference" do
-        current_user.update(preferred_language: :nl)
+        current_user.update_attribute :preferred_language, :nl
         get "/", {}, { "HTTP_ACCEPT_LANGUAGE" => "en-US,en;q=0.9" }
         expect(response.body).to match(/fietsregistratie/i)
+        # It doesn't reset users preferences based on request
+        expect(current_user.reload.preferred_language).to eq "nl"
       end
 
       it "gives lowest precedence to request headers" do
-        current_user.update(preferred_language: nil)
+        current_user.update_attribute :preferred_language, nil
         get "/", {}, { "HTTP_ACCEPT_LANGUAGE" => "nl,en;q=0.9" }
         expect(response.body).to match(/fietsregistratie/i)
+        # It doesn't reset users preferences based on request
+        expect(current_user.reload.preferred_language).to eq nil
       end
 
       it "falls back to the app default if no other locales are provided or recognized" do
@@ -88,9 +89,6 @@ RSpec.describe "Locale detection", type: :request do
 
   describe "requesting an admin path" do
     include_context :request_spec_logged_in_as_superuser
-    before do
-      allow(Flipper).to receive(:enabled?).with(:localization, current_user).and_return(true)
-    end
 
     context "given a user preference" do
       it "renders the admin dashboard in English" do


### PR DESCRIPTION
First, because the translator wants to see it. But also because why not!

- Setting language automatically leads to weird edge cases, and I don't think it adds much value. I've added a link to the edit account page, if there is a mismatch, which I think makes things better.
- When selecting a language, include the language's name in it's own language