### PR TITLE
Defer persistence until after joining threads

### DIFF
--- a/app/models/external_registry_client.rb
+++ b/app/models/external_registry_client.rb
@@ -21,9 +21,10 @@ class ExternalRegistryClient
       registries
         .flat_map { |registry| queries.map { |q| [registry, q] } }
         .map { |registry, q| Thread.new { registry.new.search(q) } }
-        .map(&:value)
-        .flatten
+        .flat_map(&:value)
         .compact
+        .each(&:save)
+        .select(&:persisted?)
 
     ExternalRegistryBike.where(id: results.map(&:id))
   end

--- a/app/models/external_registry_client/stop_heling_client.rb
+++ b/app/models/external_registry_client/stop_heling_client.rb
@@ -33,8 +33,7 @@ class ExternalRegistryClient::StopHelingClient < ExternalRegistryClient
         response.body
       end
 
-    results = results_from(response_body: response_body, request_params: req_params)
-    ::ExternalRegistryBike.where(id: results.map(&:id))
+    results_from(response_body: response_body, request_params: req_params)
   end
 
   private
@@ -60,8 +59,6 @@ class ExternalRegistryClient::StopHelingClient < ExternalRegistryClient
         .map { |result| translate_keys(result) }
         .map { |attrs| ExternalRegistryBike::StopHelingBike.build_from_api_response(attrs) }
         .compact
-        .each(&:save)
-        .select(&:persisted?)
     else
       if Rails.env.production?
         # Fail gracefully but notify Honeybadger if the request fails.

--- a/spec/models/external_registry_client/stop_heling_client_spec.rb
+++ b/spec/models/external_registry_client/stop_heling_client_spec.rb
@@ -29,11 +29,12 @@ RSpec.describe ExternalRegistryClient::StopHelingClient, type: :model do
     end
 
     context "given matching results but no bikes" do
-      it "returns an array of ExternalRegistryBikes" do
+      it "returns an array of unpersisted ExternalRegistryBikes" do
         client = build_client(results: [bike_result])
         results = client.search("28484")
         expect(results).to_not be_empty
         expect(results).to all(be_an_instance_of(ExternalRegistryBike::StopHelingBike))
+        expect(results.none?(&:persisted?)).to eq(true)
       end
     end
   end

--- a/spec/models/external_registry_client/verloren_of_gevonden_client_spec.rb
+++ b/spec/models/external_registry_client/verloren_of_gevonden_client_spec.rb
@@ -17,8 +17,9 @@ RSpec.describe ExternalRegistryClient::VerlorenOfGevondenClient, type: :model do
           results = described_class.new.search(2722)
 
           expect(results).to be_present
-          expect(results).to be_an(ActiveRecord::Relation)
+          expect(results).to be_an(Array)
           expect(results).to all(be_an_instance_of(ExternalRegistryBike::VerlorenOfGevondenBike))
+          expect(results.none?(&:persisted?)).to eq(true)
           expect(results.map(&:description)).to all(match(/fiets/))
           expect(results.first.external_id).to match(/F\d+\w*-.+/)
           expect(results.first.serial_number).to be_present
@@ -30,7 +31,7 @@ RSpec.describe ExternalRegistryClient::VerlorenOfGevondenClient, type: :model do
       it "returns an empty collection" do
         VCR.use_cassette("external_registry/verlorenofgevonden_13949483_no_results") do
           results = described_class.new.search(13949483)
-          expect(results).to be_an(ActiveRecord::Relation)
+          expect(results).to be_an(Array)
           expect(results).to be_empty
         end
       end
@@ -39,7 +40,7 @@ RSpec.describe ExternalRegistryClient::VerlorenOfGevondenClient, type: :model do
     context "given an invalid query" do
       it "returns an empty collection" do
         results = described_class.new.search("")
-        expect(results).to be_an(ActiveRecord::Relation)
+        expect(results).to be_an(Array)
         expect(results).to be_empty
       end
     end


### PR DESCRIPTION
In order to minimize simultaneous database connections, this patch updates external registry querying logic to defer persistence of external registry results until after the threads searching those external registries are joined.

```rb
# app/models/external_registry_client.rb L20-27 (8afac065)

results =
  registries
    .flat_map { |registry| queries.map { |q| [registry, q] } }
    .map { |registry, q| Thread.new { registry.new.search(q) } }
    .flat_map(&:value)
    .compact
    .each(&:save)
    .select(&:persisted?)
```
<sup>[[source](https://github.com/bikeindex/bike_index/blob/8afac065/app/models/external_registry_client.rb#L20-L27)]</sup>

Related:

https://app.honeybadger.io/projects/35931/faults/56518719
https://app.honeybadger.io/projects/35931/faults/55996932
https://app.honeybadger.io/projects/35931/faults/50925427

Closes:

https://github.com/bikeindex/bike_index/issues/1389