### PR TITLE
Use title not description for alt text

### DIFF
--- a/app/javascript/packs/partial_serial_search/components/PartialSerialSearchResult.js
+++ b/app/javascript/packs/partial_serial_search/components/PartialSerialSearchResult.js
@@ -70,7 +70,7 @@ const ResultImage = ({ bike }) => {
   }
 
   return (<a className="bike-list-image hover-expand" target="_blank" href={bike.url}>
-            <img alt={bike.description} src={bike.thumb}></img>
+            <img alt={bike.title} src={bike.thumb}></img>
           </a>);
 }
 


### PR DESCRIPTION
Replaces the alt text for partial serial search result images from `description` to `title`, which is more succinct. Some descriptions are very long. Also matches what we use on server-rendered bike templates.