### PR TITLE
Fix AdminRestriction#matches?

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -111,8 +111,8 @@ class User < ApplicationRecord
     end
 
     def from_auth(auth)
-      return nil unless auth && auth.kind_of?(Array)
-      self.where(id: auth[0], auth_token: auth[1]).first
+      return nil unless auth&.kind_of?(Array)
+      where(id: auth[0], auth_token: auth[1]).first
     end
   end
 

--- a/config/initializers/admin_restriction.rb
+++ b/config/initializers/admin_restriction.rb
@@ -1,8 +1,12 @@
 class AdminRestriction
   def self.matches?(req)
-    return false unless req.cookies["auth"].present?
+    cookie = req.cookies["auth"]
+    return false unless cookie.present?
 
-    auth = Rack::Session::Cookie::Base64::Marshal.new.decode(req.cookies["auth"])
+    auth =
+      Rack::Session::Cookie::Base64::JSON.new.decode(cookie) ||
+        Rack::Session::Cookie::Base64::Marshal.new.decode(cookie)
+
     user = User.from_auth(auth)
 
     user&.superuser?

--- a/config/initializers/admin_restriction.rb
+++ b/config/initializers/admin_restriction.rb
@@ -1,7 +1,10 @@
 class AdminRestriction
   def self.matches?(req)
+    return false unless req.cookies["auth"].present?
+
     auth = Rack::Session::Cookie::Base64::Marshal.new.decode(req.cookies["auth"])
     user = User.from_auth(auth)
-    return user && user.superuser?
+
+    user&.superuser?
   end
 end

--- a/config/initializers/cookies_serializer.rb
+++ b/config/initializers/cookies_serializer.rb
@@ -3,6 +3,6 @@
 # Specify a serializer for the signed and encrypted cookie jars.
 # Valid options are :json, :marshal, and :hybrid.
 
-# Set to hybrid because it was set to hybrid prior to 5.1
+# Set to :hybrid because it was set to :marshal prior to 5.1
 # See: https://github.com/rails/rails/issues/33580
 Rails.application.config.action_dispatch.cookies_serializer = :hybrid


### PR DESCRIPTION
Attempting to access admin pages gated by `AdminRestriction` fails currently because newly created (post-upgrade) cookies need to be decoded with `Rack::Session::Cookie::Base64::JSON`. 

Fixes https://github.com/bikeindex/bike_index/issues/1489