### PR TITLE
Make caption more robust to weird width / font size combos

### DIFF
--- a/app/assets/stylesheets/revised/pages/bikes/edit_alert.scss
+++ b/app/assets/stylesheets/revised/pages/bikes/edit_alert.scss
@@ -77,7 +77,7 @@
       background-size: cover;
       margin: auto;
       max-width: 420px;
-      padding: 13px 0 13px 36px;
+      padding: 13px 0 13px 28px;
       position: relative;
       vertical-align: middle;
       width: auto;
@@ -97,6 +97,7 @@
       background: $black;
       bottom: 4px;
       color: $white;
+      font-size: 1rem;
       font-style: italic;
       height: 10%;
       line-height: 1.5;
@@ -109,6 +110,14 @@
 
     img {
       max-height: 200px;
+    }
+  }
+
+  @media (max-width: $grid-breakpoint-md) {
+    .image-selection-container {
+      .selection-preview-caption {
+        font-size: .70rem;
+      }
     }
   }
 


### PR DESCRIPTION
Very high font magnification + very narrow viewport:

Before:
<img width="476" alt="Screen Shot 2019-08-08 at 8 02 33 PM" src="https://user-images.githubusercontent.com/4433943/62745254-0fe29600-ba18-11e9-9228-7682a2bc01c7.png">


After:
<img width="482" alt="Screen Shot 2019-08-08 at 8 05 47 PM" src="https://user-images.githubusercontent.com/4433943/62745255-1113c300-ba18-11e9-890f-420ea17387df.png">

