### PR TITLE
rename TwitterAccount and MailSnippet address attributes and 

### DIFF
--- a/app/controllers/admin/mail_snippets_controller.rb
+++ b/app/controllers/admin/mail_snippets_controller.rb
@@ -68,8 +68,15 @@ class Admin::MailSnippetsController < Admin::BaseController
   end
 
   def permitted_parameters
-    params.require(:mail_snippet).permit(:name, :body, :is_enabled, :address,
-      :is_location_triggered, :proximity_radius)
+    params.require(:mail_snippet).permit(:kind,
+      :subject,
+      :organization_id,
+      :body,
+      :is_enabled,
+      :latitude,
+      :longitude,
+      :proximity_radius,
+      :is_location_triggered)
   end
 
   def find_snippet

--- a/app/controllers/admin/twitter_accounts_controller.rb
+++ b/app/controllers/admin/twitter_accounts_controller.rb
@@ -65,7 +65,7 @@ class Admin::TwitterAccountsController < Admin::BaseController
   def permitted_parameters
     params.require(:twitter_account).permit(
       :active,
-      :address,
+      :address_string,
       :append_block,
       :city,
       :consumer_key,

--- a/app/models/tweet.rb
+++ b/app/models/tweet.rb
@@ -186,8 +186,8 @@ class Tweet < ApplicationRecord
         details[:tweet_account_image] = twitter_account&.account_info_image
         details[:retweet_screen_names] = retweets.map(&:tweetor)
 
-        if !twitter_account&.national? && twitter_account&.address.present?
-          details[:location] = twitter_account.address.split(",").first.strip
+        if !twitter_account&.national? && twitter_account&.address_string.present?
+          details[:location] = twitter_account.address_string.split(",").first.strip
         end
       end
     end

--- a/app/models/twitter_account.rb
+++ b/app/models/twitter_account.rb
@@ -61,7 +61,7 @@ class TwitterAccount < ApplicationRecord
   def self.attrs_from_user_info(info)
     {
       screen_name: info["info"]["nickname"],
-      address: info["info"]["location"],
+      address_string: info["info"]["location"],
       consumer_key: ENV["TWITTER_CONSUMER_KEY"],
       consumer_secret: ENV["TWITTER_CONSUMER_SECRET"],
       user_token: info["credentials"]["token"],

--- a/app/views/admin/mail_snippets/_form.html.haml
+++ b/app/views/admin/mail_snippets/_form.html.haml
@@ -1,20 +1,42 @@
+.mt-4
 - if @mail_snippet.errors.any?
   = render partial: "/shared/errors", locals: { name: "Mail Snippet", obj: @mail_snippet }
 
 .form-group
   = f.label :kind
   = f.select :kind, MailSnippet.kinds.map { |k| [k.humanize, k] }, { required: true }, class: "form-control"
-.form-group
-  = f.label :address
-  = f.text_field :address, required: true, class: "form-control"
-.form-group
-  = f.label :proximity_radius
-  = f.number_field :proximity_radius, required: true, class: "form-control"
 
 .form-group.fancy-select.unfancy
   = f.label :organization_id
   = f.collection_select(:organization_id, @organizations, :id, :name, { prompt: "Choose organization" }, { class: "form-control" })
 
 .form-group
+  = f.label :subject
+  = f.text_field :subject, class: "form-control"
+.form-group
   = f.label :body
-  = f.text_area :body, placeholder: "Body", class: "form-control"
+  = f.text_area :body, placeholder: "Body", class: "form-control", rows: 5
+
+-# No longer used, but keeping in case we decide to use. Check PR#415
+-# .row
+-#   .col-6
+-#     .form-group
+-#       = f.label :latitude
+-#       = f.number_field :latitude, required: true, class: "form-control"
+-#   .col-6
+-#     .form-group
+-#       = f.label :longitude
+-#       = f.number_field :longitude, required: true, class: "form-control"
+-# .row.mb-4
+-#   .col-6
+-#     .form-group
+-#       = f.label :proximity_radius
+-#       = f.number_field :proximity_radius, required: true, class: "form-control"
+-#   .col-6
+-#     .form-group
+-#       %small.less-strong.d-block.mt-3 NOTE: this isn't currently production ready
+-#       = f.check_box :is_location_triggered
+-#       = f.label :is_location_triggered do
+-#         Location triggered?
+
+

--- a/app/views/admin/mail_snippets/edit.html.haml
+++ b/app/views/admin/mail_snippets/edit.html.haml
@@ -1,5 +1,11 @@
 %h1.mt-4
   Edit Snippet
+- if @mail_snippet.organization_message?
+  %h3.mt-4.mb-4
+    %span.text-warning Organization Snippet!
+    %em.small.d-block.mt-2
+      This should actually be #{link_to "edited though organization!", edit_mail_snippet_path_for(@mail_snippet)}
+
 
 .row
   .col-md-6

--- a/app/views/admin/mail_snippets/index.html.haml
+++ b/app/views/admin/mail_snippets/index.html.haml
@@ -52,9 +52,11 @@
       %th
         = sortable "organization_id"
     %th= sortable "kind"
-    %th Body
+    %th Subject, Body
     %th
       %small Enabled
+    %th
+      %small Geo
 
     %tbody
       - @mail_snippets.each do |mail_snippet|
@@ -62,6 +64,8 @@
           %td
             %a.convertTime{ href: edit_mail_snippet_path_for(mail_snippet) }
               = l mail_snippet.created_at, format: :convert_time
+            - if display_dev_info?
+              %code.small.only-dev-visible= mail_snippet.id
           %td
             %small.convertTime
               = l mail_snippet.updated_at, format: :convert_time
@@ -72,7 +76,10 @@
           %td
             = mail_snippet.kind.humanize
           %td
+            .d-block= mail_snippet.subject
             %small
               = truncate(mail_snippet.body, length: 100)
           %td.table-cell-check
             = check_mark if mail_snippet.is_enabled
+          %td.table-cell-check
+            = check_mark if mail_snippet.with_location?

--- a/db/migrate/20211215163717_rename_twitter_account_address_attr.rb
+++ b/db/migrate/20211215163717_rename_twitter_account_address_attr.rb
@@ -1,0 +1,5 @@
+class RenameTwitterAccountAddressAttr < ActiveRecord::Migration[5.2]
+  def change
+    rename_column :twitter_accounts, :address, :address_string
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -2845,7 +2845,7 @@ CREATE TABLE public.twitter_accounts (
     "national" boolean DEFAULT false NOT NULL,
     latitude double precision,
     longitude double precision,
-    address character varying,
+    address_string character varying,
     append_block character varying,
     city character varying,
     consumer_key character varying NOT NULL,
@@ -5902,6 +5902,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20210811141935'),
 ('20210817204248'),
 ('20210820220126'),
-('20210921181852');
+('20210921181852'),
+('20211215163717');
 
 

--- a/spec/models/twitter_account_spec.rb
+++ b/spec/models/twitter_account_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe TwitterAccount, type: :model do
         skip_geocoding: false,
         state: nil
       )
-      twitter_account.address = "1 New Address"
+      twitter_account.address_string = "1 New Address"
       expect(twitter_account).to be_should_be_geocoded
       expect(twitter_account).to be_should_be_reverse_geocoded
 

--- a/spec/requests/admin/mail_snippets_request_spec.rb
+++ b/spec/requests/admin/mail_snippets_request_spec.rb
@@ -3,6 +3,16 @@ require "rails_helper"
 base_url = "/admin/mail_snippets"
 RSpec.describe Admin::MailSnippetsController, type: :request do
   include_context :request_spec_logged_in_as_superuser
+  let(:organization) { FactoryBot.create(:organization) }
+  let(:valid_params) do
+    {
+      kind: MailSnippet.kinds.first,
+      subject: "Mail Snippetted subject",
+      body: "<p>Something</p>",
+      organization_id: organization.id,
+      is_enabled: false
+    }
+  end
 
   describe "index" do
     it "renders" do
@@ -26,6 +36,18 @@ RSpec.describe Admin::MailSnippetsController, type: :request do
       get "#{base_url}/#{mail_snippet.id}/edit"
       expect(response.status).to eq(200)
       expect(response).to render_template(:edit)
+    end
+  end
+
+  describe "update" do
+    let!(:mail_snippet) { FactoryBot.create(:mail_snippet) }
+    it "updates" do
+      patch "#{base_url}/#{mail_snippet.id}", params: {mail_snippet: valid_params}
+
+      expect(response).to redirect_to(edit_admin_mail_snippet_path(mail_snippet.to_param))
+      expect(flash[:errors]).to be_blank
+      mail_snippet.reload
+      expect_attrs_to_match_hash(mail_snippet, valid_params)
     end
   end
 end


### PR DESCRIPTION
- `TwitterAccount` has an `address` string attribute - it's confusing because of the `address` method in `Geocodeable`. Rename the attribute to `address_string`
- `MailSnippet` has lingering fields for address, even though it doesn't actually include that attribute anymore. Fix that!