### PR TITLE
Fix request location zipcode access

### DIFF
--- a/app/models/bike.rb
+++ b/app/models/bike.rb
@@ -671,7 +671,7 @@ class Bike < ActiveRecord::Base
       self.longitude = request_location.longitude
       self.city = request_location.city
       self.country = Country.fuzzy_find(request_location&.country_code)
-      self.zipcode = request_location.zipcode
+      self.zipcode = request_location.postal_code
     end
   end
 

--- a/spec/models/bike_spec.rb
+++ b/spec/models/bike_spec.rb
@@ -1549,12 +1549,13 @@ RSpec.describe Bike, type: :model do
     context "given no creation org or owner location" do
       it "takes location from the geocoded request location" do
         bike = FactoryBot.build(:bike)
-        location = double(:request_location, default_location)
+        geocoder_data = default_location.merge(postal_code: default_location.delete(:zipcode))
+        location = double(:request_location, geocoder_data)
 
         bike.set_location_info(request_location: location)
 
-        expect(bike.city).to eq(default_location[:city])
-        expect(bike.zipcode).to eq(default_location[:zipcode])
+        expect(bike.city).to eq(geocoder_data[:city])
+        expect(bike.zipcode).to eq(geocoder_data[:postal_code])
         expect(bike.country).to eq(usa)
       end
     end


### PR DESCRIPTION
[Request geocoding](https://github.com/alexreisner/geocoder#custom-result-handling) exposes a `postal_code` attribute rather than `zipcode`.

Fixes https://app.honeybadger.io/projects/35931/faults/57560267