### PR TITLE
Set production log level to info

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -71,10 +71,6 @@ Rails.application.configure do
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
   config.force_ssl = true
 
-  # Use the lowest log level to ensure availability of diagnostic information
-  # when problems arise.
-  config.log_level = :debug
-
   # Prepend all log lines with the following tags.
   config.log_tags = [:request_id]
 


### PR DESCRIPTION
This patch sets the prod log level to `:info` — the Rails 5 upgrade overrode this setting.

```rb
# config/environments/production.rb L5-8 (c3b29332)

# Settings specified here will take precedence over those in config/application.rb.
# Use lograge for logging to production
config.lograge.enabled = true
config.log_level = :info
```
<sup>[[source](https://github.com/bikeindex/bike_index/blob/c3b29332/config/environments/production.rb#L5-L8)]</sup>
