### PR TITLE
Redirect to user root url after bike delete

### DIFF
--- a/app/assets/javascripts/revised/pages/bikes/edit_remove.coffee
+++ b/app/assets/javascripts/revised/pages/bikes/edit_remove.coffee
@@ -21,7 +21,7 @@ class BikeIndex.BikesEditRemove extends BikeIndex
   requestDeleteRequestCallback: (data, success) ->
     if success
       msg = "Your bike's been deleted!"
-      window.BikeIndexAlerts.add('info', msg, () -> window.location.href = "/my_account")
+      window.BikeIndexAlerts.add('info', msg, () -> window.location.href = window.userRootUrl)
     else
       msg = "Oh no! Something went wrong and we couldn't send the delete request."
       window.BikeIndexAlerts.add('error', msg)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -329,6 +329,7 @@ class User < ApplicationRecord
   end
 
   def set_calculated_attributes
+    self.preferred_language = nil if preferred_language.blank?
     self.phone = Phonifyer.phonify(phone)
     if phone_changed? # Rather than waiting for twilio to send, immediately update general_alerts
       self.general_alerts = (general_alerts || []) + ["phone_waiting_confirmation"]

--- a/app/views/bikes/edit_remove.html.haml
+++ b/app/views/bikes/edit_remove.html.haml
@@ -1,3 +1,4 @@
+
 = form_for @bike, multipart: true, html: { class: 'primary-edit-bike-form' } do |f|
   .form-well-container.container{ class: "edit-bike-page-#{@edit_template}" }
     .row
@@ -44,7 +45,11 @@
               = render 'shared/trash_icon'
               = t(".delete_this_bike", bike_type: @bike.type)
 
-
+-# Don't redirect to admin, because admin doesn't actually include js for rendering BikeIndexAlerts
+- after_delete_redirect = current_user.superuser ? my_account_path : user_root_url
+-# Referenced by the edit_remove.coffee file, so we can redirect there afterward
+:javascript
+  window.userRootUrl = "#{after_delete_redirect}";
 - modal_title = t(".modal_title", bike_type: @bike.type)
 - modal_body = capture_haml do
   = form_tag do |t|

--- a/app/views/organized/bikes/_list.html.haml
+++ b/app/views/organized/bikes/_list.html.haml
@@ -51,7 +51,10 @@
           %td
             = bike.frame_colors.to_sentence
           %td
-            = bike.first_owner_email
+            - if current_organization.enabled?("claimed_ownerships")
+              = bike.owner_email
+            - else
+              = bike.first_owner_email
             %small.less-strong
               - if bike.creation_description
                 = origin_display(bike.creation_description)

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -86,11 +86,15 @@ RSpec.describe User, type: :model do
 
       it "validates preferred_language" do
         subject.preferred_language = nil
-        expect(subject.valid?).to eq(true)
+        expect(subject).to be_valid
         subject.preferred_language = "en"
-        expect(subject.valid?).to eq(true)
+        expect(subject).to be_valid
         subject.preferred_language = "klingon"
-        expect(subject.valid?).to eq(false)
+        expect(subject).to_not be_valid
+        # We have actually make preferred_language nil, or some with_locale calls can break
+        user = FactoryBot.create(:user, preferred_language: " ")
+        expect(user.preferred_language).to eq nil
+        expect(user).to be_valid
       end
     end
 


### PR DESCRIPTION
Also:

- Show actual email for organizations with `claimed_ownerships`
- Fix a bug where `with_locale` broke in sending ownership invitation emails