### PR TITLE
Remove Bikes stolen lat/long fields

### DIFF
--- a/app/models/bike.rb
+++ b/app/models/bike.rb
@@ -734,8 +734,6 @@ class Bike < ActiveRecord::Base
   def cache_stolen_attributes
     csr = find_current_stolen_record
     self.current_stolen_record_id = csr&.id
-    self.stolen_lat = csr&.latitude
-    self.stolen_long = csr&.longitude
     self.all_description =
       [description, csr&.theft_description]
         .reject(&:blank?)

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -159,8 +159,6 @@ en:
         serial_number: Serial number
         stock_photo_url: Stock photo url
         stolen: Stolen
-        stolen_lat: Stolen lat
-        stolen_long: Stolen long
         stolen_notifications: Stolen notifications
         stolen_records: Stolen records
         tertiary_frame_color: :activerecord.models.tertiary_frame_color

--- a/db/migrate/20191117123105_drop_stolen_lat_long_from_bikes.rb
+++ b/db/migrate/20191117123105_drop_stolen_lat_long_from_bikes.rb
@@ -1,0 +1,6 @@
+class DropStolenLatLongFromBikes < ActiveRecord::Migration
+  def change
+    remove_column :bikes, :stolen_lat, :float
+    remove_column :bikes, :stolen_long, :float
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -390,8 +390,6 @@ CREATE TABLE public.bikes (
     updator_id integer,
     is_for_sale boolean DEFAULT false NOT NULL,
     made_without_serial boolean DEFAULT false NOT NULL,
-    stolen_lat double precision,
-    stolen_long double precision,
     creation_state_id integer,
     frame_material integer,
     handlebar_type integer,
@@ -3531,13 +3529,6 @@ CREATE INDEX index_bikes_on_secondary_frame_color_id ON public.bikes USING btree
 
 
 --
--- Name: index_bikes_on_stolen_lat_and_stolen_long; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX index_bikes_on_stolen_lat_and_stolen_long ON public.bikes USING btree (stolen_lat, stolen_long);
-
-
---
 -- Name: index_bikes_on_tertiary_frame_color_id; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -4865,4 +4856,6 @@ INSERT INTO schema_migrations (version) VALUES ('20191028130015');
 INSERT INTO schema_migrations (version) VALUES ('20191106210313');
 
 INSERT INTO schema_migrations (version) VALUES ('20191108195338');
+
+INSERT INTO schema_migrations (version) VALUES ('20191117123105');
 

--- a/spec/models/bike_spec.rb
+++ b/spec/models/bike_spec.rb
@@ -1243,24 +1243,16 @@ RSpec.describe Bike, type: :model do
         bike.description = "I love my bike"
         bike.cache_stolen_attributes
         expect(bike.all_description).to eq("I love my bike some theft description")
-        expect(bike.stolen_lat).to eq(40.7143528)
-        expect(bike.stolen_long).to eq(-74.0059731)
       end
     end
     context "no current_stolen_record" do
       it "sets the description and unsets current_stolen_record_id" do
-        bike = Bike.new(current_stolen_record_id: 99999,
-                        description: "lalalala",
-                        stolen_lat: 40.7143528,
-                        stolen_long: -74.0059731)
-
+        bike = Bike.new(current_stolen_record_id: 99999, description: "lalalala")
         bike.current_stolen_record = nil
         bike.cache_stolen_attributes
 
         expect(bike.current_stolen_record_id).not_to be_present
         expect(bike.all_description).to eq("lalalala")
-        expect(bike.stolen_lat).to eq nil
-        expect(bike.stolen_long).to eq nil
       end
     end
   end

--- a/spec/support/shared_examples/bike_searchable.rb
+++ b/spec/support/shared_examples/bike_searchable.rb
@@ -327,8 +327,6 @@ RSpec.shared_examples "bike_searchable" do
         it "returns bikes near the requested location" do
           bike1 = FactoryBot.create(:stolen_bike_in_amsterdam)
           bike2 = FactoryBot.create(:stolen_bike_in_nyc)
-          expect(bike1.longitude).to eq(bike1.stolen_long)
-          expect(bike2.longitude).to eq(bike2.stolen_long)
           expect(bike1.longitude).to_not eq(bike2.longitude)
 
           interpreted_params = Bike.searchable_interpreted_params(


### PR DESCRIPTION
This patch drops `bikes.stolen_lat` and `bikes.stolen_long` — the values for these have been copied to the `latitude` and `longitude` columns. 