### PR TITLE
Enable removing all organizations can edit

### DIFF
--- a/app/controllers/bikes_controller.rb
+++ b/app/controllers/bikes_controller.rb
@@ -203,7 +203,7 @@ class BikesController < ApplicationController
     rescue => e
       flash[:error] = e.message
     end
-    if ParamsNormalizer.boolean(params[:organization_ids_can_edit_claimed_present])
+    if ParamsNormalizer.boolean(params[:organization_ids_can_edit_claimed_present]) || params.key?(:organization_ids_can_edit_claimed)
       update_organizations_can_edit_claimed(@bike, params[:organization_ids_can_edit_claimed])
     end
     assign_bike_codes(params[:bike_code]) if params[:bike_code].present?

--- a/app/controllers/bikes_controller.rb
+++ b/app/controllers/bikes_controller.rb
@@ -203,7 +203,9 @@ class BikesController < ApplicationController
     rescue => e
       flash[:error] = e.message
     end
-    update_organizations_can_edit_claimed(@bike, params[:organization_ids_can_edit_claimed]) if params.key?(:organization_ids_can_edit_claimed)
+    if ParamsNormalizer.boolean(params[:organization_ids_can_edit_claimed_present])
+      update_organizations_can_edit_claimed(@bike, params[:organization_ids_can_edit_claimed])
+    end
     assign_bike_codes(params[:bike_code]) if params[:bike_code].present?
     @bike = @bike.decorate
 
@@ -334,7 +336,7 @@ class BikesController < ApplicationController
   end
 
   def update_organizations_can_edit_claimed(bike, organization_ids)
-    organization_ids = organization_ids.map(&:to_i)
+    organization_ids = (organization_ids || []).map(&:to_i)
     bike.bike_organizations.each do |bike_organization|
       bike_organization.update_attribute :can_not_edit_claimed, !organization_ids.include?(bike_organization.organization_id)
     end

--- a/app/views/bikes/edit_groups.html.haml
+++ b/app/views/bikes/edit_groups.html.haml
@@ -11,6 +11,7 @@
             %p= t(".are_you_part_of_a_school_want_to_bolster_")
 
           - if @bike.bike_organizations.any?
+            = hidden_field_tag :organization_ids_can_edit_claimed_present, true
             .related-fields.no-divider-row
               - if @bike.bike_organizations.where(organization_id: @bike.creation_organization_id) && @bike.creation_organization
                 .form-group.row

--- a/spec/controllers/bikes_controller_spec.rb
+++ b/spec/controllers/bikes_controller_spec.rb
@@ -1491,11 +1491,29 @@ RSpec.describe BikesController, type: :controller do
         expect(bike.editable_organizations.pluck(:id)).to eq([organization_2.id])
       end
       context "empty organization_ids_can_edit_claimed" do
-        it "updates the bike with the allowed_attributes" do
+        it "updates the bike with the allowed_attributes, marks no organizations can edit claimed" do
           put :update,
               id: bike.id,
               bike: allowed_attributes,
               organization_ids_can_edit_claimed: []
+          expect(response).to redirect_to edit_bike_url(bike)
+          expect(assigns(:bike)).to be_decorated
+          bike.reload
+          expect(bike.hidden).to be_falsey
+          allowed_attributes.except(*skipped_attrs).each do |key, value|
+            pp value, key unless bike.send(key) == value
+            expect(bike.send(key)).to eq value
+          end
+          expect(bike.bike_organization_ids).to match_array([organization.id, organization_2.id])
+          expect(bike.editable_organizations.pluck(:id)).to eq([])
+        end
+      end
+      context "organization_ids_can_edit_claimed_present" do
+        it "updates the bike with the allowed_attributes, marks no organizations can edit claimed" do
+          put :update,
+              id: bike.id,
+              bike: allowed_attributes,
+              organization_ids_can_edit_claimed_present: "1"
           expect(response).to redirect_to edit_bike_url(bike)
           expect(assigns(:bike)).to be_decorated
           bike.reload


### PR DESCRIPTION
If no organizations were checked, the key wasn't present so it wouldn't update the organizations.

Fix that