### PR TITLE
Fix Bike#should_be_geocoded?

### DIFF
--- a/app/models/bike.rb
+++ b/app/models/bike.rb
@@ -784,7 +784,7 @@ class Bike < ActiveRecord::Base
   def geocode_data
     return @geocode_data if defined?(@geocode_data)
 
-    # Sets lat/long, should avoid an geocode API call
+    # Sets lat/long, will avoid a geocode API call if coordinates are found
     set_location_info
 
     @geocode_data =
@@ -798,9 +798,10 @@ class Bike < ActiveRecord::Base
   end
 
   # Take lat/long from associated geocoded model
-  # Only geocode if no lat/long present
+  # Only geocode if no lat/long present and geocode data present
   def should_be_geocoded?
     return false if skip_geocoding?
-    latitude.blank? && longitude.blank?
+    return false if latitude.present? && longitude.present?
+    geocode_data.present?
   end
 end


### PR DESCRIPTION
Hotfix to only make an API request when adding lat/long to a bike  record if `geocode_data` is present, otherwise a 400 error will be returned:

```
$ bin/rake data:set_bike_location_info

Geocoded bikes: 0
Un-geocoded bikes: 294,849

Setting coordinates on stolen bikes:
------------------------------------
Updated 69,774 stolen bikes

Geocoded bikes: 69,774
Un-geocoded bikes: 225,075

Setting coordinates on non-stolen bikes:
----------------------------------------
Geocoding API error: 400 Bad Request
Google Geocoding API error: invalid request.
Geocoding API error: 400 Bad Request
Google Geocoding API error: invalid request.
 51,285/225,075 :    22.8%
```