### PR TITLE
Add Bike.currently_stolen_in

### DIFF
--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -77,6 +77,18 @@ FactoryBot.define do
     name
     country { FactoryBot.create(:country) }
     sequence(:abbreviation) { |n| "Q#{n}" }
+
+    factory :state_new_york do
+      abbreviation { "NY" }
+      country { Country.united_states }
+      name { "New York" }
+    end
+
+    factory :state_california do
+      abbreviation { "CA" }
+      country { Country.united_states }
+      name { "California" }
+    end
   end
 
   factory :lock_type do

--- a/spec/factories/bikes.rb
+++ b/spec/factories/bikes.rb
@@ -44,6 +44,28 @@ FactoryBot.define do
       factory :recovered_bike do
         stolen { false }
       end
+
+      factory :stolen_bike_in_amsterdam do
+        after(:create) do |bike, evaluator|
+          create(:stolen_record, :in_amsterdam, bike: bike, latitude: evaluator.latitude, longitude: evaluator.longitude)
+          bike.save # updates current_stolen_record
+          bike.reload
+        end
+      end
+      factory :stolen_bike_in_los_angeles do
+        after(:create) do |bike, evaluator|
+          create(:stolen_record, :in_los_angeles, bike: bike, latitude: evaluator.latitude, longitude: evaluator.longitude)
+          bike.save # updates current_stolen_record
+          bike.reload
+        end
+      end
+      factory :stolen_bike_in_nyc do
+        after(:create) do |bike, evaluator|
+          create(:stolen_record, :in_nyc, bike: bike, latitude: evaluator.latitude, longitude: evaluator.longitude)
+          bike.save # updates current_stolen_record
+          bike.reload
+        end
+      end
     end
 
     factory :organized_bikes do # don't use this factory exactly, it's used to wrap all the organized bikes

--- a/spec/factories/countries.rb
+++ b/spec/factories/countries.rb
@@ -12,5 +12,10 @@ FactoryBot.define do
       name { "United Kingdom" }
       iso { "UK" }
     end
+
+    factory :country_nl do
+      name { "Netherlands" }
+      iso { "NL" }
+    end
   end
 end

--- a/spec/factories/stolen_records.rb
+++ b/spec/factories/stolen_records.rb
@@ -3,6 +3,11 @@ FactoryBot.define do
     bike { FactoryBot.create(:bike, stolen: true) }
     date_stolen { Time.current }
 
+    after(:create) do |stolen_record, _evaluator|
+      bike = stolen_record.bike
+      bike.save # sets current_stolen_record
+    end
+
     factory :stolen_record_recovered do
       bike { FactoryBot.create(:bike) }
       recovered_at { Time.current }
@@ -25,12 +30,6 @@ FactoryBot.define do
 
     trait :with_bike_image do
       bike { FactoryBot.create(:bike, :with_image) }
-    end
-
-    trait :currently_stolen do
-      after(:create) do |stolen_record, _evaluator|
-        stolen_record.bike.update(current_stolen_record: stolen_record)
-      end
     end
 
     trait :in_los_angeles do

--- a/spec/factories/stolen_records.rb
+++ b/spec/factories/stolen_records.rb
@@ -3,11 +3,6 @@ FactoryBot.define do
     bike { FactoryBot.create(:bike, stolen: true) }
     date_stolen { Time.current }
 
-    after(:create) do |stolen_record, _evaluator|
-      bike = stolen_record.bike
-      bike.save # sets current_stolen_record
-    end
-
     factory :stolen_record_recovered do
       bike { FactoryBot.create(:bike) }
       recovered_at { Time.current }

--- a/spec/factories/stolen_records.rb
+++ b/spec/factories/stolen_records.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :stolen_record do
-    bike { FactoryBot.create(:bike) }
+    bike { FactoryBot.create(:bike, stolen: true) }
     date_stolen { Time.current }
 
     factory :stolen_record_recovered do
@@ -25,6 +25,30 @@ FactoryBot.define do
 
     trait :with_bike_image do
       bike { FactoryBot.create(:bike, :with_image) }
+    end
+
+    trait :currently_stolen do
+      after(:create) do |stolen_record, _evaluator|
+        stolen_record.bike.update(current_stolen_record: stolen_record)
+      end
+    end
+
+    trait :in_los_angeles do
+      city { "Los Angeles" }
+      state { State.find_or_create_by(FactoryBot.attributes_for(:state_california)) }
+      country { Country.united_states }
+    end
+
+    trait :in_nyc do
+      city { "New York" }
+      state { State.find_or_create_by(FactoryBot.attributes_for(:state_new_york)) }
+      country { Country.united_states }
+    end
+
+    trait :in_amsterdam do
+      city { "Amsterdam" }
+      state { nil }
+      country { Country.find_or_create_by(FactoryBot.attributes_for(:country_nl)) }
     end
   end
 end

--- a/spec/mailers/customer_mailer_spec.rb
+++ b/spec/mailers/customer_mailer_spec.rb
@@ -84,12 +84,12 @@ RSpec.describe CustomerMailer, type: :mailer do
   end
 
   describe "stolen_bike_alert_email" do
-    let!(:ownership) { FactoryBot.create(:ownership, bike: stolen_record.bike) }
-    let(:stolen_record) { FactoryBot.create(:stolen_record) }
+    let!(:ownership) { FactoryBot.create(:ownership, bike: bike) }
+    let(:bike) { FactoryBot.create(:stolen_bike) }
     let(:notification_hash) do
       {
         notification_type: "stolen_twitter_alerter",
-        bike_id: stolen_record.bike.id,
+        bike_id: bike.id,
         tweet_id: 69,
         tweet_string: "STOLEN - something special",
         tweet_account_screen_name: "bikeindex",
@@ -99,7 +99,7 @@ RSpec.describe CustomerMailer, type: :mailer do
         retweet_screen_names: %w(someother_screename and_another),
       }
     end
-    let(:customer_contact) { FactoryBot.create(:customer_contact, info_hash: notification_hash, title: "CUSTOM CUSTOMER contact Title", bike: stolen_record.bike) }
+    let(:customer_contact) { FactoryBot.create(:customer_contact, info_hash: notification_hash, title: "CUSTOM CUSTOMER contact Title", bike: bike) }
     it "renders email" do
       mail = CustomerMailer.stolen_bike_alert_email(customer_contact)
       expect(mail.to).to eq([customer_contact.user_email])
@@ -111,7 +111,7 @@ RSpec.describe CustomerMailer, type: :mailer do
   describe "recovered_from_link" do
     let(:bike) { FactoryBot.create(:stolen_bike, cycle_type: "tall-bike") }
     let(:stolen_record) { bike.current_stolen_record }
-    let!(:ownership) { FactoryBot.create(:ownership, bike: stolen_record.bike) }
+    let!(:ownership) { FactoryBot.create(:ownership, bike: bike) }
     let(:recovered_description) { "Bike Index helped me find my stolen bike and get it back!" }
     before { stolen_record.add_recovery_information(recovered_description: recovered_description) }
     it "renders email" do
@@ -124,15 +124,15 @@ RSpec.describe CustomerMailer, type: :mailer do
   end
 
   describe "admin_contact_stolen_email" do
-    let!(:ownership) { FactoryBot.create(:ownership, bike: stolen_record.bike) }
-    let(:stolen_record) { FactoryBot.create(:stolen_record) }
+    let!(:ownership) { FactoryBot.create(:ownership, bike: bike) }
+    let(:bike) { FactoryBot.create(:stolen_bike) }
     let(:user) { FactoryBot.create(:admin, email: "something@stuff.com") }
     let(:customer_contact) do
-      CustomerContact.create(user_email: stolen_record.bike.owner_email,
+      CustomerContact.create(user_email: bike.owner_email,
                              creator_email: user.email,
                              body: "some message",
                              kind: :stolen_contact,
-                             bike_id: stolen_record.bike.id,
+                             bike_id: bike.id,
                              title: "some title")
     end
     it "renders email" do
@@ -145,10 +145,10 @@ RSpec.describe CustomerMailer, type: :mailer do
   end
 
   describe "stolen_notification_email" do
-    let(:stolen_record) { FactoryBot.create(:stolen_record) }
-    let!(:ownership) { FactoryBot.create(:ownership, bike: stolen_record.bike) }
+    let(:bike) { FactoryBot.create(:stolen_bike) }
+    let!(:ownership) { FactoryBot.create(:ownership, bike: bike) }
     let(:sender) { FactoryBot.create(:user, email: "party@example.com") }
-    let(:stolen_notification) { FactoryBot.create(:stolen_notification, subject: "test subject", message: "Test Message", reference_url: "something.com", bike: stolen_record.bike, sender: sender) }
+    let(:stolen_notification) { FactoryBot.create(:stolen_notification, subject: "test subject", message: "Test Message", reference_url: "something.com", bike: bike, sender: sender) }
     it "renders email and update sent_dates" do
       mail = CustomerMailer.stolen_notification_email(stolen_notification)
       expect(mail.subject).to eq(stolen_notification.subject)

--- a/spec/models/bike_spec.rb
+++ b/spec/models/bike_spec.rb
@@ -29,8 +29,8 @@ RSpec.describe Bike, type: :model do
     context "given no matching state or country" do
       it "returns none" do
         FactoryBot.create(:country_nl)
-        FactoryBot.create(:stolen_record, :currently_stolen, :in_nyc)
-        FactoryBot.create(:stolen_record, :currently_stolen, :in_los_angeles)
+        FactoryBot.create(:stolen_record, :in_nyc)
+        FactoryBot.create(:stolen_record, :in_los_angeles)
         expect(Bike.currently_stolen_in(country: "New York City")).to be_empty
         expect(Bike.currently_stolen_in(state: "New York City", country: "Svenborgia")).to be_empty
         expect(Bike.currently_stolen_in(city: "Los Angeles", country: "NL")).to be_empty
@@ -46,9 +46,9 @@ RSpec.describe Bike, type: :model do
 
     context "given a currently stolen bike in a matching city or state" do
       it "returns only the requested bikes" do
-        FactoryBot.create(:stolen_record, :currently_stolen, :in_amsterdam)
-        FactoryBot.create(:stolen_record, :currently_stolen, :in_los_angeles)
-        FactoryBot.create(:stolen_record, :currently_stolen, :in_nyc)
+        FactoryBot.create(:stolen_record, :in_amsterdam)
+        FactoryBot.create(:stolen_record, :in_los_angeles)
+        FactoryBot.create(:stolen_record, :in_nyc)
 
         bikes = Bike.currently_stolen_in(city: "Los Angeles")
         expect(bikes.map(&:current_stolen_record).map(&:city)).to match_array(["Los Angeles"])
@@ -63,9 +63,9 @@ RSpec.describe Bike, type: :model do
 
     context "given currently stolen bikes in a matching country" do
       it "returns only the requested bikes" do
-        FactoryBot.create(:stolen_record, :currently_stolen, :in_amsterdam)
-        FactoryBot.create(:stolen_record, :currently_stolen, :in_los_angeles)
-        FactoryBot.create(:stolen_record, :currently_stolen, :in_nyc)
+        FactoryBot.create(:stolen_record, :in_amsterdam)
+        FactoryBot.create(:stolen_record, :in_los_angeles)
+        FactoryBot.create(:stolen_record, :in_nyc)
 
         bikes = Bike.currently_stolen_in(country: "NL")
         expect(bikes.map(&:current_stolen_record).map(&:city)).to match_array(["Amsterdam"])

--- a/spec/models/bike_spec.rb
+++ b/spec/models/bike_spec.rb
@@ -29,8 +29,8 @@ RSpec.describe Bike, type: :model do
     context "given no matching state or country" do
       it "returns none" do
         FactoryBot.create(:country_nl)
-        FactoryBot.create(:stolen_record, :in_nyc)
-        FactoryBot.create(:stolen_record, :in_los_angeles)
+        FactoryBot.create(:stolen_bike_in_nyc)
+        FactoryBot.create(:stolen_bike_in_los_angeles)
         expect(Bike.currently_stolen_in(country: "New York City")).to be_empty
         expect(Bike.currently_stolen_in(state: "New York City", country: "Svenborgia")).to be_empty
         expect(Bike.currently_stolen_in(city: "Los Angeles", country: "NL")).to be_empty
@@ -46,9 +46,9 @@ RSpec.describe Bike, type: :model do
 
     context "given a currently stolen bike in a matching city or state" do
       it "returns only the requested bikes" do
-        FactoryBot.create(:stolen_record, :in_amsterdam)
-        FactoryBot.create(:stolen_record, :in_los_angeles)
-        FactoryBot.create(:stolen_record, :in_nyc)
+        FactoryBot.create(:stolen_bike_in_amsterdam)
+        FactoryBot.create(:stolen_bike_in_los_angeles)
+        FactoryBot.create(:stolen_bike_in_nyc)
 
         bikes = Bike.currently_stolen_in(city: "Los Angeles")
         expect(bikes.map(&:current_stolen_record).map(&:city)).to match_array(["Los Angeles"])
@@ -63,9 +63,9 @@ RSpec.describe Bike, type: :model do
 
     context "given currently stolen bikes in a matching country" do
       it "returns only the requested bikes" do
-        FactoryBot.create(:stolen_record, :in_amsterdam)
-        FactoryBot.create(:stolen_record, :in_los_angeles)
-        FactoryBot.create(:stolen_record, :in_nyc)
+        FactoryBot.create(:stolen_bike_in_amsterdam)
+        FactoryBot.create(:stolen_bike_in_los_angeles)
+        FactoryBot.create(:stolen_bike_in_nyc)
 
         bikes = Bike.currently_stolen_in(country: "NL")
         expect(bikes.map(&:current_stolen_record).map(&:city)).to match_array(["Amsterdam"])

--- a/spec/models/bike_spec.rb
+++ b/spec/models/bike_spec.rb
@@ -25,6 +25,57 @@ RSpec.describe Bike, type: :model do
     end
   end
 
+  describe ".currently_stolen_in" do
+    context "given no matching state or country" do
+      it "returns none" do
+        FactoryBot.create(:country_nl)
+        FactoryBot.create(:stolen_record, :currently_stolen, :in_nyc)
+        FactoryBot.create(:stolen_record, :currently_stolen, :in_los_angeles)
+        expect(Bike.currently_stolen_in(country: "New York City")).to be_empty
+        expect(Bike.currently_stolen_in(state: "New York City", country: "Svenborgia")).to be_empty
+        expect(Bike.currently_stolen_in(city: "Los Angeles", country: "NL")).to be_empty
+      end
+    end
+
+    context "given no matching stolen bikes in a valid state or country" do
+      it "returns none" do
+        expect(StolenRecord.count).to eq(0)
+        expect(Bike.currently_stolen_in(country: "US")).to be_empty
+      end
+    end
+
+    context "given a currently stolen bike in a matching city or state" do
+      it "returns only the requested bikes" do
+        FactoryBot.create(:stolen_record, :currently_stolen, :in_amsterdam)
+        FactoryBot.create(:stolen_record, :currently_stolen, :in_los_angeles)
+        FactoryBot.create(:stolen_record, :currently_stolen, :in_nyc)
+
+        bikes = Bike.currently_stolen_in(city: "Los Angeles")
+        expect(bikes.map(&:current_stolen_record).map(&:city)).to match_array(["Los Angeles"])
+
+        bikes = Bike.currently_stolen_in(state: "NY", country: "US")
+        expect(bikes.map(&:current_stolen_record).map(&:city)).to match_array(["New York"])
+
+        bikes = Bike.currently_stolen_in(state: "NY", country: "NL")
+        expect(bikes).to be_empty
+      end
+    end
+
+    context "given currently stolen bikes in a matching country" do
+      it "returns only the requested bikes" do
+        FactoryBot.create(:stolen_record, :currently_stolen, :in_amsterdam)
+        FactoryBot.create(:stolen_record, :currently_stolen, :in_los_angeles)
+        FactoryBot.create(:stolen_record, :currently_stolen, :in_nyc)
+
+        bikes = Bike.currently_stolen_in(country: "NL")
+        expect(bikes.map(&:current_stolen_record).map(&:city)).to match_array(["Amsterdam"])
+
+        bikes = Bike.currently_stolen_in(country: "US")
+        expect(bikes.map(&:current_stolen_record).map(&:city)).to match_array(["New York", "Los Angeles"])
+      end
+    end
+  end
+
   context "unknown, absent serials" do
     let(:bike_with_serial) { FactoryBot.create(:bike, serial_number: "CCcc99FFF") }
     let(:bike_made_without_serial) { FactoryBot.create(:bike, made_without_serial: true) }

--- a/spec/workers/email_admin_contact_stolen_worker_spec.rb
+++ b/spec/workers/email_admin_contact_stolen_worker_spec.rb
@@ -3,9 +3,9 @@ require "rails_helper"
 RSpec.describe EmailAdminContactStolenWorker, type: :job do
   describe "perform" do
     it "sends an email" do
-      stolen_record = FactoryBot.create(:stolen_record)
-      FactoryBot.create(:ownership, bike: stolen_record.bike)
-      customer_contact = FactoryBot.create(:customer_contact, bike: stolen_record.bike)
+      stolen_bike = FactoryBot.create(:stolen_bike)
+      FactoryBot.create(:ownership, bike: stolen_bike)
+      customer_contact = FactoryBot.create(:customer_contact, bike: stolen_bike)
       ActionMailer::Base.deliveries = []
       EmailAdminContactStolenWorker.new.perform(customer_contact.id)
       expect(ActionMailer::Base.deliveries).not_to be_empty

--- a/spec/workers/email_stolen_bike_alert_worker_spec.rb
+++ b/spec/workers/email_stolen_bike_alert_worker_spec.rb
@@ -3,11 +3,11 @@ require "rails_helper"
 RSpec.describe EmailStolenBikeAlertWorker, type: :job do
   describe "perform" do
     it "sends an email" do
-      stolen_record = FactoryBot.create(:stolen_record)
-      FactoryBot.create(:ownership, bike: stolen_record.bike)
+      bike = FactoryBot.create(:stolen_bike)
+      FactoryBot.create(:ownership, bike: bike)
       info_hash = {
         notification_type: "stolen_twitter_alerter",
-        bike_id: stolen_record.bike.id,
+        bike_id: bike.id,
         tweet_id: 69,
         tweet_string: "STOLEN - something special",
         tweet_account_screen_name: "bikeindex",
@@ -16,7 +16,7 @@ RSpec.describe EmailStolenBikeAlertWorker, type: :job do
         location: "Everywhere",
         retweet_screen_names: ["someother_screename"],
       }
-      customer_contact = FactoryBot.create(:customer_contact, bike: stolen_record.bike, info_hash: info_hash)
+      customer_contact = FactoryBot.create(:customer_contact, bike: bike, info_hash: info_hash)
       ActionMailer::Base.deliveries = []
       EmailStolenBikeAlertWorker.new.perform(customer_contact.id)
       expect(ActionMailer::Base.deliveries).not_to be_empty


### PR DESCRIPTION
Introduces `Bike.currently_stolen_in` to query for bikes with currently stolen records in the given location (passed as city / state / country, matched conjointly).

Will be used to find currently stolen in NL to check against the VOG registry.

Extracted from #1280 