### PR TITLE
Twitter account remove error on update

### DIFF
--- a/app/controllers/admin/twitter_accounts_controller.rb
+++ b/app/controllers/admin/twitter_accounts_controller.rb
@@ -28,6 +28,10 @@ class Admin::TwitterAccountsController < Admin::BaseController
 
   def update
     if @twitter_account.update_attributes(permitted_parameters)
+      if ParamsNormalizer.boolean(params[:check_credentials])
+        @twitter_account.reload
+        @twitter_account.check_credentials
+      end
       flash[:notice] = "Twitter account saved!"
       redirect_to admin_twitter_account_url(@twitter_account)
     else

--- a/app/models/twitter_account.rb
+++ b/app/models/twitter_account.rb
@@ -76,11 +76,12 @@ class TwitterAccount < ActiveRecord::Base
   end
 
   def errored?
-    last_error.present?
+    last_error_at.present?
   end
 
   def check_credentials
-    clear_error if twitter_client.verify_credentials.present?
+    clear_error
+    twitter_client.verify_credentials
   rescue Twitter::Error::Unauthorized, Twitter::Error::Forbidden => err
     set_error(err.message)
   end

--- a/app/views/admin/twitter_accounts/_form.html.haml
+++ b/app/views/admin/twitter_accounts/_form.html.haml
@@ -24,6 +24,10 @@
           = f.label :national do
             = f.check_box :national
             national
+        .input-group
+          = label_tag :check_credentials do
+            = check_box_tag :check_credentials
+            Test Twitter connection on update
 
     .col-md-6.mb-4
       .card

--- a/spec/controllers/admin/twitter_accounts_controller_spec.rb
+++ b/spec/controllers/admin/twitter_accounts_controller_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe Admin::TwitterAccountsController, type: :controller, vcr: true do
   end
 
   describe "update" do
-    let(:twitter_account) { FactoryBot.create(:twitter_account_1, is_active: false) }
+    let(:twitter_account) { FactoryBot.create(:twitter_account_1, active: false) }
     before { twitter_account.set_error("Something") }
     it "updates without check_credentials" do
       expect(twitter_account.errored?).to be_truthy
@@ -53,19 +53,19 @@ RSpec.describe Admin::TwitterAccountsController, type: :controller, vcr: true do
       twitter_account.reload
       expect(twitter_account.append_block).to eq "Something special"
       expect(twitter_account.errored?).to be_truthy
-      expect(twitter_account.is_active).to be_falsey
+      expect(twitter_account.active).to be_falsey
     end
-    context "switching to is_active" do
+    context "switching to active" do
       it "updates and checks_credentials" do
         expect(twitter_account.errored?).to be_truthy
         expect(twitter_account).to receive(:check_credentials) { }
         patch :update,
               id: ambassador_task.id,
               verify_credentials: true,
-              twitter_account: { is_active: true }
+              twitter_account: { active: true }
         twitter_account.reload
         expect(twitter_account.errored?).to be_falsey
-        expect(twitter_account.is_active).to be_truthy
+        expect(twitter_account.active).to be_truthy
       end
     end
   end


### PR DESCRIPTION
I'm not sure what to make of this line in [twitter_account.rb](https://github.com/bikeindex/bike_index/blob/master/app/models/twitter_account.rb#L83):

```ruby
clear_error if twitter_client.verify_credentials.present?
```

I would like to add a checkbox to the admin page to `check_credentials`, but I don't want to mess with this line because I'm not sure why it's there. I don't understand why we wouldn't always clear the error before running `check_credentials`

It doesn't seem like anything in the app calls `check_credentials` anyway though?