### PR TITLE
Replace deprecated before/after_filter calls

### DIFF
--- a/app/controllers/admin/ads_controller.rb
+++ b/app/controllers/admin/ads_controller.rb
@@ -1,6 +1,6 @@
 class Admin::AdsController < Admin::BaseController
-  before_filter :find_ad, except: [:index, :new, :create]
-  before_filter :find_organizations, only: [:new, :edit]
+  before_action :find_ad, except: [:index, :new, :create]
+  before_action :find_organizations, only: [:new, :edit]
 
   def index
     @ads = Ad.all

--- a/app/controllers/admin/base_controller.rb
+++ b/app/controllers/admin/base_controller.rb
@@ -1,4 +1,4 @@
 class Admin::BaseController < ApplicationController
-  before_filter :require_index_admin!
+  before_action :require_index_admin!
   layout "admin"
 end

--- a/app/controllers/admin/bulk_imports_controller.rb
+++ b/app/controllers/admin/bulk_imports_controller.rb
@@ -1,6 +1,6 @@
 class Admin::BulkImportsController < Admin::BaseController
   include SortableTable
-  before_filter :find_bulk_import, only: [:show, :update]
+  before_action :find_bulk_import, only: [:show, :update]
 
   def index
     page = params[:page] || 1

--- a/app/controllers/admin/ctypes_controller.rb
+++ b/app/controllers/admin/ctypes_controller.rb
@@ -1,5 +1,5 @@
 class Admin::CtypesController < Admin::BaseController
-  before_filter :find_ctypes, only: [:edit, :update, :destroy]
+  before_action :find_ctypes, only: [:edit, :update, :destroy]
 
   def index
     @ctypes = Ctype.all

--- a/app/controllers/admin/external_registry_bikes_controller.rb
+++ b/app/controllers/admin/external_registry_bikes_controller.rb
@@ -1,6 +1,6 @@
 class Admin::ExternalRegistryBikesController < Admin::BaseController
   include SortableTable
-  before_filter :find_bike, only: %i[show]
+  before_action :find_bike, only: %i[show]
 
   def index
     @page = params[:page] || 1

--- a/app/controllers/admin/mail_snippets_controller.rb
+++ b/app/controllers/admin/mail_snippets_controller.rb
@@ -1,5 +1,5 @@
 class Admin::MailSnippetsController < Admin::BaseController
-  before_filter :find_snippet, except: [:index, :new, :create]
+  before_action :find_snippet, except: [:index, :new, :create]
 
   def index
     @mail_snippets = MailSnippet.without_organizations

--- a/app/controllers/admin/manufacturers_controller.rb
+++ b/app/controllers/admin/manufacturers_controller.rb
@@ -1,6 +1,6 @@
 class Admin::ManufacturersController < Admin::BaseController
   include SortableTable
-  before_filter :find_manufacturer, only: [:edit, :update, :destroy, :show]
+  before_action :find_manufacturer, only: [:edit, :update, :destroy, :show]
 
   def index
     @manufacturers = Manufacturer.reorder("manufacturers.#{sort_column} #{sort_direction}")

--- a/app/controllers/admin/memberships_controller.rb
+++ b/app/controllers/admin/memberships_controller.rb
@@ -1,7 +1,7 @@
 class Admin::MembershipsController < Admin::BaseController
   include SortableTable
-  before_filter :find_membership, only: [:show, :edit, :update, :destroy]
-  before_filter :find_organizations
+  before_action :find_membership, only: [:show, :edit, :update, :destroy]
+  before_action :find_organizations
 
   def index
     page = params[:page] || 1

--- a/app/controllers/admin/news_controller.rb
+++ b/app/controllers/admin/news_controller.rb
@@ -1,6 +1,6 @@
 class Admin::NewsController < Admin::BaseController
-  before_filter :find_blog, only: [:show, :edit, :update, :destroy]
-  before_filter :set_dignified_name
+  before_action :find_blog, only: [:show, :edit, :update, :destroy]
+  before_action :set_dignified_name
 
   def index
     @blogs = Blog.order("created_at asc")

--- a/app/controllers/admin/organizations/custom_layouts_controller.rb
+++ b/app/controllers/admin/organizations/custom_layouts_controller.rb
@@ -1,5 +1,5 @@
 class Admin::Organizations::CustomLayoutsController < Admin::BaseController
-  before_filter :find_and_authorize_organization
+  before_action :find_and_authorize_organization
 
   def index
   end

--- a/app/controllers/admin/organizations_controller.rb
+++ b/app/controllers/admin/organizations_controller.rb
@@ -1,6 +1,6 @@
 class Admin::OrganizationsController < Admin::BaseController
   include SortableTable
-  before_filter :find_organization, only: [:show, :edit, :update, :destroy]
+  before_action :find_organization, only: [:show, :edit, :update, :destroy]
 
   def index
     page = params[:page] || 1

--- a/app/controllers/admin/ownerships_controller.rb
+++ b/app/controllers/admin/ownerships_controller.rb
@@ -1,5 +1,5 @@
 class Admin::OwnershipsController < Admin::BaseController
-  before_filter :find_ownership
+  before_action :find_ownership
 
   def edit
   end

--- a/app/controllers/admin/paid_features_controller.rb
+++ b/app/controllers/admin/paid_features_controller.rb
@@ -1,6 +1,6 @@
 class Admin::PaidFeaturesController < Admin::BaseController
   include SortableTable
-  before_filter :find_paid_feature, only: %i[edit update]
+  before_action :find_paid_feature, only: %i[edit update]
 
   def index
     @paid_features = PaidFeature.order(sort_column + " " + sort_direction)

--- a/app/controllers/admin/paints_controller.rb
+++ b/app/controllers/admin/paints_controller.rb
@@ -1,5 +1,5 @@
 class Admin::PaintsController < Admin::BaseController
-  before_filter :find_paint, only: [:show, :edit, :update, :destroy]
+  before_action :find_paint, only: [:show, :edit, :update, :destroy]
 
   def index
     if params[:name]

--- a/app/controllers/admin/payments_controller.rb
+++ b/app/controllers/admin/payments_controller.rb
@@ -1,6 +1,6 @@
 class Admin::PaymentsController < Admin::BaseController
   include SortableTable
-  before_filter :find_payment, only: %i[edit update]
+  before_action :find_payment, only: %i[edit update]
 
   def index
     page = params[:page] || 1

--- a/app/controllers/admin/recovery_displays_controller.rb
+++ b/app/controllers/admin/recovery_displays_controller.rb
@@ -1,5 +1,5 @@
 class Admin::RecoveryDisplaysController < Admin::BaseController
-  before_filter :find_recovery_displays, only: [:edit, :update, :destroy]
+  before_action :find_recovery_displays, only: [:edit, :update, :destroy]
 
   def index
     page = params[:page] || 1

--- a/app/controllers/admin/stolen_bikes_controller.rb
+++ b/app/controllers/admin/stolen_bikes_controller.rb
@@ -1,5 +1,5 @@
 class Admin::StolenBikesController < Admin::BaseController
-  before_filter :find_bike, only: [:edit, :destroy, :approve, :update, :regenerate_alert_image]
+  before_action :find_bike, only: [:edit, :destroy, :approve, :update, :regenerate_alert_image]
 
   def index
     if params[:unapproved]

--- a/app/controllers/admin/stolen_notifications_controller.rb
+++ b/app/controllers/admin/stolen_notifications_controller.rb
@@ -1,5 +1,5 @@
 class Admin::StolenNotificationsController < Admin::BaseController
-  before_filter :find_notification, only: [:show, :resend]
+  before_action :find_notification, only: [:show, :resend]
 
   def index
     stolen_notifications = StolenNotification.order("created_at desc").includes(:bike)

--- a/app/controllers/admin/tweets_controller.rb
+++ b/app/controllers/admin/tweets_controller.rb
@@ -1,5 +1,5 @@
 class Admin::TweetsController < Admin::BaseController
-  before_filter :find_tweet, except: [:new, :create, :index]
+  before_action :find_tweet, except: [:new, :create, :index]
 
   def index
     @tweets = Tweet.excluding_retweets.order(created_at: :desc)

--- a/app/controllers/admin/twitter_accounts_controller.rb
+++ b/app/controllers/admin/twitter_accounts_controller.rb
@@ -1,6 +1,6 @@
 class Admin::TwitterAccountsController < Admin::BaseController
   include SortableTable
-  before_filter :find_twitter_account, only: %i[show edit update destroy check_credentials]
+  before_action :find_twitter_account, only: %i[show edit update destroy check_credentials]
   skip_before_action :require_index_admin!, only: %[create]
 
   def index

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -1,6 +1,6 @@
 class Admin::UsersController < Admin::BaseController
   include SortableTable
-  before_filter :find_user, only: [:show, :edit, :update, :destroy]
+  before_action :find_user, only: [:show, :edit, :update, :destroy]
 
   def index
     page = params[:page] || 1

--- a/app/controllers/api/v1/bikes_controller.rb
+++ b/app/controllers/api/v1/bikes_controller.rb
@@ -1,10 +1,10 @@
 module Api
   module V1
     class BikesController < ApiV1Controller
-      before_filter :cors_preflight_check
-      before_filter :authenticate_organization, only: [:create, :stolen_ids]
-      skip_before_filter :verify_authenticity_token
-      after_filter :cors_set_access_control_headers
+      before_action :cors_preflight_check
+      before_action :authenticate_organization, only: [:create, :stolen_ids]
+      skip_before_action :verify_authenticity_token
+      after_action :cors_set_access_control_headers
       # caches_action :search_tags
       # serialization_scope nil
 

--- a/app/controllers/api/v1/colors_controller.rb
+++ b/app/controllers/api/v1/colors_controller.rb
@@ -1,8 +1,8 @@
 module Api
   module V1
     class ColorsController < ApiV1Controller
-      before_filter :cors_preflight_check
-      after_filter :cors_set_access_control_headers
+      before_action :cors_preflight_check
+      after_action :cors_set_access_control_headers
 
       def index
         respond_with Color.all

--- a/app/controllers/api/v1/component_types_controller.rb
+++ b/app/controllers/api/v1/component_types_controller.rb
@@ -1,8 +1,8 @@
 module Api
   module V1
     class ComponentTypesController < ApiV1Controller
-      before_filter :cors_preflight_check
-      after_filter :cors_set_access_control_headers
+      before_action :cors_preflight_check
+      after_action :cors_set_access_control_headers
 
       def index
         respond_with Ctype.all

--- a/app/controllers/api/v1/cycle_types_controller.rb
+++ b/app/controllers/api/v1/cycle_types_controller.rb
@@ -1,8 +1,8 @@
 module Api
   module V1
     class CycleTypesController < ApiV1Controller
-      before_filter :cors_preflight_check
-      after_filter :cors_set_access_control_headers
+      before_action :cors_preflight_check
+      after_action :cors_set_access_control_headers
 
       def index
         respond_with CycleType::NAMES

--- a/app/controllers/api/v1/frame_materials_controller.rb
+++ b/app/controllers/api/v1/frame_materials_controller.rb
@@ -1,8 +1,8 @@
 module Api
   module V1
     class FrameMaterialsController < ApiV1Controller
-      before_filter :cors_preflight_check
-      after_filter :cors_set_access_control_headers
+      before_action :cors_preflight_check
+      after_action :cors_set_access_control_headers
 
       def index
         respond_with FrameMaterial::NAMES

--- a/app/controllers/api/v1/handlebar_types_controller.rb
+++ b/app/controllers/api/v1/handlebar_types_controller.rb
@@ -1,8 +1,8 @@
 module Api
   module V1
     class HandlebarTypesController < ApiV1Controller
-      before_filter :cors_preflight_check
-      after_filter :cors_set_access_control_headers
+      before_action :cors_preflight_check
+      after_action :cors_set_access_control_headers
 
       def index
         respond_with HandlebarType::NAMES

--- a/app/controllers/api/v1/manufacturers_controller.rb
+++ b/app/controllers/api/v1/manufacturers_controller.rb
@@ -1,8 +1,8 @@
 module Api
   module V1
     class ManufacturersController < ApiV1Controller
-      before_filter :cors_preflight_check
-      after_filter :cors_set_access_control_headers
+      before_action :cors_preflight_check
+      after_action :cors_set_access_control_headers
 
       def index
         manufacturers = Manufacturer.reorder(:name)

--- a/app/controllers/api/v1/notifications_controller.rb
+++ b/app/controllers/api/v1/notifications_controller.rb
@@ -1,8 +1,8 @@
 module Api
   module V1
     class NotificationsController < ApiV1Controller
-      before_filter :authenticate_notification_permission
-      skip_before_filter :verify_authenticity_token
+      before_action :authenticate_notification_permission
+      skip_before_action :verify_authenticity_token
 
       def create
         bike = Bike.find(params[:notification_hash][:bike_id])

--- a/app/controllers/api/v1/organizations_controller.rb
+++ b/app/controllers/api/v1/organizations_controller.rb
@@ -1,7 +1,7 @@
 module Api
   module V1
     class OrganizationsController < ApiV1Controller
-      before_filter :verify_organizations_token
+      before_action :verify_organizations_token
 
       def show
         info = { name: @organization.name, can_add_bikes: false }

--- a/app/controllers/api/v1/stolen_locking_response_suggestions_controller.rb
+++ b/app/controllers/api/v1/stolen_locking_response_suggestions_controller.rb
@@ -1,8 +1,8 @@
 module Api
   module V1
     class StolenLockingResponseSuggestionsController < ApiV1Controller
-      before_filter :cors_preflight_check
-      after_filter :cors_set_access_control_headers
+      before_action :cors_preflight_check
+      after_action :cors_set_access_control_headers
 
       def index
         descriptions = {

--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -1,7 +1,7 @@
 module Api
   module V1
     class UsersController < ApiV1Controller
-      before_filter :bust_cache!, only: [:current]
+      before_action :bust_cache!, only: [:current]
 
       def default_serializer_options
         {

--- a/app/controllers/api/v1/wheel_sizes_controller.rb
+++ b/app/controllers/api/v1/wheel_sizes_controller.rb
@@ -1,8 +1,8 @@
 module Api
   module V1
     class WheelSizesController < ApiV1Controller
-      before_filter :cors_preflight_check
-      after_filter :cors_set_access_control_headers
+      before_action :cors_preflight_check
+      after_action :cors_set_access_control_headers
 
       def index
         respond_with WheelSize.all

--- a/app/controllers/bike_codes_controller.rb
+++ b/app/controllers/bike_codes_controller.rb
@@ -1,6 +1,6 @@
 class BikeCodesController < ApplicationController
   rescue_from ActionController::RedirectBackError, with: :redirect_back # Gross. TODO: Rails 5 update
-  before_filter :find_bike_code
+  before_action :find_bike_code
 
   def update
     if current_user.present? && current_user.authorized?(@bike_code)

--- a/app/controllers/bikes/recovery_controller.rb
+++ b/app/controllers/bikes/recovery_controller.rb
@@ -1,7 +1,7 @@
 module Bikes
   class RecoveryController < ApplicationController
-    before_filter :find_bike
-    before_filter :ensure_token_match!
+    before_action :find_bike
+    before_action :ensure_token_match!
 
     def edit
       # redirect to bike show and set session - so the token isn't available to on page js

--- a/app/controllers/concerns/controller_helpers.rb
+++ b/app/controllers/concerns/controller_helpers.rb
@@ -8,7 +8,7 @@ module ControllerHelpers
     helper_method :current_user, :current_user_or_unconfirmed_user, :sign_in_partner, :user_root_url,
                   :user_root_bike_search?, :current_organization, :passive_organization, :controller_namespace, :page_id,
                   :default_bike_search_path, :bikehub_url
-    before_filter :enable_rack_profiler
+    before_action :enable_rack_profiler
 
     before_action do
       if current_user.present?

--- a/app/controllers/discourse_authentication_controller.rb
+++ b/app/controllers/discourse_authentication_controller.rb
@@ -1,5 +1,5 @@
 class DiscourseAuthenticationController < ApplicationController
-  before_filter :authenticate_and_set_redirect
+  before_action :authenticate_and_set_redirect
 
   def index
     sso = SingleSignOn.parse(session[:discourse_redirect], discourse_secret)

--- a/app/controllers/documentation_controller.rb
+++ b/app/controllers/documentation_controller.rb
@@ -1,5 +1,5 @@
 class DocumentationController < ApplicationController
-  before_filter :render_swagger_for_page, only: [:api_v3, :api_v2]
+  before_action :render_swagger_for_page, only: [:api_v3, :api_v2]
   layout false
 
   def index

--- a/app/controllers/errors_controller.rb
+++ b/app/controllers/errors_controller.rb
@@ -1,6 +1,6 @@
 class ErrorsController < ApplicationController
   respond_to :html, :json
-  before_filter :set_permitted_format
+  before_action :set_permitted_format
 
   def bad_request
     render status: 400

--- a/app/controllers/feedbacks_controller.rb
+++ b/app/controllers/feedbacks_controller.rb
@@ -1,6 +1,6 @@
 class FeedbacksController < ApplicationController
-  before_filter :set_feedback_active_section
-  before_filter :set_permitted_format
+  before_action :set_feedback_active_section
+  before_action :set_permitted_format
 
   def index
     @feedback = Feedback.new
@@ -39,7 +39,7 @@ class FeedbacksController < ApplicationController
   protected
 
   def block_the_spam(feedback)
-    # Previously, we were authenticating users in a before_filter
+    # Previously, we were authenticating users in a before_action
     # But to make it possible for non-signed in users to generate leads, we're trying this out
     return false unless feedback.looks_like_spam?
     flash[:error] = translation(:please_sign_in)

--- a/app/controllers/integrations_controller.rb
+++ b/app/controllers/integrations_controller.rb
@@ -1,6 +1,6 @@
 class IntegrationsController < ApplicationController
   include Sessionable
-  before_filter :skip_if_signed_in
+  before_action :skip_if_signed_in
 
   def create
     @integration = Integration.new(information: request.env["omniauth.auth"],

--- a/app/controllers/landing_pages_controller.rb
+++ b/app/controllers/landing_pages_controller.rb
@@ -1,6 +1,6 @@
 class LandingPagesController < ApplicationController
   before_action :force_html_response
-  before_filter :instantiate_feedback, except: [:show]
+  before_action :instantiate_feedback, except: [:show]
 
   def show
     raise ActionController::RoutingError, "Not found" unless current_organization.present?

--- a/app/controllers/locks_controller.rb
+++ b/app/controllers/locks_controller.rb
@@ -1,6 +1,6 @@
 class LocksController < ApplicationController
-  before_filter :authenticate_user
-  before_filter :find_lock, only: [:edit, :update, :destroy]
+  before_action :authenticate_user
+  before_action :find_lock, only: [:edit, :update, :destroy]
 
   def edit
   end

--- a/app/controllers/oauth/applications_controller.rb
+++ b/app/controllers/oauth/applications_controller.rb
@@ -1,8 +1,8 @@
 module Oauth
   class ApplicationsController < Doorkeeper::ApplicationsController
     include ControllerHelpers
-    before_filter :authenticate_user
-    before_filter :ensure_app_owner!, except: [:index, :new, :create]
+    before_action :authenticate_user
+    before_action :ensure_app_owner!, except: [:index, :new, :create]
 
     def index
       @applications = current_user.oauth_applications.order(created_at: :desc)

--- a/app/controllers/oauth/authorizations_controller.rb
+++ b/app/controllers/oauth/authorizations_controller.rb
@@ -1,7 +1,7 @@
 module Oauth
   class AuthorizationsController < Doorkeeper::AuthorizationsController
     include ControllerHelpers
-    before_filter :authenticate_user_permit_unconfirmed_scope
+    before_action :authenticate_user_permit_unconfirmed_scope
 
     private
 

--- a/app/controllers/oauth/authorized_applications_controller.rb
+++ b/app/controllers/oauth/authorized_applications_controller.rb
@@ -1,6 +1,6 @@
 module Oauth
   class AuthorizedApplicationsController < Doorkeeper::AuthorizedApplicationsController
     include ControllerHelpers
-    before_filter :authenticate_user
+    before_action :authenticate_user
   end
 end

--- a/app/controllers/organizations_controller.rb
+++ b/app/controllers/organizations_controller.rb
@@ -1,6 +1,6 @@
 class OrganizationsController < ApplicationController
-  before_filter :set_bparam, only: [:embed, :embed_extended]
-  skip_before_filter :set_x_frame_options_header, only: [:embed, :embed_extended, :embed_create_success]
+  before_action :set_bparam, only: [:embed, :embed_extended]
+  skip_before_action :set_x_frame_options_header, only: [:embed, :embed_extended, :embed_create_success]
 
   def new
     session[:return_to] ||= new_organization_url unless current_user.present?

--- a/app/controllers/organized/admin_controller.rb
+++ b/app/controllers/organized/admin_controller.rb
@@ -1,6 +1,6 @@
 module Organized
   class AdminController < Organized::BaseController
-    before_filter :ensure_admin!
-    skip_before_filter :ensure_member!
+    before_action :ensure_admin!
+    skip_before_action :ensure_member!
   end
 end

--- a/app/controllers/organized/ambassador_dashboards_controller.rb
+++ b/app/controllers/organized/ambassador_dashboards_controller.rb
@@ -1,7 +1,7 @@
 module Organized
   class AmbassadorDashboardsController < Organized::BaseController
-    before_filter :ensure_ambassador_authorized!
-    skip_before_filter :ensure_not_ambassador_organization!
+    before_action :ensure_ambassador_authorized!
+    skip_before_action :ensure_not_ambassador_organization!
 
     def show
       @ambassadors =

--- a/app/controllers/organized/ambassador_task_assignments_controller.rb
+++ b/app/controllers/organized/ambassador_task_assignments_controller.rb
@@ -1,7 +1,7 @@
 module Organized
   class AmbassadorTaskAssignmentsController < Organized::BaseController
-    before_filter :ensure_ambassador_authorized!
-    skip_before_filter :ensure_not_ambassador_organization!
+    before_action :ensure_ambassador_authorized!
+    skip_before_action :ensure_not_ambassador_organization!
 
     def update
       ambassador_task_assignment = AmbassadorTaskAssignment.find(params[:id])

--- a/app/controllers/organized/base_controller.rb
+++ b/app/controllers/organized/base_controller.rb
@@ -1,8 +1,8 @@
 module Organized
   class BaseController < ApplicationController
-    before_filter :ensure_not_ambassador_organization!, except: :root
-    before_filter :ensure_current_organization!
-    before_filter :ensure_member!
+    before_action :ensure_not_ambassador_organization!, except: :root
+    before_action :ensure_current_organization!
+    before_action :ensure_member!
 
     def ensure_member!
       if current_user && current_user.member_of?(current_organization)

--- a/app/controllers/organized/bikes_controller.rb
+++ b/app/controllers/organized/bikes_controller.rb
@@ -2,7 +2,7 @@ module Organized
   class BikesController < Organized::BaseController
     include SortableTable
     rescue_from ActionController::RedirectBackError, with: :redirect_back # Gross. TODO: Rails 5 update
-    skip_before_filter :ensure_not_ambassador_organization!, only: [:multi_serial_search]
+    skip_before_action :ensure_not_ambassador_organization!, only: [:multi_serial_search]
 
     def index
       @page = params[:page] || 1

--- a/app/controllers/organized/bulk_imports_controller.rb
+++ b/app/controllers/organized/bulk_imports_controller.rb
@@ -1,8 +1,8 @@
 module Organized
   class BulkImportsController < Organized::BaseController
-    skip_before_filter :ensure_member!
-    skip_before_filter :ensure_current_organization!, only: [:create]
-    skip_before_filter :verify_authenticity_token, only: [:create]
+    skip_before_action :ensure_member!
+    skip_before_action :ensure_current_organization!, only: [:create]
+    skip_before_action :verify_authenticity_token, only: [:create]
     before_action :ensure_access_to_bulk_import!, except: [:create] # Because this checks ensure_admin
 
     def index

--- a/app/controllers/organized/manage_controller.rb
+++ b/app/controllers/organized/manage_controller.rb
@@ -1,6 +1,6 @@
 module Organized
   class ManageController < Organized::AdminController
-    before_filter :assign_organization, only: [:index, :update, :locations]
+    before_action :assign_organization, only: [:index, :update, :locations]
 
     def index
       @organization.ensure_auto_user

--- a/app/controllers/organized/users_controller.rb
+++ b/app/controllers/organized/users_controller.rb
@@ -1,8 +1,8 @@
 module Organized
   class UsersController < Organized::AdminController
     include SortableTable
-    before_filter :find_membership, only: [:edit, :update, :destroy]
-    before_filter :reject_self_updates, only: [:update, :destroy]
+    before_action :find_membership, only: [:edit, :update, :destroy]
+    before_action :reject_self_updates, only: [:update, :destroy]
 
     def index
       page = params[:page] || 1

--- a/app/controllers/ownerships_controller.rb
+++ b/app/controllers/ownerships_controller.rb
@@ -1,6 +1,6 @@
 class OwnershipsController < ApplicationController
-  before_filter :find_ownership
-  before_filter :authenticate_user_and_set_flash
+  before_action :find_ownership
+  before_action :authenticate_user_and_set_flash
 
   def show
     bike = Bike.unscoped.find(@ownership.bike_id)

--- a/app/controllers/public_images_controller.rb
+++ b/app/controllers/public_images_controller.rb
@@ -1,6 +1,6 @@
 class PublicImagesController < ApplicationController
-  before_filter :find_image_if_owned, only: [:edit, :update, :destroy, :is_private]
-  before_filter :ensure_authorized_to_create!, only: [:create]
+  before_action :find_image_if_owned, only: [:edit, :update, :destroy, :is_private]
+  before_action :ensure_authorized_to_create!, only: [:create]
 
   def show
     @public_image = PublicImage.find(params[:id])

--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -1,7 +1,7 @@
 class RegistrationsController < ApplicationController
-  skip_before_filter :set_x_frame_options_header, except: [:new]
-  skip_before_filter :verify_authenticity_token, only: [:create] # Because it was causing issues, and we don't need it here
-  before_filter :simple_header
+  skip_before_action :set_x_frame_options_header, except: [:new]
+  skip_before_action :verify_authenticity_token, only: [:create] # Because it was causing issues, and we don't need it here
+  before_action :simple_header
   layout "reg_embed"
 
   def new

--- a/app/controllers/stolen_controller.rb
+++ b/app/controllers/stolen_controller.rb
@@ -1,6 +1,6 @@
 class StolenController < ApplicationController
-  before_filter :set_permitted_format, only: [:index]
-  before_filter :remove_subdomain
+  before_action :set_permitted_format, only: [:index]
+  before_action :remove_subdomain
 
   def index
     @feedback = Feedback.new

--- a/app/controllers/stolen_notifications_controller.rb
+++ b/app/controllers/stolen_notifications_controller.rb
@@ -1,5 +1,5 @@
 class StolenNotificationsController < ApplicationController
-  before_filter :authenticate_user
+  before_action :authenticate_user
 
   def new
     @stolen_notification = StolenNotification.new

--- a/app/controllers/user_emails_controller.rb
+++ b/app/controllers/user_emails_controller.rb
@@ -1,5 +1,5 @@
 class UserEmailsController < ApplicationController
-  before_filter :ensure_user_email_ownership
+  before_action :ensure_user_email_ownership
 
   def resend_confirmation
     flash[:success] = translation(:resend_confirmation)

--- a/app/controllers/user_embeds_controller.rb
+++ b/app/controllers/user_embeds_controller.rb
@@ -1,5 +1,5 @@
 class UserEmbedsController < ApplicationController
-  skip_before_filter :set_x_frame_options_header
+  skip_before_action :set_x_frame_options_header
   layout "embed_user_layout"
 
   def show

--- a/app/controllers/welcome_controller.rb
+++ b/app/controllers/welcome_controller.rb
@@ -1,8 +1,8 @@
 class WelcomeController < ApplicationController
   before_action :force_html_response
-  before_filter :authenticate_user_for_welcome_controller, only: [:user_home, :choose_registration]
+  before_action :authenticate_user_for_welcome_controller, only: [:user_home, :choose_registration]
   # Allow iframes on the index URL because safari is an asshole, and doesn't honor our iframe options
-  skip_before_filter :set_x_frame_options_header, only: [:bike_creation_graph, :index]
+  skip_before_action :set_x_frame_options_header, only: [:bike_creation_graph, :index]
 
   def index
     @recovery_displays = RecoveryDisplay.limit(5)


### PR DESCRIPTION
Refactors to use the Rails 5 `before_action` invocation instead of deprecated `before_filter`.

```
DEPRECATION WARNING: before_filter is deprecated and will be removed in Rails 5.1. 
Use before_action instead.
```

Extracted from #1426  