### PR TITLE
Fix bulk membership invitation for unregistered ambassadors

### DIFF
--- a/app/workers/process_membership_worker.rb
+++ b/app/workers/process_membership_worker.rb
@@ -50,7 +50,7 @@ class ProcessMembershipWorker < ApplicationWorker
   end
 
   def assign_all_ambassador_tasks_to(membership)
-    return unless membership.ambassador?
+    return unless membership.ambassador? && membership.user.present?
     ambassador = membership.user.becomes(Ambassador)
 
     already_assigned_task_ids =

--- a/spec/workers/process_membership_worker_spec.rb
+++ b/spec/workers/process_membership_worker_spec.rb
@@ -5,7 +5,20 @@ RSpec.describe ProcessMembershipWorker, type: :job do
   before { ActionMailer::Base.deliveries = [] }
 
   describe "#perform" do
-    context "ambassador" do
+    context "ambassador membership" do
+      context "when sending a membership intvitation" do
+        it "does not create ambassador_task_assignments" do
+          org = FactoryBot.create(:organization_ambassador)
+          membership = FactoryBot.create(:membership, organization: org)
+          FactoryBot.create(:ambassador_task)
+          expect(AmbassadorTaskAssignment.count).to eq(0)
+
+          instance.perform(membership.id)
+
+          expect(AmbassadorTaskAssignment.count).to eq(0)
+        end
+      end
+
       context "given a non-ambassador" do
         it "does not create ambassador_task_assignments" do
           membership = FactoryBot.create(:membership_claimed)


### PR DESCRIPTION
Fix an exception that occurs when inviting an unregistered user to an ambassador organization:

Resolves https://app.honeybadger.io/projects/35931/faults/53420005