### PR TITLE
Add translations for new bike form

### DIFF
--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -144,7 +144,13 @@ class Organization < ActiveRecord::Base
     additional_registration_fields.include?("reg_affiliation")
   end
 
-  def reg_affiliation_options; %w[student employee community_member] end
+  def reg_affiliation_options
+    translation_scope =
+      [:activerecord, :select_options, self.class.name.underscore, __method__]
+
+    %w[student employee community_member]
+      .map { |e| [I18n.t(e, scope: translation_scope), e] }
+  end
 
   def include_field_reg_phone?(user = nil)
     return false unless additional_registration_fields.include?("reg_phone")

--- a/app/views/bikes/bike_fields/_revised_colors.html.haml
+++ b/app/views/bikes/bike_fields/_revised_colors.html.haml
@@ -6,7 +6,7 @@
 
 .related-fields{ class: classname }
   .form-group.row
-    = f.label :primary_frame_color, class: 'form-well-label'
+    = f.label :primary_frame_color_id, t(".primary_frame_color"), class: 'form-well-label'
 
     .form-well-input.fancy-select.unfancy
       = f.select(:primary_frame_color_id, Color.select_options, required: true, prompt: t(".choose_color") )
@@ -23,7 +23,7 @@
         = t(".remove_color")
 
   #secondary-color.form-group.row.hidden-other{ class: ('unhidden' if display_secondary_color) }
-    = f.label :secondary_frame_color, class: 'form-well-label'
+    = f.label :secondary_frame_color_id, t(".secondary_frame_color"), class: 'form-well-label'
     .form-well-input.fancy-select.unfancy
       = f.select(:secondary_frame_color_id, Color.select_options, prompt: t(".choose_color") )
     .right-input-help
@@ -37,6 +37,6 @@
         = t(".remove_color")
 
   #tertiary-color.form-group.row.hidden-other{ class: ('unhidden' if display_tertiary_color) }
-    = f.label :tertiary_frame_color, class: 'form-well-label'
+    = f.label :tertiary_frame_color_id, t(".tertiary_frame_color"), class: 'form-well-label'
     .form-well-input.fancy-select.unfancy
       = f.select(:tertiary_frame_color_id, Color.select_options, prompt: t(".choose_color") )

--- a/app/views/bikes/new.html.haml
+++ b/app/views/bikes/new.html.haml
@@ -46,7 +46,7 @@
 
           .related-fields
             .form-group.row
-              = f.label :manufacturer_id, class: 'form-well-label'
+              = f.label :manufacturer_id, t(".manufacturer"), class: 'form-well-label'
 
               .form-well-input
                 - initial = @bike.manufacturer && { id: @bike.manufacturer.id, text: @bike.manufacturer.name }.to_json

--- a/app/views/bikes/new.html.haml
+++ b/app/views/bikes/new.html.haml
@@ -153,7 +153,7 @@
                 class: "form-well-label"
               .form-well-input
                 = f.select :organization_affiliation,
-                  @organization.reg_affiliation_options.map { |a| [a.humanize, a] },
+                  @organization.reg_affiliation_options,
                   class: "form-control"
 
           .form-group.row.unnested-field.no-divider-row

--- a/app/views/organizations/embed_extended.html.haml
+++ b/app/views/organizations/embed_extended.html.haml
@@ -104,8 +104,7 @@
     .input-group
       = f.label :organization_affiliation, label_affiliation
       .controls
-        - affiliation_options = @organization.reg_affiliation_options.map { |a| [a.humanize, a] }
-        = f.select :organization_affiliation, affiliation_options, class: "form-control"
+        = f.select :organization_affiliation, @organization.reg_affiliation_options, class: "form-control"
   - if @organization.paid_for?("bike_codes")
     .input-group
       .control-group

--- a/config/locales/.translation_io
+++ b/config/locales/.translation_io
@@ -1,2 +1,2 @@
 ---
-timestamp: 1571917181
+timestamp: 1571971090

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -910,6 +910,11 @@ en:
         unknown: unknown
         water_bottle_cage: water bottle cage
         wheel: wheel
+      organization:
+        reg_affiliation_options:
+          community_member: Community Member
+          employee: Employee
+          student: Student
       stolen_record:
         bike_was_not_locked: Bike was not locked
         cable_lock: Cable lock
@@ -944,7 +949,10 @@ en:
           else. You can put a more detailed description in paint description (once
           you've registered), <em>this</em> is to get a general color to make searching
           easier
+        primary_frame_color: Primary frame color
         remove_color: Remove color
+        secondary_frame_color: Secondary frame color
+        tertiary_frame_color: Tertiary frame color
       revised_component_fields:
         component_type: Component type
         model: Model
@@ -1213,6 +1221,7 @@ en:
       is_a_handmade_frame: Is a handmade frame
       it_probably_has_a_serial_number: It probably has a serial number.
       mailing_address: Mailing address
+      manufacturer: Manufacturer
       missing_serial: Missing serial
       model_year: Model year
       nevermind: Nevermind

--- a/config/locales/translation.nl.yml
+++ b/config/locales/translation.nl.yml
@@ -988,6 +988,11 @@ nl:
         two_u_locks: Twee U-sloten
         u_lock: Beugelslot
         u_lock_and_cable: U-slot en kabel
+      organization:
+        reg_affiliation_options:
+          community_member: Gemeenschap lid
+          employee: Werknemer
+          student: Student
   datetime:
     distance_in_words:
       half_a_minute: een halve minuut
@@ -1643,6 +1648,9 @@ nl:
           in de verfbeschrijving plaatsen (nadat u zich hebt geregistreerd), <em>dit</em>
           is om een algemene kleur te krijgen om het zoeken te vergemakkelijken
         remove_color: Verwijder kleur
+        primary_frame_color: Primaire framekleur
+        secondary_frame_color: Secundaire framekleur
+        tertiary_frame_color: Tertiaire framekleur
       revised_component_fields:
         component_type: Component type
         model: Model
@@ -1933,6 +1941,7 @@ nl:
       without_serial_number: Deze %{bike_type} is gemaakt zonder framenummer
       your_full_address_is_required: Uw volledige adres is vereist door %{org_name}
       zipcode: Postcode
+      manufacturer: Fabrikant
     organized_access_panel:
       access_panel: Toegangspaneel
       additional_message: Extra bericht
@@ -5328,7 +5337,7 @@ nl:
       bike_manufacturer: fietsfabrikant
       choose_specific_organization_optional: Kies specifieke organisatie (optioneel)
       owner_email: "%{owner} e-mail"
-      primary_frame_color: primaire framekleur
+      primary_frame_color: Primaire framekleur
       register: Registreer
       select_other_if_manufacturer_doesnt_show: Selecteer 'Overig' als de fabrikant
         niet verschijnt wanneer deze wordt ingevoerd


### PR DESCRIPTION
Translates some strings that were missed on a first pass because they're generated dynamically.

### Before

<img width="364" alt="Screen Shot 2019-10-24 at 10 50 20 PM" src="https://user-images.githubusercontent.com/4433943/67539625-b736a700-f6b0-11e9-9780-ef4286b8b71c.png">

### After

<img width="597" alt="Screen Shot 2019-10-24 at 10 50 00 PM" src="https://user-images.githubusercontent.com/4433943/67539637-bdc51e80-f6b0-11e9-9711-a30bdf2240b0.png">
