### PR TITLE
Refactor CustomerContact

### DIFF
--- a/app/models/customer_contact.rb
+++ b/app/models/customer_contact.rb
@@ -12,9 +12,23 @@ class CustomerContact < ActiveRecord::Base
     :user_email,
     presence: true
 
-  serialize :info_hash
-
   before_save :normalize_emails_and_find_users
+
+  # TODO: Remove below once `info_hash` migration is complete
+
+  serialize :info_hash_text
+  before_save :sync_info_hash_fields
+
+  def info_hash
+    (info_hash_text || {}).with_indifferent_access
+  end
+
+  def sync_info_hash_fields
+    self[:info_hash_text] ||= self[:info_hash]
+    self[:info_hash] ||= self[:info_hash_text]
+  end
+
+  # TODO: Remove above once `info_hash` migration is complete
 
   def normalize_emails_and_find_users
     self.user_email = EmailNormalizer.normalize(user_email)

--- a/app/models/customer_contact.rb
+++ b/app/models/customer_contact.rb
@@ -1,22 +1,28 @@
 class CustomerContact < ActiveRecord::Base
-  validates_presence_of :title
-  validates_presence_of :body
-  validates_presence_of :contact_type
-  # validates_presence_of :creator_id
-  validates_presence_of :bike_id
-  validates_presence_of :creator_email
-  validates_presence_of :user_email
-  serialize :info_hash
-
   belongs_to :bike
   belongs_to :user
   belongs_to :creator, class_name: "User"
 
-  before_save :normalize_email_and_find_user
+  validates \
+    :bike,
+    :body,
+    :contact_type,
+    :creator_email,
+    :title,
+    :user_email,
+    presence: true
 
-  def normalize_email_and_find_user
+  serialize :info_hash
+
+  before_save :normalize_emails_and_find_users
+
+  def normalize_emails_and_find_users
     self.user_email = EmailNormalizer.normalize(user_email)
     self.user ||= User.fuzzy_confirmed_or_unconfirmed_email_find(user_email)
+
+    self.creator_email = EmailNormalizer.normalize(creator_email)
+    self.creator ||= User.fuzzy_confirmed_or_unconfirmed_email_find(creator_email)
+
     true
   end
 end

--- a/db/migrate/20190916190441_add_info_hash_json_to_customer_contacts.rb
+++ b/db/migrate/20190916190441_add_info_hash_json_to_customer_contacts.rb
@@ -1,7 +1,0 @@
-class AddInfoHashJsonToCustomerContacts < ActiveRecord::Migration
-  def change
-    change_table :customer_contacts do |t|
-      t.jsonb :info_hash_json, default: {}
-    end
-  end
-end

--- a/db/migrate/20190916190441_add_info_hash_json_to_customer_contacts.rb
+++ b/db/migrate/20190916190441_add_info_hash_json_to_customer_contacts.rb
@@ -1,0 +1,7 @@
+class AddInfoHashJsonToCustomerContacts < ActiveRecord::Migration
+  def change
+    change_table :customer_contacts do |t|
+      t.jsonb :info_hash_json, default: {}
+    end
+  end
+end

--- a/db/migrate/20190916190441_rename_info_hash_to_info_hash_text_on_customer_contacts.rb
+++ b/db/migrate/20190916190441_rename_info_hash_to_info_hash_text_on_customer_contacts.rb
@@ -1,0 +1,6 @@
+class RenameInfoHashToInfoHashTextOnCustomerContacts < ActiveRecord::Migration
+  def change
+    rename_column :customer_contacts, :info_hash, :info_hash_text
+    add_column :customer_contacts, :info_hash, :jsonb, default: {}
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -733,8 +733,8 @@ CREATE TABLE public.customer_contacts (
     bike_id integer,
     created_at timestamp without time zone NOT NULL,
     updated_at timestamp without time zone NOT NULL,
-    info_hash text,
-    info_hash_json jsonb DEFAULT '{}'::jsonb
+    info_hash_text text,
+    info_hash jsonb DEFAULT '{}'::jsonb
 );
 
 

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -733,7 +733,8 @@ CREATE TABLE public.customer_contacts (
     bike_id integer,
     created_at timestamp without time zone NOT NULL,
     updated_at timestamp without time zone NOT NULL,
-    info_hash text
+    info_hash text,
+    info_hash_json jsonb DEFAULT '{}'::jsonb
 );
 
 
@@ -4667,4 +4668,6 @@ INSERT INTO schema_migrations (version) VALUES ('20190904161424');
 INSERT INTO schema_migrations (version) VALUES ('20190909190050');
 
 INSERT INTO schema_migrations (version) VALUES ('20190913132047');
+
+INSERT INTO schema_migrations (version) VALUES ('20190916190441');
 

--- a/lib/tasks/data_migrations.rake
+++ b/lib/tasks/data_migrations.rake
@@ -12,7 +12,9 @@ namespace :data do
         customer_contacts.find_each.with_index(1) do |customer_contact, i|
           customer_contact.update(info_hash: customer_contact.info_hash_text)
 
-          $stdout.print "#{i.to_s.rjust(digits, " ")}/#{total_count}\r"
+          count = [i.to_s.rjust(digits, " "), total_count].join("/")
+          percent = (i * 100 / total_count.to_f).round(1).to_s.rjust(5, " ")
+          $stdout.print "#{count} : #{percent}%\r"
           $stdout.flush
         end
       end
@@ -32,7 +34,9 @@ namespace :data do
         customer_contacts.find_each.with_index(1) do |customer_contact, i|
           customer_contact.update(info_hash_text: customer_contact.info_hash)
 
-          $stdout.print "#{i.to_s.rjust(digits, " ")}/#{total_count}\r"
+          count = [i.to_s.rjust(digits, " "), total_count].join("/")
+          percent = (i * 100 / total_count.to_f).round(1).to_s.rjust(5, " ")
+          $stdout.print "#{count} : #{percent}%\r"
           $stdout.flush
         end
       end

--- a/lib/tasks/data_migrations.rake
+++ b/lib/tasks/data_migrations.rake
@@ -1,0 +1,21 @@
+namespace :data do
+  desc "Migrate customer_contacts.info_hash to info_hash_json"
+  task migrate_info_hash: :environment do
+    customer_contacts = CustomerContact.where.not(info_hash: nil)
+    total_count = customer_contacts.count
+    digits = total_count.to_s.length
+
+    puts "Updating #{total_count} customer_contact records..."
+
+    ActiveRecord::Base.transaction do
+      customer_contacts.find_each.with_index(1) do |customer_contact, i|
+        customer_contact.update(info_hash_json: customer_contact.info_hash)
+
+        $stdout.print "#{i.to_s.rjust(digits, " ")}/#{total_count}\r"
+        $stdout.flush
+      end
+    end
+
+    puts "Done!"
+  end
+end

--- a/lib/tasks/data_migrations.rake
+++ b/lib/tasks/data_migrations.rake
@@ -1,21 +1,43 @@
 namespace :data do
-  desc "Migrate customer_contacts.info_hash to info_hash_json"
-  task migrate_info_hash: :environment do
-    customer_contacts = CustomerContact.where.not(info_hash: nil)
-    total_count = customer_contacts.count
-    digits = total_count.to_s.length
+  namespace :migrate_info_hash do
+    desc "Migrate customer_contacts.info_hash_text to info_hash"
+    task up: :environment do
+      customer_contacts = CustomerContact.where.not(info_hash: nil)
+      total_count = customer_contacts.count
+      digits = total_count.to_s.length
 
-    puts "Updating #{total_count} customer_contact records..."
+      puts "Updating #{total_count} customer_contact records..."
 
-    ActiveRecord::Base.transaction do
-      customer_contacts.find_each.with_index(1) do |customer_contact, i|
-        customer_contact.update(info_hash_json: customer_contact.info_hash)
+      ActiveRecord::Base.transaction do
+        customer_contacts.find_each.with_index(1) do |customer_contact, i|
+          customer_contact.update(info_hash: customer_contact.info_hash_text)
 
-        $stdout.print "#{i.to_s.rjust(digits, " ")}/#{total_count}\r"
-        $stdout.flush
+          $stdout.print "#{i.to_s.rjust(digits, " ")}/#{total_count}\r"
+          $stdout.flush
+        end
       end
+
+      puts "Done!"
     end
 
-    puts "Done!"
+    desc "Migrate customer_contacts.info_hash to info_hash_text"
+    task down: :environment do
+      customer_contacts = CustomerContact.where.not(info_hash: {})
+      total_count = customer_contacts.count
+      digits = total_count.to_s.length
+
+      puts "Updating #{total_count} customer_contact records..."
+
+      ActiveRecord::Base.transaction do
+        customer_contacts.find_each.with_index(1) do |customer_contact, i|
+          customer_contact.update(info_hash_text: customer_contact.info_hash)
+
+          $stdout.print "#{i.to_s.rjust(digits, " ")}/#{total_count}\r"
+          $stdout.flush
+        end
+      end
+
+      puts "Done!"
+    end
   end
 end

--- a/spec/models/customer_contact_spec.rb
+++ b/spec/models/customer_contact_spec.rb
@@ -1,16 +1,75 @@
 require "rails_helper"
 
 RSpec.describe CustomerContact, type: :model do
-  describe "normalize_email_and_find_user" do
-    it "finds email and associate" do
+  describe "validations" do
+    subject { FactoryBot.build(:customer_contact) }
+
+    it "validates presence of title" do
+      expect(subject).to be_valid
+      subject.title = nil
+      expect(subject).to be_invalid
+    end
+
+    it "validates presence of body" do
+      expect(subject).to be_valid
+      subject.body = nil
+      expect(subject).to be_invalid
+    end
+
+    it "validates presence of contact_type" do
+      expect(subject).to be_valid
+      subject.contact_type = nil
+      expect(subject).to be_invalid
+    end
+
+    it "validates presence of bike" do
+      expect(subject).to be_valid
+      subject.bike_id = 999
+      expect(subject).to be_invalid
+    end
+
+    it "validates presence of creator_email" do
+      expect(subject).to be_valid
+      subject.creator_email = nil
+      expect(subject).to be_invalid
+    end
+
+    it "validates presence of user_email" do
+      expect(subject).to be_valid
+      subject.user_email = nil
+      expect(subject).to be_invalid
+    end
+  end
+
+  describe "normalize_emails_and_find_users" do
+    it "finds user by email and associates to user" do
       user = FactoryBot.create(:user)
-      cc = CustomerContact.new
-      allow(cc).to receive(:user_email).and_return(user.email)
-      cc.normalize_email_and_find_user
+      cc = FactoryBot.build(:customer_contact, user: nil, user_email: user.email)
+
+      cc.normalize_emails_and_find_users
+      cc.save
+
       expect(cc.user_id).to eq(user.id)
     end
+
+    it "finds creator by email and associates to creator" do
+      creator = FactoryBot.create(:user)
+      cc = FactoryBot.build(:customer_contact, creator: nil, creator_email: creator.email)
+
+      cc.normalize_emails_and_find_users
+      cc.save
+
+      expect(cc.creator_id).to eq(creator.id)
+    end
+
     it "has before_save_callback_method defined as a before_save callback" do
-      expect(CustomerContact._save_callbacks.select { |cb| cb.kind.eql?(:before) }.map(&:raw_filter).include?(:normalize_email_and_find_user)).to eq(true)
+      callback_names =
+        CustomerContact
+          ._save_callbacks
+          .select { |cb| cb.kind.eql?(:before) }
+          .map(&:raw_filter)
+
+      expect(callback_names).to include(:normalize_emails_and_find_users)
     end
   end
 end


### PR DESCRIPTION
- Sets `creator` prior to saving, if `creator_email` is found
- Renames `info_hash` column to `info_hash_text`
- Adds a JSONB `info_hash` column to store any new entries as JSONB
- Adds temporary methods to customer_contact for backwards compatibility
- Adds a data migration task to copy `info_hash_text` (yaml) to `info_hash`
(follow-on work will drop in https://github.com/bikeindex/bike_index/pull/1265 `info_hash_text and kill backwards-compatibility code)