### PR TITLE
Add JS translations

### DIFF
--- a/app/assets/javascripts/application_revised.js
+++ b/app/assets/javascripts/application_revised.js
@@ -28,6 +28,10 @@
 // Can use if we need a carousel, though would be nice to use rails-assets version instead
 //= require external_scripts/slick.js
 
+// Translations
+//= require i18n
+//= require i18n/translations
+
 // Things that are required for File Upload:
 //= require external_scripts/jquery_sortable_0.9.13.js
 //= require external_scripts/jquery.ui.widget.js

--- a/app/javascript/packs/bikes_search/components/BikeSearch.js
+++ b/app/javascript/packs/bikes_search/components/BikeSearch.js
@@ -34,7 +34,9 @@ class BikeSearch extends Component {
   }
 
   resultsFetched = ({ bikes, error }) => {
-    this.setState({ results: bikes || [], loading: false });
+    const results = bikes || [];
+    const loading = (!results.length) ? null : false;
+    this.setState({ results , loading });
     if (error) { this.handleError(error) }
   }
 
@@ -53,7 +55,7 @@ class BikeSearch extends Component {
     if (this.state.loading === null) {
       return <div className="row">
                <div className="col-md-12">
-                 <h3 className="secondary-matches">
+                 <h3 className="no-exact-results">
                    {this.props.t("no_matches_found_html", { serial })}
                  </h3>
                </div>

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -8,8 +8,6 @@
     <!-- TODO: Use yarn -->
     <script src="https://kit.fontawesome.com/82eb17360c.js"></script>
     = javascript_include_tag 'application_revised'
-    = javascript_include_tag "i18n"
-    = javascript_include_tag "translations", skip_pipeline: true
     :javascript
       window.BikeIndex.translator = (keyspace) => {
         return (key, args={}) => I18n.t(`javascript.${keyspace}.${key}`, args);

--- a/config/application.rb
+++ b/config/application.rb
@@ -44,9 +44,6 @@ module Bikeindex
     require_relative "../lib/i18n/middleware"
     config.middleware.use I18n::Middleware
 
-    # Add middleware for i18n-js
-    config.middleware.use I18n::JS::Middleware
-
     config.to_prepare do
       Doorkeeper::ApplicationsController.layout "doorkeeper"
       Doorkeeper::AuthorizationsController.layout "doorkeeper"


### PR DESCRIPTION
- Switches to using the asset pipeline for JS translations (in an attempt to work around what may be browser caching preventing updates of translations.js)
- Fixes coloring of results headers when no results found

<img width="1033" alt="Screen Shot 2019-10-31 at 3 49 33 PM" src="https://user-images.githubusercontent.com/4433943/67981041-26068980-fbf6-11e9-9386-2324cecc6441.png">
