### PR TITLE
Redirect after sign in to bike for writing message

### DIFF
--- a/app/views/bikes/show.html.haml
+++ b/app/views/bikes/show.html.haml
@@ -220,7 +220,7 @@
           - if @bike.abandoned
             %p
               = t(".is_this_your_bike_send_proof_of_ownership")
-          - redirect = new_session_url(return_to: "bikes/#{@bike.id}?contact_owner=true") unless current_user.present?
+          - redirect = new_session_url(return_to: "/bikes/#{@bike.id}?contact_owner=true") unless current_user.present?
           #write_them_a_message.collapse{ class: ("in" unless @contact_owner_open), data: { redirect: redirect } }
             %a.btn.btn-primary.btn-lg{ href: '#new_stolen_message', 'aria-controls' => 'new_stolen_message', 'data-toggle' => 'collapse' }
               = t(".write_them_a_message")

--- a/app/views/sessions/new.html.haml
+++ b/app/views/sessions/new.html.haml
@@ -34,7 +34,7 @@
                 = t(".dont_have_an_account")
               = link_to t(".sign_up"), new_user_path(partner: sign_in_partner, email: params[:email])
 
-          = form_for :session, url: session_url do |f|
+          = form_for :session, url: session_url(params.permit(:return_to)) do |f|
             - if sign_in_partner
               = hidden_field_tag :partner, sign_in_partner
 


### PR DESCRIPTION
Fixes #1445

- On https://github.com/bikeindex/bike_index/blob/master/app/controllers/concerns/controller_helpers.rb#L117 it expects a string starting with `BASE_URL` or `/`.  So, just adding a `/` on the `data-redirect` attribute, already redirects the user without any other change.
- In order to redirect the user even when the password fails, I merged the `return_to` param on the login form path. So when the login fails, the `redirect_to` is not lost.