### PR TITLE
Drop therubyracer

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -97,7 +97,6 @@ gem "coffee-rails"
 gem "groupdate" # Required for charts
 gem "premailer-rails" # Inline styles for email
 gem "sprockets-rails", "~> 3.0.4"
-gem "therubyracer"
 gem "uglifier"
 gem "webpacker", "~> 4.x"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -473,7 +473,6 @@ GEM
       ffi (~> 1.0)
     redcarpet (3.3.4)
     redis (3.3.5)
-    ref (2.0.0)
     request_store (1.3.1)
     rerun (0.11.0)
       listen (~> 3.0)
@@ -588,9 +587,6 @@ GEM
     terminal-table (1.8.0)
       unicode-display_width (~> 1.1, >= 1.1.1)
     text (1.3.1)
-    therubyracer (0.12.3)
-      libv8 (~> 3.16.14.15)
-      ref
     thor (0.19.1)
     thread_safe (0.3.6)
     tilt (2.0.8)
@@ -770,7 +766,6 @@ DEPENDENCIES
   stripe
   swagger-ui_rails
   terminal-notifier
-  therubyracer
   thor
   translation
   twitter


### PR DESCRIPTION
Drops the "therubyracer" gem, since it's not needed anymore (since we ) and [consumes excess memory](https://devcenter.heroku.com/articles/rails-asset-pipeline#therubyracer). I'd like to see if this improves the asset compilation failures on `master` builds.