### PR TITLE
Stop removing partner from session

### DIFF
--- a/app/controllers/concerns/controller_helpers.rb
+++ b/app/controllers/concerns/controller_helpers.rb
@@ -242,7 +242,7 @@ module ControllerHelpers
     # We set partner in session because of AuthorizationsController - but we don't want the session to stick around
     # so people can navigate around the site and return to the sign in without unexpected results
     # we ALWAYS want to remove the session partner
-    partner = session.delete(:partner)
+    partner = session[:partner]
     partner ||= params[:partner]
     # fallback to assigning via session, but if partner was set via param, still remove the session partner.
     @sign_in_partner = partner&.downcase == "bikehub" ? "bikehub" : nil # For now, only permit bikehub partner

--- a/app/controllers/concerns/sessionable.rb
+++ b/app/controllers/concerns/sessionable.rb
@@ -26,7 +26,7 @@ module Sessionable
     end
 
     if sign_in_partner.present?
-      session.delete(:partner) # No longer removing in other places, PR#1435
+      session.delete(:partner) # Only removing once signed in, PR#1435
       redirect_to bikehub_url("account") and return # Only partner rn is bikehub, hardcode it
     elsif user.unconfirmed?
       render_partner_or_default_signin_layout(redirect_path: please_confirm_email_users_path) and return

--- a/app/controllers/concerns/sessionable.rb
+++ b/app/controllers/concerns/sessionable.rb
@@ -26,6 +26,7 @@ module Sessionable
     end
 
     if sign_in_partner.present?
+      session.delete(:partner) # No longer removing in other places, PR#1435
       redirect_to bikehub_url("account") and return # Only partner rn is bikehub, hardcode it
     elsif user.unconfirmed?
       render_partner_or_default_signin_layout(redirect_path: please_confirm_email_users_path) and return

--- a/spec/controllers/sessions_controller_spec.rb
+++ b/spec/controllers/sessions_controller_spec.rb
@@ -192,7 +192,6 @@ RSpec.describe SessionsController, type: :controller do
             expect(user.last_login_at).to be_blank
             expect(user.last_login_ip).to be_blank
             session[:partner] = "bikehub"
-            pp session
             expect(user).to receive(:authenticate).and_return(true)
             request.env["HTTP_REFERER"] = user_home_url
             request.env["HTTP_CF_CONNECTING_IP"] = "66.66.66.66"

--- a/spec/controllers/sessions_controller_spec.rb
+++ b/spec/controllers/sessions_controller_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe SessionsController, type: :controller do
           it "actually sets it, renders bikehub layout" do
             session[:partner] = "bikehub"
             get :new, return_to: "/bikes/12?contact_owner=true"
-            expect(session[:partner]).to be_nil
+            # commented in PR#1435 expect(session[:partner]).to be_nil
             expect(response).to render_template("layouts/application_bikehub")
           end
         end
@@ -192,6 +192,7 @@ RSpec.describe SessionsController, type: :controller do
             expect(user.last_login_at).to be_blank
             expect(user.last_login_ip).to be_blank
             session[:partner] = "bikehub"
+            pp session
             expect(user).to receive(:authenticate).and_return(true)
             request.env["HTTP_REFERER"] = user_home_url
             request.env["HTTP_CF_CONNECTING_IP"] = "66.66.66.66"


### PR DESCRIPTION
Testing not removing the `session[:partner]` because we aren't redirecting all the time.

After shipping, will need to uncomment the places where tests are commented out with

```ruby
# commented in PR#1435
```