### PR TITLE
Fix nil method call exception in the bike box template

### DIFF
--- a/app/views/shared/_email_bike_box.html.haml
+++ b/app/views/shared/_email_bike_box.html.haml
@@ -25,7 +25,7 @@
         = pluralize(@bike.frame_colors.count, t(".color"))
       = @bike.frame_colors.to_sentence
 
-    - if @bike.stolen
+    - if @bike.stolen && @bike.current_stolen_record.present?
       - stolen_record = @bike.current_stolen_record
       %li
         %strong


### PR DESCRIPTION
A stolen bike occasionally has no current_stolen_record—L33 will raise an exception in those cases. 

This patch adds a check for `@bike.current_stolen_record.present?` to the conditional guarding that invocation.

We could alternatively / additionally save the bike record to ensure an available CSR is set before checking `@bike.current_stolen_record.present?`

```haml
-# app/views/shared/_email_bike_box.html.haml L28-37 (5ec54ad6)

- if @bike.stolen && @bike.current_stolen_record.present?
  - stolen_record = @bike.current_stolen_record
  %li
    %strong
      = @bike.abandoned ? t(".found") : t(".stolen_from")
    = stolen_record.address(skip_default_country: true)
  %li
    %strong
      = t(".date")
    = l stolen_record.date_stolen, format: :dotted
```
<sup>[[source](https://github.com/bikeindex/bike_index/blob/5ec54ad6/app/views/shared/_email_bike_box.html.haml#L28-L37)]</sup>


Resolves https://app.honeybadger.io/projects/35931/faults/53916765