### PR TITLE
Fix asset compilation on CircleCI 

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -8,7 +8,8 @@
           "browsers": "> 1%",
           "node": "current"
         },
-        "useBuiltIns": "usage"
+        "useBuiltIns": "usage",
+        "corejs": "2"
       }
     ],
     "@babel/react"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,7 +37,7 @@ jobs:
             DOCKERIZE_VERSION: v0.6.1
 
       - restore_cache:
-          key: v2-git-2.22.0
+          key: cache-{{ .Environment.CACHE_VERSION }}-git-2.22.0
       - run:
           name: Install Git
           environment:
@@ -56,12 +56,12 @@ jobs:
             sudo make prefix=/usr/local all
             sudo cp ./git /usr/local/bin/git
       - save_cache:
-          key: v2-git-2.22.0
+          key: cache-{{ .Environment.CACHE_VERSION }}-git-2.22.0
           paths:
             - deps-git
 
       - restore_cache:
-          key: v2-hub-2.12.3
+          key: cache-{{ .Environment.CACHE_VERSION }}-hub-2.12.3
       - run:
           name: Install Hub
           environment:
@@ -75,7 +75,7 @@ jobs:
 
             sudo cp ./hub-linux-amd64-${HUB_VERSION}/bin/hub /usr/local/bin/hub
       - save_cache:
-          key: v2-hub-2.12.3
+          key: cache-{{ .Environment.CACHE_VERSION }}-hub-2.12.3
           paths:
             - deps-hub
 
@@ -89,12 +89,12 @@ jobs:
 
       # Ruby dependencies
       - restore_cache:
-          key: v2-bundler-{{ checksum "Gemfile.lock" }}
+          key: cache-{{ .Environment.CACHE_VERSION }}-bundler-{{ checksum "Gemfile.lock" }}
       - run:
           name: Bundle Gems
           command: bundle install --without development --path=vendor/bundle --jobs=4 --retry=3
       - save_cache:
-          key: v2-bundler-{{ checksum "Gemfile.lock" }}
+          key: cache-{{ .Environment.CACHE_VERSION }}-bundler-{{ checksum "Gemfile.lock" }}
           paths:
             - vendor/bundle
             - ~/.bundle
@@ -105,12 +105,12 @@ jobs:
 
       # Node dependencies
       - restore_cache:
-          key: v2-yarn-{{ checksum "yarn.lock" }}
+          key: cache-{{ .Environment.CACHE_VERSION }}-yarn-{{ checksum "yarn.lock" }}
       - run:
           name: Yarn Install
           command: yarn install --cache-folder ~/.cache/yarn
       - save_cache:
-          key: v2-yarn-{{ checksum "yarn.lock" }}
+          key: cache-{{ .Environment.CACHE_VERSION }}-yarn-{{ checksum "yarn.lock" }}
           paths:
             - ~/.cache/yarn
 
@@ -118,13 +118,13 @@ jobs:
       - restore_cache:
           keys:
             # This branch if available
-            - v2-assets-{{ .Branch }}
+            - cache-{{ .Environment.CACHE_VERSION }}-assets-{{ .Branch }}
             # Default branch if not
-            - v2-assets-master-
-            - v2-assets-
+            - cache-{{ .Environment.CACHE_VERSION }}-assets-master-
+            - cache-{{ .Environment.CACHE_VERSION }}-assets-
       - run: bundle exec rake assets:precompile
       - save_cache:
-          key: v2-assets-{{ .Branch }}
+          key: cache-{{ .Environment.CACHE_VERSION }}-assets-{{ .Branch }}
           paths:
             - public/assets
             - tmp/cache/assets/sprockets


### PR DESCRIPTION
The builds on `master` are failing because assets built pre-#1339 are cached and the cache key is unaffected by changes to yarn.lock. 

This patch:

- Adds an env-settable `CACHE_VERSION` value to cache keys


- Resolves a warning about implicit core-js version in babelrc 42636e7

```
% bundle exec rake assets:precompile
# . . .

Compiling…
Compilation failed:

WARNING: We noticed you're using the `useBuiltIns` option without declaring a
core-js version. Currently, we assume version 2.x when no version is passed.
Since this default version will likely change in future versions of Babel, we
recommend explicitly setting the core-js version you are using via the `corejs`
option.

You should also be sure that the version you pass to the `corejs` option matches
the version specified in your `package.json`'s `dependencies` section. If it
doesn't, you need to run one of the following commands:

  npm install --save core-js@2    npm install --save core-js@3
  yarn add core-js@2              yarn add core-js@3


Hash: eb5d2737ca9a5c4c7970
Version: webpack 4.41.1
Time: 83071ms
Built at: 10/16/2019 9:14:23 PM

# . . .
```

