### PR TITLE
Link directly to external registry bike

### DIFF
--- a/app/views/customer_mailer/bike_possibly_found_email.html.haml
+++ b/app/views/customer_mailer/bike_possibly_found_email.html.haml
@@ -2,9 +2,13 @@
   - bike_link = link_to(@bike.title_string, bike_url(@bike))
   = t(".html.we_think_your_stolen_bike_html", bike_title: bike_link)
 
-
 = t(".html.check_out_match_here")
 - if @match.is_a?(ExternalRegistryBike)
-  %p= link_to @match.title_string, @match.url
+  %p
+    = t(".html.bike_registry")
+    = link_to @match.registry_name, @match.registry_url
+    %br
+    = t(".html.bike")
+    = link_to @match.title_string, @match.url
 - elsif @match.is_a?(Bike)
   %p= link_to @match.title_string, bike_url(@match)

--- a/app/views/customer_mailer/bike_possibly_found_email.html.haml
+++ b/app/views/customer_mailer/bike_possibly_found_email.html.haml
@@ -2,6 +2,9 @@
   - bike_link = link_to(@bike.title_string, bike_url(@bike))
   = t(".html.we_think_your_stolen_bike_html", bike_title: bike_link)
 
-%p
-  = t(".html.check_out_match_here")
-  = link_to(@match.title_string, bike_url(@match))
+
+= t(".html.check_out_match_here")
+- if @match.is_a?(ExternalRegistryBike)
+  %p= link_to @match.title_string, @match.url
+- elsif @match.is_a?(Bike)
+  %p= link_to @match.title_string, bike_url(@match)

--- a/app/views/customer_mailer/bike_possibly_found_email.text.haml
+++ b/app/views/customer_mailer/bike_possibly_found_email.text.haml
@@ -2,7 +2,13 @@
 = bike_url(@bike)
 
 = t(".text.check_out_match_here")
+
 - if @match.is_a?(ExternalRegistryBike)
+  = t(".text.bike_registry")
+  = @match.registry_name
+  = @match.registry_url
+
+  = t(".text.bike")
   = @match.title_string
   = @match.url
 - elsif @match.is_a?(Bike)

--- a/app/views/customer_mailer/bike_possibly_found_email.text.haml
+++ b/app/views/customer_mailer/bike_possibly_found_email.text.haml
@@ -1,8 +1,10 @@
 = t(".text.we_think_your_stolen_bike", bike_title: @bike.title_string)
-
 = bike_url(@bike)
 
 = t(".text.check_out_match_here")
-
-= @match.title_string
-= bike_url(@match)
+- if @match.is_a?(ExternalRegistryBike)
+  = @match.title_string
+  = @match.url
+- elsif @match.is_a?(Bike)
+  = @match.title_string
+  = bike_url(@match)

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1833,9 +1833,13 @@ en:
           it, upload photos and make sure you never lose track of your trusty steed!
     bike_possibly_found_email:
       html:
+        bike: 'Bike:'
+        bike_registry: 'Bike Registry:'
         check_out_match_here: 'Check out the match here:'
         we_think_your_stolen_bike_html: We may have found your stolen <strong>%{bike_title}</strong>!
       text:
+        bike: 'Bike:'
+        bike_registry: 'Bike Registry:'
         check_out_match_here: 'Check out the match here:'
         we_think_your_stolen_bike: We may have found your stolen %{bike_title}!
     confirmation_email:


### PR DESCRIPTION
When notifying a bike owner of a potential match found in an external registry, link directly to the external registry url.

<img width="715" alt="Screen Shot 2019-11-20 at 11 43 38 AM" src="https://user-images.githubusercontent.com/4433943/69259028-97997e00-0b8b-11ea-88ee-d9f6f8b46db4.png">
<img width="1098" alt="Screen Shot 2019-11-20 at 11 43 30 AM" src="https://user-images.githubusercontent.com/4433943/69259029-97997e00-0b8b-11ea-8c66-6c0302d1d117.png">
