### PR TITLE
CircleCI 2 parallelism

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build:
     working_directory: ~/bikeindex/bike_index
-    parallelism: 3
+    parallelism: 2
     shell: /bin/bash --login
     environment:
       RAILS_ENV: test


### PR DESCRIPTION
Try out returning to parallelism 2

In https://github.com/bikeindex/bike_index/pull/1642 I switched to parallelism 3, because I was worried that jobs were taking too long to process. Unfortunately, this means there is only space for 1 job at a time (with our 4 workers).

So I'm going to benchmark - rerunning this 10 times on CircleCI and posting the results here.

Related: #1648 (parallelism 4)