### PR TITLE
Fix alert image css preview

### DIFF
--- a/app/assets/javascripts/revised/pages/bikes/edit_alert.coffee
+++ b/app/assets/javascripts/revised/pages/bikes/edit_alert.coffee
@@ -20,15 +20,8 @@ class BikeIndex.BikesEditAlert extends BikeIndex
 
   previewSelectedImage: ($selectedImage) =>
     selectedImageUrl = $selectedImage.data("image-url")
-    previewImage = "<img src='#{selectedImageUrl}' alt='alert image preview'>"
-
-    # ensure preview container is visible
-    $preview = @$imageSelectionContainer.find("#js-selection-preview")
-    $preview.removeClass("d-none")
-
-    # display / switch preview image
-    $previewImage = $preview.find("#js-selection-preview-image")
-    $previewImage.html(previewImage)
+    $previewImage = @$imageSelectionContainer.find("#js-selection-preview-image img")
+    $previewImage.attr("src", selectedImageUrl)
 
   setSelectedImageId: ($selectedImage) =>
     selectedImageId = $selectedImage.data("image-id")

--- a/app/assets/stylesheets/revised/pages/bikes/edit_alert.scss
+++ b/app/assets/stylesheets/revised/pages/bikes/edit_alert.scss
@@ -68,20 +68,28 @@
       background: $blue;
     }
 
+    .selection-preview {
+      margin-bottom: 4rem;
+    }
+
     .selection-preview-image-template {
       background-image: image-url('promoted_alerts/facebook-template.png');
       background-size: cover;
-      height: 225px;
-      margin-bottom: 4rem;
-      padding: 13px 0;
+      margin: auto;
+      max-width: 420px;
+      padding: 13px 0 13px 40px;
       position: relative;
+      vertical-align: middle;
+      width: auto;
     }
 
     .selection-preview-image {
-      height: 90%;
-      left: 42px;
-      position: absolute;
-      width: 90%;
+      display: inline-block;
+      vertical-align: middle;
+
+      img {
+        max-width: 300px;
+      }
     }
 
     .selection-preview-caption {

--- a/app/assets/stylesheets/revised/pages/bikes/edit_alert.scss
+++ b/app/assets/stylesheets/revised/pages/bikes/edit_alert.scss
@@ -77,7 +77,7 @@
       background-size: cover;
       margin: auto;
       max-width: 420px;
-      padding: 13px 0 13px 40px;
+      padding: 13px 0 13px 36px;
       position: relative;
       vertical-align: middle;
       width: auto;
@@ -86,9 +86,10 @@
     .selection-preview-image {
       display: inline-block;
       vertical-align: middle;
+      width: 100%;
 
       img {
-        max-width: 300px;
+        max-width: 95%;
       }
     }
 

--- a/app/views/bikes/edit_alert.html.haml
+++ b/app/views/bikes/edit_alert.html.haml
@@ -37,7 +37,7 @@
                           class: (i.zero? ? "selected js-image-select" : "js-image-select"),
                           data: {"image-url" => image.image_url(:medium), "image-id" => image.id} do
                           = image_tag image.image_url(:medium)
-                    .text-center.w-100#js-selection-preview
+                    .selection-preview.text-center.w-100#js-selection-preview
                       %h5= t(".preview")
                       .selection-preview-image-template
                         .selection-preview-image#js-selection-preview-image


### PR DESCRIPTION
The current alert image preview CSS rules assume >100% font size. (which is what I have locally because because my eyes are trash). This updates the CSS rules to make them more robust to font size changes.

Before:

<img width="841" alt="Screen Shot 2019-08-08 at 7 19 13 PM" src="https://user-images.githubusercontent.com/4433943/62744274-d7d95400-ba13-11e9-8e93-73e701787ad4.png">


After:

![demo-branch](https://user-images.githubusercontent.com/4433943/62744282-dc9e0800-ba13-11e9-8734-11c100936af5.gif)
