### PR TITLE
pause StopHeling searches

### DIFF
--- a/app/models/external_registry_client.rb
+++ b/app/models/external_registry_client.rb
@@ -11,7 +11,7 @@ class ExternalRegistryClient
   # records found that were successfully persisted.
   def self.search_for_bikes_with(query, registries: nil)
     registries ||= [
-      StopHelingClient,
+      # StopHelingClient, # Commented in PR#1868
       VerlorenOfGevondenClient
     ]
 


### PR DESCRIPTION
The request to their API is failing, so pause the searches for now.