### PR TITLE
Externalize organized skeleton templates

### DIFF
--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -209,7 +209,7 @@ class Organization < ActiveRecord::Base
       self.slug = new_slug
     end
     self.access_token ||= SecurityTokenizer.new_token
-    self.child_ids = calculated_children.pluck(:id)
+    self.child_ids = calculated_children.pluck(:id) || []
     set_auto_user
     set_ambassador_organization_defaults if ambassador?
     locations.each { |l| l.save unless l.shown == allowed_show }
@@ -227,7 +227,7 @@ class Organization < ActiveRecord::Base
   def current_parent_invoices; Invoice.where(organization_id: parent_organization_id).active end
 
   def incomplete_b_params
-    BParam.where(organization_id: child_ids + [id]).partial_registrations.without_bike
+    BParam.where(organization_id: [*child_ids, id]).partial_registrations.without_bike
   end
 
   # Enable this if they have paid for showing it, or if they use ascend

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -227,7 +227,7 @@ class Organization < ActiveRecord::Base
   def current_parent_invoices; Invoice.where(organization_id: parent_organization_id).active end
 
   def incomplete_b_params
-    BParam.where(organization_id: [*child_ids, id]).partial_registrations.without_bike
+    BParam.where(organization_id: [child_ids, id].flatten.compact).partial_registrations.without_bike
   end
 
   # Enable this if they have paid for showing it, or if they use ascend

--- a/app/views/organized/bikes/incompletes.html.haml
+++ b/app/views/organized/bikes/incompletes.html.haml
@@ -17,7 +17,7 @@
         .actions
           = submit_tag t(".search"), class: "btn btn-primary"
 
-- include_child_org = current_organization.child_ids.any?
+- include_child_org = current_organization.child_ids.present?
 %table.table.table-striped.table-hover.table-bordered.table-sm.without-exterior-border
   %thead.small-header
     %th

--- a/app/views/shared/_edit_bike_skeleton.html.haml
+++ b/app/views/shared/_edit_bike_skeleton.html.haml
@@ -1,24 +1,23 @@
 .form-well-header.container{ data: { template: @edit_template } }
   .edit-bike-header
     %h1
-      - if @bike.stolen and @bike.find_current_stolen_record.present?
+      - if @bike.stolen && @bike.find_current_stolen_record.present?
         %span.text-danger
-          = @bike.abandoned ? 'abandoned' : 'stolen'
+          = @bike.abandoned ? t(".abandoned") : t(".stolen")
       - else
-        Edit
+        = t(".edit")
       = @bike.year
       = @bike.mnfg_name
       = @bike.frame_model
       = @bike.type unless @bike.type == 'bike'
+
     - unless @bike.user?
       %p.mb-0
-        Owned by
-        %em
-          = @bike.owner_email
         - if @bike.authorized_by_organization?(org: passive_organization)
-          but #{passive_organization&.short_name} has permission to edit
+          = t(".owned_with_permission_to_edit_html", owner_email: @bike.owner_email, org_name: passive_organization&.short_name)
         - else # it's almost certainly because the user hasn't claimed it
-          but it hasn't been claimed yet
+          = t(".owned_but_hasnt_been_claimed_html", owner_email: @bike.owner_email)
+
     %p.mb-4
-      = link_to "View #{@bike.type.titleize}", bike_path(@bike), class: "gray-link"
+      = link_to t(".view_bike", bike_type: @bike.type.titleize), bike_path(@bike), class: "gray-link"
 = yield

--- a/app/views/shared/_organized_skeleton.html.haml
+++ b/app/views/shared/_organized_skeleton.html.haml
@@ -24,7 +24,7 @@
         - on_bikes_path = controller_name == "bikes" && action_name == "index" # Because we want to ignore queries and stuff
         - on_impound_bikes_path = on_bikes_path && params[:search_impoundedness] == "only_impounded"
         %li
-          = link_to t(".bikes"), organization_bikes_path(organization_id: current_organization.to_param), class: "menu-item #{(on_bikes_path && !on_impound_bikes_path) ? t(".active") : ''}"
+          = link_to t(".bikes"), organization_bikes_path(organization_id: current_organization.to_param), class: "menu-item #{(on_bikes_path && !on_impound_bikes_path) ? 'active' : ''}"
         - if current_organization.paid_for?("impound_bikes")
           %li
             = link_to t(".impounded_bikes"), organization_bikes_path(organization_id: current_organization.to_param, search_impoundedness: "only_impounded"), class: "menu-item #{on_impound_bikes_path ? 'active' : ''}"

--- a/app/views/shared/_organized_skeleton.html.haml
+++ b/app/views/shared/_organized_skeleton.html.haml
@@ -4,124 +4,123 @@
       - if current_organization.display_avatar
         = image_tag current_organization.avatar.url(:medium)
       %h3
-        Admin Panel
+        = t(".admin_panel")
         %span
           = current_organization.name
 
     %ul.organized-mainmenu
       - if current_organization.ambassador?
         %li
-          = active_link "#{passive_organization.short_name}", organization_ambassador_dashboard_path, class: "menu-item"
+          = active_link passive_organization.short_name.to_s, organization_ambassador_dashboard_path, class: "menu-item"
         %li
-          = active_link "Resources", resources_organization_ambassador_dashboard_path(organization_id: current_organization.to_param), class: "menu-item"
+          = active_link t(".resources"), resources_organization_ambassador_dashboard_path(organization_id: current_organization.to_param), class: "menu-item"
         %li
-          = active_link "Getting started", getting_started_organization_ambassador_dashboard_path(organization_id: current_organization.to_param), class: "menu-item"
+          = active_link t(".getting_started"), getting_started_organization_ambassador_dashboard_path(organization_id: current_organization.to_param), class: "menu-item"
         %li
-          = active_link "Multi serial search", multi_serial_search_organization_bikes_path(organization_id: current_organization.to_param), class: "menu-item"
+          = active_link t(".multi_serial_search"), multi_serial_search_organization_bikes_path(organization_id: current_organization.to_param), class: "menu-item"
         %li
-          = active_link "Discuss", "https://discuss.bikeindex.org", class: "menu-item"
+          = active_link t(".discuss"), "https://discuss.bikeindex.org", class: "menu-item"
       - else
         - on_bikes_path = controller_name == "bikes" && action_name == "index" # Because we want to ignore queries and stuff
         - on_impound_bikes_path = on_bikes_path && params[:search_impoundedness] == "only_impounded"
         %li
-          = link_to "Bikes", organization_bikes_path(organization_id: current_organization.to_param), class: "menu-item #{(on_bikes_path && !on_impound_bikes_path) ? 'active' : ''}"
+          = link_to t(".bikes"), organization_bikes_path(organization_id: current_organization.to_param), class: "menu-item #{(on_bikes_path && !on_impound_bikes_path) ? t(".active") : ''}"
         - if current_organization.paid_for?("impound_bikes")
           %li
-            = link_to "Impounded Bikes", organization_bikes_path(organization_id: current_organization.to_param, search_impoundedness: "only_impounded"), class: "menu-item #{on_impound_bikes_path ? 'active' : ''}"
+            = link_to t(".impounded_bikes"), organization_bikes_path(organization_id: current_organization.to_param, search_impoundedness: "only_impounded"), class: "menu-item #{on_impound_bikes_path ? 'active' : ''}"
         %li
-          = active_link "Add a bike", new_organization_bike_path(current_organization), class: "menu-item"
+          = active_link t(".add_a_bike"), new_organization_bike_path(current_organization), class: "menu-item"
         %li
           - if current_organization.paid_for?("show_partial_registrations")
-            = active_link "Incomplete registrations", incompletes_organization_bikes_path(current_organization), class: "menu-item"
+            = active_link t(".incomplete_registrations"), incompletes_organization_bikes_path(current_organization), class: "menu-item"
           - elsif !current_organization.bike_shop?
             %span.disabled-menu-item.menu-item
-              Incomplete registrations
+              = t(".incomplete_registrations")
         - if current_organization.show_multi_serial?
           %li
-            = active_link "Multi serial search", multi_serial_search_organization_bikes_path(current_organization), class: "menu-item"
+            = active_link t(".multi_serial_search"), multi_serial_search_organization_bikes_path(current_organization), class: "menu-item"
         - if current_organization.paid_for?("show_recoveries") # I don't want to show a grayed link for this
           %li
-            = active_link "Recoveries", recoveries_organization_bikes_path(current_organization), class: "menu-item"
+            = active_link t(".recoveries"), recoveries_organization_bikes_path(current_organization), class: "menu-item"
 
         - if current_organization.show_bulk_import?
           %li
-            - bulk_link_name = current_organization.ascend_imports? ? "Ascend Imports" : "Bulk Imports"
+            - bulk_link_name = current_organization.ascend_imports? ? t(".ascend_imports") : t(".bulk_imports")
             = active_link bulk_link_name, organization_bulk_imports_path(organization_id: current_organization.to_param), match_controller: true, class: "menu-item"
         - if current_organization.lightspeed_pos?
-          = active_link "Lightspeed Integration Panel", lightspeed_interface_path, class: "menu-item"
+          = active_link t(".lightspeed_integration_panel"), lightspeed_interface_path, class: "menu-item"
         %li.divider-above
           - if current_organization.paid_for?("bike_codes")
-            = active_link "Registration stickers", organization_stickers_path(organization_id: current_organization.to_param), match_controller: true, class: "menu-item"
+            = active_link t(".registration_stickers"), organization_stickers_path(organization_id: current_organization.to_param), match_controller: true, class: "menu-item"
           - else
             %span.disabled-menu-item.menu-item
-              Registration stickers
+              = t(".registration_stickers")
         - if current_organization.paid_for?("csv_exports")
           %li
-            = active_link "Exports", organization_exports_path(organization_id: current_organization.to_param), match_controller: true, class: "menu-item"
+            = active_link t(".exports"), organization_exports_path(organization_id: current_organization.to_param), match_controller: true, class: "menu-item"
         - if current_organization.message_kinds.any?
           - current_organization.message_kinds.each_with_index do |message_kind, index|
             %li{ class: index == 0 ? "divider-above" : "" }
               / (params[:kind] == message_kind ? "active" : "")
               - if message_kind == "geolocated_messages"
-                - link_title = "GeoMessaging"
+                = active_link t(".geomessaging"), organization_messages_path(organization_id: current_organization.to_param, kind: message_kind), class: "menu-item"
               - else
                 - link_title = message_kind.gsub("_messages", "").titleize
-              = active_link link_title, organization_messages_path(organization_id: current_organization.to_param, kind: message_kind), class: "menu-item"
+                = active_link link_title, organization_messages_path(organization_id: current_organization.to_param, kind: message_kind), class: "menu-item"
 
         - else
           %li.divider-above
             %span.disabled-menu-item.menu-item
-              GeoMessaging
+              = t(".geomessaging")
         - if current_user.admin_of?(current_organization) || current_user.superuser?
           - if current_organization.parent?
             %li
-              = active_link "#{current_organization.short_name} dashboard", organization_dashboard_index_path(organization_id: current_organization.to_param), class: "menu-item"
+              = active_link t(".organization_dashboard", org_name: current_organization.short_name), organization_dashboard_index_path(organization_id: current_organization.to_param), class: "menu-item"
           %li.divider-above
-            = active_link "Users", organization_users_path(organization_id: current_organization.to_param), match_controller: true, class: "menu-item"
+            = active_link t(".users"), organization_users_path(organization_id: current_organization.to_param), match_controller: true, class: "menu-item"
           %li
-            = active_link "#{current_organization.short_name} profile", organization_manage_index_path(organization_id: current_organization.to_param), class: "menu-item"
+            = active_link t(".organization_profile", org_name: current_organization.short_name), organization_manage_index_path(organization_id: current_organization.to_param), class: "menu-item"
           %li
-            = active_link "#{current_organization.short_name} locations", locations_organization_manage_index_path(organization_id: current_organization.to_param), class: "menu-item"
+            = active_link t(".organization_locations", org_name: current_organization.short_name), locations_organization_manage_index_path(organization_id: current_organization.to_param), class: "menu-item"
 
 .organized-wrap
   - orgcontainer = "container-fluid" if controller_name == "bikes" && action_name == "index" || controller_name == "messages"
+
   %div{ class: orgcontainer || "container" }
     - if current_organization.law_enforcement_missing_verified_features?
       .organization-wide-alert.alert.alert-info.in
         %button.close{'aria-label' => 'Close', 'data-dismiss' => 'alert', type: 'button'}
           %span{'aria-hidden' => 'true' } &times;
         %p
-          Bike Index provides additional features for verified Law Enforcement organizations. Please contact #{link_to "lily@bikeindex.org", "mailto:lily@bikeindex.org"} to get them enabled.
+          = t(".additional_features_html", email_link: link_to("lily@bikeindex.org", "mailto:lily@bikeindex.org"))
     - if current_organization.bike_shop_display_integration_alert?
       .organization-wide-alert.alert.alert-info.in
         %button.close{'aria-label' => 'Close', 'data-dismiss' => 'alert', type: 'button'}
           %span{'aria-hidden' => 'true' } &times;
         %p
-          Use Lightspeed Retail POS?
+          = t(".use_lightspeed_retail_pos")
           %ul
             %li
-              %strong
-                = link_to "Integrate Bike Index with Lightspeed", lightspeed_interface_path, class: ""
-              to automatically register the bikes you sell to your customers.
+              - link = link_to t(".integrate_bike_index_with_lightspeed"), lightspeed_interface_path
+              = t(".link_to_register_html", link: link)
             %li
-              Read an full explanation of #{link_to "how the integration works", lightspeed_path}.
+              - link = link_to t( ".how_integration_works"), lightspeed_path
+              = t(".read_a_full_explanation_html", link: link)
         %p.mt-2
-          Use Ascend?
+          = t(".use_ascend")
           %ul
             %li
-              %strong
-                = link_to "Integrate Bike Index with Ascend", ascend_path, class: ""
-              to automatically register the bikes you sell to your customers.
+              - link = link_to t(".integrate_bike_index_with_ascend"), ascend_path
+              = t(".link_to_register_html", link: link)
+
         %p.mt-2
-          Other Point of Sale system?
+          = t(".other_point_of_sale_system")
           %ul
             %li
               - if controller_name == "bikes" && action_name == "new"
-                You're currently viewing our streamlined Bike Shop registration page, which is what we recommend using
-
+                = t(".viewing_our_streamlined_page")
               - else
-                Register bikes with our
-                %strong
-                  = link_to "streamlined Bike Shop registration page", new_organization_bike_path(organization_id: current_organization.to_param)
+                - bike_shop_registration_link = link_to t(".streamlined_bike_shop_registration_page"), new_organization_bike_path(organization_id: current_organization.to_param)
+                = t(".register_bikes_with_link_html", link: bike_shop_registration_link)
 
     = yield

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3819,6 +3819,15 @@ en:
       multiple_serial_search_pane: Multiple serial search pane
       thank_you: Thank you so much for using Bike Index!
       thanks_for_using_bike_index: Thanks for using Bike Index!
+    edit_bike_skeleton:
+      abandoned: abandoned
+      edit: Edit
+      owned_but_hasnt_been_claimed_html: Owned by <em>%{owner_email}</em> but it hasn't
+        been claimed yet
+      owned_with_permission_to_edit_html: Owned by <em>%{owner_email}</em> but %{org_name}
+        has permission to edit
+      stolen: stolen
+      view_bike: View %{bike_type}
     email_bike_box:
       color: color
       color_may_be_incorrect: Color may be incorrect. Please update it if necessary!

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -4021,7 +4021,6 @@ en:
         <strong>%{link}</strong> to automatically register the bikes you sell to your
         customers.
       multi_serial_search: Multi serial search
-      only_impounded: only_impounded
       organization_dashboard: "%{org_name} dashboard"
       organization_locations: "%{org_name} locations"
       organization_profile: "%{org_name} profile"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3998,7 +3998,6 @@ en:
       your_bikes: Your bikes
       your_preferences: Your preferences
     organized_skeleton:
-      active: active
       add_a_bike: Add a bike
       additional_features_html: >-
         Bike Index provides additional features for verified Law Enforcement organizations.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3997,6 +3997,48 @@ en:
       you: You
       your_bikes: Your bikes
       your_preferences: Your preferences
+    organized_skeleton:
+      active: active
+      add_a_bike: Add a bike
+      additional_features_html: >-
+        Bike Index provides additional features for verified Law Enforcement organizations.
+        Please contact %{email_link} to get them enabled.
+      admin_panel: Admin Panel
+      ascend_imports: Ascend Imports
+      bikes: Bikes
+      bulk_imports: Bulk Imports
+      discuss: Discuss
+      exports: Exports
+      geomessaging: GeoMessaging
+      getting_started: Getting started
+      how_integration_works: how the integration works
+      impounded_bikes: Impounded Bikes
+      incomplete_registrations: Incomplete registrations
+      integrate_bike_index_with_ascend: Integrate Bike Index with Ascend
+      integrate_bike_index_with_lightspeed: Integrate Bike Index with Lightspeed
+      lightspeed_integration_panel: Lightspeed Integration Panel
+      link_to_register_html: >-
+        <strong>%{link}</strong> to automatically register the bikes you sell to your
+        customers.
+      multi_serial_search: Multi serial search
+      only_impounded: only_impounded
+      organization_dashboard: "%{org_name} dashboard"
+      organization_locations: "%{org_name} locations"
+      organization_profile: "%{org_name} profile"
+      other_point_of_sale_system: Other Point of Sale system?
+      read_a_full_explanation_html: Read a full explanation of %{link}.
+      recoveries: Recoveries
+      register_bikes_with_link_html: Register bikes with our <strong>%{bike_shop_registration_link}</strong>
+      registration_stickers: Registration stickers
+      resources: Resources
+      streamlined_bike_shop_registration_page: streamlined Bike Shop registration
+        page
+      use_ascend: Use Ascend?
+      use_lightspeed_retail_pos: Use Lightspeed Retail POS?
+      users: Users
+      viewing_our_streamlined_page: >-
+        You're currently viewing our streamlined Bike Shop registration page, which
+        is what we recommend using
     period_select:
       all: All
       past_30_days: past 30 days


### PR DESCRIPTION

- Refactors to fix exceptions from `Organization#child_ids` being nil.
- Externalizes strings from `_organized_skeleton.html.haml` and `_edit_bike_skeleton.html.haml`

Resolves #1185 
