### PR TITLE
Move BikePossiblyFound notification to the notifications queue

### DIFF
--- a/app/workers/email_admin_contact_stolen_worker.rb
+++ b/app/workers/email_admin_contact_stolen_worker.rb
@@ -1,5 +1,4 @@
 class EmailAdminContactStolenWorker < ApplicationWorker
-
   sidekiq_options queue: "notify"
 
   def perform(customer_contact_id)

--- a/app/workers/email_bike_possibly_found_notification_worker.rb
+++ b/app/workers/email_bike_possibly_found_notification_worker.rb
@@ -1,4 +1,6 @@
 class EmailBikePossiblyFoundNotificationWorker < ApplicationWorker
+  sidekiq_options queue: "notify"
+
   def perform(bike_id, match_class, match_id)
     bike = Bike.find(bike_id)
     match = match_class.to_s.constantize.find(match_id)

--- a/app/workers/email_confirmation_worker.rb
+++ b/app/workers/email_confirmation_worker.rb
@@ -1,5 +1,4 @@
 class EmailConfirmationWorker < ApplicationWorker
-
   sidekiq_options queue: "notify"
 
   def perform(user_id)

--- a/app/workers/email_invoice_worker.rb
+++ b/app/workers/email_invoice_worker.rb
@@ -1,5 +1,4 @@
 class EmailInvoiceWorker < ApplicationWorker
-
   sidekiq_options queue: "notify"
 
   def perform(id)

--- a/app/workers/email_lightspeed_notification_worker.rb
+++ b/app/workers/email_lightspeed_notification_worker.rb
@@ -1,5 +1,4 @@
 class EmailLightspeedNotificationWorker < ApplicationWorker
-
   sidekiq_options queue: "notify"
 
   def perform(organization_id, api_key)

--- a/app/workers/email_magic_login_link_worker.rb
+++ b/app/workers/email_magic_login_link_worker.rb
@@ -1,5 +1,4 @@
 class EmailMagicLoginLinkWorker < ApplicationWorker
-
   sidekiq_options queue: "notify"
 
   def perform(user_id)

--- a/app/workers/email_no_admins_notification_worker.rb
+++ b/app/workers/email_no_admins_notification_worker.rb
@@ -1,5 +1,4 @@
 class EmailNoAdminsNotificationWorker < ApplicationWorker
-
   sidekiq_options queue: "notify"
 
   def perform(organization_id)

--- a/app/workers/email_organization_message_worker.rb
+++ b/app/workers/email_organization_message_worker.rb
@@ -1,5 +1,4 @@
 class EmailOrganizationMessageWorker < ApplicationWorker
-
   sidekiq_options queue: "notify"
 
   def perform(organization_message_id)

--- a/app/workers/email_ownership_invitation_worker.rb
+++ b/app/workers/email_ownership_invitation_worker.rb
@@ -1,5 +1,4 @@
 class EmailOwnershipInvitationWorker < ApplicationWorker
-
   sidekiq_options queue: "notify"
 
   def perform(ownership_id)

--- a/app/workers/email_partial_registration_worker.rb
+++ b/app/workers/email_partial_registration_worker.rb
@@ -1,5 +1,4 @@
 class EmailPartialRegistrationWorker < ApplicationWorker
-
   sidekiq_options queue: "notify"
 
   def perform(b_param_id)

--- a/app/workers/email_reset_password_worker.rb
+++ b/app/workers/email_reset_password_worker.rb
@@ -1,5 +1,4 @@
 class EmailResetPasswordWorker < ApplicationWorker
-
   sidekiq_options queue: "notify"
 
   def perform(user_id)

--- a/app/workers/email_stolen_notification_worker.rb
+++ b/app/workers/email_stolen_notification_worker.rb
@@ -1,5 +1,4 @@
 class EmailStolenNotificationWorker < ApplicationWorker
-
   sidekiq_options queue: "notify"
 
   def perform(stolen_notification_id)

--- a/app/workers/email_updated_terms_worker.rb
+++ b/app/workers/email_updated_terms_worker.rb
@@ -1,5 +1,4 @@
 class EmailUpdatedTermsWorker < ApplicationWorker
-
   sidekiq_options queue: "low_priority"
   sidekiq_options retry: false
 

--- a/app/workers/email_welcome_worker.rb
+++ b/app/workers/email_welcome_worker.rb
@@ -1,5 +1,4 @@
 class EmailWelcomeWorker < ApplicationWorker
-
   sidekiq_options queue: "notify"
 
   def perform(user_id)


### PR DESCRIPTION
Notifications for possibly-found bikes are currently not being triggered (or so it seems). 
Stepping through the logic manually, we don't run into any failures, so the issue may be with enqueuing. 

What may be happening is that notifications just taking a long time to be triggered because their job is on the low priority queue. Most notifications are on "notify". 

This patch updates `EmailBikePossiblyFoundNotificationWorker` to be performed on the "notify" queue. (a53db84af0e00ffeb1e929061bfece39a25b9e1b)
