### PR TITLE
Bump rubyzip to 1.3.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -522,7 +522,7 @@ GEM
       rubocop (>= 0.67.0)
     ruby-progressbar (1.10.1)
     ruby_dep (1.5.0)
-    rubyzip (1.2.3)
+    rubyzip (1.3.0)
     rufo (0.7.0)
     safe_yaml (1.0.4)
     sass (3.4.22)


### PR DESCRIPTION
Addresses https://github.com/bikeindex/bike_index/network/alert/Gemfile.lock/rubyzip/open

```
Name: rubyzip
Version: 1.2.3
Advisory: CVE-2019-16892
Criticality: Unknown
URL: https://github.com/rubyzip/rubyzip/pull/403
Title: Denial of Service in rubyzip ("zip bombs")
Solution: upgrade to >= 1.3.0
```
