### PR TITLE
Add bike no-serial sanitizing

### DIFF
--- a/app/models/bike.rb
+++ b/app/models/bike.rb
@@ -474,6 +474,9 @@ class Bike < ActiveRecord::Base
     if serial_number == "made_without_serial"
       self.serial_normalized = nil
       self.made_without_serial = true
+    elsif serial_number == "unknown"
+      self.serial_normalized = nil
+      self.made_without_serial = false
     else
       self.serial_normalized = SerialNormalizer.new(serial: serial_number).normalized
       self.made_without_serial = false

--- a/app/models/bike.rb
+++ b/app/models/bike.rb
@@ -471,10 +471,12 @@ class Bike < ActiveRecord::Base
     end
 
     self.serial_number = SerialNormalizer.unknown_and_absent_corrected(serial_number)
-    if serial_number == "made_without_serial"
+
+    case serial_number
+    when "made_without_serial"
       self.serial_normalized = nil
       self.made_without_serial = true
-    elsif serial_number == "unknown"
+    when "unknown"
       self.serial_normalized = nil
       self.made_without_serial = false
     else

--- a/app/services/serial_normalizer.rb
+++ b/app/services/serial_normalizer.rb
@@ -3,9 +3,17 @@ class SerialNormalizer
     str = str.to_s.strip
     # Return unknown if blank, '?' or 'absent' (legacy concern - 'unknown' used to be stored as 'absent')
     return "unknown" if str.blank? || str.gsub(/\s|\?/, "").blank? || str.downcase == "absent"
-    return "made_without_serial" if str == "made_without_serial"
+    return "made_without_serial" if str == "made_without_serial" || looks_like_made_without?(str.downcase)
     return "unknown" if looks_like_unknown?(str.downcase)
     str
+  end
+
+  def self.looks_like_made_without?(str_downcase)
+    case str_downcase
+    when /none/i then true
+    when /no serial/i then true
+    when /custom/i then true
+    end
   end
 
   def self.looks_like_unknown?(str_downcase)

--- a/app/services/serial_normalizer.rb
+++ b/app/services/serial_normalizer.rb
@@ -10,7 +10,6 @@ class SerialNormalizer
 
   def self.looks_like_made_without?(str_downcase)
     case str_downcase
-    when /none/i then true
     when /no serial/i then true
     when /custom/i then true
     end

--- a/app/services/serial_normalizer.rb
+++ b/app/services/serial_normalizer.rb
@@ -9,10 +9,7 @@ class SerialNormalizer
   end
 
   def self.looks_like_made_without?(str_downcase)
-    case str_downcase
-    when /no serial/i then true
-    when /custom/i then true
-    end
+    (/custom/).match?(str_downcase)
   end
 
   def self.looks_like_unknown?(str_downcase)

--- a/spec/models/bike_spec.rb
+++ b/spec/models/bike_spec.rb
@@ -2,6 +2,7 @@ require "rails_helper"
 
 RSpec.describe Bike, type: :model do
   it_behaves_like "bike_searchable"
+
   describe "scopes" do
     it "default scopes to created_at desc" do
       expect(Bike.all.to_sql).to eq(Bike.unscoped.where(example: false, hidden: false, deleted_at: nil).order("listing_order desc").to_sql)
@@ -22,34 +23,83 @@ RSpec.describe Bike, type: :model do
       bike = FactoryBot.create(:bike)
       expect(bike.recovered_records.to_sql).to eq(StolenRecord.unscoped.where(bike_id: bike.id, current: false).order("recovered_at desc").to_sql)
     end
-    context "unknown, absent serials" do
-      let(:bike_with_serial) { FactoryBot.create(:bike, serial_number: "CCcc99FFF") }
-      let(:bike_made_without_serial) { FactoryBot.create(:bike, made_without_serial: true) }
-      let(:bike_with_unknown_serial) { FactoryBot.create(:bike, serial_number: "????  \n") }
-      it "corrects poorly entered serial numbers" do
-        [bike_with_serial, bike_made_without_serial, bike_with_unknown_serial].each { |b| b.reload }
-        expect(bike_with_serial.made_without_serial?).to be_falsey
-        expect(bike_with_serial.serial_unknown?).to be_falsey
-        expect(bike_made_without_serial.serial_number).to eq "made_without_serial"
-        expect(bike_made_without_serial.made_without_serial?).to be_truthy
-        expect(bike_made_without_serial.serial_unknown?).to be_falsey
-        expect(bike_with_unknown_serial.made_without_serial?).to be_falsey
-        expect(bike_with_unknown_serial.serial_unknown?).to be_truthy
-        expect(bike_with_serial.serial_number).to eq "CCcc99FFF"
-        expect(bike_made_without_serial.serial_number).to eq "made_without_serial"
-        expect(bike_with_unknown_serial.serial_number).to eq "unknown"
-        expect(Bike.with_known_serial.pluck(:id)).to match_array([bike_with_serial.id, bike_made_without_serial.id])
+  end
+
+  context "unknown, absent serials" do
+    let(:bike_with_serial) { FactoryBot.create(:bike, serial_number: "CCcc99FFF") }
+    let(:bike_made_without_serial) { FactoryBot.create(:bike, made_without_serial: true) }
+    let(:bike_with_unknown_serial) { FactoryBot.create(:bike, serial_number: "????  \n") }
+    it "corrects poorly entered serial numbers" do
+      [bike_with_serial, bike_made_without_serial, bike_with_unknown_serial].each { |b| b.reload }
+      expect(bike_with_serial.made_without_serial?).to be_falsey
+      expect(bike_with_serial.serial_unknown?).to be_falsey
+      expect(bike_made_without_serial.serial_number).to eq "made_without_serial"
+      expect(bike_made_without_serial.made_without_serial?).to be_truthy
+      expect(bike_made_without_serial.serial_unknown?).to be_falsey
+      expect(bike_with_unknown_serial.made_without_serial?).to be_falsey
+      expect(bike_with_unknown_serial.serial_unknown?).to be_truthy
+      expect(bike_with_serial.serial_number).to eq "CCcc99FFF"
+      expect(bike_made_without_serial.serial_number).to eq "made_without_serial"
+      expect(bike_with_unknown_serial.serial_number).to eq "unknown"
+      expect(Bike.with_known_serial.pluck(:id)).to match_array([bike_with_serial.id, bike_made_without_serial.id])
+    end
+  end
+
+  describe "#normalize_serial_number" do
+    context "given a bike made with no serial number" do
+      no_serials = [
+        "custom bike no serial has a unique frame design",
+        "custom built",
+        "custom",
+        "none",
+        "no serial",
+      ]
+      no_serials.each do |value|
+        it "('#{value}') sets the 'made_without_serial' state correctly" do
+          bike = FactoryBot.build(:bike, serial_number: value)
+          bike.normalize_serial_number
+          expect(bike.serial_number).to eq("made_without_serial")
+          expect(bike.made_without_serial).to eq(true)
+          expect(bike.serial_normalized).to eq(nil)
+        end
       end
     end
-    context "actual tests for ascend and lightspeed" do
-      let!(:bike_lightspeed_pos) { FactoryBot.create(:bike_lightspeed_pos) }
-      let!(:bike_ascend_pos) { FactoryBot.create(:bike_ascend_pos) }
-      it "scopes correctly" do
-        expect(bike_lightspeed_pos.pos_kind).to eq "lightspeed_pos"
-        expect(bike_ascend_pos.pos_kind).to eq "ascend_pos"
-        expect(Bike.lightspeed_pos.pluck(:id)).to eq([bike_lightspeed_pos.id])
-        expect(Bike.ascend_pos.pluck(:id)).to eq([bike_ascend_pos.id])
+
+    context "given a bike with an unknown serial number" do
+      unknown_serials = [
+        " UNKNOWn ",
+        "I don't know it",
+        "I don't remember",
+        "Sadly I don't know",
+        "absent",
+        "don't know",
+        "i don't know",
+        "idk",
+        "missing serial",
+        "missing",
+        "probably has one don't know it",
+        "unknown",
+      ]
+      unknown_serials.each do |value|
+        it "('#{value}') sets the 'unknown' state correctly" do
+          bike = FactoryBot.build(:bike, serial_number: value)
+          bike.normalize_serial_number
+          expect(bike.serial_number).to eq("unknown")
+          expect(bike.made_without_serial).to eq(false)
+          expect(bike.serial_normalized).to eq(nil)
+        end
       end
+    end
+  end
+
+  context "actual tests for ascend and lightspeed" do
+    let!(:bike_lightspeed_pos) { FactoryBot.create(:bike_lightspeed_pos) }
+    let!(:bike_ascend_pos) { FactoryBot.create(:bike_ascend_pos) }
+    it "scopes correctly" do
+      expect(bike_lightspeed_pos.pos_kind).to eq "lightspeed_pos"
+      expect(bike_ascend_pos.pos_kind).to eq "ascend_pos"
+      expect(Bike.lightspeed_pos.pluck(:id)).to eq([bike_lightspeed_pos.id])
+      expect(Bike.ascend_pos.pluck(:id)).to eq([bike_ascend_pos.id])
     end
   end
 
@@ -813,17 +863,10 @@ RSpec.describe Bike, type: :model do
     end
   end
 
-  describe "set_normalized_attributes" do
-    it "sets a bikes normalized_serial and switches unknown to absent" do
-      bike = Bike.new(serial_number: " UNKNOWn ")
-      expect_any_instance_of(SerialNormalizer).to receive(:normalized).and_return("normal")
-      bike.normalize_attributes
-      expect(bike.serial_number).to eq("unknown")
-      expect(bike.serial_normalized).to eq("normal")
-    end
+  describe "#normalize_emails" do
     it "sets normalized owner email" do
       bike = Bike.new(owner_email: "  somethinG@foo.orG")
-      bike.normalize_attributes
+      bike.normalize_emails
       expect(bike.owner_email).to eq("something@foo.org")
     end
 
@@ -834,7 +877,7 @@ RSpec.describe Bike, type: :model do
         bike = FactoryBot.build(:bike, owner_email: user_email.email)
         expect(user.email).to_not eq user_email.email
         expect(bike.owner_email).to eq user_email.email
-        bike.normalize_attributes
+        bike.normalize_emails
         expect(bike.owner_email).to eq user.email
       end
     end
@@ -870,10 +913,10 @@ RSpec.describe Bike, type: :model do
         expect(bike.serial_display).to eq("Unknown")
       end
     end
-    context "Made without" do
+    context "Made without serial" do
       it "returns made_without_serial" do
         bike = Bike.new(made_without_serial: true)
-        bike.normalize_attributes
+        bike.normalize_serial_number
         expect(bike.serial_display).to eq("Made without serial")
       end
     end

--- a/spec/models/bike_spec.rb
+++ b/spec/models/bike_spec.rb
@@ -51,7 +51,6 @@ RSpec.describe Bike, type: :model do
         "custom bike no serial has a unique frame design",
         "custom built",
         "custom",
-        "no serial",
       ]
       no_serials.each do |value|
         it "('#{value}') sets the 'made_without_serial' state correctly" do
@@ -76,6 +75,7 @@ RSpec.describe Bike, type: :model do
         "idk",
         "missing serial",
         "missing",
+        "no serial",
         "none",
         "probably has one don't know it",
         "unknown",

--- a/spec/models/bike_spec.rb
+++ b/spec/models/bike_spec.rb
@@ -51,7 +51,6 @@ RSpec.describe Bike, type: :model do
         "custom bike no serial has a unique frame design",
         "custom built",
         "custom",
-        "none",
         "no serial",
       ]
       no_serials.each do |value|
@@ -77,6 +76,7 @@ RSpec.describe Bike, type: :model do
         "idk",
         "missing serial",
         "missing",
+        "none",
         "probably has one don't know it",
         "unknown",
       ]

--- a/spec/services/serial_normalizer_spec.rb
+++ b/spec/services/serial_normalizer_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe SerialNormalizer do
         [
           "dont know ", "I don't know it", "i dont fucking know", "sadly I don't know... ", "I do not remember",
           "???? ??", "Unknown Serial", "IDONTKNOWTHESERIALNUMBER", "I dont remember", "Not known", "dont no", "missing",
-          "n/a", "do not have", "idk", "unkown",
+          "n/a", "do not have", "idk", "unkown", "none",
         ]
       end
       it "normalizes a bunch of misentries" do
@@ -45,9 +45,7 @@ RSpec.describe SerialNormalizer do
       entries = [
         "custom bike no serial has a unique frame design",
         "custom built ",
-        "custom",
-        "none",
-        " none ",
+        " custom ",
         "no serial",
       ]
       entries.each do |entry|

--- a/spec/services/serial_normalizer_spec.rb
+++ b/spec/services/serial_normalizer_spec.rb
@@ -22,12 +22,12 @@ RSpec.describe SerialNormalizer do
         [
           "dont know ", "I don't know it", "i dont fucking know", "sadly I don't know... ", "I do not remember",
           "???? ??", "Unknown Serial", "IDONTKNOWTHESERIALNUMBER", "I dont remember", "Not known", "dont no", "missing",
-          "n/a", "do not have", "no serial", "idk", "unkown",
+          "n/a", "do not have", "idk", "unkown",
         ]
       end
       it "normalizes a bunch of misentries" do
         sample_misentries.each do |serial|
-          expect(SerialNormalizer.unknown_and_absent_corrected(serial)).to eq "unknown"
+          expect(SerialNormalizer.unknown_and_absent_corrected(serial)).to eq("unknown"), "Failure: '#{serial}'"
         end
       end
     end
@@ -39,6 +39,23 @@ RSpec.describe SerialNormalizer do
       serial_normalizer = SerialNormalizer.new(serial: "made_without_serial")
       expect(serial_normalizer.normalized).to be_nil
       expect(serial_normalizer.normalized_segments).to eq([])
+    end
+
+    context "verbose entries" do
+      entries = [
+        "custom bike no serial has a unique frame design",
+        "custom built ",
+        "custom",
+        "none",
+        " none ",
+        "no serial",
+      ]
+      entries.each do |entry|
+        it "normalizes '#{entry}' to 'made_without_serial'" do
+          corrected_serial = SerialNormalizer.unknown_and_absent_corrected(entry)
+          expect(corrected_serial).to eq("made_without_serial")
+        end
+      end
     end
   end
 

--- a/spec/services/serial_normalizer_spec.rb
+++ b/spec/services/serial_normalizer_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe SerialNormalizer do
         [
           "dont know ", "I don't know it", "i dont fucking know", "sadly I don't know... ", "I do not remember",
           "???? ??", "Unknown Serial", "IDONTKNOWTHESERIALNUMBER", "I dont remember", "Not known", "dont no", "missing",
-          "n/a", "do not have", "idk", "unkown", "none",
+          "n/a", "do not have", "idk", "unkown", "none", "no serial",
         ]
       end
       it "normalizes a bunch of misentries" do
@@ -46,7 +46,6 @@ RSpec.describe SerialNormalizer do
         "custom bike no serial has a unique frame design",
         "custom built ",
         " custom ",
-        "no serial",
       ]
       entries.each do |entry|
         it "normalizes '#{entry}' to 'made_without_serial'" do

--- a/spec/workers/bulk_import_worker_spec.rb
+++ b/spec/workers/bulk_import_worker_spec.rb
@@ -345,11 +345,11 @@ RSpec.describe BulkImportWorker, type: :job do
       let(:blank_examples) { ["NA", "N/A", "unkown", "unkown", "           ", "none"] }
       let(:non_blank_examples) { %w[somethingna none8xc9x] }
       it "rescues blank serials, doesn't rescue non blank serials" do
-        blank_examples.each do |e|
-          expect(instance.rescue_blank_serial(e)).to eq "unknown"
+        blank_examples.each do |blank|
+          expect(instance.rescue_blank_serial(blank)).to eq("unknown"), "Failure: '#{blank}'"
         end
-        non_blank_examples.each do |e|
-          expect(instance.rescue_blank_serial(e)).to_not eq "unknown"
+        non_blank_examples.each do |non_blank|
+          expect(instance.rescue_blank_serial(non_blank)).to_not eq("unknown"), "Failure: #{non_blank}"
         end
       end
     end


### PR DESCRIPTION
- Sanitizes non-standardized forms of "made_without_serial"
- Adds a `before_save` hook to ensure the three components of "unknown" / "made_without_serial" / neither state are kept consistent with each other.

Resolves #1277 