### PR TITLE
Extract Geocodeable mixin

### DIFF
--- a/app/models/concerns/geocodeable.rb
+++ b/app/models/concerns/geocodeable.rb
@@ -1,0 +1,34 @@
+# Add to a model that can be geolocated
+# Expects `latitude` and `longitude` columns to be defined.
+module Geocodeable
+  extend ActiveSupport::Concern
+
+  included do
+    geocoded_by :geocode_data
+    after_validation :geocode, if: :should_be_geocoded?
+
+    attr_accessor :skip_geocoding
+
+    def skip_geocoding?
+      !!skip_geocoding
+    end
+
+    # Override in Geocodeable model.
+    def geocode_data; end
+
+    # An array of symbols of the db columns upon which `geocode_data`
+    # depends.These are checked for changes before geocoding using
+    # `should_be_geocoded?`. By default, empty, so we don't check for changes.
+    def geocode_columns; []; end
+
+    def any_geocode_columns_changed?
+      geocode_columns.any? { |col| public_send("#{col}_changed?") }
+    end
+
+    # Override to customize skip-geocoding logic.
+    def should_be_geocoded?
+      return false if skip_geocoding?
+      geocode_data.present? && any_geocode_columns_changed?
+    end
+  end
+end

--- a/app/models/concerns/geocodeable.rb
+++ b/app/models/concerns/geocodeable.rb
@@ -13,8 +13,10 @@ module Geocodeable
       !!skip_geocoding
     end
 
-    # Override in Geocodeable model.
-    def geocode_data; end
+    # Customize by overriding in the Geocodeable model.
+    def geocode_data
+      @geocode_data ||= address
+    end
 
     # An array of symbols of the db columns upon which `geocode_data`
     # depends.These are checked for changes before geocoding using

--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -1,4 +1,6 @@
 class Location < ActiveRecord::Base
+  include Geocodeable
+
   acts_as_paranoid
   belongs_to :organization, inverse_of: :locations # Locations are organization locations
   belongs_to :country
@@ -14,11 +16,6 @@ class Location < ActiveRecord::Base
   before_save :shown_from_organization
   before_save :set_phone
   after_commit :update_organization
-
-  unless Rails.env.test?
-    geocoded_by :address
-    after_validation :geocode
-  end
 
   def shown_from_organization
     self.shown = organization && organization.allowed_show
@@ -55,5 +52,15 @@ class Location < ActiveRecord::Base
     return name if name == organization.name
 
     "#{organization.name} - #{name}"
+  end
+
+  private
+
+  def geocode_data
+    @geocode_data ||= address
+  end
+
+  def geocode_columns
+    %i[street city state_id zipcode country_id]
   end
 end

--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -56,10 +56,6 @@ class Location < ActiveRecord::Base
 
   private
 
-  def geocode_data
-    @geocode_data ||= address
-  end
-
   def geocode_columns
     %i[street city state_id zipcode country_id]
   end

--- a/app/models/mail_snippet.rb
+++ b/app/models/mail_snippet.rb
@@ -53,10 +53,6 @@ class MailSnippet < ActiveRecord::Base
 
   private
 
-  def geocode_data
-    address
-  end
-
   def geocode_columns
     %i[address]
   end

--- a/app/models/mail_snippet.rb
+++ b/app/models/mail_snippet.rb
@@ -1,4 +1,6 @@
 class MailSnippet < ActiveRecord::Base
+  include Geocodeable
+
   KIND_ENUM = { custom: 0, header: 1, welcome: 2, footer: 3, security: 4, abandoned_bike: 5, location_triggered: 6 }.freeze
   validates_presence_of :name
 
@@ -13,8 +15,6 @@ class MailSnippet < ActiveRecord::Base
 
   enum kind: KIND_ENUM
 
-  geocoded_by :address
-  after_validation :geocode, if: lambda { is_location_triggered && address.present? }
   after_commit :update_organization
 
   before_validation :set_calculated_attributes
@@ -49,5 +49,22 @@ class MailSnippet < ActiveRecord::Base
     # Because we need to update the organization and make sure mail snippet calculations are included
     # Manually update to ensure that it runs the before save stuff
     organization && organization.update_attributes(updated_at: Time.current)
+  end
+
+  private
+
+  def geocode_data
+    address
+  end
+
+  def geocode_columns
+    %i[address]
+  end
+
+  def should_be_geocoded?
+    return false if skip_geocoding?
+    return true if is_location_triggered?
+    return false if geocode_data.blank?
+    any_geocode_columns_changed?
   end
 end

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -75,7 +75,7 @@ class Organization < ActiveRecord::Base
   after_commit :update_associations
 
   geocoded_by :search_location
-  after_validation :geocode, if: :should_be_geocoded
+  after_validation :geocode, if: :should_be_geocoded?
 
   attr_accessor :embedable_user_email, :lightspeed_cloud_api_key, :skip_update
 
@@ -327,10 +327,14 @@ class Organization < ActiveRecord::Base
 
   private
 
+  def skip_geocoding?
+    !!skip_geocoding
+  end
+
   # Skip geocoding if search location is blank or if no location fields have
   # been changed.
-  def should_be_geocoded
-    return if search_location.blank?
+  def should_be_geocoded?
+    return false if search_location.blank?
     [city_changed?, state_id_changed?, zipcode_changed?, country_id_changed?].any?
   end
 

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -1,6 +1,5 @@
 class Organization < ActiveRecord::Base
   include ActionView::Helpers::SanitizeHelper
-  include Geocodeable
 
   KIND_ENUM = {
     bike_shop: 0,
@@ -206,6 +205,9 @@ class Organization < ActiveRecord::Base
     }
   end
 
+  def search_location
+  end
+
   def paid_for?(feature_name)
     features =
       Array(feature_name)
@@ -318,21 +320,7 @@ class Organization < ActiveRecord::Base
     calculated_children.each { |o| o.update_attributes(updated_at: Time.current, skip_update: true) }
   end
 
-  def search_location
-    city_and_state = [city, state&.name].reject(&:blank?).join(", ")
-    with_zip = [city_and_state, zipcode].reject(&:blank?).join(" ")
-    [with_zip, country&.name].reject(&:blank?).join(" - ")
-  end
-
   private
-
-  def geocode_data
-    @geocode_data ||= search_location
-  end
-
-  def geocode_columns
-    %i[city state_id zipcode country_id]
-  end
 
   def calculated_paid_feature_slugs
     fslugs = current_invoices.feature_slugs

--- a/app/models/stolen_record.rb
+++ b/app/models/stolen_record.rb
@@ -1,6 +1,8 @@
 class StolenRecord < ActiveRecord::Base
   include ActiveModel::Dirty
   include Phonifyerable
+  include Geocodeable
+
   RECOVERY_DISPLAY_STATUS_ENUM = {
     not_eligible: 0,
     waiting_on_decision: 1,
@@ -10,7 +12,6 @@ class StolenRecord < ActiveRecord::Base
   }.freeze
 
   attr_accessor :timezone # Just to provide a backup and permit assignment
-  attr_accessor :skip_geocoding
 
   def self.old_attr_accessible
     # recovery_tweet, recovery_share # We edit this in the admin panel
@@ -49,9 +50,6 @@ class StolenRecord < ActiveRecord::Base
 
   before_save :set_calculated_attributes
 
-  geocoded_by :address_override_show_address
-  after_validation :geocode, if: :should_be_geocoded?
-
   reverse_geocoded_by :latitude, :longitude do |stolen_record, results|
     if (geo = results.first)
       stolen_record.country ||= Country.find_by(name: geo.country)
@@ -87,8 +85,6 @@ class StolenRecord < ActiveRecord::Base
 
   # Only display if they have put in an address - so that we don't show on initial creation
   def display_checklist?; address.present? end
-
-  def address_override_show_address; address(skip_default_country: true) end
 
   def address(skip_default_country: false, override_show_address: false)
     country_string = country && country.iso
@@ -329,14 +325,11 @@ class StolenRecord < ActiveRecord::Base
       .perform_async(theft_alerts.active.last.id, :recovered)
   end
 
-  def skip_geocoding?
-    !!skip_geocoding
+  def geocode_data
+    @geocode_data ||= address(skip_default_country: true)
   end
 
-  def should_be_geocoded?
-    return false if skip_geocoding?
-    return false if latitude.present? && longitude.present?
-
-    (city.present? || zipcode.present?) && country.present?
+  def geocode_columns
+    %i[street city state_id zipcode country_id]
   end
 end

--- a/app/models/twitter_account.rb
+++ b/app/models/twitter_account.rb
@@ -1,4 +1,6 @@
 class TwitterAccount < ActiveRecord::Base
+  include Geocodeable
+
   has_many :tweets, dependent: :destroy
 
   attr_accessor :skip_geocoding
@@ -13,8 +15,6 @@ class TwitterAccount < ActiveRecord::Base
 
   validates :screen_name, uniqueness: true
 
-  geocoded_by :address
-  after_validation :geocode, if: -> { !skip_geocoding? && address.present? && (latitude.blank? || address_changed?) }
   before_save :reverse_geocode, if: -> { !skip_geocoding? && latitude.present? && (state.blank? || state_changed?) }
   before_save :fetch_account_info
 
@@ -130,8 +130,12 @@ class TwitterAccount < ActiveRecord::Base
 
   private
 
-  def skip_geocoding?
-    !!skip_geocoding
+  def geocode_data
+    @geocode_data ||= address
+  end
+
+  def geocode_columns
+    %i[address]
   end
 
   def twitter_client

--- a/app/models/twitter_account.rb
+++ b/app/models/twitter_account.rb
@@ -14,8 +14,8 @@ class TwitterAccount < ActiveRecord::Base
   validates :screen_name, uniqueness: true
 
   geocoded_by :address
-  after_validation :geocode, if: -> { !skip_geocoding && address.present? && (latitude.blank? || address_changed?) }
-  before_save :reverse_geocode, if: -> { !skip_geocoding && latitude.present? && (state.blank? || state_changed?) }
+  after_validation :geocode, if: -> { !skip_geocoding? && address.present? && (latitude.blank? || address_changed?) }
+  before_save :reverse_geocode, if: -> { !skip_geocoding? && latitude.present? && (state.blank? || state_changed?) }
   before_save :fetch_account_info
 
   scope :active, -> { where(active: true) }
@@ -129,6 +129,10 @@ class TwitterAccount < ActiveRecord::Base
   end
 
   private
+
+  def skip_geocoding?
+    !!skip_geocoding
+  end
 
   def twitter_client
     @twitter_client ||= Twitter::REST::Client.new do |config|

--- a/app/models/twitter_account.rb
+++ b/app/models/twitter_account.rb
@@ -130,10 +130,6 @@ class TwitterAccount < ActiveRecord::Base
 
   private
 
-  def geocode_data
-    @geocode_data ||= address
-  end
-
   def geocode_columns
     %i[address]
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,6 +2,8 @@ class User < ActiveRecord::Base
   include Phonifyerable
   include ActionView::Helpers::SanitizeHelper
   include FeatureFlaggable
+  include Geocodeable
+
   cattr_accessor :current_user
 
   has_secure_password
@@ -70,10 +72,7 @@ class User < ActiveRecord::Base
   after_commit :perform_create_jobs, on: :create, if: lambda { !self.skip_create_jobs }
   before_save :set_calculated_attributes
 
-  attr_accessor :skip_geocode, :skip_create_jobs
-
-  geocoded_by :address
-  after_validation :geocode, if: lambda { !self.skip_geocode && self.geocodeable_attributes_changed? }
+  attr_accessor :skip_create_jobs
 
   class << self
     def fuzzy_email_find(email)
@@ -373,12 +372,15 @@ class User < ActiveRecord::Base
     true
   end
 
-  def geocodeable_attributes_changed?
-    return false unless city.present? || zipcode.present? || street.present?
-    city_changed? || zipcode_changed? || street_changed?
+  private
+
+  def geocode_data
+    @geolocation_data ||= address
   end
 
-  private
+  def geocode_columns
+    %i[street city zipcode]
+  end
 
   def preferred_language_is_an_available_locale
     return if preferred_language.blank?

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -374,10 +374,6 @@ class User < ActiveRecord::Base
 
   private
 
-  def geocode_data
-    @geolocation_data ||= address
-  end
-
   def geocode_columns
     %i[street city zipcode]
   end

--- a/app/workers/after_user_create_worker.rb
+++ b/app/workers/after_user_create_worker.rb
@@ -1,6 +1,5 @@
 # TODO: eventually this should merge with after_user_change_worker.rb, or something
 class AfterUserCreateWorker < ApplicationWorker
-
   sidekiq_options queue: "high_priority"
 
   # Generally, this is called inline - so it makes sense to pass in the user rather than just the user_id
@@ -70,7 +69,7 @@ class AfterUserCreateWorker < ApplicationWorker
     unless [user.street, user.city, user.zipcode, user.state, user.country].reject(&:blank?).any?
       address = user_bikes_for_attrs(user.id).map { |b| b.registration_address }.reject(&:blank?).last
       if address.present?
-        user.attributes = { skip_geocode: true,
+        user.attributes = { skip_geocoding: true,
                            street: address["address"],
                            zipcode: address["zipcode"],
                            city: address["city"],

--- a/spec/factories/locations.rb
+++ b/spec/factories/locations.rb
@@ -9,5 +9,6 @@ FactoryBot.define do
     street { "foo address" }
     latitude { 41.9282162 }
     longitude { -87.6327552 }
+    skip_geocoding { true }
   end
 end

--- a/spec/factories/stolen_records.rb
+++ b/spec/factories/stolen_records.rb
@@ -2,6 +2,7 @@ FactoryBot.define do
   factory :stolen_record do
     bike { FactoryBot.create(:bike, stolen: true) }
     date_stolen { Time.current }
+    skip_geocoding { true }
 
     factory :stolen_record_recovered do
       bike { FactoryBot.create(:bike) }

--- a/spec/workers/after_user_create_worker_spec.rb
+++ b/spec/workers/after_user_create_worker_spec.rb
@@ -95,7 +95,7 @@ RSpec.describe AfterUserCreateWorker, type: :job do
       end
     end
     context "existing attributes" do
-      let(:user) { FactoryBot.create(:user, email: "aftercreate@bikeindex.org", phone: "929292", zipcode: "89999", skip_geocode: true) }
+      let(:user) { FactoryBot.create(:user, email: "aftercreate@bikeindex.org", phone: "929292", zipcode: "89999", skip_geocoding: true) }
       it "doesn't import" do
         instance.perform(user.id, "new")
         user.reload


### PR DESCRIPTION
- Adds a `Geocodable` concern to reduce some duplication and consistify across geocoded models.  
- Expects `geocode_data` to be defined on the including model
