### PR TITLE
Stop fetching env variables because it's blocking

### DIFF
--- a/config/initializers/geocoder.rb
+++ b/config/initializers/geocoder.rb
@@ -3,8 +3,8 @@ unless Rails.env.test?
     cache: Redis.new,
     lookup: :google,
     use_https: true,
-    api_key: ENV.fetch("GOOGLE_GEOCODER"),
+    api_key: ENV["GOOGLE_GEOCODER"],
     ip_lookup: :maxmind,
-    maxmind: { service: :city, api_key: ENV.fetch("MAXMIND_KEY") },
+    maxmind: { service: :city, api_key: ENV["MAXMIND_KEY"] },
   )
 end


### PR DESCRIPTION
`ENV.fetch("xxxx")` errors if "xxxx" isn't defined. This breaks things (like the ability to run migrations locally).

I don't think it's a problem if we don't specify these geocoder env variables. When the geocoder is run it will error because a key isn't defined.

I suppose we could define a maxmind key stub, but it seems unnecessary?

