### PR TITLE
Remove Show address attribute from stolen records

### DIFF
--- a/app/controllers/api/v2/bikes.rb
+++ b/app/controllers/api/v2/bikes.rb
@@ -34,6 +34,7 @@ module API
 
             optional :police_report_number, type: String, desc: "Police report number"
             optional :police_report_department, type: String, desc: "Police department reported to (include if report number present)"
+            # show_address NO LONGER ACTUALLY DOES ANYTHING. Keeping so that the API doesn't change
             optional :show_address, type: Boolean, desc: "Display the exact address the theft happened at"
 
             optional :theft_description, type: String, desc: "stuff"

--- a/app/models/b_param.rb
+++ b/app/models/b_param.rb
@@ -142,7 +142,7 @@ class BParam < ApplicationRecord
     # Set the date_stolen if it was passed, if something else didn't already set date_stolen
     date_stolen = params.dig("bike", "date_stolen")
     s_attrs["date_stolen"] ||= date_stolen if date_stolen.present?
-    s_attrs.except("phone_no_show")
+    s_attrs.except("phone_no_show", "show_address")
   end
 
   def impound_attrs

--- a/app/models/stolen_record.rb
+++ b/app/models/stolen_record.rb
@@ -153,6 +153,11 @@ class StolenRecord < ApplicationRecord
     street.blank?
   end
 
+  # Used to be an attribute, removed in
+  def show_address
+    false
+  end
+
   def address(skip_default_country: false, force_show_address: false)
     Geocodeable.address(
       self,

--- a/app/services/stolen_record_updator.rb
+++ b/app/services/stolen_record_updator.rb
@@ -7,7 +7,7 @@ class StolenRecordUpdator
       longitude theft_description current phone secondary_phone phone_for_everyone
       phone_for_users phone_for_shops phone_for_police receive_notifications proof_of_ownership
       approved recovered_at recovered_description index_helped_recovery can_share_recovery
-      recovery_posted show_address tsved_at estimated_value].freeze
+      recovery_posted tsved_at estimated_value].freeze
   end
 
   def initialize(creation_params = {})
@@ -59,7 +59,7 @@ class StolenRecordUpdator
     ActionController::Parameters.new(params).permit(:phone, :secondary_phone, :street, :city, :zipcode,
       :country_id, :state_id, :police_report_number, :police_report_department, :estimated_value,
       :theft_description, :locking_description, :lock_defeat_description, :proof_of_ownership,
-      :receive_notifications, :show_address, :phone_for_everyone, :phone_for_users,
+      :receive_notifications, :phone_for_everyone, :phone_for_users,
       :phone_for_shops, :phone_for_police)
   end
 end

--- a/app/views/admin/bikes/_bike.html.haml
+++ b/app/views/admin/bikes/_bike.html.haml
@@ -232,12 +232,9 @@
               %td
                 Location
               %td
-                = stolen_record.address
+                = stolen_record.address(force_show_address: true)
                 - if stolen_record.without_location?
                   %em.small.text-warning missing address (user alerted)
-                - else
-                  %code.small.ml-1{ title: "When true, the street address is shown publicly. Otherwise no street address is shown" }
-                    shown: #{stolen_record.show_address}
             %tr
               %td
                 Phone

--- a/app/views/bikes/bike_fields/_stolen_location.html.haml
+++ b/app/views/bikes/bike_fields/_stolen_location.html.haml
@@ -28,11 +28,3 @@
     %label.form-well-label
     .form-well-input
       = srecord.collection_select(:state_id, State.all, :id, :name, { include_blank: true, prompt: t(".state") }, { class: "form-control" })
-
-  -# Impounded bikes never include the exact location found, because it's used as a way to verify claims
-  - if @bike.status_stolen?
-    .form-group.row
-      %label.form-well-label
-      %label.form-well-input
-        = srecord.check_box :show_address
-        = t(".publicly_display_exact_address")

--- a/config/locales/.translation_io
+++ b/config/locales/.translation_io
@@ -1,2 +1,2 @@
 ---
-timestamp: 1619049912
+timestamp: 1620841740

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -959,7 +959,6 @@ en:
         address_or_intersection: Address or intersection
         choose_country: Choose country
         city: City
-        publicly_display_exact_address: Publicly display exact address theft occurred
         state: State
         where_was_it_stolen_type: Where was it %{stolen_type}?
         zipcode: Postal code

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -585,7 +585,6 @@ en:
         recovery_share: Recovery share
         recovery_tweet: Recovery tweet
         secondary_phone: Secondary phone
-        show_address: Show address
         state: :activerecord.models.state
         street: Street
         theft_alerts: Theft alerts

--- a/config/locales/translation.nl.yml
+++ b/config/locales/translation.nl.yml
@@ -672,7 +672,6 @@ nl:
         recovery_share: Herstel aandeel
         recovery_tweet: Hersteltweet
         secondary_phone: Secundaire telefoon
-        show_address: Toon adres
         street: straat
         theft_alerts: Diefstalwaarschuwingen
         theft_description: Diefstal beschrijving
@@ -1689,7 +1688,6 @@ nl:
         address_or_intersection: Adres of kruispunt
         choose_country: Kies land
         city: City
-        publicly_display_exact_address: Openbaar weergeven exacte adresdiefstal opgetreden
         state: Staat
         where_was_it_stolen_type: Waar was het %{stolen_type}?
         zipcode: Postcode

--- a/db/migrate/20210512162607_remove_show_address_from_stolen_records.rb
+++ b/db/migrate/20210512162607_remove_show_address_from_stolen_records.rb
@@ -1,0 +1,5 @@
+class RemoveShowAddressFromStolenRecords < ActiveRecord::Migration[5.2]
+  def change
+    remove_column :stolen_records, :show_address, :boolean
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -2608,7 +2608,6 @@ CREATE TABLE public.stolen_records (
     tsved_at timestamp without time zone,
     estimated_value integer,
     recovery_link_token text,
-    show_address boolean DEFAULT false,
     recovering_user_id integer,
     recovery_display_status integer DEFAULT 0,
     neighborhood character varying
@@ -5623,6 +5622,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20210405200829'),
 ('20210420161728'),
 ('20210421174751'),
-('20210423200934');
+('20210423200934'),
+('20210512162607');
 
 

--- a/spec/controllers/bikes_controller_spec.rb
+++ b/spec/controllers/bikes_controller_spec.rb
@@ -615,7 +615,6 @@ RSpec.describe BikesController, type: :controller do
                 stolen_record = bike.current_stolen_record
                 stolen_params.except(:date_stolen, :timezone).each { |k, v| expect(stolen_record.send(k).to_s).to eq v.to_s }
                 expect(stolen_record.date_stolen.to_i).to be_within(1).of(Time.current.yesterday.to_i)
-                expect(stolen_record.show_address).to be_falsey
               end
             end
           end

--- a/spec/models/stolen_record_spec.rb
+++ b/spec/models/stolen_record_spec.rb
@@ -208,8 +208,7 @@ RSpec.describe StolenRecord, type: :model do
                                        country_id: country.id)
       expect(stolen_record.address).to eq("Chicago, XXX 60647, NEVVVV")
       expect(stolen_record.address(force_show_address: true)).to eq("2200 N Milwaukee Ave, Chicago, XXX 60647, NEVVVV")
-      stolen_record.show_address = true
-      expect(stolen_record.address).to eq("2200 N Milwaukee Ave, Chicago, XXX 60647, NEVVVV")
+      expect(stolen_record.address).to eq("Chicago, XXX 60647, NEVVVV")
       expect(stolen_record.display_checklist?).to be_truthy
     end
     it "is ok with missing information" do
@@ -218,8 +217,7 @@ RSpec.describe StolenRecord, type: :model do
                                        country_id: country.id)
       expect(stolen_record.address).to eq("60647, NEVVVV")
       expect(stolen_record.without_location?).to be_falsey
-      stolen_record.show_address = true
-      expect(stolen_record.address).to eq("2200 N Milwaukee Ave, 60647, NEVVVV")
+      expect(stolen_record.address).to eq("60647, NEVVVV")
     end
     it "returns nil if there is no country" do
       stolen_record = StolenRecord.new(street: "302666 Richmond Blvd")
@@ -586,17 +584,10 @@ RSpec.describe StolenRecord, type: :model do
   describe "latitude_public" do
     let(:latitude) { -122.2824933 }
     let(:longitude) { 37.837112 }
-    let(:stolen_record) { StolenRecord.new(latitude: latitude, longitude: longitude, show_address: true) }
-    it "is the same as latitude" do
-      expect(stolen_record.latitude_public).to eq latitude
-      expect(stolen_record.longitude_public).to eq longitude
-    end
-    context "show_address false" do
-      it "is rounded" do
-        stolen_record.show_address = false
-        expect(stolen_record.latitude_public).to eq(-122.28)
-        expect(stolen_record.longitude_public).to eq longitude.round(2)
-      end
+    let(:stolen_record) { StolenRecord.new(latitude: latitude, longitude: longitude) }
+    it "is rounded" do
+      expect(stolen_record.latitude_public).to eq(-122.28)
+      expect(stolen_record.longitude_public).to eq longitude.round(2)
     end
   end
 

--- a/spec/requests/api/v3/bikes_request_spec.rb
+++ b/spec/requests/api/v3/bikes_request_spec.rb
@@ -542,7 +542,7 @@ RSpec.describe "Bikes API V3", type: :request do
       expect(bike.current_stolen_record_id).to be_present
       expect(bike.current_stolen_record.police_report_number).to eq(bike_attrs[:stolen_record][:police_report_number])
       expect(bike.current_stolen_record.phone).to eq("1234567890")
-      expect(bike.current_stolen_record.show_address).to be_truthy
+      expect(bike.current_stolen_record.show_address).to be_falsey
     end
 
     it "does not register a stolen bike unless attrs are present" do
@@ -741,7 +741,7 @@ RSpec.describe "Bikes API V3", type: :request do
       expect(bike.status_stolen?).to be_truthy
       expect(bike.current_stolen_record.date_stolen.to_i).to be > Time.current.to_i - 10
       expect(bike.current_stolen_record.police_report_number).to eq("999999")
-      expect(bike.current_stolen_record.show_address).to be_truthy
+      expect(bike.current_stolen_record.show_address).to be_falsey
     end
 
     it "updates a bike, adds and removes components" do

--- a/spec/requests/bikes_request_spec.rb
+++ b/spec/requests/bikes_request_spec.rb
@@ -652,6 +652,7 @@ RSpec.describe BikesController, type: :request do
             # This is also where we're testing bikebook assignment
             expect_any_instance_of(BikeBookIntegration).to receive(:get_model) { bb_data }
             expect {
+              # Test that we can still pass show_address - because API backward compatibility
               post base_url, params: {bike: bike_params, stolen_record: chicago_stolen_params.merge(show_address: true)}
             }.to change(Bike, :count).by(1)
             expect(flash[:success]).to be_present
@@ -668,7 +669,6 @@ RSpec.describe BikesController, type: :request do
             expect(bike.creation_state.status).to eq "status_stolen"
             stolen_record = bike.current_stolen_record
             chicago_stolen_params.except(:state_id).each { |k, v| expect(stolen_record.send(k).to_s).to eq v.to_s }
-            expect(stolen_record.show_address).to be_truthy
           end
         end
       end
@@ -1519,7 +1519,7 @@ RSpec.describe BikesController, type: :request do
           expect(stolen_record.secondary_phone).to eq "1231231234"
           expect(stolen_record.country_id).to eq Country.united_states.id
           expect(stolen_record.state_id).to eq state.id
-          expect(stolen_record.show_address).to be_truthy
+          expect(stolen_record.show_address).to be_falsey
           expect(stolen_record.estimated_value).to eq 2101
           expect(stolen_record.locking_description).to eq "party"
           expect(stolen_record.lock_defeat_description).to eq "cool things"


### PR DESCRIPTION
Ultimately, seems like nobody wants to show their exact address, and this keeps tripping people up