### PR TITLE
Replace entity code with check_mark

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,4 +1,8 @@
 module ApplicationHelper
+  def check_mark
+    "&#x2713;".html_safe
+  end
+
   def active_link(link_text, link_path, html_options = {})
     match_controller = html_options.delete(:match_controller)
     html_options[:class] ||= ""

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -126,7 +126,7 @@ class Organization < ActiveRecord::Base
   def mail_snippet_body(type)
     return nil unless MailSnippet.organization_snippet_types.include?(type)
     snippet = mail_snippets.enabled.where(name: type).first
-    snippet && snippet.body
+    snippet&.body
   end
 
   def message_kinds # Matches organization_message kinds

--- a/app/views/admin/bikes/_bike.html.haml
+++ b/app/views/admin/bikes/_bike.html.haml
@@ -165,7 +165,7 @@
               %td
                 Approved?
               %td
-                = "&#x2713;".html_safe if stolen_record.approved
+                = check_mark if stolen_record.approved
             %tr
               %td
                 Estimated $
@@ -234,12 +234,12 @@
               %td
                 We Helped
               %td
-                = "&#x2713;".html_safe if stolen_record.index_helped_recovery
+                = check_mark if stolen_record.index_helped_recovery
             %tr
               %td
                 Can Share
               %td
-                = "&#x2713;".html_safe if stolen_record.can_share_recovery
+                = check_mark if stolen_record.can_share_recovery
       .col-sm-12.col-lg-6
         %table.table-list
           %tbody

--- a/app/views/admin/bikes/edit.html.haml
+++ b/app/views/admin/bikes/edit.html.haml
@@ -207,11 +207,11 @@
           %td
             = ownership.owner_email
           %td.table-cell-check
-            = "&#x2713;".html_safe if ownership.current
+            = check_mark if ownership.current
           %td.table-cell-check
-            = "&#x2713;".html_safe if ownership.claimed
+            = check_mark if ownership.claimed
           %td.table-cell-check.d-none.d-md-table-cell
-            = "&#x2713;".html_safe if ownership.user_hidden
+            = check_mark if ownership.user_hidden
 
 - if @bike.bike_codes.present?
   %h3.mt-4

--- a/app/views/admin/bulk_imports/show.html.haml
+++ b/app/views/admin/bulk_imports/show.html.haml
@@ -73,7 +73,7 @@
         %td
           Ascend
         %td
-          = "&#x2713;".html_safe if @bulk_import.ascend?
+          = check_mark if @bulk_import.ascend?
 
 - if @bulk_import.creation_states.count < 1 || params[:show_reprocess]
   = link_to "Reprocess Import", admin_bulk_import_path(@bulk_import, reprocess: true), method: "PUT", class: "btn btn-secondary float-right"

--- a/app/views/admin/ctypes/index.html.haml
+++ b/app/views/admin/ctypes/index.html.haml
@@ -26,4 +26,4 @@
           %td
             = ctype.cgroup.name.titleize
           %td.large-screens
-            = "&#x2713;".html_safe if ctype.image?
+            = check_mark if ctype.image?

--- a/app/views/admin/mail_snippets/index.html.haml
+++ b/app/views/admin/mail_snippets/index.html.haml
@@ -30,4 +30,4 @@
           %td
             = mail_snippet.address
           %td.table-cell-check
-            = "&#x2713;".html_safe if mail_snippet.is_enabled
+            = check_mark if mail_snippet.is_enabled

--- a/app/views/admin/manufacturers/index.html.haml
+++ b/app/views/admin/manufacturers/index.html.haml
@@ -31,7 +31,7 @@
           %td
             = link_to manufacturer.name, admin_manufacturer_url(manufacturer)
           %td.table-cell-check
-            = "&#x2713;".html_safe if manufacturer.frame_maker
+            = check_mark if manufacturer.frame_maker
           %td
             - if manufacturer.website
               = link_to "Company website", manufacturer.website

--- a/app/views/admin/memberships/_table.html.haml
+++ b/app/views/admin/memberships/_table.html.haml
@@ -67,4 +67,4 @@
             - else
               = membership.sender_id
           %td
-            = "&#x2713;".html_safe if membership.admin?
+            = check_mark if membership.admin?

--- a/app/views/admin/news/index.html.haml
+++ b/app/views/admin/news/index.html.haml
@@ -36,6 +36,6 @@
               %br
               = blog.body_abbr.html_safe if blog.body_abbr
           %td.table-cell-check
-            = "&#x2713;".html_safe if blog.is_listicle
+            = check_mark if blog.is_listicle
           %td.table-cell-check
-            = "&#x2713;".html_safe if blog.published
+            = check_mark if blog.published

--- a/app/views/admin/organizations/_table.html.haml
+++ b/app/views/admin/organizations/_table.html.haml
@@ -41,7 +41,7 @@
               %small.less-strong
                 = "paid" if organization.is_paid
             %td.table-cell-check
-              = "&#x2713;".html_safe if organization.approved
+              = check_mark if organization.approved
             %td
               %span.convertTime
                 = l organization.created_at, format: :convert_time

--- a/app/views/admin/organizations/custom_layouts/index.html.haml
+++ b/app/views/admin/organizations/custom_layouts/index.html.haml
@@ -29,7 +29,7 @@
           %small.less-strong
             page  #{ link_to 'previewable here', organization_landing_path(organization_id: @organization.to_param) }, even if "off"
         %td.table-cell-check
-          = "&#x2713;".html_safe if @organization.landing_html.present?
+          = check_mark if @organization.landing_html.present?
         %td.table-cell-check
           = link_to LandingPages::ORGANIZATIONS.include?(@organization.slug).to_s, "https://github.com/bikeindex/bike_index/blob/master/config/landing_pages.rb"
       - MailSnippet.organization_snippets.each do |snippet_name, snippet_description|
@@ -38,6 +38,6 @@
           %td
             = link_to snippet_description, edit_admin_organization_custom_layout_path(organization_id: @organization.to_param, id: snippet_name)
           %td.table-cell-check
-            = "&#x2713;".html_safe if snippet && snippet.body.present?
+            = check_mark if snippet&.body.present?
           %td.table-cell-check
-            = "&#x2713;".html_safe if snippet && snippet.is_enabled
+            = check_mark if snippet&.is_enabled

--- a/app/views/admin/recoveries/_table.html.haml
+++ b/app/views/admin/recoveries/_table.html.haml
@@ -77,11 +77,11 @@
               = recovery.city
           %td.table-cell-check
             / Posted
-            / = "&#x2713;".html_safe if recovery.recovery_posted
-            = "&#x2713;".html_safe if recovery.index_helped_recovery
+            / = check_mark if recovery.recovery_posted
+            = check_mark if recovery.index_helped_recovery
           %td.table-cell-check
-            = "&#x2713;".html_safe if recovery.can_share_recovery
+            = check_mark if recovery.can_share_recovery
           %td.table-cell-check
             - if recovery.recovery_display.present?
-              = link_to "&#x2713;".html_safe, edit_admin_recovery_display_url(recovery.recovery_display)
+              = link_to check_mark, edit_admin_recovery_display_url(recovery.recovery_display)
 

--- a/app/views/admin/recovery_displays/index.html.haml
+++ b/app/views/admin/recovery_displays/index.html.haml
@@ -47,8 +47,8 @@
           %td
             = recovery_display.quote_by
           %td.table-cell-check
-            = "&#x2713;".html_safe if recovery_display.image?
+            = check_mark if recovery_display.image?
           %td.large-screens.table-cell-check
-            = "&#x2713;".html_safe if recovery_display.stolen_record_id.present?
+            = check_mark if recovery_display.stolen_record_id.present?
 
 = paginate @recovery_displays, views_prefix: "admin"

--- a/app/views/admin/stolen_bikes/index.html.haml
+++ b/app/views/admin/stolen_bikes/index.html.haml
@@ -89,7 +89,7 @@
               %span{ class: current_stolen_record.city.blank? ? "less-strong" : "" }
                 = [current_stolen_record.city, current_stolen_record.state&.abbreviation, current_stolen_record.zipcode].reject(&:blank?).first
             %td.table-cell-check
-              = "&#x2713;".html_safe if current_stolen_record.approved
+              = check_mark if current_stolen_record.approved
               - if bike.owner&.donor?
                 <span class="donor-icon">D</span>
               - elsif bike.owner&.paid_org?

--- a/app/views/admin/stolen_notifications/index.html.haml
+++ b/app/views/admin/stolen_notifications/index.html.haml
@@ -41,7 +41,7 @@
             = stolen_notification.message.truncate(120)
           %td.table-cell-check
             - if stolen_notification.send_dates_parsed.count == 1
-              = "&#x2713;".html_safe
+              = check_mark
             - else
               = stolen_notification.send_dates_parsed.count
 

--- a/app/views/admin/theft_alert_plans/index.html.haml
+++ b/app/views/admin/theft_alert_plans/index.html.haml
@@ -25,4 +25,4 @@
           %td= plan.duration_days
           %td= plan.description_html.html_safe
           %td
-            = "&#x2713;".html_safe if plan.active?
+            = check_mark if plan.active?

--- a/app/views/admin/tweets/index.html.haml
+++ b/app/views/admin/tweets/index.html.haml
@@ -33,4 +33,4 @@
           %td
             = strip_tags(tweet.body_html)
           %td
-            = "&#x2713;".html_safe if tweet.image.present?
+            = check_mark if tweet.image.present?

--- a/app/views/admin/users/_table.html.haml
+++ b/app/views/admin/users/_table.html.haml
@@ -73,4 +73,4 @@
                 = "super" if user.superuser?
                 = "developer" if user.developer?
             %td.table-cell-check
-              = "&#x2713;".html_safe if user.confirmed
+              = check_mark if user.confirmed

--- a/app/views/admin/users/edit.html.haml
+++ b/app/views/admin/users/edit.html.haml
@@ -23,7 +23,7 @@
           %td
             Email: Newsletters
           %td
-            = "&#x2713;".html_safe if @user.notification_newsletters
+            = check_mark if @user.notification_newsletters
         %tr
           %td
             Vendor terms?
@@ -35,7 +35,7 @@
           %td
             Email: Unstolen
           %td
-            = "&#x2713;".html_safe if @user.notification_unstolen
+            = check_mark if @user.notification_unstolen
         %tr
           %td
             Created
@@ -63,7 +63,7 @@
           Confirmed?
         %td
           - if @user.confirmed?
-            = "&#x2713;".html_safe
+            = check_mark
       %tr
         %td
           email
@@ -98,7 +98,7 @@
         %td
           Ambassador?
         %td
-          = "&#x2713;".html_safe if @user.ambassador?
+          = check_mark if @user.ambassador?
       %tr
         %td
           Phone
@@ -162,7 +162,7 @@
         %td
           = payment.amount
         %td
-          = "&#x2713;".html_safe if payment.is_payment
+          = check_mark if payment.is_payment
 
 .row
   .col-md-6
@@ -197,9 +197,9 @@
                 = l user_email.created_at, format: :convert_time
           %td= user_email.email
           %td
-            = "&#x2713;".html_safe if user_email.confirmed
+            = check_mark if user_email.confirmed
           %td
-            = "&#x2713;".html_safe if user_email.primary
+            = check_mark if user_email.primary
           %td
             = user_email.old_user_id
 

--- a/app/views/bikes/_organized_access_panel.html.haml
+++ b/app/views/bikes/_organized_access_panel.html.haml
@@ -75,7 +75,7 @@
                       = l @bike.created_at, format: :convert_time
                 %tr
                   %td= t(".claimed")
-                  %td= "&#x2713;".html_safe if @bike.claimed?
+                  %td= check_mark if @bike.claimed?
                 %tr
                   %td= t(".creator")
                   %td

--- a/app/views/manufacturers/index.html.haml
+++ b/app/views/manufacturers/index.html.haml
@@ -18,7 +18,7 @@
             - else
               = manufacturer.name
           %td.large-screens.table-cell-check
-            = "&#x2713;".html_safe unless manufacturer.frame_maker
+            = check_mark unless manufacturer.frame_maker
 
   %h2.padded
     = t(".oh_no_were_missing_a_manufacturer")

--- a/app/views/organized/bikes/_search.html.haml
+++ b/app/views/organized/bikes/_search.html.haml
@@ -158,7 +158,7 @@
               %small.convertTime
                 = l bike.updated_at, format: :convert_time
             %td.hiddenColumn.hidden-xs-down.table-cell-check.stolen_cell
-              = bike.stolen ? "&#x2713;".html_safe : ""
+              = check_mark if bike.stolen?
             %td.hiddenColumn.hidden-xs-down.manufacturer_cell
               = bike.mnfg_name
             %td.hiddenColumn.hidden-xs-down.model_cell

--- a/app/views/organized/users/index.html.haml
+++ b/app/views/organized/users/index.html.haml
@@ -42,7 +42,7 @@
             - if membership.claimed_at.present?
               %span.convertTime
                 = l(membership.created_at, format: :convert_time)
-          %td= "&#x2713;".html_safe if membership.admin?
+          %td= check_mark if membership.admin?
           %td
             - if membership.sender.present?
               %small


### PR DESCRIPTION
Introduces `ApplicationHelper#check_mark` and replaces all instances of the entity code with it.