### PR TITLE
Build CI Git with submodules

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,7 +53,14 @@ jobs:
             tar -xzf git.tgz
             cd git-${GIT_VERSION}
 
+            export DEFAULT_HELP_FORMAT="man"
+            autoconf
+            ./configure
+
             sudo make prefix=/usr/local all
+            sudo make install
+            sudo make man && sudo make install-man
+
             sudo cp ./git /usr/local/bin/git
       - save_cache:
           key: cache-{{ .Environment.CACHE_VERSION }}-git-2.22.0


### PR DESCRIPTION
Adds submodule support to the Git we use on CI. (Submodule support is needed when a gem fetch from GitHub contains submodules we also want to fetch.)

Extracted from #1428 