### PR TITLE
Check for presence of an image before rendering

### DIFF
--- a/app/views/bikes/show.html.haml
+++ b/app/views/bikes/show.html.haml
@@ -72,20 +72,21 @@
     -# Bike Photo!
     .col-md-8
       .bike-photos.horizontal-thumbnails
-        - if @bike.public_images.any?
+        - bike_image = @bike.public_images.first
+        - if bike_image.present? && bike_image.image_url.present?
           #selected-photo{ class: "image-holder #{"just1photo" if @bike.public_images.count == 1}" }
-            .current-photo{ id: "image#{@bike.public_images.first.id}"}
-              = image_tag(@bike.public_images.first.image_url(:large), alt: t(".bike_photo", bike_type: @bike.type.titleize), id: "i|#{@bike.public_images.first.listing_order}", data: { action: "zoom", original: @bike.public_images.first.image_url })
+            .current-photo{ id: "image#{bike_image.id}"}
+              = image_tag(bike_image.image_url(:large), alt: t(".bike_photo", bike_type: @bike.type.titleize), id: "i|#{@bike.public_images.first.listing_order}", data: { action: "zoom", original: bike_image.image_url })
           - if @bike.public_images.count > 1
             %span.thumbnail-shadow
             %span.thumbnail-shadow-r
             #thumbnail-photos.photo-list
               %ul#thumbnails
-                - @bike.public_images.each_with_index do |public_image, index|
+                - @bike.public_images.select(&:image_url).each_with_index do |public_image, index|
                   - thumb_class = index == 0 ? 'current-thumb' : '' # make the first image current
                   %li
-                    %a.clickable-image{ class: thumb_class, data: { id: "image#{public_image.id}", img: public_image.image.url(:large), link: public_image.image.url } }
-                      = image_tag public_image.image.url(:small), alt: "#{public_image.name}", id: "i|#{public_image.listing_order}"
+                    %a.clickable-image{ class: thumb_class, data: { id: "image#{public_image.id}", img: public_image.image_url(:large), link: public_image.image.url } }
+                      = image_tag public_image.image_url(:small), alt: "#{public_image.name}", id: "i|#{public_image.listing_order}"
             :plain
               <script id="current-photo-template" type="x-tmpl-mustache">
                 <div id="{{id}}" style="display: none;">


### PR DESCRIPTION
This patch updates the bikes#show template to check for the presence of `image_url`s when rendering. `image_tag` raises an exception when passed `nil`, and until recently some image records (4) were missing an associated `image_url` (only one had an associated bike).

related: https://app.honeybadger.io/projects/35931/faults/62869392