### PR TITLE
Add AlertImageUploader specs, AlertImageGenerator branching

### DIFF
--- a/app/services/alert_image_generator.rb
+++ b/app/services/alert_image_generator.rb
@@ -99,15 +99,19 @@ class AlertImageGenerator
       alert.font caption_font
 
       # Overlay bike url within lower border
-      alert.gravity "South"
-      alert.pointsize 50
-      alert.draw "text 0,25 '#{bike_url}'"
+      if bike_url.present?
+        alert.gravity "South"
+        alert.pointsize 50
+        alert.draw "text 0,25 '#{bike_url}'"
+      end
 
       # Overlay bike location on RHS of top border
-      alert.gravity "Northeast"
-      alert.pointsize 110
-      alert.size "x#{header_height}"
-      alert.draw "text 30,30 '#{bike_location}'"
+      if bike_location.present?
+        alert.gravity "Northeast"
+        alert.pointsize 110
+        alert.size "x#{header_height}"
+        alert.draw "text 30,30 '#{bike_location}'"
+      end
     end
 
     alert_image
@@ -129,6 +133,7 @@ class AlertImageGenerator
 
   # The bike url to be displayed on the promoted alert image
   def bike_url
+    return if bike&.id.blank?
     "bikeindex.org/bikes/#{bike.id}"
   end
 

--- a/spec/factories/public_images.rb
+++ b/spec/factories/public_images.rb
@@ -14,5 +14,9 @@ FactoryBot.define do
       public_image.image = File.open(ApplicationUploader.cache_dir.join(filename), "w+")
       public_image.save
     end
+
+    trait :for_stolen_bike do
+      imageable { FactoryBot.create(:stolen_bike) }
+    end
   end
 end

--- a/spec/services/alert_image_generator_spec.rb
+++ b/spec/services/alert_image_generator_spec.rb
@@ -2,14 +2,21 @@ require "rails_helper"
 
 RSpec.describe AlertImageGenerator do
   describe "#bike_url" do
-    it "returns a simplified url string to the given bike" do
-      stolen_record = FactoryBot.create(:stolen_record)
+    context "given a bike id" do
+      it "returns a simplified url string to the given bike" do
+        stolen_record = FactoryBot.create(:stolen_record)
+        generator = described_class.new(stolen_record: stolen_record, bike_image: nil)
+        expect(generator.bike_url).to eq("bikeindex.org/bikes/#{stolen_record.bike.id}")
+      end
+    end
 
-      generator = described_class.new(stolen_record: stolen_record,
-                                      bike_image: stolen_record.bike_main_image)
-
-      bike_id = stolen_record.bike.id
-      expect(generator.bike_url).to eq("bikeindex.org/bikes/#{bike_id}")
+    context "given no bike id" do
+      it "returns a simplified url string to the given bike" do
+        stolen_record = FactoryBot.create(:stolen_record)
+        stolen_record.update_attribute(:bike, nil)
+        generator = described_class.new(stolen_record: stolen_record, bike_image: nil)
+        expect(generator.bike_url).to be_nil
+      end
     end
   end
 
@@ -18,10 +25,7 @@ RSpec.describe AlertImageGenerator do
       it "returns the stolen record location" do
         stolen_record = FactoryBot.create(:stolen_record)
         allow(stolen_record).to receive(:address_location).and_return("City, State")
-
-        generator = described_class.new(stolen_record: stolen_record,
-                                        bike_image: stolen_record.bike_main_image)
-
+        generator = described_class.new(stolen_record: stolen_record, bike_image: nil)
         expect(generator.bike_location).to eq("City, State")
       end
     end
@@ -32,10 +36,7 @@ RSpec.describe AlertImageGenerator do
         allow(stolen_record).to receive(:address_location).and_return("")
         bike = stolen_record.bike
         allow(bike).to receive(:registration_location).and_return("Another City, State")
-
-        generator = described_class.new(stolen_record: stolen_record,
-                                        bike_image: stolen_record.bike_main_image)
-
+        generator = described_class.new(stolen_record: stolen_record, bike_image: nil)
         expect(generator.bike_location).to eq("Another City, State")
       end
     end

--- a/spec/uploaders/alert_image_uploader_spec.rb
+++ b/spec/uploaders/alert_image_uploader_spec.rb
@@ -1,0 +1,44 @@
+require "rails_helper"
+require "carrierwave/test/matchers"
+
+RSpec.describe AlertImageUploader do
+  include CarrierWave::Test::Matchers
+
+  context "given a non-image or invalid base image" do
+    it "raises AlertImageGeneratorError" do
+      stolen_record = FactoryBot.create(:stolen_record, :with_bike_image)
+
+      image_assignment = -> do
+        image_path = stolen_record.bike_main_image.image.manipulate! { |img| img }
+        expect(image_path).to match(%r{tmp})
+      end
+
+      expect { image_assignment.call }.to raise_error(CarrierWave::ProcessingError)
+    end
+  end
+
+  context "given a valid bike image" do
+    let(:bike_with_valid_image) do
+      FactoryBot.create(:stolen_bike).tap do |bike|
+        FactoryBot.create(:public_image, imageable: bike, image: valid_image)
+      end
+    end
+
+    let(:valid_image) { File.open(Rails.root.join("app/assets/images/pandabike.jpg"), "r") }
+    after(:each) { valid_image.close }
+
+    it "generates landscape variant" do
+      stolen_record = FactoryBot.create(:stolen_record, bike: bike_with_valid_image)
+      image_uploader = stolen_record.bike_main_image.image
+
+      image_path = image_uploader.manipulate! { |img| img }
+      expect(image_path).to match(%r{/tmp/cache/.+JPEG})
+
+      image_path = image_uploader.manipulate! { |img| img.format(:png) }
+      expect(image_path).to match(%r{/tmp/cache/.+PNG})
+
+      image_path = image_uploader.manipulate! { |img| img.format(:gif) }
+      expect(image_path).to match(%r{/tmp/cache/.+GIF})
+    end
+  end
+end

--- a/spec/uploaders/alert_image_uploader_spec.rb
+++ b/spec/uploaders/alert_image_uploader_spec.rb
@@ -18,17 +18,13 @@ RSpec.describe AlertImageUploader do
   end
 
   context "given a valid bike image" do
-    let(:bike_with_valid_image) do
-      FactoryBot.create(:stolen_bike).tap do |bike|
-        FactoryBot.create(:public_image, imageable: bike, image: valid_image)
-      end
-    end
-
+    # define in a let in order to close file handler during teardown
     let(:valid_image) { File.open(Rails.root.join("app/assets/images/pandabike.jpg"), "r") }
     after(:each) { valid_image.close }
 
     it "generates landscape variant" do
-      stolen_record = FactoryBot.create(:stolen_record, bike: bike_with_valid_image)
+      image = FactoryBot.create(:public_image, :for_stolen_bike, image: valid_image)
+      stolen_record = image.imageable.current_stolen_record
       image_uploader = stolen_record.bike_main_image.image
 
       image_path = image_uploader.manipulate! { |img| img }


### PR DESCRIPTION
- Adds specs for `AlertImageUploader` documenting behavior when base image is invalid or empty
- Adds branching around absent bike_url, bike_location in `AlertImageGenerator`