### PR TITLE
Add exchange rate model for currency conversions

### DIFF
--- a/app/controllers/admin/exchange_rates_controller.rb
+++ b/app/controllers/admin/exchange_rates_controller.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+
+class Admin::ExchangeRatesController < Admin::BaseController
+  include SortableTable
+
+  before_action :find_exchange_rate, only: %w[edit update]
+
+  def index
+    @exchange_rates =
+      ExchangeRate.where(filter_params).order(sort_column => sort_direction)
+  end
+
+  def new
+    @exchange_rate = ExchangeRate.new
+  end
+
+  def create
+    @exchange_rate = ExchangeRate.new(exchange_rate_params)
+
+    if @exchange_rate.save
+      redirect_to admin_exchange_rates_url
+    else
+      flash.now[:error] = @exchange_rate.errors.full_messages.to_sentence
+      render :new
+    end
+  end
+
+  def edit; end
+
+  def update
+    if @exchange_rate.update(exchange_rate_params)
+      redirect_to admin_exchange_rates_url
+    else
+      flash.now[:error] = @exchange_rate.errors.full_messages.join("\n")
+      render :edit
+    end
+  end
+
+  def destroy
+    exchange_rate = ExchangeRate.find_by(id: params[:id])
+
+    if !exchange_rate&.destroy
+      flash[:error] = "Could not delete exchange rate."
+    end
+
+    redirect_to admin_exchange_rates_url
+  end
+
+  private
+
+  def exchange_rate_params
+    params.require(:exchange_rate).permit(:from, :to, :rate)
+  end
+
+  def find_exchange_rate
+    @exchange_rate = ExchangeRate.find(params[:id])
+  end
+
+  def sortable_columns
+    %w[to from rate updated_at]
+  end
+
+  def default_direction
+    "asc"
+  end
+
+  def filter_params
+    params
+      .permit(:search_to)
+      .to_h
+      .map { |k, v| [k[/(?<=search_).+/].to_sym, v] }
+      .to_h
+  end
+
+  helper_method :filter_params
+end

--- a/app/helpers/admin_helper.rb
+++ b/app/helpers/admin_helper.rb
@@ -46,6 +46,7 @@ module AdminHelper
       { title: "Duplicate Bikes", path: duplicates_admin_bikes_path, match_controller: false },
       { title: "Feature Flags", path: admin_feature_flags_path, match_controller: false },
       { title: "Scheduled Jobs", path: admin_scheduled_jobs_path, match_controller: false },
+      { title: "Exchange Rates", path: admin_exchange_rates_path, match_controller: false },
       { title: "Exit Admin", path: root_path, match_controller: false },
     ] + dev_nav_select_links
   end

--- a/app/helpers/money_helper.rb
+++ b/app/helpers/money_helper.rb
@@ -2,8 +2,7 @@
 module MoneyHelper
   include MoneyRails::ActionViewExtension
 
-  # TODO: Add a bank implementation that fetches conversion rate values
-  Money.default_bank.add_rate(:USD, :EUR, 0.88)
+  Money.default_bank = Money::Bank::VariableExchange.new(ExchangeRate)
   Money.rounding_mode = BigDecimal::ROUND_HALF_UP
   Money.locale_backend = :i18n
 

--- a/app/helpers/money_helper.rb
+++ b/app/helpers/money_helper.rb
@@ -13,7 +13,7 @@ module MoneyHelper
 
   # Return a list of currency abbreviations (USD, EUR) for all available locales.
   def available_currencies
-    I18n.available_locales.map { |locale| t(locale, scope: [:money, :currencies]) }
+    ExchangeRate.required_targets
   end
 
   # Return a list of currency symbols and abbreviations for all available locales:

--- a/app/models/exchange_rate.rb
+++ b/app/models/exchange_rate.rb
@@ -2,17 +2,39 @@
 
 class ExchangeRate < ApplicationRecord
   validates :from, :to, :rate, presence: true
+  validates :from, :to, format: { with: /\A[A-Z]{3}\z/, message: "must be a valid ISO currency code" }
   validates :rate, numericality: { greater_than_or_equal_to: 0 }
   validates :to, uniqueness: { scope: :from }
+
+  before_validation :normalize_currency_codes
+  before_destroy :forbid_destroying_required_exchange_rate
+
+  def self.add_rate(from_iso_code, to_iso_code, rate)
+    exrate = find_or_initialize_by(from: from_iso_code, to: to_iso_code)
+    exrate.rate = rate
+    exrate if exrate.save
+  end
 
   def self.get_rate(from_iso_code, to_iso_code)
     exrate = find_by(from: from_iso_code, to: to_iso_code)
     exrate&.rate
   end
 
-  def self.add_rate(from_iso_code, to_iso_code, rate)
-    exrate = find_or_initialize_by(from: from_iso_code, to: to_iso_code)
-    exrate.rate = rate
-    exrate if exrate.save
+  def self.required_targets
+    I18n.available_locales.map { |locale| I18n.t(locale, scope: [:money, :currencies]) }
+  end
+
+  private
+
+  def normalize_currency_codes
+    self.from = from&.upcase
+    self.to = to&.upcase
+  end
+
+  def forbid_destroying_required_exchange_rate
+    if from == "USD" && to.in?(self.class.required_targets)
+      errors.add :base, "Cannot delete a required exchange rate"
+      throw(:abort)
+    end
   end
 end

--- a/app/models/exchange_rate.rb
+++ b/app/models/exchange_rate.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+class ExchangeRate < ApplicationRecord
+  validates :from, :to, :rate, presence: true
+  validates :rate, numericality: { greater_than_or_equal_to: 0 }
+  validates :to, uniqueness: { scope: :from }
+
+  def self.get_rate(from_iso_code, to_iso_code)
+    exrate = find_by(from: from_iso_code, to: to_iso_code)
+    exrate&.rate
+  end
+
+  def self.add_rate(from_iso_code, to_iso_code, rate)
+    exrate = find_or_initialize_by(from: from_iso_code, to: to_iso_code)
+    exrate.rate = rate
+    exrate if exrate.save
+  end
+end

--- a/app/models/exchange_rate_api_client.rb
+++ b/app/models/exchange_rate_api_client.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+class ExchangeRateApiClient
+  attr_accessor :base_iso, :base_url
+
+  BASE_URL = ENV.fetch("EXCHANGE_RATE_API_BASE_URL", "https://api.exchangeratesapi.io")
+
+  def initialize(base_iso="USD")
+    self.base_iso = base_iso
+    self.base_url = BASE_URL
+  end
+
+  def latest
+    resp = conn.get("latest") do |req|
+      req.params = {"base" => base_iso}
+    end
+
+    unless resp.status == 200 && resp.body.is_a?(Hash)
+      raise ExchangeRateApiError, resp.body
+    end
+
+    resp.body.with_indifferent_access
+  end
+
+  private
+
+  def conn
+    @conn ||= Faraday.new(url: base_url) do |conn|
+      conn.response :json, content_type: /\bjson$/
+      conn.use Faraday::RequestResponseLogger::Middleware,
+               logger_level: :info,
+               logger: Rails.logger if Rails.env.development?
+      conn.adapter Faraday.default_adapter
+      conn.options.timeout = 5
+    end
+  end
+end
+
+class ExchangeRateApiError < StandardError; end

--- a/app/models/exchange_rate_api_client.rb
+++ b/app/models/exchange_rate_api_client.rb
@@ -1,25 +1,28 @@
 # frozen_string_literal: true
 
 class ExchangeRateApiClient
-  attr_accessor :base_iso, :base_url
+  attr_accessor :base_iso, :base_url, :cache_key
 
   BASE_URL = ENV.fetch("EXCHANGE_RATE_API_BASE_URL", "https://api.exchangeratesapi.io")
 
   def initialize(base_iso="USD")
     self.base_iso = base_iso
     self.base_url = BASE_URL
+    self.cache_key = ["exchange_rate", Date.current].join("::")
   end
 
   def latest
-    resp = conn.get("latest") do |req|
-      req.params = {"base" => base_iso}
-    end
+    Rails.cache.fetch(cache_key, expires_in: 24.hours) do
+      resp = conn.get("latest") do |req|
+        req.params = {"base" => base_iso}
+      end
 
-    unless resp.status == 200 && resp.body.is_a?(Hash)
-      raise ExchangeRateApiError, resp.body
-    end
+      unless resp.status == 200 && resp.body.is_a?(Hash)
+        raise ExchangeRateApiError, resp.body
+      end
 
-    resp.body.with_indifferent_access
+      resp.body.with_indifferent_access
+    end
   end
 
   private

--- a/app/services/exchange_rate_updator.rb
+++ b/app/services/exchange_rate_updator.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class ExchangeRateUpdator
+  def self.update
+    payload = ExchangeRateApiClient.new.latest
+    rates = payload.fetch(:rates)
+    base_iso = payload.fetch(:base)
+
+    results = rates.map do |target_iso, multiplier|
+      ExchangeRate.add_rate(base_iso, target_iso, multiplier)
+    end
+
+    results.none?(&:nil?)
+  end
+end

--- a/app/views/admin/exchange_rates/_form.html.haml
+++ b/app/views/admin/exchange_rates/_form.html.haml
@@ -1,0 +1,22 @@
+= form_for exchange_rate,
+  url: action,
+  method: method,
+  html: { class: "form" } do |f|
+
+  = f.label :from, "From (iso)", class: "form-label"
+  = f.text_field :from,
+    class: "form-control",
+    style: "text-transform: uppercase;",
+    required: true
+
+  = f.label :to, "To (iso)", class: "form-label"
+  = f.text_field :to,
+    class: "form-control",
+    style: "text-transform: uppercase;",
+    required: true
+
+  = f.label :rate, "Rate", class: "form-label"
+  = f.text_field :rate, class: "form-control"
+
+  %br
+  = submit_tag submit_label, class: "btn btn-success btn-lg"

--- a/app/views/admin/exchange_rates/edit.html.haml
+++ b/app/views/admin/exchange_rates/edit.html.haml
@@ -1,0 +1,14 @@
+.container
+  %h1 Edit Exchange Rate
+  .text-right
+    = link_to "Delete exchange rate",
+    admin_exchange_rate_path(@exchange_rate),
+    method: :delete,
+    data: { confirm: "Are you sure you want to delete this? This can't be undone" },
+    class: "text-warning"
+
+  = render "form",
+    exchange_rate: @exchange_rate,
+    action: admin_ambassador_task_path(@exchange_rate),
+    method: :put,
+    submit_label: "Save"

--- a/app/views/admin/exchange_rates/index.html.haml
+++ b/app/views/admin/exchange_rates/index.html.haml
@@ -1,0 +1,41 @@
+.admin-subnav
+  .col-md-4
+    %h1 Exchange Rates
+  .col-md-8
+    %ul
+      %li.nav-item
+        = link_to "New Exchange Rate", new_admin_exchange_rate_path
+
+.row
+  .col-md-6
+    - if filter_params.any?
+      %p
+        = pluralize number_with_delimiter(@exchange_rates.count),
+        "matching exchange rate"
+        %em= link_to "view all", admin_exchange_rates_path
+  .col-md-6
+    = form_tag admin_exchange_rates_path, method: :get,
+      class: "form-inline admin-filter-menu" do
+      = hidden_field_tag :sort, sort_column
+      = hidden_field_tag :sort_direction, sort_direction
+      .form-group.ml-2
+        = select_tag :search_to,
+          options_for_select(ExchangeRate.pluck(:to).uniq),
+          prompt: "Filter by target currency",
+          class: "form-control"
+      = submit_tag "Filter", name: "search", class: "btn btn-primary ml-2"
+
+.full-screen-table
+  %table.table.table-striped.table-bordered.table-sm.without-exterior-border
+    %thead.small-header
+      %th= sortable "from", "Source currency"
+      %th= sortable "to", "Target currency"
+      %th= sortable "rate"
+      %th= sortable "updated_at"
+    %tbody
+      - @exchange_rates.each do |xrate|
+        %tr
+          %td= xrate.from
+          %td= xrate.to
+          %td= link_to xrate.rate.truncate(2), edit_admin_exchange_rate_path(xrate)
+          %td.convertTime= l(xrate.updated_at, format: :convert_time)

--- a/app/views/admin/exchange_rates/new.html.haml
+++ b/app/views/admin/exchange_rates/new.html.haml
@@ -1,0 +1,8 @@
+.container
+  %h1 New Exchange Rate
+
+  = render "form",
+    exchange_rate: @exchange_rate,
+    action: admin_exchange_rates_path,
+    method: :post,
+    submit_label: "Create"

--- a/app/workers/scheduled_worker_runner.rb
+++ b/app/workers/scheduled_worker_runner.rb
@@ -45,6 +45,7 @@ class ScheduledWorkerRunner < ScheduledWorker
       ScheduleBikePossiblyFoundNotificationWorker,
       ScheduleSearchForExternalRegistryBikesWorker,
       FetchProject529BikesWorker,
+      UpdateExchangeRatesWorker,
       self,
     ]
   end

--- a/app/workers/update_exchange_rates_worker.rb
+++ b/app/workers/update_exchange_rates_worker.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class UpdateExchangeRatesWorker < ScheduledWorker
+  prepend ScheduledWorkerRecorder
+  sidekiq_options queue: "low_priority", retry: false
+
+  def self.frequency
+    1.day
+  end
+
+  def perform
+    ExchangeRateUpdator.update
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -153,6 +153,7 @@ Rails.application.routes.draw do
     root to: "dashboard#index", as: :root
     resources :ambassador_tasks, except: :show
     resources :ambassador_task_assignments, only: [:index]
+    resources :exchange_rates, only: %i[index new create edit update destroy]
 
     resources :external_registry_bikes, only: %i[index show]
     resources :external_registry_credentials, only: %i[index new create edit update] do

--- a/db/migrate/20200517001632_create_exchange_rates.rb
+++ b/db/migrate/20200517001632_create_exchange_rates.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+class CreateExchangeRates < ActiveRecord::Migration[5.2]
+  def change
+    create_table :exchange_rates do |t|
+      t.string :from, null: false
+      t.string :to, null: false
+      t.float :rate, null: false
+
+      t.index [:from, :to], unique: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -789,6 +789,39 @@ ALTER SEQUENCE public.duplicate_bike_groups_id_seq OWNED BY public.duplicate_bik
 
 
 --
+-- Name: exchange_rates; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.exchange_rates (
+    id bigint NOT NULL,
+    "from" character varying NOT NULL,
+    "to" character varying NOT NULL,
+    rate double precision NOT NULL,
+    created_at timestamp without time zone NOT NULL,
+    updated_at timestamp without time zone NOT NULL
+);
+
+
+--
+-- Name: exchange_rates_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.exchange_rates_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: exchange_rates_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.exchange_rates_id_seq OWNED BY public.exchange_rates.id;
+
+
+--
 -- Name: exports; Type: TABLE; Schema: public; Owner: -
 --
 
@@ -1900,6 +1933,7 @@ CREATE TABLE public.parking_notifications (
 --
 
 CREATE SEQUENCE public.parking_notifications_id_seq
+    AS integer
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -2659,6 +2693,13 @@ ALTER TABLE ONLY public.duplicate_bike_groups ALTER COLUMN id SET DEFAULT nextva
 
 
 --
+-- Name: exchange_rates id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.exchange_rates ALTER COLUMN id SET DEFAULT nextval('public.exchange_rates_id_seq'::regclass);
+
+
+--
 -- Name: exports id; Type: DEFAULT; Schema: public; Owner: -
 --
 
@@ -3117,6 +3158,14 @@ ALTER TABLE ONLY public.customer_contacts
 
 ALTER TABLE ONLY public.duplicate_bike_groups
     ADD CONSTRAINT duplicate_bike_groups_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: exchange_rates exchange_rates_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.exchange_rates
+    ADD CONSTRAINT exchange_rates_pkey PRIMARY KEY (id);
 
 
 --
@@ -3664,6 +3713,13 @@ CREATE INDEX index_creation_states_on_creator_id ON public.creation_states USING
 --
 
 CREATE INDEX index_creation_states_on_organization_id ON public.creation_states USING btree (organization_id);
+
+
+--
+-- Name: index_exchange_rates_on_from_and_to; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX index_exchange_rates_on_from_and_to ON public.exchange_rates USING btree ("from", "to");
 
 
 --
@@ -4687,6 +4743,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20200424222002'),
 ('20200428203014'),
 ('20200429004612'),
-('20200429174144');
+('20200429174144'),
+('20200517001632');
 
 

--- a/lib/tasks/rake_tasks.rake
+++ b/lib/tasks/rake_tasks.rake
@@ -58,3 +58,9 @@ task database_size: :environment do
   # Print DB size
   puts "\n#{'Total size'.ljust(name_col_length) } | #{ActiveRecord::Base.connection.execute(sql)[0]["pg_size_pretty"]}"
 end
+
+task exchange_rates_update: :environment do
+  print "\nUpdating exchange rates..."
+  is_success = ExchangeRateUpdator.update
+  print is_success ? "done.\n" : "failed.\n"
+end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -68,6 +68,12 @@ FactoryBot.define do
     ctype { FactoryBot.create(:ctype) }
   end
 
+  factory :exchange_rate do
+    from { "USD" }
+    to { 3.times.map { ("A".."Z").entries.sample }.join }
+    rate { rand.truncate(2) }
+  end
+
   factory :state do
     sequence(:name) { |n| "State #{n}" }
     sequence(:abbreviation) { |n| "state-#{n}" }

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -72,6 +72,11 @@ FactoryBot.define do
     from { "USD" }
     to { 3.times.map { ("A".."Z").entries.sample }.join }
     rate { rand.truncate(2) }
+
+    factory :exchange_rate_to_eur do
+      to { "EUR" }
+      rate { 0.88 }
+    end
   end
 
   factory :state do

--- a/spec/helpers/money_helper_spec.rb
+++ b/spec/helpers/money_helper_spec.rb
@@ -35,6 +35,10 @@ RSpec.describe MoneyHelper, type: :helper do
   end
 
   describe "#money_usd" do
+    before do
+      FactoryBot.create(:exchange_rate_to_eur)
+    end
+
     context "given a valid target currency" do
       it "returns a Money object converting to the target currency" do
         conversion_rate = Money.default_bank.get_rate(:USD, :EUR)
@@ -47,7 +51,15 @@ RSpec.describe MoneyHelper, type: :helper do
 
     context "given an invalid target currency" do
       it "raises UnknownCurrency" do
-        expect { money_usd(1.00, exchange_to: :ERR) }.to raise_error(Money::Currency::UnknownCurrency)
+        expect { money_usd(1.00, exchange_to: :ERR) }
+          .to(raise_error(Money::Currency::UnknownCurrency))
+      end
+    end
+
+    context "given an unknown exchange rate" do
+      it "raises UnknownRate" do
+        expect { money_usd(1.00, exchange_to: :CAD) }
+          .to(raise_error(Money::Bank::UnknownRate))
       end
     end
 
@@ -62,6 +74,10 @@ RSpec.describe MoneyHelper, type: :helper do
   end
 
   describe "#as_currency" do
+    before do
+      FactoryBot.create(:exchange_rate_to_eur)
+    end
+
     context "given a valid target currency" do
       it "returns a Money object converting to the default currency" do
         expect(as_currency(100, exchange_to: :EUR)).to eq("€88")
@@ -70,7 +86,15 @@ RSpec.describe MoneyHelper, type: :helper do
 
     context "given an invalid target currency" do
       it "raises UnknownCurrency" do
-        expect { as_currency(100, exchange_to: :ERR) }.to raise_error(Money::Currency::UnknownCurrency)
+        expect { as_currency(100, exchange_to: :ERR) }
+          .to(raise_error(Money::Currency::UnknownCurrency))
+      end
+    end
+
+    context "given an unknown exchange rate" do
+      it "raises UnknownRate" do
+        expect { as_currency(1.00, exchange_to: :CAD) }
+          .to(raise_error(Money::Bank::UnknownRate))
       end
     end
 

--- a/spec/models/exchange_rate_api_client_spec.rb
+++ b/spec/models/exchange_rate_api_client_spec.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe ExchangeRateApiClient, type: :model, vcr: true do
+  describe "#latest" do
+    it "returns a hash with :base and :rates keys" do
+      client = ExchangeRateApiClient.new("CAD")
+      response = client.latest
+      expect(response).to have_key(:base)
+      expect(response).to have_key(:rates)
+      expect(response).to have_key(:date)
+      expect(response[:base]).to eq("CAD")
+      expect(response[:rates]).to be_a(Hash)
+      expect(response[:rates]).to have_key("EUR")
+    end
+  end
+end

--- a/spec/models/exchange_rate_spec.rb
+++ b/spec/models/exchange_rate_spec.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe ExchangeRate, type: :model do
+  describe "validations" do
+    it "ensures rate is non-negative" do
+      rate = FactoryBot.build(:exchange_rate, rate: -1)
+      expect(rate).to be_invalid
+      rate.rate = 1.4
+      expect(rate).to be_valid
+    end
+
+    it "ensures all fields are present" do
+      rate = FactoryBot.build(:exchange_rate, rate: nil)
+      expect(rate).to be_invalid
+      rate = FactoryBot.build(:exchange_rate, from: nil)
+      expect(rate).to be_invalid
+      rate = FactoryBot.build(:exchange_rate, to: nil)
+      expect(rate).to be_invalid
+      rate = FactoryBot.build(:exchange_rate)
+      expect(rate).to be_valid
+    end
+
+    it "ensures currencies are pairwise unique" do
+      rate0 = FactoryBot.create(:exchange_rate)
+      rate1 = FactoryBot.build(:exchange_rate, from: rate0.from, to: rate0.to)
+      expect(rate1).to be_invalid
+
+      rate1.to = rate1.to.reverse
+      expect(rate1).to be_valid
+    end
+  end
+
+  describe ".add_rate" do
+    context "given a found exchange rate" do
+      it "updates the exchange rate multiplier" do
+        rate = FactoryBot.create(:exchange_rate, rate: 0.55)
+        expect(rate.rate).to eq(0.55)
+        found_rate = ExchangeRate.add_rate(rate.from, rate.to, 1.95)
+        expect(found_rate).to eq(rate)
+        expect(found_rate.rate).to eq(1.95)
+      end
+    end
+
+    context "given an absent exchange rate" do
+      it "creates the exchange rate" do
+        multiplier = ExchangeRate.get_rate("USD", "EUR")
+        expect(multiplier).to be_nil
+      end
+    end
+  end
+
+  describe ".get_rate" do
+    context "given a found exchange rate" do
+      it "returns the rate multiplier for the given exchange rate" do
+        rate = FactoryBot.create(:exchange_rate, rate: 0.55)
+        multiplier = ExchangeRate.get_rate(rate.from, rate.to)
+        expect(multiplier).to eq(0.55)
+      end
+    end
+
+    context "given an absent exchange rate" do
+      it "returns nil" do
+        expect(ExchangeRate.count).to be_zero
+        found_rate = ExchangeRate.add_rate("USD", "EUR", 1.95)
+        expect(found_rate.rate).to eq(1.95)
+        expect(ExchangeRate.count).to eq(1)
+      end
+    end
+  end
+end

--- a/spec/requests/admin/exchange_rates_request_spec.rb
+++ b/spec/requests/admin/exchange_rates_request_spec.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Admin::ExchangeRatesController, type: :request do
+  include_context :request_spec_logged_in_as_superuser
+
+  def base_url(path=nil)
+    "/admin/exchange_rates/#{path}"
+  end
+
+  describe "#index" do
+    it "responds with ok" do
+      get base_url
+      expect(response.status).to eq(200)
+      expect(response).to render_template(:index)
+      expect(flash).to_not be_present
+    end
+  end
+
+  describe "#new" do
+    it "responds with ok" do
+      get base_url("new")
+      expect(response.status).to eq(200)
+      expect(response).to render_template(:new)
+    end
+  end
+
+  describe "#create" do
+    it "responds with ok" do
+      attrs = FactoryBot.attributes_for(:exchange_rate)
+
+      post base_url, params: { exchange_rate: attrs }
+
+      expect(flash[:error]).to be_blank
+      expect(response).to redirect_to(admin_exchange_rates_url)
+    end
+  end
+
+  describe "#edit" do
+    it "responds with ok" do
+      xrate = FactoryBot.create(:exchange_rate)
+
+      get base_url("#{xrate.id}/edit")
+
+      expect(response.status).to eq(200)
+      expect(response).to render_template(:edit)
+      expect(flash).to_not be_present
+    end
+  end
+
+  describe "#update" do
+    it "responds with ok" do
+      xrate = FactoryBot.create(:exchange_rate)
+      new_rate = 1.53
+      expect(xrate.rate).to_not eq(new_rate)
+
+      patch base_url(xrate.id), params: {
+              exchange_rate: { rate: new_rate}
+            }
+
+      expect(flash[:error]).to be_blank
+      expect(response).to redirect_to(admin_exchange_rates_url)
+      expect(xrate.reload.rate).to eq(new_rate)
+    end
+  end
+
+  describe "#destroy" do
+    it "responds with ok" do
+      xrate = FactoryBot.create(:exchange_rate)
+      expect(ExchangeRate.count).to eq(1)
+
+      delete base_url(xrate.id)
+
+      expect(response).to redirect_to(admin_exchange_rates_url)
+      expect(ExchangeRate.count).to be_zero
+    end
+  end
+end

--- a/spec/requests/locale_detection_request_spec.rb
+++ b/spec/requests/locale_detection_request_spec.rb
@@ -1,6 +1,10 @@
 require "rails_helper"
 
 RSpec.describe "Locale detection", type: :request do
+  before do
+    FactoryBot.create(:exchange_rate_to_eur)
+  end
+
   describe "requesting the root path" do
     context "given a user preference" do
       include_context :request_spec_logged_in_as_user

--- a/spec/requests/locale_detection_request_spec.rb
+++ b/spec/requests/locale_detection_request_spec.rb
@@ -5,6 +5,21 @@ RSpec.describe "Locale detection", type: :request do
     FactoryBot.create(:exchange_rate_to_eur)
   end
 
+  describe "given a currency conversion with a missing required exchange rate" do
+    it "redirects to the root url in the default locale" do
+      ExchangeRate.delete_all
+      expect(ExchangeRate.count).to be_zero
+
+      get "/", params: { locale: :nl }
+      expect(response).to redirect_to(root_url)
+      expect(flash[:error]).to match(/Nederlands .+ localization is unavailable.+/)
+
+      get "/", params: {}, headers: { "HTTP_ACCEPT_LANGUAGE" => "nl,en;q=0.9" }
+      expect(response).to redirect_to(root_url)
+      expect(flash[:error]).to match(/Nederlands .+ localization is unavailable.+/)
+    end
+  end
+
   describe "requesting the root path" do
     context "given a user preference" do
       include_context :request_spec_logged_in_as_user

--- a/spec/vcr_cassettes/ExchangeRateApiClient/_latest/returns_a_hash_with_base_and_rates_keys.yml
+++ b/spec/vcr_cassettes/ExchangeRateApiClient/_latest/returns_a_hash_with_base_and_rates_keys.yml
@@ -1,0 +1,56 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.exchangeratesapi.io/latest?base=CAD
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.17.1
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Sun, 17 May 2020 11:10:13 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Vary:
+      - Accept-Encoding
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET
+      Cache-Control:
+      - max-age=1800
+      Cf-Cache-Status:
+      - HIT
+      Age:
+      - '2095'
+      Expect-Ct:
+      - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 594ce406cf3be112-IAD
+      Cf-Request-Id:
+      - 02c3ecd8380000e11207803200000001
+    body:
+      encoding: ASCII-8BIT
+      string: '{"rates":{"CAD":1.0,"HKD":5.4949116933,"ISK":103.4075241284,"PHP":35.964808614,"DKK":4.8963298536,"HUF":232.8803098943,"CZK":18.1137154488,"GBP":0.5826144048,"RON":3.1777296304,"SEK":7.0051211345,"IDR":10588.8122907229,"INR":53.830017727,"BRL":4.1475937233,"RUB":52.2754907754,"HRK":4.9696671263,"JPY":75.8518810321,"THB":22.7535946425,"CHF":0.6902370166,"EUR":0.6565557088,"MYR":3.0846300309,"BGN":1.2840916552,"TRY":4.9037489331,"CNY":5.0396559648,"NOK":7.2594051605,"NZD":1.1913203335,"ZAR":13.1810780645,"USD":0.7089488543,"MXN":17.0025605673,"SGD":1.0108988248,"AUD":1.1033418686,"ILS":2.5065983849,"KRW":874.9261374828,"PLN":2.9971768105},"base":"CAD","date":"2020-05-15"}'
+    http_version: 
+  recorded_at: Sun, 17 May 2020 11:10:13 GMT
+recorded_with: VCR 5.0.0


### PR DESCRIPTION
This patch implements a lingering `Money`-related `TODO` from `MoneyHelper`, adding a currency conversion backend that updates an `exchange_rates` table daily.

```rb
# app/workers/update_exchange_rates_worker.rb L3-14 (9e2c8b56)

class UpdateExchangeRatesWorker < ScheduledWorker
  prepend ScheduledWorkerRecorder
  sidekiq_options queue: "low_priority", retry: false

  def self.frequency
    1.day
  end

  def perform
    ExchangeRateUpdator.update
  end
end
```
<sup>[[source](https://github.com/bikeindex/bike_index/blob/9e2c8b56/app/workers/update_exchange_rates_worker.rb#L3-L14)]</sup>


```rb
# app/services/exchange_rate_updator.rb L3-15 (f55ebd33)

class ExchangeRateUpdator
  def self.update
    payload = ExchangeRateApiClient.new.latest
    rates = payload.fetch(:rates)
    base_iso = payload.fetch(:base)

    results = rates.map do |target_iso, multiplier|
      ExchangeRate.add_rate(base_iso, target_iso, multiplier)
    end

    results.none?(&:nil?)
  end
end
```
<sup>[[source](https://github.com/bikeindex/bike_index/blob/f55ebd33/app/services/exchange_rate_updator.rb#L3-L15)]</sup>

```rb
# app/models/exchange_rate_api_client.rb L3-6 (d1f7e639)

class ExchangeRateApiClient
  attr_accessor :base_iso, :base_url, :cache_key

  BASE_URL = ENV.fetch("EXCHANGE_RATE_API_BASE_URL", "https://api.exchangeratesapi.io")
```
<sup>[[source](https://github.com/bikeindex/bike_index/blob/d1f7e639/app/models/exchange_rate_api_client.rb#L3-L6)]</sup>




### post-deploy

```
bundle exec rails exchange_rates_update
```

```rake
# lib/tasks/rake_tasks.rake L62-66 (f55ebd33)

task exchange_rates_update: :environment do
  print "\nUpdating exchange rates..."
  is_success = ExchangeRateUpdator.update
  print is_success ? "done.\n" : "failed.\n"
end
```
<sup>[[source](https://github.com/bikeindex/bike_index/blob/f55ebd33/lib/tasks/rake_tasks.rake#L62-L66)]</sup>

### USD
<img width="1215" alt="USD" src="https://user-images.githubusercontent.com/4433943/82142510-d9d60c00-980a-11ea-9616-09cbfe1c48ef.png">


### EUR (pre-update)
<img width="1150" alt="EUR pre-update" src="https://user-images.githubusercontent.com/4433943/82142509-d8a4df00-980a-11ea-9157-1f8db6b8a150.png">


### EUR (post-update)

<img width="1174" alt="EUR post-update" src="https://user-images.githubusercontent.com/4433943/82142512-da6ea280-980a-11ea-91d5-47474e91a79e.png">

Resolves https://github.com/bikeindex/bike_index/issues/952


### Alternative implementation

For a less invasive implementation, we can instead merge #1592, which uses the eu_central_bank gem. One drawback there (arguably. arguably not, considering we don't deploy to ephemeral instances) is that the gem uses an XML file stored on disk to cache fetched conversion rates.

The APIs used in both implementations are free.