### PR TITLE
Fix external registry search placeholder images

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -222,4 +222,8 @@ module ApplicationHelper
       [t(locale, scope: [:locales]), locale.to_s]
     end.sort { |a, b| a[0].downcase <=> b[0].downcase }
   end
+
+  def bike_placeholder_image_path
+    image_path("revised/bike_photo_placeholder.svg")
+  end
 end

--- a/app/javascript/packs/external_registry_search/components/ExternalRegistrySearch.js
+++ b/app/javascript/packs/external_registry_search/components/ExternalRegistrySearch.js
@@ -17,7 +17,7 @@ class ExternalRegistrySearch extends Component {
     const { stolenness, query, serial } = this.props;
     // Only search external registries if looking for
     // stolen/all bikes with no query
-    if (stolenness === "non" || query) { return; }
+    if (stolenness === "non" || query || !serial) { return; }
 
     this.resultsBeingFetched();
 

--- a/app/javascript/packs/external_registry_search/components/ExternalRegistrySearchResult.js
+++ b/app/javascript/packs/external_registry_search/components/ExternalRegistrySearchResult.js
@@ -60,7 +60,7 @@ const ResultImage = ({ bike }) => {
 
   if (bike.is_stock_img) {
     return (<a href={bike.url} className="bike-list-image" target="_blank">
-              <img src={bike.thumb} className="no-image"/>
+              <img src={window.bike_placeholder_image} className="no-image"/>
             </a>);
   }
 

--- a/app/serializers/bike_v2_serializer.rb
+++ b/app/serializers/bike_v2_serializer.rb
@@ -11,7 +11,6 @@ class BikeV2Serializer < ActiveModel::Serializer
     :large_img,
     :location_found,
     :manufacturer_name,
-    :placeholder_image,
     :registry_id,
     :registry_name,
     :registry_url,
@@ -55,14 +54,6 @@ class BikeV2Serializer < ActiveModel::Serializer
 
   def date_stolen_string
     object.current_stolen_record&.date_stolen&.to_date&.to_s
-  end
-
-  def placeholder_image
-    assets = Rails.application.assets
-    return if assets.blank?
-
-    svg_path = assets["revised/bike_photo_placeholder.svg"]&.digest_path
-    "#{ENV["BASE_URL"]}/assets/#{svg_path}" if svg_path.present?
   end
 
   def thumb

--- a/app/serializers/external_bike_v3_serializer.rb
+++ b/app/serializers/external_bike_v3_serializer.rb
@@ -27,11 +27,11 @@ class ExternalBikeV3Serializer < BikeV2Serializer
   def year; end
 
   def thumb
-    object.image_url || placeholder_image
+    object.image_url
   end
 
   def large_img
-    object.image_url || placeholder_image
+    object.image_url
   end
 
   def is_stock_img

--- a/app/views/bikes/index.html.haml
+++ b/app/views/bikes/index.html.haml
@@ -81,5 +81,6 @@
 
 :javascript
   window.interpreted_params = #{@interpreted_params.to_json};
+  window.bike_placeholder_image = "#{bike_placeholder_image_path}";
 
 <script async src="//pagead2.googlesyndication.com/pagead/js/adsbygoogle.js"></script>

--- a/spec/requests/api/v3/search_request_spec.rb
+++ b/spec/requests/api/v3/search_request_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe "Search API V3", type: :request do
             thumb large_img is_stock_img stolen stolen_location date_stolen
             debug location_found registry_id registry_name registry_url
             source_name source_unique_id status url description
-            date_stolen_string placeholder_image year
+            date_stolen_string year
           ]))
         expect(response.header["Total"]).to eq("1")
       end

--- a/spec/serializers/bike_v2_show_serializer_spec.rb
+++ b/spec/serializers/bike_v2_show_serializer_spec.rb
@@ -71,7 +71,6 @@ RSpec.describe BikeV2ShowSerializer do
         stolen_record: nil,
         public_images: [public_image_target],
         components: [component_target],
-        placeholder_image: "http://test.host/assets/revised/bike_photo_placeholder-ff15adbd9bf89e10bf3cd2cd6c4e85e5d1056e50463ae722822493624db72e56.svg",
         debug: nil,
         location_found: nil,
         registry_id: nil,

--- a/spec/workers/file_cache_maintenance_worker_spec.rb
+++ b/spec/workers/file_cache_maintenance_worker_spec.rb
@@ -30,9 +30,8 @@ RSpec.describe FileCacheMaintenanceWorker, type: :job do
       expect(result["bikes"][0].keys).to(match_array <<~KEYS.split)
         id title serial manufacturer_name frame_model year frame_colors
         thumb large_img is_stock_img stolen stolen_location date_stolen
-        date_stolen_string debug description location_found placeholder_image
-        registry_id registry_name registry_url source_name source_unique_id
-        status url
+        date_stolen_string debug description location_found registry_id
+        registry_name registry_url source_name source_unique_id status url
       KEYS
     end
   end


### PR DESCRIPTION
- Assets aren't available from the API
- Sets bike_placeholder_image_path on the window object to fall back to it in the React code

### Before

<img width="907" alt="Screen Shot 2019-09-03 at 1 54 22 PM" src="https://user-images.githubusercontent.com/4433943/64196672-5ded8c80-ce52-11e9-839e-9b0f4ca3f096.png">

### After

<img width="938" alt="Screen Shot 2019-09-03 at 1 53 39 PM" src="https://user-images.githubusercontent.com/4433943/64196693-6776f480-ce52-11e9-8427-75d5b10c6bdf.png">
