### PR TITLE
Downcase VOG queries

### DIFF
--- a/app/models/external_registry_client/verloren_of_gevonden_client.rb
+++ b/app/models/external_registry_client/verloren_of_gevonden_client.rb
@@ -45,10 +45,14 @@ class ExternalRegistryClient::VerlorenOfGevondenClient < ExternalRegistryClient
   private
 
   # Query for the results page `page_num`.
+  #
+  # NB: VOG endpoint expects lowercase letters in the query string and matches
+  # case-sensitively
+  #
   # Return the JSON response body as a Hash
   def get_page(query, page: 1, per_page: ITEMS_RECEIVED_PER_PAGE)
     Rails.logger.info("Requesting page #{page}")
-    req_params = request_params(query, page, per_page)
+    req_params = request_params(query.to_s.downcase, page, per_page)
     cache_key = ["verlorenofgevonden.nl", query, req_params]
 
     response_json =


### PR DESCRIPTION
Fixes a bug whereby serial numbers with letters in them weren't being matched against bikes that by the VOG endpoint, which expects any letters in lower case.

### Before

<img width="867" alt="Screen Shot 2019-11-07 at 11 53 14 AM" src="https://user-images.githubusercontent.com/4433943/68409550-446c0800-0155-11ea-9d2e-53943098942c.png">
<img width="906" alt="Screen Shot 2019-11-07 at 11 53 18 AM" src="https://user-images.githubusercontent.com/4433943/68409552-446c0800-0155-11ea-8b93-066ae0a0a12a.png">


### After

<img width="1149" alt="Screen Shot 2019-11-07 at 11 52 43 AM" src="https://user-images.githubusercontent.com/4433943/68409561-47ff8f00-0155-11ea-9d9f-1d97dc5ca0e8.png">
<img width="1164" alt="Screen Shot 2019-11-07 at 11 53 06 AM" src="https://user-images.githubusercontent.com/4433943/68409562-47ff8f00-0155-11ea-9ea1-5bec1a030d47.png">
