### PR TITLE
Add user image selection to premium alert purchasing flow

### DIFF
--- a/app/assets/javascripts/revised/pages/bikes/edit_alert.coffee
+++ b/app/assets/javascripts/revised/pages/bikes/edit_alert.coffee
@@ -2,11 +2,37 @@ class BikeIndex.BikesEditAlert extends BikeIndex
   constructor: ->
     super()
     @$planSelectionForm = $('#js-select-plan-form')
+    @$imageSelectionContainer = $('#js-select-image-container')
     @initializeEventListeners()
 
   initializeEventListeners: =>
     @$planSelectionForm.on "click", ".js-plan-select", (event) =>
       @highlightSelectedPlan(event)
+    @$imageSelectionContainer.on "click", ".js-image-select", (event) =>
+      $selectedImage = $(event.target).closest(".js-image-select")
+      @highlightSelectedImage($selectedImage)
+      @setSelectedImageId($selectedImage)
+      @previewSelectedImage($selectedImage)
+
+  highlightSelectedImage: ($selectedImage) =>
+    $allImages = $selectedImage.siblings(".js-image-select").removeClass("selected")
+    $selectedImage.addClass("selected")
+
+  previewSelectedImage: ($selectedImage) =>
+    selectedImageUrl = $selectedImage.data("image-url")
+    previewImage = "<img src='#{selectedImageUrl}' alt='alert image preview'>"
+
+    # ensure preview container is visible
+    $preview = @$imageSelectionContainer.find("#js-selection-preview")
+    $preview.removeClass("d-none")
+
+    # display / switch preview image
+    $previewImage = $preview.find("#js-selection-preview-image")
+    $previewImage.html(previewImage)
+
+  setSelectedImageId: ($selectedImage) =>
+    selectedImageId = $selectedImage.data("image-id")
+    @$planSelectionForm.find("#selected_bike_image_id").val(selectedImageId)
 
   highlightSelectedPlan: (event) =>
     third = event.target.offsetWidth / 3

--- a/app/assets/stylesheets/revised/mixins/_colors.scss
+++ b/app/assets/stylesheets/revised/mixins/_colors.scss
@@ -9,9 +9,10 @@ $blue-light: #92c8ec;
 $blue-faint: #fffffff5;
 
 $gray-darkest: #1a1a1a;
-$gray-darker: #333333;
+$gray-darker: #333;
 $gray-dark: #222;
 $gray: #666;
+$gray-subtle: #999;
 $gray-light: #a4a4a4;
 $gray-lightish: #e4e4e4;
 

--- a/app/assets/stylesheets/revised/pages/bikes/edit_alert.scss
+++ b/app/assets/stylesheets/revised/pages/bikes/edit_alert.scss
@@ -8,7 +8,7 @@
 
     .times {
       font-size: 150%;
-      line-height: 0.8em;
+      line-height: .8em;
       vertical-align: middle;
     }
   }
@@ -41,14 +41,76 @@
     }
   }
 
+  .image-selection-container {
+    ul {
+      display: flex;
+      flex-wrap: nowrap;
+      height: 250px;
+      list-style-type: none;
+      overflow-x: auto;
+      padding: 0;
+      width: 100%;
+    }
+
+    li {
+      border: 1px solid $gray-lightish;
+      cursor: pointer;
+      flex: 0 0 auto;
+      margin: auto 5px;
+      padding: 5px;
+    }
+
+    li:first-of-type {
+      margin-left: 0;
+    }
+
+    .selected {
+      background: $blue;
+    }
+
+    .selection-preview-image-template {
+      background-image: image-url('promoted_alerts/facebook-template.png');
+      background-size: cover;
+      height: 225px;
+      margin-bottom: 4rem;
+      padding: 13px 0;
+      position: relative;
+    }
+
+    .selection-preview-image {
+      height: 90%;
+      left: 42px;
+      position: absolute;
+      width: 90%;
+    }
+
+    .selection-preview-caption {
+      background: $black;
+      bottom: 4px;
+      color: $white;
+      font-style: italic;
+      height: 10%;
+      line-height: 1.5;
+      position: absolute;
+      right: 0;
+      text-align: center;
+      vertical-align: middle;
+      width: 42%;
+    }
+
+    img {
+      max-height: 200px;
+    }
+  }
+
   .detail-card-container {
     background-color: $white;
-    border: 1px solid #999;
+    border: 1px solid $gray-subtle;
     border-radius: 4px;
     margin: 15px auto;
 
     &.selected {
-      border: 1px solid #3498db;
+      border: 1px solid $blue;
     }
   }
 
@@ -60,20 +122,20 @@
     font-weight: 400;
     letter-spacing: 1.25px;
     padding: 25px;
-    text-align: center;
     position: relative;
+    text-align: center;
   }
 
   .preferred-tag {
-    background-color: #3598da;
+    background-color: $blue;
     bottom: -7px;
-    color: #fff;
+    color: $white;
     font-size: 12px;
     line-height: 1;
     margin: 0;
     padding: 5px 10px;
     position: absolute;
-    right: 0px;
+    right: 0;
     text-align: right;
     width: 93px;
   }
@@ -150,7 +212,7 @@
     transition: all 125ms ease-in-out;
 
     &::before {
-      background-color: #ffffff;
+      background-color: $white;
       border: 2px solid #919197;
       border-radius: 50%;
       content: '';
@@ -162,15 +224,15 @@
     }
 
     &.selected {
-      background-color: #3498db;
+      background-color: $blue;
       border-bottom-left-radius: 0;
       border-bottom-right-radius: 0;
     }
 
     &.selected::before {
-      background-color: #3498db;
-      border-color: #ffffff;
-      color: #ffffff;
+      background-color: $blue;
+      border-color: $white;
+      color: $white;
       content: '\2713';
       font-family: 'zp-icons';
       font-style: normal;

--- a/app/controllers/bikes_controller.rb
+++ b/app/controllers/bikes_controller.rb
@@ -175,10 +175,14 @@ class BikesController < ApplicationController
           .where(imageable_id: @bike.id)
           .where(is_private: true)
     when /alert/
+      bike_image = PublicImage.find_by(id: params[:selected_bike_image_id])
+      @bike.current_stolen_record.generate_alert_image(bike_image: bike_image)
+
       @theft_alert_plans = TheftAlertPlan.active.price_ordered_asc
       @selected_theft_alert_plan =
         @theft_alert_plans.find_by(id: params[:selected_plan_id]) ||
         @theft_alert_plans.min_by(&:amount_cents)
+
       @theft_alerts =
         @bike
           .current_stolen_record

--- a/app/models/stolen_record.rb
+++ b/app/models/stolen_record.rb
@@ -253,6 +253,14 @@ class StolenRecord < ActiveRecord::Base
     recovery_link_token
   end
 
+  # The stolen bike's general location (city and state)
+  # Prefers the stolen record's address location, falls back to the bike's
+  # registration location, returns nil if neither yields an adequate location.
+  def bike_location
+    address_location.presence || bike.registration_location.presence
+  end
+
+  # The associated bike's first public image, if available. Else nil.
   def bike_main_image
     bike&.public_images&.order(:id)&.first
   end

--- a/app/services/alert_image_generator.rb
+++ b/app/services/alert_image_generator.rb
@@ -118,17 +118,10 @@ class AlertImageGenerator
   end
 
   # The bike location to be displayed on the promoted alert image
+  # Escape single-quotes: location is passed to Imagemagick CLI inside
+  # single-quotes
   def bike_location
-    location =
-      if stolen_record.address_location.present?
-        stolen_record.address_location
-      else
-        bike.registration_location
-      end
-
-    # escape single-quotes: location is passed to Imagemagick CLI inside
-    # single-quotes
-    location.gsub("'", "\\'")
+    stolen_record.bike_location&.gsub("'", "\\'")
   end
 
   # The bike url to be displayed on the promoted alert image

--- a/app/views/bikes/edit_alert.html.haml
+++ b/app/views/bikes/edit_alert.html.haml
@@ -19,7 +19,30 @@
           = form_tag edit_bike_url(@bike), method: :get, id: "js-select-plan-form" do
             = hidden_field_tag :page, :alert_purchase
             = hidden_field_tag :selected_plan_id
+            = hidden_field_tag :selected_bike_image_id
             = hidden_field_tag :locale, params[:locale] if params[:locale].presence
+
+            .row
+              %h3.text-center.w-100= t(".select_an_image")
+              .col-sm-12
+                - if @bike.public_images.none?
+                  %p= t(".no_photos_add_photos_here_html", link: link_to(t(".here"), edit_bike_url(@bike, page: :photos)))
+                - else
+                  = t(".select_an_image_to_see_preview")
+
+                  .image-selection-container#js-select-image-container
+                    %ul
+                      - @bike.public_images.each do |image|
+                        %li.js-image-select{"data-image-url" => image.image_url(:medium), "data-image-id" => image.id}
+                          = image_tag image.image_url(:medium)
+                    .text-center.w-100.d-none#js-selection-preview
+                      %h5= t(".preview")
+                      .selection-preview-image-template
+                        .selection-preview-image#js-selection-preview-image
+                        .selection-preview-caption
+                          -# Fall back to "City, State" as a nudge to add
+                          -# location info to stolen record
+                          = @bike.current_stolen_record.bike_location || t(".city_state")
             .row
               %h3.text-center.w-100
                 = t(".select_plan")

--- a/app/views/bikes/edit_alert.html.haml
+++ b/app/views/bikes/edit_alert.html.haml
@@ -32,13 +32,16 @@
 
                   .image-selection-container#js-select-image-container
                     %ul
-                      - @bike.public_images.each do |image|
-                        %li.js-image-select{"data-image-url" => image.image_url(:medium), "data-image-id" => image.id}
+                      - @bike.public_images.each_with_index do |image, i|
+                        = content_tag "li",
+                          class: (i.zero? ? "selected js-image-select" : "js-image-select"),
+                          data: {"image-url" => image.image_url(:medium), "image-id" => image.id} do
                           = image_tag image.image_url(:medium)
-                    .text-center.w-100.d-none#js-selection-preview
+                    .text-center.w-100#js-selection-preview
                       %h5= t(".preview")
                       .selection-preview-image-template
                         .selection-preview-image#js-selection-preview-image
+                          = image_tag @bike.public_images.first.image_url(:medium)
                         .selection-preview-caption
                           -# Fall back to "City, State" as a nudge to add
                           -# location info to stolen record

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -975,6 +975,16 @@ en:
       bike_index_can_help: >-
         Bike Index can help by purchasing targeted ads on Facebook to spread the word
         about your stolen %{bike_type}.
+      city_state: City, State
+      here: here
+      no_photos_add_photos_here_html: >-
+        Uh oh. We don't have any photos of your bike available. Upload one %{link}
+        to set up a promoted alert!
+      preview: Preview
+      select_an_image: Select an image
+      select_an_image_to_see_preview: >-
+        Select an image of your bike to see a preview of what your promoted alert
+        will look like:
       select_plan: Select Plan
       targeted_sharing_html: >-
         We've found targeted sharing on social media to have a <em>huge</em> effect

--- a/spec/uploaders/alert_image_uploader_spec.rb
+++ b/spec/uploaders/alert_image_uploader_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe AlertImageUploader do
   include CarrierWave::Test::Matchers
 
   context "given a non-image or invalid base image" do
-    it "raises AlertImageGeneratorError" do
+    it "raises CarrierWave::ProcessingError" do
       stolen_record = FactoryBot.create(:stolen_record, :with_bike_image)
 
       image_assignment = -> do


### PR DESCRIPTION
- Provides a UI for a user to select one of their bike's public images to be used in the promoted alert image. 

- Provides a preview rendered using CSS

- Begins generating / processing the alert image when the first stage of the promoted alert form is submitted



![demo](https://user-images.githubusercontent.com/4433943/62731052-4c4dcc00-b9ef-11e9-82c2-9a7c44b70369.gif)
