### PR TITLE
Fix issue with ambassador membership assignment

### DIFF
--- a/app/workers/process_membership_worker.rb
+++ b/app/workers/process_membership_worker.rb
@@ -17,7 +17,9 @@ class ProcessMembershipWorker < ApplicationWorker
     membership.organization.update_attributes(updated_at: Time.current) if membership.organization.present?
 
     # Assign ambassador tasks too
-    assign_all_ambassador_tasks_to(membership) if membership.user.present?
+    if membership.ambassador? && membership.user.present?
+      assign_all_ambassador_tasks_to(membership)
+    end
   end
 
   def assign_membership_user(membership, user_id)
@@ -50,7 +52,6 @@ class ProcessMembershipWorker < ApplicationWorker
   end
 
   def assign_all_ambassador_tasks_to(membership)
-    return unless membership.ambassador?
     ambassador = membership.user.becomes(Ambassador)
 
     already_assigned_task_ids =

--- a/app/workers/process_membership_worker.rb
+++ b/app/workers/process_membership_worker.rb
@@ -17,7 +17,7 @@ class ProcessMembershipWorker < ApplicationWorker
     membership.organization.update_attributes(updated_at: Time.current) if membership.organization.present?
 
     # Assign ambassador tasks too
-    assign_all_ambassador_tasks_to(membership)
+    assign_all_ambassador_tasks_to(membership) if membership.user.present?
   end
 
   def assign_membership_user(membership, user_id)


### PR DESCRIPTION
Fix an exception that occurs when inviting an unregistered user to an ambassador organization:

Resolves https://app.honeybadger.io/projects/35931/faults/53420005

Continuation of #1183 