### PR TITLE
Fix external credentials updating 

### DIFF
--- a/app/controllers/admin/external_registry_credentials_controller.rb
+++ b/app/controllers/admin/external_registry_credentials_controller.rb
@@ -51,8 +51,11 @@ class Admin::ExternalRegistryCredentialsController < Admin::BaseController
   end
 
   def external_registry_credential_params
+    model_type = params[:type]&.underscore&.tr("/", "_")
+    params[model_type][:type] = params[:type]
+
     params
-      .require(:external_registry_credential)
+      .require(model_type)
       .permit(:app_id, :access_token, :refresh_token, :type)
   end
 end

--- a/app/views/admin/external_registry_credentials/_form.html.haml
+++ b/app/views/admin/external_registry_credentials/_form.html.haml
@@ -3,8 +3,8 @@
   method: method,
   html: { class: "form" } do |f|
   %fieldset
-    = f.label :type, "Type", class: "form-label"
-    = f.select :type,
+    = label :type, "Type", class: "form-label"
+    = select_tag :type,
       external_registry_type_options(selected: external_registry_credential&.type),
       include_blank: true,
       class: "form-control"

--- a/app/views/admin/external_registry_credentials/edit.html.haml
+++ b/app/views/admin/external_registry_credentials/edit.html.haml
@@ -2,7 +2,7 @@
   %h1 Edit External Registry Credential
 
   = render "form",
-    external_registry_credential: @external_registry_credential ,
-    action: admin_external_registry_credentials_path(@external_registry_credential),
+    external_registry_credential: @external_registry_credential,
+    action: admin_external_registry_credential_path(@external_registry_credential),
     method: :put,
     submit_label: "Update"


### PR DESCRIPTION
Hotfix to enable updating StopHeling creds

- Fixes a typo in the update form's url helper
- Sets the STI model key based on the `type` field