### PR TITLE
Use placeholder location in promoted alert preview

### DIFF
--- a/app/assets/stylesheets/revised/pages/bikes/edit_alert.scss
+++ b/app/assets/stylesheets/revised/pages/bikes/edit_alert.scss
@@ -68,10 +68,6 @@
       background: $blue;
     }
 
-    .selection-preview {
-      margin-bottom: 4rem;
-    }
-
     .selection-preview-image-template {
       background-image: image-url('promoted_alerts/facebook-template.png');
       background-size: cover;

--- a/app/views/bikes/edit_alert.html.haml
+++ b/app/views/bikes/edit_alert.html.haml
@@ -35,17 +35,17 @@
                   %p= t(".no_photos_add_photos_here_html", link: link_to(t(".here"), edit_bike_url(@bike, page: :photos)))
                 - else
                   .image-selection-container#js-select-image-container
-                    -# Image Preview
-                    .selection-preview.text-center.w-100#js-selection-preview
+                    -# Promoted Alert Image Preview
+                    .selection-preview.text-center.w-100#js-selection-preview.mb-2
                       .selection-preview-image-template
                         .selection-preview-image#js-selection-preview-image
                           = image_tag @bike.public_images.first.image_url(:medium)
                         .selection-preview-caption
-                          -# Fall back to "City, State" as a nudge to add
-                          -# location info to stolen record
-                          = @bike.current_stolen_record.bike_location || t(".city_state")
-                      %h5= t(".preview")
-
+                          -# Display a generic location "City, State - Country"
+                             since users may see this preview before having
+                             entered theft details.
+                          = t(".city_state_country")
+                      = t(".preview")
                     = t(".select_an_image_to_see_preview")
                     %ul
                       - @bike.public_images.each_with_index do |image, i|

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1000,7 +1000,7 @@ en:
       bike_index_can_help: >-
         Bike Index can help by purchasing targeted ads on Facebook to spread the word
         about your stolen %{bike_type}.
-      city_state: City, State
+      city_state_country: City, State - Country
       here: here
       no_photos_add_photos_here_html: >-
         Uh oh. We don't have any photos of your bike available. Upload one %{link}


### PR DESCRIPTION
Since users will be channeled toward activating a promoted alert when reporting a bike as stolen, it's more likely they'll encounter the promoted alert preview before having set the stolen location on the theft_details page. 

This change displays the placeholder location to give a more accurate sense of what the promoted alert will look like.

### Before

<img width="730" alt="before" src="https://user-images.githubusercontent.com/4433943/66963549-f413f580-f041-11e9-9b81-763253d47643.png">

### After

<img width="725" alt="after" src="https://user-images.githubusercontent.com/4433943/66963557-f8401300-f041-11e9-87f4-0585bcca4108.png">
