### PR TITLE
Add cors to v3 search

### DIFF
--- a/app/controllers/api/v3/search.rb
+++ b/app/controllers/api/v3/search.rb
@@ -1,6 +1,8 @@
 module API
   module V3
     class Search < API::Base
+      include API::V2::Defaults
+
       helpers do
         params :non_serial_search_params do
           optional :query, type: String, desc: "Full text search"

--- a/spec/requests/api/v3/manufacturers_request_spec.rb
+++ b/spec/requests/api/v3/manufacturers_request_spec.rb
@@ -25,7 +25,6 @@ RSpec.describe "Manufacturers API V3", type: :request do
       expect(response.code).to eq("200")
       expect(JSON.parse(result)["manufacturer"]["id"]).to eq(@manufacturer.id)
     end
-
     it "responds with missing and cors headers" do
       get "/api/v3/manufacturers/10000"
       expect(response.code).to eq("404")

--- a/spec/requests/api/v3/search_request_spec.rb
+++ b/spec/requests/api/v3/search_request_spec.rb
@@ -14,6 +14,8 @@ RSpec.describe "Search API V3", type: :request do
         expect(response.header["Total"]).to eq("1")
         result = JSON.parse(response.body)
         expect(result["bikes"][0]["id"]).to eq bike_2.id
+        expect(response.headers["Access-Control-Allow-Origin"]).to eq("*")
+        expect(response.headers["Access-Control-Request-Method"]).to eq("*")
       end
     end
   end
@@ -122,6 +124,8 @@ RSpec.describe "Search API V3", type: :request do
           result = JSON.parse(response.body)
           expect(result).to match({ non: 1, stolen: 2, proximity: 1 }.as_json)
           expect(response.status).to eq(200)
+          expect(response.headers["Access-Control-Allow-Origin"]).to eq("*")
+          expect(response.headers["Access-Control-Request-Method"]).to eq("*")
         end
       end
     end


### PR DESCRIPTION
Thanks to @catdoch for the heads up that this was missing!

This will fix #1573 once merged