### PR TITLE
Update VOG image url

### DIFF
--- a/app/javascript/packs/external_registry_search/components/ExternalRegistrySearchResult.js
+++ b/app/javascript/packs/external_registry_search/components/ExternalRegistrySearchResult.js
@@ -66,7 +66,6 @@ const ResultImage = ({ bike }) => {
 
   return (<a href={bike.url}
              style={backgroundStyles(bike)}
-             data-img-src={bike.thumb}
              className="bike-list-image hover-expand"
              target="_blank"></a>);
 }

--- a/app/models/external_registries/verloren_of_gevonden_result.rb
+++ b/app/models/external_registries/verloren_of_gevonden_result.rb
@@ -54,7 +54,7 @@ module ExternalRegistries
     end
 
     def image_url
-      "#{self.registry_url}/images/pv_api/get_from_api.php?id=#{object_id}"
+      "#{self.registry_url}/assets/image/#{object_id}"
     end
 
     def url


### PR DESCRIPTION
Updates `image_url` for VOG bikes (VOG has changed the endpoint from which it renders bike images).

Before:

<img width="1180" alt="Screen Shot 2019-10-03 at 10 53 59 AM" src="https://user-images.githubusercontent.com/4433943/66138132-22b6b880-e5cc-11e9-9d36-4eac6c9decc7.png">


After:

<img width="1190" alt="Screen Shot 2019-10-03 at 10 52 18 AM" src="https://user-images.githubusercontent.com/4433943/66138146-25b1a900-e5cc-11e9-92b8-1d197440ded0.png">


Hotfixing since this is broken on prod