### PR TITLE
Fix failing build on master

### DIFF
--- a/app/models/abandoned_record.rb
+++ b/app/models/abandoned_record.rb
@@ -48,17 +48,19 @@ class AbandonedRecord < ActiveRecord::Base
 
   # TODO: location refactor - copied method from stolen
   def address(skip_default_country: false, override_show_address: false)
-    country_string = country && country.iso
-    if skip_default_country
-      country_string = nil if country_string == "US"
-    else
-      return nil unless country
-    end
+    return if country&.iso.blank?
+
+    country_string =
+      if country&.iso&.in?(%w[US USA])
+        skip_default_country ? nil : "USA"
+      else
+        country&.iso
+      end
+
     [
       (override_show_address || show_address) ? street : nil,
       city,
-      state&.abbreviation,
-      zipcode,
+      [state&.abbreviation, zipcode].reject(&:blank?).join(" "),
       country_string,
     ].reject(&:blank?).join(", ")
   end

--- a/app/services/bike_creator_associator.rb
+++ b/app/services/bike_creator_associator.rb
@@ -73,7 +73,7 @@ class BikeCreatorAssociator
       create_normalized_serial_segments(bike)
       assign_user_attributes(bike, ownership&.user)
       create_stolen_record(bike) if bike.stolen
-      create_abandoned_record(@b_param, bike) if @b_param.state_abandoned?
+      create_abandoned_record(@b_param, bike) if @b_param&.state_abandoned?
       attach_photo(bike)
       attach_photos(bike)
       add_other_listings(bike)

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -4092,7 +4092,6 @@ en:
         matches_visible: visible
         recorded: Recorded
         recorder: Recorder
-        retrieved: Impounded
       show:
         abandoned_record: Abandoned Record
         additional_text: Additional text

--- a/spec/models/abandoned_record_spec.rb
+++ b/spec/models/abandoned_record_spec.rb
@@ -46,10 +46,10 @@ RSpec.describe AbandonedRecord, type: :model do
                                              state_id: state.id,
                                              zipcode: "60647",
                                              country_id: country.id)
-      expect(abandoned_record.address).to eq("Chicago, XXX, 60647, NEVVVV")
-      expect(abandoned_record.address(override_show_address: true)).to eq("2200 N Milwaukee Ave, Chicago, XXX, 60647, NEVVVV")
+      expect(abandoned_record.address).to eq("Chicago, XXX 60647, NEVVVV")
+      expect(abandoned_record.address(override_show_address: true)).to eq("2200 N Milwaukee Ave, Chicago, XXX 60647, NEVVVV")
       abandoned_record.hide_address = false
-      expect(abandoned_record.address).to eq("2200 N Milwaukee Ave, Chicago, XXX, 60647, NEVVVV")
+      expect(abandoned_record.address).to eq("2200 N Milwaukee Ave, Chicago, XXX 60647, NEVVVV")
     end
     it "is ok with missing information" do
       abandoned_record = AbandonedRecord.new(street: "2200 N Milwaukee Ave",

--- a/spec/requests/organized/abandoned_records_request_spec.rb
+++ b/spec/requests/organized/abandoned_records_request_spec.rb
@@ -94,6 +94,10 @@ RSpec.describe Organized::AbandonedRecordsController, type: :request do
     end
 
     context "geolocated" do
+      before do
+        FactoryBot.create(:state_new_york)
+      end
+
       it "creates" do
         expect(current_organization.paid_for?("abandoned_bikes")).to be_truthy
         expect do


### PR DESCRIPTION
- Drops an unused key dropped in #1493 (reintroduced by a merge conflict resolution maybe?)
- Updates implementation code to pass tests failing on master

Note: this patch updates the abandoned record implementation code to return an address in a format normalized on what's pre-existing in the code (necessary since the model and request spec test have incompatible expectations of the address format — in particular, one expects a comma between a state and zip code, the other no comma).