### PR TITLE
remove handlebar_type_other and propulsion_type_other

### DIFF
--- a/app/assets/javascripts/revised/pages/bikes/edit_accessories.coffee
+++ b/app/assets/javascripts/revised/pages/bikes/edit_accessories.coffee
@@ -5,9 +5,7 @@ class BikeIndex.BikesEditAccessories extends BikeIndex
     ctype_other_val = $('#form_well_wrap').data('ctypeother')
     manufacturer_other_val = $('#form_well_wrap').data('manufacturerother')
     ctype_other_val = $('#form_well_wrap').data('ctypeother')
-    handlebar_type_other_val = $('#form_well_wrap').data('handlebartypeother')
     new BikeIndex.ToggleHiddenOther('.component-manufacturer-input', manufacturer_other_val)
-    new BikeIndex.ToggleHiddenOther('.handlebar-type-input', handlebar_type_other_val)
     new BikeIndex.ToggleHiddenOther('.component-ctype-input', ctype_other_val)
 
   initializeEventListeners: ->

--- a/app/services/bike_creator.rb
+++ b/app/services/bike_creator.rb
@@ -6,7 +6,7 @@ class BikeCreator
       serial_normalized made_without_serial extra_registration_number
       creation_organization_id manufacturer year thumb_path name
       current_stolen_record_id abandoned frame_material cycle_type frame_model number_of_seats
-      handlebar_type handlebar_type_other frame_size frame_size_number frame_size_unit
+      handlebar_type frame_size frame_size_number frame_size_unit
       rear_tire_narrow front_wheel_size_id rear_wheel_size_id front_tire_narrow
       primary_frame_color_id secondary_frame_color_id tertiary_frame_color_id paint_id paint_name
       propulsion_type street zipcode country_id state_id city belt_drive

--- a/app/views/admin/dashboard/maintenance.html.haml
+++ b/app/views/admin/dashboard/maintenance.html.haml
@@ -82,6 +82,4 @@
                 = l f.created_at, format: :convert_time
 
             %td
-              = f.handlebar_type_other
-            %td
               = link_to f.id, edit_admin_bike_url(f)

--- a/app/views/bikes_edit/accessories.html.haml
+++ b/app/views/bikes_edit/accessories.html.haml
@@ -17,7 +17,7 @@
             .form-group.row.unnested-field.no-divider-row
               = f.label :handlebar_type_id, class: 'form-well-label'
               .form-well-input.fancy-select-placeholder.unfancy
-                = select(:bike, :handlebar_type, HandlebarType.select_options , { prompt: " " }, { class: "form-control handlebar-type-input" })
+                = select(:bike, :handlebar_type, HandlebarType.select_options , { prompt: " " }, { class: "form-control" })
 
           %fieldset.add-additional
             #has_multiples_parts{ data: { ids: Ctype.where(has_multiple: true).map(&:id).to_json } }

--- a/app/views/bikes_edit/accessories.html.haml
+++ b/app/views/bikes_edit/accessories.html.haml
@@ -1,7 +1,6 @@
 - @ctype_other_id = Ctype.other.id
 - @manufacturer_other_id = Manufacturer.other.id
 
-- handlebar_type_other = "other" # Because we're assigning as an enum
 = form_for @bike, multipart: true, html: { class: 'primary-edit-bike-form' } do |f|
   - if params[:return_to].present?
     = hidden_field_tag :return_to, params[:return_to]
@@ -9,7 +8,7 @@
     .row
       = render partial: '/bikes_edit/primary_menu'
 
-      .col-md-8.form-well#form_well_wrap{ data: { ctypeother: @ctype_other_id, manufacturerother: @manufacturer_other_id, handlebartypeother: handlebar_type_other } }
+      .col-md-8.form-well#form_well_wrap{ data: { ctypeother: @ctype_other_id, manufacturerother: @manufacturer_other_id } }
         .form-wrap
           .form-well-form-header
             %h3= @edit_templates[@edit_template]
@@ -19,10 +18,6 @@
               = f.label :handlebar_type_id, class: 'form-well-label'
               .form-well-input.fancy-select-placeholder.unfancy
                 = select(:bike, :handlebar_type, HandlebarType.select_options , { prompt: " " }, { class: "form-control handlebar-type-input" })
-            .form-group.row.hidden-other{ class: @bike.handlebar_type == "other" ? "unhidden" : "" }
-              = f.label :handlebar_type_other, t(".other_handlebar_type"), class: "form-well-label"
-              .form-well-input
-                = f.text_field :handlebar_type_other, class: "form-control"
 
           %fieldset.add-additional
             #has_multiples_parts{ data: { ids: Ctype.where(has_multiple: true).map(&:id).to_json } }

--- a/config/locales/.translation_io
+++ b/config/locales/.translation_io
@@ -1,2 +1,2 @@
 ---
-timestamp: 1640970181
+timestamp: 1641139123

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -126,7 +126,6 @@ en:
         front_tire_narrow: Front tire narrow
         front_wheel_size: :activerecord.models.front_wheel_size
         handlebar_type: Handlebar type
-        handlebar_type_other: Handlebar type other
         hidden: Hidden
         invoice: :activerecord.models.invoice
         is_for_sale: Is for sale

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1345,7 +1345,6 @@ en:
   bikes_edit:
     accessories:
       add_a_component: Add a component
-      other_handlebar_type: Other handlebar type
     bike_details:
       a_qr_sticker: a QR Sticker
       add_a_sticker_label_html: Add %{sticker_information_link}

--- a/config/locales/translation.nl.yml
+++ b/config/locales/translation.nl.yml
@@ -364,7 +364,6 @@ nl:
         frame_size_unit: Framemaat eenheid
         front_tire_narrow: Voorband smal
         handlebar_type: Type stuur
-        handlebar_type_other: Type stuur anders
         hidden: Verborgen
         is_for_sale: Is te koop
         listing_order: Aanbieding bestelling
@@ -5757,7 +5756,6 @@ nl:
   bikes_edit:
     accessories:
       add_a_component: Voeg een component toe
-      other_handlebar_type: Ander type stuur
     bike_details:
       a_qr_sticker: een QR-sticker
       add_a_sticker_label_html: Voeg %{sticker_information_link} toe

--- a/db/migrate/20220102153706_remove_handlebar_type_other.rb
+++ b/db/migrate/20220102153706_remove_handlebar_type_other.rb
@@ -1,0 +1,6 @@
+class RemoveHandlebarTypeOther < ActiveRecord::Migration[5.2]
+  def change
+    remove_column :bikes, :handlebar_type_other, :string
+    remove_column :bikes, :propulsion_type_other, :string
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -365,73 +365,6 @@ ALTER SEQUENCE public.bike_stickers_id_seq OWNED BY public.bike_stickers.id;
 
 
 --
--- Name: bike_versions; Type: TABLE; Schema: public; Owner: -
---
-
-CREATE TABLE public.bike_versions (
-    id bigint NOT NULL,
-    owner_id bigint,
-    bike_id bigint,
-    paint_id bigint,
-    manufacturer_id bigint,
-    primary_frame_color_id bigint,
-    secondary_frame_color_id bigint,
-    tertiary_frame_color_id bigint,
-    front_wheel_size_id bigint,
-    rear_wheel_size_id bigint,
-    rear_gear_type_id bigint,
-    front_gear_type_id bigint,
-    name character varying,
-    frame_model text,
-    rear_tire_narrow boolean,
-    number_of_seats integer,
-    propulsion_type_other character varying,
-    manufacturer_other character varying,
-    cached_data text,
-    description text,
-    thumb_path text,
-    video_embed text,
-    year integer,
-    front_tire_narrow boolean,
-    handlebar_type_other character varying,
-    belt_drive boolean,
-    coaster_brake boolean,
-    frame_size character varying,
-    frame_size_unit character varying,
-    listing_order integer,
-    all_description text,
-    mnfg_name character varying,
-    frame_size_number double precision,
-    frame_material integer,
-    handlebar_type integer,
-    cycle_type integer,
-    propulsion_type integer,
-    visibility integer DEFAULT 0,
-    created_at timestamp without time zone NOT NULL,
-    updated_at timestamp without time zone NOT NULL
-);
-
-
---
--- Name: bike_versions_id_seq; Type: SEQUENCE; Schema: public; Owner: -
---
-
-CREATE SEQUENCE public.bike_versions_id_seq
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
-
-
---
--- Name: bike_versions_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
---
-
-ALTER SEQUENCE public.bike_versions_id_seq OWNED BY public.bike_versions.id;
-
-
---
 -- Name: bikes; Type: TABLE; Schema: public; Owner: -
 --
 
@@ -726,8 +659,7 @@ CREATE TABLE public.components (
     rear boolean,
     manufacturer_other character varying(255),
     serial_number character varying(255),
-    is_stock boolean DEFAULT false NOT NULL,
-    bike_version_id bigint
+    is_stock boolean DEFAULT false NOT NULL
 );
 
 
@@ -3200,13 +3132,6 @@ ALTER TABLE ONLY public.bike_stickers ALTER COLUMN id SET DEFAULT nextval('publi
 
 
 --
--- Name: bike_versions id; Type: DEFAULT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.bike_versions ALTER COLUMN id SET DEFAULT nextval('public.bike_versions_id_seq'::regclass);
-
-
---
 -- Name: bikes id; Type: DEFAULT; Schema: public; Owner: -
 --
 
@@ -3746,14 +3671,6 @@ ALTER TABLE ONLY public.bike_sticker_updates
 
 ALTER TABLE ONLY public.bike_stickers
     ADD CONSTRAINT bike_stickers_pkey PRIMARY KEY (id);
-
-
---
--- Name: bike_versions bike_versions_pkey; Type: CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.bike_versions
-    ADD CONSTRAINT bike_versions_pkey PRIMARY KEY (id);
 
 
 --
@@ -4411,83 +4328,6 @@ CREATE INDEX index_bike_stickers_on_secondary_organization_id ON public.bike_sti
 
 
 --
--- Name: index_bike_versions_on_bike_id; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX index_bike_versions_on_bike_id ON public.bike_versions USING btree (bike_id);
-
-
---
--- Name: index_bike_versions_on_front_gear_type_id; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX index_bike_versions_on_front_gear_type_id ON public.bike_versions USING btree (front_gear_type_id);
-
-
---
--- Name: index_bike_versions_on_front_wheel_size_id; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX index_bike_versions_on_front_wheel_size_id ON public.bike_versions USING btree (front_wheel_size_id);
-
-
---
--- Name: index_bike_versions_on_manufacturer_id; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX index_bike_versions_on_manufacturer_id ON public.bike_versions USING btree (manufacturer_id);
-
-
---
--- Name: index_bike_versions_on_owner_id; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX index_bike_versions_on_owner_id ON public.bike_versions USING btree (owner_id);
-
-
---
--- Name: index_bike_versions_on_paint_id; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX index_bike_versions_on_paint_id ON public.bike_versions USING btree (paint_id);
-
-
---
--- Name: index_bike_versions_on_primary_frame_color_id; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX index_bike_versions_on_primary_frame_color_id ON public.bike_versions USING btree (primary_frame_color_id);
-
-
---
--- Name: index_bike_versions_on_rear_gear_type_id; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX index_bike_versions_on_rear_gear_type_id ON public.bike_versions USING btree (rear_gear_type_id);
-
-
---
--- Name: index_bike_versions_on_rear_wheel_size_id; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX index_bike_versions_on_rear_wheel_size_id ON public.bike_versions USING btree (rear_wheel_size_id);
-
-
---
--- Name: index_bike_versions_on_secondary_frame_color_id; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX index_bike_versions_on_secondary_frame_color_id ON public.bike_versions USING btree (secondary_frame_color_id);
-
-
---
--- Name: index_bike_versions_on_tertiary_frame_color_id; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX index_bike_versions_on_tertiary_frame_color_id ON public.bike_versions USING btree (tertiary_frame_color_id);
-
-
---
 -- Name: index_bikes_on_current_impound_record_id; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -4618,13 +4458,6 @@ CREATE INDEX index_blog_content_tags_on_content_tag_id ON public.blog_content_ta
 --
 
 CREATE INDEX index_components_on_bike_id ON public.components USING btree (bike_id);
-
-
---
--- Name: index_components_on_bike_version_id; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX index_components_on_bike_version_id ON public.components USING btree (bike_version_id);
 
 
 --
@@ -6020,7 +5853,6 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20211222230922'),
 ('20211223213257'),
 ('20211224053713'),
-('20211227142124'),
 ('20220102153706');
 
 

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -365,6 +365,73 @@ ALTER SEQUENCE public.bike_stickers_id_seq OWNED BY public.bike_stickers.id;
 
 
 --
+-- Name: bike_versions; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.bike_versions (
+    id bigint NOT NULL,
+    owner_id bigint,
+    bike_id bigint,
+    paint_id bigint,
+    manufacturer_id bigint,
+    primary_frame_color_id bigint,
+    secondary_frame_color_id bigint,
+    tertiary_frame_color_id bigint,
+    front_wheel_size_id bigint,
+    rear_wheel_size_id bigint,
+    rear_gear_type_id bigint,
+    front_gear_type_id bigint,
+    name character varying,
+    frame_model text,
+    rear_tire_narrow boolean,
+    number_of_seats integer,
+    propulsion_type_other character varying,
+    manufacturer_other character varying,
+    cached_data text,
+    description text,
+    thumb_path text,
+    video_embed text,
+    year integer,
+    front_tire_narrow boolean,
+    handlebar_type_other character varying,
+    belt_drive boolean,
+    coaster_brake boolean,
+    frame_size character varying,
+    frame_size_unit character varying,
+    listing_order integer,
+    all_description text,
+    mnfg_name character varying,
+    frame_size_number double precision,
+    frame_material integer,
+    handlebar_type integer,
+    cycle_type integer,
+    propulsion_type integer,
+    visibility integer DEFAULT 0,
+    created_at timestamp without time zone NOT NULL,
+    updated_at timestamp without time zone NOT NULL
+);
+
+
+--
+-- Name: bike_versions_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.bike_versions_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: bike_versions_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.bike_versions_id_seq OWNED BY public.bike_versions.id;
+
+
+--
 -- Name: bikes; Type: TABLE; Schema: public; Owner: -
 --
 
@@ -379,7 +446,6 @@ CREATE TABLE public.bikes (
     creation_organization_id integer,
     created_at timestamp without time zone NOT NULL,
     updated_at timestamp without time zone NOT NULL,
-    propulsion_type_other character varying(255),
     manufacturer_other character varying(255),
     zipcode character varying(255),
     cached_data text,
@@ -393,7 +459,6 @@ CREATE TABLE public.bikes (
     primary_frame_color_id integer,
     secondary_frame_color_id integer,
     tertiary_frame_color_id integer,
-    handlebar_type_other character varying(255),
     front_wheel_size_id integer,
     rear_wheel_size_id integer,
     rear_gear_type_id integer,
@@ -661,7 +726,8 @@ CREATE TABLE public.components (
     rear boolean,
     manufacturer_other character varying(255),
     serial_number character varying(255),
-    is_stock boolean DEFAULT false NOT NULL
+    is_stock boolean DEFAULT false NOT NULL,
+    bike_version_id bigint
 );
 
 
@@ -3134,6 +3200,13 @@ ALTER TABLE ONLY public.bike_stickers ALTER COLUMN id SET DEFAULT nextval('publi
 
 
 --
+-- Name: bike_versions id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.bike_versions ALTER COLUMN id SET DEFAULT nextval('public.bike_versions_id_seq'::regclass);
+
+
+--
 -- Name: bikes id; Type: DEFAULT; Schema: public; Owner: -
 --
 
@@ -3673,6 +3746,14 @@ ALTER TABLE ONLY public.bike_sticker_updates
 
 ALTER TABLE ONLY public.bike_stickers
     ADD CONSTRAINT bike_stickers_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: bike_versions bike_versions_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.bike_versions
+    ADD CONSTRAINT bike_versions_pkey PRIMARY KEY (id);
 
 
 --
@@ -4330,6 +4411,83 @@ CREATE INDEX index_bike_stickers_on_secondary_organization_id ON public.bike_sti
 
 
 --
+-- Name: index_bike_versions_on_bike_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_bike_versions_on_bike_id ON public.bike_versions USING btree (bike_id);
+
+
+--
+-- Name: index_bike_versions_on_front_gear_type_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_bike_versions_on_front_gear_type_id ON public.bike_versions USING btree (front_gear_type_id);
+
+
+--
+-- Name: index_bike_versions_on_front_wheel_size_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_bike_versions_on_front_wheel_size_id ON public.bike_versions USING btree (front_wheel_size_id);
+
+
+--
+-- Name: index_bike_versions_on_manufacturer_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_bike_versions_on_manufacturer_id ON public.bike_versions USING btree (manufacturer_id);
+
+
+--
+-- Name: index_bike_versions_on_owner_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_bike_versions_on_owner_id ON public.bike_versions USING btree (owner_id);
+
+
+--
+-- Name: index_bike_versions_on_paint_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_bike_versions_on_paint_id ON public.bike_versions USING btree (paint_id);
+
+
+--
+-- Name: index_bike_versions_on_primary_frame_color_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_bike_versions_on_primary_frame_color_id ON public.bike_versions USING btree (primary_frame_color_id);
+
+
+--
+-- Name: index_bike_versions_on_rear_gear_type_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_bike_versions_on_rear_gear_type_id ON public.bike_versions USING btree (rear_gear_type_id);
+
+
+--
+-- Name: index_bike_versions_on_rear_wheel_size_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_bike_versions_on_rear_wheel_size_id ON public.bike_versions USING btree (rear_wheel_size_id);
+
+
+--
+-- Name: index_bike_versions_on_secondary_frame_color_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_bike_versions_on_secondary_frame_color_id ON public.bike_versions USING btree (secondary_frame_color_id);
+
+
+--
+-- Name: index_bike_versions_on_tertiary_frame_color_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_bike_versions_on_tertiary_frame_color_id ON public.bike_versions USING btree (tertiary_frame_color_id);
+
+
+--
 -- Name: index_bikes_on_current_impound_record_id; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -4460,6 +4618,13 @@ CREATE INDEX index_blog_content_tags_on_content_tag_id ON public.blog_content_ta
 --
 
 CREATE INDEX index_components_on_bike_id ON public.components USING btree (bike_id);
+
+
+--
+-- Name: index_components_on_bike_version_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_components_on_bike_version_id ON public.components USING btree (bike_version_id);
 
 
 --
@@ -5854,6 +6019,8 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20211221010148'),
 ('20211222230922'),
 ('20211223213257'),
-('20211224053713');
+('20211224053713'),
+('20211227142124'),
+('20220102153706');
 
 

--- a/spec/controllers/bikes_controller_spec.rb
+++ b/spec/controllers/bikes_controller_spec.rb
@@ -851,7 +851,6 @@ RSpec.describe BikesController, type: :controller do
           bike_attrs = {
             description: "69",
             handlebar_type: other_handlebar_type,
-            handlebar_type_other: "Joysticks",
             owner_email: "  #{bike.owner_email.upcase}",
             city: "Rotterdam",
             zipcode: "3035",
@@ -872,7 +871,6 @@ RSpec.describe BikesController, type: :controller do
           expect(bike.description).to eq("69")
           expect(response).to redirect_to edit_bike_url(bike)
           expect(bike.handlebar_type).to eq other_handlebar_type
-          expect(bike.handlebar_type_other).to eq "Joysticks"
           expect(assigns(:bike)).to be_present
           expect(bike.user_hidden).to be_falsey
           expect(bike.country&.name).to eq(Country.netherlands.name)


### PR DESCRIPTION
There are currently no `propulsion_type_other` values in the database.

`handlebar_type_other` isn't really adding much.

The values that have been added in the past year
```ruby
Bike.where.not(handlebar_type_other: [nil, ""]).where("updated_at > ?", Time.current - 1.year).pluck(:handlebar_type_other).uniq`)
```

```
["Two side by side joystick style"
"Rack and pinion steering handles"
"Recumbent trike"
"Mounted below the seat"
"Recumbent upright"
"Comfort/Cruiser style"
"Underseat Steering"
"control handles"
"Split cargo bike handle bars"
"Orange Front Rack"
"Butterfly/Trekking handlebars"
"Aluminum handle bar / steering"
"Apehangers"
"Vertical Recumbent Trike "Tank" style steering"
"Bullhorn"
"Underseat Steering"
"Brompton - P-type"
"Brompton - M-type"
"Flat"
"Riser bars"]
```

... which leads me to think that the current system accounts for all the types. I was tempted to add "underseat" or "joystick" as an option - but I realized that actually fits into the "Not handlebars" categorization very neatly.