### PR TITLE
Automate twitter accounts credential refresh

### DIFF
--- a/app/controllers/admin/twitter_accounts_controller.rb
+++ b/app/controllers/admin/twitter_accounts_controller.rb
@@ -26,9 +26,10 @@ class Admin::TwitterAccountsController < Admin::BaseController
 
   def create
     twitter_account =
-      TwitterAccount.create_from_twitter_oauth(request.env["omniauth.auth"])
+      TwitterAccount.find_or_create_from_twitter_oauth(request.env["omniauth.auth"])
 
     if twitter_account.persisted?
+      twitter_account.check_credentials
       flash[:notice] = "Twitter account #{twitter_account.screen_name} is persisted."
       redirect_to admin_twitter_account_url(twitter_account)
     else

--- a/app/views/admin/twitter_accounts/_errored.html.haml
+++ b/app/views/admin/twitter_accounts/_errored.html.haml
@@ -13,4 +13,4 @@
         %em
           = TwitterAccount.errored.pluck(:screen_name).sort.join(", ")
 
-
+      = link_to "Log in with any of these accounts to refresh their credentials", "/auth/twitter", class: "btn btn-success"

--- a/app/views/admin/twitter_accounts/edit.html.haml
+++ b/app/views/admin/twitter_accounts/edit.html.haml
@@ -3,8 +3,11 @@
     %h1
       %small Update Twitter Account:
       = @twitter_account.screen_name
-    %small
+    %small.mr-4
       = link_to "View account data", admin_twitter_account_path(@twitter_account)
+    %small
+      = link_to "Log in to refresh credentials", "/auth/twitter"
+
   .col-sm-6.text-right
     = link_to "Delete account",
       admin_twitter_account_path(@twitter_account),

--- a/app/views/admin/twitter_accounts/show.html.haml
+++ b/app/views/admin/twitter_accounts/show.html.haml
@@ -3,7 +3,6 @@
     .mr-4
       = link_to "Edit", edit_admin_twitter_account_url(@twitter_account), class: "btn btn-success"
       = link_to "Check Credentials", check_credentials_admin_twitter_account_url(@twitter_account), class: "btn btn-success"
-      = link_to "Log in to refresh credentials", "/auth/twitter", class: "btn btn-success"
 
 - if @twitter_account.errored?
   .row.mt-4.mb-4
@@ -25,6 +24,7 @@
                 Error
               %td
                 = @twitter_account.last_error
+        = link_to "Log in to refresh credentials", "/auth/twitter", class: "btn btn-success"
 .row
   .col-md-6
     %h1

--- a/app/views/admin/twitter_accounts/show.html.haml
+++ b/app/views/admin/twitter_accounts/show.html.haml
@@ -1,8 +1,9 @@
 .admin-subnav
   .col-6
     .mr-4
-      = link_to "Edit", edit_admin_twitter_account_url(@twitter_account), class: "btn btn-lg btn-success"
-      = link_to "Check Credentials", check_credentials_admin_twitter_account_url(@twitter_account), class: "btn btn-lg btn-success"
+      = link_to "Edit", edit_admin_twitter_account_url(@twitter_account), class: "btn btn-success"
+      = link_to "Check Credentials", check_credentials_admin_twitter_account_url(@twitter_account), class: "btn btn-success"
+      = link_to "Log in to refresh credentials", "/auth/twitter", class: "btn btn-success"
 
 - if @twitter_account.errored?
   .row.mt-4.mb-4

--- a/spec/factories/twitter_accounts.rb
+++ b/spec/factories/twitter_accounts.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :twitter_account do
-    sequence(:screen_name) { "TestTwitterAccount" }
+    sequence(:screen_name) { |n| "TestTwitterAccount#{n}" }
     consumer_key { "CONSUMER_KEY" }
     consumer_secret { "CONSUMER_SECRET" }
     user_token { "ACCESS_TOKEN" }

--- a/spec/models/twitter_account_spec.rb
+++ b/spec/models/twitter_account_spec.rb
@@ -58,7 +58,7 @@ RSpec.describe TwitterAccount, type: :model do
   describe "#default_account" do
     it "returns first national account" do
       national_account1 = FactoryBot.create(:twitter_account_1, :national, :active)
-      _national_account2 = FactoryBot.create(:twitter_account_1, :national, :active)
+      _national_account2 = FactoryBot.create(:twitter_account_2, :national, :active)
       expect(TwitterAccount.default_account).to eq(national_account1)
     end
   end


### PR DESCRIPTION
- Adds a "log in to refresh credentials" button to the admin/twitter_accounts#show template
- Updates the credentials on any pre-existing record and re-verifies credentials to clear errors