### PR TITLE
Add normalized serial presence validation

### DIFF
--- a/app/models/external_registry_bike.rb
+++ b/app/models/external_registry_bike.rb
@@ -10,7 +10,7 @@ class ExternalRegistryBike < ActiveRecord::Base
 
   validates :external_id, uniqueness: { scope: :type }
 
-  before_save :normalize_serial_number
+  before_validation :normalize_serial_number
 
   class << self
     def find_or_search_registry_for(serial_number:)

--- a/app/models/external_registry_bike.rb
+++ b/app/models/external_registry_bike.rb
@@ -5,6 +5,7 @@ class ExternalRegistryBike < ActiveRecord::Base
     :country,
     :external_id,
     :serial_number,
+    :serial_normalized,
     presence: true
 
   validates :external_id, uniqueness: { scope: :type }

--- a/app/models/external_registry_client/project529_client.rb
+++ b/app/models/external_registry_client/project529_client.rb
@@ -49,6 +49,8 @@ class ExternalRegistryClient::Project529Client < ExternalRegistryClient
       raise Project529ClientError, response
     end
 
+    # Exclude non-bikes, any bikes without serial numbers, since we won't be
+    # searching for these.
     results =
       response
         .dig(:body, :bikes)

--- a/app/models/external_registry_client/stop_heling_client.rb
+++ b/app/models/external_registry_client/stop_heling_client.rb
@@ -54,6 +54,8 @@ class ExternalRegistryClient::StopHelingClient < ExternalRegistryClient
   def results_from(response_body:)
     case response_body
     when Array
+      # Exclude non-bikes, any bikes without serial numbers, since we won't be
+      # searching for these.
       response_body
         .map { |result| translate_keys(result) }
         .map { |attrs| ExternalRegistryBike::StopHelingBike.build_from_api_response(attrs) }

--- a/app/models/external_registry_client/verloren_of_gevonden_client.rb
+++ b/app/models/external_registry_client/verloren_of_gevonden_client.rb
@@ -108,6 +108,8 @@ class ExternalRegistryClient::VerlorenOfGevondenClient < ExternalRegistryClient
   end
 
   def external_registry_bikes_from(result_pages:)
+    # Exclude non-bikes, any bikes without serial numbers, since we won't be
+    # searching for these.
     result_pages
       .map { |result| ExternalRegistryBike::VerlorenOfGevondenBike.build_from_api_response(result) }
       .compact

--- a/spec/models/external_registry_bike_spec.rb
+++ b/spec/models/external_registry_bike_spec.rb
@@ -17,14 +17,12 @@ RSpec.describe ExternalRegistryBike, type: :model do
     end
   end
 
-  describe "#normalize_serial_number before_save hooks" do
+  describe "#normalize_serial_number before_validation hooks" do
     it "normalizes the serial number" do
-      bike1 = FactoryBot.build(:external_registry_bike, serial_number: "hello")
-      bike1.save
+      bike1 = FactoryBot.create(:external_registry_bike, serial_number: "hello")
       expect(bike1.serial_normalized).to eq("HE110")
 
-      bike2 = FactoryBot.build(:external_registry_bike, serial_number: "heIIO")
-      bike2.save
+      bike2 = FactoryBot.create(:external_registry_bike, serial_number: "heIIO")
       expect(bike2.serial_normalized).to eq("HE110")
     end
 

--- a/spec/models/external_registry_bike_spec.rb
+++ b/spec/models/external_registry_bike_spec.rb
@@ -27,6 +27,14 @@ RSpec.describe ExternalRegistryBike, type: :model do
       bike2.save
       expect(bike2.serial_normalized).to eq("HE110")
     end
+
+    it "ensures a normalized serial number is present" do
+      bike = FactoryBot.build(:external_registry_bike, serial_number: "unknown")
+      bike.save
+      expect(bike).to_not be_valid
+      expect(bike).to_not be_persisted
+      expect(bike.errors[:serial_normalized]).to include("can't be blank")
+    end
   end
 
   describe ".find_or_search_registry_for" do


### PR DESCRIPTION
Adds a presence validation for normalized serial number to `ExternalRegistryBike`.

Resolves https://app.honeybadger.io/projects/35931/faults/56107532