### PR TITLE
Kill unused decorator methods

### DIFF
--- a/app/decorators/bike_decorator.rb
+++ b/app/decorators/bike_decorator.rb
@@ -4,18 +4,8 @@
 class BikeDecorator < ApplicationDecorator
   delegate_all
 
-  def creation_organization_name
-    object.creation_organization&.name
-  end
-
   def should_show_other_bikes
     object.user? && object.user.show_bikes
-  end
-
-  def show_other_bikes
-    return nil unless should_show_other_bikes
-    html = "<a href='/users/#{object.user.username}'>View user's other bikes</a>"
-    html.html_safe
   end
 
   def title
@@ -31,11 +21,6 @@ class BikeDecorator < ApplicationDecorator
     t += h.content_tag(:strong, object.mnfg_name)
     t += Rack::Utils.escape_html(" #{object.frame_model}") if object.frame_model.present?
     t.html_safe
-  end
-
-  def tire_width(position)
-    return "narrow" if object.send("#{position}_tire_narrow")
-    "wide"
   end
 
   def list_link_url(target = nil)
@@ -55,14 +40,6 @@ class BikeDecorator < ApplicationDecorator
       h.image_tag(small.join("/") + ext, alt: title_string)
     else
       h.image_tag("revised/bike_photo_placeholder.svg", alt: title_string, title: "No image", class: "no-image")
-    end
-  end
-
-  def list_image(target = nil)
-    h.content_tag :div, class: "blist-image-holder" do
-      h.link_to(list_link_url(target)) do
-        thumb_image
-      end
     end
   end
 end

--- a/app/helpers/header_tag_helper.rb
+++ b/app/helpers/header_tag_helper.rb
@@ -40,7 +40,7 @@ module HeaderTagHelper
 
   def auto_description
     return translation_description if translation_description.present?
-    "The best bike registry: Simple, secure and free."
+    t("meta_descriptions.welcome_index")
   end
 
   def default_meta_hash

--- a/spec/decorators/bike_decorator_spec.rb
+++ b/spec/decorators/bike_decorator_spec.rb
@@ -1,19 +1,6 @@
 require "rails_helper"
 
 RSpec.describe BikeDecorator do
-  describe "show_other_bikes" do
-    it "links to bikes if the user is the current owner and wants to share" do
-      bike = Bike.new
-      user = User.new
-      allow(bike).to receive(:user).and_return(user)
-      allow(user).to receive(:show_bikes).and_return(true)
-      allow(user).to receive(:username).and_return("i")
-      decorator = BikeDecorator.new(bike)
-      allow(bike).to receive(:user?).and_return(true)
-      expect(decorator.show_other_bikes.match("href='/users/i")).to be_present
-    end
-  end
-
   describe "title" do
     it "returns the major bike attribs formatted" do
       bike = Bike.new
@@ -22,40 +9,6 @@ RSpec.describe BikeDecorator do
       allow(bike).to receive(:mnfg_name).and_return("foo")
       decorator = BikeDecorator.new(bike)
       expect(decorator.title).to eq("<span>1999 model by </span><strong>foo</strong>")
-    end
-  end
-
-  describe "#creation_organization_name" do
-    context "given an associated creation_organization" do
-      it "returns the organization's name" do
-        org = FactoryBot.create(:organization, name: "Creation Organization")
-        bike = FactoryBot.create(:bike, creation_organization: org).decorate
-        name = bike.creation_organization_name
-        expect(name).to eq(org.name)
-      end
-    end
-
-    context "given no associated creation_organization" do
-      it "returns nil" do
-        bike = FactoryBot.create(:bike, creation_organization: nil).decorate
-        name = bike.creation_organization_name
-        expect(name).to be_nil
-      end
-    end
-  end
-
-  describe "tire_width" do
-    it "returns wide if false" do
-      bike = Bike.new
-      allow(bike).to receive(:front_tire_narrow).and_return(nil)
-      decorator = BikeDecorator.new(bike).tire_width("front")
-      expect(decorator).to eq("wide")
-    end
-    it "returns narrow if narrow" do
-      bike = Bike.new
-      allow(bike).to receive(:rear_tire_narrow).and_return(true)
-      decorator = BikeDecorator.new(bike).tire_width("rear")
-      expect(decorator).to eq("narrow")
     end
   end
 
@@ -96,24 +49,6 @@ RSpec.describe BikeDecorator do
         expect(html).to match('title=\"No image\"')
         expect(html).to match(/revised.bike_photo_placeholder.*\.svg/)
       end
-    end
-  end
-
-  describe "list_image" do
-    it "returns the link with  thumb path if nothing is passed" do
-      bike = Bike.new
-      allow(bike).to receive(:id).and_return(69)
-      decorator = BikeDecorator.new(bike)
-      allow(decorator).to receive(:thumb_image).and_return("imagey")
-      expect(decorator.list_image).not_to be_nil
-    end
-    it "returns the images thumb path" do
-      bike = Bike.new
-      allow(bike).to receive(:id).and_return(69)
-      allow(bike).to receive(:thumb_path).and_return("something")
-      decorator = BikeDecorator.new(bike)
-      allow(decorator).to receive(:thumb_image).and_return("imagey")
-      expect(decorator.list_image).not_to be_nil
     end
   end
 end


### PR DESCRIPTION
- No externalizations needed for decorators — all methods with user-facing strings aren't called anywhere. 
- Externalizes one last string from header_tag_helper

Tracking #963 