### PR TITLE
Restore data-img-src for bike image expansion

### DIFF
--- a/app/javascript/packs/external_registry_search/components/ExternalRegistrySearchResult.js
+++ b/app/javascript/packs/external_registry_search/components/ExternalRegistrySearchResult.js
@@ -66,6 +66,7 @@ const ResultImage = ({ bike }) => {
 
   return (<a href={bike.url}
              style={backgroundStyles(bike)}
+             data-img-src={bike.thumb}
              className="bike-list-image hover-expand"
              target="_blank"></a>);
 }


### PR DESCRIPTION
Fixes the fix in #1300 
`data-img-src` is used by the jQuery that runs on the page