### PR TITLE
Add tests for subsequent alert purchase stages

### DIFF
--- a/app/controllers/bikes_controller.rb
+++ b/app/controllers/bikes_controller.rb
@@ -171,8 +171,12 @@ class BikesController < ApplicationController
           .where(imageable_id: @bike.id)
           .where(is_private: true)
     when /alert/
+      unless @bike&.current_stolen_record.present?
+        redirect_to edit_bike_url(@bike, page: @edit_template) and return
+      end
+
       bike_image = PublicImage.find_by(id: params[:selected_bike_image_id])
-      @bike.current_stolen_record&.generate_alert_image(bike_image: bike_image)
+      @bike.current_stolen_record.generate_alert_image(bike_image: bike_image)
 
       @theft_alert_plans = TheftAlertPlan.active.price_ordered_asc.in_language(I18n.locale)
       @selected_theft_alert_plan =
@@ -181,12 +185,12 @@ class BikesController < ApplicationController
 
       @theft_alerts =
         @bike
-          &.current_stolen_record
-          &.theft_alerts
-          &.includes(:theft_alert_plan)
-          &.creation_ordered_desc
-          &.where(creator: current_user)
-          &.references(:theft_alert_plan) || TheftAlert.none
+          .current_stolen_record
+          .theft_alerts
+          .includes(:theft_alert_plan)
+          .creation_ordered_desc
+          .where(creator: current_user)
+          .references(:theft_alert_plan)
     end
 
     render "edit_#{@edit_template}".to_sym

--- a/app/controllers/bikes_controller.rb
+++ b/app/controllers/bikes_controller.rb
@@ -172,7 +172,7 @@ class BikesController < ApplicationController
           .where(is_private: true)
     when /alert/
       bike_image = PublicImage.find_by(id: params[:selected_bike_image_id])
-      @bike.current_stolen_record.generate_alert_image(bike_image: bike_image)
+      @bike.current_stolen_record&.generate_alert_image(bike_image: bike_image)
 
       @theft_alert_plans = TheftAlertPlan.active.price_ordered_asc.in_language(I18n.locale)
       @selected_theft_alert_plan =
@@ -181,12 +181,12 @@ class BikesController < ApplicationController
 
       @theft_alerts =
         @bike
-          .current_stolen_record
-          .theft_alerts
-          .includes(:theft_alert_plan)
-          .creation_ordered_desc
-          .where(creator: current_user)
-          .references(:theft_alert_plan)
+          &.current_stolen_record
+          &.theft_alerts
+          &.includes(:theft_alert_plan)
+          &.creation_ordered_desc
+          &.where(creator: current_user)
+          &.references(:theft_alert_plan) || TheftAlert.none
     end
 
     render "edit_#{@edit_template}".to_sym
@@ -230,7 +230,7 @@ class BikesController < ApplicationController
   # Return a Hash with keys :is_valid (boolean), :template (string)
   def target_edit_template(requested_page:)
     result = {}
-    valid_pages = [*edit_templates.keys, "alert_purchase"]
+    valid_pages = [*edit_templates.keys, "alert_purchase", "alert_purchase_confirmation"]
     default_page = @bike.stolen? ? :theft_details : :bike_details
 
     case

--- a/app/views/bikes/edit_alert_purchase.html.haml
+++ b/app/views/bikes/edit_alert_purchase.html.haml
@@ -20,12 +20,12 @@
             currency: default_currency,
             description: t(".bike_index_promoted_alert") },
             class: "confirm-form" do
-            = hidden_field_tag :stripe_amount, @selected_theft_alert_plan&.amount_cents
+            = hidden_field_tag :stripe_amount, @selected_theft_alert_plan.amount_cents
             = hidden_field_tag :stripe_currency, default_currency
             = hidden_field_tag :stripe_email
             = hidden_field_tag :stripe_token
             = hidden_field_tag :bike_id, @bike.id
-            = hidden_field_tag :theft_alert_plan_id, @selected_theft_alert_plan&.id
+            = hidden_field_tag :theft_alert_plan_id, @selected_theft_alert_plan.id
 
             .row
               %h3.text-center.w-100
@@ -35,14 +35,14 @@
             .row
               .copy.text-center
                 %strong
-                  = t(".here_is_what_youll_get", plan_name: @selected_theft_alert_plan&.name)
+                  = t(".here_is_what_youll_get", plan_name: @selected_theft_alert_plan.name)
             .row
               .description
-                = @selected_theft_alert_plan&.description_html&.html_safe
+                = @selected_theft_alert_plan.description_html.html_safe
             .row
               .copy.text-center
                 %strong
-                  = t(".charge", price: @selected_theft_alert_plan&.amount_formatted)
+                  = t(".charge", price: @selected_theft_alert_plan.amount_formatted)
             .row
               .text-center.w-100.mt-2
                 %button.btn.btn-lg.btn-primary#js-confirm-plan-button

--- a/app/views/bikes/edit_alert_purchase.html.haml
+++ b/app/views/bikes/edit_alert_purchase.html.haml
@@ -20,12 +20,12 @@
             currency: default_currency,
             description: t(".bike_index_promoted_alert") },
             class: "confirm-form" do
-            = hidden_field_tag :stripe_amount, @selected_theft_alert_plan.amount_cents
+            = hidden_field_tag :stripe_amount, @selected_theft_alert_plan&.amount_cents
             = hidden_field_tag :stripe_currency, default_currency
             = hidden_field_tag :stripe_email
             = hidden_field_tag :stripe_token
             = hidden_field_tag :bike_id, @bike.id
-            = hidden_field_tag :theft_alert_plan_id, @selected_theft_alert_plan.id
+            = hidden_field_tag :theft_alert_plan_id, @selected_theft_alert_plan&.id
 
             .row
               %h3.text-center.w-100
@@ -35,15 +35,14 @@
             .row
               .copy.text-center
                 %strong
-                  = t(".here_is_what_youll_get", plan_name: @selected_theft_alert_plan.name)
+                  = t(".here_is_what_youll_get", plan_name: @selected_theft_alert_plan&.name)
             .row
               .description
-                = @selected_theft_alert_plan.description_html.html_safe
+                = @selected_theft_alert_plan&.description_html&.html_safe
             .row
               .copy.text-center
                 %strong
-                  - price = @selected_theft_alert_plan.amount_cents
-                  = t(".charge", price: number_to_currency(price / 100.0), unit: "$", separator: ".")
+                  = t(".charge", price: @selected_theft_alert_plan&.amount_formatted)
             .row
               .text-center.w-100.mt-2
                 %button.btn.btn-lg.btn-primary#js-confirm-plan-button

--- a/spec/controllers/bikes_controller_spec.rb
+++ b/spec/controllers/bikes_controller_spec.rb
@@ -1119,7 +1119,12 @@ RSpec.describe BikesController, type: :controller do
         templates.each do |template|
           context "with query param ?page=#{template}" do
             it "renders the #{template} template" do
+              FactoryBot.create_list(:theft_alert_plan, 3)
+              bike.update(current_stolen_record: FactoryBot.create(:stolen_record, bike: bike))
+              expect(bike.current_stolen_record).to be_present
+
               get :edit, id: bike.id, page: template
+
               expect(response.status).to eq(200)
               expect(response).to render_template("edit_#{template}")
               expect(assigns(:edit_template)).to eq(template)

--- a/spec/controllers/bikes_controller_spec.rb
+++ b/spec/controllers/bikes_controller_spec.rb
@@ -1115,7 +1115,8 @@ RSpec.describe BikesController, type: :controller do
         # can't use the let block
         bc = BikesController.new
         bc.instance_variable_set(:@bike, Bike.new)
-        bc.edit_templates.each_pair do |template, _label|
+        templates = bc.edit_templates.keys.concat(["alert_purchase", "alert_purchase_confirmation"])
+        templates.each do |template|
           context "with query param ?page=#{template}" do
             it "renders the #{template} template" do
               get :edit, id: bike.id, page: template


### PR DESCRIPTION
The exception in https://github.com/bikeindex/bike_index/pull/1372 was enabled by an oversight on my part — the second- and third-stage alert purchase templates aren't included in `BikesController#edit_templates`, so they weren't being exercised by tests. 

This line replaces the relevant line with 

```rb
templates = bc.edit_templates.keys.concat(["alert_purchase", "alert_purchase_confirmation"])
```

to reproduce https://github.com/bikeindex/bike_index/pull/1372. 