### PR TITLE
Add client-side translation facilities, localize Bike search components

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,4 @@ coverage
 # Ignore test results
 test-results/
 spec/examples.txt
+public/javascripts

--- a/Gemfile
+++ b/Gemfile
@@ -165,6 +165,7 @@ group :development, :test do
   gem "rubocop-performance", "~> 1.1.0", require: false
   gem "rufo", "~> 0.7.0", require: false
   # I18n - localization/translation
+  gem "i18n-js"
   gem "i18n-tasks"
   gem "i18n_generators"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -245,6 +245,8 @@ GEM
     i18n-country-translations (1.2.4)
       i18n (~> 0.5)
       railties (>= 4.0)
+    i18n-js (3.4.0)
+      i18n (>= 0.6.6)
     i18n-tasks (0.9.29)
       activesupport (>= 4.0.2)
       ast (>= 2.1.0)
@@ -696,6 +698,7 @@ DEPENDENCIES
   honeybadger
   httparty
   i18n-country-translations
+  i18n-js
   i18n-tasks
   i18n_generators
   jazz_fingers

--- a/app/javascript/packs/external_registry_search/components/ExternalRegistrySearchResult.js
+++ b/app/javascript/packs/external_registry_search/components/ExternalRegistrySearchResult.js
@@ -6,6 +6,8 @@ import lodashInflection from "lodash-inflection";
 
 _.mixin(lodashInflection);
 
+const t = BikeIndex.translator("bikes_search");
+
 const ExternalRegistrySearchResult = ({ bike }) => (
   <li className="bike-box-item">
     <ResultImage bike={bike}/>
@@ -14,41 +16,55 @@ const ExternalRegistrySearchResult = ({ bike }) => (
       <h5 className="title-link">
         <a href={bike.url} target="_blank">
           <strong>
-            {_.titleize(bike.manufacturer_name)}
+            {
+              bike.manufacturer_name === "unknown_brand"
+                ? t(bike.manufacturer_name)
+                : _.titleize(bike.manufacturer_name)
+            }
           </strong> {_.titleize(bike.frame_model)}
         </a>
       </h5>
 
       <ul className="attr-list">
         <li>
-          <span className="attr-title">Color</span>
-          {bike.frame_colors.map(c => _.titleize(c)).join(", ")}
+          <span className="attr-title">{t("color")}</span>
+          {
+            bike.frame_colors.length
+              ? bike.frame_colors.map(c => _.titleize(c)).join(", ")
+              : t("unknown")
+          }
         </li>
         <li>
-          <span className="attr-title">Serial</span>
-          {bike.serial}
+          <span className="attr-title">{t("serial")}</span>
+          {
+            bike.serial === "absent"
+              ? t("absent")
+              : bike.serial === "Hidden"
+              ? t("hidden")
+              : bike.serial
+          }
         </li>
       </ul>
 
       <ul className="attr-list">
         <li>
           <span className="attr-title text-danger">
-            {_.titleize(bike.status)}
+            {t(bike.status)}
           </span>
           <span className="convertTime">
             {bike.date_stolen}
           </span>
         </li>
         <li>
-          <span className="attr-title">Registry</span>
+          <span className="attr-title">{t("registry")}</span>
           <a href={bike.registry_url} target="_blank">{bike.registry_name}</a>
         </li>
         <li>
-          <span className="attr-title">Registry ID</span>
+          <span className="attr-title">{t("registry_id")}</span>
           {bike.external_id}
         </li>
         <li>
-          <span className="attr-title">Location</span>
+          <span className="attr-title">{t("location")}</span>
           {bike.stolen_location}
         </li>
       </ul>

--- a/app/javascript/packs/partial_serial_search/components/PartialSerialSearchResult.js
+++ b/app/javascript/packs/partial_serial_search/components/PartialSerialSearchResult.js
@@ -2,6 +2,8 @@
 
 import React, { Fragment } from "react";
 
+const t = BikeIndex.translator("bikes_search");
+
 const PartialSerialSearchResult = ({bike}) => (
   <li className="bike-box-item">
     <ResultImage bike={bike}/>
@@ -10,19 +12,33 @@ const PartialSerialSearchResult = ({bike}) => (
       <h5 className="title-link">
         <a href={bike.url} target="_blank">
           <strong>
-            {[bike.year, bike.manufacturer_name].filter(a => a).join(' ')}
+            {
+              bike.manufacturer_name === "unknown_brand"
+                ? t(bike.manufacturer_name)
+                : [bike.year, bike.manufacturer_name].filter(a => a).join(' ')
+            }
           </strong> {bike.frame_model}
         </a>
       </h5>
 
       <ul className="attr-list">
         <li>
-          <span className="attr-title">Color</span>
-          {bike.frame_colors.join(", ")}
+          <span className="attr-title">{t("color")}</span>
+          {
+            bike.frame_colors.length
+              ? bike.frame_colors.join(", ")
+              : t("unknown")
+          }
         </li>
         <li>
-          <span className="attr-title">Serial</span>
-          {bike.serial}
+          <span className="attr-title">{t("serial")}</span>
+          {
+            bike.serial === "absent"
+              ? t("absent")
+              : bike.serial === "Hidden"
+              ? t("hidden")
+              : bike.serial
+          }
         </li>
       </ul>
 
@@ -42,7 +58,7 @@ const AbandonedOrStolenDateItem = ({bike}) => {
   return (
     <li>
       <span className="attr-title text-danger">
-        {bike.stolen ? "Stolen" : "Abandoned"}
+        {bike.stolen ? t("stolen") : t("abandoned") }
       </span>
       <span className="convertTime">{bike.date_stolen}</span>
     </li>
@@ -56,7 +72,7 @@ const LocationItem = ({bike}) => {
 
   return (
     <li>
-      <span className="attr-title">Location</span>
+      <span className="attr-title">{t("location")}</span>
       {bike.stolen_location}
     </li>
   )

--- a/app/jest/setup.js
+++ b/app/jest/setup.js
@@ -7,3 +7,4 @@ import Adapter from 'enzyme-adapter-react-16';
 configure({ adapter: new Adapter() });
 
 global.$ = global.jQuery = $;
+global.BikeIndex = { translator: () => () => {}}

--- a/app/models/external_registry_bike.rb
+++ b/app/models/external_registry_bike.rb
@@ -30,12 +30,12 @@ class ExternalRegistryBike < ActiveRecord::Base
     private
 
     def brand(brand_name)
-      return "Unknown Brand" if absent?(brand_name)
+      return "unknown_brand" if absent?(brand_name)
       brand_name
     end
 
     def colors(frame_color)
-      return "Unknown" if absent?(frame_color)
+      return "unknown" if absent?(frame_color)
       frame_color
     end
 

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -10,6 +10,10 @@
     = javascript_include_tag 'application_revised'
     = javascript_include_tag "i18n"
     = javascript_include_tag "translations", skip_pipeline: true
+    :javascript
+      window.BikeIndex.translator = (keyspace) => {
+        return (key, args={}) => I18n.t(`javascript.${keyspace}.${key}`, args);
+      }
     <!--[if IE]>$('body').prepend("<div id='old-browser-warning'><h4>Your browser is out of date!</h4><p>As a result, Bike Index will not function correctly. <a href=\"http://whatbrowser.com\">Learn more here</a>.</p></div>")<![endif]-->
   %body{ id: page_id, class:  body_class }
     %nav.primary-header-nav
@@ -155,3 +159,7 @@
     = render "/shared/donate_modal", locals: { kind: donation_request } if donation_request.present?
 
     = render 'shared/footer_revised'
+
+:javascript
+  I18n.defaultLocale = "#{I18n.default_locale}"
+  I18n.locale = "#{I18n.locale}"

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -8,6 +8,8 @@
     <!-- TODO: Use yarn -->
     <script src="https://kit.fontawesome.com/82eb17360c.js"></script>
     = javascript_include_tag 'application_revised'
+    = javascript_include_tag "i18n"
+    = javascript_include_tag "translations", skip_pipeline: true
     <!--[if IE]>$('body').prepend("<div id='old-browser-warning'><h4>Your browser is out of date!</h4><p>As a result, Bike Index will not function correctly. <a href=\"http://whatbrowser.com\">Learn more here</a>.</p></div>")<![endif]-->
   %body{ id: page_id, class:  body_class }
     %nav.primary-header-nav

--- a/config/application.rb
+++ b/config/application.rb
@@ -44,6 +44,9 @@ module Bikeindex
     require_relative "../lib/i18n/middleware"
     config.middleware.use I18n::Middleware
 
+    # Add middleware for i18n-js
+    config.middleware.use I18n::JS::Middleware
+
     config.to_prepare do
       Doorkeeper::ApplicationsController.layout "doorkeeper"
       Doorkeeper::AuthorizationsController.layout "doorkeeper"

--- a/config/i18n-js.yml
+++ b/config/i18n-js.yml
@@ -1,0 +1,3 @@
+translations:
+- file: "public/javascripts/translations.js"
+  only: "*.javascript.*"

--- a/config/i18n-tasks.yml
+++ b/config/i18n-tasks.yml
@@ -74,9 +74,8 @@ search:
   ## Files or `File.fnmatch` patterns to exclude from search. Some files are always excluded regardless of this setting:
   ##   %w(*.jpg *.png *.gif *.svg *.ico *.eot *.otf *.ttf *.woff *.woff2 *.pdf *.css *.sass *.scss *.less *.yml *.json)
   exclude:
-    - app/assets/images
-    - app/assets/fonts
-    - app/assets/videos
+    - app/assets
+    - app/javascript
 
   ## Alternatively, the only files or `File.fnmatch patterns` to search in `paths`:
   ## If specified, this settings takes priority over `exclude`, but `exclude` still applies.
@@ -129,6 +128,7 @@ ignore_unused:
 - 'helpers.page_entries_info.*'
 - 'locales.*'
 - 'money.*'
+- 'javascript.*'
 
 ## Exclude these keys from the `i18n-tasks eq-base' report:
 # ignore_eq_base:

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -5,7 +5,7 @@ Rails.application.config.assets.version = "1.2"
 
 Rails.application.config.assets.precompile += %w(
   graphs.js embed.js embed_user.js documentation_v2_and_v3.js
-  application_revised.js registrations.js
+  application_revised.js i18n.js registrations.js
   spokecard.css embed_styles.css embed_user_styles.css registration_pdf.css
   documentation_v2.css revised.css og_application.css admin.css
   registrations.css email.css

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3210,6 +3210,15 @@ en:
       signup_page: signup page
       us_partner_organizations: US Partner organizations
       website_for_organization: "%{org_name} website"
+  javascript:
+    bikes_search:
+      abandoned: Abandoned
+      color: Color
+      location: Location
+      registry: Registry
+      registry_id: Registry ID
+      serial: Serial
+      stolen: Stolen
   landing_pages:
     ambassadors_current:
       after_a_couple_of_recoveries_i_got_hooked: >-

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3213,12 +3213,16 @@ en:
   javascript:
     bikes_search:
       abandoned: Abandoned
+      absent: Absent
       color: Color
+      hidden: Hidden
       location: Location
       registry: Registry
       registry_id: Registry ID
       serial: Serial
       stolen: Stolen
+      unknown: Unknown
+      unknown_brand: Unknown Brand
   landing_pages:
     ambassadors_current:
       after_a_couple_of_recoveries_i_got_hooked: >-

--- a/config/locales/translation.nl.yml
+++ b/config/locales/translation.nl.yml
@@ -5583,3 +5583,16 @@ nl:
       edit: Bewerken
       image_from: Afbeelding van %{image_title}
       looks_like_this_is_your_image: Het lijkt erop dat dit jouw afbeelding is.
+  javascript:
+    bikes_search:
+      abandoned: Verlaten
+      color: Kleur
+      location: Plaats
+      registry: Fietsregister
+      registry_id: Fietsregister ID
+      serial: Serie
+      stolen: Gestolen
+      unknown_brand: Onbekend merk
+      unknown: Onbekend
+      absent: Afwezig
+      hidden: Verborgen

--- a/lib/tasks/rake_tasks.rake
+++ b/lib/tasks/rake_tasks.rake
@@ -24,4 +24,7 @@ task prepare_translations: :environment do
   i18n_tasks = I18n::Tasks::CLI.new
   i18n_tasks.start(["normalize"])
   i18n_tasks.start(["health"])
+
+  # Export JS translations to public/javascripts/translations.js
+  I18n::JS.export
 end

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "es6-promise": "^4.2.8",
     "eslint-plugin-react-hooks": "^1.6.0",
     "honeybadger-js": "^0.5.5",
+    "i18n-js": "^3.3.0",
     "jquery": "^3.4.0",
     "lodash": "^4.17.13",
     "lodash-inflection": "^1.5.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5916,6 +5916,11 @@ humanize@^0.0.9:
   resolved "https://registry.yarnpkg.com/humanize/-/humanize-0.0.9.tgz#1994ffaecdfe9c441ed2bdac7452b7bb4c9e41a4"
   integrity sha1-GZT/rs3+nEQe0r2sdFK3u0yeQaQ=
 
+i18n-js@^3.3.0:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/i18n-js/-/i18n-js-3.3.0.tgz#05512f7184b5117c087ab597be649720a834c068"
+  integrity sha512-+m8jh84IIWlFwEJgwrWCkeIwIES9ilJKBOj5qx8ZTLLmlPz7bjKnCdxf254wRf6M4pkQHtgXGT9r9lGk0e9aug==
+
 iconv-lite@0.4.24, iconv-lite@^0.4.24, iconv-lite@^0.4.4, iconv-lite@~0.4.13:
   version "0.4.24"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.24.tgz#2022b4b25fbddc21d2f524974a474aafe733908b"


### PR DESCRIPTION
Adds [i18n-js](https://github.com/fnando/i18n-js) ruby gem and npm package to generate client-side translations from the Rails translation file.

### Usage

1. Initialize a `t()` translation helper function with the appropriate keyspace for the given module. For example, for `ExternalRegistrySearchResult`, we can either invoke `I18n.t` with a full scope or use the following:

```js
// app/javascript/packs/external_registry_search/components/ExternalRegistrySearchResult.js L9 (5364dea1)

const t = BikeIndex.translator("bikes_search");
```
<sup>[[source](https://github.com/bikeindex/bike_index/blob/5364dea1/app/javascript/packs/external_registry_search/components/ExternalRegistrySearchResult.js#L9-L9)]</sup>



```js
// app/javascript/packs/external_registry_search/components/ExternalRegistrySearchResult.js L18-24 (5364dea1)

<strong>
  {
    bike.manufacturer_name === "unknown_brand"
      ? t(bike.manufacturer_name)
      : _.titleize(bike.manufacturer_name)
  }
</strong> {_.titleize(bike.frame_model)}
```
<sup>[[source](https://github.com/bikeindex/bike_index/blob/5364dea1/app/javascript/packs/external_registry_search/components/ExternalRegistrySearchResult.js#L18-L24)]</sup>


```haml
-# app/views/layouts/application.html.haml L10-16 (37db61e1)

= javascript_include_tag 'application_revised'
= javascript_include_tag "i18n"
= javascript_include_tag "translations", skip_pipeline: true
:javascript
  window.BikeIndex.translator = (keyspace) => {
    return (key, args={}) => I18n.t(`javascript.${keyspace}.${key}`, args);
  }
```
<sup>[[source](https://github.com/bikeindex/bike_index/blob/37db61e1/app/views/layouts/application.html.haml#L10-L16)]</sup>

by convention, client-side translations are nested within the `javascript` key in translation files.


### Configuration

Client-side translations are generated in an object loaded from `public/javascripts/translation.js` and populated with entries from translation files (only those found within the `javascript` key space):

```yml
# config/i18n-js.yml L1-3 (f03a54ff)

translations:
- file: "public/javascripts/translations.js"
  only: "*.javascript.*"
```
<sup>[[source](https://github.com/bikeindex/bike_index/blob/f03a54ff/config/i18n-js.yml#L1-L3)]</sup>


```yml
# config/locales/en.yml L3213-3223 (a57b8087)

javascript:
  bikes_search:
    abandoned: Abandoned
    color: Color
    location: Location
    registry: Registry
    registry_id: Registry ID
    serial: Serial
    stolen: Stolen
    unknown: Unknown
    unknown_brand: Unknown Brand
```
<sup>[[source](https://github.com/bikeindex/bike_index/blob/a57b8087/config/locales/en.yml#L3213-L3223)]</sup>

### Generation

The JS translation file can be generated manually with `bin/rake i18n:js:export`.

This patch adds JS translation file generation as a step to `bin/rake prepare_translations`:


```rake
# lib/tasks/rake_tasks.rake L21-30 (2d51de17)

desc "Prepare translations for committing to master"
task prepare_translations: :environment do
  # . . .
  # Export JS translations to public/javascripts/translations.js
  I18n::JS.export
end
```
<sup>[[source](https://github.com/bikeindex/bike_index/blob/2d51de17/lib/tasks/rake_tasks.rake#L21-L30)]</sup>

### Before

<img width="1165" alt="Screen Shot 2019-10-20 at 2 28 20 PM" src="https://user-images.githubusercontent.com/4433943/67165046-97b91a80-f34e-11e9-9ab4-1243d848a100.png">


### After

<img width="1163" alt="Screen Shot 2019-10-20 at 3 21 34 PM" src="https://user-images.githubusercontent.com/4433943/67165053-a1db1900-f34e-11e9-9255-d1be74bab766.png">

Closes https://github.com/bikeindex/bike_index/issues/963