### PR TITLE
Fix stolen bike alert email with no tweet string

### DIFF
--- a/app/mailers/customer_mailer.rb
+++ b/app/mailers/customer_mailer.rb
@@ -74,6 +74,7 @@ class CustomerMailer < ActionMailer::Base
     @twitter_account_url = "https://twitter.com/#{@tweet_account_screen_name}"
     tweet_id = @info["tweet_id"]
     @tweet_url = "https://twitter.com/#{@tweet_account_screen_name}/status/#{tweet_id}"
+    @tweet_text = @info["tweet_string"]&.split("https://bikeindex.org")&.first
 
     I18n.with_locale(@user&.preferred_language) do
       mail(to: @customer_contact.user_email, subject: @customer_contact.title)

--- a/app/views/customer_mailer/stolen_bike_alert_email.html.haml
+++ b/app/views/customer_mailer/stolen_bike_alert_email.html.haml
@@ -1,7 +1,8 @@
-- stolen_word = @bike.abandoned? ? t(".html.recovered_or_found") : t(".html.stolen")
-
 %h1{style: "font-weight: 400; font-size: 30px;"}
-  = t(".html.were_spreading_the_word_about_your_stolen", stolen_word: stolen_word, bike_type: @bike_type)
+  - if @bike.abandoned?
+    = t(".html.were_spreading_the_word_about_your_found", bike_type: @bike_type)
+  - else
+    = t(".html.were_spreading_the_word_about_your_stolen", bike_type: @bike_type)
 
 %p{style: ""}
   = t(".html.we_sent_out_this_tweet_from")
@@ -14,33 +15,42 @@
     = t(".html.area")
   = t(".html.stolen_bike_alerter")
 
-%div{style: "margin: 30px 0 0; border: 1px solid #dfe3ee;border-radius: 4px; padding: 15px 2%; min-height: 120px;"}
-  %div{style: "width: 10%; float: left; height: 120px;"}
-    = link_to @twitter_account_url do
-      = image_tag @twitter_account_image_url, style: "max-width: 100%;"
-  %div{style: "width: 86%; margin-left: 2%; float: right;"}
-    %a{href: @tweet_url, style: "display: block; text-decoration: none; font-family: 'Helvetica Neue',Helvetica,Arial,sans-serif;"}
-      %h3{style: "font-size: 14px; line-height: 14px; margin: 0; font-weight: bold; color: #333333;"}= @tweet_account_name
-      %h3{style: "font-size: 14px; line-height: 17px; margin: 0; color: #999; font-weight: 400;"}
-        = "@#{@tweet_account_screen_name}"
-    %p{style: "margin:0;color:#333333;font-family:Georgia,'Times New Roman',serif;font-size:22px;line-height:27px;margin-bottom:0;margin-top:5px;"}
-      = @info["tweet_string"].split('https://bikeindex.org')[0]
-      %a{href: @bike_url, style: "border:none;color:#0084b4;text-decoration:none"} Bike Index link
-    %a{href: @tweet_url, style: "display:block;border:none;color:#0084b4;text-decoration:none;color:#999999;font-size: 12px; margin-top: 5px;", :target => "_blank"}
-      = Time.current.strftime("%I:%M %P - %d %b %y")
-  - if @retweet_screen_names.present?
-    - retweets = @retweet_screen_names.map{ |sn| "<a href='https://twitter.com/#{sn}'>@#{sn}</a>" }
-    %p{style: "color: #95A5A5; font-size: .9em; text-align: center; margin: 0 auto; clear: both; padding: .25em 1em .75em; width: 90%; background: #f7f7f7; border: 1px solid #dfe3ee; border-radius: 0 0 4px 4px;"}
-      = t(".html.alert_retweeted_by_html", retweets: retweets.to_sentence.html_safe)
+- if @tweet_text.blank?
+  = link_to @tweet_url, @tweet_url
+- else
+  %div{style: "margin: 30px 0 0; border: 1px solid #dfe3ee;border-radius: 4px; padding: 15px 2%; min-height: 120px;"}
+    %div{style: "width: 10%; float: left; height: 120px;"}
+      = link_to @twitter_account_url do
+        = image_tag @twitter_account_image_url, style: "max-width: 100%;"
+    %div{style: "width: 86%; margin-left: 2%; float: right;"}
+      %a{href: @tweet_url, style: "display: block; text-decoration: none; font-family: 'Helvetica Neue',Helvetica,Arial,sans-serif;"}
+        %h3{style: "font-size: 14px; line-height: 14px; margin: 0; font-weight: bold; color: #333333;"}= @tweet_account_name
+        %h3{style: "font-size: 14px; line-height: 17px; margin: 0; color: #999; font-weight: 400;"}
+          = "@#{@tweet_account_screen_name}"
+      %p{style: "margin:0;color:#333333;font-family:Georgia,'Times New Roman',serif;font-size:22px;line-height:27px;margin-bottom:0;margin-top:5px;"}
+        = @tweet_text
+        %a{href: @bike_url, style: "border:none;color:#0084b4;text-decoration:none"} Bike Index link
+      %a{href: @tweet_url, style: "display:block;border:none;color:#0084b4;text-decoration:none;color:#999999;font-size: 12px; margin-top: 5px;", :target => "_blank"}
+        = Time.current.strftime("%I:%M %P - %d %b %y")
+    - if @retweet_screen_names.present?
+      - retweets = @retweet_screen_names.map{ |sn| "<a href='https://twitter.com/#{sn}'>@#{sn}</a>" }
+      %p{style: "color: #95A5A5; font-size: .9em; text-align: center; margin: 0 auto; clear: both; padding: .25em 1em .75em; width: 90%; background: #f7f7f7; border: 1px solid #dfe3ee; border-radius: 0 0 4px 4px;"}
+        = t(".html.alert_retweeted_by_html", retweets: retweets.to_sentence.html_safe)
 
-%h3{style: "margin: 2rem 0 1rem"}= t(".html.improve_your_chances_of_recovery_by_doing")
 
-= render partial: "bikes/stolen_checklist", locals: { stolen_record: @bike.current_stolen_record }
+- if @bike.current_stolen_record&.display_checklist?
+  %h3{style: "margin: 2rem 0 1rem"}
+    = t(".html.improve_your_chances_of_recovery_by_doing")
+  = render partial: "bikes/stolen_checklist",
+  locals: { stolen_record: @bike.current_stolen_record }
 
 %hr/
 
 %p{style: "margin: 50px 0 0; padding: 20px 0 0; font-weight: 400; color: #95A5A5; text-align: center;"}
   - date = @bike.created_at.strftime("%m.%d.%y")
-  = t(".html.this_email_is_about_the_stolen_bike", was_stolen: stolen_word, bike_type: @bike_type, date: date)
+  - if @bike.abandoned?
+    = t(".html.this_email_is_about_the_found_bike", bike_type: @bike_type, date: date)
+  - else
+    = t(".html.this_email_is_about_the_stolen_bike", bike_type: @bike_type, date: date)
 
 = render partial: 'shared/email_bike_box', locals: { bike_url: bike_url(@bike) }

--- a/app/views/customer_mailer/stolen_bike_alert_email.text.haml
+++ b/app/views/customer_mailer/stolen_bike_alert_email.text.haml
@@ -3,6 +3,15 @@
 
 \--------------------------------
 
+- if @bike.abandoned?
+  = t(".text.were_spreading_the_word_about_your_found", bike_type: @bike_type)
+- else
+  = t(".text.were_spreading_the_word_about_your_stolen", bike_type: @bike_type)
+
+= t(".text.we_sent_out_this_tweet_from", twitter_handle: @tweet_account_screen_name)
+
+= @tweet_url
+
 \---
 
 = t(".text.make")
@@ -24,10 +33,6 @@
 
 - if @customer_contact.bike.stolen
   = t(".text.hopefully_you_find_the_bike_soon", bike_type: bike_type)
-
-= t(".text.claim_the_bike_type_here_bike_url", bike_type: bike_type, bike_url: bike_url)
-
-= t(".text.sign_up_or_in", bike_type: bike_type)
 
 
 \--------------------------------

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1811,7 +1811,7 @@ en:
         serial: 'Serial:'
         we_sent_out_this_tweet_from: 'We sent out this tweet from %{twitter_handle},
           a Bike Index stolen bike alerter:'
-        were_spreading_the_word_about_your_recovered: We are spreading the word about
+        were_spreading_the_word_about_your_found: We are spreading the word about
           your recovered/found %{bike_type}!
         were_spreading_the_word_about_your_stolen: We are spreading the word about
           your stolen %{bike_type}!

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1792,26 +1792,29 @@ en:
         area: area
         improve_your_chances_of_recovery_by_doing: Improve your chances of recovery
           by doing all these things!
-        recovered_or_found: recovered/found
-        stolen: stolen
-        stolen_bike_alerter: stolen bike alerter.
-        this_email_is_about_the_stolen_bike: >-
-          This email is about the %{was_stolen} %{bike_type} registered on Bike Index
-          on %{date}
+        stolen_bike_alerter: 'a Bike Index stolen bike alerter:'
+        this_email_is_about_the_found_bike: >-
+          This email is about the recovered/found %{bike_type} registered on Bike
+          Index on %{date}
+        this_email_is_about_the_stolen_bike: This email is about the stolen %{bike_type}
+          registered on Bike Index on %{date}
         we_sent_out_this_tweet_from: We sent out this tweet from
+        were_spreading_the_word_about_your_found: We're spreading the word about your
+          recovered/found %{bike_type}!
         were_spreading_the_word_about_your_stolen: We're spreading the word about
-          your %{stolen_word} %{bike_type}!
+          your stolen %{bike_type}!
       text:
-        claim_the_bike_type_here_bike_url: "* Claim the %{bike_type} here: %{bike_url}
-          *"
         color: 'Color:'
         hopefully_you_find_the_bike_soon: Hopefully you find the %{bike_type} soon.
           Give us a heads up when you do!
         make: 'Make:'
         serial: 'Serial:'
-        sign_up_or_in: >-
-          Sign up or sign in to BikeIndex.org to claim your %{bike_type} and edit
-          it, upload photos and make sure you never lose track of your trusty steed!
+        we_sent_out_this_tweet_from: 'We sent out this tweet from %{twitter_handle},
+          a Bike Index stolen bike alerter:'
+        were_spreading_the_word_about_your_recovered: We are spreading the word about
+          your recovered/found %{bike_type}!
+        were_spreading_the_word_about_your_stolen: We are spreading the word about
+          your stolen %{bike_type}!
     stolen_notification_email:
       html:
         if_you_believe_this_email_is_illegitimate: If you believe this email is illegitimate,


### PR DESCRIPTION
Updates stolen bike alert email to account for `CustomerContact` records with no "tweet_string" stored in their info_hash.

When no tweet string is available, link directly to the tweet rather than displaying a preview:

<img width="772" alt="Screen Shot 2019-10-12 at 11 39 11 AM" src="https://user-images.githubusercontent.com/4433943/66703970-fbf03480-ece5-11e9-9480-a716ff6ad806.png">
<img width="641" alt="Screen Shot 2019-10-12 at 11 40 30 AM" src="https://user-images.githubusercontent.com/4433943/66703971-fbf03480-ece5-11e9-93b4-a14557b9aaa7.png">


Resolves: https://app.honeybadger.io/projects/35931/faults/54852624