### PR TITLE
Add unauthenticated redirect

### DIFF
--- a/.standard_todo.yml
+++ b/.standard_todo.yml
@@ -23,7 +23,6 @@ ignore:
   - app/controllers/bikes/recovery_controller.rb
   - app/controllers/bikes_controller.rb
   - app/controllers/concerns/controller_helpers.rb
-  - app/controllers/oauth/applications_controller.rb
   - app/controllers/org_public/customer_appointments_controller.rb
   - app/controllers/organized/ambassador_dashboards_controller.rb
   - app/controllers/organized/appointment_configurations_controller.rb

--- a/Gemfile
+++ b/Gemfile
@@ -163,7 +163,7 @@ group :development, :test do
   gem "rspec", "~> 3.4"
   gem "rspec-rails", "~> 3.8"
   gem "rspec_junit_formatter" # For circle ci
-  gem "standard"
+  gem "standard" # Ruby linter
   # I18n - localization/translation
   gem "i18n-tasks"
   gem "i18n_generators"

--- a/app/controllers/bikes_controller.rb
+++ b/app/controllers/bikes_controller.rb
@@ -367,12 +367,9 @@ class BikesController < ApplicationController
       end
     end
 
-    if error.present? # Can't assign directly to flash here, sometimes kick out of edit because other flash error
-      flash[:error] = error
-      redirect_to bike_path(@bike) and return
-    end
-
-    authenticate_user(translation_key: :create_account, flash_type: :info)
+    return true unless error.present? # Can't assign directly to flash here, sometimes kick out of edit because other flash error
+    flash[:error] = error
+    redirect_to bike_path(@bike) and return
   end
 
   def update_organizations_can_edit_claimed(bike, organization_ids)

--- a/app/controllers/concerns/controller_helpers.rb
+++ b/app/controllers/concerns/controller_helpers.rb
@@ -41,13 +41,16 @@ module ControllerHelpers
     elsif current_user&.unconfirmed? || unconfirmed_current_user.present?
       redirect_to please_confirm_email_users_path and return
     else
-      flash[flash_type] = translation(
-        translation_key,
-        **translation_args,
-        scope: [:controllers, :concerns, :controller_helpers, __method__],
-      )
+      force_sign_up = params[:unauthenticated_redirect] == "sign_up"
+      unless force_sign_up # Force signup doesn't show a flash message
+        flash[flash_type] = translation(
+          translation_key,
+          **translation_args,
+          scope: [:controllers, :concerns, :controller_helpers, __method__],
+        )
+      end
 
-      if translation_key.to_s.match?(/create.+account/)
+      if force_sign_up || translation_key.to_s.match?(/create.+account/)
         redirect_to new_user_url(subdomain: false, partner: sign_in_partner) and return
       else
         redirect_to new_session_url(subdomain: false, partner: sign_in_partner) and return

--- a/app/controllers/oauth/applications_controller.rb
+++ b/app/controllers/oauth/applications_controller.rb
@@ -17,7 +17,7 @@ module Oauth
         Doorkeeper::AccessToken.create!(
           application_id: @application.id,
           resource_owner_id: ENV["V2_ACCESSOR_ID"],
-          expires_in: nil, scopes: "write_bikes",
+          expires_in: nil, scopes: "write_bikes"
         )
 
         redirect_to oauth_application_url(@application)
@@ -31,7 +31,7 @@ module Oauth
     def ensure_app_owner!
       return true if @current_user&.superuser? || @current_user&.id == @application&.owner_id
       flash[:error] = translation(:not_your_application)
-      redirect_to oauth_applications_url and return
+      redirect_to(oauth_applications_url) && return
     end
   end
 end

--- a/config/initializers/doorkeeper.rb
+++ b/config/initializers/doorkeeper.rb
@@ -31,7 +31,11 @@ Doorkeeper.configure do
         user
       else
         session[:return_to] = request.fullpath
-        redirect_to(new_session_url)
+        if request_envi&.params && request_envi.params[:unauthenticated_redirect]
+          redirect_to(new_user_url)
+        else
+          redirect_to(new_session_url)
+        end
       end
     end
   end

--- a/config/initializers/doorkeeper.rb
+++ b/config/initializers/doorkeeper.rb
@@ -31,7 +31,7 @@ Doorkeeper.configure do
         user
       else
         session[:return_to] = request.fullpath
-        if request_envi&.params && request_envi.params[:unauthenticated_redirect]
+        if request_envi&.params && request_envi.params[:unauthenticated_redirect] == "sign_up"
           redirect_to(new_user_url)
         else
           redirect_to(new_session_url)

--- a/spec/controllers/locks_controller_spec.rb
+++ b/spec/controllers/locks_controller_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe LocksController, type: :controller do
       end
     end
     context "no user" do
-      let(:user) { nil}
+      let(:user) { nil }
       it "redirects to sign_in" do
         get :edit, params: {id: lock.id}
         expect(flash[:error]).to be_present

--- a/spec/controllers/locks_controller_spec.rb
+++ b/spec/controllers/locks_controller_spec.rb
@@ -47,6 +47,21 @@ RSpec.describe LocksController, type: :controller do
         expect(response).to render_template("edit")
       end
     end
+    context "no user" do
+      let(:user) { nil}
+      it "redirects to sign_in" do
+        get :edit, params: {id: lock.id}
+        expect(flash[:error]).to be_present
+        expect(response).to redirect_to(new_session_path)
+      end
+      context "unauthenticated_redirect" do
+        it "redirects to sign up" do
+          get :edit, params: {id: lock.id, unauthenticated_redirect: "sign_up"}
+          expect(flash).to be_blank
+          expect(response).to redirect_to(new_user_path)
+        end
+      end
+    end
   end
 
   describe "update" do

--- a/spec/requests/authorizations_request_spec.rb
+++ b/spec/requests/authorizations_request_spec.rb
@@ -12,6 +12,7 @@ RSpec.describe Oauth::AuthorizationsController, type: :request do
       expect(response).to redirect_to new_session_url
       expect(session[:return_to]).to match(/#{doorkeeper_app.uid}/)
       expect(session[:partner]).to be_nil
+      expect(flash).to be_blank
     end
     context "partner parameter" do
       it "redirects to sign in with the partners parameter included" do
@@ -19,6 +20,16 @@ RSpec.describe Oauth::AuthorizationsController, type: :request do
         expect(response).to redirect_to new_session_url
         expect(session[:return_to]).to match(/#{doorkeeper_app.uid}/)
         expect(session[:partner]).to eq "bikehub"
+        expect(flash).to be_blank
+      end
+      context "passing unauthenticated_redirect" do
+        it "redirects to sign up with the partners parameter" do
+          get "#{authorization_url}&partner=bikehub&unauthenticated_redirect=sign_up"
+          expect(response).to redirect_to new_user_url
+          expect(session[:return_to]).to match(/#{doorkeeper_app.uid}/)
+          expect(session[:partner]).to eq "bikehub"
+          expect(flash).to be_blank
+        end
       end
     end
   end

--- a/spec/requests/authorizations_request_spec.rb
+++ b/spec/requests/authorizations_request_spec.rb
@@ -22,10 +22,19 @@ RSpec.describe Oauth::AuthorizationsController, type: :request do
         expect(session[:partner]).to eq "bikehub"
         expect(flash).to be_blank
       end
-      context "passing unauthenticated_redirect" do
+      context "unauthenticated_redirect=signup" do
         it "redirects to sign up with the partners parameter" do
           get "#{authorization_url}&partner=bikehub&unauthenticated_redirect=sign_up"
           expect(response).to redirect_to new_user_url
+          expect(session[:return_to]).to match(/#{doorkeeper_app.uid}/)
+          expect(session[:partner]).to eq "bikehub"
+          expect(flash).to be_blank
+        end
+      end
+      context "unauthenticated_redirect=no" do
+        it "redirects to sign in with the partners parameter" do
+          get "#{authorization_url}&partner=bikehub&unauthenticated_redirect=no"
+          expect(response).to redirect_to new_session_url
           expect(session[:return_to]).to match(/#{doorkeeper_app.uid}/)
           expect(session[:partner]).to eq "bikehub"
           expect(flash).to be_blank

--- a/spec/support/controller_spec_helpers.rb
+++ b/spec/support/controller_spec_helpers.rb
@@ -2,6 +2,7 @@
 # via Rspec.configure (rails_helper)
 module ControllerSpecHelpers
   def set_current_user(user)
+    return unless user.present?
     cookies.signed[:auth] =
       {secure: true, httponly: true, value: [user.id, user.auth_token]}
   end


### PR DESCRIPTION
`unauthenticated_redirect=sign_up` redirects to `users/new` rather than `/session/new` - functionality for https://github.com/bikeindex/omniauth-bike-index/pull/5