### PR TITLE
Parking notification update fixes

### DIFF
--- a/app/assets/javascripts/init.coffee
+++ b/app/assets/javascripts/init.coffee
@@ -85,17 +85,21 @@ class BikeIndex.Init extends BikeIndex
         scrollTop: $($target.attr('href')).offset().top + offset, 'fast'
       )
 
-  displayLocalDate: (time, preciseTime = false) ->
+  displayLocalDate: (time, preciseTime = false, withPreposition = false) ->
     # Ensure we return if it's a big future day
     if time < window.tomorrow
       if time > window.today
-        return time.format("h:mma")
+        if withPreposition
+          return "at #{time.format("h:mma")}"
+        else
+          return time.format("h:mma")
       else if time > window.yesterday
         return "Yesterday #{time.format('h:mma')}"
     if time.year() == moment().year()
-      if preciseTime then time.format("MMM Do[,] h:mma") else time.format("MMM Do[,] ha")
+      str = if preciseTime then time.format("MMM Do[,] h:mma") else time.format("MMM Do[,] ha")
     else
-      if preciseTime then time.format("YYYY-MM-DD h:mma") else time.format("YYYY-MM-DD")
+      str = if preciseTime then time.format("YYYY-MM-DD h:mma") else time.format("YYYY-MM-DD")
+    "on #{str}"
 
   localizeTimes: ->
     window.localTimezone ||= moment.tz.guess()
@@ -116,7 +120,7 @@ class BikeIndex.Init extends BikeIndex
       return unless text.length > 0
       time = moment(text, moment.ISO_8601)
       return unless time.isValid
-      $this.text(displayLocalDate(time, $this.hasClass("preciseTime")))
+      $this.text(displayLocalDate(time, $this.hasClass("preciseTime"), $this.hasClass("withPreposition")))
 
     # Write timezone
     $(".convertTimezone").each ->

--- a/app/controllers/organized/impound_records_controller.rb
+++ b/app/controllers/organized/impound_records_controller.rb
@@ -68,10 +68,10 @@ module Organized
 
     def find_impound_record
       # NOTE: Uses display_id, not normal id, unless id starts with pkey-
-      if params[:id].start_with?("pkey-")
-        @impound_record = impound_records.find_by_id(params[:id].gsub("pkey-", ""))
+      @impound_record = if params[:id].start_with?("pkey-")
+        impound_records.find_by_id(params[:id].gsub("pkey-", ""))
       else
-        @impound_record = impound_records.find_by_display_id(params[:id])
+        impound_records.find_by_display_id(params[:id])
       end
       raise ActiveRecord::RecordNotFound unless @impound_record.present?
     end

--- a/app/controllers/organized/parking_notifications_controller.rb
+++ b/app/controllers/organized/parking_notifications_controller.rb
@@ -127,7 +127,7 @@ module Organized
         @redirect_location = organization_parking_notification_path(success_ids.first, organization_id: current_organization.to_param)
       end
       session[:notifications_repeated_ids] = @notifications_repeated.pluck(:id)
-      # If the notification was repeated, it can't also be failed (relevant for marking resolved)
+      # If the notification was repeated, it can't also be failed (relevant when marking resolved)
       session[:notifications_failed_resolved_ids] = notifications_failed_resolved_ids - session[:notifications_repeated_ids]
       @notifications_failed_resolved ||= ParkingNotification.where(id: session[:notifications_failed_resolved_ids])
       session[:repeated_kind] = kind

--- a/app/javascript/packs/utils/time_parser.js
+++ b/app/javascript/packs/utils/time_parser.js
@@ -23,12 +23,13 @@ export default class TimeParser {
   // If we're display time with the hour, we have different formats based on whether we include seconds
   // this manages that functionality
   hourFormat(time, baseTimeFormat, includeSeconds, includePreposition) {
+    const prefix = includePreposition ? " at " : "";
     if (includeSeconds) {
-      return `${time.format(baseTimeFormat)}:<small>${time.format(
+      return `${prefix}${time.format(baseTimeFormat)}:<small>${time.format(
         "ss"
       )}</small> ${time.format("a")}`;
     } else {
-      return time.format(`${baseTimeFormat}a`);
+      return prefix + time.format(`${baseTimeFormat}a`);
     }
   }
 
@@ -42,12 +43,14 @@ export default class TimeParser {
       } else if (time > this.todayEnd) {
         prefix = "Tomorrow ";
       }
-      if (classList.contains("withPreposition")) {
-        prefix += " at ";
-      }
       return (
         prefix +
-        this.hourFormat(time, "h:mm", classList.contains("preciseTimeSeconds"))
+        this.hourFormat(
+          time,
+          "h:mm",
+          classList.contains("preciseTimeSeconds"),
+          classList.contains("withPreposition")
+        )
       );
     }
     if (classList.contains("withPreposition")) {
@@ -59,30 +62,26 @@ export default class TimeParser {
       classList.contains("preciseTime") ||
       classList.contains("preciseTimeSeconds")
     ) {
+      let hourStr = this.hourFormat(
+        time,
+        "h:mm",
+        classList.contains("preciseTimeSeconds"),
+        classList.contains("withPreposition")
+      );
       // Include the year if it isn't the current year
       if (time.year() === moment().year()) {
-        return (
-          prefix +
-          this.hourFormat(
-            time,
-            "MMM Do[,] h:mm",
-            classList.contains("preciseTimeSeconds")
-          )
-        );
+        return prefix + time.format("MMM Do[,]") + hourStr;
       } else {
-        return (
-          prefix +
-          this.hourFormat(
-            time,
-            "YYYY-MM-DD h:mm",
-            classList.contains("preciseTimeSeconds")
-          )
-        );
+        return prefix + time.format("YYYY-MM-DD") + hourStr;
       }
     }
     // Otherwise, format in basic format
     if (time.year() === moment().year()) {
-      return prefix + time.format("MMM Do[,] ha");
+      if (classList.contains("withPreposition")) {
+        return prefix + time.format("MMM Do[,]") + " at " + time.format("ha");
+      } else {
+        return prefix + time.format("MMM Do[,] ha");
+      }
     } else {
       return prefix + time.format("YYYY-MM-DD");
     }

--- a/app/javascript/packs/utils/time_parser.js
+++ b/app/javascript/packs/utils/time_parser.js
@@ -14,19 +14,15 @@ export default class TimeParser {
     }
     this.localTimezone = window.localTimezone;
     moment.tz.setDefault(this.localTimezone);
-    this.yesterdayStart = moment()
-      .subtract(1, "day")
-      .startOf("day");
+    this.yesterdayStart = moment().subtract(1, "day").startOf("day");
     this.todayStart = moment().startOf("day");
     this.todayEnd = moment().endOf("day");
-    this.tomorrowEnd = moment()
-      .add(1, "day")
-      .endOf("day");
+    this.tomorrowEnd = moment().add(1, "day").endOf("day");
   }
 
   // If we're display time with the hour, we have different formats based on whether we include seconds
   // this manages that functionality
-  hourFormat(time, baseTimeFormat, includeSeconds) {
+  hourFormat(time, baseTimeFormat, includeSeconds, includePreposition) {
     if (includeSeconds) {
       return `${time.format(baseTimeFormat)}:<small>${time.format(
         "ss"
@@ -37,19 +33,25 @@ export default class TimeParser {
   }
 
   localizedDateText(time, classList) {
+    let prefix = "";
     // If we're dealing with yesterday or today (not the future)
     if (time < this.tomorrowEnd && time > this.yesterdayStart) {
       // If we're dealing with yesterday or tomorrow, we prepend that
-      let prefix = "";
       if (time < this.todayStart) {
         prefix = "Yesterday ";
       } else if (time > this.todayEnd) {
         prefix = "Tomorrow ";
       }
+      if (classList.contains("withPreposition")) {
+        prefix += " at ";
+      }
       return (
         prefix +
         this.hourFormat(time, "h:mm", classList.contains("preciseTimeSeconds"))
       );
+    }
+    if (classList.contains("withPreposition")) {
+      prefix = "on ";
     }
 
     // If it's preciseTime (or preciseTimeSeconds), always show the hours and mins
@@ -59,24 +61,30 @@ export default class TimeParser {
     ) {
       // Include the year if it isn't the current year
       if (time.year() === moment().year()) {
-        return this.hourFormat(
-          time,
-          "MMM Do[,] h:mm",
-          classList.contains("preciseTimeSeconds")
+        return (
+          prefix +
+          this.hourFormat(
+            time,
+            "MMM Do[,] h:mm",
+            classList.contains("preciseTimeSeconds")
+          )
         );
       } else {
-        return this.hourFormat(
-          time,
-          "YYYY-MM-DD h:mm",
-          classList.contains("preciseTimeSeconds")
+        return (
+          prefix +
+          this.hourFormat(
+            time,
+            "YYYY-MM-DD h:mm",
+            classList.contains("preciseTimeSeconds")
+          )
         );
       }
     }
     // Otherwise, format in basic format
     if (time.year() === moment().year()) {
-      return time.format("MMM Do[,] ha");
+      return prefix + time.format("MMM Do[,] ha");
     } else {
-      return time.format("YYYY-MM-DD");
+      return prefix + time.format("YYYY-MM-DD");
     }
   }
 
@@ -121,18 +129,18 @@ export default class TimeParser {
 
   localize() {
     // Write times
-    Array.from(document.getElementsByClassName("convertTime")).forEach(el =>
+    Array.from(document.getElementsByClassName("convertTime")).forEach((el) =>
       this.writeUpdatedTimeText(el)
     );
 
     // Write timezones
-    Array.from(document.getElementsByClassName("convertTimezone")).forEach(el =>
-      this.writeTimezone(el)
-    );
+    Array.from(
+      document.getElementsByClassName("convertTimezone")
+    ).forEach((el) => this.writeTimezone(el));
 
     // Write hidden timezone fields - so if we're submitting a form, it includes the current timezone
-    Array.from(document.getElementsByClassName("hiddenFieldTimezone")).forEach(
-      el => this.setHiddenTimezoneFields(el)
-    );
+    Array.from(
+      document.getElementsByClassName("hiddenFieldTimezone")
+    ).forEach((el) => this.setHiddenTimezoneFields(el));
   }
 }

--- a/app/models/graduated_notification.rb
+++ b/app/models/graduated_notification.rb
@@ -83,6 +83,10 @@ class GraduatedNotification < ApplicationRecord
       bikes_to_notify_expired_notifications(organization).pluck(:id)
   end
 
+  def message
+    nil # for parity with parking_notifications
+  end
+
   # Get it unscoped, because we really want it
   def bike
     @bike ||= bike_id.present? ? Bike.unscoped.find_by_id(bike_id) : nil
@@ -142,6 +146,11 @@ class GraduatedNotification < ApplicationRecord
     return Bike.none unless user.present? || bike.present?
     # We want to order the bikes by when the ownership was created, so perform that on either result
     (processed? ? bikes_from_associated_notifications : user_or_email_bikes).reorder("ownerships.created_at DESC")
+  end
+
+  def sent_at
+    return nil unless email_success?
+    created_at + PENDING_PERIOD
   end
 
   def send_email?

--- a/app/models/parking_notification.rb
+++ b/app/models/parking_notification.rb
@@ -83,6 +83,10 @@ class ParkingNotification < ActiveRecord::Base
     false
   end
 
+  def sent_at
+    email_success? ? created_at : nil
+  end
+
   # Get it unscoped, because unregistered_bike notifications
   def bike
     @bike ||= bike_id.present? ? Bike.unscoped.find_by_id(bike_id) : nil

--- a/app/views/admin/organizations/invoices/edit.html.haml
+++ b/app/views/admin/organizations/invoices/edit.html.haml
@@ -38,8 +38,8 @@
           %ul
             - @invoice.payments.each do |payment|
               %li
-                = link_to "#{payment.amount_formatted} on", admin_payment_path(payment)
-                %span.convertTime
+                = link_to "#{payment.amount_formatted}", admin_payment_path(payment)
+                %span.convertTime.withPreposition
                   = l payment.created_at, format: :convert_time
   .col-sm-6
     %table.table-list
@@ -67,7 +67,7 @@
             %span.text-warning Endless
             (invoice never ends)
           - elsif @invoice.subscription_end_at.present?
-            %span.convertTime
+            %span.convertTime.preciseTimeSeconds
               = l @invoice.subscription_end_at, format: :convert_time
 
 

--- a/app/views/bikes/_bike_show_overlays.html.haml
+++ b/app/views/bikes/_bike_show_overlays.html.haml
@@ -27,7 +27,7 @@
 
         - if @matching_notification.organization.present?
           .mt-2.small.less-strong
-            #{@matching_notification.organization.name} sent this notification
+            = t(".organization_sent_this_message", org_name: @matching_notification.organization.name)
             - if @matching_notification.sent_at.present?
               %span.convertTime.preciseTime.withPreposition
                 = l @matching_notification.sent_at, format: :convert_time
@@ -35,11 +35,7 @@
           - organization_email = @matching_notification.organization.auto_user&.email
           - if organization_email.present?
             .mt-1
-              -#= t(".you_sent_this_bike_html", bike_type: @bike.type, owner_email: @bike.current_ownership.owner_email)
-              Please email
-              = link_to(organization_email, "mailto:#{organization_email}")
-              / biking@psu.edu
-              if you have any questions.
+              = t(".please_email_organization_with_questions_html", email_link: link_to(organization_email, "mailto:#{organization_email}"))
 
 - if modal_title.blank? || @bike.stolen && session[:recovery_link_token].present?
   -# Delete token so modal doesn't keep rendering

--- a/app/views/bikes/_bike_show_overlays.html.haml
+++ b/app/views/bikes/_bike_show_overlays.html.haml
@@ -1,32 +1,47 @@
-- if @token.present?
-  .container
-    .card
-      .card-body{ style: "padding: 2rem; background: #eceeef" }
-        - if @matching_notification.present?
-          %h3.uncap
-            = @matching_notification.subject
-          - organization_message_snippet = @matching_notification.organization&.mail_snippets&.enabled&.where(kind: @token_type)&.first
-          - if organization_message_snippet.present?
-            = organization_message_snippet.body.html_safe
+- if @token.present? && @matching_notification.present?
+  - modal_title = @matching_notification.subject
+  - modal_body = capture_haml do
+    .modal-body
+      - if @matching_notification.message.present?
+        %p
+          = @matching_notification.message
+      - organization_message_snippet = @matching_notification.organization&.mail_snippets&.enabled&.where(kind: @token_type)&.first
+      - if organization_message_snippet.present?
+        = organization_message_snippet.body.html_safe
 
-        .text-center.mt-4
-          - if @matching_notification&.resolved?
-            %strong.text-info{ style: "font-size: 125%;" }
-              - if @token_type == "graduated_notification"
-                = t(".you_have_already_marked_remaining", bike_type: @bike.type)
-              - else
-                = t(".you_have_already_marked_resolved")
+      .text-center.mt-4
+        - if @matching_notification&.resolved?
+          %strong.text-info{ style: "font-size: 125%;" }
+            - if @token_type == "graduated_notification"
+              = t(".you_have_already_marked_remaining", bike_type: @bike.type)
+            - else
+              = t(".you_have_already_marked_resolved")
+          .mt-1
+            %em.small.less-strong=t(".no_futher_action_necessary")
+        - else
+          = form_tag resolve_token_bike_path(@bike), method: "PUT" do
+            = hidden_field_tag :token, @token
+            = hidden_field_tag :token_type, @token_type
+            - button_value = @token_type == "graduated_notification" ? t(".mark_graduated_resolved", bike_type: @bike.type) : t(".mark_parking_resolved", bike_type: @bike.type)
+            %input{ type: "submit", value: button_value, class: 'btn btn-success btn-lg' }
+
+        - if @matching_notification.organization.present?
+          .mt-2.small.less-strong
+            #{@matching_notification.organization.name} sent this notification
+            - if @matching_notification.sent_at.present?
+              %span.convertTime.preciseTime.withPreposition
+                = l @matching_notification.sent_at, format: :convert_time
+
+          - organization_email = @matching_notification.organization.auto_user&.email
+          - if organization_email.present?
             .mt-1
-              %em.small.less-strong=t(".no_futher_action_necessary")
-          - else
+              -#= t(".you_sent_this_bike_html", bike_type: @bike.type, owner_email: @bike.current_ownership.owner_email)
+              Please email
+              = link_to(organization_email, "mailto:#{organization_email}")
+              / biking@psu.edu
+              if you have any questions.
 
-            = form_tag resolve_token_bike_path(@bike), method: "PUT" do
-              = hidden_field_tag :token, @token
-              = hidden_field_tag :token_type, @token_type
-              - button_value = @token_type == "graduated_notification" ? t(".mark_graduated_resolved", bike_type: @bike.type) : t(".mark_parking_resolved", bike_type: @bike.type)
-              %input{ type: "submit", value: button_value, class: 'btn btn-success btn-lg' }
-
-- if @bike.stolen && session[:recovery_link_token].present?
+- if modal_title.blank? || @bike.stolen && session[:recovery_link_token].present?
   -# Delete token so modal doesn't keep rendering
   - stolen_record = StolenRecord.find_matching_token(bike_id: @bike.id, recovery_link_token: session.delete(:recovery_link_token))
 
@@ -67,7 +82,7 @@
                 %button.btn.btn-secondary{ 'data-dismiss' => 'modal', type: 'button' }
                   = t(".nevermind")
 
-- unless @bike.created_by_parking_notification # We don't want to show claiming info for parking notification unregistered bikes
+- unless modal_title.present? || @bike.created_by_parking_notification # We don't want to show claiming info for parking notification unregistered bikes
   - if current_user.present?
     - if @bike.claimable_by?(current_user)
       - modal_title = t(".your_bike", bike_type: @bike.type)

--- a/app/views/bikes/show.html.haml
+++ b/app/views/bikes/show.html.haml
@@ -14,7 +14,7 @@
 
 
   - if current_user&.superuser
-    - if !@bike.created_by_parking_notification && @bike.user_hidden
+    - if !@bike.unregistered_parking_notification? && @bike.user_hidden
       %h2.text-danger.mb-4.text-center
         = t(".hidden_by_owner")
         %small.less-strong

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -48,7 +48,7 @@
                 - if passive_organization.appointment_functionality_enabled?
                   = active_link t(".virtual_line"), organization_lines_path(organization_id: passive_organization.to_param), class: "nav-link", match_controller: true
                   %li.divider-nav-item
-                - on_bikes_path = controller_name == "bikes" && action_name == "index" # Because we want to ignore queries and stuff
+                - on_bikes_path = controller_name == "bikes" && action_name == "index" && params[:organization_id].present? # Because we want to ignore queries and stuff
                 %li
                   = link_to t(".org_bikes", org_name: passive_organization.short_name), organization_bikes_path(organization_id: passive_organization.to_param), class: "nav-link #{on_bikes_path ? 'active' : ''}"
                 - if passive_organization.enabled?("impound_bikes")

--- a/app/views/shared/_modal.html.haml
+++ b/app/views/shared/_modal.html.haml
@@ -9,7 +9,7 @@
     .modal-content
       - if title
         .modal-header
-          %h2.modal-title
+          %h2.modal-title.uncap
             = title
             %button.close{ 'aria-label' => 'Close', 'data-dismiss' => 'modal', type: 'button' }
               %span{ 'aria-hidden' => 'true' }

--- a/config/locales/.translation_io
+++ b/config/locales/.translation_io
@@ -1,2 +1,2 @@
 ---
-timestamp: 1595975750
+timestamp: 1596227091

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -979,6 +979,9 @@ en:
       nevermind: Nevermind
       no_futher_action_necessary: no further action necessary!
       no_one_can_see_it_but_you: No one can see it but you
+      organization_sent_this_message: "%{org_name} sent this notification"
+      please_email_organization_with_questions_html: Please email %{email_link} if
+        you have any questions
       please_tell_us_how_you_got_your_bike: Please tell us how you got your %{bike_type}
         back, we really care!
       thank_you_for_recovering_this_bike_type: Thank you for recovering this %{bike_type}!

--- a/config/locales/translation.nl.yml
+++ b/config/locales/translation.nl.yml
@@ -1727,6 +1727,9 @@ nl:
       you_have_already_marked_remaining: U heeft deze %{bike_type} al gemarkeerd als
         resterend
       you_have_already_marked_resolved: Je hebt deze melding als opgelost gemarkeerd
+      organization_sent_this_message: "%{org_name} heeft deze melding verzonden"
+      please_email_organization_with_questions_html: Stuur een e-mail naar %{email_link}
+        als u vragen heeft
     edit_accessories:
       add_a_component: Voeg een component toe
       other_handlebar_type: Ander type stuur

--- a/spec/models/graduated_notification_spec.rb
+++ b/spec/models/graduated_notification_spec.rb
@@ -30,6 +30,7 @@ RSpec.describe GraduatedNotification, type: :model do
       expect(graduated_notification.processed?).to be_truthy
       expect(graduated_notification.user).to be_blank
       expect(graduated_notification.email).to eq bike.owner_email
+      expect(graduated_notification.sent_at).to be_within(1).of graduated_notification.created_at + GraduatedNotification::PENDING_PERIOD
       expect(bike.graduated?(organization)).to be_truthy
     end
     context "organization doesn't have graduated_interval set" do
@@ -267,6 +268,7 @@ RSpec.describe GraduatedNotification, type: :model do
 
         graduated_notification2 = GraduatedNotification.create(organization: organization, bike: bike2)
         expect(graduated_notification2.in_pending_period?).to be_falsey
+        expect(graduated_notification2.sent_at).to be_blank
         expect(graduated_notification2.processable?).to be_falsey
         expect(graduated_notification1.processable?).to be_truthy
         # Processing right now

--- a/spec/requests/organized/parking_notifications_request_spec.rb
+++ b/spec/requests/organized/parking_notifications_request_spec.rb
@@ -319,12 +319,12 @@ RSpec.describe Organized::ParkingNotificationsController, type: :request do
           }
         end
         expect(ParkingNotification.count).to eq 1
+        expect(ActionMailer::Base.deliveries.count).to eq 0
         parking_notification_initial.reload
         expect(parking_notification_initial.current?).to be_falsey
         expect(parking_notification_initial.delivery_status).to eq "failed for unknown reason" # This should not have been bumped
         expect(parking_notification_initial.retrieved_kind).to eq "organization_recovery"
         expect(parking_notification_initial.retrieved_by).to eq current_user
-        expect(ActionMailer::Base.deliveries.count).to eq 0
 
         expect(assigns(:notifications_failed_resolved).pluck(:id)).to eq([])
         expect(assigns(:notifications_repeated).pluck(:id)).to eq([parking_notification_initial.id])
@@ -334,7 +334,29 @@ RSpec.describe Organized::ParkingNotificationsController, type: :request do
         expect(bike.status).to eq "status_with_owner"
       end
       context "multiple parking notifications" do
-        it "marks both retrieved"
+        let!(:parking_notification2) { FactoryBot.create(:parking_notification_organized, :in_los_angeles, organization: current_organization, delivery_status: "email_success") }
+        it "marks both retrieved" do
+          Sidekiq::Worker.clear_all
+          ActionMailer::Base.deliveries = []
+          Sidekiq::Testing.inline! do
+            post base_url, params: {
+              organization_id: current_organization.to_param,
+              kind: "mark_retrieved",
+              ids: "#{parking_notification_initial.id}, #{parking_notification2.id}"
+            }
+          end
+          expect(ParkingNotification.count).to eq 2
+          expect(ActionMailer::Base.deliveries.count).to eq 0
+          parking_notification_initial.reload
+          expect(parking_notification_initial.current?).to be_falsey
+          expect(parking_notification_initial.retrieved_kind).to eq "organization_recovery"
+          expect(parking_notification_initial.retrieved_by).to eq current_user
+
+          parking_notification2.reload
+          expect(parking_notification2.current?).to be_falsey
+          expect(parking_notification2.retrieved_kind).to eq "organization_recovery"
+          expect(parking_notification2.retrieved_by).to eq current_user
+        end
       end
     end
     context "parking notification not active" do

--- a/spec/requests/organized/parking_notifications_request_spec.rb
+++ b/spec/requests/organized/parking_notifications_request_spec.rb
@@ -301,6 +301,42 @@ RSpec.describe Organized::ParkingNotificationsController, type: :request do
       bike.reload
       expect(bike.status).to eq "status_with_owner"
     end
+    context "mark_retrieved" do
+      it "marks the parking_notification retrieved" do
+        bike.reload
+        expect(bike.status).to eq "status_with_owner"
+        parking_notification_initial.reload
+        expect(parking_notification_initial.current?).to be_truthy
+        expect(parking_notification_initial.user).to_not eq current_user
+        expect(ParkingNotification.count).to eq 1
+        Sidekiq::Worker.clear_all
+        ActionMailer::Base.deliveries = []
+        Sidekiq::Testing.inline! do
+          post base_url, params: {
+            organization_id: current_organization.to_param,
+            kind: "mark_retrieved",
+            ids: parking_notification_initial.id
+          }
+        end
+        expect(ParkingNotification.count).to eq 1
+        parking_notification_initial.reload
+        expect(parking_notification_initial.current?).to be_falsey
+        expect(parking_notification_initial.delivery_status).to eq "failed for unknown reason" # This should not have been bumped
+        expect(parking_notification_initial.retrieved_kind).to eq "organization_recovery"
+        expect(parking_notification_initial.retrieved_by).to eq current_user
+        expect(ActionMailer::Base.deliveries.count).to eq 0
+
+        expect(assigns(:notifications_failed_resolved).pluck(:id)).to eq([])
+        expect(assigns(:notifications_repeated).pluck(:id)).to eq([parking_notification_initial.id])
+        expect(response).to redirect_to organization_parking_notification_path(parking_notification_initial, organization_id: current_organization.to_param)
+
+        bike.reload
+        expect(bike.status).to eq "status_with_owner"
+      end
+      context "multiple parking notifications" do
+        it "marks both retrieved"
+      end
+    end
     context "parking notification not active" do
       let!(:parking_notification_initial) { FactoryBot.create(:parking_notification, :retrieved, bike: bike, organization: current_organization) }
       it "shows an alert" do


### PR DESCRIPTION
- Fix issue where marking a parking notification resolved would show "unable to mark that parking notification resolved because it's already resolved"
- Require clicking "mark resolved" to mark a bike retrieved for a parking notification