### PR TITLE
Drop date_stolen_string from bike serializers

### DIFF
--- a/app/assets/javascripts/init.coffee
+++ b/app/assets/javascripts/init.coffee
@@ -104,7 +104,7 @@ class BikeIndex.Init extends BikeIndex
 
     displayLocalDate = @displayLocalDate
 
-    # Write local time
+    # Write local time (format: 2018-07-14T01:00:00-0500)
     $(".convertTime").each ->
       $this = $(this)
       $this.removeClass("convertTime")

--- a/app/javascript/packs/external_registry_search/components/ExternalRegistrySearch.js
+++ b/app/javascript/packs/external_registry_search/components/ExternalRegistrySearch.js
@@ -6,6 +6,7 @@ import ExternalRegistrySearchResult from "./ExternalRegistrySearchResult";
 import { fetchSerialExternalSearch } from "../../api";
 import Loading from "../../Loading";
 import honeybadger from "../../utils/honeybadger";
+import TimeParser from "../../utils/time_parser";
 
 class ExternalRegistrySearch extends Component {
   state = {
@@ -55,6 +56,10 @@ class ExternalRegistrySearch extends Component {
 
     const sectionTitle = header.getElementsByClassName(titleDisplay)[0];
     sectionTitle.classList.remove("d-none");
+  }
+
+  componentDidUpdate() {
+    TimeParser().localize();
   }
 
   render() {

--- a/app/javascript/packs/external_registry_search/components/ExternalRegistrySearchResult.js
+++ b/app/javascript/packs/external_registry_search/components/ExternalRegistrySearchResult.js
@@ -27,7 +27,7 @@ const ExternalRegistrySearchResult = ({ bike }) => (
       <ul className="attr-list">
         <li>
           <span className="attr-title text-danger">{bike.status}</span>
-          <span className="convertTime">{bike.date_stolen_string}</span>
+          <span className="convertTime">{bike.date_stolen}</span>
         </li>
         <li>
           <span className="attr-title">Registry</span>

--- a/app/jest/setup.js
+++ b/app/jest/setup.js
@@ -1,6 +1,9 @@
 /* eslint import/no-extraneous-dependencies: 0 */
 
+import $ from 'jquery';
 import { configure } from 'enzyme';
 import Adapter from 'enzyme-adapter-react-16';
 
 configure({ adapter: new Adapter() });
+
+global.$ = global.jQuery = $;

--- a/app/serializers/bike_v2_serializer.rb
+++ b/app/serializers/bike_v2_serializer.rb
@@ -1,7 +1,6 @@
 class BikeV2Serializer < ActiveModel::Serializer
   attributes \
     :date_stolen,
-    :date_stolen_string,
     :debug,
     :description,
     :frame_colors,
@@ -50,10 +49,6 @@ class BikeV2Serializer < ActiveModel::Serializer
 
   def date_stolen
     object.current_stolen_record && object.current_stolen_record.date_stolen.to_i
-  end
-
-  def date_stolen_string
-    object.current_stolen_record&.date_stolen&.to_date&.to_s
   end
 
   def thumb

--- a/app/serializers/external_bike_v3_serializer.rb
+++ b/app/serializers/external_bike_v3_serializer.rb
@@ -20,10 +20,6 @@ class ExternalBikeV3Serializer < BikeV2Serializer
     object.date_stolen&.to_i
   end
 
-  def date_stolen_string
-    object.date_stolen&.to_date&.to_s
-  end
-
   def year; end
 
   def thumb

--- a/spec/requests/api/v3/search_request_spec.rb
+++ b/spec/requests/api/v3/search_request_spec.rb
@@ -42,15 +42,15 @@ RSpec.describe "Search API V3", type: :request do
             serial: serial_number,
             format: :json
 
+        expect(json_result[:error]).to be_blank
         bike_list = json_result[:bikes]
         expect(bike_list.count).to eq(1)
         expect(bike_list.first.keys)
           .to(match_array(%w[
-            id title serial manufacturer_name frame_model frame_colors
-            thumb large_img is_stock_img stolen stolen_location date_stolen
-            debug location_found registry_id registry_name registry_url
-            source_name source_unique_id status url description
-            date_stolen_string year
+            id title serial manufacturer_name frame_model frame_colors thumb
+            large_img is_stock_img stolen stolen_location date_stolen debug
+            location_found registry_id registry_name registry_url source_name
+            source_unique_id status url description year
           ]))
         expect(response.header["Total"]).to eq("1")
       end

--- a/spec/serializers/bike_v2_show_serializer_spec.rb
+++ b/spec/serializers/bike_v2_show_serializer_spec.rb
@@ -47,7 +47,6 @@ RSpec.describe BikeV2ShowSerializer do
         stolen: false,
         stolen_location: nil,
         date_stolen: nil,
-        date_stolen_string: nil,
         registration_created_at: bike.created_at.to_i,
         registration_updated_at: bike.updated_at.to_i,
         url: "http://test.host/bikes/#{bike.id}",

--- a/spec/workers/file_cache_maintenance_worker_spec.rb
+++ b/spec/workers/file_cache_maintenance_worker_spec.rb
@@ -28,10 +28,10 @@ RSpec.describe FileCacheMaintenanceWorker, type: :job do
       expect(result["bikes"].count).to eq(1)
       expect(result["bikes"][0]["serial"]).to eq("party seri8al")
       expect(result["bikes"][0].keys).to(match_array <<~KEYS.split)
-        id title serial manufacturer_name frame_model year frame_colors
-        thumb large_img is_stock_img stolen stolen_location date_stolen
-        date_stolen_string debug description location_found registry_id
-        registry_name registry_url source_name source_unique_id status url
+        date_stolen debug description frame_colors frame_model id is_stock_img
+        large_img location_found manufacturer_name registry_id registry_name
+        registry_url serial source_name source_unique_id status stolen
+        stolen_location thumb title url year
       KEYS
     end
   end


### PR DESCRIPTION
- Drops `date_stolen_string` from bike serializers
- Uses `TimeParser` to convert times rendered using React (assuming `BikeIndex.Init` is vintage? Happy to update it to match if not)

<img width="1164" alt="Screen Shot 2019-10-02 at 9 12 56 AM" src="https://user-images.githubusercontent.com/4433943/66047266-75717100-e4f5-11e9-8273-2074e4f88368.png">
