### PR TITLE
Add regional organization data to organized dashboard

### DIFF
--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -198,12 +198,14 @@ class Organization < ActiveRecord::Base
     return @bikes_in_region_counts if defined?(@bikes_in_region_counts)
 
     bikes_in_orgs = regional_suborganizations.includes(:bikes).flat_map(&:bikes).map(&:id)
-    bikes_in_region = search_location.blank? ? [] : Bike.all.near(search_location, search_radius).reorder(:id).pluck(:id)
+    bikes_in_region = Bike.all.near(search_location, search_radius).reorder(:id).pluck(:id)
+    bikes_unaffiliated = (bikes_in_region - bikes_in_orgs)
 
     @bikes_in_region_count = {
       in_organizations: bikes_in_orgs.count,
       in_region: bikes_in_region.count,
-      in_region_unaffiliated: (bikes_in_region - bikes_in_orgs).count,
+      in_region_unaffiliated: bikes_unaffiliated.count,
+      all: (bikes_in_orgs + bikes_unaffiliated).count,
     }
   end
 

--- a/app/views/organized/dashboard/index.html.haml
+++ b/app/views/organized/dashboard/index.html.haml
@@ -3,6 +3,47 @@
     %em= current_organization.name
     Dashboard
 
+- if current_organization.regional? && current_organization.is_paid?
+  %h3.mt-4 Bikes in Region
+  - counts = current_organization.bikes_in_region_counts
+  .full-screen-table.mt-4
+    %table.table.table-striped.table-bordered.table-sm
+      %tbody
+        %tr
+          %td
+            Total registrations in regional organizations
+          %td= number_with_delimiter(counts[:in_organizations])
+        %tr
+          %td
+            Total registrations not in regional organizations
+            %small (within #{current_organization.search_radius} mi of city center)
+          %td= number_with_delimiter(counts[:in_region_unaffiliated])
+      %tfoot
+        %td
+          %strong Total
+        %td
+          %strong= number_with_delimiter(counts[:all])
+
+  %h3.mt-4 Organizations in Region
+  .full-screen-table.mt-4
+    %table.table.table-striped.table-bordered.table-sm
+      %thead
+        %th Organization
+        %th Bikes
+      %tbody
+        - total_bikes_count = 0
+        - current_organization.regional_suborganizations.each do |organization|
+          - count = organization.bikes.count
+          - total_bikes_count += count
+          %tr
+            %td= organization.name
+            %td= number_with_delimiter(count)
+      %tfoot
+        %td
+          %strong Total
+        %td
+          %strong= number_with_delimiter(total_bikes_count)
+
 - if current_organization.parent?
   %h3.mt-4
     Associated organizations


### PR DESCRIPTION
Adds counts of bikes within regional sub-organizations and within `search_radius` miles of the `Organization#search_location`

```rb
    @bikes_in_region_count = {
      in_organizations: bikes_in_orgs.count,	      
      in_region: bikes_in_region.count,
      in_region_unaffiliated: (bikes_in_region - bikes_in_orgs).count,	      
      all: (bikes_in_orgs + bikes_unaffiliated).count,
    }	    
```


<img width="1046" alt="Screen Shot 2019-11-09 at 3 07 05 PM" src="https://user-images.githubusercontent.com/4433943/68534449-a453e180-0302-11ea-82c2-2330bcc053a9.png">