### PR TITLE
Hotfix: Require twitter_tweeter_integration

### DIFF
--- a/app/workers/approve_stolen_listing_worker.rb
+++ b/app/workers/approve_stolen_listing_worker.rb
@@ -1,3 +1,5 @@
+require "twitter_tweeter_integration"
+
 class ApproveStolenListingWorker < ApplicationWorker
   sidekiq_options queue: "notify"
 


### PR DESCRIPTION
Manually require module in `lib`. Hotfixing for now.