### PR TITLE
Externalize remaining info templates

### DIFF
--- a/app/views/info/serials.html.haml
+++ b/app/views/info/serials.html.haml
@@ -1,94 +1,77 @@
 %h1
-  Bike Serial numbers
+  = t(".bike_serial_numbers")
 
 %p#fnref-all-bikes-serials
-  All bikes
+  = t(".all_bikes")
   %sup
     %a.footnote-ref{ href: '#fn-all-bikes-serials' }
       1
-  all have unique serial numbers.
+  = t(".all_have_unique_serial_numbers")
 
 %h3.header-font-uncap#find-serial-number.mt-4
-  Finding a bicycle serial number
+  = t(".finding_a_bicycle_serial_number")
 
-%p
-  Most bicycles have their serial number engraved beneath their bottom bracket, but sometimes serial numbers are found in other places. Here are some examples of where and what to look for:
+%p= t(".most_bicycles_have_their_serial_number_en")
 
 
 %ul.serial-pictures
   %li
-    = link_to image_tag('serials/serial_bb.jpg', alt: 'Bike with bottom bracket circled'), image_path('serials/serial_bb.jpg'), class: 'serial-image'
-    %p
-      The <em>bottom bracket</em> (where serial numbers are typically located) is circled.
+    = link_to image_tag('serials/serial_bb.jpg', alt: t('.bike_with_bottom_circled')), image_path('serials/serial_bb.jpg'), class: 'serial-image'
+    %p= t(".the_bottom_bracket_html")
   %li
-    = link_to image_tag('serials/serial_peters.jpg', alt: 'Standard serial number'), image_path('serials/serial_peters.jpg'), class: 'serial-image'
-    %p
-      A serial number on the underside of a <em>bottom bracket</em>.
+    = link_to image_tag('serials/serial_peters.jpg', alt: t('.standard_serial_number')), image_path('serials/serial_peters.jpg'), class: 'serial-image'
+    %p= t(".a_serial_number_on_the_underside_html")
   %li
-    = link_to image_tag('serials/serial_fixie.jpg', alt: 'Another standard serial number. Sometime to be replaced with a serial number covered up by routing.'), image_path('serials/serial_fixie.jpg'), class: 'serial-image'
-    %p
-      Another serial number beneath the <em>bottom bracket</em>, aligned parallel to the frame.
+    = link_to image_tag('serials/serial_fixie.jpg', alt: t('.another_standard_serial_number')), image_path('serials/serial_fixie.jpg'), class: 'serial-image'
+    %p= t(".another_serial_number_beneath_html")
   %li
-    = link_to image_tag('serials/serial_headtube.jpg', alt: 'Schwinn Serial.'), image_path('serials/serial_headtube.jpg'), class: 'serial-image'
-    %p
-      Some Schwinn bicycles have the unique identifying number (their serial number) on the <em>head tube</em>. This is on the front of the bike.
+    = link_to image_tag('serials/serial_headtube.jpg', alt: t('.schwinn_serial')), image_path('serials/serial_headtube.jpg'), class: 'serial-image'
+    %p= t(".some_schwinn_bicycles_have_html")
 
   %li
-    = link_to image_tag('serials/serial_pinsch.jpg', alt: 'Doberman dropout serial number'), image_path('serials/serial_pinsch.jpg'), class: 'serial-image'
-    %p
-      A serial number located on a <em>rear dropout</em>. Some BMX bikes and a few Schwinn bicycles place the serial on the rear dropout.  On older Schwinns there are numbers stamped on both the drive side and non-drive side rear dropouts; the one on the non-drive side dropout is the serial number.
+    = link_to image_tag('serials/serial_pinsch.jpg', alt: t('.doberman_serial')), image_path('serials/serial_pinsch.jpg'), class: 'serial-image'
+    %p= t(".a_serial_number_located_on_a_html")
 
   %li#fnref-all-bikes-serials
-    = link_to image_tag('serials/serial_look.jpg', alt: 'Look serial number'), image_path('serials/serial_look.jpg'), class: 'serial-image'
+    = link_to image_tag('serials/serial_look.jpg', alt: t('.look_serial')), image_path('serials/serial_look.jpg'), class: 'serial-image'
     %p
-      Some bikes have <em>multiple serial numbers</em>.
+      = t(".some_bikes_have_multiple_html")
       %sup
         %a.footnote-ref{ href: '#fn-second-serial-number' }
           2
-      When adding a bike to the Index, it's best to enter all the groups of numbers and letters separated by spaces.
+      = t(".when_adding_a_bike_to_the_index")
 
 %p
-  Hopefully you can find the serial number on the bicycle you're looking at -
-  / # = link_to 'Check out the forum', discuss_url
-  email #{link_to 'contact@bikeindex.org', 'mailto:contact@bikeindex.org'}
-  if you're having trouble.
+  - link = link_to 'contact@bikeindex.org', 'mailto:contact@bikeindex.org'
+  = t(".hopefully_you_can_find_the_serial_html", link: link)
 
 %h3.header-font-uncap#searching-bike-index-serials.mt-4
-  Searching serials on Bike Index
+  = t(".searching_serials_on_bike_index")
 
 %p
-  Finding bicycles by serial number on Bike Index is a <em>critical</em> part of our functionality. When searching for a serial number, use our serial search bar - it's the second bar on #{link_to "our search form", default_bike_search_path}.
+  - search_form_link = link_to t(".our_search_form"), default_bike_search_path
+  = t(".finding_bicycles_by_serial_number_html", search_form_link: search_form_link)
 
-= link_to image_tag("serials/serial_search_bar.png", alt: "Serial search input"), default_bike_search_path, class: "serial-search-screenshot"
+= link_to image_tag("serials/serial_search_bar.png", alt: t(".serial_search_input")), default_bike_search_path, class: "serial-search-screenshot"
 
 %p.mt-2{ style: "margin-bottom: 0;" }
-  We've done a few things to make it more likely that you'll find the bike you're looking for.
+  = t(".weve_done_a_few_things_to_make_it_more_li")
 
 %ul
-  %li
-    Certain numbers and letters are difficult or impossible to distinguish between (e.g. 0 and O, S and 5). We treat all these numbers the same way - <em>a search for <code>005LLL</code> will match a bike with the serial <code>OOS111</code></em>.
-  %li
-    We split bike serials up by spaces and store each separately. If you see multiple numbers on a bicycle - such as in the photo of the Look bike above - try searching for <strong>just one</strong> of the numbers at a time. Searching for <em>either</em> <code>M4106I9CA1</code> or <code>200910427-2A</code> will find the bike.
-  %li
-    We do close serial matching - bikes with serial numbers that are close to the serial you entered are shown below the matching results under the heading "Serial Numbers Close to ..." - <em>given a search of a serial number with a couple numbers/letters that are different or missing</em>.
-  %li
-    We do not currently do partial serial searches. If you search for <code>1234</code>, you will only find bikes with serial numbers of <code>1234</code> and serials close to that - not a bike with serial number of <code>12345689</code>.
+  %li= t(".certain_numbers_and_letters_html")
+  %li= t(".we_split_bike_serials_up_by_html")
+  %li= t(".we_do_close_serial_matching_html")
+  %li= t(".we_do_not_currently_do_partial_html")
 
 
 
 .footnotes
   %ol
     %li#fn-all-bikes-serials
-      Okay, fine, so
-      %em
-        maybe
-      there are a few bikes without serial numbers, but this is rare and typical only on hand made bikes or really old bicycles.
-      %a.footnote-back-link{ href: "#fnref-all-bikes-serials", title: "Jump back to footnote 1 in the text."}
+      = t(".okay_fine_so_maybe_html")
+      %a.footnote-back-link{ href: "#fnref-all-bikes-serials", title: t(".jump_back_to_footnote", num: 1) }
         &#8617;
     %li#fn-second-serial-number
-      In this picture
-      %em
-        200910427-2A
-      is a manufacturer number and not a serial number. However, to make bikes as easy as possible to find, we'd love it if you entered all numbers you encounter.
-      %a.footnote-back-link{ href: "#fnref-second-serial-number", title: "Jump back to footnote 2 in the text."}
+      = t(".in_this_picture_html")
+      %a.footnote-back-link{ href: "#fnref-second-serial-number", title: t(".jump_back_to_footnote", num: 2) }
         &#8617;

--- a/app/views/info/where.html.haml
+++ b/app/views/info/where.html.haml
@@ -1,24 +1,26 @@
 - cache("where/shown-#{@organizations.count}-#{@organizations.maximum(:updated_at)}") do
-  / Cache these queries
+  -# Cache these queries
   - @states = State.includes(:locations).all
   - @countries = Country.where('iso != ?', 'US').includes(:locations)
-  / Set the locations on the window for the partial
+
+  -# Set the locations on the window for the partial
   - locations = []
   - @organizations.each do |organization|
     - organization.locations.each_with_index do |location, index|
       - next unless location.latitude && location.longitude
       - locations << [ "#shop#{location.org_location_id}", location.latitude, location.longitude]
+
   :javascript
     window.shop_locations = #{locations};
+
   %h1#where-bike-index
-    Bike Index partners
-    %small
-      = link_to 'Sign up your organization', new_organization_path
+    = t(".bike_index_partners")
+    %small= link_to t(".sign_up_your_organization"), new_organization_path
   %article
     .map-of-shops
       = render '/shared/shops_map'
   %h3.padded
-    US Partner organizations
+    = t(".us_partner_organizations")
 
   %article.where-shops-list#list_of_partners
     - @states.each do |state|
@@ -35,34 +37,29 @@
                   &#x25B6;
                 = location.display_name
                 %em
-                  &nbsp;&nbsp;#{location.city}
+                  &nbsp;&nbsp;
+                  = location.city
             .shop-info.collapse{ id: "shop#{location.org_location_id}" }
               - if location.street.present?
                 %a.where-shop-location{data: { lat: location.latitude, long: location.longitude } }
-                  Show #{location.display_name} on map
-                %p
-                  #{location.street}, #{location.city}, #{location.state.abbreviation} #{location.zipcode}
-              - if location.phone
-                %p
-                  %a{ href: "tel:#{ location.phone }" }
-                    = display_phone(location.phone)
+                  = t(".show_location_on_map", location_name: location.display_name)
+                %p= [location.street, location.city, "#{location.state.abbreviation} #{location.zipcode}"].join(", ")
+              - if location.phone.present?
+                %p= link_to display_phone(location.phone), "tel:#{ location.phone }"
               - if location&.organization&.website.present?
-                %p
-                  = link_to "#{location.organization.name} website", location.organization.website, target: "_blank", class: "shop-site"
+                %p= link_to t(".website_for_organization", org_name: location.organization.name), location.organization.website, target: "_blank", class: "shop-site"
               .map-window
                 .window-content
-                  %h3
-                    = location.display_name
+                  %h3= location.display_name
                   %p
                     = location.street
                     %br
-                    #{location.city}, #{location.state.abbreviation} #{location.zipcode}
-                  - if location.phone
+                    = [location.city, "#{location.state.abbreviation} #{location.zipcode}"].join(", ")
+                  - if location.phone.present?
                     .map-telephone
-                      %a{ href: "tel:#{ location.phone }" }
-                        = number_to_phone(location.phone)
+                      = link_to number_to_phone(location.phone), "tel:#{ location.phone }"
     %h3.padded
-      International Partner organizations
+      = t(".international_partner_organizations")
 
     - @countries.each do |country|
       - next unless country.locations.where(shown: true).any?
@@ -78,35 +75,35 @@
                   &#x25B6;
                 = location.display_name
                 %em
-                  &nbsp;&nbsp;#{location.city}
+                  &nbsp;&nbsp;
+                  = location.city
             .shop-info.collapse{ id: "shop#{location.org_location_id}" }
               - if location.street.present?
                 %a.where-shop-location{data: { lat: location.latitude, long: location.longitude } }
-                  Show #{location.display_name} on map
-                %p
-                  #{location.street}, #{location.city}, #{location.zipcode}, #{location.country.name}
-              - if location.phone
-                %p
-                  %a{ href: "tel:#{ location.phone }" }
-                    = display_phone(location.phone)
+                  = t(".show_location_on_map", location_name: location.display_name)
+                %p= [location.street, location.city, location.zipcode, location.country.name].join(", ")
+
+              - if location.phone.present?
+                %p= link_to display_phone(location.phone), "tel:#{ location.phone }"
+
               - if location&.organization&.website.present?
-                %p
-                  = link_to "#{location.organization.name} website", location.organization.website, target: "_blank", class: "shop-site"
+                %p= link_to t(".website_for_organization", org_name: location.organization.name), location.organization.website, target: "_blank", class: "shop-site"
+
               .map-window
                 .window-content
-                  %h3
-                    = location.display_name
+                  %h3= location.display_name
                   %p
                     = location.street
                     %br
-                    #{location.city}, #{location.zipcode}, #{location.country.name}
-                  - if location.phone
+                    = [location.city, location.zipcode, location.country.name].join(", ")
+
+                  - if location.phone.present?
                     .map-telephone
-                      %a{ href: "tel:#{ location.phone }" }
-                        = number_to_phone(location.phone)
+                      = link_to number_to_phone(location.phone), "tel:#{ location.phone }"
 
 
   %hr.where-add-shops
 
   %p
-    If you're a bike shop and would like to join us, check out our #{link_to "signup page", new_organization_path}.
+    - signup_link = link_to t(".signup_page"), new_organization_path
+    = t(".if_you_would_like_to_join_html", signup_link: signup_link)

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1679,7 +1679,7 @@ en:
     - Fri
     - Sat
     abbr_month_names:
-    -
+    - 
     - Jan
     - Feb
     - Mar
@@ -1705,7 +1705,7 @@ en:
       long: "%B %d, %Y"
       short: "%b %d"
     month_names:
-    -
+    - 
     - January
     - February
     - March
@@ -2806,6 +2806,16 @@ en:
         well as other matters set forth therein and which explains how and for what
         purposes we collect, use, retain, disclose and safeguard the information you
         provide to us.
+    where:
+      bike_index_partners: Bike Index partners
+      if_you_would_like_to_join_html: If you're a bike shop and would like to join
+        us, check out our %{signup_link}.
+      international_partner_organizations: International Partner organizations
+      show_location_on_map: Show %{location_name} on map
+      sign_up_your_organization: Sign up your organization
+      signup_page: signup page
+      us_partner_organizations: US Partner organizations
+      website_for_organization: "%{org_name} website"
   landing_pages:
     ambassadors_current:
       after_a_couple_of_recoveries_i_got_hooked: >-

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1679,7 +1679,7 @@ en:
     - Fri
     - Sat
     abbr_month_names:
-    - 
+    -
     - Jan
     - Feb
     - Mar
@@ -1705,7 +1705,7 @@ en:
       long: "%B %d, %Y"
       short: "%b %d"
     month_names:
-    - 
+    -
     - January
     - February
     - March
@@ -2130,6 +2130,82 @@ en:
       we_have_an_open_api_check_out_html: We have an open API - check out our %{link}.
       were_open_source_view_this_app_html: We're open source, view this app (and other
         things) on %{github_link}.
+    serials:
+      a_serial_number_located_on_a_html: >-
+        A serial number located on a <em>rear dropout</em>. Some BMX bikes and a few
+        Schwinn bicycles place the serial on the rear dropout.  On older Schwinns
+        there are numbers stamped on both the drive side and non-drive side rear dropouts;
+        the one on the non-drive side dropout is the serial number.
+      a_serial_number_on_the_underside_html: A serial number on the underside of a
+        <em>bottom bracket</em>.
+      all_bikes: All bikes
+      all_have_unique_serial_numbers: all have unique serial numbers.
+      another_serial_number_beneath_html: >-
+        Another serial number beneath the <em>bottom bracket</em>, aligned parallel
+        to the frame.
+      another_standard_serial_number: >-
+        Another standard serial number. Sometime to be replaced with a serial number
+        covered up by routing.
+      bike_serial_numbers: Bike Serial numbers
+      bike_with_bottom_circled: Bike with bottom bracket circled
+      certain_numbers_and_letters_html: >-
+        Certain numbers and letters are difficult or impossible to distinguish between
+        (e.g. 0 and O, S and 5). We treat all these numbers the same way - <em>a search
+        for <code>005LLL</code> will match a bike with the serial <code>OOS111</code></em>.
+      doberman_serial: Doberman dropout serial number
+      finding_a_bicycle_serial_number: Finding a bicycle serial number
+      finding_bicycles_by_serial_number_html: >-
+        Finding bicycles by serial number on Bike Index is a <em>critical</em> part
+        of our functionality. When searching for a serial number, use our serial search
+        bar - it's the second bar on %{search_form_link}.
+      hopefully_you_can_find_the_serial_html: >-
+        Hopefully you can find the serial number on the bicycle you're looking at
+        - email %{link} if you're having trouble.
+      in_this_picture_html: >-
+        In this picture <em>200910427-2A</em> is a manufacturer number and not a serial
+        number. However, to make bikes as easy as possible to find, we'd love it if
+        you entered all numbers you encounter.
+      jump_back_to_footnote: Jump back to footnote %{num} in the text.
+      look_serial: Look serial number
+      most_bicycles_have_their_serial_number_en: >-
+        Most bicycles have their serial number engraved beneath their bottom bracket,
+        but sometimes serial numbers are found in other places. Here are some examples
+        of where and what to look for:
+      okay_fine_so_maybe_html: >-
+        Okay, fine, so <em>maybe</em> there are a few bikes without serial numbers,
+        but this is rare and typical only on hand made bikes or really old bicycles.
+      our_search_form: our search form
+      schwinn_serial: Schwinn serial number.
+      searching_serials_on_bike_index: Searching serials on Bike Index
+      serial_search_input: Serial search input
+      some_bikes_have_multiple_html: Some bikes have <em>multiple serial numbers</em>.
+      some_schwinn_bicycles_have_html: >-
+        Some Schwinn bicycles have the unique identifying number (their serial number)
+        on the <em>head tube</em>. This is on the front of the bike.
+      standard_serial_number: Standard serial number
+      the_bottom_bracket_html: >-
+        The <em>bottom bracket</em> (where serial numbers are typically located) is
+        circled.
+      we_do_close_serial_matching_html: >-
+        We do close serial matching - bikes with serial numbers that are close to
+        the serial you entered are shown below the matching results under the heading
+        "Serial Numbers Close to..." - <em>given a search of a serial number with
+        a couple numbers/letters that are different or missing</em>.
+      we_do_not_currently_do_partial_html: >-
+        We do not currently do partial serial searches. If you search for <code>1234</code>,
+        you will only find bikes with serial numbers of <code>1234</code> and serials
+        close to that - not a bike with serial number of <code>12345689</code>.
+      we_split_bike_serials_up_by_html: >-
+        We split bike serials up by spaces and store each separately. If you see multiple
+        numbers on a bicycle - such as in the photo of the Look bike above - try searching
+        for <strong>just one</strong> of the numbers at a time. Searching for <em>either</em>
+        <code>M4106I9CA1</code> or <code>200910427-2A</code> will find the bike.
+      weve_done_a_few_things_to_make_it_more_li: >-
+        We've done a few things to make it more likely that you'll find the bike you're
+        looking for.
+      when_adding_a_bike_to_the_index: >-
+        When adding a bike to the Index, it's best to enter all the groups of numbers
+        and letters separated by spaces.
     terms_text:
       about_our_terms_of_service: About our Terms of Service
       available_here: available here


### PR DESCRIPTION
Wraps up the last couple of `views/info` templates.

Related: https://github.com/bikeindex/bike_index/issues/963