### PR TITLE
Externalize controller flash strings

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -13,7 +13,7 @@ class ApplicationController < ActionController::Base
                           x_permitted_cross_domain_policies: false)
 
   def handle_unverified_request
-    flash[:error] = "CSRF invalid. If you don't know why you're receiving this message, please contact us"
+    flash[:error] = translation(:csrf_invalid, scope: %i[controllers application handle_unverified_request])
     redirect_to user_root_url
   end
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -13,7 +13,7 @@ class ApplicationController < ActionController::Base
                           x_permitted_cross_domain_policies: false)
 
   def handle_unverified_request
-    flash[:error] = t(:csrf_invalid, scope: [:controllers, :application, __method__])
+    flash[:error] = translation(:csrf_invalid, scope: [:controllers, :application, __method__])
     redirect_to user_root_url
   end
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -13,7 +13,7 @@ class ApplicationController < ActionController::Base
                           x_permitted_cross_domain_policies: false)
 
   def handle_unverified_request
-    flash[:error] = translation(:csrf_invalid, scope: %i[controllers application handle_unverified_request])
+    flash[:error] = translation(:csrf_invalid, controller_method: __method__)
     redirect_to user_root_url
   end
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -13,7 +13,7 @@ class ApplicationController < ActionController::Base
                           x_permitted_cross_domain_policies: false)
 
   def handle_unverified_request
-    flash[:error] = t(:csrf_invalid)
+    flash[:error] = t(:csrf_invalid, scope: [:controllers, :application, __method__])
     redirect_to user_root_url
   end
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -13,7 +13,7 @@ class ApplicationController < ActionController::Base
                           x_permitted_cross_domain_policies: false)
 
   def handle_unverified_request
-    flash[:error] = translation(:csrf_invalid)
+    flash[:error] = t(:csrf_invalid)
     redirect_to user_root_url
   end
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -13,7 +13,7 @@ class ApplicationController < ActionController::Base
                           x_permitted_cross_domain_policies: false)
 
   def handle_unverified_request
-    flash[:error] = translation(:csrf_invalid, controller_method: __method__)
+    flash[:error] = translation(:csrf_invalid)
     redirect_to user_root_url
   end
 

--- a/app/controllers/bike_codes_controller.rb
+++ b/app/controllers/bike_codes_controller.rb
@@ -14,7 +14,7 @@ class BikeCodesController < ApplicationController
         end
       end
     else
-      flash[:error] = "You can't update that #{@bike_code.kind}. Please contact support@bikeindex.org if you think you should be able to"
+      flash[:error] = translation(:cannot_update, kind: @bike_code.kind)
     end
     redirect_to :back
   end
@@ -27,7 +27,7 @@ class BikeCodesController < ApplicationController
 
   def find_bike_code
     unless current_user.present?
-      flash[:error] = "You must be signed in to do that"
+      flash[:error] = translation(:must_be_signed_in, scope: %i[controllers bike_codes find_bike_code])
       redirect_to :back
       return
     end
@@ -35,7 +35,9 @@ class BikeCodesController < ApplicationController
     # use the loosest lookup, but only permit it if the user can claim that
     @bike_code = bike_code if bike_code.present? && bike_code.claimable_by?(current_user)
     return @bike_code if @bike_code.present?
-    flash[:error] = "Unable to find sticker with code: #{bike_code_code}"
+    flash[:error] = translation(:unable_to_find_sticker,
+                                code: bike_code_code,
+                                scope: %i[controllers bike_codes find_bike_code])
     redirect_to :back and return
   end
 

--- a/app/controllers/bike_codes_controller.rb
+++ b/app/controllers/bike_codes_controller.rb
@@ -14,7 +14,7 @@ class BikeCodesController < ApplicationController
         end
       end
     else
-      flash[:error] = translation(:cannot_update, kind: @bike_code.kind)
+      flash[:error] = t(:cannot_update, kind: @bike_code.kind)
     end
     redirect_to :back
   end
@@ -27,7 +27,7 @@ class BikeCodesController < ApplicationController
 
   def find_bike_code
     unless current_user.present?
-      flash[:error] = translation(:must_be_signed_in)
+      flash[:error] = t(:must_be_signed_in)
       redirect_to :back
       return
     end
@@ -35,9 +35,7 @@ class BikeCodesController < ApplicationController
     # use the loosest lookup, but only permit it if the user can claim that
     @bike_code = bike_code if bike_code.present? && bike_code.claimable_by?(current_user)
     return @bike_code if @bike_code.present?
-    flash[:error] = translation(:unable_to_find_sticker,
-                                code: bike_code_code,
-                                scope: %i[controllers bike_codes find_bike_code])
+    flash[:error] = t(:unable_to_find_sticker, code: bike_code_code)
     redirect_to :back and return
   end
 

--- a/app/controllers/bike_codes_controller.rb
+++ b/app/controllers/bike_codes_controller.rb
@@ -27,7 +27,7 @@ class BikeCodesController < ApplicationController
 
   def find_bike_code
     unless current_user.present?
-      flash[:error] = translation(:must_be_signed_in, controller_method: __method__)
+      flash[:error] = translation(:must_be_signed_in)
       redirect_to :back
       return
     end

--- a/app/controllers/bike_codes_controller.rb
+++ b/app/controllers/bike_codes_controller.rb
@@ -27,7 +27,7 @@ class BikeCodesController < ApplicationController
 
   def find_bike_code
     unless current_user.present?
-      flash[:error] = translation(:must_be_signed_in, scope: %i[controllers bike_codes find_bike_code])
+      flash[:error] = translation(:must_be_signed_in, controller_method: __method__)
       redirect_to :back
       return
     end

--- a/app/controllers/bike_codes_controller.rb
+++ b/app/controllers/bike_codes_controller.rb
@@ -14,7 +14,7 @@ class BikeCodesController < ApplicationController
         end
       end
     else
-      flash[:error] = t(:cannot_update, kind: @bike_code.kind)
+      flash[:error] = translation(:cannot_update, kind: @bike_code.kind)
     end
     redirect_to :back
   end
@@ -27,7 +27,7 @@ class BikeCodesController < ApplicationController
 
   def find_bike_code
     unless current_user.present?
-      flash[:error] = t(:must_be_signed_in)
+      flash[:error] = translation(:must_be_signed_in)
       redirect_to :back
       return
     end
@@ -35,7 +35,7 @@ class BikeCodesController < ApplicationController
     # use the loosest lookup, but only permit it if the user can claim that
     @bike_code = bike_code if bike_code.present? && bike_code.claimable_by?(current_user)
     return @bike_code if @bike_code.present?
-    flash[:error] = t(:unable_to_find_sticker, code: bike_code_code)
+    flash[:error] = translation(:unable_to_find_sticker, code: bike_code_code)
     redirect_to :back and return
   end
 

--- a/app/controllers/bikes/recovery_controller.rb
+++ b/app/controllers/bikes/recovery_controller.rb
@@ -13,7 +13,7 @@ module Bikes
     def update
       if @stolen_record.add_recovery_information(permitted_params)
         EmailRecoveredFromLinkWorker.perform_async(@stolen_record.id)
-        flash[:success] = t(:bike_recovered)
+        flash[:success] = translation(:bike_recovered)
         redirect_to bike_path(@bike)
       else
         render :edit, bike_id: @bike.id, token: params[:token]
@@ -43,9 +43,9 @@ module Bikes
                                                         recovery_link_token: params[:token])
       if @stolen_record.present?
         return true if @bike.stolen
-        flash[:info] = t(:already_recovered)
+        flash[:info] = translation(:already_recovered)
       else
-        flash[:error] = t(:incorrect_token)
+        flash[:error] = translation(:incorrect_token)
       end
       redirect_to bike_path(@bike) and return
     end

--- a/app/controllers/bikes/recovery_controller.rb
+++ b/app/controllers/bikes/recovery_controller.rb
@@ -43,9 +43,9 @@ module Bikes
                                                         recovery_link_token: params[:token])
       if @stolen_record.present?
         return true if @bike.stolen
-        flash[:info] = translation(:already_recovered, controller_method: __method__)
+        flash[:info] = translation(:already_recovered)
       else
-        flash[:error] = translation(:incorrect_token, controller_method: __method__)
+        flash[:error] = translation(:incorrect_token)
       end
       redirect_to bike_path(@bike) and return
     end

--- a/app/controllers/bikes/recovery_controller.rb
+++ b/app/controllers/bikes/recovery_controller.rb
@@ -39,14 +39,13 @@ module Bikes
     end
 
     def ensure_token_match!
-      t_scope = %i[controllers bikes recovery ensure_token_match]
       @stolen_record = StolenRecord.find_matching_token(bike_id: @bike && @bike.id,
                                                         recovery_link_token: params[:token])
       if @stolen_record.present?
         return true if @bike.stolen
-        flash[:info] = translation(:already_recovered, scope: t_scope)
+        flash[:info] = translation(:already_recovered, controller_method: __method__)
       else
-        flash[:error] = translation(:incorrect_token, scope: t_scope)
+        flash[:error] = translation(:incorrect_token, controller_method: __method__)
       end
       redirect_to bike_path(@bike) and return
     end

--- a/app/controllers/bikes/recovery_controller.rb
+++ b/app/controllers/bikes/recovery_controller.rb
@@ -13,7 +13,7 @@ module Bikes
     def update
       if @stolen_record.add_recovery_information(permitted_params)
         EmailRecoveredFromLinkWorker.perform_async(@stolen_record.id)
-        flash[:success] = translation(:bike_recovered)
+        flash[:success] = t(:bike_recovered)
         redirect_to bike_path(@bike)
       else
         render :edit, bike_id: @bike.id, token: params[:token]
@@ -43,9 +43,9 @@ module Bikes
                                                         recovery_link_token: params[:token])
       if @stolen_record.present?
         return true if @bike.stolen
-        flash[:info] = translation(:already_recovered)
+        flash[:info] = t(:already_recovered)
       else
-        flash[:error] = translation(:incorrect_token)
+        flash[:error] = t(:incorrect_token)
       end
       redirect_to bike_path(@bike) and return
     end

--- a/app/controllers/bikes/recovery_controller.rb
+++ b/app/controllers/bikes/recovery_controller.rb
@@ -13,7 +13,7 @@ module Bikes
     def update
       if @stolen_record.add_recovery_information(permitted_params)
         EmailRecoveredFromLinkWorker.perform_async(@stolen_record.id)
-        flash[:success] = "Bike marked recovered! Thank you!"
+        flash[:success] = translation(:bike_recovered)
         redirect_to bike_path(@bike)
       else
         render :edit, bike_id: @bike.id, token: params[:token]
@@ -39,13 +39,14 @@ module Bikes
     end
 
     def ensure_token_match!
+      t_scope = %i[controllers bikes recovery ensure_token_match]
       @stolen_record = StolenRecord.find_matching_token(bike_id: @bike && @bike.id,
                                                         recovery_link_token: params[:token])
       if @stolen_record.present?
         return true if @bike.stolen
-        flash[:info] = "Bike has already been marked recovered!"
+        flash[:info] = translation(:already_recovered, scope: t_scope)
       else
-        flash[:error] = "Incorrect Token, check your email again"
+        flash[:error] = translation(:incorrect_token, scope: t_scope)
       end
       redirect_to bike_path(@bike) and return
     end

--- a/app/controllers/bikes_controller.rb
+++ b/app/controllers/bikes_controller.rb
@@ -16,7 +16,7 @@ class BikesController < ApplicationController
     @interpreted_params = Bike.searchable_interpreted_params(permitted_search_params, ip: forwarded_ip_address)
     @stolenness = @interpreted_params[:stolenness]
     if params[:stolenness] == "proximity" && @stolenness != "proximity"
-      flash[:info] = t(:we_dont_know_location, location: params[:location])
+      flash[:info] = translation(:we_dont_know_location, location: params[:location])
     end
     @bikes = Bike.search(@interpreted_params).page(params[:page] || 1).per(params[:per_page] || 10).decorate
     @selected_query_items_options = Bike.selected_query_items_options(@interpreted_params)
@@ -62,7 +62,7 @@ class BikesController < ApplicationController
   def scanned
     @bike_code = BikeCode.lookup_with_fallback(scanned_id, organization_id: params[:organization_id], user: current_user)
     if @bike_code.blank?
-      flash[:error] = t(:unable_to_find_sticker, scanned_id: params[:scanned_id])
+      flash[:error] = translation(:unable_to_find_sticker, scanned_id: params[:scanned_id])
       redirect_to user_root_url
     elsif @bike_code.bike.present?
       redirect_to bike_url(@bike_code.bike_id, scanned_id: params[:scanned_id], organization_id: params[:organization_id]) and return
@@ -86,13 +86,13 @@ class BikesController < ApplicationController
   def new
     unless current_user.present?
       store_return_to(new_bike_path(b_param_token: params[:b_param_token], stolen: params[:stolen]))
-      flash[:info] = t(:please_sign_in_to_register)
+      flash[:info] = translation(:please_sign_in_to_register)
       redirect_to new_user_path and return
     end
     find_or_new_b_param
     redirect_to bike_path(@b_param.created_bike_id) and return if @b_param.created_bike.present?
     # Let them know if they sent an invalid b_param token - use flash#info rather than error because we're aggressive about removing b_params
-    flash[:info] = t(:we_couldnt_find_that_registration) if @b_param.id.blank? && params[:b_param_token].present?
+    flash[:info] = translation(:we_couldnt_find_that_registration) if @b_param.id.blank? && params[:b_param_token].present?
     @bike ||= @b_param.bike_from_attrs(is_stolen: params[:stolen], abandoned: params[:abandoned])
     # Fallback to active (i.e. passed organization_id), then passive_organization
     @bike.creation_organization ||= current_organization || passive_organization
@@ -129,7 +129,7 @@ class BikesController < ApplicationController
         end
       else
         if params[:bike][:embeded_extended]
-          flash[:success] = t("bike_was_sent_to", bike_type: @bike.type, owner_email: @bike.owner_email)
+          flash[:success] = translation(:bike_was_sent_to, bike_type: @bike.type, owner_email: @bike.owner_email)
           @persist_email = ParamsNormalizer.boolean(params[:persist_email])
           redirect_to embed_extended_organization_url(@bike.creation_organization, email: @persist_email ? @bike.owner_email : nil) and return
         else
@@ -146,7 +146,7 @@ class BikesController < ApplicationController
         @b_param.update_attributes(bike_errors: @bike.cleaned_error_messages)
         redirect_to new_bike_url(b_param_token: @b_param.id_token)
       else
-        flash[:success] = t(:bike_was_added)
+        flash[:success] = translation(:bike_was_added)
         redirect_to edit_bike_url(@bike)
       end
     end
@@ -207,7 +207,7 @@ class BikesController < ApplicationController
     if @bike.errors.any? || flash[:error].present?
       edit and return
     else
-      flash[:success] ||= t(:bike_was_updated)
+      flash[:success] ||= translation(:bike_was_updated)
       return if return_to_if_present
       redirect_to edit_bike_url(@bike, page: params[:edit_template]) and return
     end
@@ -253,11 +253,11 @@ class BikesController < ApplicationController
   # are used as haml header tag text in the corresponding templates.
   def theft_templates
     {}.with_indifferent_access.tap do |h|
-      h[:theft_details] = t(:recovery_details, controller_method: :edit) if @bike.abandoned?
-      h[:theft_details] = t(:theft_details, controller_method: :edit) unless @bike.abandoned?
-      h[:publicize] = t(:publicize, controller_method: :edit)
-      h[:alert] = t(:alert, controller_method: :edit)
-      h[:report_recovered] = t(:report_recovered, controller_method: :edit) unless @bike.abandoned?
+      h[:theft_details] = translation(:recovery_details, controller_method: :edit) if @bike.abandoned?
+      h[:theft_details] = translation(:theft_details, controller_method: :edit) unless @bike.abandoned?
+      h[:publicize] = translation(:publicize, controller_method: :edit)
+      h[:alert] = translation(:alert, controller_method: :edit)
+      h[:report_recovered] = translation(:report_recovered, controller_method: :edit) unless @bike.abandoned?
     end
   end
 
@@ -266,14 +266,14 @@ class BikesController < ApplicationController
   # are used as haml header tag text in the corresponding templates.
   def bike_templates
     {}.with_indifferent_access.tap do |h|
-      h[:bike_details] = t(:bike_details, controller_method: :edit)
-      h[:photos] = t(:photos, controller_method: :edit)
-      h[:drivetrain] = t(:drivetrain, controller_method: :edit)
-      h[:accessories] = t(:accessories, controller_method: :edit)
-      h[:ownership] = t(:ownership, controller_method: :edit)
-      h[:groups] = t(:groups, controller_method: :edit)
-      h[:remove] = t(:remove, controller_method: :edit)
-      h[:report_stolen] = t(:report_stolen, controller_method: :edit) unless @bike.stolen?
+      h[:bike_details] = translation(:bike_details, controller_method: :edit)
+      h[:photos] = translation(:photos, controller_method: :edit)
+      h[:drivetrain] = translation(:drivetrain, controller_method: :edit)
+      h[:accessories] = translation(:accessories, controller_method: :edit)
+      h[:ownership] = translation(:ownership, controller_method: :edit)
+      h[:groups] = translation(:groups, controller_method: :edit)
+      h[:remove] = translation(:remove, controller_method: :edit)
+      h[:report_stolen] = translation(:report_stolen, controller_method: :edit) unless @bike.stolen?
     end
   end
 
@@ -298,7 +298,7 @@ class BikesController < ApplicationController
     end
     if @bike.hidden || @bike.deleted?
       unless current_user.present? && @bike.visible_by(current_user)
-        flash[:error] = t(:bike_deleted)
+        flash[:error] = translation(:bike_deleted)
         redirect_to root_url and return
       end
     end
@@ -317,12 +317,12 @@ class BikesController < ApplicationController
     return true if @bike.authorize_and_claim_for_user(current_user)
 
     if current_user.present?
-      error = t(:you_dont_own_that, bike_type: type)
+      error = translation(:you_dont_own_that, bike_type: type)
     else
       if @current_ownership && @bike.current_ownership.claimed
-        error = t(:you_have_to_sign_in, bike_type: type)
+        error = translation(:you_have_to_sign_in, bike_type: type)
       else
-        error = t(:bike_has_not_been_claimed_yet, bike_type: type)
+        error = translation(:bike_has_not_been_claimed_yet, bike_type: type)
       end
     end
 
@@ -331,7 +331,7 @@ class BikesController < ApplicationController
       redirect_to bike_path(@bike) and return
     end
 
-    authenticate_user(t(:please_create_an_account), flash_type: :info)
+    authenticate_user(translation(:please_create_an_account), flash_type: :info)
   end
 
   def update_organizations_can_edit_claimed(bike, organization_ids)

--- a/app/controllers/bikes_controller.rb
+++ b/app/controllers/bikes_controller.rb
@@ -343,9 +343,9 @@ class BikesController < ApplicationController
 
   def assign_bike_codes(bike_code)
     bike_code = BikeCode.lookup_with_fallback(bike_code)
-    return flash[:error] = translation(:unable_to_find_sticker, code: bike_code) unless bike_code.present?
+    return flash[:error] = translation(:unable_to_find_sticker, bike_code: bike_code) unless bike_code.present?
     if bike_code.claim_if_permitted(current_user, @bike)
-      flash[:success] = translation(:sticker_assigned, code: bike_code.pretty_code, bike_type: @bike.type)
+      flash[:success] = translation(:sticker_assigned, bike_code: bike_code.pretty_code, bike_type: @bike.type)
     else
       flash[:error] = bike_code.errors.full_messages
     end

--- a/app/controllers/bikes_controller.rb
+++ b/app/controllers/bikes_controller.rb
@@ -16,7 +16,7 @@ class BikesController < ApplicationController
     @interpreted_params = Bike.searchable_interpreted_params(permitted_search_params, ip: forwarded_ip_address)
     @stolenness = @interpreted_params[:stolenness]
     if params[:stolenness] == "proximity" && @stolenness != "proximity"
-      flash[:info] = translation("we_dont_know_location", location: params[:location])
+      flash[:info] = t(:we_dont_know_location, location: params[:location])
     end
     @bikes = Bike.search(@interpreted_params).page(params[:page] || 1).per(params[:per_page] || 10).decorate
     @selected_query_items_options = Bike.selected_query_items_options(@interpreted_params)
@@ -62,7 +62,7 @@ class BikesController < ApplicationController
   def scanned
     @bike_code = BikeCode.lookup_with_fallback(scanned_id, organization_id: params[:organization_id], user: current_user)
     if @bike_code.blank?
-      flash[:error] = translation("unable_to_find_sticker", scanned_id: params[:scanned_id])
+      flash[:error] = t(:unable_to_find_sticker, scanned_id: params[:scanned_id])
       redirect_to user_root_url
     elsif @bike_code.bike.present?
       redirect_to bike_url(@bike_code.bike_id, scanned_id: params[:scanned_id], organization_id: params[:organization_id]) and return
@@ -86,13 +86,13 @@ class BikesController < ApplicationController
   def new
     unless current_user.present?
       store_return_to(new_bike_path(b_param_token: params[:b_param_token], stolen: params[:stolen]))
-      flash[:info] = translation("please_sign_in_to_register")
+      flash[:info] = t(:please_sign_in_to_register)
       redirect_to new_user_path and return
     end
     find_or_new_b_param
     redirect_to bike_path(@b_param.created_bike_id) and return if @b_param.created_bike.present?
     # Let them know if they sent an invalid b_param token - use flash#info rather than error because we're aggressive about removing b_params
-    flash[:info] = translation("we_couldnt_find_that_registration") if @b_param.id.blank? && params[:b_param_token].present?
+    flash[:info] = t(:we_couldnt_find_that_registration) if @b_param.id.blank? && params[:b_param_token].present?
     @bike ||= @b_param.bike_from_attrs(is_stolen: params[:stolen], abandoned: params[:abandoned])
     # Fallback to active (i.e. passed organization_id), then passive_organization
     @bike.creation_organization ||= current_organization || passive_organization
@@ -129,7 +129,7 @@ class BikesController < ApplicationController
         end
       else
         if params[:bike][:embeded_extended]
-          flash[:success] = translation("bike_was_sent_to", bike_type: @bike.type, owner_email: @bike.owner_email)
+          flash[:success] = t("bike_was_sent_to", bike_type: @bike.type, owner_email: @bike.owner_email)
           @persist_email = ParamsNormalizer.boolean(params[:persist_email])
           redirect_to embed_extended_organization_url(@bike.creation_organization, email: @persist_email ? @bike.owner_email : nil) and return
         else
@@ -146,7 +146,7 @@ class BikesController < ApplicationController
         @b_param.update_attributes(bike_errors: @bike.cleaned_error_messages)
         redirect_to new_bike_url(b_param_token: @b_param.id_token)
       else
-        flash[:success] = translation("bike_was_added")
+        flash[:success] = t(:bike_was_added)
         redirect_to edit_bike_url(@bike)
       end
     end
@@ -207,7 +207,7 @@ class BikesController < ApplicationController
     if @bike.errors.any? || flash[:error].present?
       edit and return
     else
-      flash[:success] ||= translation("bike_was_updated")
+      flash[:success] ||= t(:bike_was_updated)
       return if return_to_if_present
       redirect_to edit_bike_url(@bike, page: params[:edit_template]) and return
     end
@@ -253,11 +253,11 @@ class BikesController < ApplicationController
   # are used as haml header tag text in the corresponding templates.
   def theft_templates
     {}.with_indifferent_access.tap do |h|
-      h[:theft_details] = translation(:recovery_details, controller_method: :edit) if @bike.abandoned?
-      h[:theft_details] = translation(:theft_details, controller_method: :edit) unless @bike.abandoned?
-      h[:publicize] = translation(:publicize, controller_method: :edit)
-      h[:alert] = translation(:alert, controller_method: :edit)
-      h[:report_recovered] = translation(:report_recovered, controller_method: :edit) unless @bike.abandoned?
+      h[:theft_details] = t(:recovery_details, controller_method: :edit) if @bike.abandoned?
+      h[:theft_details] = t(:theft_details, controller_method: :edit) unless @bike.abandoned?
+      h[:publicize] = t(:publicize, controller_method: :edit)
+      h[:alert] = t(:alert, controller_method: :edit)
+      h[:report_recovered] = t(:report_recovered, controller_method: :edit) unless @bike.abandoned?
     end
   end
 
@@ -266,14 +266,14 @@ class BikesController < ApplicationController
   # are used as haml header tag text in the corresponding templates.
   def bike_templates
     {}.with_indifferent_access.tap do |h|
-      h[:bike_details] = translation(:bike_details, controller_method: :edit)
-      h[:photos] = translation(:photos, controller_method: :edit)
-      h[:drivetrain] = translation(:drivetrain, controller_method: :edit)
-      h[:accessories] = translation(:accessories, controller_method: :edit)
-      h[:ownership] = translation(:ownership, controller_method: :edit)
-      h[:groups] = translation(:groups, controller_method: :edit)
-      h[:remove] = translation(:remove, controller_method: :edit)
-      h[:report_stolen] = translation(:report_stolen, controller_method: :edit) unless @bike.stolen?
+      h[:bike_details] = t(:bike_details, controller_method: :edit)
+      h[:photos] = t(:photos, controller_method: :edit)
+      h[:drivetrain] = t(:drivetrain, controller_method: :edit)
+      h[:accessories] = t(:accessories, controller_method: :edit)
+      h[:ownership] = t(:ownership, controller_method: :edit)
+      h[:groups] = t(:groups, controller_method: :edit)
+      h[:remove] = t(:remove, controller_method: :edit)
+      h[:report_stolen] = t(:report_stolen, controller_method: :edit) unless @bike.stolen?
     end
   end
 
@@ -298,7 +298,7 @@ class BikesController < ApplicationController
     end
     if @bike.hidden || @bike.deleted?
       unless current_user.present? && @bike.visible_by(current_user)
-        flash[:error] = translation("bike_deleted")
+        flash[:error] = t(:bike_deleted)
         redirect_to root_url and return
       end
     end
@@ -317,12 +317,12 @@ class BikesController < ApplicationController
     return true if @bike.authorize_and_claim_for_user(current_user)
 
     if current_user.present?
-      error = translation("you_dont_own_that", bike_type: type)
+      error = t(:you_dont_own_that, bike_type: type)
     else
       if @current_ownership && @bike.current_ownership.claimed
-        error = translation("you_have_to_sign_in", bike_type: type)
+        error = t(:you_have_to_sign_in, bike_type: type)
       else
-        error = translation("bike_has_not_been_claimed_yet", bike_type: type)
+        error = t(:bike_has_not_been_claimed_yet, bike_type: type)
       end
     end
 
@@ -331,7 +331,7 @@ class BikesController < ApplicationController
       redirect_to bike_path(@bike) and return
     end
 
-    authenticate_user(translation("please_create_an_account"), flash_type: :info)
+    authenticate_user(t(:please_create_an_account), flash_type: :info)
   end
 
   def update_organizations_can_edit_claimed(bike, organization_ids)

--- a/app/controllers/bikes_controller.rb
+++ b/app/controllers/bikes_controller.rb
@@ -343,9 +343,9 @@ class BikesController < ApplicationController
 
   def assign_bike_codes(bike_code)
     bike_code = BikeCode.lookup_with_fallback(bike_code)
-    return flash[:error] = "Unable to find a sticker matching #{bike_code}" unless bike_code.present?
+    return flash[:error] = translation(:unable_to_find_sticker, code: bike_code) unless bike_code.present?
     if bike_code.claim_if_permitted(current_user, @bike)
-      flash[:success] = "Success! Sticker '#{bike_code.pretty_code}' has been assigned to your #{@bike.type}"
+      flash[:success] = translation(:sticker_assigned, code: bike_code.pretty_code, bike_type: @bike.type)
     else
       flash[:error] = bike_code.errors.full_messages
     end

--- a/app/controllers/bikes_controller.rb
+++ b/app/controllers/bikes_controller.rb
@@ -253,11 +253,11 @@ class BikesController < ApplicationController
   # are used as haml header tag text in the corresponding templates.
   def theft_templates
     {}.with_indifferent_access.tap do |h|
-      h[:theft_details] = translation(:recovery_details, scope: %i[controllers bikes edit]) if @bike.abandoned?
-      h[:theft_details] = translation(:theft_details, scope: %i[controllers bikes edit]) unless @bike.abandoned?
-      h[:publicize] = translation(:publicize, scope: %i[controllers bikes edit])
-      h[:alert] = translation(:alert, scope: %i[controllers bikes edit])
-      h[:report_recovered] = translation(:report_recovered, scope: %i[controllers bikes edit]) unless @bike.abandoned?
+      h[:theft_details] = translation(:recovery_details, controller_method: :edit) if @bike.abandoned?
+      h[:theft_details] = translation(:theft_details, controller_method: :edit) unless @bike.abandoned?
+      h[:publicize] = translation(:publicize, controller_method: :edit)
+      h[:alert] = translation(:alert, controller_method: :edit)
+      h[:report_recovered] = translation(:report_recovered, controller_method: :edit) unless @bike.abandoned?
     end
   end
 
@@ -266,14 +266,14 @@ class BikesController < ApplicationController
   # are used as haml header tag text in the corresponding templates.
   def bike_templates
     {}.with_indifferent_access.tap do |h|
-      h[:bike_details] = translation(:bike_details, scope: %i[controllers bikes edit])
-      h[:photos] = translation(:photos, scope: %i[controllers bikes edit])
-      h[:drivetrain] = translation(:drivetrain, scope: %i[controllers bikes edit])
-      h[:accessories] = translation(:accessories, scope: %i[controllers bikes edit])
-      h[:ownership] = translation(:ownership, scope: %i[controllers bikes edit])
-      h[:groups] = translation(:groups, scope: %i[controllers bikes edit])
-      h[:remove] = translation(:remove, scope: %i[controllers bikes edit])
-      h[:report_stolen] = translation(:report_stolen, scope: %i[controllers bikes edit]) unless @bike.stolen?
+      h[:bike_details] = translation(:bike_details, controller_method: :edit)
+      h[:photos] = translation(:photos, controller_method: :edit)
+      h[:drivetrain] = translation(:drivetrain, controller_method: :edit)
+      h[:accessories] = translation(:accessories, controller_method: :edit)
+      h[:ownership] = translation(:ownership, controller_method: :edit)
+      h[:groups] = translation(:groups, controller_method: :edit)
+      h[:remove] = translation(:remove, controller_method: :edit)
+      h[:report_stolen] = translation(:report_stolen, controller_method: :edit) unless @bike.stolen?
     end
   end
 
@@ -298,7 +298,7 @@ class BikesController < ApplicationController
     end
     if @bike.hidden || @bike.deleted?
       unless current_user.present? && @bike.visible_by(current_user)
-        flash[:error] = translation("bike_deleted", scope: %i[controllers bikes find_bike])
+        flash[:error] = translation("bike_deleted", controller_method: __method__)
         redirect_to root_url and return
       end
     end
@@ -316,15 +316,13 @@ class BikesController < ApplicationController
 
     return true if @bike.authorize_and_claim_for_user(current_user)
 
-    translation_scope = %i[controllers bikes ensure_user_allowed_to_edit]
-
     if current_user.present?
-      error = translation("you_dont_own_that", bike_type: type, scope: translation_scope)
+      error = translation("you_dont_own_that", bike_type: type, controller_method: __method__)
     else
       if @current_ownership && @bike.current_ownership.claimed
-        error = translation("you_have_to_sign_in", bike_type: type, scope: translation_scope)
+        error = translation("you_have_to_sign_in", bike_type: type, controller_method: __method__)
       else
-        error = translation("bike_has_not_been_claimed_yet", bike_type: type, scope: translation_scope)
+        error = translation("bike_has_not_been_claimed_yet", bike_type: type, controller_method: __method__)
       end
     end
 
@@ -333,7 +331,7 @@ class BikesController < ApplicationController
       redirect_to bike_path(@bike) and return
     end
 
-    authenticate_user(translation("please_create_an_account", scope: translation_scope), flash_type: :info)
+    authenticate_user(translation("please_create_an_account", controller_method: __method__), flash_type: :info)
   end
 
   def update_organizations_can_edit_claimed(bike, organization_ids)

--- a/app/controllers/bikes_controller.rb
+++ b/app/controllers/bikes_controller.rb
@@ -298,7 +298,7 @@ class BikesController < ApplicationController
     end
     if @bike.hidden || @bike.deleted?
       unless current_user.present? && @bike.visible_by(current_user)
-        flash[:error] = translation("bike_deleted", controller_method: __method__)
+        flash[:error] = translation("bike_deleted")
         redirect_to root_url and return
       end
     end
@@ -317,12 +317,12 @@ class BikesController < ApplicationController
     return true if @bike.authorize_and_claim_for_user(current_user)
 
     if current_user.present?
-      error = translation("you_dont_own_that", bike_type: type, controller_method: __method__)
+      error = translation("you_dont_own_that", bike_type: type)
     else
       if @current_ownership && @bike.current_ownership.claimed
-        error = translation("you_have_to_sign_in", bike_type: type, controller_method: __method__)
+        error = translation("you_have_to_sign_in", bike_type: type)
       else
-        error = translation("bike_has_not_been_claimed_yet", bike_type: type, controller_method: __method__)
+        error = translation("bike_has_not_been_claimed_yet", bike_type: type)
       end
     end
 
@@ -331,7 +331,7 @@ class BikesController < ApplicationController
       redirect_to bike_path(@bike) and return
     end
 
-    authenticate_user(translation("please_create_an_account", controller_method: __method__), flash_type: :info)
+    authenticate_user(translation("please_create_an_account"), flash_type: :info)
   end
 
   def update_organizations_can_edit_claimed(bike, organization_ids)

--- a/app/controllers/concerns/controller_helpers.rb
+++ b/app/controllers/concerns/controller_helpers.rb
@@ -112,6 +112,8 @@ module ControllerHelpers
     I18n.t(key, kwargs, scope: scope.compact)
   end
 
+  alias_method :t, :translation
+
   def controller_namespace
     @controller_namespace ||= self.class.parent.name != "Object" ? self.class.parent.name.downcase : nil
   end

--- a/app/controllers/concerns/controller_helpers.rb
+++ b/app/controllers/concerns/controller_helpers.rb
@@ -104,8 +104,9 @@ module ControllerHelpers
     end
   end
 
-  def translation(key, scope: nil, **kwargs)
-    scope ||= [:controllers, controller_namespace, controller_name, action_name]
+  def translation(key, scope: nil, controller_method: nil, **kwargs)
+    controller_method = controller_method.presence || action_name
+    scope ||= [:controllers, controller_namespace, controller_name, controller_method.to_sym]
     I18n.t(key, kwargs, scope: scope.compact)
   end
 

--- a/app/controllers/concerns/controller_helpers.rb
+++ b/app/controllers/concerns/controller_helpers.rb
@@ -106,13 +106,14 @@ module ControllerHelpers
   end
 
   def translation(key, scope: nil, controller_method: nil, **kwargs)
-    controller_method = controller_method.presence
-    controller_method ||=
-      caller_locations
-        .map(&:label)
-        .slice(0, 2)
-        .reject { |label| label =~ /rescue in/ }
-        .first
+    if scope.blank? && controller_method.blank?
+      controller_method =
+        caller_locations
+          .map(&:label)
+          .slice(0, 2)
+          .reject { |label| label =~ /rescue in/ }
+          .first
+    end
 
     scope ||= [:controllers, controller_namespace, controller_name, controller_method.to_sym]
     I18n.t(key, kwargs, scope: scope.compact)

--- a/app/controllers/concerns/controller_helpers.rb
+++ b/app/controllers/concerns/controller_helpers.rb
@@ -106,8 +106,14 @@ module ControllerHelpers
   end
 
   def translation(key, scope: nil, controller_method: nil, **kwargs)
-    calling_method = caller_locations.first.label
-    controller_method = controller_method.presence || calling_method
+    controller_method = controller_method.presence
+    controller_method ||=
+      caller_locations
+        .map(&:label)
+        .slice(0, 2)
+        .reject { |label| label =~ /rescue in/ }
+        .first
+
     scope ||= [:controllers, controller_namespace, controller_name, controller_method.to_sym]
     I18n.t(key, kwargs, scope: scope.compact)
   end

--- a/app/controllers/concerns/controller_helpers.rb
+++ b/app/controllers/concerns/controller_helpers.rb
@@ -119,8 +119,6 @@ module ControllerHelpers
     I18n.t(key, kwargs, scope: scope.compact)
   end
 
-  alias_method :t, :translation
-
   def controller_namespace
     @controller_namespace ||= self.class.parent.name != "Object" ? self.class.parent.name.downcase : nil
   end

--- a/app/controllers/concerns/controller_helpers.rb
+++ b/app/controllers/concerns/controller_helpers.rb
@@ -31,7 +31,8 @@ module ControllerHelpers
     Rack::MiniProfiler.authorize_request unless Rails.env.test?
   end
 
-  def authenticate_user(msg = "Sorry, you have to log in", flash_type: :error)
+  def authenticate_user(msg = nil, flash_type: :error)
+    msg ||= "Sorry, you have to log in"
     # Make absolutely sure the current user is confirmed - mainly for testing
     if current_user&.confirmed?
       return true if current_user.terms_of_service
@@ -105,7 +106,8 @@ module ControllerHelpers
   end
 
   def translation(key, scope: nil, controller_method: nil, **kwargs)
-    controller_method = controller_method.presence || action_name
+    calling_method = caller_locations.first.label
+    controller_method = controller_method.presence || calling_method
     scope ||= [:controllers, controller_namespace, controller_name, controller_method.to_sym]
     I18n.t(key, kwargs, scope: scope.compact)
   end

--- a/app/controllers/concerns/controller_helpers.rb
+++ b/app/controllers/concerns/controller_helpers.rb
@@ -116,7 +116,7 @@ module ControllerHelpers
     end
 
     scope ||= [:controllers, controller_namespace, controller_name, controller_method.to_sym]
-    I18n.t(key, kwargs, scope: scope.compact)
+    I18n.t(key, **kwargs, scope: scope.compact)
   end
 
   def controller_namespace

--- a/app/controllers/concerns/controller_helpers.rb
+++ b/app/controllers/concerns/controller_helpers.rb
@@ -109,8 +109,8 @@ module ControllerHelpers
     if scope.blank? && controller_method.blank?
       controller_method =
         caller_locations
-          .map(&:label)
           .slice(0, 2)
+          .map(&:label)
           .reject { |label| label =~ /rescue in/ }
           .first
     end

--- a/app/controllers/feedbacks_controller.rb
+++ b/app/controllers/feedbacks_controller.rb
@@ -12,9 +12,9 @@ class FeedbacksController < ApplicationController
     return true if block_the_spam(@feedback)
     if @feedback.save
       if @feedback.lead?
-        flash[:success] = t(:we_will_contact_you)
+        flash[:success] = translation(:we_will_contact_you)
       else
-        flash[:success] = t(:thanks_for_your_message)
+        flash[:success] = translation(:thanks_for_your_message)
       end
       if request.env["HTTP_REFERER"].present? and request.env["HTTP_REFERER"] != request.env["REQUEST_URI"]
         redirect_to :back
@@ -42,7 +42,7 @@ class FeedbacksController < ApplicationController
     # Previously, we were authenticating users in a before_filter
     # But to make it possible for non-signed in users to generate leads, we're trying this out
     return false unless feedback.looks_like_spam?
-    flash[:error] = t(:please_sign_in)
+    flash[:error] = translation(:please_sign_in)
     redirect_to :back and return true
   end
 

--- a/app/controllers/feedbacks_controller.rb
+++ b/app/controllers/feedbacks_controller.rb
@@ -42,7 +42,7 @@ class FeedbacksController < ApplicationController
     # Previously, we were authenticating users in a before_filter
     # But to make it possible for non-signed in users to generate leads, we're trying this out
     return false unless feedback.looks_like_spam?
-    flash[:error] = translation(:please_sign_in, controller_method: __method__)
+    flash[:error] = translation(:please_sign_in)
     redirect_to :back and return true
   end
 

--- a/app/controllers/feedbacks_controller.rb
+++ b/app/controllers/feedbacks_controller.rb
@@ -42,7 +42,7 @@ class FeedbacksController < ApplicationController
     # Previously, we were authenticating users in a before_filter
     # But to make it possible for non-signed in users to generate leads, we're trying this out
     return false unless feedback.looks_like_spam?
-    flash[:error] = translation(:please_sign_in, scope: %i[controllers feedbacks block_the_spam])
+    flash[:error] = translation(:please_sign_in, controller_method: __method__)
     redirect_to :back and return true
   end
 

--- a/app/controllers/feedbacks_controller.rb
+++ b/app/controllers/feedbacks_controller.rb
@@ -12,9 +12,9 @@ class FeedbacksController < ApplicationController
     return true if block_the_spam(@feedback)
     if @feedback.save
       if @feedback.lead?
-        flash[:success] = "Thank you! We'll contact you soon."
+        flash[:success] = translation(:we_will_contact_you)
       else
-        flash[:success] = "Thanks for your message!"
+        flash[:success] = translation(:thanks_for_your_message)
       end
       if request.env["HTTP_REFERER"].present? and request.env["HTTP_REFERER"] != request.env["REQUEST_URI"]
         redirect_to :back
@@ -42,7 +42,7 @@ class FeedbacksController < ApplicationController
     # Previously, we were authenticating users in a before_filter
     # But to make it possible for non-signed in users to generate leads, we're trying this out
     return false unless feedback.looks_like_spam?
-    flash[:error] = "Please sign in to send that message"
+    flash[:error] = translation(:please_sign_in, scope: %i[controllers feedbacks block_the_spam])
     redirect_to :back and return true
   end
 

--- a/app/controllers/feedbacks_controller.rb
+++ b/app/controllers/feedbacks_controller.rb
@@ -12,9 +12,9 @@ class FeedbacksController < ApplicationController
     return true if block_the_spam(@feedback)
     if @feedback.save
       if @feedback.lead?
-        flash[:success] = translation(:we_will_contact_you)
+        flash[:success] = t(:we_will_contact_you)
       else
-        flash[:success] = translation(:thanks_for_your_message)
+        flash[:success] = t(:thanks_for_your_message)
       end
       if request.env["HTTP_REFERER"].present? and request.env["HTTP_REFERER"] != request.env["REQUEST_URI"]
         redirect_to :back
@@ -42,7 +42,7 @@ class FeedbacksController < ApplicationController
     # Previously, we were authenticating users in a before_filter
     # But to make it possible for non-signed in users to generate leads, we're trying this out
     return false unless feedback.looks_like_spam?
-    flash[:error] = translation(:please_sign_in)
+    flash[:error] = t(:please_sign_in)
     redirect_to :back and return true
   end
 

--- a/app/controllers/integrations_controller.rb
+++ b/app/controllers/integrations_controller.rb
@@ -19,8 +19,9 @@ class IntegrationsController < ApplicationController
   def integrations_controller_creation_error
     provider_name = request.env["omniauth.auth"] && request.env["omniauth.auth"]["provider"]
     provider_name ||= params[:strategy]
-    msg = "There was a problem authenticating you with #{provider_name}. Please sign in a different way or email us at contact@bikeindex.org"
-    flash[:error] = msg
+
+    flash[:error] = translation(:problem_authenticating_with_provider,
+                                provider_name: provider_name)
     redirect_to new_session_path and return
   end
 end

--- a/app/controllers/integrations_controller.rb
+++ b/app/controllers/integrations_controller.rb
@@ -20,7 +20,8 @@ class IntegrationsController < ApplicationController
     provider_name = request.env["omniauth.auth"] && request.env["omniauth.auth"]["provider"]
     provider_name ||= params[:strategy]
 
-    flash[:error] = t(:problem_authenticating_with_provider, provider_name: provider_name)
+    flash[:error] = translation(:problem_authenticating_with_provider,
+                                provider_name: provider_name)
     redirect_to new_session_path and return
   end
 end

--- a/app/controllers/integrations_controller.rb
+++ b/app/controllers/integrations_controller.rb
@@ -20,8 +20,7 @@ class IntegrationsController < ApplicationController
     provider_name = request.env["omniauth.auth"] && request.env["omniauth.auth"]["provider"]
     provider_name ||= params[:strategy]
 
-    flash[:error] = translation(:problem_authenticating_with_provider,
-                                provider_name: provider_name)
+    flash[:error] = t(:problem_authenticating_with_provider, provider_name: provider_name)
     redirect_to new_session_path and return
   end
 end

--- a/app/controllers/locks_controller.rb
+++ b/app/controllers/locks_controller.rb
@@ -21,7 +21,7 @@ class LocksController < ApplicationController
   def create
     @lock = current_user.locks.build(permitted_parameters)
     if @lock.save
-      flash[:success] = "Lock created successfully!"
+      flash[:success] = translation(:lock_created)
       redirect_to user_home_path(active_tab: "locks")
     else
       @page_errors = @lock.errors
@@ -39,7 +39,7 @@ class LocksController < ApplicationController
   def find_lock
     @lock = current_user.locks.where(id: params[:id]).first
     unless @lock.present?
-      flash[:error] = "Whoops, that's not your lock!"
+      flash[:error] = translation(:not_your_lock, scope: %i[controllers locks find_lock])
       redirect_to user_home_path and return
     end
   end

--- a/app/controllers/locks_controller.rb
+++ b/app/controllers/locks_controller.rb
@@ -21,7 +21,7 @@ class LocksController < ApplicationController
   def create
     @lock = current_user.locks.build(permitted_parameters)
     if @lock.save
-      flash[:success] = translation(:lock_created)
+      flash[:success] = t(:lock_created)
       redirect_to user_home_path(active_tab: "locks")
     else
       @page_errors = @lock.errors
@@ -39,7 +39,7 @@ class LocksController < ApplicationController
   def find_lock
     @lock = current_user.locks.where(id: params[:id]).first
     unless @lock.present?
-      flash[:error] = translation(:not_your_lock)
+      flash[:error] = t(:not_your_lock)
       redirect_to user_home_path and return
     end
   end

--- a/app/controllers/locks_controller.rb
+++ b/app/controllers/locks_controller.rb
@@ -21,7 +21,7 @@ class LocksController < ApplicationController
   def create
     @lock = current_user.locks.build(permitted_parameters)
     if @lock.save
-      flash[:success] = t(:lock_created)
+      flash[:success] = translation(:lock_created)
       redirect_to user_home_path(active_tab: "locks")
     else
       @page_errors = @lock.errors
@@ -39,7 +39,7 @@ class LocksController < ApplicationController
   def find_lock
     @lock = current_user.locks.where(id: params[:id]).first
     unless @lock.present?
-      flash[:error] = t(:not_your_lock)
+      flash[:error] = translation(:not_your_lock)
       redirect_to user_home_path and return
     end
   end

--- a/app/controllers/locks_controller.rb
+++ b/app/controllers/locks_controller.rb
@@ -39,7 +39,7 @@ class LocksController < ApplicationController
   def find_lock
     @lock = current_user.locks.where(id: params[:id]).first
     unless @lock.present?
-      flash[:error] = translation(:not_your_lock, scope: %i[controllers locks find_lock])
+      flash[:error] = translation(:not_your_lock, controller_method: __method__)
       redirect_to user_home_path and return
     end
   end

--- a/app/controllers/locks_controller.rb
+++ b/app/controllers/locks_controller.rb
@@ -39,7 +39,7 @@ class LocksController < ApplicationController
   def find_lock
     @lock = current_user.locks.where(id: params[:id]).first
     unless @lock.present?
-      flash[:error] = translation(:not_your_lock, controller_method: __method__)
+      flash[:error] = translation(:not_your_lock)
       redirect_to user_home_path and return
     end
   end

--- a/app/controllers/oauth/applications_controller.rb
+++ b/app/controllers/oauth/applications_controller.rb
@@ -13,7 +13,7 @@ module Oauth
       @application = Doorkeeper::Application.new(application_params)
       @application.owner = current_user
       if @application.save
-        flash[:notice] = translation(:notice, scope: %i[doorkeeper flash applications create])
+        flash[:notice] = t(:notice, scope: %i[doorkeeper flash applications create])
         # respond_with( :oauth, @application, location: oauth_application_url(@application) )
         Doorkeeper::AccessToken.create!(application_id: @application.id, resource_owner_id: ENV["V2_ACCESSOR_ID"], expires_in: nil, scopes: "write_bikes")
         redirect_to oauth_application_url(@application)

--- a/app/controllers/oauth/applications_controller.rb
+++ b/app/controllers/oauth/applications_controller.rb
@@ -13,7 +13,7 @@ module Oauth
       @application = Doorkeeper::Application.new(application_params)
       @application.owner = current_user
       if @application.save
-        flash[:notice] = translation(:notice, scope: [:doorkeeper, :flash, :applications, :create])
+        flash[:notice] = translation(:notice, scope: %i[doorkeeper flash applications create])
         # respond_with( :oauth, @application, location: oauth_application_url(@application) )
         Doorkeeper::AccessToken.create!(application_id: @application.id, resource_owner_id: ENV["V2_ACCESSOR_ID"], expires_in: nil, scopes: "write_bikes")
         redirect_to oauth_application_url(@application)

--- a/app/controllers/oauth/applications_controller.rb
+++ b/app/controllers/oauth/applications_controller.rb
@@ -13,7 +13,7 @@ module Oauth
       @application = Doorkeeper::Application.new(application_params)
       @application.owner = current_user
       if @application.save
-        flash[:notice] = t(:notice, scope: %i[doorkeeper flash applications create])
+        flash[:notice] = translation(:notice, scope: %i[doorkeeper flash applications create])
         # respond_with( :oauth, @application, location: oauth_application_url(@application) )
         Doorkeeper::AccessToken.create!(application_id: @application.id, resource_owner_id: ENV["V2_ACCESSOR_ID"], expires_in: nil, scopes: "write_bikes")
         redirect_to oauth_application_url(@application)

--- a/app/controllers/organizations_controller.rb
+++ b/app/controllers/organizations_controller.rb
@@ -15,10 +15,10 @@ class OrganizationsController < ApplicationController
 
     session[:return_to] = lightspeed_interface_path
     if current_user.present?
-      flash[:info] = t(:must_create_an_organization_first)
+      flash[:info] = translation(:must_create_an_organization_first)
       redirect_to new_organization_path
     else
-      flash[:info] = t(:must_create_an_account_first)
+      flash[:info] = translation(:must_create_an_account_first)
       redirect_to new_user_path and return
     end
   end
@@ -28,7 +28,7 @@ class OrganizationsController < ApplicationController
     if @organization.save
       Membership.create(user_id: current_user.id, role: "admin", organization_id: @organization.id)
       notify_admins("organization_created")
-      flash[:success] = t(:organization_created)
+      flash[:success] = translation(:organization_created)
       if current_user.present?
         redirect_to organization_manage_index_path(organization_id: @organization.to_param)
       end
@@ -69,7 +69,7 @@ class OrganizationsController < ApplicationController
   def set_bparam
     return true unless find_organization.present?
     unless find_organization.auto_user.present?
-      flash[:error] = t(:no_user)
+      flash[:error] = translation(:no_user)
       redirect_to root_url and return
     end
     if params[:b_param_id_token].present?
@@ -110,7 +110,7 @@ class OrganizationsController < ApplicationController
   def find_organization
     @organization = Organization.friendly_find(params[:id])
     return @organization if @organization.present?
-    flash[:error] = t(:not_found)
+    flash[:error] = translation(:not_found)
     redirect_to root_url and return
   end
 

--- a/app/controllers/organizations_controller.rb
+++ b/app/controllers/organizations_controller.rb
@@ -15,10 +15,10 @@ class OrganizationsController < ApplicationController
 
     session[:return_to] = lightspeed_interface_path
     if current_user.present?
-      flash[:info] = "You have to create an organization on Bike Index before you can connect with Lightspeed"
+      flash[:info] = translation(:must_create_an_organization_first)
       redirect_to new_organization_path
     else
-      flash[:info] = "You have to sign up for an account on Bike Index before you can connect with Lightspeed"
+      flash[:info] = translation(:must_create_an_account_first)
       redirect_to new_user_path and return
     end
   end
@@ -28,7 +28,7 @@ class OrganizationsController < ApplicationController
     if @organization.save
       Membership.create(user_id: current_user.id, role: "admin", organization_id: @organization.id)
       notify_admins("organization_created")
-      flash[:success] = "Organization Created successfully!"
+      flash[:success] = translation(:organization_created)
       if current_user.present?
         redirect_to organization_manage_index_path(organization_id: @organization.to_param)
       end
@@ -69,7 +69,7 @@ class OrganizationsController < ApplicationController
   def set_bparam
     return true unless find_organization.present?
     unless find_organization.auto_user.present?
-      flash[:error] = "We're sorry, that organization doesn't have a user set up to register bikes through. Email contact@bikeindex.org if this seems like an error."
+      flash[:error] = translation(:no_user, scope: %i[controllers organizations set_bparam])
       redirect_to root_url and return
     end
     if params[:b_param_id_token].present?
@@ -110,7 +110,7 @@ class OrganizationsController < ApplicationController
   def find_organization
     @organization = Organization.friendly_find(params[:id])
     return @organization if @organization.present?
-    flash[:error] = "We're sorry, that organization isn't on Bike Index yet. Email contact@bikeindex.org if this seems like an error."
+    flash[:error] = translation(:not_found, scope: %i[controllers organizations find_organization])
     redirect_to root_url and return
   end
 

--- a/app/controllers/organizations_controller.rb
+++ b/app/controllers/organizations_controller.rb
@@ -15,10 +15,10 @@ class OrganizationsController < ApplicationController
 
     session[:return_to] = lightspeed_interface_path
     if current_user.present?
-      flash[:info] = translation(:must_create_an_organization_first)
+      flash[:info] = t(:must_create_an_organization_first)
       redirect_to new_organization_path
     else
-      flash[:info] = translation(:must_create_an_account_first)
+      flash[:info] = t(:must_create_an_account_first)
       redirect_to new_user_path and return
     end
   end
@@ -28,7 +28,7 @@ class OrganizationsController < ApplicationController
     if @organization.save
       Membership.create(user_id: current_user.id, role: "admin", organization_id: @organization.id)
       notify_admins("organization_created")
-      flash[:success] = translation(:organization_created)
+      flash[:success] = t(:organization_created)
       if current_user.present?
         redirect_to organization_manage_index_path(organization_id: @organization.to_param)
       end
@@ -69,7 +69,7 @@ class OrganizationsController < ApplicationController
   def set_bparam
     return true unless find_organization.present?
     unless find_organization.auto_user.present?
-      flash[:error] = translation(:no_user)
+      flash[:error] = t(:no_user)
       redirect_to root_url and return
     end
     if params[:b_param_id_token].present?
@@ -110,7 +110,7 @@ class OrganizationsController < ApplicationController
   def find_organization
     @organization = Organization.friendly_find(params[:id])
     return @organization if @organization.present?
-    flash[:error] = translation(:not_found)
+    flash[:error] = t(:not_found)
     redirect_to root_url and return
   end
 

--- a/app/controllers/organizations_controller.rb
+++ b/app/controllers/organizations_controller.rb
@@ -69,7 +69,7 @@ class OrganizationsController < ApplicationController
   def set_bparam
     return true unless find_organization.present?
     unless find_organization.auto_user.present?
-      flash[:error] = translation(:no_user, controller_method: __method__)
+      flash[:error] = translation(:no_user)
       redirect_to root_url and return
     end
     if params[:b_param_id_token].present?
@@ -110,7 +110,7 @@ class OrganizationsController < ApplicationController
   def find_organization
     @organization = Organization.friendly_find(params[:id])
     return @organization if @organization.present?
-    flash[:error] = translation(:not_found, controller_method: __method__)
+    flash[:error] = translation(:not_found)
     redirect_to root_url and return
   end
 

--- a/app/controllers/organizations_controller.rb
+++ b/app/controllers/organizations_controller.rb
@@ -69,7 +69,7 @@ class OrganizationsController < ApplicationController
   def set_bparam
     return true unless find_organization.present?
     unless find_organization.auto_user.present?
-      flash[:error] = translation(:no_user, scope: %i[controllers organizations set_bparam])
+      flash[:error] = translation(:no_user, controller_method: __method__)
       redirect_to root_url and return
     end
     if params[:b_param_id_token].present?
@@ -110,7 +110,7 @@ class OrganizationsController < ApplicationController
   def find_organization
     @organization = Organization.friendly_find(params[:id])
     return @organization if @organization.present?
-    flash[:error] = translation(:not_found, scope: %i[controllers organizations find_organization])
+    flash[:error] = translation(:not_found, controller_method: __method__)
     redirect_to root_url and return
   end
 

--- a/app/controllers/public_images_controller.rb
+++ b/app/controllers/public_images_controller.rb
@@ -108,8 +108,7 @@ class PublicImagesController < ApplicationController
   def find_image_if_owned
     @public_image = PublicImage.unscoped.find(params[:id])
     unless current_user_image_owner(@public_image)
-      t_scope = %i[controllers public_images find_image_if_owned]
-      flash[:error] = translation(:no_permission_to_edit, scope: t_scope)
+      flash[:error] = translation(:no_permission_to_edit, controller_method: __method__)
       redirect_to @public_image.imageable and return
     end
   end

--- a/app/controllers/public_images_controller.rb
+++ b/app/controllers/public_images_controller.rb
@@ -27,7 +27,7 @@ class PublicImagesController < ApplicationController
       @public_image.save
       render json: { public_image: @public_image } and return
     end
-    flash[:error] = translation(:cannot_create)
+    flash[:error] = t(:cannot_create)
     redirect_to @public_image.present? ? @public_image.imageable : user_root_url
   end
 
@@ -41,7 +41,7 @@ class PublicImagesController < ApplicationController
 
   def update
     if @public_image.update_attributes(permitted_parameters)
-      redirect_to edit_bike_url(@public_image.imageable), notice: translation(:image_updated)
+      redirect_to edit_bike_url(@public_image.imageable), notice: t(:image_updated)
     else
       render :edit
     end
@@ -52,11 +52,11 @@ class PublicImagesController < ApplicationController
     imageable_id = @public_image.imageable_id
     imageable_type = @public_image.imageable_type
     if imageable_type == "MailSnippet"
-      flash[:error] = translation(:cannot_delete)
+      flash[:error] = t(:cannot_delete)
       redirect_to admin_organization_custom_layouts_path(imageable_id) and return
     end
     @public_image.destroy
-    flash[:success] = translation(:image_deleted)
+    flash[:success] = t(:image_deleted)
     if params[:page].present?
       redirect_to edit_bike_url(imageable_id, page: params[:page]) and return
     elsif imageable_type == "Blog"
@@ -108,7 +108,7 @@ class PublicImagesController < ApplicationController
   def find_image_if_owned
     @public_image = PublicImage.unscoped.find(params[:id])
     unless current_user_image_owner(@public_image)
-      flash[:error] = translation(:no_permission_to_edit)
+      flash[:error] = t(:no_permission_to_edit)
       redirect_to @public_image.imageable and return
     end
   end

--- a/app/controllers/public_images_controller.rb
+++ b/app/controllers/public_images_controller.rb
@@ -108,7 +108,7 @@ class PublicImagesController < ApplicationController
   def find_image_if_owned
     @public_image = PublicImage.unscoped.find(params[:id])
     unless current_user_image_owner(@public_image)
-      flash[:error] = translation(:no_permission_to_edit, controller_method: __method__)
+      flash[:error] = translation(:no_permission_to_edit)
       redirect_to @public_image.imageable and return
     end
   end

--- a/app/controllers/public_images_controller.rb
+++ b/app/controllers/public_images_controller.rb
@@ -27,7 +27,7 @@ class PublicImagesController < ApplicationController
       @public_image.save
       render json: { public_image: @public_image } and return
     end
-    flash[:error] = "Whoops! We can't let you create that image."
+    flash[:error] = translation(:cannot_create)
     redirect_to @public_image.present? ? @public_image.imageable : user_root_url
   end
 
@@ -41,7 +41,7 @@ class PublicImagesController < ApplicationController
 
   def update
     if @public_image.update_attributes(permitted_parameters)
-      redirect_to edit_bike_url(@public_image.imageable), notice: "Image was successfully updated."
+      redirect_to edit_bike_url(@public_image.imageable), notice: translation(:image_updated)
     else
       render :edit
     end
@@ -52,11 +52,11 @@ class PublicImagesController < ApplicationController
     imageable_id = @public_image.imageable_id
     imageable_type = @public_image.imageable_type
     if imageable_type == "MailSnippet"
-      flash[:error] = "Whoops! How'd you do that? Can't delete mail snippet images."
+      flash[:error] = translation(:cannot_delete)
       redirect_to admin_organization_custom_layouts_path(imageable_id) and return
     end
     @public_image.destroy
-    flash[:success] = "Image was successfully deleted"
+    flash[:success] = translation(:image_deleted)
     if params[:page].present?
       redirect_to edit_bike_url(imageable_id, page: params[:page]) and return
     elsif imageable_type == "Blog"
@@ -108,7 +108,8 @@ class PublicImagesController < ApplicationController
   def find_image_if_owned
     @public_image = PublicImage.unscoped.find(params[:id])
     unless current_user_image_owner(@public_image)
-      flash[:error] = "Sorry! You don't have permission to edit that image."
+      t_scope = %i[controllers public_images find_image_if_owned]
+      flash[:error] = translation(:no_permission_to_edit, scope: t_scope)
       redirect_to @public_image.imageable and return
     end
   end

--- a/app/controllers/public_images_controller.rb
+++ b/app/controllers/public_images_controller.rb
@@ -27,7 +27,7 @@ class PublicImagesController < ApplicationController
       @public_image.save
       render json: { public_image: @public_image } and return
     end
-    flash[:error] = t(:cannot_create)
+    flash[:error] = translation(:cannot_create)
     redirect_to @public_image.present? ? @public_image.imageable : user_root_url
   end
 
@@ -41,7 +41,7 @@ class PublicImagesController < ApplicationController
 
   def update
     if @public_image.update_attributes(permitted_parameters)
-      redirect_to edit_bike_url(@public_image.imageable), notice: t(:image_updated)
+      redirect_to edit_bike_url(@public_image.imageable), notice: translation(:image_updated)
     else
       render :edit
     end
@@ -52,11 +52,11 @@ class PublicImagesController < ApplicationController
     imageable_id = @public_image.imageable_id
     imageable_type = @public_image.imageable_type
     if imageable_type == "MailSnippet"
-      flash[:error] = t(:cannot_delete)
+      flash[:error] = translation(:cannot_delete)
       redirect_to admin_organization_custom_layouts_path(imageable_id) and return
     end
     @public_image.destroy
-    flash[:success] = t(:image_deleted)
+    flash[:success] = translation(:image_deleted)
     if params[:page].present?
       redirect_to edit_bike_url(imageable_id, page: params[:page]) and return
     elsif imageable_type == "Blog"
@@ -108,7 +108,7 @@ class PublicImagesController < ApplicationController
   def find_image_if_owned
     @public_image = PublicImage.unscoped.find(params[:id])
     unless current_user_image_owner(@public_image)
-      flash[:error] = t(:no_permission_to_edit)
+      flash[:error] = translation(:no_permission_to_edit)
       redirect_to @public_image.imageable and return
     end
   end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -22,10 +22,10 @@ class SessionsController < ApplicationController
     user = User.fuzzy_confirmed_or_unconfirmed_email_find(params[:email])
     if user.present?
       user.send_magic_link_email
-      flash[:success] = t(:link_sent)
+      flash[:success] = translation(:link_sent)
       redirect_to root_path
     else
-      flash[:error] = t(:user_not_found)
+      flash[:error] = translation(:user_not_found)
       redirect_to new_user_path
     end
   end
@@ -37,16 +37,16 @@ class SessionsController < ApplicationController
         sign_in_and_redirect(@user)
       else
         # User couldn't authenticate, so password is invalid
-        flash.now[:error] = t(:invalid_email_or_password)
+        flash.now[:error] = translation(:invalid_email_or_password)
         # If user is banned, tell them about it.
         if @user.banned?
-          flash.now[:error] = t(:user_is_banned)
+          flash.now[:error] = translation(:user_is_banned)
         end
         render_partner_or_default_signin_layout(render_action: :new)
       end
     else
       # Email address is not in the DB
-      flash.now[:error] = t(:invalid_email_or_password)
+      flash.now[:error] = translation(:invalid_email_or_password)
       render_partner_or_default_signin_layout(render_action: :new)
     end
   end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -22,10 +22,10 @@ class SessionsController < ApplicationController
     user = User.fuzzy_confirmed_or_unconfirmed_email_find(params[:email])
     if user.present?
       user.send_magic_link_email
-      flash[:success] = "Sign in link sent! Just click the link in your email to sign in"
+      flash[:success] = translation(:link_sent)
       redirect_to root_path
     else
-      flash[:error] = "Unable to find that user"
+      flash[:error] = translation(:user_not_found)
       redirect_to new_user_path
     end
   end
@@ -37,16 +37,16 @@ class SessionsController < ApplicationController
         sign_in_and_redirect(@user)
       else
         # User couldn't authenticate, so password is invalid
-        flash.now[:error] = "Invalid email/password"
+        flash.now[:error] = translation(:invalid_email_or_password)
         # If user is banned, tell them about it.
         if @user.banned?
-          flash.now[:error] = "We're sorry, but it appears that your account has been locked. If you are unsure as to the reasons for this, please contact us"
+          flash.now[:error] = translation(:user_is_banned)
         end
         render_partner_or_default_signin_layout(render_action: :new)
       end
     else
       # Email address is not in the DB
-      flash.now[:error] = "Invalid email/password"
+      flash.now[:error] = translation(:invalid_email_or_password)
       render_partner_or_default_signin_layout(render_action: :new)
     end
   end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -22,10 +22,10 @@ class SessionsController < ApplicationController
     user = User.fuzzy_confirmed_or_unconfirmed_email_find(params[:email])
     if user.present?
       user.send_magic_link_email
-      flash[:success] = translation(:link_sent)
+      flash[:success] = t(:link_sent)
       redirect_to root_path
     else
-      flash[:error] = translation(:user_not_found)
+      flash[:error] = t(:user_not_found)
       redirect_to new_user_path
     end
   end
@@ -37,16 +37,16 @@ class SessionsController < ApplicationController
         sign_in_and_redirect(@user)
       else
         # User couldn't authenticate, so password is invalid
-        flash.now[:error] = translation(:invalid_email_or_password)
+        flash.now[:error] = t(:invalid_email_or_password)
         # If user is banned, tell them about it.
         if @user.banned?
-          flash.now[:error] = translation(:user_is_banned)
+          flash.now[:error] = t(:user_is_banned)
         end
         render_partner_or_default_signin_layout(render_action: :new)
       end
     else
       # Email address is not in the DB
-      flash.now[:error] = translation(:invalid_email_or_password)
+      flash.now[:error] = t(:invalid_email_or_password)
       render_partner_or_default_signin_layout(render_action: :new)
     end
   end

--- a/app/controllers/stolen_notifications_controller.rb
+++ b/app/controllers/stolen_notifications_controller.rb
@@ -10,13 +10,13 @@ class StolenNotificationsController < ApplicationController
     @stolen_notification.sender = current_user
     @bike = @stolen_notification.bike
     if !@bike.contact_owner?(current_user)
-      flash[:error] = t(:unauthorized)
+      flash[:error] = translation(:unauthorized)
       redirect_to @bike
     elsif @stolen_notification.save
-      flash[:success] = t(:thanks)
+      flash[:success] = translation(:thanks)
       redirect_to @bike
     else
-      flash[:error] = t(:failure)
+      flash[:error] = translation(:failure)
       render @bike
     end
   end

--- a/app/controllers/stolen_notifications_controller.rb
+++ b/app/controllers/stolen_notifications_controller.rb
@@ -10,13 +10,13 @@ class StolenNotificationsController < ApplicationController
     @stolen_notification.sender = current_user
     @bike = @stolen_notification.bike
     if !@bike.contact_owner?(current_user)
-      flash[:error] = translation(:unauthorized)
+      flash[:error] = t(:unauthorized)
       redirect_to @bike
     elsif @stolen_notification.save
-      flash[:success] = translation(:thanks)
+      flash[:success] = t(:thanks)
       redirect_to @bike
     else
-      flash[:error] = translation(:failure)
+      flash[:error] = t(:failure)
       render @bike
     end
   end

--- a/app/controllers/stolen_notifications_controller.rb
+++ b/app/controllers/stolen_notifications_controller.rb
@@ -10,13 +10,13 @@ class StolenNotificationsController < ApplicationController
     @stolen_notification.sender = current_user
     @bike = @stolen_notification.bike
     if !@bike.contact_owner?(current_user)
-      flash[:error] = "You don't have permission to send that notification! Please contact support@bikeindex.org"
+      flash[:error] = translation(:unauthorized)
       redirect_to @bike
     elsif @stolen_notification.save
-      flash[:success] = "Thanks for looking out!"
+      flash[:success] = translation(:thanks)
       redirect_to @bike
     else
-      flash[:error] = "Crap! We couldn't send your notification. Please try again."
+      flash[:error] = translation(:failure)
       render @bike
     end
   end

--- a/app/controllers/theft_alerts_controller.rb
+++ b/app/controllers/theft_alerts_controller.rb
@@ -18,11 +18,11 @@ class TheftAlertsController < ApplicationController
 
     theft_alert.update(payment: payment)
   rescue ActiveRecord::RecordInvalid, ActiveRecord::RecordNotFound
-    flash[:error] = t(:unable_to_process_order)
+    flash[:error] = translation(:unable_to_process_order)
     redirect_to edit_bike_url(@bike, params: { page: :alert_purchase })
   rescue Stripe::CardError
     TheftAlertPurchaseNotificationWorker.perform_async(theft_alert.id)
-    flash[:error] = t(:order_is_pending)
+    flash[:error] = translation(:order_is_pending)
     redirect_to edit_bike_url(@bike, params: { page: :alert_purchase })
   else
     TheftAlertPurchaseNotificationWorker.perform_async(theft_alert.id)
@@ -36,7 +36,7 @@ class TheftAlertsController < ApplicationController
     @current_ownership = @bike&.current_ownership
     return true if @bike&.authorize_and_claim_for_user(current_user)
 
-    flash[:error] = t(:unauthorized)
+    flash[:error] = translation(:unauthorized)
     redirect_to bikes_url and return
   end
 end

--- a/app/controllers/theft_alerts_controller.rb
+++ b/app/controllers/theft_alerts_controller.rb
@@ -18,11 +18,11 @@ class TheftAlertsController < ApplicationController
 
     theft_alert.update(payment: payment)
   rescue ActiveRecord::RecordInvalid, ActiveRecord::RecordNotFound
-    flash[:error] = "We were unable to process your order. Please contact support."
+    flash[:error] = translation(:unable_to_process_order)
     redirect_to edit_bike_url(@bike, params: { page: :alert_purchase })
   rescue Stripe::CardError
     TheftAlertPurchaseNotificationWorker.perform_async(theft_alert.id)
-    flash[:error] = "Your order is pending, but we were unable to complete payment. Please contact support to complete your purchase."
+    flash[:error] = translation(:order_is_pending)
     redirect_to edit_bike_url(@bike, params: { page: :alert_purchase })
   else
     TheftAlertPurchaseNotificationWorker.perform_async(theft_alert.id)
@@ -36,7 +36,8 @@ class TheftAlertsController < ApplicationController
     @current_ownership = @bike&.current_ownership
     return true if @bike&.authorize_and_claim_for_user(current_user)
 
-    flash[:error] = "You don't have permission to do that. Please contact support."
+    t_scope = %i[controllers theft_alerts ensure_user_allowed_to_create_theft_alert]
+    flash[:error] = translation(:unauthorized, scope: t_scope)
     redirect_to bikes_url and return
   end
 end

--- a/app/controllers/theft_alerts_controller.rb
+++ b/app/controllers/theft_alerts_controller.rb
@@ -36,7 +36,7 @@ class TheftAlertsController < ApplicationController
     @current_ownership = @bike&.current_ownership
     return true if @bike&.authorize_and_claim_for_user(current_user)
 
-    flash[:error] = translation(:unauthorized, controller_method: __method__)
+    flash[:error] = translation(:unauthorized)
     redirect_to bikes_url and return
   end
 end

--- a/app/controllers/theft_alerts_controller.rb
+++ b/app/controllers/theft_alerts_controller.rb
@@ -18,11 +18,11 @@ class TheftAlertsController < ApplicationController
 
     theft_alert.update(payment: payment)
   rescue ActiveRecord::RecordInvalid, ActiveRecord::RecordNotFound
-    flash[:error] = translation(:unable_to_process_order)
+    flash[:error] = t(:unable_to_process_order)
     redirect_to edit_bike_url(@bike, params: { page: :alert_purchase })
   rescue Stripe::CardError
     TheftAlertPurchaseNotificationWorker.perform_async(theft_alert.id)
-    flash[:error] = translation(:order_is_pending)
+    flash[:error] = t(:order_is_pending)
     redirect_to edit_bike_url(@bike, params: { page: :alert_purchase })
   else
     TheftAlertPurchaseNotificationWorker.perform_async(theft_alert.id)
@@ -36,7 +36,7 @@ class TheftAlertsController < ApplicationController
     @current_ownership = @bike&.current_ownership
     return true if @bike&.authorize_and_claim_for_user(current_user)
 
-    flash[:error] = translation(:unauthorized)
+    flash[:error] = t(:unauthorized)
     redirect_to bikes_url and return
   end
 end

--- a/app/controllers/theft_alerts_controller.rb
+++ b/app/controllers/theft_alerts_controller.rb
@@ -36,8 +36,7 @@ class TheftAlertsController < ApplicationController
     @current_ownership = @bike&.current_ownership
     return true if @bike&.authorize_and_claim_for_user(current_user)
 
-    t_scope = %i[controllers theft_alerts ensure_user_allowed_to_create_theft_alert]
-    flash[:error] = translation(:unauthorized, scope: t_scope)
+    flash[:error] = translation(:unauthorized, controller_method: __method__)
     redirect_to bikes_url and return
   end
 end

--- a/app/controllers/welcome_controller.rb
+++ b/app/controllers/welcome_controller.rb
@@ -46,7 +46,7 @@ class WelcomeController < ApplicationController
     @recovery_displays = RecoveryDisplay.page(page).per(@per_page)
     @slice1, @slice2 = list_halves(@recovery_displays)
 
-    flash[:notice] = translation(:no_stories_to_display) if @recovery_displays.empty?
+    flash[:notice] = t(:no_stories_to_display) if @recovery_displays.empty?
   end
 
   # Adding for testing purposes - so we can test where the root url for a user goes - sethherr, 2019-7-9
@@ -55,7 +55,7 @@ class WelcomeController < ApplicationController
   private
 
   def authenticate_user_for_welcome_controller
-    authenticate_user(translation(:create_account), flash_type: :info)
+    authenticate_user(t(:create_account), flash_type: :info)
   end
 
   # Split the given array `list` into two halves

--- a/app/controllers/welcome_controller.rb
+++ b/app/controllers/welcome_controller.rb
@@ -55,8 +55,7 @@ class WelcomeController < ApplicationController
   private
 
   def authenticate_user_for_welcome_controller
-    t_scope = %i[controllers welcome authenticate_user_for_welcome_controller]
-    authenticate_user(translation(:create_account, scope: t_scope), flash_type: :info)
+    authenticate_user(translation(:create_account, controller_method: __method__), flash_type: :info)
   end
 
   # Split the given array `list` into two halves

--- a/app/controllers/welcome_controller.rb
+++ b/app/controllers/welcome_controller.rb
@@ -46,7 +46,7 @@ class WelcomeController < ApplicationController
     @recovery_displays = RecoveryDisplay.page(page).per(@per_page)
     @slice1, @slice2 = list_halves(@recovery_displays)
 
-    flash[:notice] = t(:no_stories_to_display) if @recovery_displays.empty?
+    flash[:notice] = translation(:no_stories_to_display) if @recovery_displays.empty?
   end
 
   # Adding for testing purposes - so we can test where the root url for a user goes - sethherr, 2019-7-9
@@ -55,7 +55,7 @@ class WelcomeController < ApplicationController
   private
 
   def authenticate_user_for_welcome_controller
-    authenticate_user(t(:create_account), flash_type: :info)
+    authenticate_user(translation(:create_account), flash_type: :info)
   end
 
   # Split the given array `list` into two halves

--- a/app/controllers/welcome_controller.rb
+++ b/app/controllers/welcome_controller.rb
@@ -46,7 +46,7 @@ class WelcomeController < ApplicationController
     @recovery_displays = RecoveryDisplay.page(page).per(@per_page)
     @slice1, @slice2 = list_halves(@recovery_displays)
 
-    flash[:notice] = "No recovery stories to display" if @recovery_displays.empty?
+    flash[:notice] = translation(:no_stories_to_display) if @recovery_displays.empty?
   end
 
   # Adding for testing purposes - so we can test where the root url for a user goes - sethherr, 2019-7-9
@@ -55,7 +55,8 @@ class WelcomeController < ApplicationController
   private
 
   def authenticate_user_for_welcome_controller
-    authenticate_user("Please create an account", flash_type: :info)
+    t_scope = %i[controllers welcome authenticate_user_for_welcome_controller]
+    authenticate_user(translation(:create_account, scope: t_scope), flash_type: :info)
   end
 
   # Split the given array `list` into two halves

--- a/app/controllers/welcome_controller.rb
+++ b/app/controllers/welcome_controller.rb
@@ -55,7 +55,7 @@ class WelcomeController < ApplicationController
   private
 
   def authenticate_user_for_welcome_controller
-    authenticate_user(translation(:create_account, controller_method: __method__), flash_type: :info)
+    authenticate_user(translation(:create_account), flash_type: :info)
   end
 
   # Split the given array `list` into two halves

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1493,6 +1493,12 @@ en:
         please_sign_in_to_register: Please sign in to register a bike
         we_couldnt_find_that_registration: Oops! We couldn't find that registration,
           please re-enter the information here
+      recovery:
+        ensure_token_match:
+          already_recovered: Bike has already been marked recovered!
+          incorrect_token: Incorrect Token, check your email again
+        update:
+          bike_recovered: Bike marked recovered! Thank you!
       scanned:
         unable_to_find_sticker: 'Unable to find sticker: %{scanned_id}'
       update:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1500,6 +1500,11 @@ en:
         problem_authenticating_with_provider: >-
           There was a problem authenticating you with %{provider_name}. Please sign
           in a different way or email us at contact@bikeindex.org
+    locks:
+      create:
+        lock_created: Lock created successfully!
+      find_lock:
+        not_your_lock: Whoops, that's not your lock!
     organizations:
       create:
         organization_created: Organization Created successfully!

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1517,6 +1517,15 @@ en:
         no_permission_to_edit: Sorry! You don't have permission to edit that image.
       update:
         image_updated: Image was successfully updated.
+    sessions:
+      create:
+        invalid_email_or_password: Invalid email/password
+        user_is_banned: >-
+          We're sorry, but it appears that your account has been locked. If you are
+          unsure as to the reasons for this, please contact us.
+      create_magic_link:
+        link_sent: Sign in link sent! Just click the link in your email to sign in
+        user_not_found: Unable to find that user
     stolen_notifications:
       create:
         failure: Crap! We couldn't send your notification. Please try again.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1495,6 +1495,11 @@ en:
       create:
         thanks_for_your_message: Thanks for your message!
         we_will_contact_you: Thank you! We'll contact you soon.
+    integrations:
+      create:
+        problem_authenticating_with_provider: >-
+          There was a problem authenticating you with %{provider_name}. Please sign
+          in a different way or email us at contact@bikeindex.org
     organizations:
       create:
         organization_created: Organization Created successfully!

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1517,6 +1517,12 @@ en:
         no_permission_to_edit: Sorry! You don't have permission to edit that image.
       update:
         image_updated: Image was successfully updated.
+    stolen_notifications:
+      create:
+        failure: Crap! We couldn't send your notification. Please try again.
+        thanks: Thanks for looking out!
+        unauthorized: >-
+          You don't have permission to send that notification! Please contact support@bikeindex.org
     theft_alerts:
       create:
         order_is_pending: >-

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1459,6 +1459,9 @@ en:
           You can't update that %{kind}. Please contact support@bikeindex.org if you
           think you should be able to.
     bikes:
+      assign_bike_codes:
+        sticker_assigned: Success! Sticker '%{code}' has been assigned to your %{bike_type}
+        unable_to_find_sticker: Unable to find a sticker matching %{bike_code}
       create:
         bike_was_added: Bike successfully added to the index!
         bike_was_sent_to: Success! %{bike_type} was sent to %{owner_email}.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1450,6 +1450,14 @@ en:
         csrf_invalid: >-
           CSRF invalid. If you don't know why you're receiving this message, please
           contact us.
+    bike_codes:
+      find_bike_code:
+        must_be_signed_in: You must be signed in to do that.
+        unable_to_find_sticker: 'Unable to find sticker with code: %{code}'
+      update:
+        cannot_update: >-
+          You can't update that %{kind}. Please contact support@bikeindex.org if you
+          think you should be able to.
     bikes:
       create:
         bike_was_added: Bike successfully added to the index!

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1541,6 +1541,11 @@ en:
           support.
       ensure_user_allowed_to_create_theft_alert:
         unauthorized: You don't have permission to do that. Please contact support.
+    welcome:
+      authenticate_user_for_welcome_controller:
+        create_account: Please create an account
+      recovery_stories:
+        no_stories_to_display: No recovery stories to display
   customer_mailer:
     additional_email_confirmation:
       html:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1489,6 +1489,12 @@ en:
         unable_to_find_sticker: 'Unable to find sticker: %{scanned_id}'
       update:
         bike_was_updated: Bike successfully updated!
+    feedbacks:
+      block_the_spam:
+        please_sign_in: Please sign in to send that message
+      create:
+        thanks_for_your_message: Thanks for your message!
+        we_will_contact_you: Thank you! We'll contact you soon.
     organizations:
       create:
         organization_created: Organization Created successfully!

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1507,6 +1507,16 @@ en:
         no_user: >-
           We're sorry, that organization doesn't have a user set up to register bikes
           through. Email contact@bikeindex.org if this seems like an error.
+    public_images:
+      create:
+        cannot_create: Whoops! We can't let you create that image.
+      destroy:
+        cannot_delete: Whoops! How'd you do that? Can't delete mail snippet images.
+        image_deleted: Image was successfully deleted
+      find_image_if_owned:
+        no_permission_to_edit: Sorry! You don't have permission to edit that image.
+      update:
+        image_updated: Image was successfully updated.
     theft_alerts:
       create:
         order_is_pending: >-

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1494,7 +1494,7 @@ en:
         we_couldnt_find_that_registration: Oops! We couldn't find that registration,
           please re-enter the information here
       recovery:
-        ensure_token_match:
+        ensure_token_match!:
           already_recovered: Bike has already been marked recovered!
           incorrect_token: Incorrect Token, check your email again
         update:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1489,6 +1489,24 @@ en:
         unable_to_find_sticker: 'Unable to find sticker: %{scanned_id}'
       update:
         bike_was_updated: Bike successfully updated!
+    organizations:
+      create:
+        organization_created: Organization Created successfully!
+      find_organization:
+        not_found: >-
+          We're sorry, that organization isn't on Bike Index yet. Email contact@bikeindex.org
+          if this seems like an error.
+      lightspeed_interface:
+        must_create_an_account_first: >-
+          You have to sign up for an account on Bike Index before you can connect
+          with Lightspeed
+        must_create_an_organization_first: >-
+          You have to create an organization on Bike Index before you can connect
+          with Lightspeed
+      set_bparam:
+        no_user: >-
+          We're sorry, that organization doesn't have a user set up to register bikes
+          through. Email contact@bikeindex.org if this seems like an error.
     theft_alerts:
       create:
         order_is_pending: >-

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1504,7 +1504,7 @@ en:
         thanks_for_your_message: Thanks for your message!
         we_will_contact_you: Thank you! We'll contact you soon.
     integrations:
-      create:
+      integrations_controller_creation_error:
         problem_authenticating_with_provider: >-
           There was a problem authenticating you with %{provider_name}. Please sign
           in a different way or email us at contact@bikeindex.org

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1460,7 +1460,8 @@ en:
           think you should be able to.
     bikes:
       assign_bike_codes:
-        sticker_assigned: Success! Sticker '%{code}' has been assigned to your %{bike_type}
+        sticker_assigned: Success! Sticker '%{bike_code}' has been assigned to your
+          %{bike_type}
         unable_to_find_sticker: Unable to find a sticker matching %{bike_code}
       create:
         bike_was_added: Bike successfully added to the index!

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1445,6 +1445,11 @@ en:
       start: Start
       status: Status
   controllers:
+    application:
+      handle_unverified_request:
+        csrf_invalid: >-
+          CSRF invalid. If you don't know why you're receiving this message, please
+          contact us.
     bikes:
       create:
         bike_was_added: Bike successfully added to the index!
@@ -1484,6 +1489,15 @@ en:
         unable_to_find_sticker: 'Unable to find sticker: %{scanned_id}'
       update:
         bike_was_updated: Bike successfully updated!
+    theft_alerts:
+      create:
+        order_is_pending: >-
+          Your order is pending, but we were unable to complete payment. Please contact
+          support to complete your purchase.
+        unable_to_process_order: We were unable to process your order. Please contact
+          support.
+      ensure_user_allowed_to_create_theft_alert:
+        unauthorized: You don't have permission to do that. Please contact support.
   customer_mailer:
     additional_email_confirmation:
       html:


### PR DESCRIPTION
- Externalizes flash strings from ~half our controllers

- Deepens `ControllerHelpers#translation` so it infers the method invoking it rather than the controller action in which it's invoked. This is useful because a private helper method or before action can be invoked in the context of multiple controller actions but we need a 1:1 mapping from call site to translation file key. 

```rb
# app/controllers/concerns/controller_helpers.rb L108-120 (c60a89ea)

def translation(key, scope: nil, controller_method: nil, **kwargs)
  if scope.blank? && controller_method.blank?
    controller_method =
      caller_locations
        .slice(0, 2)
        .map(&:label)
        .reject { |label| label =~ /rescue in/ }
        .first
  end

  scope ||= [:controllers, controller_namespace, controller_name, controller_method.to_sym]
  I18n.t(key, kwargs, scope: scope.compact)
end
```
<sup>[[source](https://github.com/bikeindex/bike_index/blob/c60a89ea/app/controllers/concerns/controller_helpers.rb#L108-L120)]</sup>

This allows the method to be invoked more often without passing the scope:

```rb
# app/controllers/bike_codes_controller.rb L22-30 (5b97a9e6)

protected

# . . .

def find_bike_code
  unless current_user.present?
    flash[:error] = translation(:must_be_signed_in)
# . . .
```
<sup>[[source](https://github.com/bikeindex/bike_index/blob/5b97a9e6/app/controllers/bike_codes_controller.rb#L22-L30)]</sup>

Instead of 
```rb
def find_bike_code
  unless current_user.present?
    flash[:error] = translation(:must_be_signed_in, scope: %i[controllers bike_codes find_bike_code])
```



Tracking: #963 