### PR TITLE
Refactor CustomerContact.possibly_found_notification_sent?

### DIFF
--- a/app/models/customer_contact.rb
+++ b/app/models/customer_contact.rb
@@ -26,6 +26,8 @@ class CustomerContact < ActiveRecord::Base
   # ExternalBike), determine if an email has been sent alerting the current
   # `bike` owner that the given `match` may be their found bike.
   def self.possibly_found_notification_sent?(bike, match)
+    return false unless bike.present? && match.present?
+
     where(kind: kinds["bike_possibly_found"], bike: bike, user_email: bike.owner_email)
       .where("info_hash->>'match_id' = ?", match.id.to_s)
       .where("info_hash->>'match_type' = ?", match.class.to_s)

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -130,9 +130,6 @@ FactoryBot.define do
     factory :customer_contact_potentially_found_bike do
       creator { FactoryBot.create(:user) }
       bike { FactoryBot.create(:stolen_bike) }
-      title { "We may have found your bike" }
-      body { "Your bike may have been found" }
-      creator_email { "sender@example.com" }
       kind { :bike_possibly_found }
 
       transient do
@@ -145,7 +142,13 @@ FactoryBot.define do
           "match_type" => evaluator.match.class.to_s,
           "stolen_record_id" => cc.bike.current_stolen_record.id.to_s,
         }
-        cc.update(info_hash: info_hash, user_email: cc.bike.owner_email)
+        cc.update(
+          info_hash: info_hash,
+          user_email: cc.bike.owner_email,
+          creator_email: cc.creator.email,
+          title: "We may have found your stolen #{cc.bike.title_string}",
+          body: "Check this matching bike: #{evaluator.match.title_string}",
+        )
       end
     end
   end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -126,5 +126,27 @@ FactoryBot.define do
     trait :stolen_bike do
       bike { FactoryBot.create(:stolen_bike) }
     end
+
+    factory :customer_contact_potentially_found_bike do
+      creator { FactoryBot.create(:user) }
+      bike { FactoryBot.create(:stolen_bike) }
+      title { "We may have found your bike" }
+      body { "Your bike may have been found" }
+      creator_email { "sender@example.com" }
+      kind { :bike_possibly_found }
+
+      transient do
+        match { FactoryBot.create(:abandoned_bike) }
+      end
+
+      after(:create) do |cc, evaluator|
+        info_hash = {
+          "match_id" => evaluator.match.id.to_s,
+          "match_type" => evaluator.match.class.to_s,
+          "stolen_record_id" => cc.bike.current_stolen_record.id.to_s,
+        }
+        cc.update(info_hash: info_hash, user_email: cc.bike.owner_email)
+      end
+    end
   end
 end


### PR DESCRIPTION
Adds lower-level tests for `CustomerContact.possibly_found_notification_sent?`, adds a guard clause. Used in `EmailBikePossiblyFoundNotificationWorker` to prevent re-sending notices:

```rb
# app/workers/email_bike_possibly_found_notification_worker.rb L13-14 (ad0842fd)

Bike.possibly_found_with_match.each do |bike, match|
  next if CustomerContact.possibly_found_notification_sent?(bike, match)
```
<sup>[[source](https://github.com/bikeindex/bike_index/blob/ad0842fd/app/workers/email_bike_possibly_found_notification_worker.rb#L13-L14)]</sup>

```rb
# spec/workers/email_bike_possibly_found_notification_worker_spec.rb L36-51 (ad0842fd)

it "skips the bike if a notification for it has already been sent" do
  bike = FactoryBot.create(:stolen_bike, abandoned: false, serial_number: "HELL0")
  match = FactoryBot.create(:abandoned_bike, stolen: false, serial_number: "HE11O")

  # an already-sent notification
  contact = CustomerContact.build_bike_possibly_found_notification(bike, match)
  contact.email = CustomerMailer.bike_possibly_found_email(contact)
  contact.save

  allow(CustomerMailer).to receive(:bike_possibly_found_email).and_call_original

  described_class.new.perform

  expect(CustomerMailer).to_not have_received(:bike_possibly_found_email)
  expect(ActionMailer::Base.deliveries.length).to eq(0)
end
```
<sup>[[source](https://github.com/bikeindex/bike_index/blob/ad0842fd/spec/workers/email_bike_possibly_found_notification_worker_spec.rb#L36-L51)]</sup>

Extracted from #1280 