### PR TITLE
Speed up ownership migration

### DIFF
--- a/app/workers/migrate_ownership_worker.rb
+++ b/app/workers/migrate_ownership_worker.rb
@@ -20,9 +20,8 @@ class MigrateOwnershipWorker < ApplicationWorker
     bike = Bike.unscoped.find_by_id(bike_id)
     return if bike.blank?
     bike.update_column :soon_current_ownership_id, bike.current_ownership&.id
+    return if bike.conditional_information.blank?
     new_info = (bike.current_ownership&.registration_info || {}).merge(bike.conditional_information)
-    if new_info.present?
-      bike.current_ownership&.update(registration_info: new_info)
-    end
+    bike.current_ownership&.update(registration_info: new_info)
   end
 end

--- a/app/workers/migrate_ownership_worker.rb
+++ b/app/workers/migrate_ownership_worker.rb
@@ -6,7 +6,9 @@ class MigrateOwnershipWorker < ApplicationWorker
   TO_ENQUEUE = (ENV["MIGRATE_OWNERSHIP_QUEUE"] || 2500).to_i
 
   def self.bikes
-    Bike.unscoped.where("updated_at < ?", Time.at(END_TIMESTAMP)).order(updated_at: :desc)
+    Bike.unscoped.where("updated_at < ?", Time.at(END_TIMESTAMP))
+      .where.not(soon_current_ownership_id: nil)
+      .order(updated_at: :desc)
   end
 
   def self.enqueue

--- a/app/workers/migrate_ownership_worker.rb
+++ b/app/workers/migrate_ownership_worker.rb
@@ -7,7 +7,7 @@ class MigrateOwnershipWorker < ApplicationWorker
 
   def self.bikes
     Bike.unscoped.where("updated_at < ?", Time.at(END_TIMESTAMP))
-      .where.not(soon_current_ownership_id: nil)
+      .where(soon_current_ownership_id: nil)
       .order(updated_at: :desc)
   end
 

--- a/app/workers/migrate_ownership_worker.rb
+++ b/app/workers/migrate_ownership_worker.rb
@@ -19,8 +19,10 @@ class MigrateOwnershipWorker < ApplicationWorker
   def perform(bike_id)
     bike = Bike.unscoped.find_by_id(bike_id)
     return if bike.blank?
-    bike.save
+    bike.update_column :soon_current_ownership_id, bike.current_ownership&.id
     new_info = (bike.current_ownership&.registration_info || {}).merge(bike.conditional_information)
-    bike.current_ownership&.update(registration_info: new_info)
+    if new_info.present?
+      bike.current_ownership&.update(registration_info: new_info)
+    end
   end
 end


### PR DESCRIPTION
Follows #2110

There are a number of bikes without ownerships. Because this migration isn't updating the `updated_at` column, they were getting re-enqueued over and over.

I bumped their `updated_at` to post the `END_TIMESTAMP` time:

```ruby
Bike.unscoped.where(soon_current_ownership_id: nil).includes(:ownerships).where(ownerships: {id: nil}).update_all(updated_at: Time.at(1640292127))
```