### PR TITLE
Bump the ruby version in the docker image to match the Gemfile.lock

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.5.8
+FROM ruby:2.7.2
 WORKDIR /src
 
 RUN apt-get update -yq \


### PR DESCRIPTION
Per #1844 trying to address the docker build ruby version mismatch and the Gemfile.lock

Is possible this PR is a noop and the solution is the fix the Gemfile.lock to build built with the correct version of ruby. 

I'm assuming the current version of ruby is 2.7 but just was not been updated in the respective docker files. 