### PR TITLE
Fix coffeescript indentation, donation modal bug

### DIFF
--- a/app/assets/javascripts/revised/pages/info/payments.coffee
+++ b/app/assets/javascripts/revised/pages/info/payments.coffee
@@ -21,10 +21,10 @@ class BikeIndex.Payments extends BikeIndex
     $active = $('.amount-list .active')
     # Return the button amount if an arbitrary amount isn't entered
     return $active.data('amount') unless $active.attr('id') == 'arbitrary-amount'
-    amount = parseFloat($active.val())
-    # Return the entered amount if it's greater than 0
-    return amount if amount > 0
-    window.BikeIndexAlerts.add('info', 'Please enter a number')
+    amount_cents = parseFloat($active.val()) * 100
+    # Return the entered amount if it's greater than $0.50 (Stripe minimum)
+    return amount_cents if amount_cents > 50
+    window.BikeIndexAlerts.add('info', 'Please enter an amount greater than 0.50')
     null
 
   selectPaymentOption: (e) ->

--- a/app/assets/javascripts/revised/pages/info/payments.coffee
+++ b/app/assets/javascripts/revised/pages/info/payments.coffee
@@ -1,6 +1,7 @@
 class BikeIndex.Payments extends BikeIndex
   constructor: ->
     @initializeEventListeners()
+    @t = window.BikeIndex.translator("payments");
 
   initializeEventListeners: ->
     $('#bikeindex-stripe-initial-form').submit (e) =>
@@ -16,15 +17,15 @@ class BikeIndex.Payments extends BikeIndex
   # Returns null if there isn't a valid value selected
   getAmountSelected: ->
     unless $('.amount-list .active').length > 0
-      window.BikeIndexAlerts.add('info', 'Please select or enter an amount')
+      window.BikeIndexAlerts.add('info', @t("select_or_enter_amount"))
       return null
     $active = $('.amount-list .active')
     # Return the button amount if an arbitrary amount isn't entered
     return $active.data('amount') unless $active.attr('id') == 'arbitrary-amount'
     amount_cents = parseFloat($active.val()) * 100
-    # Return the entered amount if it's greater than $0.50 (Stripe minimum)
-    return amount_cents if amount_cents > 50
-    window.BikeIndexAlerts.add('info', 'Please enter an amount greater than 0.50')
+    # Return the entered amount if it's greater than $1 (Stripe minimum is 0.50)
+    return amount_cents if amount_cents > 100
+    window.BikeIndexAlerts.add('info', @t('enter_the_minimum_amount'))
     null
 
   selectPaymentOption: (e) ->

--- a/app/assets/javascripts/revised/pages/welcome/index.coffee
+++ b/app/assets/javascripts/revised/pages/welcome/index.coffee
@@ -17,34 +17,33 @@ class BikeIndex.WelcomeIndex extends BikeIndex
     $(window).scroll ->
       $('.root-landing-who').addClass('scrolled')
 
+  # Return the DOM node for the slide with index `index` in the slides
+  # container element.
+  findSlide: (index) =>
+    @container.find(".js-recovery-slide")[index]
 
-   # Return the DOM node for the slide with index `index` in the slides
-   # container element.
-   findSlide: (index) =>
-     @container.find(".js-recovery-slide")[index]
+  # Set or get the text of the slide.
+  slideText: ($slide, textValue) =>
+    $container = $slide.find(".precovery")
+    return $container.text().trim() if not textValue
+    $container.text(textValue)
 
-   # Set or get the text of the slide.
-   slideText: ($slide, textValue) =>
-     $container = $slide.find(".precovery")
-     return $container.text().trim() if not textValue
-     $container.text(textValue)
+  translateText: (index) =>
+    return if I18n.locale == "en"
 
-   translateText: (index) =>
-     return if I18n.locale == "en"
+    slide = @findSlide(index)
+    return unless slide
 
-     slide = @findSlide(index)
-     return unless slide
+    $slide = $(slide)
+    return if $slide.data("translated")
 
-     $slide = $(slide)
-     return if $slide.data("translated")
+    text = @slideText($slide)
 
-     text = @slideText($slide)
-
-     @translator.translate(text).then (translatedText) =>
-       return if not translatedText
-       @slideText($slide, translatedText)
-       $slide.data("translated", true)
-       $slide.find(".translation-credit").toggleClass("d-none")
+    @translator.translate(text).then (translatedText) =>
+      return if not translatedText
+      @slideText($slide, translatedText)
+      $slide.data("translated", true)
+      $slide.find(".translation-credit").toggleClass("d-none")
 
   renderGivingPopup: ->
     hideModal = localStorage.getItem("hideGivingTuesdayModal")

--- a/app/views/payments/_form.html.haml
+++ b/app/views/payments/_form.html.haml
@@ -28,7 +28,7 @@
             %li.col-xs-8
               .input-group
                 .input-group-addon
-                  $
+                  = t("number.currency.format.unit")
                 %input#arbitrary-amount.form-control{ type: 'number', min: '0', placeholder: t('.other_amount'), step: 1, value: @initial_amount, class: ('active' if @initial_amount) }
         .next-step
           = submit_tag t(".next"), class: 'btn btn-primary'

--- a/app/views/payments/_form.html.haml
+++ b/app/views/payments/_form.html.haml
@@ -29,7 +29,7 @@
               .input-group
                 .input-group-addon
                   $
-                %input#arbitrary-amount.form-control{ type: 'number', min: '0', placeholder: t('.other_amount'), step: 0.01, value: @initial_amount, class: ('active' if @initial_amount) }
+                %input#arbitrary-amount.form-control{ type: 'number', min: '0', placeholder: t('.other_amount'), step: 1, value: @initial_amount, class: ('active' if @initial_amount) }
         .next-step
           = submit_tag t(".next"), class: 'btn btn-primary'
 

--- a/app/views/welcome/index.html.haml
+++ b/app/views/welcome/index.html.haml
@@ -182,7 +182,7 @@
               .input-group
                 .input-group-addon
                   $
-                %input#arbitrary-amount.form-control{ type: "number", min: "0", placeholder: t("payments.form.other_amount"), step: 0.01 }
+                %input#arbitrary-amount.form-control{ type: "number", min: "0", placeholder: t("payments.form.other_amount"), step: 1 }
           .row
             .col-xs-6.text-left
               %a.close.btn.btn-secondary{ "aria-label" => "Close", "data-dismiss" => "modal", style: "display: inline-block; float: none;" }

--- a/app/views/welcome/index.html.haml
+++ b/app/views/welcome/index.html.haml
@@ -181,7 +181,7 @@
             %li.col-xs-8
               .input-group
                 .input-group-addon
-                  $
+                  = t("number.currency.format.unit")
                 %input#arbitrary-amount.form-control{ type: "number", min: "0", placeholder: t("payments.form.other_amount"), step: 1 }
           .row
             .col-xs-6.text-left

--- a/app/views/welcome/index.html.haml
+++ b/app/views/welcome/index.html.haml
@@ -166,11 +166,11 @@
             &times;
         = image_tag "revised/logo_blue_black.svg", class: "modal-title-logo", alt: "Bike Index home"
         %h2.modal-title
-          Annual Giving Campaign
+          = t(".annual_giving_campaign")
         %hr
         %p.mt-2
           %strong.em
-            We rely on your donations to support our efforts!
+            = t(".we_rely_on_your_contributions")
         %form#bikeindex-stripe-initial-form
           %ul.row.amount-list
             - numbers = [10, 25, 50, 100, 200, 300, 500]
@@ -186,14 +186,14 @@
           .row
             .col-xs-6.text-left
               %a.close.btn.btn-secondary{ "aria-label" => "Close", "data-dismiss" => "modal", style: "display: inline-block; float: none;" }
-                Skip
+                = t(".skip")
             .col-xs-6.text-right
               = submit_tag t("payments.form.next"), class: "btn btn-primary"
 
         %p.nfp-info
-          Bike Index is a #{link_to "501(c)(3) nonprofit", news_url("bike-index--now-a-nonprofit")}
-          %br
-          Support our non-profit effort to fight bike theft!
+          - link = link_to t(".nonprofit_501c3"), news_url("bike-index--now-a-nonprofit")
+          = t(".is_a_nonprofit_html", blog_link: link)
+
 
 
 <script src="https://checkout.stripe.com/checkout.js"></script>

--- a/config/locales/.translation_io
+++ b/config/locales/.translation_io
@@ -1,2 +1,2 @@
 ---
-timestamp: 1574273089
+timestamp: 1574781511

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3249,6 +3249,9 @@ en:
       stolen: Stolen
       unknown: Unknown
       unknown_brand: Unknown Brand
+    payments:
+      enter_the_minimum_amount: Please enter an amount greater than 1
+      select_or_enter_amount: Please select or enter an amount
   landing_pages:
     ambassadors_current:
       after_a_couple_of_recoveries_i_got_hooked: >-

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -5212,6 +5212,7 @@ en:
       youve_been_logged_out: You've been logged out
     index:
       alert_the_community: Alert the Community
+      annual_giving_campaign: Annual Giving Campaign
       bike_index_statistics: Bike Index statistics
       bikes_registered_this_week: Bikes registered this week
       but_how_does_it_work: But How Does it work?
@@ -5226,6 +5227,10 @@ en:
       if_your_bike_goes_missing: >-
         If your bike goes missing, mark it as lost or stolen to notify the entire
         Bike Index community and its partners.
+      is_a_nonprofit_html: >-
+        Bike Index is a %{blog_link}<br>Support our non-profit effort to fight bike
+        theft!
+      nonprofit_501c3: 501(c)(3) nonprofit
       partner_organizations: Partner Organizations
       read_more_recovery_stories: Read more recovery stories
       recover_your_bike_for_free: >-
@@ -5234,6 +5239,7 @@ en:
         we do.
       register_now: Register now!
       register_your_bike: Register Your Bike
+      skip: Skip
       stolen_bikes_recovered: Stolen Bikes Recovered
       stolen_bikes_registered: Stolen Bikes Registered
       the_community_responds: The community responds
@@ -5241,6 +5247,7 @@ en:
       total_recovery_value: Total Recovery value
       used_by: Used By
       value_of_bikes_recovered: Over %{value} Worth of Bikes Recovered
+      we_rely_on_your_contributions: We rely on your donations to support our efforts!
       you_get_your_bike_back: You Get your Bike Back
     recovery_stories:
       recovery_stories: Recovery Stories

--- a/config/locales/translation.nl.yml
+++ b/config/locales/translation.nl.yml
@@ -4114,7 +4114,7 @@ nl:
       login: Login
       register: Registreer
       teamed_up: We hebben samengewerkt met Bike Index!
-      non_profit: Bike Index is een 501 (c) (3) non-profit en de meest gebruikte fietsregistratieservice
+      non_profit: Bike Index is een non-profit organisatie en de meest gebruikte fietsregistratieservice
         ter wereld.
       security: Bij BikeHub geloven we dat fietsbeveiliging meer is dan alleen een
         sterk U-slot.
@@ -5205,6 +5205,13 @@ nl:
       used_by: Gebruikt door
       value_of_bikes_recovered: Meer dan %{value} aan fietsen die teruggevonden zijn
       you_get_your_bike_back: U krijgt uw fiets terug
+      annual_giving_campaign: Jaarlijkse campagne geven
+      is_a_nonprofit_html: Bike Index is een %{blog_link} <br> Steun onze non-profit
+        inspanning om fietsdiefstal te bestrijden!
+      nonprofit_501c3: non-profit organisatie
+      skip: Overslaan
+      we_rely_on_your_contributions: We vertrouwen op uw donaties om onze inspanningen
+        te ondersteunen!
     recovery_stories:
       recovery_stories: Verhalen over teruggekregen fietsen
     update_browser:
@@ -5316,7 +5323,7 @@ nl:
       your_donation_saved_bikes: Uw donatie van € %{amount} heeft zojuist de fietsen
         gered.
     form:
-      501c3_nonprofit: 501 (c) (3) non-profit
+      501c3_nonprofit: non-profit organisatie
       bike_index_is_a_nonprofit_html: Bike Index is een %{nonprofit_link}.
       donate_today: Doneer vandaag nog
       next: volgende>
@@ -5633,3 +5640,6 @@ nl:
         searching_html: Zoeken naar fietsen met serienummers vergelijkbaar met %{serial}
           ...
       serial_search: 'Serienummer: %{serial}'
+    payments:
+      enter_the_minimum_amount: Voer een bedrag groter dan 1 in
+      select_or_enter_amount: Selecteer of voer een bedrag in


### PR DESCRIPTION
This patch updates the donation modals and associated coffeescript with the following changes:

- Scales arbitrary amounts by 100 since Stripe expects cents (minimum possible Stripe purchase is $0.50)
- Externalizes strings and localizes currency
- Sets the arbitrary currency step size to 1 (which lets the browser do some validation)

Also fixes inconsistent indentation in welcome/index.coffee

Fixes https://app.honeybadger.io/projects/35931/faults/57750107#notice-params