### PR TITLE
Add admin management of external registry bikes

### DIFF
--- a/app/controllers/admin/external_registry_bikes_controller.rb
+++ b/app/controllers/admin/external_registry_bikes_controller.rb
@@ -1,0 +1,38 @@
+class Admin::ExternalRegistryBikesController < Admin::BaseController
+  include SortableTable
+  before_filter :find_bike, only: %i[show]
+
+  def index
+    @page = params[:page] || 1
+    @bikes =
+      matching_bikes
+        .reorder("external_registry_bikes.#{sort_column} #{sort_direction}")
+        .page(@page)
+        .per(params[:per_page] || 100)
+  end
+
+  def show
+  end
+
+  private
+
+  def find_bike
+    @bike = ExternalRegistryBike.find(params[:id])
+  end
+
+  def matching_bikes
+    return @matching_bikes if defined?(@matching_bikes)
+
+    @matching_bikes = ExternalRegistryBike.all
+
+    if params[:search_serial_normalized].present?
+      @matching_bikes = @matching_bikes.where(serial_normalized: params[:search_serial_normalized])
+    end
+
+    @matching_bikes
+  end
+
+  def sortable_columns
+    %i[type country date_stolen created_at]
+  end
+end

--- a/app/helpers/admin_helper.rb
+++ b/app/helpers/admin_helper.rb
@@ -4,6 +4,7 @@ module AdminHelper
       { title: "Users", path: admin_users_path, match_controller: true },
       { title: "Bikes", path: admin_bikes_path, match_controller: true },
       { title: "Stolen Bikes", path: admin_stolen_bikes_path, match_controller: true },
+      { title: "External Registry Bikes", path: admin_external_registry_bikes_path, match_controller: true },
       { title: "Organizations", path: admin_organizations_path, match_controller: true },
       { title: "News", path: admin_news_index_path, match_controller: true },
       { title: "POS Integration", path: lightspeed_interface_path, match_controller: false },

--- a/app/views/admin/external_registry_bikes/_table.html.haml
+++ b/app/views/admin/external_registry_bikes/_table.html.haml
@@ -1,0 +1,52 @@
+- bikes ||= @bikes
+- no_show_header ||= false
+- show_serial ||= params[:show_serial].present?
+- render_sortable ||= false
+
+.full-screen-table
+  %table.table.table-striped.table-bordered.table-sm{ class: show_serial ? "show-admin-bike-table-serial-cell" : "" }
+    - unless no_show_header
+      %thead.thead-light.sortable
+        %th
+          - if render_sortable
+            = sortable "id", "Added"
+          - else
+            Added
+        %th
+          - if render_sortable
+            = sortable "manufacturer_id"
+          - else
+            Manufacturer
+        %th.d-none.d-lg-table-cell
+          Info
+        %th.admin-bike-table-serial-cell
+          Serial
+        %th.d-sm-table-cell
+          Registry
+
+    %tbody
+      - bikes.each do |bike|
+        - cache(bike) do
+          %tr
+            %td
+              .less-strong-hold
+                %a.small.convertTime{ href: admin_external_registry_bike_url(bike) }
+                  = l bike.created_at, format: :convert_time
+                %span.less-strong-right.d-none.d-md-block
+                  = bike.id
+            %td
+              = bike.mnfg_name
+            %td.d-none.d-lg-table-cell
+              .less-strong-hold
+                = bike.title_string
+                %span.less-strong
+                  = bike.frame_colors.to_sentence
+                - if bike.stolen?
+                  %span.less-strong-right
+                    stolen
+            %td.admin-bike-table-serial-cell
+              %small.less-strong
+                = bike.serial_number
+            %td.d-sm-table-cell
+              .less-strong-hold
+                = link_to bike.registry_name, admin_external_registry_bikes_path(sortable_search_params.merge(type: bike.type))

--- a/app/views/admin/external_registry_bikes/index.html.haml
+++ b/app/views/admin/external_registry_bikes/index.html.haml
@@ -1,0 +1,46 @@
+.admin-subnav
+  .col-md-5
+    %h1
+      Manage External Registry Bikes
+  .col-md-7
+    %ul
+      %li.nav-item
+        - all_ignored_params = %w[render_chart period sort direction]
+        - all_active = !@unknown && (sortable_search_params.keys - all_ignored_params).blank?
+        = link_to "All", admin_external_registry_bikes_path(sortable_search_params.slice(*all_ignored_params)),
+          class: "nav-link #{all_active ? 'active' : ''}"
+
+- if all_active
+  %p
+    = number_with_delimiter(ExternalRegistryBike.count)
+    stored external registry bikes,
+    %em
+      (#{ExternalRegistryBike.where("created_at >= ?", Time.current.beginning_of_day).count} today)
+
+.row.mt-4
+  .col-md-5
+    %p
+      %strong
+        = number_with_delimiter(@bikes.total_count)
+      = "Matching Bike".pluralize(@bikes.total_count)
+
+  .col-md-7
+    = form_tag admin_external_registry_bikes_path, method: :get, class: "form-inline" do
+      = hidden_field_tag :sort, params[:sort]
+      = hidden_field_tag :direction, params[:direction]
+      = hidden_field_tag :type, params[:type]
+      .form-group.ml-auto.mr-2.mb-2
+        = text_field_tag :search_serial_normalized,
+          params[:search_serial_normalized],
+          placeholder: "Search by serial number",
+          class: "form-control"
+
+      = submit_tag "Search", name: "search", class: "btn btn-primary mb-2"
+
+.row.mt-4
+  .col
+    = paginate @bikes, views_prefix: "admin"
+
+= render partial: "table", locals: { render_sortable: true }
+
+= paginate @bikes, views_prefix: "admin"

--- a/app/views/admin/external_registry_bikes/show.html.haml
+++ b/app/views/admin/external_registry_bikes/show.html.haml
@@ -1,0 +1,60 @@
+.admin-subnav.midpage-subnav
+  .col-12
+    %h1 External Registry Bike
+
+.admin-bike-partial
+  .row
+    .col-lg-2.col-3.mt-auto.mb-2.admin-image-thumb
+      - if @bike.thumb_url.present?
+        = image_tag @bike.thumb_url, alt: @bike.title_string
+      - else
+        %h3.less-strong
+          No Image
+    .col-lg-5.col-9.mt-auto.mb-2
+      %p.strong.mb-0
+        %span.text-danger= @bike.status.titleize
+        = @bike.title_string
+      %table.table-list.mb-0
+        %tbody
+          %tr
+            %td Serial number
+            %td= @bike.serial_number
+          %tr
+            %td Registry
+            %td= @bike.registry_name
+          %tr
+            %td Registry ID
+            %td= @bike.external_id
+          %tr
+            %td Description
+            %td= @bike.description
+          %tr
+            %td Colors
+            %td= @bike.frame_colors.to_sentence
+          %tr
+            %td Created
+            %td
+              %span.convertTime= l @bike.created_at, format: :convert_time
+              %small.convertTimezone
+          %tr
+            %td Updated
+            %td
+              %span.convertTime= l @bike.updated_at, format: :convert_time
+
+    .col-lg-5.col-9.mt-auto.mb-2
+      %table.table-list
+        %tr
+          %td Date Stolen
+          %td.convertTime= l @bike.date_stolen, format: :convert_time
+        %tr
+          %td Location Found
+          %td= @bike.location_found
+        %tr
+          %td Registry Link
+          %td= link_to @bike.url, @bike.url, target: :_blank
+
+.container.mt-4
+  .row
+    %h3 Info hash
+  .row
+    = debug @bike.info_hash

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -150,6 +150,9 @@ Bikeindex::Application.routes.draw do
     root to: "dashboard#index"
     resources :ambassador_tasks, except: :show
     resources :ambassador_task_assignments, only: [:index]
+
+    resources :external_registry_bikes, only: %i[index show]
+
     resources :bikes do
       collection do
         get :duplicates


### PR DESCRIPTION
Adds admin views for external registry bikes (minimally, index and show)


<img width="1415" alt="Screen Shot 2019-10-11 at 9 59 00 AM" src="https://user-images.githubusercontent.com/4433943/66661151-88cabd80-ec14-11e9-8333-f2efdf76b9a6.png">
<img width="1400" alt="Screen Shot 2019-10-11 at 9 59 06 AM" src="https://user-images.githubusercontent.com/4433943/66661152-88cabd80-ec14-11e9-801e-66f5ded2ca11.png">
