### PR TITLE
Don't search external registries if no serial given

### DIFF
--- a/app/javascript/packs/external_registry_search/components/ExternalRegistrySearch.js
+++ b/app/javascript/packs/external_registry_search/components/ExternalRegistrySearch.js
@@ -17,7 +17,7 @@ class ExternalRegistrySearch extends Component {
     const { stolenness, query, serial } = this.props;
     // Only search external registries if looking for
     // stolen/all bikes with no query
-    if (stolenness === "non" || query) { return; }
+    if (stolenness === "non" || query || !serial) { return; }
 
     this.resultsBeingFetched();
 


### PR DESCRIPTION
Prevent External Registry Search component from mounting if no serial number has been entered.