### PR TITLE
Minor admin bike display update

### DIFF
--- a/app/views/admin/bikes/edit.html.haml
+++ b/app/views/admin/bikes/edit.html.haml
@@ -228,8 +228,9 @@
 .row.mt-4.mb-4
   .col-6
     = link_to "Bike messages", admin_feedbacks_path(search_bike_id: @bike.to_param), class: "btn btn-outline-primary"
-  .col-6.text-right
-    = link_to "Delete bike", admin_bike_url(@bike), method: :delete, data: { confirm: "Are you sure?" }, class: "btn btn-danger ml-4"
+  - unless @bike.deleted?
+    .col-6.text-right
+      = link_to "Delete bike", admin_bike_url(@bike), method: :delete, data: { confirm: "Are you sure?" }, class: "btn btn-danger ml-4"
 
 #BParamsView.mt-4.collapse
   %hr

--- a/app/views/admin/ownerships/edit.html.haml
+++ b/app/views/admin/ownerships/edit.html.haml
@@ -55,6 +55,11 @@
           = @bike.owner.email
       %tr
         %td
+          Send Email
+        %td
+          = @ownership.send_email
+      %tr
+        %td
           Cached Data
         %td
           = @bike.cached_data

--- a/app/views/admin/ownerships/edit.html.haml
+++ b/app/views/admin/ownerships/edit.html.haml
@@ -57,7 +57,7 @@
         %td
           Send Email
         %td
-          = @ownership.send_email
+          = check_mark if @ownership.send_email
       %tr
         %td
           Cached Data


### PR DESCRIPTION
- Remove delete button on deleted bikes (because it doesn't do anything)
- Add a way to view the ownership `send_email`