### PR TITLE
Extract bikehub_url helper, env var

### DIFF
--- a/.env
+++ b/.env
@@ -1,5 +1,6 @@
 BASE_URL: http://localhost:3001
 DISCOURSE_URL: http://localhost:4000
+BIKEHUB_URL: https://new.bikehub.com
 SECRET_KEY_BASE: kniYBQYeaVoi9vejDMjUnmNRBvfzU2khgkTNaTqVYLBnkniYBQYeaVoi9vejDMjUnmNRBvfzU2khgkTNaTqVYLBn
 DISCOURSE_SECRET: kniYBQYeaVoi9vejDMjUnmNRBvfzU2khgkTNaTqVYLBn
 VERIFICATION_SECRET: kljhcvzx67q23bhjvcxz768432gadfjhaerwkjfasdfasdffc

--- a/app/controllers/concerns/controller_helpers.rb
+++ b/app/controllers/concerns/controller_helpers.rb
@@ -7,7 +7,7 @@ module ControllerHelpers
   included do
     helper_method :current_user, :current_user_or_unconfirmed_user, :sign_in_partner, :user_root_url,
                   :user_root_bike_search?, :current_organization, :passive_organization, :controller_namespace, :page_id,
-                  :default_bike_search_path
+                  :default_bike_search_path, :bikehub_url
     before_filter :enable_rack_profiler
 
     before_action do
@@ -245,5 +245,12 @@ module ControllerHelpers
     return true if current_user.present? && current_user.superuser?
     flash[:error] = translation(:not_permitted_to_do_that, scope: [:controllers, :concerns, :controller_helpers, __method__])
     redirect_to user_root_url and return
+  end
+
+  def bikehub_url(path)
+    [
+      ENV["BIKEHUB_URL"].presence || "https://new.bikehub.com",
+      path,
+    ].join("/")
   end
 end

--- a/app/controllers/concerns/sessionable.rb
+++ b/app/controllers/concerns/sessionable.rb
@@ -26,7 +26,7 @@ module Sessionable
     end
 
     if sign_in_partner.present?
-      redirect_to "https://new.bikehub.com/account" and return # Only partner rn is bikehub, hardcode it
+      redirect_to bikehub_url("account") and return # Only partner rn is bikehub, hardcode it
     elsif user.unconfirmed?
       render_partner_or_default_signin_layout(redirect_path: please_confirm_email_users_path) and return
     elsif !return_to_if_present

--- a/app/views/users/new.html.haml
+++ b/app/views/users/new.html.haml
@@ -45,7 +45,7 @@
                 = f.check_box :terms_of_service
                 - if sign_in_partner == "bikehub"
                   = t(".agree_bikeindex_bikehub_toc_html",
-                  bikehub_toc_link: link_to(t(".terms_and_conditions"), nil, data: { target: "https://new.bikehub.com/terms" }, class: "no-tab"),
+                  bikehub_toc_link: link_to(t(".terms_and_conditions"), nil, data: { target: bikehub_url("terms") }, class: "no-tab"),
                   bikeindex_toc_link: link_to(t(".terms_and_conditions"), nil, data: { target: terms_path }, class: "no-tab"))
                 - else
                   = t(".agree_bikeindex_toc_html", bikeindex_toc_link: link_to(t(".terms_and_conditions"), nil, data: { target: terms_path }, class: "no-tab"))


### PR DESCRIPTION
Extracts a `bikehub_url` helper with env-settable bikehub url. Allows for overriding with `localhost` when needed.