### PR TITLE
Fix 529 integration issues

### DIFF
--- a/app/models/external_registry_bike.rb
+++ b/app/models/external_registry_bike.rb
@@ -38,7 +38,7 @@ class ExternalRegistryBike < ApplicationRecord
       case status.downcase
       when "stolen" then "status_stolen"
       when "abandoned" then "status_impounded"
-      when "new", "transferred", "registered", "pending transfer" then "status_with_owner"
+      when "new", "transferred", "registered", "pending transfer", "recovered", "for_sale" then "status_with_owner"
       else # There is a new status! Fail, we need to figure out what to do with it
         raise "Unknown external registry status: #{status}"
       end

--- a/app/models/external_registry_bike/project529_bike.rb
+++ b/app/models/external_registry_bike/project529_bike.rb
@@ -19,7 +19,15 @@ class ExternalRegistryBike::Project529Bike < ExternalRegistryBike
     info_hash["thumb_url"]
   end
 
+  def updated_at_529
+    TimeParser.parse(info_hash["updated_at_529"])
+  end
+
   class << self
+    def fetch_from_date
+      maximum(:external_updated_at) || Time.current - 3.years
+    end
+
     def build_from_api_response(attrs = {})
       return if attrs["status"]&.downcase == "recovered"
 
@@ -36,9 +44,10 @@ class ExternalRegistryBike::Project529Bike < ExternalRegistryBike
       bike.location_found = attrs.dig("active_incident", "location_address")
       bike.frame_colors = frame_colors(attrs)
       bike.description = description(attrs)
-      bike.date_stolen = date_stolen(attrs)
+      bike.date_stolen = StolenRecord.corrected_date_stolen(date_stolen(attrs))
       bike.country = country(attrs)
       bike.info_hash = info_hash(attrs)
+      bike.external_updated_at = TimeParser.parse(attrs["updated_at"])
 
       bike
     end
@@ -47,6 +56,7 @@ class ExternalRegistryBike::Project529Bike < ExternalRegistryBike
 
     def info_hash(attrs)
       photo = primary_photo(attrs)
+      u_529 = TimeParser.parse(attrs["updated_at"])
 
       {
         url: attrs["url"],

--- a/app/models/external_registry_bike/project529_bike.rb
+++ b/app/models/external_registry_bike/project529_bike.rb
@@ -19,10 +19,6 @@ class ExternalRegistryBike::Project529Bike < ExternalRegistryBike
     info_hash["thumb_url"]
   end
 
-  def updated_at_529
-    TimeParser.parse(info_hash["updated_at_529"])
-  end
-
   class << self
     def fetch_from_date
       maximum(:external_updated_at) || Time.current - 3.years
@@ -56,7 +52,6 @@ class ExternalRegistryBike::Project529Bike < ExternalRegistryBike
 
     def info_hash(attrs)
       photo = primary_photo(attrs)
-      u_529 = TimeParser.parse(attrs["updated_at"])
 
       {
         url: attrs["url"],

--- a/app/models/external_registry_client/project529_client.rb
+++ b/app/models/external_registry_client/project529_client.rb
@@ -29,7 +29,6 @@ class ExternalRegistryClient::Project529Client < ExternalRegistryClient
     # searching for these.
     bike_attrs =
       request_bikes(page, per_page, updated_at)
-        .dig(:body, :bikes)
         .map { |attrs| ExternalRegistryBike::Project529Bike.build_from_api_response(attrs) }
         .compact
 
@@ -59,11 +58,11 @@ class ExternalRegistryClient::Project529Client < ExternalRegistryClient
           req.params = req_params.merge(access_token: credentials.access_token)
         }
 
-        {status: response.status, body: response.body.with_indifferent_access}
+        {status: response.status, body: response.body}
       }
 
     if cached_response[:status] == 200 && cached_response[:body].is_a?(Hash)
-      cached_response
+      cached_response[:body].with_indifferent_access[:bikes]
     else
       raise Project529ClientError, cached_response
     end

--- a/app/models/external_registry_client/project529_client.rb
+++ b/app/models/external_registry_client/project529_client.rb
@@ -35,7 +35,6 @@ class ExternalRegistryClient::Project529Client < ExternalRegistryClient
     saved_bikes = bike_attrs.each(&:save).select(&:persisted?)
 
     ExternalRegistryBike.where(id: saved_bikes.map(&:id))
-
   rescue Faraday::TimeoutError
     ExternalRegistryBike.none
   end

--- a/app/models/external_registry_credential/project529_credential.rb
+++ b/app/models/external_registry_credential/project529_credential.rb
@@ -1,6 +1,7 @@
 class ExternalRegistryCredential::Project529Credential < ExternalRegistryCredential
   validates :app_id, :refresh_token, presence: true
 
+  # Our credential thought it was expired, but apparently it wasn't. See PR#2076
   def set_access_token
     return unless access_token_can_be_reset?
 

--- a/app/models/stolen_record.rb
+++ b/app/models/stolen_record.rb
@@ -121,6 +121,22 @@ class StolenRecord < ApplicationRecord
     end
   end
 
+  def self.corrected_date_stolen(date = nil)
+    date ||= Time.current
+    date = TimeParser.parse(date) if date.is_a?(String)
+    year = date.year
+    if year < (Time.current - 100.years).year
+      decade = year.to_s[-2..].chars.join("")
+      corrected = date.change(year: "20#{decade}".to_i)
+      date = corrected
+    end
+    if date > Time.current + 2.days
+      corrected = date.change(year: Time.current.year - 1)
+      date = corrected
+    end
+    date
+  end
+
   def recovered?
     !current?
   end
@@ -337,17 +353,7 @@ class StolenRecord < ApplicationRecord
   end
 
   def fix_date
-    self.date_stolen ||= Time.current
-    year = date_stolen.year
-    if date_stolen.year < (Time.current - 100.years).year
-      decade = year.to_s[-2..].chars.join("")
-      corrected = date_stolen.change(year: "20#{decade}".to_i)
-      self.date_stolen = corrected
-    end
-    if date_stolen > Time.current + 2.days
-      corrected = date_stolen.change(year: Time.current.year - 1)
-      self.date_stolen = corrected
-    end
+    self.date_stolen = self.class.corrected_date_stolen(date_stolen)
   end
 
   def update_not_current_records

--- a/app/workers/fetch_project529_bikes_worker.rb
+++ b/app/workers/fetch_project529_bikes_worker.rb
@@ -7,7 +7,7 @@ class FetchProject529BikesWorker < ScheduledWorker
 
   def perform(page = 1)
     client = ExternalRegistryClient::Project529Client.new
-    results = client.bikes(updated_at: from_start_date, per_page: 20, page: page)
+    results = client.bikes(updated_at: from_start_date, per_page: 100, page: page)
     return if results.empty?
 
     self.class.perform_async(page + 1)
@@ -17,9 +17,9 @@ class FetchProject529BikesWorker < ScheduledWorker
   # bounded to 20 days because of performance constraints on the api.
   def from_start_date
     if ExternalRegistryBike::Project529Bike.count.zero?
-      Time.current - 20.day
+      Time.current - 20.days
     else
-      Time.current - 1.day
+      Time.current - 2.days
     end
   end
 end

--- a/app/workers/fetch_project529_bikes_worker.rb
+++ b/app/workers/fetch_project529_bikes_worker.rb
@@ -9,8 +9,8 @@ class FetchProject529BikesWorker < ScheduledWorker
     client = ExternalRegistryClient::Project529Client.new
 
     created_bikes = client.bikes(per_page: 100,
-      page: page,
-      updated_at: ExternalRegistryBike::Project529Bike.fetch_from_date)
+                                 page: page,
+                                 updated_at: ExternalRegistryBike::Project529Bike.fetch_from_date)
 
     return if created_bikes.empty?
 

--- a/app/workers/fetch_project529_bikes_worker.rb
+++ b/app/workers/fetch_project529_bikes_worker.rb
@@ -7,19 +7,13 @@ class FetchProject529BikesWorker < ScheduledWorker
 
   def perform(page = 1)
     client = ExternalRegistryClient::Project529Client.new
-    results = client.bikes(updated_at: from_start_date, per_page: 100, page: page)
-    return if results.empty?
+
+    created_bikes = client.bikes(per_page: 100,
+      page: page,
+      updated_at: ExternalRegistryBike::Project529Bike.fetch_from_date)
+
+    return if created_bikes.empty?
 
     self.class.perform_async(page + 1)
-  end
-
-  # historical or delta query, depending on the pre-existence of 529 records.
-  # bounded to 20 days because of performance constraints on the api.
-  def from_start_date
-    if ExternalRegistryBike::Project529Bike.count.zero?
-      Time.current - 20.days
-    else
-      Time.current - 2.days
-    end
   end
 end

--- a/db/migrate/20210921181852_add_external_updated_at_to_external_bikes.rb
+++ b/db/migrate/20210921181852_add_external_updated_at_to_external_bikes.rb
@@ -1,0 +1,5 @@
+class AddExternalUpdatedAtToExternalBikes < ActiveRecord::Migration[5.2]
+  def change
+    add_column :external_registry_bikes, :external_updated_at, :datetime
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -993,7 +993,8 @@ CREATE TABLE public.external_registry_bikes (
     info_hash jsonb DEFAULT '{}'::jsonb,
     created_at timestamp without time zone NOT NULL,
     updated_at timestamp without time zone NOT NULL,
-    status integer
+    status integer,
+    external_updated_at timestamp without time zone
 );
 
 
@@ -5900,6 +5901,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20210730172142'),
 ('20210811141935'),
 ('20210817204248'),
-('20210820220126');
+('20210820220126'),
+('20210921181852');
 
 

--- a/spec/models/external_registry_bike/project529_bike_spec.rb
+++ b/spec/models/external_registry_bike/project529_bike_spec.rb
@@ -46,6 +46,7 @@ RSpec.describe ExternalRegistryBike::Project529Bike, type: :model do
       expect(bike.url).to match("https://project529.com/.+")
       expect(bike.image_url).to match("https://529garage-production.s3.amazonaws.com/photos/attachments")
       expect(bike.thumb_url).to match("https://529garage-production.s3.amazonaws.com/photos/attachments")
+      expect(bike.external_updated_at).to be_within(1).of TimeParser.parse("2019-10-02T03:25:47.080Z")
     end
   end
 


### PR DESCRIPTION
```ruby
# ExternalRegistryCredential::Project529Credential thought it was expired, but apparently it doesn't expire
# I'm currently setting it to be a time 20 years in the future, because it can't be set to not expiring
credential = ExternalRegistryCredential.find(2)
credential.update(access_token_expires_at: Time.current + 20.years)
```