### PR TITLE
Add ApplicationMailer base class

### DIFF
--- a/app/mailers/admin_mailer.rb
+++ b/app/mailers/admin_mailer.rb
@@ -1,9 +1,9 @@
-class AdminMailer < ActionMailer::Base
+class AdminMailer < ApplicationMailer
   helper LocalizationHelper
 
-  default from: "contact@bikeindex.org", content_type: "multipart/alternative", parts_order: ["text/calendar", "text/plain", "text/html", "text/enriched"]
+  default content_type: "multipart/alternative",
+          parts_order: ["text/calendar", "text/plain", "text/html", "text/enriched"]
   default to: "contact@bikeindex.org"
-  layout "email"
 
   def feedback_notification_email(feedback)
     @feedback = feedback

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -1,0 +1,6 @@
+class ApplicationMailer < ActionMailer::Base
+  CONTACT_BIKEINDEX = '"Bike Index" <contact@bikeindex.org>'.freeze
+  default from: CONTACT_BIKEINDEX
+
+  layout "email"
+end

--- a/app/mailers/customer_mailer.rb
+++ b/app/mailers/customer_mailer.rb
@@ -1,9 +1,6 @@
-class CustomerMailer < ActionMailer::Base
-  CONTACT_BIKEINDEX = '"Bike Index" <contact@bikeindex.org>'.freeze
-  default from: CONTACT_BIKEINDEX,
-          content_type: "multipart/alternative",
+class CustomerMailer < ApplicationMailer
+  default content_type: "multipart/alternative",
           parts_order: ["text/calendar", "text/plain", "text/html", "text/enriched"]
-  layout "email"
 
   def welcome_email(user)
     @user = user

--- a/app/mailers/organized_mailer.rb
+++ b/app/mailers/organized_mailer.rb
@@ -1,11 +1,8 @@
 # Every email in here has the potential to be owned by an organization -
 # but they aren't necessarily
-class OrganizedMailer < ActionMailer::Base
-  CONTACT_BIKEINDEX = "Bike Index <contact@bikeindex.org>".freeze
-  default from: CONTACT_BIKEINDEX,
-          content_type: "multipart/alternative",
+class OrganizedMailer < ApplicationMailer
+  default content_type: "multipart/alternative",
           parts_order: ["text/calendar", "text/plain", "text/html", "text/enriched"]
-  layout "email"
 
   def partial_registration(b_param)
     @b_param = b_param


### PR DESCRIPTION
- Updates mailers to inherit from an `ApplicationMailer` base class
- Moves common macro-style methods to the base class

Extracted from #1426 