### PR TITLE
Use CEST+2 TZ in hmac date

### DIFF
--- a/app/models/external_registries/stop_heling_client.rb
+++ b/app/models/external_registries/stop_heling_client.rb
@@ -110,7 +110,7 @@ module ExternalRegistries
     def hmac(search_term)
       raise ArgumentError, "search term required" if search_term.blank?
 
-      date = Time.now.strftime("%Y%m%d")
+      date = Time.now.in_time_zone("Amsterdam").strftime("%Y%m%d")
       data = "#{search_term}#{date}#{APP_ID}"
 
       digest = OpenSSL::Digest.new("md5")


### PR DESCRIPTION
- Uses today's date in Amsterdam when computing the HMAC hash for connecting 

Potential fix for https://app.honeybadger.io/projects/35931/faults/54723228