### PR TITLE
No regional dashboard for parent organizations

### DIFF
--- a/app/controllers/organized/dashboard_controller.rb
+++ b/app/controllers/organized/dashboard_controller.rb
@@ -13,6 +13,12 @@ module Organized
     end
 
     def index
+      # Only render this page if the organization has overview_dashboard (or it's a superuser)
+      if !current_organization.overview_dashboard? && !current_user.superuser?
+        redirect_to organization_bikes_path
+        return
+      end
+
       @child_organizations = current_organization.child_organizations
       @bikes_in_organizations = Bike.unscoped.current.organization(current_organization.nearby_and_partner_organization_ids).where(created_at: @time_range)
       @bikes_in_organization_count = current_organization.bikes.where(created_at: @time_range).count

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -283,7 +283,7 @@ class Organization < ApplicationRecord
   end
 
   def overview_dashboard?
-    parent? || regional? || enabled?("claimed_ownerships")
+    regional? || enabled?("claimed_ownerships")
   end
 
   def bike_stickers

--- a/app/views/bikes/edit_theft_details.html.haml
+++ b/app/views/bikes/edit_theft_details.html.haml
@@ -97,10 +97,11 @@
             = render "shared/form_well_footer_save"
 
 -# "Try a Promoted Theft Alert" modal
+-# Only show if there is a stolen_record_id, the session_key hasn't been stored, and there isn't a paid alert
 
 - stolen_record_id = @bike&.current_stolen_record&.id
 - session_key = "promoted_theft_alert_modal_#{stolen_record_id}_seen"
-- if session[session_key].blank?
+- if stolen_record_id.present? && session[session_key].blank? && TheftAlert.paid.where(stolen_record_id: stolen_record_id).none?
   - session[session_key] = true
   - modal_title = t(".promoted_theft_alerts")
   - modal_body = capture_haml do

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -130,14 +130,14 @@
         - elsif current_user.blank?
           .center-navbar-signup-link-container
             = link_to t(".sign_up"), new_user_url, class: "center-navbar-signup-link signup-link upcase"
-
+        - bike_search_active = controller_name == "bikes" && action_name == "index"
         %a#menu-opened-backdrop
         .hamburgler
           %a#primary_nav_hamburgler
             &#9776;
         %ul.primary-main-menu
           %li.primary-nav-item.d-lg-none
-            = link_to t(".search_bikes"), default_bike_search_path, class: 'nav-link defaultBikeSearchLink', id: 'search_bikes_header_link'
+            = link_to t(".search_bikes"), default_bike_search_path, class: "nav-link defaultBikeSearchLink #{bike_search_active ? 'active' : ''}", id: "search_bikes_header_link"
           %li.divider-nav-item.d-lg-none
           - if current_user_or_unconfirmed_user.present?
             %li.primary-nav-item
@@ -178,7 +178,7 @@
           %li.primary-nav-item
             = active_link t(".blog"), news_index_path, class: 'nav-link', match_controller: true
           %li.primary-nav-item.d-none.d-lg-block
-            = active_link t(".search_bikes"), default_bike_search_path, class: 'nav-link defaultBikeSearchLink', match_controller: true
+            = link_to t(".search_bikes"), default_bike_search_path, class: "nav-link defaultBikeSearchLink #{bike_search_active ? 'active' : ''}", match_controller: true
     = render 'layouts/revised_messages'
 
     - if current_page_skeleton

--- a/spec/requests/organized/dashboard_request_spec.rb
+++ b/spec/requests/organized/dashboard_request_spec.rb
@@ -100,13 +100,5 @@ RSpec.describe Organized::BaseController, type: :request do
         expect(assigns(:end_time)).to be_within(5).of Time.current
       end
     end
-    context "organization without overview_dashboard?" do
-      it "renders" do
-        current_organization.reload
-        expect(current_organization.overview_dashboard?).to be_falsey
-        get "/o/#{current_organization.to_param}/dashboard"
-        expect(response).to render_template(:index)
-      end
-    end
   end
 end

--- a/spec/requests/organized/dashboard_request_spec.rb
+++ b/spec/requests/organized/dashboard_request_spec.rb
@@ -56,11 +56,15 @@ RSpec.describe Organized::BaseController, type: :request do
       let(:current_organization) { FactoryBot.create(:organization, kind: "law_enforcement", search_radius: 50) }
       let!(:organization_child1) { FactoryBot.create(:organization, kind: "law_enforcement", search_radius: 3, parent_organization: current_organization) }
       let!(:bike) { FactoryBot.create(:bike_organized, organization: organization_child1) }
-      it "renders" do
+      it "does not rendern" do
         current_organization.update(updated_at: Time.current)
         current_organization.reload
         expect(current_organization.parent?).to be_truthy
-        expect(current_organization.overview_dashboard?).to be_truthy
+        expect(current_organization.overview_dashboard?).to be_falsey
+        get "/o/#{current_organization.to_param}/dashboard"
+        expect(response).to redirect_to(organization_bikes_path)
+        # ... but it renders if the current_user is superuser
+        current_user.update(superuser: true)
         get "/o/#{current_organization.to_param}/dashboard"
         expect(response).to render_template(:index)
       end


### PR DESCRIPTION
Only for `regional_bike_counts` & `claimmed_ownerships`

Also:

- Don't make bike search active, unless actually viewing bike search
- Don't render the promoted alert modal if they've already bought a promoted alert