### PR TITLE
Explicitly set fog path style to silence warnings

### DIFF
--- a/config/initializers/carrierwave.rb
+++ b/config/initializers/carrierwave.rb
@@ -46,6 +46,7 @@ CarrierWave.configure do |config|
       aws_access_key_id: ENV["S3_ACCESS_KEY"],
       aws_secret_access_key: ENV["S3_SECRET_KEY"],
       region: "us-east-1",
+      path_style: true,
     }
     config.fog_directory = ENV["S3_BUCKET"]
     config.fog_attributes = { "Cache-Control" => "max-age=315576000" }


### PR DESCRIPTION
Silences fog warnings about s3 bucket names with dots:

```
[fog][WARNING] fog: the specified s3 bucket name(files.bikeindex.org) contains a '.' so is not accessible over https as a virtual hosted bucket, which will negatively impact performance.  For details see: http://docs.amazonwebservices.com/AmazonS3/latest/dev/BucketRestrictions.html
[fog][WARNING] fog: the specified s3 bucket name(files.bikeindex.org) contains a '.' so is not accessible over https as a virtual hosted bucket, which will negatively impact performance.  For details see: http://docs.amazonwebservices.com/AmazonS3/latest/dev/BucketRestrictions.html
[fog][WARNING] fog: the specified s3 bucket name(files.bikeindex.org) contains a '.' so is not accessible over https as a virtual hosted bucket, which will negatively impact performance.  For details see: http://docs.amazonwebservices.com/AmazonS3/latest/dev/BucketRestrictions.html
[fog][WARNING] fog: the specified s3 bucket name(files.bikeindex.org) contains a '.' so is not accessible over https as a virtual hosted bucket, which will negatively impact performance.  For details see: http://docs.amazonwebservices.com/AmazonS3/latest/dev/BucketRestrictions.html
[fog][WARNING] fog: the specified s3 bucket name(files.bikeindex.org) contains a '.' so is not accessible over https as a virtual hosted bucket, which will negatively impact performance.  For details see: http://docs.amazonwebservices.com/AmazonS3/latest/dev/BucketRestrictions.html
[fog][WARNING] fog: the specified s3 bucket name(files.bikeindex.org) contains a '.' so is not accessible over https as a virtual hosted bu
```

https://papertrailapp.com/groups/871953/events?q=program%3Auser_hard_worker_1.log

See: https://github.com/fog/fog/issues/3318