### PR TITLE
Additional racial language fixes

### DIFF
--- a/app/controllers/admin/dashboard_controller.rb
+++ b/app/controllers/admin/dashboard_controller.rb
@@ -37,13 +37,13 @@ class Admin::DashboardController < Admin::BaseController
   end
 
   def tsvs
-    @blacklist = FileCacheMaintainer.blacklist
+    @blocklist = FileCacheMaintainer.blocklist
     @tsvs = FileCacheMaintainer.files
   end
 
-  def update_tsv_blacklist
-    new_blacklist = params[:blacklist].split(/\n|\r/).reject { |t| t.blank? }
-    FileCacheMaintainer.reset_blacklist_ids(new_blacklist)
+  def update_tsv_blocklist
+    new_blocklist = params[:blocklist].split(/\n|\r/).reject { |t| t.blank? }
+    FileCacheMaintainer.reset_blocklist_ids(new_blocklist)
     redirect_to admin_tsvs_path
   end
 end

--- a/app/integrations/file_cache_maintainer.rb
+++ b/app/integrations/file_cache_maintainer.rb
@@ -1,32 +1,32 @@
 class FileCacheMaintainer
   class << self
-    def assign_blacklist_ids(ids)
+    def assign_blocklist_ids(ids)
       if ids.present?
-        redis.sadd blacklist_id, ids.map { |i| normalized(i) }.reject { |i| i.blank? }
+        redis.sadd blocklist_id, ids.map { |i| normalized(i) }.reject { |i| i.blank? }
       end
     end
 
-    def blacklist
+    def blocklist
       return [] unless redis.type(info_id) == "set"
-      redis.smembers blacklist_id
+      redis.smembers blocklist_id
     end
 
-    def reset_blacklist_ids(ids)
-      redis.expire(blacklist_id, 0)
-      assign_blacklist_ids(ids)
+    def reset_blocklist_ids(ids)
+      redis.expire(blocklist_id, 0)
+      assign_blocklist_ids(ids)
     end
 
-    def blacklist_include?(id)
-      redis.sismember blacklist_id, normalized(id)
+    def blocklist_include?(id)
+      redis.sismember blocklist_id, normalized(id)
     end
 
     def descriptions
       {
         "manufacturers.tsv" => "Manufacturers list",
         "current_stolen_bikes.tsv" => "Stolen",
-        "approved_current_stolen_bikes.tsv" => "Stolen (without blacklisted bikes)",
+        "approved_current_stolen_bikes.tsv" => "Stolen (without blocklisted bikes)",
         "current_stolen_with_reports.tsv" => "Stolen with serials & police reports",
-        "approved_current_stolen_with_reports.tsv" => "Stolen with serials & police reports (without blacklisted bikes)",
+        "approved_current_stolen_with_reports.tsv" => "Stolen with serials & police reports (without blocklisted bikes)",
         "all_stolen_cache.json" => "Cached API response of all stolen bikes",
       }
     end
@@ -79,7 +79,7 @@ class FileCacheMaintainer
       "#{base_id}_info"
     end
 
-    def blacklist_id
+    def blocklist_id
       "#{base_id}_info"
     end
 

--- a/app/integrations/tsv_creator.rb
+++ b/app/integrations/tsv_creator.rb
@@ -78,9 +78,9 @@ class TsvCreator
     send_to_uploader(output)
   end
 
-  def create_stolen(blacklist = false, stolen_records: nil)
+  def create_stolen(blocklist = false, stolen_records: nil)
     stolen_records ||= StolenRecord.approveds
-    filename = "#{@file_prefix}#{"approved_" if blacklist}current_stolen_bikes.tsv"
+    filename = "#{@file_prefix}#{"approved_" if blocklist}current_stolen_bikes.tsv"
     out_file = File.join(Rails.root, filename)
     output = File.open(out_file, "w")
     output.puts stolen_header
@@ -90,9 +90,9 @@ class TsvCreator
     send_to_uploader(output)
   end
 
-  def create_stolen_with_reports(blacklist = false, stolen_records: nil)
+  def create_stolen_with_reports(blocklist = false, stolen_records: nil)
     stolen_records ||= StolenRecord.approveds_with_reports
-    filename = "#{@file_prefix}#{"approved_" if blacklist}current_stolen_with_reports.tsv"
+    filename = "#{@file_prefix}#{"approved_" if blocklist}current_stolen_with_reports.tsv"
     out_file = File.join(Rails.root, filename)
     output = File.open(out_file, "w")
     output.puts stolen_with_reports_header

--- a/app/models/export.rb
+++ b/app/models/export.rb
@@ -28,7 +28,7 @@ class Export < ApplicationRecord
   def self.default_kind_options
     {
       stolen: {
-        with_blacklist: false,
+        with_blocklist: false,
         only_serials_and_police_reports: false,
       },
       organization: {
@@ -165,7 +165,7 @@ class Export < ApplicationRecord
     if kind == "stolen"
       txt = "Stolen"
       txt += " with serials & police reports" if option?("only_serials_and_police_reports")
-      txt += " (without blacklisted bikes)" unless option?("with_blacklist")
+      txt += " (without blocklisted bikes)" unless option?("with_blocklist")
       txt
     elsif kind == "manufacturer"
       "Manufacturer"

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -140,7 +140,7 @@ class Organization < ApplicationRecord
     where("enabled_feature_slugs ?& array[:keys]", keys: matching_slugs)
   end
 
-  def self.whitelisted_passwordless_signin
+  def self.permitted_domain_passwordless_signin
     where.not(passwordless_user_domain: nil).with_enabled_feature_slugs("passwordless_users")
   end
 
@@ -148,7 +148,7 @@ class Organization < ApplicationRecord
     str = EmailNormalizer.normalize(str)
     return nil unless str.present? && str.count("@") == 1 && str.match?(/.@.*\../)
     domain = str.split("@").last
-    whitelisted_passwordless_signin.detect { |o| o.passwordless_user_domain == domain }
+    permitted_domain_passwordless_signin.detect { |o| o.passwordless_user_domain == domain }
   end
 
   # never geocode, use default_location lat/long

--- a/app/services/component_creator.rb
+++ b/app/services/component_creator.rb
@@ -23,7 +23,7 @@ class ComponentCreator
     { ctype_id: Ctype.other.id, ctype_other: component[:component_type] }
   end
 
-  def whitelist_attributes(component)
+  def permitted_attributes(component)
     comp_attributes = {
       cmodel_name: component[:model_name] || component[:model],
       description: component[:description],
@@ -39,7 +39,7 @@ class ComponentCreator
   end
 
   def create_component(component)
-    Component.create(whitelist_attributes(component).merge(bike_id: @bike.id))
+    Component.create(permitted_attributes(component).merge(bike_id: @bike.id))
   end
 
   def update_components_from_params
@@ -50,7 +50,7 @@ class ComponentCreator
       else
         component = @bike.components.new
       end
-      component.update_attributes(whitelist_attributes(comp.with_indifferent_access))
+      component.update_attributes(permitted_attributes(comp.with_indifferent_access))
     end
   end
 

--- a/app/views/admin/dashboard/tsvs.html.haml
+++ b/app/views/admin/dashboard/tsvs.html.haml
@@ -12,11 +12,11 @@
         Tsv reports:
 .row
   .col-md-6
-    = form_tag admin_update_tsv_blacklist_path, method: :put, multipart: true do
-      = label_tag :tsv_blacklist do
-        Blacklist Bike Urls, <strong>1 per line</strong>. These can be the id (the number in the url), the bike url, admin url or edit url
+    = form_tag admin_update_tsv_blocklist_path, method: :put, multipart: true do
+      = label_tag :tsv_blocklist do
+        Blocklist Bike Urls, <strong>1 per line</strong>. These can be the id (the number in the url), the bike url, admin url or edit url
         .form-group
-          = text_area_tag :blacklist, @blacklist.map{|i| "#{ENV['BASE_URL']}/bikes/#{i}"}.join("\n"), rows: 10, class: 'form-control'
+          = text_area_tag :blocklist, @blocklist.map{|i| "#{ENV['BASE_URL']}/bikes/#{i}"}.join("\n"), rows: 10, class: 'form-control'
 
     = submit_tag "Save changes", class: "btn btn-success submit-bike-update"
   - if @tsvs.any?

--- a/app/views/admin/organizations/_form.html.haml
+++ b/app/views/admin/organizations/_form.html.haml
@@ -17,7 +17,7 @@
       .d-md-block.d-none
         %label &nbsp;
         .text-form-control
-          Whitelisted domain with passwordless sign in, no invite restrictions
+          permitted domain with passwordless sign in, no invite restrictions
 .row
   .col-md-6
     .form-group
@@ -143,7 +143,7 @@
             .form-group
               = f.label :passwordless_user_domain do
                 %span
-                Whitelisted domain for passwordless sign in
+                permitted domain for passwordless sign in
                 %small
                   <span class="text-success">passwordless user feature</span>
               .input-group

--- a/app/views/admin/organizations/show.html.haml
+++ b/app/views/admin/organizations/show.html.haml
@@ -113,7 +113,7 @@
             = number_with_delimiter @organization.remaining_invitation_count
           - else
             %em
-              Whitelisted domain, no invite restrictions
+              permitted domain, no invite restrictions
       %tr
         %td
           Website

--- a/app/views/organized/users/index.html.haml
+++ b/app/views/organized/users/index.html.haml
@@ -19,7 +19,7 @@
         #{user_count}
       = t(".current_users")
     %p
-      = t(".whitelisted_domain_info_html", email_suffix: "@#{current_organization.passwordless_user_domain}", org_name: current_organization.short_name)
+      = t(".permitted_domain_info_html", email_suffix: "@#{current_organization.passwordless_user_domain}", org_name: current_organization.short_name)
       %em.less-strong
         = t(".you_can_also")
         #{link_to t(".manually_invite_email"), new_organization_user_path(organization_id: current_organization.to_param)}.

--- a/app/views/organized/users/new.html.haml
+++ b/app/views/organized/users/new.html.haml
@@ -14,9 +14,9 @@
     - if current_organization.passwordless_user_domain.present?
       .alert.alert-info.mt-4.col-md-8.offset-md-1
         %strong
-          = t(".you_have_a_whitelisted_domain")
+          = t(".you_have_a_permitted_domain")
         %br
-        = t(".signing_in_with_whitelisted_html", email_suffix: "@#{current_organization.passwordless_user_domain}", org_name: current_organization.short_name)
+        = t(".signing_in_with_permitted_domain_html", email_suffix: "@#{current_organization.passwordless_user_domain}", org_name: current_organization.short_name)
 
 = form_for @membership, { as: :membership, url: organization_users_path(organization_id: current_organization.to_param), action: 'create', html: { class: 'organized-form' } } do |f|
 

--- a/app/views/shared/_content_skeleton.html.haml
+++ b/app/views/shared/_content_skeleton.html.haml
@@ -1,6 +1,6 @@
 .container
   .row
-    / Unless one of the whitelisted pages, wrap it in .legacy-content-wrap
+    -# Unless one of the permitted pages, wrap it in .legacy-content-wrap
     - additional_class = %w().include?(content_page_type) ? "" : "legacy-content-wrap"
     .col-md-8.primary-content-block{ class: additional_class }
 

--- a/app/workers/bike_book_update_worker.rb
+++ b/app/workers/bike_book_update_worker.rb
@@ -17,7 +17,7 @@ class BikeBookUpdateWorker < ApplicationWorker
           end
           component.is_stock = true
           component.setting_is_stock = true
-          component.update_attributes(ComponentCreator.new.whitelist_attributes(bb_comp))
+          component.update_attributes(ComponentCreator.new.permitted_attributes(bb_comp))
         end
       end
     end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -14,7 +14,7 @@ Rails.application.configure do
     }
   end
 
-  # Log times where people pass non-whitelisted params
+  # Log times where people pass non-permitted params
   config.action_controller.action_on_unpermitted_parameters :log
 
   # Code is not reloaded between requests.

--- a/config/locales/.translation_io
+++ b/config/locales/.translation_io
@@ -1,2 +1,2 @@
 ---
-timestamp: 1592947431
+timestamp: 1593012881

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -4535,6 +4535,9 @@ en:
         manage_users: Manage Users
         manually_invite_email: manually invite emails
         matching_user: Matching user
+        permitted_domain_info_html: >-
+          You have a permitted domain, anyone signing up with an email address ending
+          in <code>%{email_suffix}</code> will be a member of %{org_name}.
         remaining_invites_html: You can add <strong>%{invitations_count}</strong>
           more
         search: Search
@@ -4542,9 +4545,6 @@ en:
         to: To
         update_email: Update email
         user: user
-        whitelisted_domain_info_html: >-
-          You have a whitelisted domain, anyone signing up with an email address ending
-          in <code>%{email_suffix}</code> will be a member of %{org_name}.
         you_can_also: You can also
         you_have_invited_html: 'You have invited: <strong>%{users_count}</strong>'
       new:
@@ -4564,11 +4564,11 @@ en:
         remaining_invites_html: You can add <strong>%{invitations_count}</strong>
           more
         send_invitation: Send invitation
-        signing_in_with_whitelisted_html: >-
+        signing_in_with_permitted_domain_html: >-
           Signing in with an "Emailed sign in link" using an address that ends with
           <code>%{email_suffix}</code> will automatically make you a member of %{org_name}.
         user: user
-        you_have_a_whitelisted_domain: You have a whitelisted domain
+        you_have_a_permitted_domain: You have a permitted domain
         you_have_invited_html: 'You have invited: <strong>%{users_count}</strong>'
   organized_mailer:
     custom_message:

--- a/config/locales/translation.nl.yml
+++ b/config/locales/translation.nl.yml
@@ -4597,13 +4597,13 @@ nl:
         you_have_invited_html: 'U heeft uitgenodigd: <strong>%{users_count}</strong>'
         current_users: Huidige gebruikers
         manually_invite_email: e-mails handmatig uitnodigen
-        whitelisted_domain_info_html: Je hebt een domein op de witte lijst. Iedereen
-          die zich aanmeldt met een e-mailadres dat eindigt op <code>%{email_suffix}</code>
-          , wordt lid van %{org_name}.
         you_can_also: Je kan ook
         find_by_name_or_email: Zoek op naam of e-mailadres
         matching_user: Overeenkomende gebruiker
         search: Zoeken
+        permitted_domain_info_html: Je hebt een toegestaan domein. Iedereen die zich
+          aanmeldt met een e-mailadres dat eindigt op <code>%{email_suffix}</code>
+          , wordt lid van %{org_name}.
       new:
         1_email_per_line: 1 e-mail per regel
         admin_of_organization: Beheerder van organisatie
@@ -4622,10 +4622,10 @@ nl:
         send_invitation: Verstuur uitnodiging
         user: Gebruiker
         you_have_invited_html: 'U heeft uitgenodigd: <strong>%{users_count}</strong>'
-        signing_in_with_whitelisted_html: Als u zich aanmeldt met een "Aanmeldlink
+        signing_in_with_permitted_domain_html: Als u zich aanmeldt met een "Aanmeldlink
           per e-mail" met een adres dat eindigt op <code>%{email_suffix}</code> wordt
           u automatisch lid van %{org_name}.
-        you_have_a_whitelisted_domain: Je hebt een domein op de witte lijst
+        you_have_a_permitted_domain: Je hebt een toegestaan domein
     parking_notifications:
       index:
         parking_notifications: Verlaten records

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -180,7 +180,7 @@ Rails.application.routes.draw do
     resources :partial_bikes, only: [:index]
     get "maintenance", to: "dashboard#maintenance"
     get "scheduled_jobs", to: "dashboard#scheduled_jobs"
-    put "update_tsv_blacklist", to: "dashboard#update_tsv_blacklist"
+    put "update_tsv_blocklist", to: "dashboard#update_tsv_blocklist"
     get "tsvs", to: "dashboard#tsvs"
     get "bust_z_cache", to: "dashboard#bust_z_cache"
     get "destroy_example_bikes", to: "dashboard#destroy_example_bikes"

--- a/spec/controllers/admin/dashboard_controller_spec.rb
+++ b/spec/controllers/admin/dashboard_controller_spec.rb
@@ -87,20 +87,20 @@ RSpec.describe Admin::DashboardController, type: :controller do
         t = Time.current
         FileCacheMaintainer.reset_file_info("current_stolen_bikes.tsv", t)
         # tsvs = [{ filename: 'current_stolen_bikes.tsv', updated_at: t.to_i.to_s, description: 'Approved Stolen bikes' }]
-        blacklist = %w(1010101 2 4 6)
-        FileCacheMaintainer.reset_blacklist_ids(blacklist)
+        blocklist = %w(1010101 2 4 6)
+        FileCacheMaintainer.reset_blocklist_ids(blocklist)
         get :tsvs
         expect(response.code).to eq("200")
         # assigns(:tsvs).should eq(tsvs)
-        expect(assigns(:blacklist).include?("2")).to be_truthy
+        expect(assigns(:blocklist).include?("2")).to be_truthy
       end
     end
 
-    describe "update_tsv_blacklist" do
+    describe "update_tsv_blocklist" do
       it "renders and updates" do
         ids = "\n1\n2\n69\n200\n22222\n\n\n"
-        put :update_tsv_blacklist, params: { blacklist: ids }
-        expect(FileCacheMaintainer.blacklist).to eq([1, 2, 69, 200, 22222].map(&:to_s))
+        put :update_tsv_blocklist, params: { blocklist: ids }
+        expect(FileCacheMaintainer.blocklist).to eq([1, 2, 69, 200, 22222].map(&:to_s))
       end
     end
   end

--- a/spec/lib/file_cache_maintainer_spec.rb
+++ b/spec/lib/file_cache_maintainer_spec.rb
@@ -17,22 +17,22 @@ RSpec.describe FileCacheMaintainer do
     end
   end
 
-  describe "blacklist_ids" do
+  describe "blocklist_ids" do
     it "gets and sets the ids" do
-      FileCacheMaintainer.reset_blacklist_ids([1, 1, 2, 4, "https://bikeindex.org/admin/bikes/6"])
-      expect(FileCacheMaintainer.blacklist).to eq %w(1 2 4 6)
+      FileCacheMaintainer.reset_blocklist_ids([1, 1, 2, 4, "https://bikeindex.org/admin/bikes/6"])
+      expect(FileCacheMaintainer.blocklist).to eq %w(1 2 4 6)
     end
     it "doesn't break if it's empty" do
-      FileCacheMaintainer.reset_blacklist_ids([])
-      expect(FileCacheMaintainer.blacklist).to eq([])
+      FileCacheMaintainer.reset_blocklist_ids([])
+      expect(FileCacheMaintainer.blocklist).to eq([])
     end
   end
 
-  describe "blacklist_include" do
-    it "checks if blacklist includes something" do
-      FileCacheMaintainer.reset_blacklist_ids([1010101, 2, 4, 6])
-      expect(FileCacheMaintainer.blacklist_include?("http://bikeindex.org/bikes/1010101/edit")).to be_truthy
-      expect(FileCacheMaintainer.blacklist_include?(7)).to be_falsey
+  describe "blocklist_include" do
+    it "checks if blocklist includes something" do
+      FileCacheMaintainer.reset_blocklist_ids([1010101, 2, 4, 6])
+      expect(FileCacheMaintainer.blocklist_include?("http://bikeindex.org/bikes/1010101/edit")).to be_truthy
+      expect(FileCacheMaintainer.blocklist_include?(7)).to be_falsey
     end
   end
 

--- a/spec/models/export_spec.rb
+++ b/spec/models/export_spec.rb
@@ -3,11 +3,11 @@ require "rails_helper"
 RSpec.describe Export, type: :model do
   let(:organization) { export.organization }
 
-  describe "scope and method for stolen_no_blacklist" do
-    let(:export) { FactoryBot.create(:export, options: { with_blacklist: true, headers: %w[party registered_at] }) }
-    it "is with blacklist" do
+  describe "scope and method for stolen_no_blocklist" do
+    let(:export) { FactoryBot.create(:export, options: { with_blocklist: true, headers: %w[party registered_at] }) }
+    it "is with blocklist" do
       expect(export.stolen?).to be_truthy
-      expect(export.option?(:with_blacklist)).to be_truthy
+      expect(export.option?(:with_blocklist)).to be_truthy
       expect(export.option?(:only_serials_and_police_reports)).to be_falsey
       expect(export.description).to eq "Stolen"
       expect(export.headers).to eq(["registered_at"]) # Just checking that we ignore things

--- a/spec/models/organization_spec.rb
+++ b/spec/models/organization_spec.rb
@@ -311,7 +311,7 @@ RSpec.describe Organization, type: :model do
     end
   end
 
-  describe "restrict_invitations?, whitelisted_passwordless_signin, matching_domain" do
+  describe "restrict_invitations?, permitted_domain_passwordless_signin, matching_domain" do
     it "is truthy" do
       expect(Organization.new.restrict_invitations?).to be_truthy
     end
@@ -319,7 +319,7 @@ RSpec.describe Organization, type: :model do
       let(:organization) { FactoryBot.create(:organization_with_paid_features, enabled_feature_slugs: ["passwordless_users"], passwordless_user_domain: "example.gov") }
       it "is falsey" do
         expect(organization.restrict_invitations?).to be_falsey
-        expect(Organization.whitelisted_passwordless_signin.pluck(:id)).to eq([organization.id])
+        expect(Organization.permitted_domain_passwordless_signin.pluck(:id)).to eq([organization.id])
         expect(Organization.passwordless_email_matching("fakeexample.gov")).to be_blank
         expect(Organization.passwordless_email_matching("f@example.gov@party.gov")).to be_blank
         expect(Organization.passwordless_email_matching("f@éxample.gov")).to be_blank # accent

--- a/spec/requests/api/v2/bikes_request_spec.rb
+++ b/spec/requests/api/v2/bikes_request_spec.rb
@@ -445,7 +445,7 @@ RSpec.describe "Bikes API V2", type: :request do
       expect(bike.reload.public_images.count).to eq(0)
     end
 
-    it "errors on non whitelisted file extensions" do
+    it "errors on non permitted file extensions" do
       bike = FactoryBot.create(:ownership, creator_id: user.id).bike
       file = File.open(File.join(Rails.root, "spec", "spec_helper.rb"))
       url = "/api/v2/bikes/#{bike.id}/image?access_token=#{token.token}"

--- a/spec/requests/api/v3/bikes_request_spec.rb
+++ b/spec/requests/api/v3/bikes_request_spec.rb
@@ -830,7 +830,7 @@ RSpec.describe "Bikes API V3", type: :request do
       expect(bike.reload.public_images.count).to eq(0)
     end
 
-    it "errors on non whitelisted file extensions" do
+    it "errors on non permitted file extensions" do
       bike = FactoryBot.create(:ownership, creator_id: user.id).bike
       file = File.open(File.join(Rails.root, "spec", "spec_helper.rb"))
       url = "/api/v3/bikes/#{bike.id}/image?access_token=#{token.token}"


### PR DESCRIPTION
Fix #1644 by removing blacklist and whitelist from code in Bike Index.

There are still some `white_list` methods, because they are calls to [Carrierwave](https://github.com/carrierwaveuploader/carrierwave) and references to master in git paths of other repositories, but at this point, I believe we've taken responsibility for the language we've written.