### PR TITLE
Display phone for stolen_record consistently

### DIFF
--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -35,6 +35,7 @@ class Admin::UsersController < Admin::BaseController
     @user.banned = params[:user][:banned]
     @user.username = params[:user][:username]
     @user.can_send_many_stolen_notifications = params[:user][:can_send_many_stolen_notifications]
+    @user.phone = params[:user][:phone]
     if @user.save
       @user.confirm(@user.confirmation_token) if params[:user][:confirmed]
       redirect_to admin_users_url, notice: "User Updated"

--- a/app/views/admin/bikes/_bike.html.haml
+++ b/app/views/admin/bikes/_bike.html.haml
@@ -180,7 +180,7 @@
               %td
                 Phone
               %td
-                = stolen_record.phone
+                = stolen_record.phone_display
                 - if stolen_record.secondary_phone.present?
                   %br
                   %small

--- a/app/views/admin/users/edit.html.haml
+++ b/app/views/admin/users/edit.html.haml
@@ -227,7 +227,11 @@
         = f.label :secondary_emails
         = text_area_tag :secondary_emails, @user.secondary_emails.join(", "), disabled: true, rows: 1, class: "form-control"
   .row
-    .col-md-5
+    .col-md-6
+      .form-group
+        = f.label :phone
+        = f.text_field :phone, class: "form-control"
+    .col-lg-3.col-6
       .form-group
         .form-check
           = f.check_box :confirmed, disabled: @user.confirmed, class: "form-check-input"
@@ -240,7 +244,7 @@
         .form-check.form-check-inline
           = f.check_box :can_send_many_stolen_notifications, class: "form-check-input"
           = f.label :can_send_many_stolen_notifications, class: "form-check-label"
-    .col-md-5
+    .col-lg-3.col-6
       .form-group
         .form-check.form-check-inline
           = f.check_box :superuser, class: "form-check-input"
@@ -250,8 +254,9 @@
           .form-check.form-check-inline
             = f.check_box :developer, class: "form-check-input"
             = f.label :developer, class: "form-check-label"
-    .col-md-2
-      = f.submit 'Save', class: 'btn btn-success'
+    .col-6
+      .form-group.mt-2
+        = f.submit 'Save', class: 'btn btn-success'
 
 %hr{ style: "margin-top: 60px;" }
 .mt-4.mb-4.row

--- a/spec/requests/admin/users_request_spec.rb
+++ b/spec/requests/admin/users_request_spec.rb
@@ -53,6 +53,7 @@ RSpec.describe Admin::UsersController, type: :request do
                                                 developer: true,
                                                 can_send_many_stolen_notifications: true,
                                                 banned: true,
+                                                phone: "9876543210",
                                               }
         expect(user_subject.reload.name).to eq("New Name")
         expect(user_subject.email).to eq("newemailexample.com")
@@ -61,6 +62,7 @@ RSpec.describe Admin::UsersController, type: :request do
         expect(user_subject.developer).to be_falsey
         expect(user_subject.can_send_many_stolen_notifications).to be_truthy
         expect(user_subject.banned).to be_truthy
+        expect(user_subject.phone).to eq "9876543210"
       end
     end
     context "developer" do


### PR DESCRIPTION
Because of recent conversation.

Also, because we should use the helper method