### PR TITLE
Allow selection of bike photo for promoted alert image

### DIFF
--- a/app/controllers/admin/stolen_bikes_controller.rb
+++ b/app/controllers/admin/stolen_bikes_controller.rb
@@ -21,8 +21,15 @@ class Admin::StolenBikesController < Admin::BaseController
   end
 
   def regenerate_alert_image
-    @bike.current_stolen_record.generate_alert_image
-    redirect_to edit_admin_stolen_bike_url(@bike), notice: "Promoted alert images regenerated."
+    selected_image = PublicImage.find(params[:public_image_id])
+
+    if @bike.current_stolen_record.generate_alert_image(bike_image: selected_image)
+      flash[:notice] = "Promoted alert bike image updated."
+    else
+      flash[:error] = "Could not update promoted alert image."
+    end
+
+    redirect_to edit_admin_stolen_bike_url(@bike)
   end
 
   def show

--- a/app/views/admin/bikes/_theft_alert_images.html.haml
+++ b/app/views/admin/bikes/_theft_alert_images.html.haml
@@ -9,11 +9,57 @@
     - alert_image_versions.each do |name, image|
       .col-3.col-lg-2
         = link_to image.url, target: "_blank" do
-          = image_tag image.url, class: "ml-auto mr-auto", style: "display: block; max-width: 150px; height: auto;"
+          = image_tag image.url,
+            class: "ml-auto mr-auto",
+            style: "display: block; max-width: 150px; height: auto;"
         .text-center= name
     .col-3.col-lg-2
-      = link_to "Regenerate",
-        regenerate_alert_image_admin_stolen_bike_path(bike),
-        method: :patch,
-        data: { confirm: "Are you sure you want to regenerate promoted alert images?" },
-        class: "btn btn-danger mb-4"
+      = button_tag "Update / Regenerate promoted alert image",
+        id: "js-alert-image-regenerate",
+        class: "btn btn-primary mb-4"
+
+- modal_body = capture_haml do
+  - first_image, *bike_images = bike.public_images
+
+  - if first_image.blank?
+    No images available
+  - else
+    = form_tag regenerate_alert_image_admin_stolen_bike_path(bike),
+      method: :patch, class: "alert-image-regenerate-form" do |f|
+      .modal-body.text-center
+        .row.mt-2.mb-4
+          = image_tag first_image.image_url(:small),
+            class: "js-alert-image-option m-2 ml-auto mr-auto",
+            style: "cursor: pointer; border: 5px solid #3498db;",
+            data: { public_image_id: first_image.id }
+        .row.mt-2.mb-4
+          - bike_images.to_a.each do |image|
+            = image_tag image.image_url(:small),
+              class: "js-alert-image-option m-2 ml-auto mr-auto",
+              style: "cursor: pointer; border: 5px solid #fff;",
+              data: { public_image_id: image.id }
+
+        = hidden_field_tag :public_image_id, first_image.id
+        = submit_tag "Update promoted alert images", class: "btn btn-primary btn-md m-auto"
+
+
+= render partial: "shared/modal",
+  locals: { title: "Select an image to use in the promoted alert", id: "chooseTheftAlertImageModal", modal_body: modal_body }
+
+:javascript
+  $("body").on("click", "#js-alert-image-regenerate", () => {
+    $("#chooseTheftAlertImageModal").modal("show");
+  })
+
+:javascript
+  $("body").on("click", ".js-alert-image-option", (e) => {
+    $selectedImage = $(e.target);
+
+    $form = $(e.target).closest("form");
+    $images = $form.find("img");
+    $images.attr("style", "cursor: pointer; border: 5px solid #fff;");
+
+    selectedImageId = $selectedImage.data("publicImageId")
+    $form.find("#public_image_id").val(selectedImageId)
+    $selectedImage.attr("style", "border: 5px solid #3498db;")
+  });

--- a/app/views/admin/stolen_bikes/edit.html.haml
+++ b/app/views/admin/stolen_bikes/edit.html.haml
@@ -1,4 +1,4 @@
-= render partial: "admin/bikes/bike", locals: { bike: @bike, target: "show", stolen_record: @stolen_record }
+= render partial: "/admin/bikes/bike", locals: { bike: @bike, target: "show", stolen_record: @stolen_record }
 
 = render partial: "/admin/twitter_accounts/errored"
 
@@ -6,7 +6,6 @@
 
 .row.mt-2.mb-4
   - @bike.public_images.each_with_index do |img, index|
-    - next if index == 1
     .col-3.mb-2.col-lg-2
       = image_tag img.image_url(:small), class: "ml-auto mr-auto", style: "display: block; max-width: 150px; height: auto;"
 

--- a/app/views/admin/stolen_bikes/edit.html.haml
+++ b/app/views/admin/stolen_bikes/edit.html.haml
@@ -5,7 +5,7 @@
 %h3 Public Images
 
 .row.mt-2.mb-4
-  - @bike.public_images.each_with_index do |img, index|
+  - @bike.public_images.each do |img|
     .col-3.mb-2.col-lg-2
       = image_tag img.image_url(:small), class: "ml-auto mr-auto", style: "display: block; max-width: 150px; height: auto;"
 

--- a/app/views/shared/_modal.html.haml
+++ b/app/views/shared/_modal.html.haml
@@ -20,3 +20,12 @@
 - if start_open && id.present?
   :javascript
     $(document).ready(function() { $("##{id}").modal("show"); });
+
+:javascript
+  $(function() {
+    $("body").on("keyup", (e) => {
+      const ESC = 27;
+      if (e.keyCode !== ESC) { return; }
+      $("##{id}").modal("hide");
+    });
+  });


### PR DESCRIPTION
Adds a modal to the stolen bikes and theft alert admin dashboards to select an image to use for a theft alert.

![demo](https://user-images.githubusercontent.com/4433943/66859901-25b19180-ef5a-11e9-9d3f-5410efaeebd6.gif)


Fixes #1285 