### PR TITLE
Fix text breaking out of container at medium breakpoint

### DIFF
--- a/app/assets/stylesheets/revised/pages/landing/_packages.scss
+++ b/app/assets/stylesheets/revised/pages/landing/_packages.scss
@@ -191,7 +191,7 @@ $compare-packages-blue: rgb(19, 71, 106);
       }
       h3 {
         color: $compare-packages-blue;
-        font-size: 50px;
+        font-size: 230%;
         text-align: center;
         line-height: 1;
         margin: 0;


### PR DESCRIPTION
Quick fix for this:

<img width="892" alt="Screen Shot 2019-09-14 at 7 58 46 AM" src="https://user-images.githubusercontent.com/4433943/64907859-21c5f180-d6c6-11e9-840c-6beda19115de.png">

After:

<img width="873" alt="Screen Shot 2019-09-14 at 7 58 55 AM" src="https://user-images.githubusercontent.com/4433943/64907862-27bbd280-d6c6-11e9-840c-353fcbfb6c15.png">
<img width="986" alt="Screen Shot 2019-09-14 at 7 59 05 AM" src="https://user-images.githubusercontent.com/4433943/64907863-28546900-d6c6-11e9-8c7c-97a3e6704368.png">
