### PR TITLE
Use to_param for organized links

### DIFF
--- a/app/views/organized/bikes/index.html.haml
+++ b/app/views/organized/bikes/index.html.haml
@@ -1,7 +1,7 @@
 - if @bike_code.present?
   - if @bike_code.claimed?
     %h2
-      %a{ href: edit_organization_sticker_path(organization_id: current_organization.id, id: @bike_code.code) }
+      %a{ href: edit_organization_sticker_path(organization_id: current_organization.to_param, id: @bike_code.code) }
         = @bike_code.kind
         = @bike_code.code
       = t(".is_currently_linked")
@@ -11,13 +11,13 @@
       = t(".connected_to_bike_html", bike_link: bike_link)
   - else
     %h2
-      %a{ href: edit_organization_sticker_path(organization_id: current_organization.id, id: @bike_code.code) }
+      %a{ href: edit_organization_sticker_path(organization_id: current_organization.to_param, id: @bike_code.code) }
         = @bike_code.kind
         %em= @bike_code.code
       = t(".isnt_linked_to_a_bike")
   %p
     = t(".enter_url_of_the_bike_html", bike_code_kind: @bike_code.kind)
-  = form_tag bike_code_path(id: @bike_code.code, organization_id: current_organization.id), method: "PUT", class: "row" do
+  = form_tag bike_code_path(id: @bike_code.code, organization_id: current_organization.to_param), method: "PUT", class: "row" do
     .col-sm-8.col-lg-10
       .form-group
         = text_field_tag :bike_id, "", placeholder: "https://bikeindex.org/bikes/1234", class: "form-control"

--- a/app/views/organized/manage/index.html.haml
+++ b/app/views/organized/manage/index.html.haml
@@ -67,7 +67,7 @@
   #delete-organization.collapse
     .text-md-center
       = link_to t(".delete_organization"),
-        organization_manage_path(id: current_organization.id, organization_id: current_organization.to_param),
+        organization_manage_path(id: current_organization.to_param, organization_id: current_organization.to_param),
         method: :delete,
         data: { confirm: t(".removal_confirmation", org_name: current_organization.name) },
         class: 'btn btn-danger'

--- a/app/views/organized/stickers/index.html.haml
+++ b/app/views/organized/stickers/index.html.haml
@@ -61,7 +61,7 @@
       - @bike_codes.each do |bike_code|
         %tr
           %td
-            %a.convertTime{ href: edit_organization_sticker_path(organization_id: current_organization.id, id: bike_code.code) }
+            %a.convertTime{ href: edit_organization_sticker_path(organization_id: current_organization.to_param, id: bike_code.code) }
               = l(bike_code.created_at, format: :convert_time)
           %td
             - if bike_code.claimed? && bike_code.claimed_at.present?


### PR DESCRIPTION
A few urls in organized pages used id rather than the slug. Update them!