### PR TITLE
Add currency form fields to admin dashboards

### DIFF
--- a/app/controllers/admin/paid_features_controller.rb
+++ b/app/controllers/admin/paid_features_controller.rb
@@ -42,7 +42,7 @@ class Admin::PaidFeaturesController < Admin::BaseController
   end
 
   def permitted_update_parameters
-    permitted_parameters = params.require(:paid_feature).permit(:amount, :description, :details_link, :kind, :name)
+    permitted_parameters = params.require(:paid_feature).permit(:amount, :description, :details_link, :kind, :name, :currency)
     if current_user.developer?
       permitted_parameters.merge(params.require(:paid_feature).permit(:feature_slugs_string))
     elsif @paid_feature&.id&.present? && @paid_feature.locked?

--- a/app/controllers/admin/payments_controller.rb
+++ b/app/controllers/admin/payments_controller.rb
@@ -83,7 +83,7 @@ class Admin::PaymentsController < Admin::BaseController
   end
 
   def permitted_create_parameters
-    params.require(:payment).permit(:kind, :amount, :email, :created_at).merge(invoice_parameters)
+    params.require(:payment).permit(:kind, :amount, :email, :currency, :created_at).merge(invoice_parameters)
   end
 
   def find_payment

--- a/app/controllers/admin/theft_alert_plans_controller.rb
+++ b/app/controllers/admin/theft_alert_plans_controller.rb
@@ -38,6 +38,6 @@ class Admin::TheftAlertPlansController < Admin::BaseController
   def theft_alert_plan_params
     params
       .require(:theft_alert_plan)
-      .permit(:name, :amount_cents, :views, :duration_days, :description, :active, :language)
+      .permit(:name, :amount_cents, :views, :duration_days, :description, :active, :language, :currency)
   end
 end

--- a/app/helpers/money_helper.rb
+++ b/app/helpers/money_helper.rb
@@ -1,3 +1,4 @@
+# coding: utf-8
 module MoneyHelper
   include MoneyRails::ActionViewExtension
 
@@ -7,6 +8,22 @@ module MoneyHelper
   # Return the currency abbreviation (USD, EUR) for the current locale.
   def default_currency
     t(I18n.locale, scope: [:money, :currencies])
+  end
+
+  # Return a list of currency abbreviations (USD, EUR) for all available locales.
+  def available_currencies
+    I18n.available_locales.map { |locale| t(locale, scope: [:money, :currencies]) }
+  end
+
+  # Return a list of currency symbols and abbreviations for all available locales:
+  # ["$ (USD)", "€ (EUR)"]
+  def currency_symbols
+    I18n.available_locales.map do |locale|
+      [
+        I18n.with_locale(locale) { number_to_currency(1, format: "%u") },
+        "(#{t(locale, scope: [:money, :currencies])})",
+      ].join(" ")
+    end
   end
 
   def money_usd(dollars, exchange_to: default_currency)

--- a/app/views/admin/paid_features/_form.html.haml
+++ b/app/views/admin/paid_features/_form.html.haml
@@ -32,7 +32,8 @@
         = f.label :amount
         .input-group.mb-2
           .input-group-prepend
-            .input-group-text $
+            .input-group-text
+              = f.select :currency, options_for_select(currency_symbols.zip(available_currencies))
           = f.number_field :amount, step: 1, min: 0, class: "form-control"
 
     .col-md-6.col-xs-12

--- a/app/views/admin/payments/new.html.haml
+++ b/app/views/admin/payments/new.html.haml
@@ -20,7 +20,7 @@
       .input-group
         .input-group-prepend
           %span.input-group-text
-            $
+            = f.select :currency, options_for_select(currency_symbols.zip(available_currencies))
         = f.number_field :amount, step: 1, min: 0, class: "form-control"
     .col-md-6
       .form-group

--- a/app/views/admin/theft_alert_plans/_form.html.haml
+++ b/app/views/admin/theft_alert_plans/_form.html.haml
@@ -5,6 +5,10 @@
   = f.label :amount_cents, "Price (cents)", class: "form-label font-weight-bold mt-2 mb-0"
   = f.number_field :amount_cents, class: "form-control"
 
+  %fieldset
+    = f.label :currency, "Currency", class: "form-label font-weight-bold mt-2 mb-0"
+    = f.select :currency, options_for_select(available_currencies, selected: record.currency), class: "form-control"
+
   = f.label :views, "Views Provided", class: "form-label font-weight-bold mt-2 mb-0"
   = f.number_field :views, class: "form-control"
 

--- a/app/views/admin/theft_alert_plans/index.html.haml
+++ b/app/views/admin/theft_alert_plans/index.html.haml
@@ -21,7 +21,7 @@
       - @theft_alert_plans.each do |plan|
         %tr
           %td= link_to plan.name , edit_admin_theft_alert_plan_path(plan)
-          %td= number_to_currency(plan.amount_cents / 100.0, unit: "$")
+          %td= plan.amount_formatted
           %td= number_with_delimiter(plan.views)
           %td= plan.duration_days
           %td= plan.description_html.html_safe


### PR DESCRIPTION
Adds form fields to allow setting / updated the currency column value from the admin dashboard.

<img width="706" alt="Screen Shot 2019-10-23 at 9 59 19 PM" src="https://user-images.githubusercontent.com/4433943/67446972-62c3f680-f5e0-11e9-81aa-ed800be686b0.png">
