### PR TITLE
Add language to blog posts

### DIFF
--- a/app/assets/stylesheets/revised/pages/news/index.scss
+++ b/app/assets/stylesheets/revised/pages/news/index.scss
@@ -1,26 +1,42 @@
 #news_index {
-  .blog-index-head {
-    a {
-      float: right;
-      opacity: 0.4;
+  .rss-svg {
+    height: .75em;
+    margin-right: 0;
+    margin-top: -0.2em;
+  }
 
-      &:hover {
-        opacity: 1;
-      }
+  .rss-link-container {
+    display: inline;
+    width: 50%;
+  }
 
-      img {
-        height: 0.75em;
-        margin-top: -0.2em;
-      }
+  .blog-rss-link {
+    opacity: .4;
+    width: 50px;
+
+    &:hover {
+      opacity: 1;
     }
   }
 
-  ul.news-index-list {
-    width: 100%;
-    max-width: 100%;
+  .blog-language-selection-container {
+    display: inline;
+    margin-top: -15px;
+    width: 50%;
+  }
+
+  .blog-language-selection {
+    input {
+      max-width: 20px;
+    }
+  }
+
+  .news-index-list {
     list-style-type: none;
     margin: 0;
+    max-width: 100%;
     padding: 0;
+    width: 100%;
 
     li {
       @include clearfix;

--- a/app/controllers/admin/news_controller.rb
+++ b/app/controllers/admin/news_controller.rb
@@ -1,7 +1,6 @@
 class Admin::NewsController < Admin::BaseController
   before_filter :find_blog, only: [:show, :edit, :update, :destroy]
   before_filter :set_dignified_name
-  before_filter :normalize_params
 
   def index
     @blogs = Blog.order("created_at asc")
@@ -83,11 +82,6 @@ class Admin::NewsController < Admin::BaseController
       :user_email,
       :user_id,
     )
-  end
-
-  def normalize_params
-    language = params.dig(:blog, :language)
-    params[:blog][:language] = language.to_i if language.present?
   end
 
   def set_dignified_name

--- a/app/controllers/admin/news_controller.rb
+++ b/app/controllers/admin/news_controller.rb
@@ -63,8 +63,26 @@ class Admin::NewsController < Admin::BaseController
   protected
 
   def permitted_parameters
-    params.require(:blog).permit(*%w(title body user_id published_at post_date post_now tags published old_title_slug
-                                     timezone description_abbr update_title is_listicle listicles_attributes user_email index_image_id index_image).map(&:to_sym).freeze)
+    params.require(:blog).permit(
+      :body,
+      :description_abbr,
+      :index_image,
+      :index_image_id,
+      :is_listicle,
+      :language,
+      :listicles_attributes,
+      :old_title_slug,
+      :post_date,
+      :post_now,
+      :published,
+      :published_at,
+      :tags,
+      :timezone,
+      :title,
+      :update_title,
+      :user_email,
+      :user_id,
+    )
   end
 
   def set_dignified_name

--- a/app/controllers/news_controller.rb
+++ b/app/controllers/news_controller.rb
@@ -1,8 +1,9 @@
 class NewsController < ApplicationController
   def index
     selected_language = params[:language].presence || I18n.locale.to_s
+    language_code = Blog.languages[selected_language]
 
-    @blogs = Blog.published.where(language: selected_language)
+    @blogs = Blog.published.where(language: language_code)
 
     redirect_to news_index_url(format: "atom") if request.format == "xml"
   end

--- a/app/controllers/news_controller.rb
+++ b/app/controllers/news_controller.rb
@@ -1,9 +1,19 @@
 class NewsController < ApplicationController
+  def index
+    selected_language = params[:language].presence || I18n.locale.to_s
+
+    @blogs = Blog.published.where(language: selected_language)
+
+    redirect_to news_index_url(format: "atom") if request.format == "xml"
+  end
+
   def show
     @blog = Blog.friendly_find(params[:id])
+
     unless @blog
       raise ActionController::RoutingError.new("Not Found")
     end
+
     if @blog.is_listicle
       @page = params[:page].to_i
       @page = 1 unless @page > 0
@@ -11,11 +21,7 @@ class NewsController < ApplicationController
       @next_item = true unless @page >= @blog.listicles.count
       @prev_item = true unless @page == 1
     end
-    @blogger = @blog.user
-  end
 
-  def index
-    @blogs = Blog.published
-    redirect_to news_index_url(format: "atom") if request.format == "xml"
+    @blogger = @blog.user
   end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -231,9 +231,12 @@ module ApplicationHelper
     end.sort { |a, b| a[0].downcase <=> b[0].downcase }
   end
 
+  # Language choices available for displaying blog entries.
+  # Return an array of tuples, each of the form:
+  # [<localized language name>, <language key (from Blog::LANGUAGE_ENUM)>]
   def blog_languages
     @blog_languages ||=
-      Blog.languages.map { |lang, num| [t(lang, scope: [:locales]), num] }
+      Blog.languages.map { |lang, _| [t(lang, scope: [:locales]), lang] }
   end
 
   def bike_placeholder_image_path

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -231,6 +231,11 @@ module ApplicationHelper
     end.sort { |a, b| a[0].downcase <=> b[0].downcase }
   end
 
+  def blog_languages
+    @blog_languages ||=
+      Blog.languages.map { |lang, num| [t(lang, scope: [:locales]), num] }
+  end
+
   def bike_placeholder_image_path
     image_path("revised/bike_photo_placeholder.svg")
   end

--- a/app/views/admin/news/edit.html.haml
+++ b/app/views/admin/news/edit.html.haml
@@ -84,7 +84,9 @@
               = f.hidden_field :index_image_id
           .form-group
             = f.label :language, class: "control-label"
-            = f.select :language, options_for_select(blog_languages), class: "form-control"
+            = f.select :language,
+              options_for_select(blog_languages, selected: Blog.languages[@blog.language]),
+              class: "form-control"
 
       .row.mt-4
         .col-md-6

--- a/app/views/admin/news/edit.html.haml
+++ b/app/views/admin/news/edit.html.haml
@@ -85,7 +85,7 @@
           .form-group
             = f.label :language, class: "control-label"
             = f.select :language,
-              options_for_select(blog_languages, selected: Blog.languages[@blog.language]),
+              options_for_select(blog_languages, selected: @blog.language),
               class: "form-control"
 
       .row.mt-4

--- a/app/views/admin/news/edit.html.haml
+++ b/app/views/admin/news/edit.html.haml
@@ -23,7 +23,7 @@
 - url = {action: "update", controller: "news"}
 = form_for [:admin, @blog], :url => url do |f|
   - if @blog.errors.any?
-    = render partial: "/shared/errors", locals: { name: "Blog", obj: @blog }
+    = render partial: "shared/errors", locals: { name: "Blog", obj: @blog }
 
   - if @blog.is_listicle
     %h2.text-danger
@@ -82,14 +82,20 @@
                 <input type="radio" name="index_image_id" value="0" class="index_image_0">
                 No primary image
               = f.hidden_field :index_image_id
+          .form-group
+            = f.label :language, class: "control-label"
+            = f.select :language, options_for_select(blog_languages), class: "form-control"
+
       .row.mt-4
         .col-md-6
           .form-group
+            = f.label :title, class: "control-label"
             = f.text_field :title, placeholder: "Blog title", class: "form-control"
           %em.less-strong
             = @blog.body_abbr
         .col-md-6
           .form-group
+            = f.label :description_abbr, "Abbreviated description", class: "control-label"
             = f.text_field :description_abbr, placeholder: "Description/subtitle shown on the homepage - will be the text below unless you enter something.", class: "form-control"
       .row.mt-4
         .col-5
@@ -111,4 +117,3 @@
 .alert.alert-info.mt-2
   %p
     The content blocks accept HTML or Markdown for styling and linking things. Check out this #{link_to "Markdown cheat sheet", "https://github.com/adam-p/markdown-here/wiki/Markdown-Cheatsheet", target: "_blank"} if you're curious.
-

--- a/app/views/admin/news/index.html.haml
+++ b/app/views/admin/news/index.html.haml
@@ -17,6 +17,8 @@
       %th.d-none.d-lg-table-cell
         Vignettes
       %th
+        Language
+      %th
         Published
     %tbody
       - @blogs.each do |blog|
@@ -37,5 +39,7 @@
               = blog.body_abbr.html_safe if blog.body_abbr
           %td.table-cell-check
             = check_mark if blog.is_listicle
+          %td
+            = t(blog.language, scope: [:locales])
           %td.table-cell-check
             = check_mark if blog.published

--- a/app/views/admin/news/new.html.haml
+++ b/app/views/admin/news/new.html.haml
@@ -4,7 +4,7 @@
 - url = {action: "create", controller: "news"}
 = form_for [:admin, @blog], :url => url do |f|
   - if @blog.errors.any?
-    = render partial: "/shared/errors", locals: { name: "Blog", obj: @blog }
+    = render partial: "shared/errors", locals: { name: "Blog", obj: @blog }
   .row
     .col-auto
       .form-group

--- a/app/views/news/index.html.haml
+++ b/app/views/news/index.html.haml
@@ -17,18 +17,6 @@
           onchange: "this.form.submit()"
   %hr
 
-:javascript
-  const setBlogLanguageSelection = () => {
-    // Set the language drop-down to the currently selected language.
-    // Workaround for the selection sticking when navigating using the back
-    // button.
-    const langOptions = document.querySelector("#js-blog-language-selection #language");
-    const langSelection = document.location.search.split("&").filter(e => e.match("language"));
-    const language = (langSelection[0] || "language=0").split("=")[1];
-    langOptions.selectedIndex = language;
-  }
-  setBlogLanguageSelection()
-
 %article
   %ul.news-index-list
     - @blogs.each_with_index do |blog, index|

--- a/app/views/news/index.html.haml
+++ b/app/views/news/index.html.haml
@@ -1,13 +1,21 @@
 #news_display
-  %h1.blog-index-head
-    = t(".bike_index_blog")
-    = form_tag nil, method: :get, class: "" do
-      = select_tag(:language,
-        options_for_select(blog_languages, selected: params[:language].presence),
-        class: "display: inline", onchange: "this.form.submit()")
-    = link_to image_tag('feed_icon.svg'), news_index_url(format: 'atom'), { title: t('.bike_index_blog_feed')}
+  .row
+    .col-md-12.col-lg-8.col-xl-9
+      %h1
+        = t(".bike_index_blog")
+        = link_to image_tag('feed_icon.svg', class: "rss-svg"),
+          news_index_url(format: 'atom'),
+          title: t('.bike_index_blog_feed'),
+          class: "blog-rss-link"
 
+    .col-md-12.col-lg-3.blog-language-selection-container
+      View posts in
+      = form_tag nil, method: :get, class: "blog-language-selection" do
+        = select_tag :language,
+          options_for_select(blog_languages, selected: params[:language].presence),
+          onchange: "this.form.submit()"
   %hr
+
 %article
   %ul.news-index-list
     - @blogs.each_with_index do |blog, index|

--- a/app/views/news/index.html.haml
+++ b/app/views/news/index.html.haml
@@ -1,7 +1,11 @@
 #news_display
   %h1.blog-index-head
     = t(".bike_index_blog")
-    = link_to image_tag('feed_icon.svg'), news_index_url(format: 'atom'), { title: t('.bike_index_blog_feed' )}
+    = form_tag nil, method: :get, class: "" do
+      = select_tag(:language,
+        options_for_select(blog_languages, selected: params[:language].presence),
+        class: "display: inline", onchange: "this.form.submit()")
+    = link_to image_tag('feed_icon.svg'), news_index_url(format: 'atom'), { title: t('.bike_index_blog_feed')}
 
   %hr
 %article

--- a/app/views/news/index.html.haml
+++ b/app/views/news/index.html.haml
@@ -10,11 +10,24 @@
 
     .col-md-12.col-lg-3.blog-language-selection-container
       View posts in
-      = form_tag nil, method: :get, class: "blog-language-selection" do
+      = form_tag nil, method: :get,
+        class: "blog-language-selection", id: "js-blog-language-selection" do
         = select_tag :language,
           options_for_select(blog_languages, selected: params[:language].presence),
           onchange: "this.form.submit()"
   %hr
+
+:javascript
+  const setBlogLanguageSelection = () => {
+    // Set the language drop-down to the currently selected language.
+    // Workaround for the selection sticking when navigating using the back
+    // button.
+    const langOptions = document.querySelector("#js-blog-language-selection #language");
+    const langSelection = document.location.search.split("&").filter(e => e.match("language"));
+    const language = (langSelection[0] || "language=0").split("=")[1];
+    langOptions.selectedIndex = language;
+  }
+  setBlogLanguageSelection()
 
 %article
   %ul.news-index-list

--- a/db/migrate/20190919145324_add_language_to_blogs.rb
+++ b/db/migrate/20190919145324_add_language_to_blogs.rb
@@ -1,0 +1,5 @@
+class AddLanguageToBlogs < ActiveRecord::Migration
+  def change
+    add_column :blogs, :language, :integer, default: 0, null: false
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -135,6 +135,7 @@ CREATE TABLE public.ambassador_task_assignments (
 --
 
 CREATE SEQUENCE public.ambassador_task_assignments_id_seq
+    AS integer
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -167,6 +168,7 @@ CREATE TABLE public.ambassador_tasks (
 --
 
 CREATE SEQUENCE public.ambassador_tasks_id_seq
+    AS integer
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -245,6 +247,7 @@ CREATE TABLE public.bike_code_batches (
 --
 
 CREATE SEQUENCE public.bike_code_batches_id_seq
+    AS integer
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -101,6 +101,7 @@ CREATE TABLE public.alert_images (
 --
 
 CREATE SEQUENCE public.alert_images_id_seq
+    AS integer
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -441,7 +442,8 @@ CREATE TABLE public.blogs (
     is_listicle boolean DEFAULT false NOT NULL,
     index_image character varying(255),
     index_image_id integer,
-    index_image_lg character varying(255)
+    index_image_lg character varying(255),
+    language integer DEFAULT 0 NOT NULL
 );
 
 
@@ -879,6 +881,7 @@ CREATE TABLE public.flipper_features (
 --
 
 CREATE SEQUENCE public.flipper_features_id_seq
+    AS integer
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -912,6 +915,7 @@ CREATE TABLE public.flipper_gates (
 --
 
 CREATE SEQUENCE public.flipper_gates_id_seq
+    AS integer
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -981,6 +985,7 @@ CREATE TABLE public.impound_records (
 --
 
 CREATE SEQUENCE public.impound_records_id_seq
+    AS integer
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -2083,6 +2088,7 @@ CREATE TABLE public.theft_alert_plans (
 --
 
 CREATE SEQUENCE public.theft_alert_plans_id_seq
+    AS integer
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -2122,6 +2128,7 @@ CREATE TABLE public.theft_alerts (
 --
 
 CREATE SEQUENCE public.theft_alerts_id_seq
+    AS integer
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -2210,6 +2217,7 @@ CREATE TABLE public.twitter_accounts (
 --
 
 CREATE SEQUENCE public.twitter_accounts_id_seq
+    AS integer
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -2306,8 +2314,8 @@ CREATE TABLE public.users (
     notification_unstolen boolean DEFAULT true,
     my_bikes_hash jsonb,
     preferred_language character varying,
-    last_login_ip character varying,
-    magic_link_token text
+    magic_link_token text,
+    last_login_ip character varying
 );
 
 
@@ -4671,4 +4679,6 @@ INSERT INTO schema_migrations (version) VALUES ('20190916191514');
 INSERT INTO schema_migrations (version) VALUES ('20190918121951');
 
 INSERT INTO schema_migrations (version) VALUES ('20190918143646');
+
+INSERT INTO schema_migrations (version) VALUES ('20190919145324');
 

--- a/spec/controllers/admin/news_controller_spec.rb
+++ b/spec/controllers/admin/news_controller_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe Admin::NewsController, type: :controller do
       blog_attrs = {
         title: "new title thing stuff",
         body: "<p>html</p>",
-        language: "1",
+        language: "en",
       }
       put :update, id: subject.to_param, blog: blog_attrs
       subject.reload

--- a/spec/controllers/admin/news_controller_spec.rb
+++ b/spec/controllers/admin/news_controller_spec.rb
@@ -24,7 +24,11 @@ RSpec.describe Admin::NewsController, type: :controller do
 
   describe "update" do
     it "updates available attributes" do
-      blog_attrs = { title: "new title thing stuff", body: "<p>html</p>" }
+      blog_attrs = {
+        title: "new title thing stuff",
+        body: "<p>html</p>",
+        language: "1",
+      }
       put :update, id: subject.to_param, blog: blog_attrs
       subject.reload
       expect(subject.title).to eq blog_attrs[:title]

--- a/spec/controllers/news_controller_spec.rb
+++ b/spec/controllers/news_controller_spec.rb
@@ -46,6 +46,18 @@ RSpec.describe NewsController, type: :controller do
           expect(response).to render_template("index")
         end
       end
+      context "given a language selection" do
+        it "renders blog posts in that language" do
+          FactoryBot.create(:blog, :published)
+          FactoryBot.create(:blog, :published, :dutch)
+
+          get :index, language: "nl"
+
+          expect(response.status).to eq(200)
+          expect(response).to render_template("index")
+          expect(assigns(:blogs).length).to eq(1)
+        end
+      end
       context "xml" do
         it "redirects to atom" do
           get :index, format: :xml

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -97,6 +97,14 @@ FactoryBot.define do
     user
     body { "Some sweet blog content that everyone loves" }
     sequence(:title) { |n| "Blog title #{n}" }
+
+    trait :published do
+      published { true }
+    end
+
+    trait :dutch do
+      language { "nl" }
+    end
   end
 
   factory :stolen_notification do


### PR DESCRIPTION
- Adds a `language` attribute to `Blog`, defaulting to English
- `blogs.language` enum includes only current locale languages
- Adds a drop-down to the public-facing blog index to select posts in other languages
- Current blog language defaults to the user's current locale
- Changing blog language doesn't change the user's current locale

### UI
<img width="495" alt="Screen Shot 2019-09-19 at 1 35 58 PM" src="https://user-images.githubusercontent.com/4433943/65267200-8fb55300-dae2-11e9-893e-6d5aa9e91d57.png">
<img width="666" alt="Screen Shot 2019-09-19 at 1 36 04 PM" src="https://user-images.githubusercontent.com/4433943/65267202-8fb55300-dae2-11e9-8503-578136b66178.png">
<img width="1084" alt="Screen Shot 2019-09-19 at 1 36 11 PM" src="https://user-images.githubusercontent.com/4433943/65267203-8fb55300-dae2-11e9-87b9-3759227990cd.png">

### Admin UI

<img width="787" alt="Screen Shot 2019-09-19 at 1 38 14 PM" src="https://user-images.githubusercontent.com/4433943/65267320-c2f7e200-dae2-11e9-99ca-533ad23b5ca1.png">
