### PR TITLE
Hotfix: Fix bike creator require

### DIFF
--- a/app/services/bike_creator.rb
+++ b/app/services/bike_creator.rb
@@ -1,3 +1,5 @@
+require "bike_book_integration"
+
 class BikeCreator
   def initialize(b_param = nil, location: nil)
     @b_param = b_param

--- a/app/workers/bike_book_update_worker.rb
+++ b/app/workers/bike_book_update_worker.rb
@@ -1,10 +1,12 @@
+require "bike_book_integration"
+
 class BikeBookUpdateWorker < ApplicationWorker
   sidekiq_options queue: "high_priority"
 
   def perform(bike_id)
     bike = Bike.unscoped.where(id: bike_id).first
     if bike.present?
-      bb_data = ::BikeBookIntegration.new.get_model(bike)
+      bb_data = BikeBookIntegration.new.get_model(bike)
 
       if bb_data.present?
         bb_data["components"].each do |bb_comp|


### PR DESCRIPTION
`lib` directory is no longer autoloaded in Rails 5 (not thread-safe).

Repro locally with 

```diff
+++ b/config/environments/test.rb
@@ -10,7 +10,7 @@ Rails.application.configure do
   # Do not eager load code on boot. This avoids loading your whole application
   # just for the purpose of running a single test. If you are using a tool that
   # preloads Rails for running tests, you may have to set it to true.
-  config.eager_load = false
+  config.eager_load = true

```

This is a hotfix for bike creator