### PR TITLE
Render close serials asynchronously 

### DIFF
--- a/app/assets/stylesheets/revised/sections/bike_boxes.scss
+++ b/app/assets/stylesheets/revised/sections/bike_boxes.scss
@@ -72,6 +72,7 @@ $bike-box-bg: $gray-lighter;
 .bike-list-image {
   display: inherit;
   flex: 0 0 20%;
+  height: 200px;
   position: relative;
 
   img {

--- a/app/controllers/bikes_controller.rb
+++ b/app/controllers/bikes_controller.rb
@@ -19,11 +19,6 @@ class BikesController < ApplicationController
       flash[:info] = "Sorry, we don't know the location \"#{params[:location]}\". Please try a different location to search nearby stolen bikes"
     end
     @bikes = Bike.search(@interpreted_params).page(params[:page] || 1).per(params[:per_page] || 10).decorate
-
-    if @interpreted_params[:serial].present?
-      @close_serials = Bike.search_close_serials(@interpreted_params).limit(10).decorate
-    end
-
     @selected_query_items_options = Bike.selected_query_items_options(@interpreted_params)
   end
 

--- a/app/decorators/application_decorator.rb
+++ b/app/decorators/application_decorator.rb
@@ -52,12 +52,4 @@ class ApplicationDecorator < Draper::Decorator
       object.send(attribute)
     end
   end
-
-  def short_address(item)
-    return nil unless item.country
-    html = "#{item.city}"
-    html << ", #{item.state.abbreviation}" if item.state.present?
-    html << " - #{item.country.iso}"
-    html
-  end
 end

--- a/app/javascript/packs/api.js
+++ b/app/javascript/packs/api.js
@@ -4,13 +4,24 @@
 
 const url = urn => [process.env.BASE_URL, urn].join("/");
 
-const serialSearchUrl = serial => url(`api/v2/bikes_search?serial=${serial}`);
+const serialSearchUrl = serial =>
+  url(`api/v2/bikes_search?serial=${serial}`);
 
 const fuzzySearchUrl = serial =>
   url(`api/v2/bikes_search/close_serials?serial=${serial}`);
 
 const serialExternalSearchUrl = serial =>
   url(`api/v3/search/external_registries?serial=${serial}`);
+
+const serialPartialSearchUrl = ({serial, stolenness, location, query }) => {
+  const params = {};
+  if (serial) { params.serial = serial; }
+  if (stolenness) { params.stolenness = stolenness; }
+  if (location) { params.location = location; }
+  if (query) { params.query = query; }
+  const queryString = Object.keys(params).map(k => `${k}=${params[k]}`).join("&");
+  return url(`api/v3/search/close_serials?${queryString}`);
+}
 
 const request = async url => {
   const resp = await fetch(url);
@@ -37,4 +48,14 @@ const fetchSerialExternalSearch = serial => {
   return request(url);
 }
 
-export { fetchSerialResults, fetchFuzzyResults, fetchSerialExternalSearch };
+const fetchSerialPartialSearch = interpretedParams => {
+  const url = serialPartialSearchUrl(interpretedParams);
+  return request(url);
+}
+
+export {
+  fetchSerialResults,
+  fetchFuzzyResults,
+  fetchSerialExternalSearch,
+  fetchSerialPartialSearch,
+};

--- a/app/javascript/packs/external_registry_search/components/ExternalRegistrySearch.js
+++ b/app/javascript/packs/external_registry_search/components/ExternalRegistrySearch.js
@@ -27,6 +27,10 @@ class ExternalRegistrySearch extends Component {
       .catch(this.handleError);
   }
 
+  componentDidUpdate() {
+    TimeParser().localize();
+  }
+
   resultsBeingFetched = () => {
     this.setState({ loading: true });
     this.toggleHeader({ isLoading: true });
@@ -56,10 +60,6 @@ class ExternalRegistrySearch extends Component {
 
     const sectionTitle = header.getElementsByClassName(titleDisplay)[0];
     sectionTitle.classList.remove("d-none");
-  }
-
-  componentDidUpdate() {
-    TimeParser().localize();
   }
 
   render() {

--- a/app/javascript/packs/external_registry_search/components/ExternalRegistrySearchResult.js
+++ b/app/javascript/packs/external_registry_search/components/ExternalRegistrySearchResult.js
@@ -13,8 +13,9 @@ const ExternalRegistrySearchResult = ({ bike }) => (
     <div className="bike-information">
       <h5 className="title-link">
         <a href={bike.url} target="_blank">
-          <strong>{_.titleize(bike.manufacturer_name)}</strong>&nbsp;
-          {_.titleize(bike.frame_model)}
+          <strong>
+            {_.titleize(bike.manufacturer_name)}
+          </strong> {_.titleize(bike.frame_model)}
         </a>
       </h5>
 
@@ -31,8 +32,12 @@ const ExternalRegistrySearchResult = ({ bike }) => (
 
       <ul className="attr-list">
         <li>
-          <span className="attr-title text-danger">{_.titleize(bike.status)}</span>
-          <span className="convertTime">{bike.date_stolen}</span>
+          <span className="attr-title text-danger">
+            {_.titleize(bike.status)}
+          </span>
+          <span className="convertTime">
+            {bike.date_stolen}
+          </span>
         </li>
         <li>
           <span className="attr-title">Registry</span>
@@ -61,7 +66,7 @@ const ResultImage = ({ bike }) => {
 
   if (bike.is_stock_img) {
     return (<a href={bike.url} className="bike-list-image" target="_blank">
-              <img src={window.bike_placeholder_image} className="no-image"/>
+              <img src={window.bike_placeholder_image} className="no-image" />
             </a>);
   }
 

--- a/app/javascript/packs/partial_serial_search/components/PartialSerialSearch.js
+++ b/app/javascript/packs/partial_serial_search/components/PartialSerialSearch.js
@@ -26,7 +26,7 @@ class PartialSerialSearch extends Component {
   }
 
   resultsFetched = response => {
-    this.setState({ results: response.bikes, loading: false });
+    this.setState({ results: response.bikes || [], loading: false });
     this.toggleHeader({ isLoading: false, resultsCount: this.state.results.length });
   }
 

--- a/app/javascript/packs/partial_serial_search/components/PartialSerialSearch.js
+++ b/app/javascript/packs/partial_serial_search/components/PartialSerialSearch.js
@@ -1,0 +1,68 @@
+/* eslint import/no-unresolved: 0 */
+
+import React, { Fragment, Component } from "react";
+
+import PartialSerialSearchResult from "./PartialSerialSearchResult";
+import { fetchSerialPartialSearch } from "../../api";
+import Loading from "../../Loading";
+import honeybadger from "../../utils/honeybadger";
+
+class PartialSerialSearch extends Component {
+  state = {
+    loading: false,
+    results: []
+  }
+
+  componentWillMount() {
+    this.resultsBeingFetched();
+    fetchSerialPartialSearch(this.props.interpretedParams)
+      .then(this.resultsFetched)
+      .catch(this.handleError);
+  }
+
+  resultsBeingFetched = () => {
+    this.setState({ loading: true });
+    this.toggleHeader({ isLoading: true });
+  }
+
+  resultsFetched = response => {
+    this.setState({ results: response.bikes, loading: false });
+    this.toggleHeader({ isLoading: false, resultsCount: this.state.results.length });
+  }
+
+  handleError = error => {
+    honeybadger.notify(error, { component: "PartialSerialSearch" });
+  }
+
+  toggleHeader = ({ isLoading, resultsCount }) => {
+    const header = document.getElementById("js-partial-serial-search-header");
+    if (!header) { return; }
+
+    header.childNodes.forEach(node => node.classList && node.classList.add("d-none"));
+
+    const titleDisplay = (isLoading)
+          ? "loading"
+          : (resultsCount)
+          ? "loaded"
+          : "loaded-none";
+
+    const sectionTitle = header.getElementsByClassName(titleDisplay)[0]
+    sectionTitle.classList.remove("d-none");
+  }
+
+  render() {
+    if (this.state.loading) {
+      return <Loading />;
+    }
+
+    return (
+      <Fragment>
+        <ul className="bike-boxes">
+          {this.state.results.map(bike => <PartialSerialSearchResult key={bike.id} bike={bike} />)}
+        </ul>
+      </Fragment>
+    );
+  }
+};
+
+export default PartialSerialSearch;

--- a/app/javascript/packs/partial_serial_search/components/PartialSerialSearch.js
+++ b/app/javascript/packs/partial_serial_search/components/PartialSerialSearch.js
@@ -6,6 +6,7 @@ import PartialSerialSearchResult from "./PartialSerialSearchResult";
 import { fetchSerialPartialSearch } from "../../api";
 import Loading from "../../Loading";
 import honeybadger from "../../utils/honeybadger";
+import TimeParser from "../../utils/time_parser";
 
 class PartialSerialSearch extends Component {
   state = {
@@ -20,14 +21,19 @@ class PartialSerialSearch extends Component {
       .catch(this.handleError);
   }
 
+  componentDidUpdate() {
+    TimeParser().localize();
+  }
+
   resultsBeingFetched = () => {
     this.setState({ loading: true });
     this.toggleHeader({ isLoading: true });
   }
 
-  resultsFetched = response => {
-    this.setState({ results: response.bikes || [], loading: false });
+  resultsFetched = ({ bikes, error }) => {
+    this.setState({ results: bikes || [], loading: false });
     this.toggleHeader({ isLoading: false, resultsCount: this.state.results.length });
+    if (error) { this.handleError(error) }
   }
 
   handleError = error => {

--- a/app/javascript/packs/partial_serial_search/components/PartialSerialSearchResult.js
+++ b/app/javascript/packs/partial_serial_search/components/PartialSerialSearchResult.js
@@ -63,16 +63,14 @@ const LocationItem = ({bike}) => {
 }
 
 const ResultImage = ({ bike }) => {
-  if (bike.is_stock_img) {
+  if (!bike.thumb || bike.is_stock_img) {
     return (<a className="bike-list-image" target="_blank" href={bike.url}>
               <img src={window.bike_placeholder_image} className="no-image"/>
             </a>);
   }
 
-  return (<a className="bike-list-image hover-expand"
-             target="_blank"
-             href={bike.url}>
-            <img alt="" src={bike.thumb}></img>
+  return (<a className="bike-list-image hover-expand" target="_blank" href={bike.url}>
+            <img alt={bike.description} src={bike.thumb}></img>
           </a>);
 }
 

--- a/app/javascript/packs/partial_serial_search/components/PartialSerialSearchResult.js
+++ b/app/javascript/packs/partial_serial_search/components/PartialSerialSearchResult.js
@@ -6,7 +6,7 @@ const PartialSerialSearchResult = ({bike}) => (
   <li className="bike-box-item">
     <ResultImage bike={bike}/>
 
-    <div className="bike-information">
+    <div className="bike-information multi-attr-lists">
       <h5 className="title-link">
         <a href={bike.url} target="_blank">
           <strong>
@@ -27,44 +27,53 @@ const PartialSerialSearchResult = ({bike}) => (
       </ul>
 
       <ul className="attr-list">
-        <li>
-          <span className="attr-title text-danger">
-            {bike.stolen ? "Stolen" : "Abandoned"}
-          </span>
-          <span className="convertTime">{bike.date_stolen_string}</span>
-        </li>
-        <li>
-          <span className="attr-title">Location</span>
-          {bike.stolen_location}
-        </li>
+        {<AbandonedOrStolenDateItem bike={bike}/>}
+        {<LocationItem bike={bike}/>}
       </ul>
     </div>
-
-    <pre className="d-none">
-      {JSON.stringify(bike)}
-    </pre>
   </li>
 )
 
-const ResultImage = ({ bike }) => {
-  const backgroundStyles = ({ thumb }) => ({
-    backgroundSize: "contain",
-    backgroundPosition: "left",
-    backgroundRepeat: "no-repeat",
-    backgroundImage: `url('${thumb}')`
-  });
+const AbandonedOrStolenDateItem = ({bike}) => {
+  if (!bike.date_stolen) {
+    return <li/>
+  }
 
+  return (
+    <li>
+      <span className="attr-title text-danger">
+        {bike.stolen ? "Stolen" : "Abandoned"}
+      </span>
+      <span className="convertTime">{bike.date_stolen}</span>
+    </li>
+  )
+}
+
+const LocationItem = ({bike}) => {
+  if (!bike.stolen_location) {
+    return <li/>
+  }
+
+  return (
+    <li>
+      <span className="attr-title">Location</span>
+      {bike.stolen_location}
+    </li>
+  )
+}
+
+const ResultImage = ({ bike }) => {
   if (bike.is_stock_img) {
-    return (<a href={bike.url} className="bike-list-image" target="_blank">
-              <img src={bike.placeholder_image} className="no-image"/>
+    return (<a className="bike-list-image" target="_blank" href={bike.url}>
+              <img src={window.bike_placeholder_image} className="no-image"/>
             </a>);
   }
 
-  return (<a href={bike.url}
-             style={backgroundStyles(bike)}
-             data-img-src={bike.thumb}
-             className="bike-list-image hover-expand"
-             target="_blank" />);
+  return (<a className="bike-list-image hover-expand"
+             target="_blank"
+             href={bike.url}>
+            <img alt="" src={bike.thumb}></img>
+          </a>);
 }
 
 export default PartialSerialSearchResult;

--- a/app/javascript/packs/partial_serial_search/components/PartialSerialSearchResult.js
+++ b/app/javascript/packs/partial_serial_search/components/PartialSerialSearchResult.js
@@ -1,0 +1,70 @@
+/* eslint import/no-unresolved: 0 */
+
+import React, { Fragment } from "react";
+
+const PartialSerialSearchResult = ({bike}) => (
+  <li className="bike-box-item">
+    <ResultImage bike={bike}/>
+
+    <div className="bike-information">
+      <h5 className="title-link">
+        <a href={bike.url} target="_blank">
+          <strong>
+            {[bike.year, bike.manufacturer_name].filter(a => a).join(' ')}
+          </strong> {bike.frame_model}
+        </a>
+      </h5>
+
+      <ul className="attr-list">
+        <li>
+          <span className="attr-title">Color</span>
+          {bike.frame_colors.join(", ")}
+        </li>
+        <li>
+          <span className="attr-title">Serial</span>
+          {bike.serial}
+        </li>
+      </ul>
+
+      <ul className="attr-list">
+        <li>
+          <span className="attr-title text-danger">
+            {bike.stolen ? "Stolen" : "Abandoned"}
+          </span>
+          <span className="convertTime">{bike.date_stolen_string}</span>
+        </li>
+        <li>
+          <span className="attr-title">Location</span>
+          {bike.stolen_location}
+        </li>
+      </ul>
+    </div>
+
+    <pre className="d-none">
+      {JSON.stringify(bike)}
+    </pre>
+  </li>
+)
+
+const ResultImage = ({ bike }) => {
+  const backgroundStyles = ({ thumb }) => ({
+    backgroundSize: "contain",
+    backgroundPosition: "left",
+    backgroundRepeat: "no-repeat",
+    backgroundImage: `url('${thumb}')`
+  });
+
+  if (bike.is_stock_img) {
+    return (<a href={bike.url} className="bike-list-image" target="_blank">
+              <img src={bike.placeholder_image} className="no-image"/>
+            </a>);
+  }
+
+  return (<a href={bike.url}
+             style={backgroundStyles(bike)}
+             data-img-src={bike.thumb}
+             className="bike-list-image hover-expand"
+             target="_blank" />);
+}
+
+export default PartialSerialSearchResult;

--- a/app/javascript/packs/partial_serial_search/index.js
+++ b/app/javascript/packs/partial_serial_search/index.js
@@ -1,0 +1,16 @@
+import React from "react";
+import ReactDOM from "react-dom";
+import ErrorBoundary from "@honeybadger-io/react";
+import PartialSerialSearch from "./components/PartialSerialSearch";
+import honeybadger from "../utils/honeybadger";
+
+document.addEventListener("DOMContentLoaded", () => {
+  const el = document.getElementById("js-partial-serial-search");
+
+  ReactDOM.render(
+    <ErrorBoundary honeybadger={honeybadger}>
+    <PartialSerialSearch interpretedParams={window.interpreted_params} />
+    </ErrorBoundary>,
+    el
+  );
+});

--- a/app/serializers/bike_v2_serializer.rb
+++ b/app/serializers/bike_v2_serializer.rb
@@ -82,6 +82,15 @@ class BikeV2Serializer < ActiveModel::Serializer
   end
 
   def stolen_location
-    object.current_stolen_record && object.current_stolen_record.address_short
+    stolen_record = object.current_stolen_record
+    return if stolen_record.blank?
+
+    [
+      [
+        stolen_record.city,
+        stolen_record.state&.abbreviation,
+      ].select(&:present?).join(", "),
+      stolen_record.country&.iso,
+    ].select(&:present?).join(" - ")
   end
 end

--- a/app/serializers/bike_v2_serializer.rb
+++ b/app/serializers/bike_v2_serializer.rb
@@ -69,15 +69,6 @@ class BikeV2Serializer < ActiveModel::Serializer
   end
 
   def stolen_location
-    stolen_record = object.current_stolen_record
-    return if stolen_record.blank?
-
-    [
-      [
-        stolen_record.city,
-        stolen_record.state&.abbreviation,
-      ].select(&:present?).join(", "),
-      stolen_record.country&.iso,
-    ].select(&:present?).join(" - ")
+    object.current_stolen_record&.address_location(include_all: true)
   end
 end

--- a/app/serializers/bike_v2_serializer.rb
+++ b/app/serializers/bike_v2_serializer.rb
@@ -63,6 +63,20 @@ class BikeV2Serializer < ActiveModel::Serializer
     end
   end
 
+  def placeholder_image
+    svg_path =
+      Rails
+        .application
+        .assets["revised/bike_photo_placeholder.svg"]
+        .digest_path
+
+    "#{ENV["BASE_URL"]}/assets/#{svg_path}"
+  end
+
+  def url
+    "#{ENV["BASE_URL"]}/bikes/#{object.id}"
+  end
+
   def is_stock_img
     object.public_images.present? ? false : object.stock_photo_url.present?
   end

--- a/app/serializers/stolen_record_v2_serializer.rb
+++ b/app/serializers/stolen_record_v2_serializer.rb
@@ -20,6 +20,6 @@ class StolenRecordV2Serializer < ActiveModel::Serializer
   end
 
   def location
-    object.address_short
+    object.address_location(include_all: true)
   end
 end

--- a/app/views/bikes/_bike.html.haml
+++ b/app/views/bikes/_bike.html.haml
@@ -19,4 +19,4 @@
               = bike.abandoned ? t(".abandoned") : t(".stolen")
             %span.convertTime
               = l bike.current_stolen_record.date_stolen, format: :convert_time
-          = bike.attr_list_item(bike.short_address(bike.current_stolen_record), t(".location"))
+          = bike.attr_list_item(bike.current_stolen_record.address_location(include_all: true), t(".location"))

--- a/app/views/bikes/index.html.haml
+++ b/app/views/bikes/index.html.haml
@@ -67,9 +67,9 @@
     .row
       .col-md-12
         %h3.secondary-matches#js-partial-serial-search-header
-          .loading.d-none Searching for near-matching serial numbers...
+          .loading.d-none= t(".searching_for_near_matches")
           .loaded.d-none= t(".with_serial_numbers_html", stolenness: stolenness_desc, serial: params[:serial])
-          .loaded-none.no-exact-results.d-none No near-matching serials found
+          .loaded-none.no-exact-results.d-none= t("no_near_matches_found")
         #js-partial-serial-search
 
     .row

--- a/app/views/bikes/index.html.haml
+++ b/app/views/bikes/index.html.haml
@@ -63,18 +63,23 @@
         %h3.no-exact-results
           = t(".no_bikes_matched", stolenness: stolenness_desc)
 
-      %h3.secondary-matches#js-partial-serial-search-header
-        .loading.d-none Searching for near-matching serial numbers...
-        .loaded.d-none= t(".with_serial_numbers_html", stolenness: stolenness_desc, serial: params[:serial])
-        .loaded-none.no-exact-results.d-none No near-matching serials found
-      #js-partial-serial-search
+  - if @interpreted_params[:serial].present?
+    .row
+      .col-md-12
+        %h3.secondary-matches#js-partial-serial-search-header
+          .loading.d-none Searching for near-matching serial numbers...
+          .loaded.d-none= t(".with_serial_numbers_html", stolenness: stolenness_desc, serial: params[:serial])
+          .loaded-none.no-exact-results.d-none No near-matching serials found
+        #js-partial-serial-search
 
-      - if Flipper.enabled?(:external_registry_search, current_user)
-        %h3.secondary-matches#js-external-registry-search-header
-          .loading.d-none= t(".searching_external_registries")
-          .loaded.d-none= t(".external_matches_found")
-          .loaded-none.no-exact-results.d-none= t(".no_external_matches_found")
-        #js-external-registry-search
+    - if Flipper.enabled?(:external_registry_search, current_user)
+      .row
+        .col-md-12
+          %h3.secondary-matches#js-external-registry-search-header
+            .loading.d-none= t(".searching_external_registries")
+            .loaded.d-none= t(".external_matches_found")
+            .loaded-none.no-exact-results.d-none= t(".no_external_matches_found")
+          #js-external-registry-search
 
     .col-md-4.ad-col
       .ad-block#right300x600

--- a/app/views/bikes/index.html.haml
+++ b/app/views/bikes/index.html.haml
@@ -1,4 +1,5 @@
 = javascript_pack_tag "external_registry_search/index"
+= javascript_pack_tag "partial_serial_search/index"
 
 - stolenness_desc = { 'proximity' => 'nearby stolen', 'non' => 'non-stolen', 'stolen' => 'stolen', 'all' => 'all' }[@interpreted_params[:stolenness]]
 
@@ -62,12 +63,11 @@
         %h3.no-exact-results
           = t(".no_bikes_matched", stolenness: stolenness_desc)
 
-      - if @close_serials.present?
-        %h3.secondary-matches
-          = t(".with_serial_numbers_html", stolenness: stolenness_desc, serial: params[:serial])
-
-        %ul.bike-boxes
-          = render partial: 'bikes/bike', collection: @close_serials, as: :bike
+      %h3.secondary-matches#js-partial-serial-search-header
+        .loading.d-none Searching for near-matching serial numbers...
+        .loaded.d-none= t(".with_serial_numbers_html", stolenness: stolenness_desc, serial: params[:serial])
+        .loaded-none.no-exact-results.d-none No near-matching serials found
+      #js-partial-serial-search
 
       - if Flipper.enabled?(:external_registry_search, current_user)
         %h3.secondary-matches#js-external-registry-search-header

--- a/app/views/bikes/index.html.haml
+++ b/app/views/bikes/index.html.haml
@@ -69,7 +69,7 @@
         %h3.secondary-matches#js-partial-serial-search-header
           .loading.d-none= t(".searching_for_near_matches")
           .loaded.d-none= t(".with_serial_numbers_html", stolenness: stolenness_desc, serial: params[:serial])
-          .loaded-none.no-exact-results.d-none= t("no_near_matches_found")
+          .loaded-none.no-exact-results.d-none= t(".no_near_matches_found")
         #js-partial-serial-search
 
     .row

--- a/app/views/bikes/index.html.haml
+++ b/app/views/bikes/index.html.haml
@@ -72,14 +72,13 @@
           .loaded-none.no-exact-results.d-none No near-matching serials found
         #js-partial-serial-search
 
-    - if Flipper.enabled?(:external_registry_search, current_user)
-      .row
-        .col-md-12
-          %h3.secondary-matches#js-external-registry-search-header
-            .loading.d-none= t(".searching_external_registries")
-            .loaded.d-none= t(".external_matches_found")
-            .loaded-none.no-exact-results.d-none= t(".no_external_matches_found")
-          #js-external-registry-search
+    .row
+      .col-md-12
+        %h3.secondary-matches#js-external-registry-search-header
+          .loading.d-none= t(".searching_external_registries")
+          .loaded.d-none= t(".external_matches_found")
+          .loaded-none.no-exact-results.d-none= t(".no_external_matches_found")
+        #js-external-registry-search
 
     .col-md-4.ad-col
       .ad-block#right300x600

--- a/app/views/welcome/user_home.html.haml
+++ b/app/views/welcome/user_home.html.haml
@@ -47,7 +47,7 @@
                       - if bike.current_stolen_record.present?
                         - abandoned_or_stolen =  bike.abandoned? ? t(".date_abandoned") : t('.date_stolen')
                         = bike.attr_list_item(l(bike.current_stolen_record.date_stolen, format: :dotted), abandoned_or_stolen)
-                        = bike.attr_list_item(bike.short_address(bike.current_stolen_record), t(".location"))
+                        = bike.attr_list_item(bike.current_stolen_record.address_location(include_all: true), t(".location"))
                     %ul.attr-list
                       %li= link_to t(".edit_bike"), edit_bike_path(bike)
                       %li

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1148,11 +1148,13 @@ en:
       miles_of: miles of
       no_bikes_matched: No %{stolenness} bikes matched your search
       no_external_matches_found: No matches found in external registries
+      no_near_matches_found: No near-matching serials found
       not_marked_stolen: Not marked stolen
       search_bike_descriptions: Search bike descriptions
       search_for_serial_number: Search for serial number
       search_for_stolenness_desc_bikes: Search for %{stolenness_desc} bikes
       searching_external_registries: Searching external registries...
+      searching_for_near_matches: Searching for near-matching serial numbers...
       stolen_anywhere: Stolen anywhere
       stolen_within: Stolen within
       submit: submit

--- a/spec/controllers/bikes_controller_spec.rb
+++ b/spec/controllers/bikes_controller_spec.rb
@@ -42,7 +42,6 @@ RSpec.describe BikesController, type: :controller do
           expect(assigns(:interpreted_params)).to eq target_interpreted_params
           expect(assigns(:selected_query_items_options)).to eq target_selected_query_items_options
           expect(assigns(:bikes).map(&:id)).to eq([])
-          expect(assigns(:close_serials).map(&:id)).to eq([non_stolen_bike.id])
         end
       end
       context "ip proximity" do

--- a/spec/factories/stolen_records.rb
+++ b/spec/factories/stolen_records.rb
@@ -28,18 +28,24 @@ FactoryBot.define do
     end
 
     trait :in_los_angeles do
+      latitude { nil }
+      longitude { nil }
       city { "Los Angeles" }
       state { State.find_or_create_by(FactoryBot.attributes_for(:state_california)) }
       country { Country.united_states }
     end
 
     trait :in_nyc do
+      latitude { nil }
+      longitude { nil }
       city { "New York" }
       state { State.find_or_create_by(FactoryBot.attributes_for(:state_new_york)) }
       country { Country.united_states }
     end
 
     trait :in_amsterdam do
+      latitude { nil }
+      longitude { nil }
       city { "Amsterdam" }
       state { nil }
       country { Country.netherlands }

--- a/spec/models/stolen_record_spec.rb
+++ b/spec/models/stolen_record_spec.rb
@@ -496,11 +496,35 @@ RSpec.describe StolenRecord, type: :model do
   end
 
   describe "#address_location" do
-    context "given a city and state" do
+    context "given include_all" do
+      it "returns all available location components" do
+        stolen_record = FactoryBot.create(:stolen_record, :in_nyc)
+        expect(stolen_record.address_location(include_all: true)).to eq("New York, NY - US")
+
+        ca = FactoryBot.create(:state, name: "California", abbreviation: "CA")
+        stolen_record = FactoryBot.create(:stolen_record, city: nil, state: ca, country: Country.united_states)
+        expect(stolen_record.address_location(include_all: true)).to eq("CA - US")
+      end
+    end
+
+    context "given an domestic location" do
       it "returns the city and state" do
-        ny_state = FactoryBot.create(:state, abbreviation: "NY")
-        stolen_record = FactoryBot.create(:stolen_record, city: "New Paltz", state: ny_state)
-        expect(stolen_record.address_location).to eq("New Paltz, NY")
+        stolen_record = FactoryBot.create(:stolen_record, :in_nyc)
+        expect(stolen_record.address_location).to eq("New York, NY")
+      end
+    end
+
+    context "given an international location" do
+      it "returns the city and state" do
+        stolen_record = FactoryBot.create(:stolen_record, :in_amsterdam, state: nil)
+        expect(stolen_record.address_location).to eq("Amsterdam - NL")
+      end
+    end
+
+    context "given only a country" do
+      it "returns only the country" do
+        stolen_record = FactoryBot.create(:stolen_record, city: nil, state: nil, country: Country.netherlands)
+        expect(stolen_record.address_location).to eq("NL")
       end
     end
 
@@ -513,9 +537,9 @@ RSpec.describe StolenRecord, type: :model do
     end
 
     context "given only a city" do
-      it "returns an empty string" do
+      it "returns nil" do
         stolen_record = FactoryBot.create(:stolen_record, city: "New Paltz", state: nil)
-        expect(stolen_record.address_location).to eq("")
+        expect(stolen_record.address_location).to eq(nil)
       end
     end
   end

--- a/spec/serializers/bike_v2_show_serializer_spec.rb
+++ b/spec/serializers/bike_v2_show_serializer_spec.rb
@@ -53,7 +53,6 @@ RSpec.describe BikeV2ShowSerializer do
         api_url: "http://test.host/api/v1/bikes/#{bike.id}",
         manufacturer_id: bike.manufacturer_id,
         paint_description: nil,
-        placeholder_image: "http://test.host/assets/revised/bike_photo_placeholder-ff15adbd9bf89e10bf3cd2cd6c4e85e5d1056e50463ae722822493624db72e56.svg",
         name: nil,
         frame_size: "42cm",
         description: nil,

--- a/spec/serializers/bike_v2_show_serializer_spec.rb
+++ b/spec/serializers/bike_v2_show_serializer_spec.rb
@@ -53,6 +53,7 @@ RSpec.describe BikeV2ShowSerializer do
         api_url: "http://test.host/api/v1/bikes/#{bike.id}",
         manufacturer_id: bike.manufacturer_id,
         paint_description: nil,
+        placeholder_image: "http://test.host/assets/revised/bike_photo_placeholder-ff15adbd9bf89e10bf3cd2cd6c4e85e5d1056e50463ae722822493624db72e56.svg",
         name: nil,
         frame_size: "42cm",
         description: nil,


### PR DESCRIPTION
Refactors close-serials search results to render asynchronously on page load

<img width="1170" alt="Screen Shot 2019-10-06 at 5 27 19 PM" src="https://user-images.githubusercontent.com/4433943/66276182-9112a980-e85e-11e9-83e8-a685eced86b2.png">

![demo](https://user-images.githubusercontent.com/4433943/66276101-8d325780-e85d-11e9-9b60-b474477500ce.gif)
