### PR TITLE
Fix logout redirect for Bikehub

### DIFF
--- a/app/controllers/concerns/controller_helpers.rb
+++ b/app/controllers/concerns/controller_helpers.rb
@@ -363,6 +363,10 @@ module ControllerHelpers
     "#{valid_partner_domain || "https://parkit.bikehub.com"}/#{path}"
   end
 
+  def bikehub_website_url(path = nil)
+    return "#{valid_partner_domain || 'https://bikehub.com'}/#{path}"
+  end
+
   def valid_partner_domain
     # Sometimes might just be return_to, but if there is a redirect_uri query param, use that
     redirect_redirect_uri = Addressable::URI.parse(session[:return_to])&.query_values&.dig("redirect_uri")

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -68,7 +68,7 @@ class SessionsController < ApplicationController
   def destroy
     remove_session
     if params[:partner] == "bikehub"
-      redirect_to(bikehub_url) && return
+      redirect_to(bikehub_website_url) && return
     elsif params[:redirect_location].present?
       if params[:redirect_location].match?("new_user")
         redirect_to(new_user_path, notice: "Logged out!") && return

--- a/spec/controllers/sessions_controller_spec.rb
+++ b/spec/controllers/sessions_controller_spec.rb
@@ -173,7 +173,7 @@ RSpec.describe SessionsController, type: :controller do
         get :destroy, params: {partner: "bikehub"}
         expect(cookies.signed[:auth]).to be_nil
         expect(session[:user_id]).to be_nil
-        expect(response).to redirect_to "https://parkit.bikehub.com/"
+        expect(response).to redirect_to "https://bikehub.com/"
         expect(session[:return_to]).to be_nil
         expect(session[:partner]).to be_nil
         expect(session[:passive_organization_id]).to be_nil
@@ -197,7 +197,7 @@ RSpec.describe SessionsController, type: :controller do
             get :destroy, params: {partner: "bikehub", return_to: "https://badplace.stuff.com/"}
             expect(cookies.signed[:auth]).to be_nil
             expect(session[:user_id]).to be_nil
-            expect(response).to redirect_to "https://parkit.bikehub.com/"
+            expect(response).to redirect_to "https://bikehub.com/"
             expect(session[:return_to]).to be_nil
             expect(session[:partner]).to be_nil
             expect(session[:passive_organization_id]).to be_nil


### PR DESCRIPTION
By default, redirect back to `bikehub.com` so that folks won't then get immediately redirected back to the Bikehub login page.