### PR TITLE
Non hiredis soulheart

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,7 +18,7 @@ jobs:
         environment:
           PGHOST: 127.0.0.1
           PGUSER: root
-      - image: circleci/postgres:10.4-alpine-postgis
+      - image: circleci/postgres:12.0-alpine-postgis
         environment:
           POSTGRES_USER: root
           POSTGRES_DB: bikeindex_test

--- a/Gemfile
+++ b/Gemfile
@@ -51,7 +51,6 @@ gem "kaminari" # pagination
 gem "kramdown", "2.3.1" # Markdown
 gem "kramdown-parser-gfm" # Parser required to render grape-swagger
 gem "money-rails", "~> 1.11"
-gem "nokogiri", ">= 1.10.4"
 gem "omniauth", "~> 1.6"
 gem "omniauth-facebook"
 gem "omniauth-globalid"

--- a/Gemfile
+++ b/Gemfile
@@ -38,8 +38,8 @@ gem "translation"
 gem "redis"
 gem "sidekiq" # Background job processing
 gem "sidekiq-failures" # Sidekiq failure tracking and viewing
-# Autocomplete loader
-gem "soulheart", github: "sethherr/soulheart", branch: "non-hiredis"
+# soulheart on branch because github.com/sethherr/soulheart/pull/32
+gem "soulheart", github: "sethherr/soulheart", branch: "non-hiredis" # Autocomplete loader
 
 gem "draper", require: false # NB: Draper is deprecated in this project
 gem "eventmachine"

--- a/Gemfile
+++ b/Gemfile
@@ -36,9 +36,10 @@ gem "translation"
 
 # Redis and redis dependents
 gem "redis"
-gem "sidekiq"
-gem "sidekiq-failures"
-gem "soulheart"
+gem "sidekiq" # Background job processing
+gem "sidekiq-failures" # Sidekiq failure tracking and viewing
+# Autocomplete loader
+gem "soulheart", github: "sethherr/soulheart", branch: "non-hiredis"
 
 gem "draper", require: false # NB: Draper is deprecated in this project
 gem "eventmachine"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -18,6 +18,16 @@ GIT
   specs:
     faraday-request_response_logger (0.1.0)
 
+GIT
+  remote: https://github.com/sethherr/soulheart.git
+  revision: 301ff545ad8449994bee5018272e22fac11b3e05
+  branch: non-hiredis
+  specs:
+    soulheart (0.4.0)
+      redis (>= 3.0.5)
+      sinatra (>= 1.4.4)
+      vegas (>= 0.1.0)
+
 GEM
   remote: https://rubygems.org/
   remote: https://rails-assets.org/
@@ -591,10 +601,6 @@ GEM
       builder (~> 3.0)
     skylight (5.0.1)
       activesupport (>= 5.2.0)
-    soulheart (0.4.0)
-      redis (>= 3.0.5)
-      sinatra (>= 1.4.4)
-      vegas (>= 0.1.0)
     sprockets (4.0.0)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
@@ -779,7 +785,7 @@ DEPENDENCIES
   simplecov
   sitemap_generator (~> 6)
   skylight
-  soulheart
+  soulheart!
   sprockets (= 4.0.0)
   sprockets-rails
   stackprof

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -734,7 +734,6 @@ DEPENDENCIES
   mini_magick
   money-rails (~> 1.11)
   multi_json
-  nokogiri (>= 1.10.4)
   oj
   omniauth (~> 1.6)
   omniauth-facebook

--- a/bin/update
+++ b/bin/update
@@ -26,8 +26,8 @@ chdir APP_ROOT do
   puts "\n== Removing old logs and tempfiles =="
   system! 'bin/rails log:clear tmp:clear'
 
-  puts "\n== loading manufacturer type ahead and bike counts =="
-  system "bin/rake sm_import_manufacturers load_counts"
+  puts "\n== loading typeahead and bike counts =="
+  system "bin/rake reset_autocomplete load_counts"
 
 
   puts "\n== Restarting application server =="

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -25,7 +25,7 @@ COMMENT ON EXTENSION fuzzystrmatch IS 'determine similarities and distance betwe
 
 SET default_tablespace = '';
 
-SET default_with_oids = false;
+SET default_table_access_method = heap;
 
 --
 -- Name: ads; Type: TABLE; Schema: public; Owner: -

--- a/lib/tasks/rake_tasks.rake
+++ b/lib/tasks/rake_tasks.rake
@@ -15,7 +15,7 @@ end
 
 desc "Reset Soulheart - colors and frame_makers"
 task reset_autocomplete: :environment do
-  AutocompleteLoaderWorker.perform_async("load_manufacturers")
+  AutocompleteLoaderWorker.perform_async("reset")
 end
 
 desc "Load counts" # This is a rake task so it can be loaded from bin/update

--- a/lib/tasks/rake_tasks.rake
+++ b/lib/tasks/rake_tasks.rake
@@ -13,8 +13,8 @@ task slow_save: :environment do
   # end
 end
 
-desc "Create frame_makers and push to redis"
-task sm_import_manufacturers: :environment do
+desc "Reset Soulheart - colors and frame_makers"
+task reset_autocomplete: :environment do
   AutocompleteLoaderWorker.perform_async("load_manufacturers")
 end
 


### PR DESCRIPTION
This is a hotfix. The new deployment accesses Redis through TLS, which the hiredis driver doesn't support.

https://github.com/sethherr/soulheart/pull/32