### PR TITLE
Refactor CustomerContact (2)

### DIFF
--- a/app/models/customer_contact.rb
+++ b/app/models/customer_contact.rb
@@ -14,21 +14,9 @@ class CustomerContact < ActiveRecord::Base
 
   before_save :normalize_emails_and_find_users
 
-  # TODO: Remove below once `info_hash` migration is complete
-
-  serialize :info_hash_text
-  before_save :sync_info_hash_fields
-
   def info_hash
-    (info_hash_text || {}).with_indifferent_access
+    @info_hash ||= self[:info_hash].with_indifferent_access
   end
-
-  def sync_info_hash_fields
-    self[:info_hash_text] ||= self[:info_hash]
-    self[:info_hash] ||= self[:info_hash_text]
-  end
-
-  # TODO: Remove above once `info_hash` migration is complete
 
   def normalize_emails_and_find_users
     self.user_email = EmailNormalizer.normalize(user_email)

--- a/db/migrate/20190916190442_drop_info_hash_text_from_customer_contacts.rb
+++ b/db/migrate/20190916190442_drop_info_hash_text_from_customer_contacts.rb
@@ -1,0 +1,5 @@
+class DropInfoHashTextFromCustomerContacts < ActiveRecord::Migration
+  def change
+    remove_column :customer_contacts, :info_hash_text, :text
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -732,7 +732,6 @@ CREATE TABLE public.customer_contacts (
     bike_id integer,
     created_at timestamp without time zone NOT NULL,
     updated_at timestamp without time zone NOT NULL,
-    info_hash_text text,
     info_hash jsonb DEFAULT '{}'::jsonb
 );
 
@@ -4664,6 +4663,8 @@ INSERT INTO schema_migrations (version) VALUES ('20190909190050');
 INSERT INTO schema_migrations (version) VALUES ('20190913132047');
 
 INSERT INTO schema_migrations (version) VALUES ('20190916190441');
+
+INSERT INTO schema_migrations (version) VALUES ('20190916190442');
 
 INSERT INTO schema_migrations (version) VALUES ('20190916191514');
 


### PR DESCRIPTION
- Drop `info_hash_text`
- Kill temp methods and `serialize` invocation in `CustomerContact` 

```
jake6001@hawk:/var/deploy/bike_index/web_head/current$ bin/rake data:migrate_info_hash:up
Updating 46942 customer_contact records...
46942/46942 : 100.0%
Done!
```