### PR TITLE
Fix bike box images at small breakpoint

### DIFF
--- a/app/assets/stylesheets/revised/sections/bike_boxes.scss
+++ b/app/assets/stylesheets/revised/sections/bike_boxes.scss
@@ -107,6 +107,36 @@ $bike-box-bg: $gray-lighter;
 }
 
 @media (min-width: $grid-breakpoint-md) {
+  .bike-list-image .no-image {
+    padding: 3 * $vertical-height;
+  }
+}
+
+@media (max-width: $grid-breakpoint-md) {
+  .bike-boxes .bike-box-item {
+    text-align: center;
+    padding-top: 10px;
+  }
+
+  .bike-list-image {
+    flex: none;
+    margin: auto;
+    max-height: 200px;
+    max-width: 200px;
+  }
+
+  .no-image {
+    margin: auto;
+    height: 200px;
+  }
+
+  .bike-information {
+    flex: none;
+    margin: auto;
+  }
+}
+
+@media (min-width: $grid-breakpoint-md) {
   .bike-boxes {
     .hover-expand-block {
       width: 200%;


### PR DESCRIPTION
Updates styling in bike search results to lay out results vertically at small breakpoints.

<img width="873" alt="Screen Shot 2019-09-10 at 10 40 46 PM" src="https://user-images.githubusercontent.com/4433943/64664485-5d8a5e00-d41d-11e9-8bac-ac316e78e35e.png">
<img width="286" alt="Screen Shot 2019-09-10 at 10 40 56 PM" src="https://user-images.githubusercontent.com/4433943/64664486-5d8a5e00-d41d-11e9-878e-2d849f316186.png">
<img width="1131" alt="Screen Shot 2019-09-10 at 10 49 11 PM" src="https://user-images.githubusercontent.com/4433943/64664487-5d8a5e00-d41d-11e9-8b46-0b8f367e8b81.png">
<img width="401" alt="Screen Shot 2019-09-10 at 10 49 30 PM" src="https://user-images.githubusercontent.com/4433943/64664488-5d8a5e00-d41d-11e9-88d6-5bec003475be.png">
<img width="556" alt="Screen Shot 2019-09-10 at 10 49 42 PM" src="https://user-images.githubusercontent.com/4433943/64664489-5d8a5e00-d41d-11e9-8152-72075ae8baa7.png">
