### PR TITLE
Add AlertImage model, update stolen_bike admin, kill logging

### DIFF
--- a/app/controllers/admin/stolen_bikes_controller.rb
+++ b/app/controllers/admin/stolen_bikes_controller.rb
@@ -32,6 +32,8 @@ class Admin::StolenBikesController < Admin::BaseController
   def edit
     @customer_contact = CustomerContact.new(user_email: @bike.owner_email)
     @bike = @bike.decorate
+    @alert_image_versions =
+      @bike&.current_stolen_record&.current_alert_image&.image&.versions || []
   end
 
   def update

--- a/app/models/alert_image.rb
+++ b/app/models/alert_image.rb
@@ -1,5 +1,7 @@
 class AlertImage < ActiveRecord::Base
   belongs_to :stolen_record
+  validates :stolen_record, presence: true
+
   delegate :bike, to: :stolen_record, allow_nil: true
 
   mount_uploader :image, AlertImageUploader

--- a/app/models/alert_image.rb
+++ b/app/models/alert_image.rb
@@ -5,18 +5,20 @@ class AlertImage < ActiveRecord::Base
   mount_uploader :image, AlertImageUploader
   process_in_background :image
 
-  scope :current, -> { where(current: true) }
+  scope :current, -> { where(retired_at: nil) }
 
   after_save :remove_image_if_retired
 
   def self.retire_all
-    current.find_each do |alert_image|
-      alert_image.update(current: false)
-    end
+    current.find_each(&:retired!)
   end
 
   def retired?
-    !current?
+    retired_at.present?
+  end
+
+  def retired!
+    update(retired_at: Time.current)
   end
 
   private

--- a/app/models/alert_image.rb
+++ b/app/models/alert_image.rb
@@ -1,0 +1,26 @@
+class AlertImage < ActiveRecord::Base
+  belongs_to :stolen_record
+  delegate :bike, to: :stolen_record, allow_nil: true
+
+  mount_uploader :image, AlertImageUploader
+  process_in_background :image
+
+  scope :current, -> { where(current: true) }
+  after_save :remove_image_if_retired
+
+  def self.retire_all
+    current.find_each do |alert_image|
+      alert_image.update(current: false)
+    end
+  end
+
+  def retired?
+    !current?
+  end
+
+  private
+
+  def remove_image_if_retired
+    image.remove! if retired?
+  end
+end

--- a/app/models/alert_image.rb
+++ b/app/models/alert_image.rb
@@ -6,6 +6,7 @@ class AlertImage < ActiveRecord::Base
   process_in_background :image
 
   scope :current, -> { where(current: true) }
+
   after_save :remove_image_if_retired
 
   def self.retire_all

--- a/app/models/alert_image.rb
+++ b/app/models/alert_image.rb
@@ -5,25 +5,5 @@ class AlertImage < ActiveRecord::Base
   mount_uploader :image, AlertImageUploader
   process_in_background :image
 
-  scope :current, -> { where(retired_at: nil) }
-
-  after_save :remove_image_if_retired
-
-  def self.retire_all
-    current.find_each(&:retired!)
-  end
-
-  def retired?
-    retired_at.present?
-  end
-
-  def retired!
-    update(retired_at: Time.current)
-  end
-
-  private
-
-  def remove_image_if_retired
-    image.remove! if retired?
-  end
+  before_destroy -> { image.remove! }
 end

--- a/app/models/bike.rb
+++ b/app/models/bike.rb
@@ -523,12 +523,7 @@ class Bike < ActiveRecord::Base
   end
 
   def alert_image_url(version = nil)
-    return if current_stolen_record.blank?
-
-    if current_stolen_record&.alert_image.present? ||
-       current_stolen_record.generate_alert_image
-      current_stolen_record.alert_image_url(version)
-    end
+    current_stolen_record&.current_alert_image&.image_url(version)
   end
 
   def load_external_images(urls = nil)

--- a/app/models/stolen_record.rb
+++ b/app/models/stolen_record.rb
@@ -51,7 +51,7 @@ class StolenRecord < ActiveRecord::Base
   geocoded_by :address_override_show_address
   after_validation :geocode, if: lambda { (self.city.present? || self.zipcode.present?) && self.country.present? }
 
-  after_commit :remove_outdated_alert_images
+  after_save :remove_outdated_alert_images
 
   def self.find_matching_token(bike_id:, recovery_link_token:)
     return nil unless bike_id.present? && recovery_link_token.present?

--- a/app/models/stolen_record.rb
+++ b/app/models/stolen_record.rb
@@ -29,6 +29,7 @@ class StolenRecord < ActiveRecord::Base
   belongs_to :creation_organization, class_name: "Organization"
   belongs_to :recovering_user, class_name: "User"
   has_many :theft_alerts
+  has_many :alert_images
 
   validates_presence_of :bike
   validates_presence_of :date_stolen
@@ -50,9 +51,7 @@ class StolenRecord < ActiveRecord::Base
   geocoded_by :address_override_show_address
   after_validation :geocode, if: lambda { (self.city.present? || self.zipcode.present?) && self.country.present? }
 
-  mount_uploader :alert_image, AlertImageUploader
-  process_in_background :alert_image
-  after_commit :remove_outdated_alert_image
+  after_commit :remove_outdated_alert_images
 
   def self.find_matching_token(bike_id:, recovery_link_token:)
     return nil unless bike_id.present? && recovery_link_token.present?
@@ -255,26 +254,26 @@ class StolenRecord < ActiveRecord::Base
   end
 
   def bike_main_image
-    bike&.public_images&.order(:id)&.first&.image
+    bike&.public_images&.order(:id)&.first
+  end
+
+  def current_alert_image
+    alert_images.current.first || generate_alert_image
   end
 
   # Generate the "promoted alert image"
   # (One of the stolen bike's public images, placed on a branded template)
   #
   # The URL is available immediately - processing is performed in the background.
-  #
-  # TODO: Allow selection of which bike image to use for the alert image
+  # bike_image: [PublicImage]
   def generate_alert_image(bike_image: bike_main_image)
-    return if bike_image.blank?
-    alert_image.remove!
-    self.alert_image = bike_image
-    save
+    return if bike_image&.image.blank?
+    alert_images.retire_all
+    alert_images.create(image: bike_image.image)
   end
 
   # If the bike has been recovered, remove the alert_image
-  def remove_outdated_alert_image
-    if bike.blank? || !bike.stolen?
-      alert_image.remove!
-    end
+  def remove_outdated_alert_images
+    alert_images.retire_all if bike.blank? || !bike.stolen?
   end
 end

--- a/app/models/stolen_record.rb
+++ b/app/models/stolen_record.rb
@@ -268,8 +268,16 @@ class StolenRecord < ActiveRecord::Base
   # bike_image: [PublicImage]
   def generate_alert_image(bike_image: bike_main_image)
     return if bike_image&.image.blank?
+
     alert_image&.destroy
-    AlertImage.create(image: bike_image.image, stolen_record: self)
+    new_image = AlertImage.create(image: bike_image.image, stolen_record: self)
+
+    if new_image.valid?
+      new_image
+    else
+      update(alert_image: nil)
+      nil
+    end
   end
 
   # If the bike has been recovered, remove the alert_image

--- a/app/uploaders/alert_image_uploader.rb
+++ b/app/uploaders/alert_image_uploader.rb
@@ -2,14 +2,14 @@ class AlertImageUploader < ApplicationUploader
   include CarrierWave::MiniMagick
   include ::CarrierWave::Backgrounder::Delay
 
-  alias stolen_record model
+  delegate :stolen_record, to: :model
 
   def store_dir
-    "#{base_store_dir}/#{stolen_record.id}"
+    "#{base_store_dir}/#{model.id}"
   end
 
   def base_store_dir
-    "uploads/#{stolen_record.class.to_s[0, 2]}"
+    "uploads/#{model.class.to_s[0, 2]}"
   end
 
   def extension_white_list
@@ -36,20 +36,20 @@ class AlertImageUploader < ApplicationUploader
   end
 
   def generate_landscape(variant)
-    Rails.logger.info "Processing #{variant} #{current_path}"
     manipulate! do |img|
-      alert_image = AlertImageGenerator.new(stolen_record: stolen_record, bike_image: img)
-      img = alert_image.build_landscape(variant)
+      img =
+        AlertImageGenerator
+          .new(stolen_record: stolen_record, bike_image: img)
+          .build_landscape(variant)
     end
-    Rails.logger.info "Finished #{variant} #{current_path}"
   end
 
   def generate_square
-    Rails.logger.info "Processing square #{current_path}"
     manipulate! do |img|
-      alert_image = AlertImageGenerator.new(stolen_record: stolen_record, bike_image: img)
-      img = alert_image.build_square
+      img =
+        AlertImageGenerator
+          .new(stolen_record: stolen_record, bike_image: img)
+          .build_square
     end
-    Rails.logger.info "Finished square #{current_path}"
   end
 end

--- a/app/views/admin/stolen_bikes/edit.html.haml
+++ b/app/views/admin/stolen_bikes/edit.html.haml
@@ -10,20 +10,20 @@
 
 %h3 Promoted Alert Images
 
-= link_to "Regenerate",
-  regenerate_alert_image_admin_stolen_bike_path(@bike),
-  method: :patch,
-  data: { confirm: "Are you sure you want to regenerate promoted alert images?" },
-  class: "btn btn-danger mb-4"
-
-.row.mt-2.mb-4
-  - @bike&.current_stolen_record&.alert_image&.versions.keys.each do |version|
-    .col-3.mb-2.col-lg-2
-      = link_to @bike.alert_image_url(version), target: "_blank" do
-        = image_tag @bike.alert_image_url(version),
-          class: "ml-auto mr-auto",
-          style: "display: block; max-width: 150px; height: auto;"
-      .text-center= version
+- if @alert_image_versions.blank?
+  None
+- else
+  = link_to "Regenerate",
+    regenerate_alert_image_admin_stolen_bike_path(@bike),
+    method: :patch,
+    data: { confirm: "Are you sure you want to regenerate promoted alert images?" },
+    class: "btn btn-danger mb-4"
+  .row.mt-2.mb-4
+    - @alert_image_versions.each do |name, image|
+      .col-3.mb-2.col-lg-2
+        = link_to image.url, target: "_blank" do
+          = image_tag image.url, class: "ml-auto mr-auto", style: "display: block; max-width: 150px; height: auto;"
+        .text-center= name
 
 - if @stolen_record.blank?
   %h1.mt-4

--- a/db/migrate/20190806155914_create_alert_images.rb
+++ b/db/migrate/20190806155914_create_alert_images.rb
@@ -1,0 +1,11 @@
+class CreateAlertImages < ActiveRecord::Migration
+  def change
+    create_table :alert_images do |t|
+      t.belongs_to :stolen_record, null: false, index: true, foreign_key: true
+      t.boolean :current, null: false, default: true
+      t.string :image
+
+      t.timestamps null: false
+    end
+  end
+end

--- a/db/migrate/20190806155914_create_alert_images.rb
+++ b/db/migrate/20190806155914_create_alert_images.rb
@@ -2,7 +2,7 @@ class CreateAlertImages < ActiveRecord::Migration
   def change
     create_table :alert_images do |t|
       t.belongs_to :stolen_record, null: false, index: true, foreign_key: true
-      t.boolean :current, null: false, default: true
+      t.datetime :retired_at
       t.string :image
 
       t.timestamps null: false

--- a/db/migrate/20190806155914_create_alert_images.rb
+++ b/db/migrate/20190806155914_create_alert_images.rb
@@ -2,7 +2,6 @@ class CreateAlertImages < ActiveRecord::Migration
   def change
     create_table :alert_images do |t|
       t.belongs_to :stolen_record, null: false, index: true, foreign_key: true
-      t.datetime :retired_at
       t.string :image
 
       t.timestamps null: false

--- a/db/migrate/20190806170520_drop_alert_image_from_stolen_records.rb
+++ b/db/migrate/20190806170520_drop_alert_image_from_stolen_records.rb
@@ -1,0 +1,5 @@
+class DropAlertImageFromStolenRecords < ActiveRecord::Migration
+  def change
+    remove_column :stolen_records, :alert_image, :string
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -77,7 +77,6 @@ ALTER SEQUENCE public.ads_id_seq OWNED BY public.ads.id;
 CREATE TABLE public.alert_images (
     id integer NOT NULL,
     stolen_record_id integer NOT NULL,
-    retired_at timestamp without time zone,
     image character varying,
     created_at timestamp without time zone NOT NULL,
     updated_at timestamp without time zone NOT NULL

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -2,8 +2,8 @@
 -- PostgreSQL database dump
 --
 
--- Dumped from database version 10.3
--- Dumped by pg_dump version 10.3
+-- Dumped from database version 11.4
+-- Dumped by pg_dump version 11.4
 
 SET statement_timeout = 0;
 SET lock_timeout = 0;
@@ -12,22 +12,9 @@ SET client_encoding = 'UTF8';
 SET standard_conforming_strings = on;
 SELECT pg_catalog.set_config('search_path', '', false);
 SET check_function_bodies = false;
+SET xmloption = content;
 SET client_min_messages = warning;
 SET row_security = off;
-
---
--- Name: plpgsql; Type: EXTENSION; Schema: -; Owner: -
---
-
-CREATE EXTENSION IF NOT EXISTS plpgsql WITH SCHEMA pg_catalog;
-
-
---
--- Name: EXTENSION plpgsql; Type: COMMENT; Schema: -; Owner: -
---
-
-COMMENT ON EXTENSION plpgsql IS 'PL/pgSQL procedural language';
-
 
 --
 -- Name: fuzzystrmatch; Type: EXTENSION; Schema: -; Owner: -
@@ -81,6 +68,40 @@ CREATE SEQUENCE public.ads_id_seq
 --
 
 ALTER SEQUENCE public.ads_id_seq OWNED BY public.ads.id;
+
+
+--
+-- Name: alert_images; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.alert_images (
+    id integer NOT NULL,
+    stolen_record_id integer NOT NULL,
+    current boolean DEFAULT true NOT NULL,
+    image character varying,
+    created_at timestamp without time zone NOT NULL,
+    updated_at timestamp without time zone NOT NULL
+);
+
+
+--
+-- Name: alert_images_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.alert_images_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: alert_images_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.alert_images_id_seq OWNED BY public.alert_images.id;
 
 
 --
@@ -846,6 +867,7 @@ CREATE TABLE public.flipper_features (
 --
 
 CREATE SEQUENCE public.flipper_features_id_seq
+    AS integer
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -879,6 +901,7 @@ CREATE TABLE public.flipper_gates (
 --
 
 CREATE SEQUENCE public.flipper_gates_id_seq
+    AS integer
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -1880,7 +1903,7 @@ ALTER SEQUENCE public.recovery_displays_id_seq OWNED BY public.recovery_displays
 --
 
 CREATE TABLE public.schema_migrations (
-    version character varying(255) NOT NULL
+    version character varying NOT NULL
 );
 
 
@@ -2003,8 +2026,7 @@ CREATE TABLE public.stolen_records (
     recovery_link_token text,
     show_address boolean DEFAULT false,
     recovering_user_id integer,
-    recovery_display_status integer DEFAULT 0,
-    alert_image character varying
+    recovery_display_status integer DEFAULT 0
 );
 
 
@@ -2049,6 +2071,7 @@ CREATE TABLE public.theft_alert_plans (
 --
 
 CREATE SEQUENCE public.theft_alert_plans_id_seq
+    AS integer
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -2088,6 +2111,7 @@ CREATE TABLE public.theft_alerts (
 --
 
 CREATE SEQUENCE public.theft_alerts_id_seq
+    AS integer
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -2282,6 +2306,13 @@ ALTER SEQUENCE public.wheel_sizes_id_seq OWNED BY public.wheel_sizes.id;
 --
 
 ALTER TABLE ONLY public.ads ALTER COLUMN id SET DEFAULT nextval('public.ads_id_seq'::regclass);
+
+
+--
+-- Name: alert_images id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.alert_images ALTER COLUMN id SET DEFAULT nextval('public.alert_images_id_seq'::regclass);
 
 
 --
@@ -2682,6 +2713,14 @@ ALTER TABLE ONLY public.wheel_sizes ALTER COLUMN id SET DEFAULT nextval('public.
 
 ALTER TABLE ONLY public.ads
     ADD CONSTRAINT ads_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: alert_images alert_images_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.alert_images
+    ADD CONSTRAINT alert_images_pkey PRIMARY KEY (id);
 
 
 --
@@ -3130,6 +3169,13 @@ ALTER TABLE ONLY public.users
 
 ALTER TABLE ONLY public.wheel_sizes
     ADD CONSTRAINT wheel_sizes_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: index_alert_images_on_stolen_record_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_alert_images_on_stolen_record_id ON public.alert_images USING btree (stolen_record_id);
 
 
 --
@@ -3702,6 +3748,14 @@ ALTER TABLE ONLY public.ambassador_task_assignments
 
 ALTER TABLE ONLY public.theft_alerts
     ADD CONSTRAINT fk_rails_6dac5d87d9 FOREIGN KEY (payment_id) REFERENCES public.payments(id);
+
+
+--
+-- Name: alert_images fk_rails_95dc479c85; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.alert_images
+    ADD CONSTRAINT fk_rails_95dc479c85 FOREIGN KEY (stolen_record_id) REFERENCES public.stolen_records(id);
 
 
 --
@@ -4465,4 +4519,8 @@ INSERT INTO schema_migrations (version) VALUES ('20190725141309');
 INSERT INTO schema_migrations (version) VALUES ('20190725172835');
 
 INSERT INTO schema_migrations (version) VALUES ('20190726183859');
+
+INSERT INTO schema_migrations (version) VALUES ('20190806155914');
+
+INSERT INTO schema_migrations (version) VALUES ('20190806170520');
 

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -77,7 +77,7 @@ ALTER SEQUENCE public.ads_id_seq OWNED BY public.ads.id;
 CREATE TABLE public.alert_images (
     id integer NOT NULL,
     stolen_record_id integer NOT NULL,
-    current boolean DEFAULT true NOT NULL,
+    retired_at timestamp without time zone,
     image character varying,
     created_at timestamp without time zone NOT NULL,
     updated_at timestamp without time zone NOT NULL

--- a/spec/factories/alert_images.rb
+++ b/spec/factories/alert_images.rb
@@ -3,10 +3,6 @@ FactoryBot.define do
     stolen_record { FactoryBot.create(:stolen_record) }
     image { nil }
 
-    trait :retired do
-      retired_at { Time.current }
-    end
-
     trait :with_image do
       transient do
         filename { nil }

--- a/spec/factories/alert_images.rb
+++ b/spec/factories/alert_images.rb
@@ -1,0 +1,26 @@
+FactoryBot.define do
+  factory :alert_image do
+    stolen_record { FactoryBot.create(:stolen_record) }
+    image { nil }
+
+    trait :retired do
+      current { false }
+    end
+
+    trait :with_image do
+      transient do
+        filename { nil }
+      end
+
+      after(:build) do |alert_image, evaluator|
+        next if alert_image.image.present?
+
+        stolen_record_id = alert_image.stolen_record_id
+        filename = evaluator.filename || "stolen_record-#{stolen_record_id}.jpg"
+        alert_image.image = File.open(ApplicationUploader.cache_dir.join(filename), "w+")
+
+        alert_image.save
+      end
+    end
+  end
+end

--- a/spec/factories/alert_images.rb
+++ b/spec/factories/alert_images.rb
@@ -4,7 +4,7 @@ FactoryBot.define do
     image { nil }
 
     trait :retired do
-      current { false }
+      retired_at { Time.current }
     end
 
     trait :with_image do

--- a/spec/factories/stolen_records.rb
+++ b/spec/factories/stolen_records.rb
@@ -1,11 +1,10 @@
 FactoryBot.define do
   factory :stolen_record do
-    bike { FactoryBot.create(:bike, :with_image) }
+    bike { FactoryBot.create(:bike) }
     date_stolen { Time.current }
-    alert_image { nil }
 
     factory :stolen_record_recovered do
-      bike { FactoryBot.create(:bike, :with_image) }
+      bike { FactoryBot.create(:bike) }
       date_recovered { Time.current }
       recovered_description { "Awesome help by Bike Index" }
       current { false }
@@ -17,14 +16,15 @@ FactoryBot.define do
       end
 
       after(:create) do |stolen_record, evaluator|
-        filename = evaluator.filename || "stolen_record-#{stolen_record.id}.jpg"
-        stolen_record.alert_image = File.open(ApplicationUploader.cache_dir.join(filename), "w+")
-        stolen_record.save
+        FactoryBot.create(:alert_image,
+                          :with_image,
+                          stolen_record: stolen_record,
+                          filename: evaluator.filename)
       end
     end
 
-    trait :no_bike_image do
-      bike { FactoryBot.create(:bike) }
+    trait :with_bike_image do
+      bike { FactoryBot.create(:bike, :with_image) }
     end
   end
 end

--- a/spec/models/alert_image_spec.rb
+++ b/spec/models/alert_image_spec.rb
@@ -1,0 +1,69 @@
+require "rails_helper"
+
+RSpec.describe AlertImage, type: :model do
+  describe ".retire_all" do
+    it "toggles current status and removes images" do
+      image1 = FactoryBot.create(:alert_image, :with_image)
+      image2 = FactoryBot.create(:alert_image, :with_image)
+      FactoryBot.create(:alert_image, :retired)
+
+      expect(AlertImage.current).to match_array([image1, image2])
+      expect(AlertImage.current.all? { |i| i.image.present? }).to eq(true)
+
+      AlertImage.retire_all
+
+      expect(AlertImage.current).to be_empty
+      expect(AlertImage.current.all? { |i| i.image.blank? }).to eq(true)
+    end
+
+    it "retires all within an association scope" do
+      stolen_record = FactoryBot.create(:stolen_record)
+      image1 = FactoryBot.create(:alert_image, stolen_record: stolen_record)
+      image2 = FactoryBot.create(:alert_image, stolen_record: stolen_record)
+      FactoryBot.create(:alert_image, :retired, stolen_record: stolen_record)
+      image3 = FactoryBot.create(:alert_image)
+      FactoryBot.create(:alert_image, :retired)
+
+      current_alert_images = stolen_record.alert_images.current
+      expect(current_alert_images.pluck(:id)).to match_array([image1.id, image2.id])
+      expect(AlertImage.current.pluck(:id)).to match_array([image1, image2, image3].map(&:id))
+
+      stolen_record.alert_images.retire_all
+
+      expect(current_alert_images.pluck(:id)).to be_empty
+      expect(AlertImage.current.pluck(:id)).to match_array([image3.id])
+    end
+  end
+
+  describe ".current" do
+    it "returns images marked as current" do
+      image1 = FactoryBot.create(:alert_image)
+      FactoryBot.create(:alert_image, :retired)
+      image3 = FactoryBot.create(:alert_image)
+      expect(AlertImage.current).to match_array([image1, image3])
+    end
+
+    it "subsets association results" do
+      stolen_record = FactoryBot.create(:stolen_record)
+      image1 = FactoryBot.create(:alert_image, stolen_record: stolen_record)
+      image2 = FactoryBot.create(:alert_image, stolen_record: stolen_record)
+      FactoryBot.create(:alert_image, :retired, stolen_record: stolen_record)
+      FactoryBot.create(:alert_image)
+      FactoryBot.create(:alert_image, :retired)
+      expect(stolen_record.alert_images.current).to match_array([image1, image2])
+    end
+  end
+
+  describe "#retired?" do
+    it "negates current status" do
+      old_image = FactoryBot.build_stubbed(:alert_image, :retired)
+      expect(old_image).to be_retired
+
+      curr_image = FactoryBot.build_stubbed(:alert_image)
+      expect(curr_image).to_not be_retired
+    end
+  end
+
+  describe "after_save commit hooks" do
+  end
+end

--- a/spec/models/alert_image_spec.rb
+++ b/spec/models/alert_image_spec.rb
@@ -1,6 +1,26 @@
 require "rails_helper"
 
 RSpec.describe AlertImage, type: :model do
+  describe "after_save commit hooks" do
+    it "removes alert_image if no longer current" do
+      alert_image = FactoryBot.create(:alert_image, :with_image, current: true)
+      expect(alert_image.image).to be_present
+
+      alert_image.update(current: false)
+
+      expect(alert_image.image).to be_blank
+    end
+
+    it "does not remove alert_image if still current" do
+      alert_image = FactoryBot.create(:alert_image, :with_image, current: true)
+      expect(alert_image.image).to be_present
+
+      alert_image.update(updated_at: Time.current)
+
+      expect(alert_image.image).to be_present
+    end
+  end
+
   describe ".retire_all" do
     it "toggles current status and removes images" do
       image1 = FactoryBot.create(:alert_image, :with_image)
@@ -62,8 +82,5 @@ RSpec.describe AlertImage, type: :model do
       curr_image = FactoryBot.build_stubbed(:alert_image)
       expect(curr_image).to_not be_retired
     end
-  end
-
-  describe "after_save commit hooks" do
   end
 end

--- a/spec/models/alert_image_spec.rb
+++ b/spec/models/alert_image_spec.rb
@@ -3,16 +3,16 @@ require "rails_helper"
 RSpec.describe AlertImage, type: :model do
   describe "after_save commit hooks" do
     it "removes alert_image if no longer current" do
-      alert_image = FactoryBot.create(:alert_image, :with_image, current: true)
+      alert_image = FactoryBot.create(:alert_image, :with_image)
       expect(alert_image.image).to be_present
 
-      alert_image.update(current: false)
+      alert_image.retired!
 
       expect(alert_image.image).to be_blank
     end
 
     it "does not remove alert_image if still current" do
-      alert_image = FactoryBot.create(:alert_image, :with_image, current: true)
+      alert_image = FactoryBot.create(:alert_image, :with_image)
       expect(alert_image.image).to be_present
 
       alert_image.update(updated_at: Time.current)

--- a/spec/models/alert_image_spec.rb
+++ b/spec/models/alert_image_spec.rb
@@ -1,86 +1,14 @@
 require "rails_helper"
 
 RSpec.describe AlertImage, type: :model do
-  describe "after_save commit hooks" do
-    it "removes alert_image if no longer current" do
+  describe "before_destroy commit hooks" do
+    it "removes alert_image before destroy" do
       alert_image = FactoryBot.create(:alert_image, :with_image)
       expect(alert_image.image).to be_present
 
-      alert_image.retired!
+      alert_image.destroy
 
       expect(alert_image.image).to be_blank
-    end
-
-    it "does not remove alert_image if still current" do
-      alert_image = FactoryBot.create(:alert_image, :with_image)
-      expect(alert_image.image).to be_present
-
-      alert_image.update(updated_at: Time.current)
-
-      expect(alert_image.image).to be_present
-    end
-  end
-
-  describe ".retire_all" do
-    it "toggles current status and removes images" do
-      image1 = FactoryBot.create(:alert_image, :with_image)
-      image2 = FactoryBot.create(:alert_image, :with_image)
-      FactoryBot.create(:alert_image, :retired)
-
-      expect(AlertImage.current).to match_array([image1, image2])
-      expect(AlertImage.current.all? { |i| i.image.present? }).to eq(true)
-
-      AlertImage.retire_all
-
-      expect(AlertImage.current).to be_empty
-      expect(AlertImage.current.all? { |i| i.image.blank? }).to eq(true)
-    end
-
-    it "retires all within an association scope" do
-      stolen_record = FactoryBot.create(:stolen_record)
-      image1 = FactoryBot.create(:alert_image, stolen_record: stolen_record)
-      image2 = FactoryBot.create(:alert_image, stolen_record: stolen_record)
-      FactoryBot.create(:alert_image, :retired, stolen_record: stolen_record)
-      image3 = FactoryBot.create(:alert_image)
-      FactoryBot.create(:alert_image, :retired)
-
-      current_alert_images = stolen_record.alert_images.current
-      expect(current_alert_images.pluck(:id)).to match_array([image1.id, image2.id])
-      expect(AlertImage.current.pluck(:id)).to match_array([image1, image2, image3].map(&:id))
-
-      stolen_record.alert_images.retire_all
-
-      expect(current_alert_images.pluck(:id)).to be_empty
-      expect(AlertImage.current.pluck(:id)).to match_array([image3.id])
-    end
-  end
-
-  describe ".current" do
-    it "returns images marked as current" do
-      image1 = FactoryBot.create(:alert_image)
-      FactoryBot.create(:alert_image, :retired)
-      image3 = FactoryBot.create(:alert_image)
-      expect(AlertImage.current).to match_array([image1, image3])
-    end
-
-    it "subsets association results" do
-      stolen_record = FactoryBot.create(:stolen_record)
-      image1 = FactoryBot.create(:alert_image, stolen_record: stolen_record)
-      image2 = FactoryBot.create(:alert_image, stolen_record: stolen_record)
-      FactoryBot.create(:alert_image, :retired, stolen_record: stolen_record)
-      FactoryBot.create(:alert_image)
-      FactoryBot.create(:alert_image, :retired)
-      expect(stolen_record.alert_images.current).to match_array([image1, image2])
-    end
-  end
-
-  describe "#retired?" do
-    it "negates current status" do
-      old_image = FactoryBot.build_stubbed(:alert_image, :retired)
-      expect(old_image).to be_retired
-
-      curr_image = FactoryBot.build_stubbed(:alert_image)
-      expect(curr_image).to_not be_retired
     end
   end
 end

--- a/spec/models/bike_spec.rb
+++ b/spec/models/bike_spec.rb
@@ -1324,7 +1324,7 @@ RSpec.describe Bike, type: :model do
       end
     end
 
-    context "given a current_stolen_record and public images" do
+    context "given a current_stolen_record and public bike images" do
       it "returns the alert_image url" do
         bike = FactoryBot.create(:stolen_bike, :with_image)
         expect(bike.alert_image_url).to match(%r{https?://.+/bike-#{bike.id}.jpg})

--- a/spec/models/stolen_record_spec.rb
+++ b/spec/models/stolen_record_spec.rb
@@ -45,26 +45,39 @@ RSpec.describe StolenRecord, type: :model do
 
   describe "#generate_alert_image" do
     context "given no bike image" do
-      it "returns with no changes" do
+      it "returns falsey with no changes" do
         stolen_record = FactoryBot.create(:stolen_record)
 
         result = stolen_record.generate_alert_image
 
-        expect(result).to be_falsey
+        expect(result).to be_nil
         expect(stolen_record.alert_image).to be_blank
-        expect(AlertImage.count).to eq(0)
+        expect(AlertImage.count).to be_zero
       end
     end
 
     context "given a bike image" do
-      it "updates alert_image" do
+      it "returns truthy and persists the alert image" do
         stolen_record = FactoryBot.create(:stolen_record, :with_bike_image)
 
         result = stolen_record.generate_alert_image
 
-        expect(result).to be_truthy
-        expect(stolen_record.alert_image).to be_present
+        expect(result).to be_an_instance_of(AlertImage)
+        expect(stolen_record.alert_image).to eq(result)
         expect(AlertImage.count).to eq(1)
+      end
+    end
+
+    context "given alert image creation fails" do
+      it "returns falsey with no changes" do
+        stolen_record = FactoryBot.create(:stolen_record, :with_bike_image)
+
+        bad_image = double(:image, image: 0)
+        result = stolen_record.generate_alert_image(bike_image: bad_image)
+
+        expect(result).to be_nil
+        expect(stolen_record.alert_image).to be_nil
+        expect(AlertImage.count).to eq(0)
       end
     end
 

--- a/spec/models/stolen_record_spec.rb
+++ b/spec/models/stolen_record_spec.rb
@@ -1,16 +1,15 @@
 require "rails_helper"
 
 RSpec.describe StolenRecord, type: :model do
-  describe "after_commit hooks" do
+  describe "after_save hooks" do
     context "if bike no longer exists" do
       it "removes alert_image" do
         stolen_record = FactoryBot.create(:stolen_record, :with_alert_image)
-        stolen_record.update_attribute(:bike, nil)
-        expect(stolen_record.bike).to be_blank
         expect(stolen_record.current_alert_image).to be_present
 
-        stolen_record.run_callbacks(:commit)
+        stolen_record.update_attribute(:bike, nil)
 
+        expect(stolen_record.bike).to be_blank
         expect(stolen_record.current_alert_image).to be_blank
       end
     end

--- a/spec/models/stolen_record_spec.rb
+++ b/spec/models/stolen_record_spec.rb
@@ -5,12 +5,12 @@ RSpec.describe StolenRecord, type: :model do
     context "if bike no longer exists" do
       it "removes alert_image" do
         stolen_record = FactoryBot.create(:stolen_record, :with_alert_image)
-        expect(stolen_record.current_alert_image).to be_present
+        expect(stolen_record.alert_image).to be_present
 
         stolen_record.update_attribute(:bike, nil)
 
         expect(stolen_record.bike).to be_blank
-        expect(stolen_record.current_alert_image).to be_blank
+        expect(stolen_record.alert_image).to be_blank
       end
     end
 
@@ -18,16 +18,15 @@ RSpec.describe StolenRecord, type: :model do
       it "removes alert_image" do
         bike = FactoryBot.create(:bike, stolen: true)
         stolen_record = FactoryBot.create(:stolen_record, :with_alert_image, bike: bike)
-        expect(stolen_record.current_alert_image).to be_present
+        expect(stolen_record.alert_image).to be_present
         expect(stolen_record.bike.stolen).to eq(true)
 
         stolen_record.add_recovery_information
         stolen_record.save
+        stolen_record.reload
+
         expect(stolen_record.bike.stolen).to eq(false)
-
-        stolen_record.run_callbacks(:commit)
-
-        expect(stolen_record.current_alert_image).to be_blank
+        expect(stolen_record.alert_image).to be_blank
       end
     end
 
@@ -35,11 +34,11 @@ RSpec.describe StolenRecord, type: :model do
       it "does not removes alert_image" do
         bike = FactoryBot.create(:bike, stolen: true)
         stolen_record = FactoryBot.create(:stolen_record, :with_alert_image, bike: bike)
-        expect(stolen_record.current_alert_image).to be_present
+        expect(stolen_record.alert_image).to be_present
 
         stolen_record.run_callbacks(:commit)
 
-        expect(stolen_record.current_alert_image).to be_present
+        expect(stolen_record.alert_image).to be_present
       end
     end
   end
@@ -52,7 +51,7 @@ RSpec.describe StolenRecord, type: :model do
         result = stolen_record.generate_alert_image
 
         expect(result).to be_falsey
-        expect(stolen_record.alert_images).to be_blank
+        expect(stolen_record.alert_image).to be_blank
         expect(AlertImage.count).to eq(0)
       end
     end
@@ -64,7 +63,7 @@ RSpec.describe StolenRecord, type: :model do
         result = stolen_record.generate_alert_image
 
         expect(result).to be_truthy
-        expect(stolen_record.alert_images).to be_present
+        expect(stolen_record.alert_image).to be_present
         expect(AlertImage.count).to eq(1)
       end
     end
@@ -76,12 +75,12 @@ RSpec.describe StolenRecord, type: :model do
 
         image1 = FactoryBot.create(:public_image, imageable: bike)
         FactoryBot.create(:public_image, imageable: bike)
-        expect(stolen_record.alert_images).to be_blank
+        expect(stolen_record.alert_image).to be_blank
 
         stolen_record.generate_alert_image
-        expect(stolen_record.alert_images).to be_present
+        expect(stolen_record.alert_image).to be_present
 
-        alert_image = stolen_record.alert_images.first
+        alert_image = stolen_record.alert_image
         alert_image_name = File.basename(alert_image.image.path, ".*")
         image1_name = File.basename(image1.image.path, ".*")
         expect(alert_image_name).to eq(image1_name)


### PR DESCRIPTION
- Adds `AlertImage` model to back alert image versions
- Update stolen records admin to use the new model
- Updates specs so that image files are created on an opt-in basis with the inclusion of a trait: `:with_alert_image` `:with_image`, etc

<img width="800" alt="Screen Shot 2019-08-06 at 6 29 42 PM" src="https://user-images.githubusercontent.com/4433943/62581781-310c8080-b878-11e9-946c-e41e13af045e.png">
