### PR TITLE
Rename PartialSerialSearch -> CloseSerialSearch

### DIFF
--- a/app/javascript/packs/api.js
+++ b/app/javascript/packs/api.js
@@ -13,7 +13,7 @@ const fuzzySearchUrl = serial =>
 const serialExternalSearchUrl = serial =>
   url(`api/v3/search/external_registries?serial=${serial}`);
 
-const serialPartialSearchUrl = ({serial, stolenness, location, query }) => {
+const serialCloseSearchUrl = ({serial, stolenness, location, query }) => {
   const params = {};
   if (serial) { params.serial = serial; }
   if (stolenness) { params.stolenness = stolenness; }
@@ -48,8 +48,8 @@ const fetchSerialExternalSearch = serial => {
   return request(url);
 }
 
-const fetchSerialPartialSearch = interpretedParams => {
-  const url = serialPartialSearchUrl(interpretedParams);
+const fetchSerialCloseSearch = interpretedParams => {
+  const url = serialCloseSearchUrl(interpretedParams);
   return request(url);
 }
 
@@ -57,5 +57,5 @@ export {
   fetchSerialResults,
   fetchFuzzyResults,
   fetchSerialExternalSearch,
-  fetchSerialPartialSearch,
+  fetchSerialCloseSearch,
 };

--- a/app/javascript/packs/close_serial_search/components/CloseSerialSearch.js
+++ b/app/javascript/packs/close_serial_search/components/CloseSerialSearch.js
@@ -2,13 +2,13 @@
 
 import React, { Fragment, Component } from "react";
 
-import PartialSerialSearchResult from "./PartialSerialSearchResult";
-import { fetchSerialPartialSearch } from "../../api";
+import CloseSerialSearchResult from "./CloseSerialSearchResult";
+import { fetchSerialCloseSearch } from "../../api";
 import Loading from "../../Loading";
 import honeybadger from "../../utils/honeybadger";
 import TimeParser from "../../utils/time_parser";
 
-class PartialSerialSearch extends Component {
+class CloseSerialSearch extends Component {
   state = {
     loading: false,
     results: []
@@ -16,7 +16,7 @@ class PartialSerialSearch extends Component {
 
   componentWillMount() {
     this.resultsBeingFetched();
-    fetchSerialPartialSearch(this.props.interpretedParams)
+    fetchSerialCloseSearch(this.props.interpretedParams)
       .then(this.resultsFetched)
       .catch(this.handleError);
   }
@@ -37,11 +37,11 @@ class PartialSerialSearch extends Component {
   }
 
   handleError = error => {
-    honeybadger.notify(error, { component: "PartialSerialSearch" });
+    honeybadger.notify(error, { component: "CloseSerialSearch" });
   }
 
   toggleHeader = ({ isLoading, resultsCount }) => {
-    const header = document.getElementById("js-partial-serial-search-header");
+    const header = document.getElementById("js-close-serial-search-header");
     if (!header) { return; }
 
     header.childNodes.forEach(node => node.classList && node.classList.add("d-none"));
@@ -64,11 +64,11 @@ class PartialSerialSearch extends Component {
     return (
       <Fragment>
         <ul className="bike-boxes">
-          {this.state.results.map(bike => <PartialSerialSearchResult key={bike.id} bike={bike} />)}
+          {this.state.results.map(bike => <CloseSerialSearchResult key={bike.id} bike={bike} />)}
         </ul>
       </Fragment>
     );
   }
 };
 
-export default PartialSerialSearch;
+export default CloseSerialSearch;

--- a/app/javascript/packs/close_serial_search/components/CloseSerialSearchResult.js
+++ b/app/javascript/packs/close_serial_search/components/CloseSerialSearchResult.js
@@ -4,7 +4,7 @@ import React, { Fragment } from "react";
 
 const t = BikeIndex.translator("bikes_search");
 
-const PartialSerialSearchResult = ({bike}) => (
+const CloseSerialSearchResult = ({bike}) => (
   <li className="bike-box-item">
     <ResultImage bike={bike}/>
 
@@ -90,4 +90,4 @@ const ResultImage = ({ bike }) => {
           </a>);
 }
 
-export default PartialSerialSearchResult;
+export default CloseSerialSearchResult;

--- a/app/javascript/packs/close_serial_search/index.js
+++ b/app/javascript/packs/close_serial_search/index.js
@@ -1,16 +1,16 @@
 import React from "react";
 import ReactDOM from "react-dom";
 import ErrorBoundary from "@honeybadger-io/react";
-import PartialSerialSearch from "./components/PartialSerialSearch";
+import CloseSerialSearch from "./components/CloseSerialSearch";
 import honeybadger from "../utils/honeybadger";
 
 document.addEventListener("DOMContentLoaded", () => {
-  const el = document.getElementById("js-partial-serial-search");
+  const el = document.getElementById("js-close-serial-search");
   if (!el) { return; }
 
   ReactDOM.render(
     <ErrorBoundary honeybadger={honeybadger}>
-    <PartialSerialSearch interpretedParams={window.interpreted_params} />
+    <CloseSerialSearch interpretedParams={window.interpreted_params} />
     </ErrorBoundary>,
     el
   );

--- a/app/views/bikes/index.html.haml
+++ b/app/views/bikes/index.html.haml
@@ -1,5 +1,5 @@
 = javascript_pack_tag "external_registry_search/index"
-= javascript_pack_tag "partial_serial_search/index"
+= javascript_pack_tag "close_serial_search/index"
 
 - stolenness_desc = { 'proximity' => 'nearby stolen', 'non' => 'non-stolen', 'stolen' => 'stolen', 'all' => 'all' }[@interpreted_params[:stolenness]]
 
@@ -67,11 +67,11 @@
   - if @interpreted_params[:serial].present?
     .row
       .col-md-12
-        %h3.secondary-matches#js-partial-serial-search-header
+        %h3.secondary-matches#js-close-serial-search-header
           .loading.d-none= t(".searching_for_near_matches")
           .loaded.d-none= t(".with_serial_numbers_html", stolenness: stolenness_desc, serial: params[:serial])
           .loaded-none.no-exact-results.d-none= t(".no_near_matches_found")
-        #js-partial-serial-search
+        #js-close-serial-search
 
     .row
       .col-md-12


### PR DESCRIPTION
- Renames what was formerly `PartialSerialSearch` to `CloseSerialSearch` so it mirrors the API endpoint name

Extracted from #1387 