### PR TITLE
Consistify locale param forwarding

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -59,7 +59,7 @@ class ApplicationController < ActionController::Base
   end
 
   def locale_from_request_params
-    params.fetch(:locale, "").strip
+    params[:locale].to_s.strip
   end
 
   def requested_locale

--- a/app/views/bikes/edit_alert.html.haml
+++ b/app/views/bikes/edit_alert.html.haml
@@ -20,7 +20,7 @@
             = hidden_field_tag :page, :alert_purchase
             = hidden_field_tag :selected_plan_id
             = hidden_field_tag :selected_bike_image_id
-            = hidden_field_tag :locale, params[:locale] if params[:locale].presence
+            = hidden_field_tag :locale, params[:locale] if params[:locale].present?
 
             .row
               %h3.text-center.w-100= t(".select_an_image")

--- a/app/views/bikes/index.html.haml
+++ b/app/views/bikes/index.html.haml
@@ -13,7 +13,7 @@
     .col-md-12
       = form_tag bikes_path, id: 'bikes_search_form', class: 'bikes-search-form', enforce_utf8: false, method: :get do
         .query-field-wrap.nojs
-          = hidden_field_tag :locale, params[:locale]
+          = hidden_field_tag :locale, params[:locale] if params[:locale].present?
           - opt_vals = @selected_query_items_options.map { |i| i.is_a?(String) ? [i, i] : [i['text'], i['search_id']]  }
           = select_tag :query_items, options_for_select(opt_vals, selected: opt_vals.map(&:last)), placeholder: t(".search_bike_descriptions"), class: 'form-control query-field', multiple: true
           = text_field_tag :query, params[:query], placeholder: t(".search_bike_descriptions"), class: 'form-control query-field'

--- a/spec/requests/locale_detection_request_spec.rb
+++ b/spec/requests/locale_detection_request_spec.rb
@@ -28,6 +28,9 @@ RSpec.describe "Locale detection", type: :request do
       it "renders the homepage in the default language" do
         get "/", locale: :klingon
         expect(response.body).to match(/bike registration/i)
+
+        get "/", locale: nil
+        expect(response.body).to match(/bike registration/i)
       end
     end
 


### PR DESCRIPTION
- Only forward the `:locale` param in form submissions if it's currently set
- For robustness, when detecting locale from params hash, prefer `params[:locale].to_s` to `params.fetch(:locale, "")`, since the latter will only fall back to the default value if the key is missing, not if the locale value is blank.

Resolves https://app.honeybadger.io/projects/35931/faults/55913724