### PR TITLE
Use a form post JS submission

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -1,6 +1,6 @@
 class SessionsController < ApplicationController
   include Sessionable
-  before_action :skip_if_signed_in, only: [:new]
+  before_action :skip_if_signed_in, only: [:new, :magic_link]
 
   def new
     render_partner_or_default_signin_layout

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -7,6 +7,11 @@ class SessionsController < ApplicationController
   end
 
   def magic_link
+    @token = params[:token]
+    @incorrect_token = params[:incorrect_token].presence
+  end
+
+  def sign_in_with_magic_link
     user = User.find_by_magic_link_token(params[:token])
     if user.present? && !user.auth_token_expired?("magic_link_token")
       user.confirm(user.confirmation_token) unless user.confirmed?
@@ -14,7 +19,7 @@ class SessionsController < ApplicationController
       user.update_attributes(magic_link_token: nil)
       sign_in_and_redirect(@user)
     else
-      @incorrect_token = params[:token].present?
+      redirect_to magic_link_session_path(incorrect_token: params[:token])
     end
   end
 

--- a/app/views/sessions/magic_link.html.haml
+++ b/app/views/sessions/magic_link.html.haml
@@ -2,12 +2,11 @@
   - if @token.present?
     .text-center
       %h3
-        You should be automatically signed in.
-      %p
-        If you are not, please click the below button
+        = t(".you_should_be_signed_in_automatically")
+      %p= t(".if_not_click_button")
       = form_tag sign_in_with_magic_link_session_path, id: "sign_in_with_magic_link", method: "post" do
         = hidden_field_tag :token, params[:token]
-        %input{ type: "submit", value: "sign in", class: 'btn btn-success btn-lg' }
+        %input{ type: "submit", value: t(".sign_in"), class: 'btn btn-success btn-lg' }
       :javascript
         document.forms["sign_in_with_magic_link"].submit()
   - else

--- a/app/views/sessions/magic_link.html.haml
+++ b/app/views/sessions/magic_link.html.haml
@@ -1,13 +1,25 @@
 .container
-  %h3= t(".sign_in_with_magic_link")
-  - if @incorrect_token
-    .alert.alert-warning.mt-2.mb-4
-      %h3.header-font-alt.mb-2=t(".unable_to_auth")
-      %p=t(".reenter_email")
+  - if @token.present?
+    .text-center
+      %h3
+        You should be automatically signed in.
+      %p
+        If you are not, please click the below button
+      = form_tag sign_in_with_magic_link_session_path, id: "sign_in_with_magic_link", method: "post" do
+        = hidden_field_tag :token, params[:token]
+        %input{ type: "submit", value: "sign in", class: 'btn btn-success btn-lg' }
+      :javascript
+        document.forms["sign_in_with_magic_link"].submit()
+  - else
+    %h3= t(".sign_in_with_magic_link")
+    - if @incorrect_token
+      .alert.alert-warning.mt-2.mb-4
+        %h3.header-font-alt.mb-2=t(".unable_to_auth")
+        %p=t(".reenter_email")
 
-  %p= t(".enter_email_address")
+    %p= t(".enter_email_address")
 
-  = form_tag create_magic_link_session_path, method: 'post' do
-    .form-group
-      %input{ name: 'email', id: 'email', type: 'text', placeholder: t(".your_email_address"), class: 'form-control' }
-    %input{ type: 'submit', value: t(".get_sign_in_link"), class: 'btn btn-primary btn-lg' }
+    = form_tag create_magic_link_session_path, method: 'post' do
+      .form-group
+        %input{ name: 'email', id: 'email', type: 'text', placeholder: t(".your_email_address"), class: 'form-control' }
+      %input{ type: 'submit', value: t(".get_sign_in_link"), class: 'btn btn-primary btn-lg' }

--- a/config/locales/.translation_io
+++ b/config/locales/.translation_io
@@ -1,2 +1,2 @@
 ---
-timestamp: 1590377707
+timestamp: 1590617141

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -4730,9 +4730,12 @@ en:
       enter_email_address: Enter your email address, we'll send you an email with
         a link to log in.
       get_sign_in_link: Get sign in link
+      if_not_click_button: If you are not, please click the button below
       reenter_email: Please re-enter your email address to receive a new token
+      sign_in: Sign in
       sign_in_with_magic_link: Passwordless sign in
       unable_to_auth: Unable to authenticate that token
+      you_should_be_signed_in_automatically: You should be automatically signed in.
       your_email_address: your email address
     new:
       dont_have_an_account: don't have an account?

--- a/config/locales/translation.nl.yml
+++ b/config/locales/translation.nl.yml
@@ -4818,6 +4818,9 @@ nl:
       sign_in_with_magic_link: Inloggen zonder wachtwoord
       unable_to_auth: Kan dat token niet verifiëren
       your_email_address: Uw e-mailadres
+      if_not_click_button: Zo niet, klik dan op de onderstaande knop
+      sign_in: Log in
+      you_should_be_signed_in_automatically: Je zou automatisch ingelogd moeten zijn.
     new:
       dont_have_an_account: Heb je nog geen account?
       email: E-mail

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -69,6 +69,7 @@ Rails.application.routes.draw do
   resource :session, only: %i[new create destroy] do
     collection do
       get :magic_link
+      post :sign_in_with_magic_link
       post :create_magic_link
     end
   end

--- a/spec/controllers/sessions_controller_spec.rb
+++ b/spec/controllers/sessions_controller_spec.rb
@@ -58,6 +58,7 @@ RSpec.describe SessionsController, type: :controller do
       expect(cookies.signed[:auth]).to be_nil
       expect(response.code).to eq "200"
       expect(response).to render_template("magic_link")
+      expect(response).to render_template("layouts/application")
     end
     context "incorrect_token" do
       it "renders" do
@@ -66,6 +67,7 @@ RSpec.describe SessionsController, type: :controller do
         expect(cookies.signed[:auth]).to be_nil
         expect(response.code).to eq "200"
         expect(response).to render_template("magic_link")
+        expect(response).to render_template("layouts/application")
       end
     end
   end


### PR DESCRIPTION
Turns out, some email clients visit the links prior to the user visiting them.

Since signing in expires the link, we need to make sure merely loading the link doesn't expire the URL.

This will probably need to be done for other links - e.g. abandoned bike recovery, graduated bikes, maybe even password reset