### PR TITLE
Fix Honeybadger notify invocation

### DIFF
--- a/app/models/external_registries/stop_heling_client.rb
+++ b/app/models/external_registries/stop_heling_client.rb
@@ -54,7 +54,10 @@ module ExternalRegistries
         if Rails.env.production?
           # Fail gracefully but notify Honeybadger if the request fails.
           # Typically an HMAC key error message will be returned as a Hash.
-          Honeybadger.notify(request: req_params, response: response_body)
+          Honeybadger.notify("StopHeling API request failed", {
+            error_class: "StopHelingClient",
+            context: { request: req_params, response: response_body },
+          })
         end
         []
       end


### PR DESCRIPTION
Fixes the `StopHelingClient` `Honeybadger.notify` invocation — we're currently not getting context for these notifications because it's being passed [incorrectly](https://www.rubydoc.info/gems/honeybadger/Honeybadger/Agent#notify-instance_method).