### PR TITLE
Ignore facebook specs when the FB ads integration is not configured

### DIFF
--- a/spec/integrations/facebook_ads_integration_spec.rb
+++ b/spec/integrations/facebook_ads_integration_spec.rb
@@ -1,7 +1,9 @@
 require "rails_helper"
 
+facebook_imported = 'Facebook::AdsIntegration'.constantize rescue nil
+
 # Not set up to run on CI currently
-if !ENV["CI"] && Facebook::AdsIntegration::TOKEN.present?
+if !ENV["CI"] && facebook_imported && Facebook::AdsIntegration::TOKEN.present?
   RSpec.describe Facebook::AdsIntegration do
     let(:instance) { described_class.new }
     it "gets account" do

--- a/spec/workers/activate_theft_alert_worker_spec.rb
+++ b/spec/workers/activate_theft_alert_worker_spec.rb
@@ -1,6 +1,8 @@
 require "rails_helper"
 
-if !ENV["CI"] && Facebook::AdsIntegration::TOKEN.present?
+facebook_imported = 'Facebook::AdsIntegration'.constantize rescue nil
+
+if !ENV["CI"] && facebook_imported && Facebook::AdsIntegration::TOKEN.present?
   RSpec.describe ActivateTheftAlertWorker, type: :job do
     let(:instance) { described_class.new }
 


### PR DESCRIPTION
I found that I had a couple of test failures due to `Facebook::AdsIntegration` being an undefined constant. I think it makes sense to ignore these things when the configuration is not done to allow folks to have a green suite out of the gate. Let me know if you disagree and I'll jump through the hoops to get it set up.