### PR TITLE
Fix sorting and filtering of admin external bikes

### DIFF
--- a/app/controllers/admin/external_registry_bikes_controller.rb
+++ b/app/controllers/admin/external_registry_bikes_controller.rb
@@ -11,8 +11,7 @@ class Admin::ExternalRegistryBikesController < Admin::BaseController
         .per(params[:per_page] || 100)
   end
 
-  def show
-  end
+  def show; end
 
   private
 
@@ -29,10 +28,14 @@ class Admin::ExternalRegistryBikesController < Admin::BaseController
       @matching_bikes = @matching_bikes.where(serial_normalized: params[:search_serial_normalized])
     end
 
+    if params[:type].present?
+      @matching_bikes = @matching_bikes.where(type: params[:type])
+    end
+
     @matching_bikes
   end
 
   def sortable_columns
-    %i[type country date_stolen created_at]
+    %w[created_at mnfg_name]
   end
 end

--- a/app/views/admin/external_registry_bikes/_table.html.haml
+++ b/app/views/admin/external_registry_bikes/_table.html.haml
@@ -9,12 +9,12 @@
       %thead.thead-light.sortable
         %th
           - if render_sortable
-            = sortable "id", "Added"
+            = sortable "created_at", "Added"
           - else
             Added
         %th
           - if render_sortable
-            = sortable "manufacturer_id"
+            = sortable "mnfg_name", "Manufacturer"
           - else
             Manufacturer
         %th.d-none.d-lg-table-cell
@@ -49,4 +49,5 @@
                 = bike.serial_number
             %td.d-sm-table-cell
               .less-strong-hold
-                = link_to bike.registry_name, admin_external_registry_bikes_path(sortable_search_params.merge(type: bike.type))
+                = link_to bike.registry_name,
+                  admin_external_registry_bikes_path(sortable_search_params.merge(type: bike.type))

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -607,7 +607,7 @@ RSpec.describe UsersController, type: :controller do
         expect(user.preferred_language).to eq(nil)
         set_current_user(user)
         patch :update, id: user.username, locale: "nl", user: { preferred_language: "en" }
-        expect(flash[:success]).to match(/successfully updated/i)
+        expect(flash[:success]).to match(/succesvol/i)
         expect(response).to redirect_to(my_account_url)
         expect(user.reload.preferred_language).to eq("en")
       end


### PR DESCRIPTION
- Fixes sorting and filtering on external registry bikes admin dashboard.
- Fixes a test in the `nl` locale, which now renders flash messages in Dutch.