### PR TITLE
Better handling for canonical urls in blogs

### DIFF
--- a/app/models/blog.rb
+++ b/app/models/blog.rb
@@ -10,7 +10,6 @@ class Blog < ApplicationRecord
   validates_presence_of :title, :body, :user_id
   validates_uniqueness_of :title, message: "has already been taken. If you believe that this message is an error, contact us!"
   validates_uniqueness_of :title_slug, message: "somehow that overlaps with another title! Sorrys."
-  validates_format_of :canonical_url, with: %r{https?://\w+\.\w+/.+}, unless: -> { self.canonical_url.blank? }
 
   before_save :set_calculated_attributes
   before_create :set_title_slug
@@ -45,6 +44,7 @@ class Blog < ApplicationRecord
 
   def set_calculated_attributes
     self.published_at ||= Time.current # We need to have a published time...
+    self.canonical_url = Urlifyer.urlify(canonical_url)
     set_published_at_and_published
     update_title_save
     create_abbreviation

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -289,7 +289,7 @@ class User < ApplicationRecord
     self.username = Slugifyer.slugify(username) if username
     self.email = EmailNormalizer.normalize(email)
     self.title = strip_tags(title) if title.present?
-    self.website = Urlifyer.urlify(website) if website.present?
+    self.website = Urlifyer.urlify(website)
     if my_bikes_link_target.present? || my_bikes_link_title.present?
       mbh = my_bikes_hash || {}
       mbh["link_target"] = Urlifyer.urlify(my_bikes_link_target) if my_bikes_link_target.present?

--- a/app/services/urlifyer.rb
+++ b/app/services/urlifyer.rb
@@ -4,10 +4,9 @@ class Urlifyer
   # TODO: Improve this, add errors or something
 
   def self.urlify(string)
-    if string && string.length > 1
-      return string if string.match(/\Ahttp.?:\/\//i).present?
-      "http://#{string.strip}"
-    end
+    return nil unless string.present? && string.length > 1
+    return string if string.match(/\Ahttp.?:\/\//i).present?
+    "http://#{string.strip}"
   end
 
   def self.uri?(string)

--- a/spec/models/blog_spec.rb
+++ b/spec/models/blog_spec.rb
@@ -115,31 +115,45 @@ RSpec.describe Blog, type: :model do
   end
 
   describe "canonical_url validation" do
-    context "given a blank value" do
+    let(:blog) { FactoryBot.build(:blog, canonical_url: canonical_url) }
+    before { blog.set_calculated_attributes }
+    context "blank" do
+      let(:canonical_url) { " " }
       it "is valid" do
-        blog = FactoryBot.build(:blog, canonical_url: "")
         expect(blog).to be_valid
-
-        blog = FactoryBot.build(:blog, canonical_url: nil)
+        expect(blog.canonical_url).to be_nil
+      end
+    end
+    context "nil" do
+      let(:canonical_url) { nil }
+      it "is valid" do
         expect(blog).to be_valid
+        expect(blog.canonical_url).to be_nil
       end
     end
 
-    context "given a minimally complete url" do
-      it "is valid" do
-        blog = FactoryBot.build(:blog, canonical_url: "http://blogger.com/myblog")
-        expect(blog).to be_valid
-
-        blog = FactoryBot.build(:blog, canonical_url: "https://blogger.com/myblog")
-        expect(blog).to be_valid
+    context "given a complete url" do
+      context "http" do
+        let(:canonical_url) { "http://blogger.com/myblog" }
+        it "is valid" do
+          expect(blog).to be_valid
+          expect(blog.canonical_url).to eq canonical_url
+        end
+      end
+      context "https" do
+        let(:canonical_url) { "https://www.usacycling.org/article/in-our-own-words-lily-williams-olympic-postponement" }
+        it "is valid" do
+          expect(blog).to be_valid
+          expect(blog.canonical_url).to eq canonical_url
+        end
       end
     end
 
     context "given an incomplete url" do
+      let(:canonical_url) { "blogger.com/myblog" }
       it "is invalid" do
-        blog = FactoryBot.build(:blog, canonical_url: "blogger.com/myblog")
-        expect(blog).to be_invalid
-        expect(blog.errors[:canonical_url]).to include("is invalid")
+        expect(blog).to be_valid
+        expect(blog.canonical_url).to eq "http://#{canonical_url}"
       end
     end
   end

--- a/spec/services/urlifyer_spec.rb
+++ b/spec/services/urlifyer_spec.rb
@@ -5,6 +5,8 @@ RSpec.describe Urlifyer do
     it "does nothing if no website is present" do
       website = Urlifyer.urlify(nil)
       expect(website).to be_nil
+      website = Urlifyer.urlify("  ")
+      expect(website).to be_nil
       website = Urlifyer.urlify("i")
       expect(website).to be_nil
     end


### PR DESCRIPTION
Validation failed for `https://www.usacycling.org/article/in-our-own-words-lily-williams-olympic-postponement` - and didn't give info as to why it was failing.

Rather than validate, coerce using existing `Urlifyer` method.