### PR TITLE
Fix mobile layout to accommodate translated copy

### DIFF
--- a/app/assets/stylesheets/revised/pages/landing/_home.scss
+++ b/app/assets/stylesheets/revised/pages/landing/_home.scss
@@ -347,9 +347,15 @@
 }
 
 // Prevent overflow on tiny screens
-@media (max-width: 350px) {
-  .root-landing-banner-header .root-landing-header-text h1 {
-    font-size: 35px;
+@media (max-width: $grid-breakpoint-md) {
+  .root-landing-banner-header .root-landing-header-text {
+    h1 {
+      font-size: 2.3rem;
+    }
+
+    h2 {
+      line-height: 35px;
+    }
   }
 }
 

--- a/app/assets/stylesheets/revised/pages/landing/_home.scss
+++ b/app/assets/stylesheets/revised/pages/landing/_home.scss
@@ -199,7 +199,7 @@
     h1,
     h2,
     p {
-      color: white;
+      color: $white;
       display: block;
       margin: 15px auto;
       text-align: center;
@@ -221,7 +221,7 @@
     }
 
     h2 {
-      color: #ffffff;
+      color: $white;
       font-size: 24px;
       font-weight: 600;
       letter-spacing: 0.5px;

--- a/app/assets/stylesheets/revised/sections/primary_header_nav.scss
+++ b/app/assets/stylesheets/revised/sections/primary_header_nav.scss
@@ -499,7 +499,7 @@ $mainmenu-open-zindex: 10;
       text-decoration: none;
       margin: 11px $vertical-height 0 $vertical-height;
       transition: margin $mainmenu-transform-speed linear;
-      width: 90px;
+      width: 100px;
     }
 
     &.headroom--pinned .nonprofit-subtitle,


### PR DESCRIPTION
Fixes #1371 

<img width="393" alt="Screen Shot 2019-10-25 at 6 32 32 PM" src="https://user-images.githubusercontent.com/4433943/67608469-5eb9e500-f756-11e9-8aa9-5350df6274ca.png">
<img width="1177" alt="Screen Shot 2019-10-25 at 6 32 45 PM" src="https://user-images.githubusercontent.com/4433943/67608470-5eb9e500-f756-11e9-972a-1527af8cd32a.png">

Adds spacing to let the non-profit copy breathe when the nav bar is compressed:

<img width="305" alt="Screen Shot 2019-10-25 at 6 34 21 PM" src="https://user-images.githubusercontent.com/4433943/67608504-8f9a1a00-f756-11e9-84f7-3817b92252a9.png">
<img width="315" alt="Screen Shot 2019-10-25 at 6 34 07 PM" src="https://user-images.githubusercontent.com/4433943/67608506-8f9a1a00-f756-11e9-83ec-cae9fab89e5b.png">

