### PR TITLE
Minor account display improvements

### DIFF
--- a/app/assets/stylesheets/revised/pages/my_accounts/_show.scss
+++ b/app/assets/stylesheets/revised/pages/my_accounts/_show.scss
@@ -1,4 +1,10 @@
 #my_accounts_show {
+  .title-link {
+    font-size: 17px;
+    a {
+      color: $body-font-color;
+    }
+  }
   .lock-group {
     @extend .row;
 

--- a/app/helpers/bike_helper.rb
+++ b/app/helpers/bike_helper.rb
@@ -19,13 +19,18 @@ module BikeHelper
     end
   end
 
-  # The same thing as title_string - but with the manufacturer bold
-  def bike_title_html(bike)
+  def bike_title_html(bike, include_status: false)
     content_tag(:span) do
-      concat("#{bike.year} ") if bike.year.present?
-      concat(content_tag(:strong, bike.mnfg_name))
+      if include_status && bike_status_span(bike).present?
+        concat(bike_status_span(bike))
+        concat(" ")
+      end
+      year_and_mnfg = [bike.year, bike.mnfg_name].compact.join(" ")
+      concat(content_tag(:strong, year_and_mnfg))
       concat(" #{bike.frame_model_truncated}") if bike.frame_model.present?
-      concat(" #{bike.type}") if bike.type != "bike"
+      if bike.type != "bike"
+        concat(content_tag(:em, " #{bike.type&.titleize}"))
+      end
     end
   end
 end

--- a/app/helpers/header_tag_helper.rb
+++ b/app/helpers/header_tag_helper.rb
@@ -117,9 +117,9 @@ module HeaderTagHelper
       status_prefix = @bike.status_with_owner? ? "" : @bike.status_humanized.titleize
       self.page_title = [status_prefix, @bike.title_string].compact.join(" ")
       special_status_string = if @bike.status_stolen? && @bike.current_stolen_record.present?
-        "#{status_prefix}: #{@bike.current_stolen_record.date_stolen&.strftime("%Y-%m-%d")}, from: #{@bike.current_stolen_record.address}"
+        "#{status_prefix}: #{@bike.current_stolen_record.date_stolen&.strftime("%Y-%m-%d")}, from: #{@bike.current_stolen_record.address(country: [:iso])}"
       elsif @bike.current_impound_record.present?
-        "#{status_prefix}: #{@bike.current_impound_record.impounded_at&.strftime("%Y-%m-%d")}, in: #{@bike.current_impound_record.address}"
+        "#{status_prefix}: #{@bike.current_impound_record.impounded_at&.strftime("%Y-%m-%d")}, in: #{@bike.current_impound_record.address(country: [:iso, :optional])}"
       end
       self.page_description = [
         "#{@bike.frame_colors.to_sentence} #{@bike.title_string}, serial: #{@bike.serial_display}.",

--- a/app/models/bike.rb
+++ b/app/models/bike.rb
@@ -537,6 +537,14 @@ class Bike < ApplicationRecord
     self.current_stolen_record = StolenRecord.where(bike_id: id, current: true).reorder(:id).last
   end
 
+  def current_record
+    current_impound_record || current_stolen_record
+  end
+
+  def current_record_date
+    current_impound_record&.impounded_at || current_stolen_record&.date_stolen
+  end
+
   def bike_organization_ids
     bike_organizations.pluck(:organization_id)
   end

--- a/app/models/impound_record.rb
+++ b/app/models/impound_record.rb
@@ -105,7 +105,7 @@ class ImpoundRecord < ApplicationRecord
   end
 
   # force_show_address, just like parking_notification
-  def address(force_show_address: false, country: [:skip_default, :iso])
+  def address(force_show_address: false, country: [:iso, :optional, :skip_default])
     Geocodeable.address(
       self,
       street: (force_show_address || show_address),

--- a/app/models/impound_record.rb
+++ b/app/models/impound_record.rb
@@ -105,11 +105,11 @@ class ImpoundRecord < ApplicationRecord
   end
 
   # force_show_address, just like parking_notification
-  def address(force_show_address: false)
+  def address(force_show_address: false, country: [:skip_default, :iso])
     Geocodeable.address(
       self,
       street: (force_show_address || show_address),
-      country: %i[skip_default optional]
+      country: country
     ).presence
   end
 

--- a/app/models/parking_notification.rb
+++ b/app/models/parking_notification.rb
@@ -220,11 +220,11 @@ class ParkingNotification < ActiveRecord::Base
   end
 
   # force_show_address, just like stolen_record - but this has a hide_address attr, so by default we show addresses
-  def address(force_show_address: false)
+  def address(force_show_address: false, country: [:skip_default, :iso])
     Geocodeable.address(
       self,
       street: (force_show_address || show_address),
-      country: %i[skip_default optional]
+      country: county
     ).presence
   end
 

--- a/app/models/parking_notification.rb
+++ b/app/models/parking_notification.rb
@@ -220,11 +220,11 @@ class ParkingNotification < ActiveRecord::Base
   end
 
   # force_show_address, just like stolen_record - but this has a hide_address attr, so by default we show addresses
-  def address(force_show_address: false, country: [:skip_default, :iso])
+  def address(force_show_address: false, country: [:iso, :optional, :skip_default])
     Geocodeable.address(
       self,
       street: (force_show_address || show_address),
-      country: county
+      country: country
     ).presence
   end
 

--- a/app/models/stolen_record.rb
+++ b/app/models/stolen_record.rb
@@ -170,7 +170,7 @@ class StolenRecord < ApplicationRecord
     false
   end
 
-  def address(force_show_address: false, country: [:iso])
+  def address(force_show_address: false, country: [:iso, :optional, :skip_default])
     Geocodeable.address(
       self,
       street: (force_show_address || show_address),

--- a/app/models/stolen_record.rb
+++ b/app/models/stolen_record.rb
@@ -170,28 +170,12 @@ class StolenRecord < ApplicationRecord
     false
   end
 
-  def address(force_show_address: false, country: [:iso, :optional, :skip_default])
+  def address(force_show_address: false, country: [:iso, :optional])
     Geocodeable.address(
       self,
       street: (force_show_address || show_address),
       country: country
     ).presence
-  end
-
-  # The stolen bike's general location (city and state / city and country if non-US)
-  # Include all available components (city, state, country) unconditionally if
-  # `include_all` is passed.
-  def address_location(include_all: false)
-    city_and_state =
-      [city&.titleize, state&.abbreviation&.upcase].reject(&:blank?).join(", ")
-
-    if include_all.present?
-      [city_and_state, country&.iso].reject(&:blank?).join(" - ")
-    elsif state.present?
-      city_and_state
-    elsif country.present?
-      [city&.titleize, country&.iso].reject(&:blank?).join(" - ")
-    end
   end
 
   def set_calculated_attributes

--- a/app/models/stolen_record.rb
+++ b/app/models/stolen_record.rb
@@ -170,11 +170,11 @@ class StolenRecord < ApplicationRecord
     false
   end
 
-  def address(skip_default_country: false, force_show_address: false)
+  def address(force_show_address: false, country: [:iso])
     Geocodeable.address(
       self,
       street: (force_show_address || show_address),
-      country: [(:skip_default if skip_default_country)]
+      country: country
     ).presence
   end
 

--- a/app/serializers/bike_v2_serializer.rb
+++ b/app/serializers/bike_v2_serializer.rb
@@ -82,7 +82,7 @@ class BikeV2Serializer < ApplicationSerializer
   end
 
   def stolen_location
-    current_stolen_record&.address_location(include_all: true)
+    current_stolen_record&.address
   end
 
   def stolen_coordinates

--- a/app/serializers/stolen_record_v2_serializer.rb
+++ b/app/serializers/stolen_record_v2_serializer.rb
@@ -21,7 +21,7 @@ class StolenRecordV2Serializer < ApplicationSerializer
   end
 
   def location
-    object.address_location(include_all: true)
+    object.address
   end
 
   def latitude

--- a/app/views/bikes/_bike.html.haml
+++ b/app/views/bikes/_bike.html.haml
@@ -24,17 +24,10 @@
                 = t(".hidden_for_unauthorized_users")
               = t(".hidden_because_status", bike_type: bike.type, status: bike.status_humanized_translated)
       = attr_list_item(bike.frame_colors.to_sentence, t(".primary_colors"))
-    - if bike.current_stolen_record.present?
+    - if bike.current_record_date.present?
       %ul.attr-list
         %li
           #{bike_status_span(bike)}:
           %span.convertTime
-            = l bike.current_stolen_record.date_stolen, format: :convert_time
-        = attr_list_item(bike.current_stolen_record.address_location(include_all: true), t(".location"))
-    - if bike.current_impound_record.present?
-      %ul.attr-list
-        %li
-          #{bike_status_span(bike)}:
-          %span.convertTime
-            = l bike.current_impound_record.impounded_at, format: :convert_time
-        = attr_list_item(bike.current_impound_record.address, t(".location"))
+            = l bike.current_record_date, format: :convert_time
+        = attr_list_item(bike.current_record.address(country: [:iso]), t(".location"))

--- a/app/views/bikes/_main_show_block.html.haml
+++ b/app/views/bikes/_main_show_block.html.haml
@@ -92,7 +92,7 @@
           = render partial: "stolen_map", locals: { mapping_record: @stolen_record }
         .col-md-4
           %ul.attr-list.separate-lines
-            = attr_list_item(@stolen_record.address(skip_default_country: true), t(".location"))
+            = attr_list_item(@stolen_record.address(country: [:skip_default]), t(".location"))
             = attr_list_item(@stolen_record.locking_description, t(".locking_description"))
             = attr_list_item(@stolen_record.lock_defeat_description, t(".locking_circumvented"))
             %li

--- a/app/views/my_accounts/show.html.haml
+++ b/app/views/my_accounts/show.html.haml
@@ -33,15 +33,18 @@
                       = bike_thumb_image(bike)
                     .bike-information.multi-attr-lists
                       %h5.title-link
-                        = bike_status_span(bike)
-                        %strong
-                          - unless bike.type == 'bike'
-                            = bike.type
-                          = [bike.year, bike.mnfg_name].reject(&:blank?).join(' ')
-                        #{bike.frame_model}
+                        = link_to bike_title_html(bike, include_status: true), bike_path(bike)
                       %ul.attr-list
                         = attr_list_item(bike.serial_display(current_user), t(".serial"))
                         = attr_list_item(bike.frame_colors.to_sentence, t(".primary_colors"))
+                        %li.less-strong
+                          %strong.attr-title #{t(".registered")}:
+                          %span.convertTime= l bike.created_at, format: :convert_time
+                        %li.less-strong
+                          %strong.attr-title #{t(".updated")}:
+                          %span.convertTime= l bike.updated_by_user_fallback, format: :convert_time
+
+                      %ul.attr-list
                         - if bike.bike_stickers.any?
                           - sticker_count = bike.bike_stickers.count
                           %li
@@ -54,21 +57,12 @@
                             - else
                               - bike.bike_stickers.includes(:bike_sticker_batch).each do |bike_sticker|
                                 %code.sticker-code= bike_sticker.pretty_code
-                        %br
                         - if bike.current_record_date.present?
                           %li
-                            %strong.attr-title= bike.status_humanized.titleize
+                            %strong.attr-title #{bike.status_humanized.titleize}:
                             %span.convertTime= l bike.current_record_date, format: :convert_time
                         - if bike.current_record.present?
                           = attr_list_item(bike.current_record.address(country: [:skip_default]), t(".location"))
-
-                      %ul.attr-list
-                        %li
-                          %strong.attr-title= t(".registered")
-                          %span.convertTime= l bike.created_at, format: :convert_time
-                        %li
-                          %strong.attr-title= t(".updated")
-                          %span.convertTime= l bike.updated_by_user_fallback, format: :convert_time
 
                         %li= link_to t(".edit_bike"), edit_bike_path(bike, edit_template: bike.default_edit_template)
                         - if bike.status_stolen?

--- a/app/views/my_accounts/show.html.haml
+++ b/app/views/my_accounts/show.html.haml
@@ -5,7 +5,7 @@
         = t(".user_bikes", current_user_name: current_user.display_name)
 
     .col-md-4.ad-col
-      .ad-block.ad-binx.ad468x60
+      .ad-block.ad-binx.ad468x60.d-none.d-sm-block
   .row
     .col-md-8
       %ul.user-items-nav.nav.nav-tabs{ role: 'tablist' }
@@ -55,13 +55,21 @@
                               - bike.bike_stickers.includes(:bike_sticker_batch).each do |bike_sticker|
                                 %code.sticker-code= bike_sticker.pretty_code
                         %br
-                        - if bike.current_stolen_record.present?
-                          = attr_list_item(l(bike.current_stolen_record.date_stolen, format: :dotted), t('.date_stolen'))
-                          = attr_list_item(bike.current_stolen_record.address_location(include_all: true), t(".location"))
-                        - elsif bike.current_impound_record.present?
-                          = attr_list_item(l(bike.current_impound_record.impounded_at, format: :dotted), t('.date_found'))
-                          = attr_list_item(bike.current_impound_record.address, t(".location"))
+                        - if bike.current_record_date.present?
+                          %li
+                            %strong.attr-title= bike.status_humanized.titleize
+                            %span.convertTime= l bike.current_record_date, format: :convert_time
+                        - if bike.current_record.present?
+                          = attr_list_item(bike.current_record.address(country: [:skip_default]), t(".location"))
+
                       %ul.attr-list
+                        %li
+                          %strong.attr-title= t(".registered")
+                          %span.convertTime= l bike.created_at, format: :convert_time
+                        %li
+                          %strong.attr-title= t(".updated")
+                          %span.convertTime= l bike.updated_by_user_fallback, format: :convert_time
+
                         %li= link_to t(".edit_bike"), edit_bike_path(bike, edit_template: bike.default_edit_template)
                         - if bike.status_stolen?
                           -# %li

--- a/app/views/shared/_email_bike_box.html.haml
+++ b/app/views/shared/_email_bike_box.html.haml
@@ -34,7 +34,7 @@
             %li
               %strong
                 = @bike.status_impounded? ? t(".found") : t(".stolen_from")
-              = stolen_record.address(skip_default_country: true)
+              = stolen_record.address(country: [:skip_default])
             %li
               %strong
                 = t(".stolen_at")

--- a/config/locales/.translation_io
+++ b/config/locales/.translation_io
@@ -1,2 +1,2 @@
 ---
-timestamp: 1642539356
+timestamp: 1642612068

--- a/config/locales/.translation_io
+++ b/config/locales/.translation_io
@@ -1,2 +1,2 @@
 ---
-timestamp: 1642619311
+timestamp: 1642622881

--- a/config/locales/.translation_io
+++ b/config/locales/.translation_io
@@ -1,2 +1,2 @@
 ---
-timestamp: 1642619223
+timestamp: 1642619311

--- a/config/locales/.translation_io
+++ b/config/locales/.translation_io
@@ -1,2 +1,2 @@
 ---
-timestamp: 1642612068
+timestamp: 1642619223

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -4143,14 +4143,10 @@ en:
       add_a_bike: Add a bike
       add_a_lock: Add a lock
       add_a_photo: Add a photo
-      registered: Registered
-      updated: Updated
       add_it_now: Add it now!
       bike_sticker: Bike Sticker
       bikes: bikes
       combination: Combination
-      date_found: Date found
-      date_stolen: Date stolen
       edit: Edit
       edit_bike: Edit Bike
       generally_connect_to_org: >-
@@ -4167,6 +4163,7 @@ en:
       next: Next steps
       primary_colors: Primary colors
       register_new_items: Register new items
+      registered: Registered
       serial: Serial
       sorry_your_bike_was_stolen: >-
         We're sorry your %{bikes_last_type} was stolen, but hopefully, with everyone
@@ -4176,6 +4173,7 @@ en:
         to the Index.
       to_bike_index_thanks_for_signing_up: to Bike Index. Thanks for signing up!
       update_your_profile: Update your profile
+      updated: Updated
       user_bikes: "%{current_user_name} bikes"
       user_hidden: Hidden from other users
       want_to_sell_your_bikes: Want to sell one of your registered bikes?

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2074,7 +2074,6 @@ en:
           back!
         your_bike_type_was_marked_recovered_on_bik: 'Your %{bike_type} was marked
           recovered on Bike Index:'
-      subject: Your %{bike_type} has been marked recovered!
       text:
         if_you_didnt_recover_your_bike_or_marked_: >-
           If you didn't recover your bike, or marked it recovered accidentally, reply
@@ -4841,10 +4840,6 @@ en:
           We're a 501(c)(3) nonprofit and depend on donations to operate
         before_locking_check: Before locking, check that what you are locking to can't
           be easily removed.
-        bike_register_with_bike_index: Congrats on registering your %{bike_type} with
-          Bike Index
-        bike_register_with_bike_index_and_org: Congrats on registering your %{bike_type}
-          with Bike Index and %{org_name}
         bike_type_thieves_are_jerks: "%{bike_type} thieves are jerks."
         cable_locks_should_never_be_used: Cable locks should never be used as a primary
           means of locking a bike in a city.
@@ -4853,7 +4848,6 @@ en:
         correctly_locking_a_bike: Correctly locking a bike
         donating: donating
         give_us_a_heads_up: Give us a heads up
-        hopefully_you_find_the_bike_html: Hopefully you find the %{bike_type} soon.
         hopefully_you_find_the_owner_html: Hopefully you find the owner soon. %{edit_bike_link}
           when you do!
         mark_recovered_link_html: "%{mark_recovered_link} when you do!"
@@ -4874,9 +4868,6 @@ en:
         secure_both_wheels_either_with_two_ulocks: >-
           Secure both wheels - either with two U-locks, or one U-lock and one heavy
           duty cable.
-        sign_up_on_bikeindexorg_to_claim_your_bik: >-
-          Sign up on BikeIndex.org to claim your %{bike_type} and edit it, upload
-          photos and make sure you never lose track of your trusty steed!
         stolen_bike_type: stolen %{bike_type}
         thanks_for_adding_this_bike_type_you_found: Thanks for adding this %{bike_type}
           you found to Bike Index
@@ -4901,8 +4892,6 @@ en:
         edit_it_upload_photos: Edit it, upload photos and make sure you never lose
           track of your trusty steed!
         give_us_a_heads_up_when_you_do: Give us a heads up when you do (%{bike_edit_url})
-        hopefully_you_find_the_bike_type_soon: Hopefully you find the %{bike_type}
-          soon.
         hopefully_you_find_the_owner_soon: Hopefully you find the owner soon.
         org_added_a_bike: "%{org_name} added a %{bike_type} on Bike Index for you"
         org_sent_a_bike: "%{org_name} sent you a %{bike_type} on Bike Index"
@@ -4912,7 +4901,6 @@ en:
         secure_both_wheels: >-
           - Secure both wheels - either with two U-locks, or one U-lock and one heavy
           duty cable.
-        sign_up_on_bikeindex_to_claim: Sign up on BikeIndex.org to claim your %{bike_type}
         stolen_bike_type: stolen %{bike_type}
         use_a_ulock: >-
           - *Use a U-Lock.* Cable locks should never be used as a primary means of

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2074,6 +2074,7 @@ en:
           back!
         your_bike_type_was_marked_recovered_on_bik: 'Your %{bike_type} was marked
           recovered on Bike Index:'
+      subject: Your %{bike_type} has been marked recovered!
       text:
         if_you_didnt_recover_your_bike_or_marked_: >-
           If you didn't recover your bike, or marked it recovered accidentally, reply
@@ -4840,6 +4841,10 @@ en:
           We're a 501(c)(3) nonprofit and depend on donations to operate
         before_locking_check: Before locking, check that what you are locking to can't
           be easily removed.
+        bike_register_with_bike_index: Congrats on registering your %{bike_type} with
+          Bike Index
+        bike_register_with_bike_index_and_org: Congrats on registering your %{bike_type}
+          with Bike Index and %{org_name}
         bike_type_thieves_are_jerks: "%{bike_type} thieves are jerks."
         cable_locks_should_never_be_used: Cable locks should never be used as a primary
           means of locking a bike in a city.
@@ -4848,6 +4853,7 @@ en:
         correctly_locking_a_bike: Correctly locking a bike
         donating: donating
         give_us_a_heads_up: Give us a heads up
+        hopefully_you_find_the_bike_html: Hopefully you find the %{bike_type} soon.
         hopefully_you_find_the_owner_html: Hopefully you find the owner soon. %{edit_bike_link}
           when you do!
         mark_recovered_link_html: "%{mark_recovered_link} when you do!"
@@ -4868,6 +4874,9 @@ en:
         secure_both_wheels_either_with_two_ulocks: >-
           Secure both wheels - either with two U-locks, or one U-lock and one heavy
           duty cable.
+        sign_up_on_bikeindexorg_to_claim_your_bik: >-
+          Sign up on BikeIndex.org to claim your %{bike_type} and edit it, upload
+          photos and make sure you never lose track of your trusty steed!
         stolen_bike_type: stolen %{bike_type}
         thanks_for_adding_this_bike_type_you_found: Thanks for adding this %{bike_type}
           you found to Bike Index
@@ -4892,6 +4901,8 @@ en:
         edit_it_upload_photos: Edit it, upload photos and make sure you never lose
           track of your trusty steed!
         give_us_a_heads_up_when_you_do: Give us a heads up when you do (%{bike_edit_url})
+        hopefully_you_find_the_bike_type_soon: Hopefully you find the %{bike_type}
+          soon.
         hopefully_you_find_the_owner_soon: Hopefully you find the owner soon.
         org_added_a_bike: "%{org_name} added a %{bike_type} on Bike Index for you"
         org_sent_a_bike: "%{org_name} sent you a %{bike_type} on Bike Index"
@@ -4901,6 +4912,7 @@ en:
         secure_both_wheels: >-
           - Secure both wheels - either with two U-locks, or one U-lock and one heavy
           duty cable.
+        sign_up_on_bikeindex_to_claim: Sign up on BikeIndex.org to claim your %{bike_type}
         stolen_bike_type: stolen %{bike_type}
         use_a_ulock: >-
           - *Use a U-Lock.* Cable locks should never be used as a primary means of

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -4143,6 +4143,8 @@ en:
       add_a_bike: Add a bike
       add_a_lock: Add a lock
       add_a_photo: Add a photo
+      registered: Registered
+      updated: Updated
       add_it_now: Add it now!
       bike_sticker: Bike Sticker
       bikes: bikes

--- a/config/locales/translation.nl.yml
+++ b/config/locales/translation.nl.yml
@@ -2543,7 +2543,7 @@ nl:
           terug hebt!
         your_bike_type_was_marked_recovered_on_bik: 'Je %{bike_type} is gemarkeerd
           als hersteld op Bike Index:'
-      subject: Je %{biketype} is gemarkeerd als hersteld!
+      subject: Je %{bike_type} is gemarkeerd als hersteld!
       text:
         if_you_didnt_recover_your_bike_or_marked_: Als je je fiets niet hebt hersteld
           of hebt gemarkeerd dat deze per ongeluk is hersteld, beantwoord je deze
@@ -4653,16 +4653,16 @@ nl:
           en zijn afhankelijk van donaties om te opereren
         before_locking_check: Controleer voordat u vergrendelt, dat wat u vergrendelt,
           niet eenvoudig kan worden verwijderd.
-        bike_register_with_bike_index: Gefeliciteerd met het registreren van uw %{biketype}
+        bike_register_with_bike_index: Gefeliciteerd met het registreren van uw %{bike_type}
           bij Bike Index
         bike_register_with_bike_index_and_org: Gefeliciteerd met het registreren van
-          uw %{biketype} bij Bike Index en %{org_name}
+          uw %{bike_type} bij Bike Index en %{org_name}
         cable_locks_should_never_be_used: Kabelsloten mogen nooit worden gebruikt
           als primair middel om een fiets in een stad te vergrendelen.
         correctly_locking_a_bike: Een fiets correct vergrendelen
         donating: doneren
         give_us_a_heads_up: Geef ons een waarschuwing
-        hopefully_you_find_the_bike_html: Hopelijk vindt u de %{biketype} binnenkort.
+        hopefully_you_find_the_bike_html: Hopelijk vindt u de %{bike_type} binnenkort.
         hopefully_you_find_the_owner_html: Hopelijk vind je snel de eigenaar. %{edit_bike_link}
           wanneer u dat doet!
         mark_recovered_link_html: "%{mark_recovered_link} wanneer u dat doet!"
@@ -4682,7 +4682,7 @@ nl:
         secure_both_wheels_either_with_two_ulocks: Beveilig beide wielen - hetzij
           met twee U-sloten, of één U-slot en één zware kabel.
         sign_up_on_bikeindexorg_to_claim_your_bik: Meld je aan op BikeIndex.org om
-          je %{biketype} te claimen en te bewerken, foto's te uploaden en ervoor te
+          je %{bike_type} te claimen en te bewerken, foto's te uploaden en ervoor te
           zorgen dat je nooit je vertrouwde ros uit het oog verliest!
         use_a_ulock: Gebruik een U-Lock.
         welcome_to_bike_index: Welkom bij Bike Index
@@ -4722,14 +4722,14 @@ nl:
         read_more_here: 'Lees hier meer: %{protect_your_bike_url}'
         secure_both_wheels: "- Beveilig beide wielen - hetzij met twee U-sloten, hetzij
           één U-slot en één zware kabel."
-        sign_up_on_bikeindex_to_claim: Meld u aan op BikeIndex.org om uw %{biketype}
+        sign_up_on_bikeindex_to_claim: Meld u aan op BikeIndex.org om uw %{bike_type}
           te claimen
         use_a_ulock: "- * Gebruik een U-Lock. * Kabelsloten mogen nooit worden gebruikt
           als primair middel om een fiets in een stad te vergrendelen."
         you_added_a_bike_type_on_bike_index: U heeft een %{bike_type} toegevoegd op
           Bike Index
         claim_the_bike_type_at_this_url: 'Claim de %{bike_type} op deze URL: %{bike_url}'
-        hopefully_you_find_the_bike_type_soon: Hopelijk vindt u de %{biketype} binnenkort.
+        hopefully_you_find_the_bike_type_soon: Hopelijk vindt u de %{bike_type} binnenkort.
         recovered_bike_type: hersteld / gevonden %{bike_type}
         stolen_bike_type: gestolen %{bike_type}
     finished_stolen_registration:

--- a/config/locales/translation.nl.yml
+++ b/config/locales/translation.nl.yml
@@ -2543,7 +2543,7 @@ nl:
           terug hebt!
         your_bike_type_was_marked_recovered_on_bik: 'Je %{bike_type} is gemarkeerd
           als hersteld op Bike Index:'
-      subject: Je %{bike_type} is gemarkeerd als hersteld!
+      subject: Je %{biketype} is gemarkeerd als hersteld!
       text:
         if_you_didnt_recover_your_bike_or_marked_: Als je je fiets niet hebt hersteld
           of hebt gemarkeerd dat deze per ongeluk is hersteld, beantwoord je deze
@@ -4653,16 +4653,16 @@ nl:
           en zijn afhankelijk van donaties om te opereren
         before_locking_check: Controleer voordat u vergrendelt, dat wat u vergrendelt,
           niet eenvoudig kan worden verwijderd.
-        bike_register_with_bike_index: Gefeliciteerd met het registreren van uw %{bike_type}
+        bike_register_with_bike_index: Gefeliciteerd met het registreren van uw %{biketype}
           bij Bike Index
         bike_register_with_bike_index_and_org: Gefeliciteerd met het registreren van
-          uw %{bike_type} bij Bike Index en %{org_name}
+          uw %{biketype} bij Bike Index en %{org_name}
         cable_locks_should_never_be_used: Kabelsloten mogen nooit worden gebruikt
           als primair middel om een fiets in een stad te vergrendelen.
         correctly_locking_a_bike: Een fiets correct vergrendelen
         donating: doneren
         give_us_a_heads_up: Geef ons een waarschuwing
-        hopefully_you_find_the_bike_html: Hopelijk vindt u de %{bike_type} binnenkort.
+        hopefully_you_find_the_bike_html: Hopelijk vindt u de %{biketype} binnenkort.
         hopefully_you_find_the_owner_html: Hopelijk vind je snel de eigenaar. %{edit_bike_link}
           wanneer u dat doet!
         mark_recovered_link_html: "%{mark_recovered_link} wanneer u dat doet!"
@@ -4682,7 +4682,7 @@ nl:
         secure_both_wheels_either_with_two_ulocks: Beveilig beide wielen - hetzij
           met twee U-sloten, of één U-slot en één zware kabel.
         sign_up_on_bikeindexorg_to_claim_your_bik: Meld je aan op BikeIndex.org om
-          je %{bike_type} te claimen en te bewerken, foto's te uploaden en ervoor te
+          je %{biketype} te claimen en te bewerken, foto's te uploaden en ervoor te
           zorgen dat je nooit je vertrouwde ros uit het oog verliest!
         use_a_ulock: Gebruik een U-Lock.
         welcome_to_bike_index: Welkom bij Bike Index
@@ -4722,14 +4722,14 @@ nl:
         read_more_here: 'Lees hier meer: %{protect_your_bike_url}'
         secure_both_wheels: "- Beveilig beide wielen - hetzij met twee U-sloten, hetzij
           één U-slot en één zware kabel."
-        sign_up_on_bikeindex_to_claim: Meld u aan op BikeIndex.org om uw %{bike_type}
+        sign_up_on_bikeindex_to_claim: Meld u aan op BikeIndex.org om uw %{biketype}
           te claimen
         use_a_ulock: "- * Gebruik een U-Lock. * Kabelsloten mogen nooit worden gebruikt
           als primair middel om een fiets in een stad te vergrendelen."
         you_added_a_bike_type_on_bike_index: U heeft een %{bike_type} toegevoegd op
           Bike Index
         claim_the_bike_type_at_this_url: 'Claim de %{bike_type} op deze URL: %{bike_url}'
-        hopefully_you_find_the_bike_type_soon: Hopelijk vindt u de %{bike_type} binnenkort.
+        hopefully_you_find_the_bike_type_soon: Hopelijk vindt u de %{biketype} binnenkort.
         recovered_bike_type: hersteld / gevonden %{bike_type}
         stolen_bike_type: gestolen %{bike_type}
     finished_stolen_registration:
@@ -5647,7 +5647,6 @@ nl:
       add_a_photo: Voeg een foto toe
       bikes: fietsen
       combination: Combinatie
-      date_stolen: Datum gestolen
       edit: Bewerken
       edit_bike: Fiets bewerken
       key_serial: Sleutel serienummer
@@ -5673,7 +5672,6 @@ nl:
       welcome: Welkom
       you_have_no_registered_bikes: U heeft geen geregistreerde fietsen
       you_have_no_registered_locks: U heeft geen geregistreerde sloten
-      date_found: Datum gevonden
       bike_sticker: Fiets sticker
       add_it_now: Voeg het nu toe!
       generally_connect_to_org: Sommige van uw fietsen zijn geassocieerd met %{org_name},
@@ -5681,6 +5679,8 @@ nl:
         -
       ignore: Negeren
       user_hidden: Verborgen voor andere gebruikers
+      registered: Geregistreerd
+      updated: Bijgewerkt
     edit:
       save_changes: Wijzigingen opslaan
     password:

--- a/config/locales/translation.nl.yml
+++ b/config/locales/translation.nl.yml
@@ -2543,7 +2543,6 @@ nl:
           terug hebt!
         your_bike_type_was_marked_recovered_on_bik: 'Je %{bike_type} is gemarkeerd
           als hersteld op Bike Index:'
-      subject: Je %{biketype} is gemarkeerd als hersteld!
       text:
         if_you_didnt_recover_your_bike_or_marked_: Als je je fiets niet hebt hersteld
           of hebt gemarkeerd dat deze per ongeluk is hersteld, beantwoord je deze
@@ -4653,16 +4652,11 @@ nl:
           en zijn afhankelijk van donaties om te opereren
         before_locking_check: Controleer voordat u vergrendelt, dat wat u vergrendelt,
           niet eenvoudig kan worden verwijderd.
-        bike_register_with_bike_index: Gefeliciteerd met het registreren van uw %{biketype}
-          bij Bike Index
-        bike_register_with_bike_index_and_org: Gefeliciteerd met het registreren van
-          uw %{biketype} bij Bike Index en %{org_name}
         cable_locks_should_never_be_used: Kabelsloten mogen nooit worden gebruikt
           als primair middel om een fiets in een stad te vergrendelen.
         correctly_locking_a_bike: Een fiets correct vergrendelen
         donating: doneren
         give_us_a_heads_up: Geef ons een waarschuwing
-        hopefully_you_find_the_bike_html: Hopelijk vindt u de %{biketype} binnenkort.
         hopefully_you_find_the_owner_html: Hopelijk vind je snel de eigenaar. %{edit_bike_link}
           wanneer u dat doet!
         mark_recovered_link_html: "%{mark_recovered_link} wanneer u dat doet!"
@@ -4681,9 +4675,6 @@ nl:
         read_more_about_protecting_html: Lees meer over %{link}.
         secure_both_wheels_either_with_two_ulocks: Beveilig beide wielen - hetzij
           met twee U-sloten, of één U-slot en één zware kabel.
-        sign_up_on_bikeindexorg_to_claim_your_bik: Meld je aan op BikeIndex.org om
-          je %{biketype} te claimen en te bewerken, foto's te uploaden en ervoor te
-          zorgen dat je nooit je vertrouwde ros uit het oog verliest!
         use_a_ulock: Gebruik een U-Lock.
         welcome_to_bike_index: Welkom bij Bike Index
         you_added_a_bike_type_on_bike_index: U heeft een %{bike_type} toegevoegd op
@@ -4722,14 +4713,11 @@ nl:
         read_more_here: 'Lees hier meer: %{protect_your_bike_url}'
         secure_both_wheels: "- Beveilig beide wielen - hetzij met twee U-sloten, hetzij
           één U-slot en één zware kabel."
-        sign_up_on_bikeindex_to_claim: Meld u aan op BikeIndex.org om uw %{biketype}
-          te claimen
         use_a_ulock: "- * Gebruik een U-Lock. * Kabelsloten mogen nooit worden gebruikt
           als primair middel om een fiets in een stad te vergrendelen."
         you_added_a_bike_type_on_bike_index: U heeft een %{bike_type} toegevoegd op
           Bike Index
         claim_the_bike_type_at_this_url: 'Claim de %{bike_type} op deze URL: %{bike_url}'
-        hopefully_you_find_the_bike_type_soon: Hopelijk vindt u de %{biketype} binnenkort.
         recovered_bike_type: hersteld / gevonden %{bike_type}
         stolen_bike_type: gestolen %{bike_type}
     finished_stolen_registration:

--- a/config/locales/translation.nl.yml
+++ b/config/locales/translation.nl.yml
@@ -2551,6 +2551,7 @@ nl:
           terug hebt!
         your_bike_type_was_marked_recovered: 'Je %{bike_type} is gemarkeerd als hersteld
           op Bike Index: %{bike_url}'
+      subject: Je %{bike_type} is gemarkeerd als hersteld!
     stolen_bike_alert_email:
       html:
         alert_retweeted_by_html: Melding geretweet door %{retweets}
@@ -4689,6 +4690,14 @@ nl:
           deze %{bike_type} die je aan Bike Index hebt gevonden
         were_sorry_your_bike_type_was_stolen: Het spijt ons dat uw %{bike_type} is
           gestolen.
+        bike_register_with_bike_index: Gefeliciteerd met het registreren van uw %{bike_type}
+          bij Bike Index
+        bike_register_with_bike_index_and_org: Gefeliciteerd met het registreren van
+          uw %{bike_type} bij Bike Index en %{org_name}
+        hopefully_you_find_the_bike_html: Hopelijk vindt u de %{bike_type} binnenkort.
+        sign_up_on_bikeindexorg_to_claim_your_bik: Meld je aan op BikeIndex.org om
+          je %{bike_type} te claimen en te bewerken, foto's te uploaden en ervoor
+          te zorgen dat je nooit je vertrouwde ros uit het oog verliest!
       subject: Bevestig uw %{organization_name} Bike Index-registratie
       text:
         before_locking_check: "- Controleer voordat u vergrendelt of datgene waarnaar
@@ -4720,6 +4729,9 @@ nl:
         claim_the_bike_type_at_this_url: 'Claim de %{bike_type} op deze URL: %{bike_url}'
         recovered_bike_type: hersteld / gevonden %{bike_type}
         stolen_bike_type: gestolen %{bike_type}
+        hopefully_you_find_the_bike_type_soon: Hopelijk vindt u de %{bike_type} binnenkort.
+        sign_up_on_bikeindex_to_claim: Meld u aan op BikeIndex.org om uw %{bike_type}
+          te claimen
     finished_stolen_registration:
       subject: Bevestig uw %{organization_name} gestolen %{bike_type} op Bike Index
     organization_invitation:

--- a/spec/helpers/bike_helper_spec.rb
+++ b/spec/helpers/bike_helper_spec.rb
@@ -34,10 +34,21 @@ RSpec.describe BikeHelper, type: :helper do
         expect(bike_title_html(bike)).to eq("<span><strong></strong> escape tags?&lt;/p&gt;</span>")
       end
     end
-    context "html frame_model" do
+    context "quotes" do
       let(:bike) { Bike.new(frame_model: "Bullit 'Love Ride'") }
+      let(:target) { "<span><strong></strong> Bullit &#39;Love Ride&#39;</span>" }
       it "escapes the HTML" do
-        expect(bike_title_html(bike)).to eq("<span><strong></strong> Bullit &#39;Love Ride&#39;</span>")
+        expect(bike_title_html(bike)).to eq target
+        expect(bike_title_html(bike, include_status: true)).to eq target
+      end
+    end
+    context "year and cycle_type and status" do
+      let(:bike) { Bike.new(frame_model: '"Love Ride"', cycle_type: "trailer", year: 2020, status: "status_stolen", mnfg_name: "Bullit") }
+      let(:target_no_span) { "<strong>2020 Bullit</strong> &quot;Love Ride&quot;<em> Bike Trailer</em></span>" }
+      it "escapes the HTML" do
+        expect(bike_title_html(bike)).to eq "<span>#{target_no_span}"
+        expect(bike_title_html(bike, include_status: false)).to eq "<span>#{target_no_span}"
+        expect(bike_title_html(bike, include_status: true)).to eq "<span>#{bike_status_span(bike)} #{target_no_span}"
       end
     end
   end

--- a/spec/helpers/header_tag_helper_spec.rb
+++ b/spec/helpers/header_tag_helper_spec.rb
@@ -342,7 +342,7 @@ RSpec.describe HeaderTagHelper, type: :helper do
           let!(:impound_record) { FactoryBot.create(:impound_record, :in_nyc, bike: bike) }
           let(:target_page_description) do
             "#{@bike.primary_frame_color.name} #{title_string}, serial: Hidden. Cool description. " \
-            "Found: #{Time.current.strftime("%Y-%m-%d")}, in: New York, NY 10007"
+            "Found: #{Time.current.strftime("%Y-%m-%d")}, in: New York, NY 10007, US"
           end
           it "returns expected things" do
             expect(bike.reload.current_impound_record.address).to eq "New York, NY 10007"

--- a/spec/models/bike_spec.rb
+++ b/spec/models/bike_spec.rb
@@ -1359,7 +1359,7 @@ RSpec.describe Bike, type: :model do
         bike = stolen_record.bike
         bike.update(description: "I love my bike")
         expect(bike.reload.all_description).to eq("I love my bike some theft description")
-        expect(bike.current_record_date).to eq stolen_record.date_stolen
+        expect(bike.current_record_date).to eq stolen_record.reload.date_stolen
         expect(bike.current_record&.id).to eq stolen_record.id
       end
     end

--- a/spec/models/bike_spec.rb
+++ b/spec/models/bike_spec.rb
@@ -833,6 +833,7 @@ RSpec.describe Bike, type: :model do
         expect(bike.status).to eq "status_impounded"
         expect(bike.status_humanized).to eq "found"
         expect(bike.status_humanized_translated).to eq "found"
+        expect(bike.current_record&.id).to eq impound_record.id
         expect(bike.authorized?(user)).to be_truthy
         expect(bike.authorized?(superuser)).to be_truthy
       end
@@ -1358,6 +1359,8 @@ RSpec.describe Bike, type: :model do
         bike = stolen_record.bike
         bike.update(description: "I love my bike")
         expect(bike.reload.all_description).to eq("I love my bike some theft description")
+        expect(bike.current_record_date).to eq stolen_record.date_stolen
+        expect(bike.current_record&.id).to eq stolen_record.id
       end
     end
     context "no current_stolen_record" do

--- a/spec/models/impound_record_spec.rb
+++ b/spec/models/impound_record_spec.rb
@@ -341,6 +341,7 @@ RSpec.describe ImpoundRecord, type: :model do
           expect(impound_record.street).to eq "3554 W Shakespeare Ave"
           expect(impound_record.address).to eq "Chicago, IL 60647"
           expect(impound_record.address(force_show_address: true)).to eq "3554 W Shakespeare Ave, Chicago, IL 60647"
+          expect(impound_record.address(force_show_address: true, country: [:skip_default])).to eq "3554 W Shakespeare Ave, Chicago, IL 60647"
           expect(impound_record.latitude).to eq latitude
           expect(impound_record.longitude).to eq longitude
           expect(impound_record.valid?).to be_truthy

--- a/spec/models/stolen_record_spec.rb
+++ b/spec/models/stolen_record_spec.rb
@@ -524,6 +524,8 @@ RSpec.describe StolenRecord, type: :model do
       it "returns all available location components" do
         stolen_record = FactoryBot.create(:stolen_record, :in_nyc)
         expect(stolen_record.address_location(include_all: true)).to eq("New York, NY - US")
+        expect(stolen_record.address).to eq("New York, NY 10007, US")
+        expect(stolen_record.address(country: [:skip_default])).to eq("New York, NY 10007")
         stolen_record.street = ""
         expect(stolen_record.without_location?).to be_truthy
 

--- a/spec/models/stolen_record_spec.rb
+++ b/spec/models/stolen_record_spec.rb
@@ -519,55 +519,26 @@ RSpec.describe StolenRecord, type: :model do
     end
   end
 
-  describe "#address_location" do
+  describe "#address" do
     context "given include_all" do
       it "returns all available location components" do
         stolen_record = FactoryBot.create(:stolen_record, :in_nyc)
-        expect(stolen_record.address_location(include_all: true)).to eq("New York, NY - US")
-        expect(stolen_record.address).to eq("New York, NY 10007")
+        expect(stolen_record.address).to eq("New York, NY 10007, US")
         expect(stolen_record.address(country: [:skip_default])).to eq("New York, NY 10007")
         stolen_record.street = ""
         expect(stolen_record.without_location?).to be_truthy
 
         ca = FactoryBot.create(:state, name: "California", abbreviation: "CA")
         stolen_record = FactoryBot.create(:stolen_record, city: nil, state: ca, country: Country.united_states)
-        expect(stolen_record.address_location(include_all: true)).to eq("CA - US")
-      end
-    end
-
-    context "given an domestic location" do
-      it "returns the city and state" do
-        stolen_record = FactoryBot.create(:stolen_record, :in_nyc)
-        expect(stolen_record.address_location).to eq("New York, NY")
-      end
-    end
-
-    context "given an international location" do
-      it "returns the city and state" do
-        stolen_record = FactoryBot.create(:stolen_record, :in_amsterdam, state: nil)
-        expect(stolen_record.address_location).to eq("Amsterdam - NL")
-      end
-    end
-
-    context "given only a country" do
-      it "returns only the country" do
-        stolen_record = FactoryBot.create(:stolen_record, city: nil, state: nil, country: Country.netherlands)
-        expect(stolen_record.address_location).to eq("NL")
-      end
-    end
-
-    context "given only a state" do
-      it "returns only the state" do
-        ny_state = FactoryBot.create(:state, abbreviation: "NY")
-        stolen_record = FactoryBot.create(:stolen_record, city: nil, state: ny_state)
-        expect(stolen_record.address_location).to eq("NY")
+        expect(stolen_record.address).to eq("CA, US")
+        expect(stolen_record.address(country: [:skip_default])).to eq("CA")
       end
     end
 
     context "given only a city" do
       it "returns nil" do
         stolen_record = FactoryBot.create(:stolen_record, city: "New Paltz", state: nil)
-        expect(stolen_record.address_location).to eq(nil)
+        expect(stolen_record.address).to eq("New Paltz")
       end
     end
 

--- a/spec/models/stolen_record_spec.rb
+++ b/spec/models/stolen_record_spec.rb
@@ -524,7 +524,7 @@ RSpec.describe StolenRecord, type: :model do
       it "returns all available location components" do
         stolen_record = FactoryBot.create(:stolen_record, :in_nyc)
         expect(stolen_record.address_location(include_all: true)).to eq("New York, NY - US")
-        expect(stolen_record.address).to eq("New York, NY 10007, US")
+        expect(stolen_record.address).to eq("New York, NY 10007")
         expect(stolen_record.address(country: [:skip_default])).to eq("New York, NY 10007")
         stolen_record.street = ""
         expect(stolen_record.without_location?).to be_truthy

--- a/spec/serializers/bike_v2_serializer_spec.rb
+++ b/spec/serializers/bike_v2_serializer_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe BikeV2Serializer do
       let(:target_stolen) do
         target.merge(year: nil,
           status: "stolen",
-          stolen_location: "New York, NY - US",
+          stolen_location: "New York, NY 10007, US",
           stolen: true,
           stolen_coordinates: [40.71, -74.01], # public (truncated) coordinates
           date_stolen: bike.current_stolen_record.date_stolen.to_i)


### PR DESCRIPTION
- Add `current_record` and `current_record_date` to reduce some duplicate code.
- Make the `address` method consistent across stolen records, impound records and parking notifications
- Fix translation issue where #2125 updated some string interpolation and didn't fix the translated files