### PR TITLE
Improve signup speed

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -431,7 +431,7 @@ GEM
     pry-rails (0.3.9)
       pry (>= 0.10.4)
     public_suffix (4.0.1)
-    puma (3.12.2)
+    puma (3.12.4)
     rack (2.0.8)
     rack-accept (0.4.5)
       rack (>= 0.4)

--- a/app/javascript/packs/application_css.scss
+++ b/app/javascript/packs/application_css.scss
@@ -24,11 +24,6 @@
 @import "../stylesheets/admin";
 @import "../stylesheets/period_selection";
 
-// For now, because we don't want to replicate all the styles immediately, we're hiding the footer
-footer.primary-footer {
-  display: none;
-}
-
 // Uppy Styles
 @import "@uppy/core/dist/style.css";
 @import "@uppy/dashboard/dist/style.css";

--- a/app/views/layouts/admin.html.haml
+++ b/app/views/layouts/admin.html.haml
@@ -47,8 +47,8 @@
         = link_to "Exit Admin", root_path, class: "btn btn-outline-secondary ml-auto less-strong d-none d-lg-inline-block"
     = render 'layouts/revised_messages'
 
-    %section#admin-content
-      .container-fluid.mt-4.mb-4
+    %section#admin-content.pb-4.mb-4
+      .container-fluid.mt-4.pb-4
         = yield
 
-    = render 'shared/footer_revised'
+

--- a/app/workers/after_user_create_worker.rb
+++ b/app/workers/after_user_create_worker.rb
@@ -37,7 +37,7 @@ class AfterUserCreateWorker < ApplicationWorker
   def perform_async_jobs(user, email)
     # These jobs don't need to happen immediately
     import_user_attributes(user)
-    associate_ownerships(user, email)
+    associate_ownerships(user, email) if user.confirmed?
   end
 
   def send_welcoming_email(user)

--- a/app/workers/after_user_create_worker.rb
+++ b/app/workers/after_user_create_worker.rb
@@ -7,34 +7,34 @@ class AfterUserCreateWorker < ApplicationWorker
     user ||= User.find(user_id)
     email ||= user.email
     if job_stage == "new"
-      perform_create_tasks(user, email)
+      perform_create_jobs(user, email)
     elsif job_stage == "confirmed"
-      perform_confirmed_tasks(user, email)
+      perform_confirmed_jobs(user, email)
     elsif job_stage == "merged"
-      perform_merged_tasks(user, email)
+      perform_merged_jobs(user, email)
     elsif job_stage == "async"
-      perform_async_tasks(user, email)
+      perform_async_jobs(user, email)
     end
     # We want to run async after every job
     AfterUserCreateWorker.perform_async(user.id, "async") unless job_stage == "async"
   end
 
-  def perform_create_tasks(user, email)
+  def perform_create_jobs(user, email)
     # This may confirm the user. We auto-confirm users that belong to orgs.
-    # Auto confirming the user actually ends up running perform_confirmed_tasks.
+    # Auto confirming the user actually ends up running perform_confirmed_jobs.
     associate_membership_invites(user, email)
     send_welcoming_email(user)
   end
 
-  def perform_merged_tasks(user, email)
+  def perform_merged_jobs(user, email)
     associate_membership_invites(user, email, without_confirm: true)
   end
 
-  def perform_confirmed_tasks(user, email)
+  def perform_confirmed_jobs(user, email)
     UserEmail.create_confirmed_primary_email(user)
   end
 
-  def perform_async_tasks(user, email)
+  def perform_async_jobs(user, email)
     # These jobs don't need to happen immediately
     import_user_attributes(user)
     associate_ownerships(user, email)

--- a/app/workers/after_user_create_worker.rb
+++ b/app/workers/after_user_create_worker.rb
@@ -3,33 +3,40 @@ class AfterUserCreateWorker < ApplicationWorker
   sidekiq_options queue: "high_priority"
 
   # Generally, this is called inline - so it makes sense to pass in the user rather than just the user_id
-  def perform(user_id, user_state, user: nil, email: nil)
+  def perform(user_id, job_stage, user: nil, email: nil)
     user ||= User.find(user_id)
     email ||= user.email
-    if user_state == "new"
-      perform_create_jobs(user, email)
-    elsif user_state == "confirmed"
-      perform_confirmed_jobs(user, email)
-    elsif user_state == "merged"
-      perform_merged_jobs(user, email)
+    if job_stage == "new"
+      perform_create_tasks(user, email)
+    elsif job_stage == "confirmed"
+      perform_confirmed_tasks(user, email)
+    elsif job_stage == "merged"
+      perform_merged_tasks(user, email)
+    elsif job_stage == "async"
+      perform_async_tasks(user, email)
     end
+    # We want to run async after every job
+    AfterUserCreateWorker.perform_async(user.id, "async") unless job_stage == "async"
   end
 
-  def perform_create_jobs(user, email)
+  def perform_create_tasks(user, email)
     # This may confirm the user. We auto-confirm users that belong to orgs.
-    # Auto confirming the user actually ends up running perform_confirmed_jobs.
+    # Auto confirming the user actually ends up running perform_confirmed_tasks.
     associate_membership_invites(user, email)
-    import_user_attributes(user)
     send_welcoming_email(user)
   end
 
-  def perform_merged_jobs(user, email)
-    associate_ownerships(user, email)
+  def perform_merged_tasks(user, email)
     associate_membership_invites(user, email, without_confirm: true)
   end
 
-  def perform_confirmed_jobs(user, email)
+  def perform_confirmed_tasks(user, email)
     UserEmail.create_confirmed_primary_email(user)
+  end
+
+  def perform_async_tasks(user, email)
+    # These jobs don't need to happen immediately
+    import_user_attributes(user)
     associate_ownerships(user, email)
   end
 
@@ -73,13 +80,13 @@ class AfterUserCreateWorker < ApplicationWorker
       address = user_bikes_for_attrs(user.id).map { |b| b.registration_address }.reject(&:blank?).last
       if address.present?
         user.attributes = { skip_geocoding: true,
-                           street: address["address"],
-                           zipcode: address["zipcode"],
-                           city: address["city"],
-                           state: State.fuzzy_find(address["state"]),
-                           country: Country.fuzzy_find(address["country"]),
-                           latitude: address["latitude"],
-                           longitude: address["longitude"] }
+                            street: address["address"],
+                            zipcode: address["zipcode"],
+                            city: address["city"],
+                            state: State.fuzzy_find(address["state"]),
+                            country: Country.fuzzy_find(address["country"]),
+                            latitude: address["latitude"],
+                            longitude: address["longitude"] }
       end
     end
     user.save if user.changed?

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -149,7 +149,6 @@ RSpec.describe UsersController, type: :controller do
               expect(user.user_emails.count).to eq 1
               expect(user.user_emails.first.email).to eq email
               expect(User.fuzzy_email_find(email)).to eq user
-              expect(AfterUserCreateWorker)
               # bike association is processed async, so we have to drain the queue
               expect(AfterUserCreateWorker.jobs.map { |j| j["args"] }.last.flatten).to eq([user.id, "async"])
               AfterUserCreateWorker.drain

--- a/spec/workers/after_user_create_worker_spec.rb
+++ b/spec/workers/after_user_create_worker_spec.rb
@@ -54,12 +54,22 @@ RSpec.describe AfterUserCreateWorker, type: :job do
     end
 
     context "stage: async" do
-      it "calls import and associate_ownerships" do
-        expect(instance).to receive(:associate_ownerships)
+      it "calls import" do
+        expect(instance).to_not receive(:associate_ownerships)
         expect(instance).to receive(:import_user_attributes)
         expect do
           instance.perform(user.id, "async")
         end.to_not change(AfterUserCreateWorker.jobs, :count)
+      end
+      context "confirmed user" do
+        let(:user) { FactoryBot.create(:user_confirmed) }
+        it "calls import and associate_ownerships" do
+          expect(instance).to receive(:associate_ownerships)
+          expect(instance).to receive(:import_user_attributes)
+          expect do
+            instance.perform(user.id, "async")
+          end.to_not change(AfterUserCreateWorker.jobs, :count)
+        end
       end
     end
   end

--- a/spec/workers/after_user_create_worker_spec.rb
+++ b/spec/workers/after_user_create_worker_spec.rb
@@ -45,11 +45,11 @@ RSpec.describe AfterUserCreateWorker, type: :job do
 
     context "stage: merged" do
       it "associates" do
+        expect(instance).to receive(:associate_ownerships)
         expect(instance).to receive(:associate_membership_invites)
         expect do
           instance.perform(user.id, "merged", user: user)
-        end.to change(AfterUserCreateWorker.jobs, :count).by 1
-        expect(AfterUserCreateWorker.jobs.map { |j| j["args"] }.last.flatten).to eq([user.id, "async"])
+        end.to_not change(AfterUserCreateWorker.jobs, :count)
       end
     end
 


### PR DESCRIPTION
Because of the calculations that were being done inline for users, signup was taking a _long_ time. This was causing a number of issues.

This PR moves some of the calculations to async jobs and simplifies others. 