### PR TITLE
Don't render search components if id not present

### DIFF
--- a/app/javascript/packs/external_registry_search/index.js
+++ b/app/javascript/packs/external_registry_search/index.js
@@ -6,6 +6,7 @@ import honeybadger from "../utils/honeybadger";
 
 document.addEventListener("DOMContentLoaded", () => {
   const el = document.getElementById("js-external-registry-search");
+  if (!el) { return; }
 
   ReactDOM.render(
     <ErrorBoundary honeybadger={honeybadger}>

--- a/app/javascript/packs/partial_serial_search/index.js
+++ b/app/javascript/packs/partial_serial_search/index.js
@@ -6,6 +6,7 @@ import honeybadger from "../utils/honeybadger";
 
 document.addEventListener("DOMContentLoaded", () => {
   const el = document.getElementById("js-partial-serial-search");
+  if (!el) { return; }
 
   ReactDOM.render(
     <ErrorBoundary honeybadger={honeybadger}>


### PR DESCRIPTION
Resolves https://app.honeybadger.io/projects/61305/faults/54294090

> Target container is not a DOM element.

