### PR TITLE
Fix nil NoMethodError from Organization#parent?

### DIFF
--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -119,7 +119,7 @@ class Organization < ActiveRecord::Base
 
   def ascend_imports?; ascend_name.present? end
 
-  def parent?; child_ids.any? end
+  def parent?; child_ids.present? end
 
   def child_organizations; Organization.where(id: child_ids) end
 


### PR DESCRIPTION
Fixes `NoMethodError` when `child_ids` is `nil`:

> NoMethodError in Welcome#user_home
> Showing app/views/layouts/application_revised.html.haml where line #38 raised:
> undefined method `any?' for nil:NilClass

```rb
2.5.5 (bikeindex)[1] » Organization.where(child_ids: nil).count
 (1.6ms)  SELECT COUNT(*) FROM "organizations" WHERE "organizations"."deleted_at" IS NULL AND "organizations"."child_ids" IS NULL
724
```