### PR TITLE
Drop twitter_accounts country and state fields

### DIFF
--- a/app/models/country.rb
+++ b/app/models/country.rb
@@ -35,7 +35,11 @@ class Country < ApplicationRecord
     StatesAndCountries.countries.map { |c| c[:name] }
   end
 
+  def united_states?
+    iso.upcase == "US"
+  end
+
   def default?
-    name == "United States"
+    united_states?
   end
 end

--- a/app/models/twitter_account.rb
+++ b/app/models/twitter_account.rb
@@ -28,9 +28,9 @@ class TwitterAccount < ApplicationRecord
     if (geo = results.first)
       account.city = geo.city
       account.neighborhood = geo.neighborhood
-      account.country = Country.fuzzy_find(geo.country)
-      account.state =
-        State.fuzzy_find(geo.state_code) if account.country&.united_states?
+      country = Country.fuzzy_find(geo.country)
+      account.country = country
+      account.state = State.fuzzy_find(geo.state_code) if country&.united_states?
     end
   end
 

--- a/app/models/twitter_account.rb
+++ b/app/models/twitter_account.rb
@@ -28,8 +28,9 @@ class TwitterAccount < ApplicationRecord
     if (geo = results.first)
       account.city = geo.city
       account.neighborhood = geo.neighborhood
-      account.state = State.fuzzy_find(geo.state_code)
       account.country = Country.fuzzy_find(geo.country)
+      account.state =
+        State.fuzzy_find(geo.state_code) if account.country&.united_states?
     end
   end
 

--- a/app/views/admin/twitter_accounts/index.html.haml
+++ b/app/views/admin/twitter_accounts/index.html.haml
@@ -46,7 +46,7 @@
           %td
             %small.less-strong= twitter_account.city
           %td
-            %small.less-strong= twitter_account.state
+            %small.less-strong= twitter_account.state&.abbreviation
           %td
-            %small.less-strong= twitter_account.country
+            %small.less-strong= twitter_account.country&.name
           %td= twitter_account.tweets.count

--- a/db/migrate/20200414055431_drop_state_and_country_from_twitter_accounts.rb
+++ b/db/migrate/20200414055431_drop_state_and_country_from_twitter_accounts.rb
@@ -1,0 +1,6 @@
+class DropStateAndCountryFromTwitterAccounts < ActiveRecord::Migration[5.2]
+  def change
+    remove_column :twitter_accounts, :state, :string
+    remove_column :twitter_accounts, :country, :string
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -2344,11 +2344,9 @@ CREATE TABLE public.twitter_accounts (
     city character varying,
     consumer_key character varying NOT NULL,
     consumer_secret character varying NOT NULL,
-    country character varying,
     language character varying,
     neighborhood character varying,
     screen_name character varying NOT NULL,
-    state character varying,
     user_secret character varying NOT NULL,
     user_token character varying NOT NULL,
     twitter_account_info jsonb DEFAULT '{}'::jsonb,
@@ -4659,6 +4657,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20200409201638'),
 ('20200410043813'),
 ('20200410183949'),
-('20200414055430');
+('20200414055430'),
+('20200414055431');
 
 


### PR DESCRIPTION
Drops the `state` and `country` columns from `twitter_accounts`, which are replaced by foreign keys in PR #1546. 

The data migration in #1546 should be completed on prod before this PR is merged into master.
