### PR TITLE
External registry UI fixes

### DIFF
--- a/app/javascript/packs/external_registry_search/components/ExternalRegistrySearchResult.js
+++ b/app/javascript/packs/external_registry_search/components/ExternalRegistrySearchResult.js
@@ -27,7 +27,7 @@ const ExternalRegistrySearchResult = ({ bike }) => (
       <ul className="attr-list">
         <li>
           <span className="attr-title text-danger">{bike.status}</span>
-          <span className="convertTime">{bike.date_stolen}</span>
+          <span className="convertTime">{bike.date_stolen_string}</span>
         </li>
         <li>
           <span className="attr-title">Registry</span>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1143,10 +1143,10 @@ en:
     index:
       all: All
       anywhere: Anywhere
-      external_matches_found: Near-matches found in external registries
+      external_matches_found: Matches found in external registries
       miles_of: miles of
       no_bikes_matched: No %{stolenness} bikes matched your search
-      no_external_matches_found: No near-matches found in external registries
+      no_external_matches_found: No matches found in external registries
       not_marked_stolen: Not marked stolen
       search_bike_descriptions: Search bike descriptions
       search_for_serial_number: Search for serial number


### PR DESCRIPTION
- Removes "near" in "near-matches"
- Renders string form of the date 

<img width="788" alt="Screen Shot 2019-09-10 at 5 35 00 AM" src="https://user-images.githubusercontent.com/4433943/64602441-d1305a80-d38c-11e9-89a4-5d10095a4cdf.png">
