### PR TITLE
Move i18n-js out of dev group

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -18,6 +18,7 @@ gem "flipper-ui"
 
 # I18n - localization/translation
 gem "i18n-country-translations"
+gem "i18n-js"
 gem "rails-i18n"
 gem "translation"
 
@@ -165,7 +166,6 @@ group :development, :test do
   gem "rubocop-performance", "~> 1.1.0", require: false
   gem "rufo", "~> 0.7.0", require: false
   # I18n - localization/translation
-  gem "i18n-js"
   gem "i18n-tasks"
   gem "i18n_generators"
 end


### PR DESCRIPTION
Resolves deploy failure
```
[147.75.69.187] executing command
rake aborted!
NameError: uninitialized constant I18n::JS
/var/deploy/bike_index/web_head/releases/20191021230451/config/application.rb:48:in `'
/var/deploy/bike_index/web_head/releases/20191021230451/config/application.rb:11:in `'
/var/deploy/bike_index/web_head/releases/20191021230451/config/application.rb:10:in `'
/var/deploy/bike_index/web_head/releases/20191021230451/Rakefile:5:in `require'
/var/deploy/bike_index/web_head/releases/20191021230451/Rakefile:5:in `'
/var/deploy/bike_index/web_head/shared/bundle/ruby/2.5.0/gems/rake-12.3.2/exe/rake:27:in `'
/usr/local/bin/bundle:23:in `load'
/usr/local/bin/bundle:23:in `'
(See full trace by running task with --trace)
command finished in 3207ms
*** [deploy:update_code] rolling back
```