### PR TITLE
Add terminal notifier, growlnotify

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -90,6 +90,7 @@ gem "secure_headers", "~> 2.5.0"
 # Frontend
 gem "bootstrap", "~> 4.0.0.alpha3" # Bootstrap 4 - used for revised stylesheets
 gem "chartkick" # Display charts
+gem "coderay" # Pretty print code
 gem "coffee-rails"
 gem "groupdate" # Required for charts
 gem "jquery-datatables-rails", "~>3.4.0"
@@ -98,7 +99,6 @@ gem "sprockets-rails", "~> 3.0.4"
 gem "therubyracer"
 gem "uglifier"
 gem "webpacker", "~> 4.x"
-gem "coderay" # Pretty print code
 
 # Show performance metrics
 gem "flamegraph", require: false
@@ -145,6 +145,7 @@ group :development do
   gem "spring"
   gem "spring-commands-rspec"
   gem "spring-commands-rubocop"
+  gem "terminal-notifier"
 end
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -585,6 +585,7 @@ GEM
       faraday (~> 0.9)
     swagger-ui_rails (0.1.7)
     temple (0.8.0)
+    terminal-notifier (2.0.0)
     terminal-table (1.8.0)
       unicode-display_width (~> 1.1, >= 1.1.1)
     text (1.3.1)
@@ -768,6 +769,7 @@ DEPENDENCIES
   stackprof
   stripe
   swagger-ui_rails
+  terminal-notifier
   therubyracer
   thor
   translation

--- a/bin/setup
+++ b/bin/setup
@@ -9,6 +9,7 @@ Dir.chdir APP_ROOT do
   # Add necessary setup steps to this file:
 
   puts "== Installing dependencies =="
+  system "command -v brew >/dev/null && brew cask info growlnotify"
   system "gem install bundler --conservative"
   system "yarn install"
 


### PR DESCRIPTION
#### Add terminal-notifier to Gemfile

Resolves the following error:

```
~/.asdf/installs/ruby/2.5.5/lib/ruby/gems/2.5.0/gems/bundler-1.17.3/lib/bundler/rubygems_integration.rb:462: 
in `block in replace_bin_path': can't find executable terminal-notifier for gem terminal-notifier. 
terminal-notifier is not currently included in the bundle, perhaps you meant to add it to your Gemfile? (Gem::Exception)
```

#### Add growlnotify to bin/setup

Resolves the following error when starting sidekiq:

```
which: no growlnotify in (....)
Traceback (most recent call last):
        4: from ~/.asdf/installs/ruby/2.5.5/bin/ruby_executable_hooks:24:in `<main>'
        3: from ~/.asdf/installs/ruby/2.5.5/bin/ruby_executable_hooks:24:in `eval'
        2: from ~/.asdf/installs/ruby/2.5.5/bin/terminal-notifier:23:in `<main>'
        1: from ~/.asdf/installs/ruby/2.5.5/lib/ruby/gems/2.5.0/gems/bundler-1.17.3/lib/bundler/rubygems_integration.rb:482:in `block in replace_bin_path'
```