### PR TITLE
Add Instagram accounts to user model, user edit/show pages

### DIFF
--- a/app/controllers/my_accounts_controller.rb
+++ b/app/controllers/my_accounts_controller.rb
@@ -109,9 +109,9 @@ class MyAccountsController < ApplicationController
     pparams = params.require(:user)
       .permit(:name, :username, :notification_newsletters, :notification_unstolen,
         :additional_emails, :title, :description, :phone, :street, :city, :zipcode, :country_id,
-        :state_id, :avatar, :avatar_cache, :twitter, :show_twitter, :website, :show_website,
-        :show_bikes, :show_phone, :my_bikes_link_target, :my_bikes_link_title, :password,
-        :password_confirmation, :preferred_language,
+        :state_id, :avatar, :avatar_cache, :twitter, :show_twitter, :instagram, :show_instagram,
+        :website, :show_website, :show_bikes, :show_phone, :my_bikes_link_target,
+        :my_bikes_link_title, :password, :password_confirmation, :preferred_language,
         user_registration_organization_attributes: [:all_bikes, :can_edit_claimed])
     if pparams.key?("username")
       pparams.delete("username") unless pparams["username"].present?

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -202,28 +202,25 @@ module ApplicationHelper
     end
   end
 
-  # TODO: location refactor - do something more sophisticated
-  def address_formatted(obj)
-    obj.address
-  end
-
   def websiteable(user)
     if user.show_website && user.website
       link_to "Website", user.website
     end
   end
 
-  def show_twitter_and_website(user)
-    if twitterable(user) || websiteable(user)
-      html = ""
-      if twitterable(user)
-        html << twitterable(user)
-        html << " and #{websiteable(user)}" if websiteable(user)
-      else
-        html << websiteable(user)
-      end
-      html.html_safe
+  def instagramable(user)
+    if user.show_instagram && user.instagram
+      link_to "Instagram", "https://instagram.com/#{user.instagram}"
     end
+  end
+
+  # TODO: location refactor - do something more sophisticated
+  def address_formatted(obj)
+    obj.address
+  end
+
+  def show_sharing_links(user)
+    [twitterable(user), instagramable(user), websiteable(user)].compact.to_sentence.html_safe
   end
 
   def pretty_print_json(data, no_blank = false)

--- a/app/views/my_accounts/_sharing.html.haml
+++ b/app/views/my_accounts/_sharing.html.haml
@@ -18,6 +18,21 @@
       .form-well-input
         = f.text_field :twitter, placeholder: t(".twitter_handle"), class: 'form-control'
 
+    .form-group.row.sharing-collapser{ data: { target: '#instagram-field' } }
+      %label.form-well-label
+        = t(".show_instagram")
+      .form-well-input
+        %label.radio-inline
+          = f.radio_button :show_instagram, true
+          = t(".show_instagram")
+        %label.radio-inline
+          = f.radio_button :show_instagram, false
+          = t(".no_instagram")
+    #instagram-field.form-group.row.collapse
+      = f.label :instagram, t(".instagram_handle"), class: 'form-well-label'
+      .form-well-input
+        = f.text_field :instagram, placeholder: t(".instagram_handle"), class: 'form-control'
+
     .form-group.row.sharing-collapser{ data: { target: '#personal-field' } }
       %label.form-well-label
         = t(".show_personal_site")

--- a/app/views/users/show.html.haml
+++ b/app/views/users/show.html.haml
@@ -15,7 +15,7 @@
               - else
                 = t(".this_users_bikes")
             %p.sharing-links
-              = show_twitter_and_website(@user)
+              = show_sharing_links(@user)
       .col-md-6.ad-col
         .ad-block.ad-binx.ad468x60
     - if @user.description

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -4117,7 +4117,9 @@ en:
       create_page: Create page
       create_public_page: Create public page
       example_url: http://example.com
+      instagram_handle: Instagram handle
       my_awesome_link: My awesome link
+      no_instagram: No Instagram
       no_personal_site: No personal site
       no_please_dont_create_me_a_page: No, please don't create me a page
       no_twitter: No Twitter
@@ -4127,6 +4129,7 @@ en:
       preview_page: preview page
       profile_avatar: Profile avatar
       sharing_and_personal_page_settings: Sharing and Personal page settings
+      show_instagram: Show Instagram
       show_personal_site: Show Personal Site
       show_personal_website: Show personal website
       show_twitter: Show Twitter

--- a/db/migrate/20220201213958_add_instragram_accounts_to_users.rb
+++ b/db/migrate/20220201213958_add_instragram_accounts_to_users.rb
@@ -1,0 +1,6 @@
+class AddInstragramAccountsToUsers < ActiveRecord::Migration[5.2]
+  def change
+    add_column :users, :show_instagram, :boolean, default: false
+    add_column :users, :instagram, :string
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -3154,7 +3154,9 @@ CREATE TABLE public.users (
     magic_link_token text,
     alert_slugs jsonb DEFAULT '[]'::jsonb,
     address_set_manually boolean DEFAULT false,
-    no_address boolean DEFAULT false
+    no_address boolean DEFAULT false,
+    show_instagram boolean DEFAULT false,
+    instagram character varying
 );
 
 
@@ -6168,6 +6170,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20220113194041'),
 ('20220118221319'),
 ('20220121230959'),
-('20220124192245');
+('20220124192245'),
+('20220201213958');
 
 

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -45,6 +45,11 @@ RSpec.describe ApplicationHelper, type: :helper do
       html = show_sharing_links(user)
       expect(html).to eq("<a href=\"website\">Website</a>")
     end
+    it "handles when no sharing links are present" do
+      user = User.new(show_website: false, show_twitter: false, show_instagram: false)
+      html = show_sharing_links(user)
+      expect(html).to eq("")
+    end
   end
 
   describe "#websiteable" do

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -27,18 +27,22 @@ RSpec.describe ApplicationHelper, type: :helper do
     end
   end
 
-  describe "#show_twitter_and_website" do
-    it "combines twitter and website" do
-      user = User.new(show_website: true,
+  describe "#show_sharing_links" do
+    it "combines twitter, instagram, and website" do
+      user = User.new(
+        show_website: true,
         website: "website",
         show_twitter: true,
-        twitter: "twitter")
-      html = show_twitter_and_website(user)
-      expect(html).to eq("<a href=\"https://twitter.com/twitter\">Twitter</a> and <a href=\"website\">Website</a>")
+        twitter: "twitter",
+        show_instagram: true,
+        instagram: "instagram",
+      )
+      html = show_sharing_links(user)
+      expect(html).to eq("<a href=\"https://twitter.com/twitter\">Twitter</a>, <a href=\"https://instagram.com/instagram\">Instagram</a>, and <a href=\"website\">Website</a>")
     end
-    it "justs return website if no twitter" do
+    it "justs return website if no twitter or instagram" do
       user = User.new(show_website: true, website: "website")
-      html = show_twitter_and_website(user)
+      html = show_sharing_links(user)
       expect(html).to eq("<a href=\"website\">Website</a>")
     end
   end

--- a/spec/requests/my_accounts_request_spec.rb
+++ b/spec/requests/my_accounts_request_spec.rb
@@ -238,6 +238,35 @@ RSpec.describe MyAccountsController, type: :request do
       end
     end
 
+    describe "settings sharing links (twitter, instagram, website)" do
+      it "updates sharing links on the User" do
+        current_user.update(
+          show_twitter: false,
+          twitter: nil,
+          show_instagram: false,
+          instagram: nil,
+          show_website: false,
+          website: nil,
+        )
+
+        patch base_url, params: { id: current_user.id,
+          user: {
+            instagram: "bikeinsta", show_instagram: true,
+            twitter: "biketwitter", show_twitter: true,
+            website: "https://bikeindex.org", show_website: true,
+          }
+        }
+
+        current_user.reload
+        expect(current_user.instagram).to eq "bikeinsta"
+        expect(current_user.show_instagram).to be true
+        expect(current_user.twitter).to eq "biketwitter"
+        expect(current_user.show_twitter).to be true
+        expect(current_user.website).to eq "https://bikeindex.org"
+        expect(current_user.show_website).to be true
+      end
+    end
+
     describe "updating phone" do
       it "updates and adds the phone" do
         current_user.reload


### PR DESCRIPTION
I'll look at this again in the next day or two, but I think we are mostly there.
Let me know if there is anything that is wildly or mildly off.

I did a little bit of simplifying on `#show_twitter_and_website` but it ends up producing the same thing (I think) without having to manually handle the html string. Happy to add a basic `User` test too that checks for the new columns, but didn't see anything equivalent right now so wasn't sure if you generally skip these safety specs, ie `User.new(...); expect(user.instagram).to be_present` etc

<img width="1029" alt="Screen Shot 2022-02-01 at 3 20 18 PM" src="https://user-images.githubusercontent.com/3782822/152067958-9c03d4f4-647a-49d7-befc-73ecd7b9c22b.png">

<img width="835" alt="Screen Shot 2022-02-01 at 3 19 44 PM" src="https://user-images.githubusercontent.com/3782822/152067977-5993c7b5-b948-4b76-af49-5403c61d695d.png">

This closes #813 