### PR TITLE
Migrate customer_contacts.contact_type to kind enum

### DIFF
--- a/app/controllers/admin/customer_contacts_controller.rb
+++ b/app/controllers/admin/customer_contacts_controller.rb
@@ -14,6 +14,15 @@ class Admin::CustomerContactsController < Admin::BaseController
   private
 
   def permitted_parameters
-    params.require(:customer_contact).permit(:creator_email, :user_email, :title, :contact_type, :creator_id, :bike_id, :body)
+    params.require(:customer_contact).permit(
+      :bike_id,
+      :body,
+      :contact_type,
+      :creator_email,
+      :creator_id,
+      :kind,
+      :title,
+      :user_email
+    )
   end
 end

--- a/app/controllers/api/v1/notifications_controller.rb
+++ b/app/controllers/api/v1/notifications_controller.rb
@@ -11,6 +11,7 @@ module Api
             customer_contact = CustomerContact.new(body: "EMPTY",
                                                    bike_id: bike.id,
                                                    contact_type: "stolen_twitter_alerter",
+                                                   kind: :stolen_twitter_alerter,
                                                    title: title_tag(bike),
                                                    user_email: bike.owner_email,
                                                    creator_email: "bryan@bikeindex.org",

--- a/app/models/customer_contact.rb
+++ b/app/models/customer_contact.rb
@@ -3,10 +3,20 @@ class CustomerContact < ActiveRecord::Base
   belongs_to :user
   belongs_to :creator, class_name: "User"
 
+  KIND_ENUM = {
+    stolen_contact: 0,
+    stolen_twitter_alerter: 1,
+    held_bike_notification: 2,
+    externally_held_bike_notification: 3,
+  }.freeze
+
+  enum kind: KIND_ENUM
+
   validates \
     :bike,
     :body,
     :contact_type,
+    :kind,
     :creator_email,
     :title,
     :user_email,

--- a/app/models/customer_contact.rb
+++ b/app/models/customer_contact.rb
@@ -37,4 +37,11 @@ class CustomerContact < ActiveRecord::Base
 
     true
   end
+
+  # TODO: Remove after `contact_type` is migrated to `kind` enum
+  before_save :sync_contact_type_and_kind
+
+  def sync_contact_type_and_kind
+    self[:kind] = self.class.kinds[self[:contact_type]]
+  end
 end

--- a/app/views/admin/stolen_bikes/edit.html.haml
+++ b/app/views/admin/stolen_bikes/edit.html.haml
@@ -109,6 +109,7 @@
             = f.label :bike, "Your stolen bike"
             = f.text_field :title, value: "Your stolen #{@bike.title_string}", class: "form-control"
             = f.hidden_field :contact_type, value: 'stolen_contact'
+            = f.hidden_field :kind, value: 'stolen_contact'
             = f.hidden_field :creator_id, value: current_user.id
             = f.hidden_field :bike_id, value: @bike.id
       .col-lg-8

--- a/app/workers/approve_stolen_listing_worker.rb
+++ b/app/workers/approve_stolen_listing_worker.rb
@@ -24,6 +24,7 @@ class ApproveStolenListingWorker < ApplicationWorker
         body: "EMPTY",
         bike_id: bike.id,
         contact_type: "stolen_twitter_alerter",
+        kind: :stolen_twitter_alerter,
         title: title_string,
         user_email: bike.owner_email,
         creator_email: "bryan@bikeindex.org",

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -270,6 +270,7 @@ en:
         creator: :activerecord.models.creator
         creator_email: Creator email
         info_hash: Info hash
+        kind: Kind
         title: Title
         user: :activerecord.models.user
         user_email: User email

--- a/db/migrate/20190918121951_add_kind_to_customer_contacts.rb
+++ b/db/migrate/20190918121951_add_kind_to_customer_contacts.rb
@@ -1,0 +1,5 @@
+class AddKindToCustomerContacts < ActiveRecord::Migration
+  def change
+    add_column :customer_contacts, :kind, :integer, default: 0, null: false
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -732,7 +732,8 @@ CREATE TABLE public.customer_contacts (
     bike_id integer,
     created_at timestamp without time zone NOT NULL,
     updated_at timestamp without time zone NOT NULL,
-    info_hash jsonb DEFAULT '{}'::jsonb
+    info_hash jsonb DEFAULT '{}'::jsonb,
+    kind integer DEFAULT 0 NOT NULL
 );
 
 
@@ -4667,4 +4668,6 @@ INSERT INTO schema_migrations (version) VALUES ('20190916190441');
 INSERT INTO schema_migrations (version) VALUES ('20190916190442');
 
 INSERT INTO schema_migrations (version) VALUES ('20190916191514');
+
+INSERT INTO schema_migrations (version) VALUES ('20190918121951');
 

--- a/lib/tasks/data_migrations.rake
+++ b/lib/tasks/data_migrations.rake
@@ -4,44 +4,73 @@ namespace :data do
     task up: :environment do
       customer_contacts = CustomerContact.where.not(info_hash: nil)
       total_count = customer_contacts.count
-      digits = total_count.to_s.length
-
       puts "Updating #{total_count} customer_contact records..."
 
       ActiveRecord::Base.transaction do
         customer_contacts.find_each.with_index(1) do |customer_contact, i|
           customer_contact.update(info_hash: customer_contact.info_hash_text)
-
-          count = [i.to_s.rjust(digits, " "), total_count].join("/")
-          percent = (i * 100 / total_count.to_f).round(1).to_s.rjust(5, " ")
-          $stdout.print "#{count} : #{percent}%\r"
-          $stdout.flush
+          print_status(i, total_count)
         end
       end
 
-      puts "Done!"
+      puts "\nDone!"
     end
 
     desc "Migrate customer_contacts.info_hash to info_hash_text"
     task down: :environment do
       customer_contacts = CustomerContact.where.not(info_hash: {})
       total_count = customer_contacts.count
-      digits = total_count.to_s.length
-
       puts "Updating #{total_count} customer_contact records..."
 
       ActiveRecord::Base.transaction do
         customer_contacts.find_each.with_index(1) do |customer_contact, i|
           customer_contact.update(info_hash_text: customer_contact.info_hash)
-
-          count = [i.to_s.rjust(digits, " "), total_count].join("/")
-          percent = (i * 100 / total_count.to_f).round(1).to_s.rjust(5, " ")
-          $stdout.print "#{count} : #{percent}%\r"
-          $stdout.flush
+          print_status(i, total_count)
         end
       end
 
-      puts "Done!"
+      puts "\nDone!"
     end
   end
+
+  namespace :migrate_customer_contact_types do
+    desc "Migrate customer_contacts.contact_type to kind"
+    task up: :environment do
+      total_count = CustomerContact.count
+      puts "Updating #{total_count} customer_contact records..."
+
+      CustomerContact.transaction do
+        CustomerContact.find_each.with_index(1) do |customer_contact, i|
+          kind_code = CustomerContact.kinds[customer_contact.contact_type]
+          customer_contact.update(kind: kind_code)
+          print_status(i, total_count)
+        end
+      end
+
+      puts "\nDone!"
+    end
+
+    desc "Migrate customer_contacts.kind to contact_type"
+    task down: :environment do
+      total_count = CustomerContact.count
+      puts "Updating #{total_count} customer_contact records..."
+
+      CustomerContact.transaction do
+        CustomerContact.find_each.with_index(1) do |customer_contact, i|
+          customer_contact.update(contact_type: customer_contact.kind)
+          print_status(i, total_count)
+        end
+      end
+
+      puts "\nDone!"
+    end
+  end
+end
+
+def print_status(curr, total_count)
+  digits = total_count.to_s.length
+  count = [curr.to_s.rjust(digits, " "), total_count].join("/")
+  percent = (curr * 100 / total_count.to_f).round(1).to_s.rjust(5, " ")
+  $stdout.print "#{count} : #{percent}%\r"
+  $stdout.flush
 end

--- a/spec/controllers/admin/customer_contacts_controller_spec.rb
+++ b/spec/controllers/admin/customer_contacts_controller_spec.rb
@@ -13,6 +13,7 @@ RSpec.describe Admin::CustomerContactsController, type: :controller do
         title: "some title",
         body: "some message",
         contact_type: "stolen_contact",
+        kind: :stolen_contact,
       }
       set_current_user(user)
       expect do

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -113,7 +113,7 @@ FactoryBot.define do
     body { "some message" }
     creator_email { "something@example.com" }
     user_email { "something_else@example.com" }
-    contact_type { "stolen_message" }
-    kind { :stolen_message }
+    contact_type { "stolen_contact" }
+    kind { :stolen_contact }
   end
 end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -114,5 +114,6 @@ FactoryBot.define do
     creator_email { "something@example.com" }
     user_email { "something_else@example.com" }
     contact_type { "stolen_message" }
+    kind { :stolen_message }
   end
 end

--- a/spec/mailers/customer_mailer_spec.rb
+++ b/spec/mailers/customer_mailer_spec.rb
@@ -131,6 +131,7 @@ RSpec.describe CustomerMailer, type: :mailer do
       CustomerContact.create(user_email: stolen_record.bike.owner_email,
                              creator_email: user.email,
                              body: "some message",
+                             kind: :stolen_contact,
                              contact_type: "stolen_contact",
                              bike_id: stolen_record.bike.id,
                              title: "some title")

--- a/spec/mailers/previews/customer_mailer_preview.rb
+++ b/spec/mailers/previews/customer_mailer_preview.rb
@@ -37,7 +37,7 @@ class CustomerMailerPreview < ActionMailer::Preview
   end
 
   def admin_contact_stolen_email
-    customer_contact = CustomerContact.where(contact_type: "stolen_contact").last
+    customer_contact = CustomerContact.where(kind: :stolen_contact).last
     CustomerMailer.admin_contact_stolen_email(customer_contact)
   end
 


### PR DESCRIPTION
- Adds a `kind` enum to `CustomerContact`
- Adds a data migration to populate `kind` with an appropriate mapping from `contact_type`
- Adds logic to keep `contact_type` and `kind` in sync until the former is dropped

### Post-deploy
```
bin/rake data:migrate_customer_contact_types:up
```

