### PR TITLE
Fix bike search listing images

### DIFF
--- a/app/assets/stylesheets/revised/sections/bike_boxes.scss
+++ b/app/assets/stylesheets/revised/sections/bike_boxes.scss
@@ -76,10 +76,16 @@ $bike-box-bg: $gray-lighter;
 
   img {
     display: block;
+    margin: auto;
+    max-height: 200px;
+    min-width: 70px;
   }
 
   .no-image {
     background: $bike-box-bg;
+    height: 200px;
+    margin: auto;
+    min-width: 70px;
     padding: 2 * $vertical-height;
     vertical-align: middle;
   }


### PR DESCRIPTION
Minimally fixes sizing of bike search listing images across browsers

### Before

#### Safari

<img width="1419" alt="before-safari" src="https://user-images.githubusercontent.com/4433943/65532373-b3551080-dec9-11e9-9572-15082b3ba9a9.png">

#### Chrome 

<img width="1396" alt="before-chrome" src="https://user-images.githubusercontent.com/4433943/65532374-b3551080-dec9-11e9-9cde-a9276f018b65.png">


### After

#### Chrome


<img width="1326" alt="after-chrome" src="https://user-images.githubusercontent.com/4433943/65532394-bd770f00-dec9-11e9-9b02-1aa86aa8c60e.png">

<img width="490" alt="Screen Shot 2019-09-24 at 12 46 34 PM" src="https://user-images.githubusercontent.com/4433943/65532395-bd770f00-dec9-11e9-9779-1793b4bedeb8.png">


#### Safari


<img width="1195" alt="after-safari" src="https://user-images.githubusercontent.com/4433943/65532405-c36cf000-dec9-11e9-8cfa-61916f5bf7c4.png">

<img width="302" alt="Screen Shot 2019-09-24 at 12 46 59 PM" src="https://user-images.githubusercontent.com/4433943/65532406-c36cf000-dec9-11e9-915e-7689e4774e0a.png">
