### PR TITLE
Add ScheduledWorkerRecorder

### DIFF
--- a/app/workers/deactivate_expired_theft_alert_worker.rb
+++ b/app/workers/deactivate_expired_theft_alert_worker.rb
@@ -1,15 +1,13 @@
 class DeactivateExpiredTheftAlertWorker < ScheduledWorker
+  prepend ScheduledWorkerRecorder
+
   def self.frequency
     24.hours
   end
 
   def perform
-    record_scheduler_started
-
     TheftAlert
       .should_expire
       .update_all(status: TheftAlert.statuses[:inactive])
-
-    record_scheduler_finished
   end
 end

--- a/app/workers/email_bike_possibly_found_notification_worker.rb
+++ b/app/workers/email_bike_possibly_found_notification_worker.rb
@@ -1,12 +1,12 @@
 class EmailBikePossiblyFoundNotificationWorker < ScheduledWorker
+  prepend ScheduledWorkerRecorder
+
   def self.frequency
     24.hours
   end
 
   def perform
-    record_scheduler_started
     notify_of_bike_index_held
-    record_scheduler_finished
   end
 
   def notify_of_bike_index_held

--- a/app/workers/file_cache_maintenance_worker.rb
+++ b/app/workers/file_cache_maintenance_worker.rb
@@ -1,10 +1,11 @@
 class FileCacheMaintenanceWorker < ScheduledWorker
+  prepend ScheduledWorkerRecorder
+
   def self.frequency
     6.hours
   end
 
   def perform
-    record_scheduler_started
     write_stolen
     uploader = JsonUploader.new
     file = File.open(tmp_path)
@@ -12,7 +13,6 @@ class FileCacheMaintenanceWorker < ScheduledWorker
     file.close
     FileCacheMaintainer.update_file_info(output_url(uploader))
     expired_file_hashes.each { |fh| FileCacheMaintainer.remove_file(fh) }
-    record_scheduler_finished
   end
 
   def output_url(uploader)

--- a/app/workers/scheduled_worker_recorder.rb
+++ b/app/workers/scheduled_worker_recorder.rb
@@ -1,0 +1,7 @@
+module ScheduledWorkerRecorder
+  def perform
+    record_scheduler_started
+    super
+    record_scheduler_finished
+  end
+end

--- a/app/workers/update_counts_worker.rb
+++ b/app/workers/update_counts_worker.rb
@@ -1,11 +1,11 @@
 class UpdateCountsWorker < ScheduledWorker
+  prepend ScheduledWorkerRecorder
+
   def self.frequency
     1.hours
   end
 
   def perform
-    record_scheduler_started
     Counts.count_keys.each { |k| Counts.send("assign_#{k}") }
-    record_scheduler_finished
   end
 end

--- a/app/workers/update_expired_invoice_worker.rb
+++ b/app/workers/update_expired_invoice_worker.rb
@@ -1,11 +1,11 @@
 class UpdateExpiredInvoiceWorker < ScheduledWorker
+  prepend ScheduledWorkerRecorder
+
   def self.frequency
     12.hours
   end
 
   def perform
-    record_scheduler_started
     Invoice.should_expire.each { |invoice| invoice.update_attributes(updated_at: Time.current) }
-    record_scheduler_finished
   end
 end

--- a/app/workers/update_organization_pos_kind_worker.rb
+++ b/app/workers/update_organization_pos_kind_worker.rb
@@ -1,15 +1,15 @@
 class UpdateOrganizationPosKindWorker < ScheduledWorker
+  prepend ScheduledWorkerRecorder
+
   def self.frequency
     6.3.hours
   end
 
   def perform
-    record_scheduler_started
     Organization.bike_shop.find_each do |organization|
       pos_kind = organization.calculated_pos_kind
       next unless organization.pos_kind != pos_kind
       organization.update_attributes(pos_kind: pos_kind)
     end
-    record_scheduler_finished
   end
 end


### PR DESCRIPTION
- Introduces `ScheduledWorkerRecorder`, which can be prepended to record start/stop of the worker's `perform` method

- `record_scheduler_started`/`record_scheduler_finished` can still be used where greater customization is needed