### PR TITLE
Match confirmation codes with spaces

### DIFF
--- a/app/controllers/user_phones_controller.rb
+++ b/app/controllers/user_phones_controller.rb
@@ -11,7 +11,7 @@ class UserPhonesController < ApplicationController
         flash[:success] = "Verification code sent!"
       end
     elsif params[:confirmation_code]
-      if @user_phone.confirmation_code == params[:confirmation_code]
+      if @user_phone.confirmation_matches?(params[:confirmation_code])
         if @user_phone.expired?
           flash[:error] = "Verification code expired. We've sent a new code, please verify it in the next 30 minutes"
           @user_phone.resend_confirmation_if_reasonable!

--- a/app/integrations/twilio_integration.rb
+++ b/app/integrations/twilio_integration.rb
@@ -5,12 +5,16 @@ class TwilioIntegration
   AUTH_TOKEN = ENV["TWILIO_TOKEN"]
   OUTGOING_NUMBER = ENV["TWILIO_NUMBER"]
 
+  def self.twilio_formatted(str)
+    str.gsub(/\A0+/, "")
+  end
+
   def client
     @client ||= Twilio::REST::Client.new ACCOUNT_SID, AUTH_TOKEN
   end
 
   def send_message(to:, body:)
-    client.messages.create(body: body, from: OUTGOING_NUMBER, to: to)
+    client.messages.create(body: body, from: OUTGOING_NUMBER, to: self.class.twilio_formatted(to))
   end
 
   def get_message(sid)

--- a/app/integrations/twilio_integration.rb
+++ b/app/integrations/twilio_integration.rb
@@ -14,7 +14,9 @@ class TwilioIntegration
   end
 
   def send_message(to:, body:)
-    client.messages.create(body: body, from: OUTGOING_NUMBER, to: self.class.twilio_formatted(to))
+    client.messages.create(body: body,
+                           from: OUTGOING_NUMBER,
+                           to: self.class.twilio_formatted(to))
   end
 
   def get_message(sid)

--- a/app/models/manufacturer.rb
+++ b/app/models/manufacturer.rb
@@ -80,7 +80,6 @@ class Manufacturer < ApplicationRecord
     errors.add(:name, :cannot_match_a_color_name) if Color.pluck(:name).map(&:downcase).include?(name.strip.downcase)
   end
 
-
   def set_calculated_attributes
     self.slug = Slugifyer.manufacturer(name)
     self.website = website.present? ? Urlifyer.urlify(website) : nil

--- a/app/models/user_phone.rb
+++ b/app/models/user_phone.rb
@@ -18,8 +18,17 @@ class UserPhone < ApplicationRecord
     Time.current - 1.hour
   end
 
+  def self.code_display(str)
+    return nil unless str.present?
+    str[0..2] + " " + str[3..-1]
+  end
+
+  def self.code_normalize(str)
+    str.gsub(/\s/, "")
+  end
+
   def self.find_confirmation_code(str)
-    waiting_confirmation.where(confirmation_code: str.gsub(/\s/, "")).first
+    waiting_confirmation.where(confirmation_code: code_normalize(str)).first
   end
 
   def self.add_phone_for_user_id(user_id, phone_number)
@@ -71,13 +80,16 @@ class UserPhone < ApplicationRecord
     result
   end
 
-  def confirmation_display
-    return nil unless confirmation_code.present?
-    confirmation_code[0..2] + " " + confirmation_code[3..-1]
+  def code_display
+    self.class.code_display(confirmation_code)
+  end
+
+  def confirmation_matches?(str)
+    confirmation_code == self.class.code_normalize(str)
   end
 
   def confirmation_message
-    "Bike Index confirmation code:  #{confirmation_display}"
+    "Bike Index confirmation code:  #{code_display}"
   end
 
   def set_calculated_attributes

--- a/app/views/my_accounts/show.html.haml
+++ b/app/views/my_accounts/show.html.haml
@@ -123,6 +123,5 @@
                 %p
                   = t(".want_to_sell_your_bikes")
                   = link_to t(".list_a_bike_on_bikefair"), "https://bikefair.org/auth/bikeindex"
-      .ad-block#right300x600
 
 = render "/shared/donation_modal"

--- a/spec/integrations/twilio_integration_spec.rb
+++ b/spec/integrations/twilio_integration_spec.rb
@@ -3,6 +3,12 @@ require "rails_helper"
 RSpec.describe TwilioIntegration do
   let(:instance) { described_class.new }
 
+  describe "twilio_formatted" do
+    it "strips leading zeros" do
+      expect(TwilioIntegration.twilio_formatted("00100000000")).to eq "100000000"
+    end
+  end
+
   describe "send_message" do
     it "sends a message" do
       VCR.use_cassette("twilio_integration-send_message", match_requests_on: [:path]) do
@@ -19,7 +25,7 @@ RSpec.describe TwilioIntegration do
     it "sends a message, stores the sid" do
       VCR.use_cassette("twilio_integration-send_notification", match_requests_on: [:path]) do
         expect(notification.twilio_sid).to be_blank
-        instance.send_notification(notification, to: "5102224444", body: "This is a test message")
+        instance.send_notification(notification, to: "05102224444", body: "This is a test message")
         notification.reload
         expect(notification.twilio_sid).to be_present
         notification.twilio_sid

--- a/spec/requests/user_phones_request_spec.rb
+++ b/spec/requests/user_phones_request_spec.rb
@@ -71,6 +71,23 @@ RSpec.describe UserPhonesController, type: :request do
     end
 
     describe "confirm" do
+      it "confirms" do
+        expect(current_user).to be_present
+        expect(user_phone.confirmed?).to be_falsey
+        expect(user_phone.confirmation_code).to eq "6666666"
+        expect(user_phone.resend_confirmation?).to be_falsey
+        patch "#{base_url}/#{user_phone.to_param}", params: {confirmation_code: "666 6666"}
+        expect(flash[:success]).to be_present
+
+        current_user.reload
+        expect(current_user.phone_waiting_confirmation?).to be_falsey
+        expect(current_user.user_phones.count).to eq 1
+        expect(current_user.general_alerts).to eq([])
+
+        user_phone.reload
+        expect(user_phone.confirmed?).to be_truthy
+        expect(user_phone.confirmed_at).to be_within(5).of Time.current
+      end
       context "incorrect confirmation" do
         it "does not confirm" do
           user_phone.reload


### PR DESCRIPTION
We text the code with spaces in it, we should actually accept what we send