### PR TITLE
Set default geocoder location globally

### DIFF
--- a/app/models/bike.rb
+++ b/app/models/bike.rb
@@ -46,7 +46,7 @@ class Bike < ActiveRecord::Base
   accepts_nested_attributes_for :components, allow_destroy: true
 
   geocoded_by nil, latitude: :stolen_lat, longitude: :stolen_long
-  after_validation :geocode, if: lambda { |o| false } # Never geocode, it's from stolen_record
+  after_validation :geocode, if: lambda { false } # Never geocode, it's from stolen_record
 
   validates_presence_of :serial_number
   validates_presence_of :propulsion_type

--- a/app/views/admin/bikes/missing_manufacturer.html.haml
+++ b/app/views/admin/bikes/missing_manufacturer.html.haml
@@ -7,7 +7,7 @@
       %li.nav-item
         = link_to "all bikes", admin_bikes_path, class: "nav-link"
       %li.nav-item
-        = link_to "Alphabeticall view", missing_manufacturer_admin_bikes_path(reset_view: true), class: !session[:missing_manufacturer_time_order] ? "nav-link active" : "nav-link"
+        = link_to "Alphabetical view", missing_manufacturer_admin_bikes_path(reset_view: true), class: !session[:missing_manufacturer_time_order] ? "nav-link active" : "nav-link"
       %li.nav-item
         = link_to "Time ordered view", missing_manufacturer_admin_bikes_path(time_ordered: true), class: session[:missing_manufacturer_time_order] ? "nav-link active" : "nav-link"
 
@@ -36,7 +36,7 @@
       %thead.thead-light
         %th.table-cell-check
           %a#multi-mnfg-selector{ href: "#" }
-            &#x2713;
+            = check_mark
         %th
           Date indexed
         %th

--- a/spec/controllers/api/v1/bikes_controller_spec.rb
+++ b/spec/controllers/api/v1/bikes_controller_spec.rb
@@ -242,6 +242,7 @@ RSpec.describe Api::V1::BikesController, type: :controller do
       end
 
       include_context :geocoder_real
+
       it "creates a stolen record" do
         VCR.use_cassette("v1_bikes_create-stolen") do
           manufacturer = FactoryBot.create(:manufacturer)

--- a/spec/controllers/bikes_controller_spec.rb
+++ b/spec/controllers/bikes_controller_spec.rb
@@ -4,7 +4,6 @@ RSpec.describe BikesController, type: :controller do
   let(:manufacturer) { FactoryBot.create(:manufacturer) }
   let(:color) { FactoryBot.create(:color, name: "black") }
   describe "index" do
-    include_context :geocoder_default_location
     let!(:non_stolen_bike) { FactoryBot.create(:bike, serial_number: "1234567890") }
     let!(:stolen_bike) { FactoryBot.create(:stolen_bike, latitude: default_location[:latitude], longitude: default_location[:longitude]) }
     let(:serial) { "1234567890" }
@@ -79,7 +78,8 @@ RSpec.describe BikesController, type: :controller do
           end
         end
         context "unknown location" do
-          let(:bounding_box) { [66.00, -84.22, 67.000, (0.0 / 0)] } # Override bounding box stub in geocoder_default_location
+          # Override bounding box stub in geocoder_default_location shared context
+          let(:bounding_box) { [66.00, -84.22, 67.000, (0.0 / 0)] }
           it "includes a flash[:info] for unknown location, renders non-proximity" do
             get :index, query_params
             expect(response.status).to eq 200
@@ -895,7 +895,6 @@ RSpec.describe BikesController, type: :controller do
               owner_email: "something@stuff.com",
             }
           end
-          include_context :geocoder_default_location
           let(:target_address) { { address: "278 Broadway", city: "New York", state: "NY", zipcode: "10007", country: "USA" } }
           let(:b_param) { BParam.create(params: { "bike" => bike_params.as_json }, origin: "embed_partial") }
           before do

--- a/spec/controllers/organized/messages_controller_spec.rb
+++ b/spec/controllers/organized/messages_controller_spec.rb
@@ -1,7 +1,6 @@
 require "rails_helper"
 
 RSpec.describe Organized::MessagesController, type: :controller do
-  include_context :geocoder_default_location
   include_context :organization_with_geolocated_messages
   let(:root_path) { organization_messages_path(organization_id: organization.to_param, kind: kind_slug) }
   let(:user) { FactoryBot.create(:organization_member, organization: organization) }

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -566,7 +566,6 @@ RSpec.describe UsersController, type: :controller do
     context "setting address" do
       let(:country) { Country.united_states }
       let(:state) { FactoryBot.create(:state, name: "New York", abbreviation: "NY") }
-      include_context :geocoder_default_location
       it "sets address, geocodes" do
         set_current_user(user)
         expect(user.notification_newsletters).to be_falsey

--- a/spec/models/bike_spec.rb
+++ b/spec/models/bike_spec.rb
@@ -867,7 +867,6 @@ RSpec.describe Bike, type: :model do
       expect(bike.registration_address).to eq({})
     end
     context "with user with address" do
-      include_context :geocoder_default_location
       let(:country) { Country.united_states }
       let(:state) { FactoryBot.create(:state, name: "New York", abbreviation: "NY") }
       let(:user) { FactoryBot.create(:user, country_id: country.id, state_id: state.id, city: "New York", street: "278 Broadway", zipcode: "10007") }

--- a/spec/models/organization_message_spec.rb
+++ b/spec/models/organization_message_spec.rb
@@ -10,7 +10,6 @@ RSpec.describe OrganizationMessage, type: :model do
   end
 
   describe "set_calculated_attributes" do
-    include_context :geocoder_default_location
     context "geolocated" do
       let(:ownership) { FactoryBot.create(:ownership, owner_email: "stuff@stuff.com") }
       let(:bike) { ownership.bike }

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -75,6 +75,11 @@ RSpec::Sidekiq.configure do |config|
   config.warn_when_jobs_not_processed_by_sidekiq = false
 end
 
+# Set default geocoder location
+RSpec.configure do |config|
+  config.include_context :geocoder_default_location
+end
+
 RSpec.configure do |config|
   config.before(:each) do
     # Reset feature-flipping between examples

--- a/spec/requests/api/v2/bikes_request_spec.rb
+++ b/spec/requests/api/v2/bikes_request_spec.rb
@@ -42,7 +42,6 @@ RSpec.describe "Bikes API V2", type: :request do
     before :each do
       FactoryBot.create(:wheel_size, iso_bsd: 559)
     end
-    include_context :geocoder_default_location
 
     it "responds with 401" do
       post "/api/v2/bikes", bike_attrs.to_json

--- a/spec/requests/api/v3/bikes_request_spec.rb
+++ b/spec/requests/api/v3/bikes_request_spec.rb
@@ -43,7 +43,6 @@ RSpec.describe "Bikes API V3", type: :request do
     before :each do
       FactoryBot.create(:wheel_size, iso_bsd: 559)
     end
-    include_context :geocoder_default_location
 
     context "no token" do
       let(:token) { nil }

--- a/spec/requests/organized/messages_request_spec.rb
+++ b/spec/requests/organized/messages_request_spec.rb
@@ -1,7 +1,6 @@
 require "rails_helper"
 
 RSpec.describe Organized::MessagesController, type: :request do
-  include_context :geocoder_default_location
   include_context :organization_with_geolocated_messages
   let(:base_url) { "/o/#{organization.to_param}/messages" }
 

--- a/spec/support/geocoder_default_location.rb
+++ b/spec/support/geocoder_default_location.rb
@@ -5,8 +5,10 @@ RSpec.shared_context :geocoder_default_location do
       longitude: -74.0059731,
       address: "New York, NY, USA",
       formatted_address: "278 Broadway, New York, NY 10007, USA",
+      city: "New York",
       state: "New York",
       state_code: "NY",
+      neighborhood: "Tribeca",
       country: "United States",
       country_code: "US",
     }

--- a/spec/support/shared_examples/bike_searchable.rb
+++ b/spec/support/shared_examples/bike_searchable.rb
@@ -117,7 +117,6 @@ RSpec.shared_examples "bike_searchable" do
         end
       end
       context "proximity" do
-        include_context :geocoder_default_location
         context "ignored locations" do
           context "proximity of anywhere" do
             let(:query_params) { { stolenness: "proximity", location: "anywhere", distance: 100 } }
@@ -143,7 +142,8 @@ RSpec.shared_examples "bike_searchable" do
           end
           context "with a broken bounding box" do
             let(:nan) { 0.0 / 0 }
-            let(:bounding_box) { [nan, nan, nan, nan] } # Override bounding box stub in geocoder_default_location
+            # Override bounding box stub in geocoder_default_location shared_context
+            let(:bounding_box) { [nan, nan, nan, nan] }
             let(:target) { { stolenness: "stolen" } }
             it "returns a non-proximity search" do
               expect(Bike.searchable_interpreted_params(query_params, ip: ip_address)).to eq target
@@ -319,7 +319,6 @@ RSpec.shared_examples "bike_searchable" do
         end
       end
       context "proximity" do
-        include_context :geocoder_default_location
         let(:bike_1) { FactoryBot.create(:stolen_bike, latitude: default_location[:latitude], longitude: default_location[:longitude]) }
         let(:stolen_record_1) { bike_1.find_current_stolen_record }
         let(:bike_2) { FactoryBot.create(:stolen_bike, latitude: 41.8961603, longitude: -87.677215) }

--- a/spec/workers/bulk_import_worker_spec.rb
+++ b/spec/workers/bulk_import_worker_spec.rb
@@ -160,7 +160,6 @@ RSpec.describe BulkImportWorker, type: :job do
       let(:organization) { FactoryBot.create(:organization_with_auto_user) }
       # We're stubbing the method to use a remote file, don't pass the file in and let it use the factory default
       let!(:bulk_import) { FactoryBot.create(:bulk_import, progress: "pending", user_id: nil, organization_id: organization.id) }
-      include_context :geocoder_default_location
       it "creates the bikes, doesn't have any errors" do
         # In production, we actually use remote files rather than local files.
         # simulate what that process looks like by loading a remote file in the way we use open_file in BulkImport


### PR DESCRIPTION
Extracted from #1214, which adds reverse geocoding to `StolenRecord` (necessitating a default geocoder location be available more broadly in the test suite.)