### PR TITLE
Add canonical_url to blog posts

### DIFF
--- a/app/controllers/admin/news_controller.rb
+++ b/app/controllers/admin/news_controller.rb
@@ -64,6 +64,7 @@ class Admin::NewsController < Admin::BaseController
   def permitted_parameters
     params.require(:blog).permit(
       :body,
+      :canonical_url,
       :description_abbr,
       :index_image,
       :index_image_id,

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -228,4 +228,11 @@ module ApplicationHelper
   def bike_placeholder_image_path
     image_path("revised/bike_photo_placeholder.svg")
   end
+
+  # Return the canonical url for the given blog post.
+  # If none available, default to the bike index url, removing any query params.
+  def canonical_url(blog)
+    url = blog.canonical_url.presence || news_url(blog)
+    url.split("?").first
+  end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -230,7 +230,8 @@ module ApplicationHelper
   end
 
   # Return the canonical url for the given blog post.
-  # If none available, default to the bike index url, removing any query params.
+  # If none available, default to the bike index url, removing any query params
+  # (e.g. the locale param).
   def canonical_url(blog)
     url = blog.canonical_url.presence || news_url(blog)
     url.split("?").first

--- a/app/models/blog.rb
+++ b/app/models/blog.rb
@@ -10,6 +10,7 @@ class Blog < ActiveRecord::Base
   validates_presence_of :title, :body, :user_id
   validates_uniqueness_of :title, message: "has already been taken. If you believe that this message is an error, contact us!"
   validates_uniqueness_of :title_slug, message: "somehow that overlaps with another title! Sorrys."
+  validates_format_of :canonical_url, with: %r{https?://\w+\.\w+/.+}, unless: -> { self.canonical_url.blank? }
 
   before_save :set_calculated_attributes
   before_create :set_title_slug

--- a/app/views/admin/news/edit.html.haml
+++ b/app/views/admin/news/edit.html.haml
@@ -87,6 +87,9 @@
             = f.select :language,
               options_for_select(language_choices, selected: @blog.language),
               class: "form-control"
+          .form-group
+            = f.label :canonical_url, "Canonical URL (e.g. https://blogspot.com/post/1)", class: "control-label"
+            = f.text_field :canonical_url, class: "form-control"
 
       .row.mt-4
         .col-md-6

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -14,6 +14,8 @@
       window.BikeIndex.translator = (keyspace) => {
         return (key, args={}) => I18n.t(`javascript.${keyspace}.${key}`, args);
       }
+    -# Use with content_for(:header) -- see news/show for an example of content yielded to a named `yield`.
+    -# https://guides.rubyonrails.org/layouts_and_rendering.html#using-the-content-for-method
     = yield :header
     <!--[if IE]>$('body').prepend("<div id='old-browser-warning'><h4>Your browser is out of date!</h4><p>As a result, Bike Index will not function correctly. <a href=\"http://whatbrowser.com\">Learn more here</a>.</p></div>")<![endif]-->
   %body{ id: page_id, class:  body_class }

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -14,6 +14,7 @@
       window.BikeIndex.translator = (keyspace) => {
         return (key, args={}) => I18n.t(`javascript.${keyspace}.${key}`, args);
       }
+    = yield :header
     <!--[if IE]>$('body').prepend("<div id='old-browser-warning'><h4>Your browser is out of date!</h4><p>As a result, Bike Index will not function correctly. <a href=\"http://whatbrowser.com\">Learn more here</a>.</p></div>")<![endif]-->
   %body{ id: page_id, class:  body_class }
     %nav.primary-header-nav

--- a/app/views/news/show.html.haml
+++ b/app/views/news/show.html.haml
@@ -1,3 +1,6 @@
+= content_for :header do
+  %link{rel: :canonical, href: canonical_url(@blog) }
+
 #news_display
   .blog-header
     %h1.global-title

--- a/db/migrate/20191028130015_add_canonical_url_to_blog.rb
+++ b/db/migrate/20191028130015_add_canonical_url_to_blog.rb
@@ -1,0 +1,5 @@
+class AddCanonicalUrlToBlog < ActiveRecord::Migration
+  def change
+    add_column :blogs, :canonical_url, :string
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -442,7 +442,8 @@ CREATE TABLE public.blogs (
     index_image character varying(255),
     index_image_id integer,
     index_image_lg character varying(255),
-    language integer DEFAULT 0 NOT NULL
+    language integer DEFAULT 0 NOT NULL,
+    canonical_url character varying
 );
 
 
@@ -4838,4 +4839,6 @@ INSERT INTO schema_migrations (version) VALUES ('20191018140618');
 INSERT INTO schema_migrations (version) VALUES ('20191022123037');
 
 INSERT INTO schema_migrations (version) VALUES ('20191022143755');
+
+INSERT INTO schema_migrations (version) VALUES ('20191028130015');
 

--- a/spec/models/blog_spec.rb
+++ b/spec/models/blog_spec.rb
@@ -114,6 +114,36 @@ RSpec.describe Blog, type: :model do
     end
   end
 
+  describe "canonical_url validation" do
+    context "given a blank value" do
+      it "is valid" do
+        blog = FactoryBot.build(:blog, canonical_url: "")
+        expect(blog).to be_valid
+
+        blog = FactoryBot.build(:blog, canonical_url: nil)
+        expect(blog).to be_valid
+      end
+    end
+
+    context "given a minimally complete url" do
+      it "is valid" do
+        blog = FactoryBot.build(:blog, canonical_url: "http://blogger.com/myblog")
+        expect(blog).to be_valid
+
+        blog = FactoryBot.build(:blog, canonical_url: "https://blogger.com/myblog")
+        expect(blog).to be_valid
+      end
+    end
+
+    context "given an incomplete url" do
+      it "is invalid" do
+        blog = FactoryBot.build(:blog, canonical_url: "blogger.com/myblog")
+        expect(blog).to be_invalid
+        expect(blog.errors[:canonical_url]).to include("is invalid")
+      end
+    end
+  end
+
   describe "feed_content" do
     it "returns html content for non-listicles" do
       blog = Blog.new(body: "something")


### PR DESCRIPTION
- Adds `canonical_url` to blog model
- Renders canonical url in the header for blog posts
- Adds field to blog edit form