### PR TITLE
Admin theft alerts

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -144,7 +144,7 @@ group :development do
   # Extra faraday response logging. Used in exchange rate api client and external registry
   # Commented out because of facebook upgrade
   # gem "faraday-request_response_logger", github: "pramod-sharma/faraday-request_response_logger"
-  gem "guard"
+  gem "guard", require: false
   gem "guard-rspec", require: false
   gem "letter_opener"
   gem "rerun"

--- a/Guardfile
+++ b/Guardfile
@@ -32,12 +32,4 @@ group :red_green_refactor, halt_on_fail: true do
     watch(%r{^app/controllers/(.+)_controller\.rb$}) { |m| "spec/requests/#{m[1]}_request_spec.rb" }
     watch(%r{^app/controllers/(.+)_controller\.rb$}) { |m| "spec/requests/#{m[1]}_controller_spec.rb" }
   end
-
-  guard :rubocop, all_on_start: false do
-    watch(%r{^app/(.+)\.rb$})
-    watch(%r{^spec/(.+)\.rb$})
-    watch(%r{^config/(.+)\.rb$})
-    watch(%r{^db/(.+)\.rb$})
-    watch(%r{(?:.+/)?\.rubocop\.yml$}) { |m| File.dirname(m[0]) }
-  end
 end

--- a/app/controllers/admin/theft_alerts_controller.rb
+++ b/app/controllers/admin/theft_alerts_controller.rb
@@ -73,7 +73,7 @@ class Admin::TheftAlertsController < Admin::BaseController
     end
   end
 
-  helper_method :matching_theft_alerts, :available_statuses
+  helper_method :matching_theft_alerts, :available_statuses, :available_paid_admin
 
   private
 
@@ -112,6 +112,10 @@ class Admin::TheftAlertsController < Admin::BaseController
     TheftAlert.statuses + ["posted"]
   end
 
+  def available_paid_admin
+    %w[paid admin paid_or_admin]
+  end
+
   def matching_theft_alerts
     @search_recovered = ParamsNormalizer.boolean(params[:search_recovered])
     theft_alerts = if @search_recovered
@@ -121,8 +125,9 @@ class Admin::TheftAlertsController < Admin::BaseController
     else
       TheftAlert
     end
-    @search_paid = ParamsNormalizer.boolean(params[:search_paid])
-    theft_alerts = theft_alerts.paid if @search_paid
+    @search_paid_admin = available_paid_admin.include?(params[:search_paid_admin]) ? params[:search_paid_admin] : nil
+    theft_alerts = theft_alerts.send(@search_paid_admin) if @search_paid_admin.present?
+
     @search_facebook_data = ParamsNormalizer.boolean(params[:search_facebook_data])
     theft_alerts = theft_alerts.facebook_updateable if @search_facebook_data
     if available_statuses.include?(params[:search_status])

--- a/app/controllers/admin/theft_alerts_controller.rb
+++ b/app/controllers/admin/theft_alerts_controller.rb
@@ -52,7 +52,7 @@ class Admin::TheftAlertsController < Admin::BaseController
 
   def theft_alert_params
     params.require(:theft_alert).permit(
-      :begin_at,
+      :start_at,
       :end_at,
       :notes,
       :status,
@@ -70,7 +70,7 @@ class Admin::TheftAlertsController < Admin::BaseController
   end
 
   def sortable_columns
-    %w[created_at theft_alert_plan_id amount_cents_facebook_spent reach status begin_at end_at]
+    %w[created_at theft_alert_plan_id amount_cents_facebook_spent reach status start_at end_at]
   end
 
   def available_statuses
@@ -130,14 +130,14 @@ class Admin::TheftAlertsController < Admin::BaseController
     if currently_pending && transitioning_to_active
       theft_alert_plan = TheftAlertPlan.find(theft_alert_attrs[:theft_alert_plan_id])
       now = Time.current
-      theft_alert_attrs[:begin_at] = now
+      theft_alert_attrs[:start_at] = now
       theft_alert_attrs[:end_at] = now + theft_alert_plan.duration_days.days
     elsif transitioning_to_pending
-      theft_alert_attrs[:begin_at] = nil
+      theft_alert_attrs[:start_at] = nil
       theft_alert_attrs[:end_at] = nil
     else
       timezone = TimeParser.parse_timezone(params[:timezone])
-      theft_alert_attrs[:begin_at] = TimeParser.parse(theft_alert_attrs[:begin_at], timezone)
+      theft_alert_attrs[:start_at] = TimeParser.parse(theft_alert_attrs[:start_at], timezone)
       theft_alert_attrs[:end_at] = TimeParser.parse(theft_alert_attrs[:end_at], timezone)
     end
 

--- a/app/controllers/bikes/theft_alerts_controller.rb
+++ b/app/controllers/bikes/theft_alerts_controller.rb
@@ -80,7 +80,9 @@ class Bikes::TheftAlertsController < Bikes::BaseController
       .theft_alerts
       .includes(:theft_alert_plan)
       .creation_ordered_desc
-      .where(user: current_user)
       .references(:theft_alert_plan)
+    # Only show non-user theft_alerts to superuser
+    return @theft_alerts if current_user.superuser?
+    @theft_alerts = @theft_alerts.where(user: current_user)
   end
 end

--- a/app/models/theft_alert.rb
+++ b/app/models/theft_alert.rb
@@ -24,7 +24,7 @@ class TheftAlert < ApplicationRecord
 
   scope :should_expire, -> { active.where('"theft_alerts"."end_at" <= ?', Time.current) }
   scope :paid, -> { joins(:payment).where.not(payments: {first_payment_date: nil}) }
-  scope :posted, -> { where.not(begin_at: nil) }
+  scope :posted, -> { where.not(start_at: nil) }
   scope :creation_ordered_desc, -> { order(created_at: :desc) }
   scope :facebook_updateable, -> { where("(facebook_data -> 'campaign_id') IS NOT NULL") }
   scope :should_update_facebook, -> { facebook_updateable.where("theft_alerts.end_at > ?", update_end_buffer) }
@@ -77,7 +77,7 @@ class TheftAlert < ApplicationRecord
 
   # Active or has been active
   def posted?
-    begin_at.present?
+    start_at.present?
   end
 
   def facebook_updateable?
@@ -183,13 +183,13 @@ class TheftAlert < ApplicationRecord
     "#{stolen_record&.city}: Keep an eye out for this stolen #{bike.mnfg_name}. If you see it, let the owner know on Bike Index!"
   end
 
-  def calculated_begin_at
-    begin_at.present? ? begin_at : Time.current
+  def calculated_start_at
+    start_at.present? ? start_at : Time.current
   end
 
   # Default to 3 days, because something
   def calculated_end_at
-    calculated_begin_at + (duration_days_facebook || 3).days
+    calculated_start_at + (duration_days_facebook || 3).days
   end
 
   def set_calculated_attributes
@@ -204,13 +204,13 @@ class TheftAlert < ApplicationRecord
   private
 
   def alert_cannot_begin_in_past_or_after_ends
-    return if begin_at.blank? && end_at.blank?
+    return if start_at.blank? && end_at.blank?
 
-    if begin_at.blank?
-      errors.add(:begin_at, :must_be_present)
+    if start_at.blank?
+      errors.add(:start_at, :must_be_present)
     elsif end_at.blank?
       errors.add(:end_at, :must_be_present)
-    elsif begin_at >= end_at
+    elsif start_at >= end_at
       errors.add(:end_at, :must_be_later_than_start_time)
     end
   end

--- a/app/models/theft_alert.rb
+++ b/app/models/theft_alert.rb
@@ -24,6 +24,8 @@ class TheftAlert < ApplicationRecord
 
   scope :should_expire, -> { active.where('"theft_alerts"."end_at" <= ?', Time.current) }
   scope :paid, -> { joins(:payment).where.not(payments: {first_payment_date: nil}) }
+  scope :admin, -> { where(admin: true) }
+  scope :paid_or_admin, -> { paid.or(admin) }
   scope :posted, -> { where.not(start_at: nil) }
   scope :creation_ordered_desc, -> { order(created_at: :desc) }
   scope :facebook_updateable, -> { where("(facebook_data -> 'campaign_id') IS NOT NULL") }

--- a/app/models/theft_alert.rb
+++ b/app/models/theft_alert.rb
@@ -62,7 +62,7 @@ class TheftAlert < ApplicationRecord
   end
 
   def notify?
-    return false if facebook_data.blank? || facebook_data&.dig("no_notify").present?
+    return false if admin? || facebook_data.blank? || facebook_data&.dig("no_notify").present?
     stolen_record.present? && stolen_record.receive_notifications?
   end
 

--- a/app/views/admin/theft_alerts/_table.html.haml
+++ b/app/views/admin/theft_alerts/_table.html.haml
@@ -17,7 +17,7 @@
         %th
           = sortable "amount_cents_facebook_spent", "Fbook spent", render_sortable: render_sortable
         %th
-          = sortable "begin_at", "Start", render_sortable: render_sortable
+          = sortable "start_at", "Start", render_sortable: render_sortable
         %th
           = sortable "end_at", render_sortable: render_sortable
         %th
@@ -75,7 +75,7 @@
             - if theft_alert.amount_cents_facebook_spent.to_i > 0
               = theft_alert.amount_facebook_spent
           %td
-            %small.convertTime= l(theft_alert.begin_at, format: :convert_time) if theft_alert.begin_at.present?
+            %small.convertTime= l(theft_alert.start_at, format: :convert_time) if theft_alert.start_at.present?
           %td
             %small.convertTime= l(theft_alert.end_at, format: :convert_time) if theft_alert.end_at.present?
           %td

--- a/app/views/admin/theft_alerts/_table.html.haml
+++ b/app/views/admin/theft_alerts/_table.html.haml
@@ -65,6 +65,8 @@
               - if theft_alert.bike.present?
                 = link_to theft_alert.bike.title_string, edit_admin_bike_path(theft_alert.bike)
           %td
+            - if theft_alert.admin
+              %small.text-info admin:
             = link_to theft_alert.user.display_name, edit_admin_user_path(theft_alert.user.to_param)
           %td
             - theft_alert_plan = theft_alert.theft_alert_plan

--- a/app/views/admin/theft_alerts/edit.html.haml
+++ b/app/views/admin/theft_alerts/edit.html.haml
@@ -145,34 +145,38 @@
   url: admin_theft_alert_path(@theft_alert),
   method: :patch,
   html: { class: "m-0" } do |f|
+
+  -# Can't edit many things here! They're set via the theft_alert_plan
+  -# - unless @theft_alert.pending?
   .row
-    .col-sm-6
+    .col-sm-4
       .form-group
         = f.label :status
         = f.select :status,
           options_for_select(TheftAlert.statuses, @theft_alert.status),
           {},
-          class: "form-control"
-    .col-sm-6
+          {disabled: true, class: "form-control"}
+    .col-sm-4
       .form-group
         - plan_options = TheftAlertPlan.active.map { |e| [theft_alert_plan_title(e), e.id] }
         = f.label :theft_alert_plan_id
         = f.select :theft_alert_plan_id,
           options_for_select(plan_options, @theft_alert.theft_alert_plan.id),
           {},
-          class: "form-control"
-
-  - unless @theft_alert.pending?
-    .row
-      = f.hidden_field :timezone, value: "", class: "hiddenFieldTimezone"
-      .col-sm-6
-        .form-group
-          = f.label :start_at
-          = f.datetime_local_field :start_at, include_blank: true, class: "form-control"
-      .col-sm-6
-        .form-group
-          = f.label :end_at
-          = f.datetime_local_field :end_at, include_blank: true, class: "form-control"
+          {disabled: true, class: "form-control"}
+    .col-sm-4
+      .form-group
+        = f.label :ad_radius_miles
+        = f.number_field :ad_radius_miles, disabled: true, class: "form-control"
+  .row
+    .col-sm-6
+      .form-group
+        = f.label :start_at
+        = f.datetime_local_field :start_at, step: 60, disabled: true, class: "form-control"
+    .col-sm-6
+      .form-group
+        = f.label :end_at
+        = f.datetime_local_field :end_at, step: 60, disabled: true, class: "form-control"
 
   .form-group
     = f.label :notes

--- a/app/views/admin/theft_alerts/edit.html.haml
+++ b/app/views/admin/theft_alerts/edit.html.haml
@@ -167,8 +167,8 @@
       = f.hidden_field :timezone, value: "", class: "hiddenFieldTimezone"
       .col-sm-6
         .form-group
-          = f.label :begin_at
-          = f.datetime_local_field :begin_at, include_blank: true, class: "form-control"
+          = f.label :start_at
+          = f.datetime_local_field :start_at, include_blank: true, class: "form-control"
       .col-sm-6
         .form-group
           = f.label :end_at

--- a/app/views/admin/theft_alerts/index.html.haml
+++ b/app/views/admin/theft_alerts/index.html.haml
@@ -19,8 +19,17 @@
             .dropdown-divider
             - available_statuses.each do |status|
               = link_to "#{status.humanize} alerts", url_for(sortable_search_params.merge(search_status: status)), class: "dropdown-item #{@status == status ? 'active' : '' }"
-        %li.nav-item
-          = link_to "paid", url_for(sortable_search_params.merge(search_paid: !@search_paid)), class: "nav-link #{@search_paid ? 'active' : ''}"
+        %li.nav-item.dropdown
+          %a.nav-link.dropdown-toggle{ href: "#", role: "button", "data-toggle" => "dropdown", "aria-haspopup" => "true", "aria-expanded" => "false", class: (@search_paid_admin.present? ? "active" : "") }
+            - if @search_paid_admin.present?
+              = @search_paid_admin.humanize
+            - else
+              Any paid/admin
+          .dropdown-menu
+            = link_to "Any paid/admin", url_for(sortable_search_params.merge(search_paid_admin: nil)), class: "dropdown-item #{@search_paid_admin == 'all' ? 'active' : '' }"
+            .dropdown-divider
+            - available_paid_admin.each do |paid_admin|
+              = link_to paid_admin.humanize, url_for(sortable_search_params.merge(search_paid_admin: paid_admin)), class: "dropdown-item #{@search_paid_admin == paid_admin ? 'active' : '' }"
         %li.nav-item
           = link_to "fbook data", url_for(sortable_search_params.merge(search_facebook_data: !@search_facebook_data)), class: "nav-link #{@search_facebook_data ? 'active' : ''}"
         %li.nav-item

--- a/app/views/admin/theft_alerts/index.html.haml
+++ b/app/views/admin/theft_alerts/index.html.haml
@@ -1,6 +1,10 @@
 - if @bike.present?
-  = render partial: "/admin/bikes/bike_tabs", locals: { bike: @bike, active_tab: "theft_alerts", display_recovery: true }
-  %h1.mt-5.mb-4 Promoted Alerts
+  = render partial: "/admin/bikes/bike_tabs", locals: {bike: @bike, active_tab: "theft_alerts", display_recovery: true}
+  %h1.mt-5.mb-4
+    Promoted Alerts
+    = link_to "New Promoted alert", new_admin_theft_alert_path(bike_id: @bike.id), class: "small btn btn-outline-success btn-sm ml-2"
+
+
 - else
   .admin-subnav
     .col-md-5
@@ -125,8 +129,9 @@
                 %td= MoneyFormater.money_format(fbook_cents_total)
                 %td.small= admin_number_display(recovered_count_total)
 
+
 = render partial: "/shared/pagination", locals: {collection: @theft_alerts, count: matching_theft_alerts.count, name: "Promoted Alert", views_prefix: "admin"}
 
-= render partial: "/admin/theft_alerts/table", locals: { render_sortable: true, theft_alerts: @theft_alerts }
+= render partial: "/admin/theft_alerts/table", locals: {render_sortable: true, theft_alerts: @theft_alerts, skip_bike: @bike.present?}
 
 = render partial: "/shared/pagination", locals: {collection: @theft_alerts, count: matching_theft_alerts.count, name: "Promoted Alert", views_prefix: "admin", skip_total: true}

--- a/app/views/admin/theft_alerts/new.html.haml
+++ b/app/views/admin/theft_alerts/new.html.haml
@@ -1,0 +1,56 @@
+= render partial: "/admin/bikes/bike_tabs", locals: {bike: @bike, active_tab: "theft_alerts", display_recovery: true}
+
+%h1.mt-5.mb-4
+  New Promoted Alert
+
+- if @theft_alerts.any?
+  %h4 Existing alerts
+  = render partial: "/admin/theft_alerts/table", locals: {render_sortable: true, theft_alerts: @theft_alerts, skip_bike: true}
+
+.row.mt-5.mb-4
+  .offset-md-2.col-md-8
+    - if @theft_alert.activateable?
+      .alert.alert-info
+        %h4
+          This alert will active as soon as you create it
+    - else
+      .alert.alert-warning
+        %h4
+          This alert won't activate,
+          %small it's missing required stuff:
+        %ul
+          - if @theft_alert.missing_photo?
+            %li.text-danger It doesn't have a photo
+          - if @theft_alert.missing_location?
+            %li.text-danger It doesn't have a location - "#{@theft_alert.latitude}"
+          - unless @theft_alert.stolen_record_approved?
+            %li.text-danger Stolen record isn't approved
+
+= form_for @theft_alert, url: admin_theft_alerts_path, method: :post, html: {class: "m-0"} do |f|
+  = f.hidden_field :stolen_record_id
+  .row
+    .col-md-6
+      .form-group
+        - plan_options = TheftAlertPlan.active.map { |e| [theft_alert_plan_title(e), e.id] }
+        = f.label :theft_alert_plan_id
+        = f.select :theft_alert_plan_id,
+          options_for_select(plan_options, @theft_alert.theft_alert_plan.id),
+          {},
+          class: "form-control"
+
+    - @theft_alert.ad_radius_miles ||= @theft_alert.theft_alert_plan.ad_radius_miles
+    .col-md-6
+      .form-group
+        = f.label :ad_radius_miles
+        = f.number_field :ad_radius_miles, step: 1, min: 1, class: "form-control"
+
+  .form-group
+    = label_tag :location
+    = text_field_tag :location, @theft_alert.address_string, disabled: true, class: "form-control"
+
+  .form-group
+    = f.label :notes
+    = f.text_area :notes, rows: 3, class: "form-control"
+
+  .form-group
+    = submit_tag "Create", class: "btn btn-info"

--- a/app/views/admin/theft_alerts/new.html.haml
+++ b/app/views/admin/theft_alerts/new.html.haml
@@ -10,9 +10,9 @@
 .row.mt-5.mb-4
   .offset-md-2.col-md-8
     - if @theft_alert.activateable?
-      .alert.alert-info
+      .alert.alert-success
         %h4
-          This alert will active as soon as you create it
+          This alert will activate as soon as you create it.
     - else
       .alert.alert-warning
         %h4
@@ -53,4 +53,4 @@
     = f.text_area :notes, rows: 3, class: "form-control"
 
   .form-group
-    = submit_tag "Create", class: "btn btn-info"
+    = submit_tag "Create", class: "btn btn-success"

--- a/app/views/bikes/theft_alerts/_table.html.haml
+++ b/app/views/bikes/theft_alerts/_table.html.haml
@@ -17,7 +17,7 @@
               %th= t(".start")
               %th= t(".end")
               - if show_creator
-                %th.small Creator
+                %th.small=t(".creator")
 
           %tbody
             - theft_alerts.each do |theft_alert|

--- a/app/views/bikes/theft_alerts/_table.html.haml
+++ b/app/views/bikes/theft_alerts/_table.html.haml
@@ -25,8 +25,8 @@
                 %td= alert.theft_alert_plan.name
                 %td= alert.status
                 %td
-                  - if alert.begin_at.present?
-                    %span.convertTime= l(alert.begin_at, format: :convert_time)
+                  - if alert.start_at.present?
+                    %span.convertTime= l(alert.start_at, format: :convert_time)
                 %td
                   - if alert.end_at.present?
                     .convertTime= l(alert.end_at, format: :convert_time)

--- a/app/views/bikes/theft_alerts/_table.html.haml
+++ b/app/views/bikes/theft_alerts/_table.html.haml
@@ -1,6 +1,7 @@
 - first_form_well ||= false
 
 - if theft_alerts.present?
+  - show_creator = theft_alerts.pluck(:user_id).uniq != [current_user.id]
   .form-wrap{ class: first_form_well ? "" : "secondary-form-wrap" }
     .form-well-form-header-always-visible
       %h3
@@ -15,18 +16,23 @@
               %th= t(".status")
               %th= t(".start")
               %th= t(".end")
+              - if show_creator
+                %th.small Creator
 
           %tbody
-            - theft_alerts.each do |alert|
+            - theft_alerts.each do |theft_alert|
               %tr
                 %td
                   %span.convertTime
-                    = l(alert.created_at, format: :convert_time)
-                %td= alert.theft_alert_plan.name
-                %td= alert.status
+                    = l(theft_alert.created_at, format: :convert_time)
+                %td= theft_alert.theft_alert_plan.name
+                %td= theft_alert.status
                 %td
-                  - if alert.start_at.present?
-                    %span.convertTime= l(alert.start_at, format: :convert_time)
+                  - if theft_alert.start_at.present?
+                    %span.convertTime= l(theft_alert.start_at, format: :convert_time)
                 %td
-                  - if alert.end_at.present?
-                    .convertTime= l(alert.end_at, format: :convert_time)
+                  - if theft_alert.end_at.present?
+                    .convertTime= l(theft_alert.end_at, format: :convert_time)
+                - if show_creator
+                  %td
+                    %small= theft_alert.user&.display_name

--- a/app/views/shared/_pagination.html.haml
+++ b/app/views/shared/_pagination.html.haml
@@ -26,7 +26,7 @@
             = humanized_time_range(@time_range)
         - elsif !skip_total
           %em.less-strong
-            (#{number_with_delimiter(collection.where("created_at >= ?", Time.current.beginning_of_day).total_count)} today)
+            (#{number_with_delimiter(collection.where("#{collection.table_name}.created_at >= ?", Time.current.beginning_of_day).total_count)} today)
   - unless skip_pagination
     .pagination-flex.justify-content-md-end{class: (skip_total ? "col-12" : "col-md-7")}
       = paginate collection, views_prefix: views_prefix

--- a/app/workers/activate_theft_alert_worker.rb
+++ b/app/workers/activate_theft_alert_worker.rb
@@ -12,7 +12,7 @@ class ActivateTheftAlertWorker < ApplicationWorker
     Facebook::AdsIntegration.new.create_for(theft_alert)
     theft_alert.reload
     # And mark the theft alert active
-    theft_alert.update(begin_at: theft_alert.calculated_begin_at,
+    theft_alert.update(start_at: theft_alert.calculated_start_at,
       end_at: theft_alert.calculated_end_at,
       status: "active")
     # Generally, there is information that didn't get saved when the ad was created, so enqueue update

--- a/app/workers/after_user_change_worker.rb
+++ b/app/workers/after_user_change_worker.rb
@@ -33,7 +33,7 @@ class AfterUserChangeWorker < ApplicationWorker
     end
 
     # Activate activateable theft alerts!
-    user.theft_alerts.paid.where(begin_at: nil).each do |theft_alert|
+    user.theft_alerts.paid.where(start_at: nil).each do |theft_alert|
       next unless theft_alert.activateable?
       ActivateTheftAlertWorker.perform_async(theft_alert.id)
     end

--- a/config/locales/.translation_io
+++ b/config/locales/.translation_io
@@ -1,2 +1,2 @@
 ---
-timestamp: 1648839419
+timestamp: 1649696641

--- a/config/locales/.translation_io
+++ b/config/locales/.translation_io
@@ -1,2 +1,2 @@
 ---
-timestamp: 1649696641
+timestamp: 1649704616

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -595,7 +595,7 @@ en:
         end_at: End at
         notes: Notes
         payment: :activerecord.models.payment
-        start_at: Begin at
+        start_at: Start at
         status: Status
         stolen_record: :activerecord.models.stolen_record
         theft_alert_plan: :activerecord.models.theft_alert_plan
@@ -1342,6 +1342,7 @@ en:
         your_order_is_pending: Your order is pending.
       table:
         created: Created
+        creator: Creator
         end: End
         existing_theft_alerts: Existing Promoted Alerts
         plan: Plan

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -591,11 +591,11 @@ en:
         tsved_at: Tsved at
         zipcode: Postal code
       theft_alert:
-        start_at: Begin at
         creator: :activerecord.models.creator
         end_at: End at
         notes: Notes
         payment: :activerecord.models.payment
+        start_at: Begin at
         status: Status
         stolen_record: :activerecord.models.stolen_record
         theft_alert_plan: :activerecord.models.theft_alert_plan

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -591,7 +591,7 @@ en:
         tsved_at: Tsved at
         zipcode: Postal code
       theft_alert:
-        begin_at: Begin at
+        start_at: Begin at
         creator: :activerecord.models.creator
         end_at: End at
         notes: Notes

--- a/config/locales/translation.nl.yml
+++ b/config/locales/translation.nl.yml
@@ -2031,6 +2031,7 @@ nl:
         plan: Plan
         start: Begin
         status: Toestand
+        creator: Schepper
     main_show_block:
       bike_photo: "%{bike_type} foto"
       color_may_not_match: Kleur komt mogelijk niet overeen!

--- a/config/locales/translation.nl.yml
+++ b/config/locales/translation.nl.yml
@@ -719,10 +719,10 @@ nl:
         zipcode: Postcode
         recovered_at: Datum hersteld
       theft_alert:
-        begin_at: Begin bij
         end_at: Eindig op
         notes: Notes
         status: Toestand
+        start_at: Begin bij
       theft_alert_plan:
         active: Actief
         amount_cents: Bedrag centen

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -197,13 +197,12 @@ Rails.application.routes.draw do
       :paints, :ads, :recovery_displays, :mail_snippets, :organization_features, :payments,
       :ctypes, :parking_notifications, :impound_records, :graduated_notifications,
       :content_tags, :impound_claims, :mailchimp_values, :mailchimp_data, :user_alerts,
-      :notifications, :user_registration_organizations
+      :notifications, :user_registration_organizations, :theft_alerts
 
     resources :bike_stickers do
       collection { get :reassign }
     end
     resources :invoices, only: [:index]
-    resources :theft_alerts, only: %i[show index edit update]
     resources :theft_alert_plans, only: %i[index edit update new create]
 
     resources :organizations do

--- a/db/migrate/20220411165641_rename_theft_alerts_begin_at_to_start_at.rb
+++ b/db/migrate/20220411165641_rename_theft_alerts_begin_at_to_start_at.rb
@@ -1,5 +1,7 @@
 class RenameTheftAlertsBeginAtToStartAt < ActiveRecord::Migration[6.1]
   def change
     rename_column :theft_alerts, :begin_at, :start_at
+    add_column :theft_alerts, :admin, :boolean, default: false
+    add_column :theft_alerts, :ad_radius_miles, :integer
   end
 end

--- a/db/migrate/20220411165641_rename_theft_alerts_begin_at_to_start_at.rb
+++ b/db/migrate/20220411165641_rename_theft_alerts_begin_at_to_start_at.rb
@@ -1,0 +1,5 @@
+class RenameTheftAlertsBeginAtToStartAt < ActiveRecord::Migration[6.1]
+  def change
+    rename_column :theft_alerts, :begin_at, :start_at
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -2843,7 +2843,9 @@ CREATE TABLE public.theft_alerts (
     reach integer,
     bike_id bigint,
     facebook_updated_at timestamp without time zone,
-    amount_cents_facebook_spent integer
+    amount_cents_facebook_spent integer,
+    admin boolean DEFAULT false,
+    ad_radius_miles integer
 );
 
 

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -2832,7 +2832,7 @@ CREATE TABLE public.theft_alerts (
     payment_id integer,
     user_id integer,
     status integer DEFAULT 0 NOT NULL,
-    begin_at timestamp without time zone,
+    start_at timestamp without time zone,
     end_at timestamp without time zone,
     created_at timestamp without time zone NOT NULL,
     updated_at timestamp without time zone NOT NULL,
@@ -6173,6 +6173,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20220124192245'),
 ('20220201213958'),
 ('20220324004315'),
-('20220405173312');
+('20220405173312'),
+('20220411165641');
 
 

--- a/spec/factories/theft_alerts.rb
+++ b/spec/factories/theft_alerts.rb
@@ -12,13 +12,13 @@ FactoryBot.define do
 
     trait :begun do
       status { "active" }
-      begin_at { Time.current }
-      end_at { begin_at + theft_alert_plan.duration_days.days }
+      start_at { Time.current }
+      end_at { start_at + theft_alert_plan.duration_days.days }
     end
 
     trait :ended do
       status { "inactive" }
-      begin_at { end_at - theft_alert_plan.duration_days.days }
+      start_at { end_at - theft_alert_plan.duration_days.days }
       end_at { Time.current }
     end
 

--- a/spec/models/theft_alert_spec.rb
+++ b/spec/models/theft_alert_spec.rb
@@ -112,4 +112,28 @@ RSpec.describe TheftAlert, type: :model do
       end
     end
   end
+
+  describe "admin" do
+    let(:theft_alert_plan) { FactoryBot.create(:theft_alert_plan, ad_radius_miles: 24) }
+    let(:stolen_record) { FactoryBot.create(:stolen_record, :with_alert_image, :in_vancouver, approved: true) }
+    let(:theft_alert) do
+      FactoryBot.create(:theft_alert,
+        theft_alert_plan: theft_alert_plan,
+        ad_radius_miles: 333,
+        stolen_record: stolen_record,
+        admin: admin)
+    end
+    let(:admin) { false }
+    it "is via plan" do
+      expect(theft_alert.reload.ad_radius_miles).to eq 24
+      expect(theft_alert.activateable?).to be_falsey
+    end
+    context "admin" do
+      let(:admin) { true }
+      it "is what is set" do
+        expect(theft_alert.reload.ad_radius_miles).to eq 333
+        expect(theft_alert.activateable?).to be_truthy
+      end
+    end
+  end
 end

--- a/spec/models/theft_alert_spec.rb
+++ b/spec/models/theft_alert_spec.rb
@@ -92,7 +92,7 @@ RSpec.describe TheftAlert, type: :model do
     end
     context "campaign_id" do
       let(:end_at) { Time.current - 1.hour }
-      let(:theft_alert) { FactoryBot.create(:theft_alert, facebook_data: {campaign_id: "cxcxc"}, begin_at: Time.current - 1.week, end_at: end_at) }
+      let(:theft_alert) { FactoryBot.create(:theft_alert, facebook_data: {campaign_id: "cxcxc"}, start_at: Time.current - 1.week, end_at: end_at) }
       it "is truthy" do
         expect(theft_alert.reload.facebook_updateable?).to be_truthy
         expect(theft_alert.live?).to be_falsey

--- a/spec/models/theft_alert_spec.rb
+++ b/spec/models/theft_alert_spec.rb
@@ -113,7 +113,7 @@ RSpec.describe TheftAlert, type: :model do
     end
   end
 
-  describe "admin" do
+  describe "admin differences" do
     let(:theft_alert_plan) { FactoryBot.create(:theft_alert_plan, ad_radius_miles: 24) }
     let(:stolen_record) { FactoryBot.create(:stolen_record, :with_alert_image, :in_vancouver, approved: true) }
     let(:theft_alert) do
@@ -124,15 +124,19 @@ RSpec.describe TheftAlert, type: :model do
         admin: admin)
     end
     let(:admin) { false }
-    it "is via plan" do
+    it "is default attributes" do
       expect(theft_alert.reload.ad_radius_miles).to eq 24
       expect(theft_alert.activateable?).to be_falsey
+      theft_alert.facebook_data = {activating_at: Time.current.to_i}
+      expect(theft_alert.notify?).to be_truthy
     end
     context "admin" do
       let(:admin) { true }
       it "is what is set" do
         expect(theft_alert.reload.ad_radius_miles).to eq 333
         expect(theft_alert.activateable?).to be_truthy
+        theft_alert.facebook_data = {activating_at: Time.current.to_i}
+        expect(theft_alert.notify?).to be_falsey
       end
     end
   end

--- a/spec/requests/admin/stolen_bikes_request_spec.rb
+++ b/spec/requests/admin/stolen_bikes_request_spec.rb
@@ -67,7 +67,7 @@ RSpec.describe Admin::StolenBikesController, type: :request do
           expect(theft_alert.reload.bike_id).to eq bike.id
           expect(theft_alert.activateable?).to be_falsey
           expect(theft_alert.activateable_except_approval?).to be_truthy
-          expect(theft_alert.begin_at).to be_blank
+          expect(theft_alert.start_at).to be_blank
           bike.reload
           stolen_record.reload
           expect(stolen_record.approved).to be_falsey

--- a/spec/requests/admin/theft_alerts_request_spec.rb
+++ b/spec/requests/admin/theft_alerts_request_spec.rb
@@ -89,7 +89,7 @@ RSpec.describe Admin::TheftAlertsController, type: :request do
       it "sets alert timestamps when beginning an alert" do
         alert = FactoryBot.create(:theft_alert)
         expect(alert.status).to eq("pending")
-        expect(alert.begin_at).to eq(nil)
+        expect(alert.start_at).to eq(nil)
         expect(alert.end_at).to eq(nil)
 
         patch "/admin/theft_alerts/#{alert.id}",
@@ -102,7 +102,7 @@ RSpec.describe Admin::TheftAlertsController, type: :request do
 
         expect(response).to redirect_to(admin_theft_alerts_path)
         expect(alert.reload.status).to eq("active")
-        expect(alert.begin_at).to be_within(2.seconds).of(Time.current)
+        expect(alert.start_at).to be_within(2.seconds).of(Time.current)
         expect(alert.end_at).to be_within(2.seconds).of(Time.current + 7.days)
       end
 
@@ -110,7 +110,7 @@ RSpec.describe Admin::TheftAlertsController, type: :request do
         alert = FactoryBot.create(:theft_alert)
         expect(alert.status).to eq("pending")
         expect(alert.notes).to be_nil
-        expect(alert.begin_at).to be_nil
+        expect(alert.start_at).to be_nil
         expect(alert.end_at).to be_nil
 
         patch "/admin/theft_alerts/#{alert.id}",
@@ -125,7 +125,7 @@ RSpec.describe Admin::TheftAlertsController, type: :request do
         expect(response).to redirect_to(admin_theft_alerts_path)
         expect(alert.reload.status).to eq("pending")
         expect(alert.notes).to eq("updated note")
-        expect(alert.begin_at).to be_nil
+        expect(alert.start_at).to be_nil
         expect(alert.end_at).to be_nil
       end
 
@@ -139,14 +139,14 @@ RSpec.describe Admin::TheftAlertsController, type: :request do
             theft_alert: {
               status: "active",
               theft_alert_plan_id: alert.theft_alert_plan.id,
-              begin_at: now,
+              start_at: now,
               end_at: now + 1.day
             }
           }
 
         expect(response).to redirect_to(admin_theft_alerts_path)
         expect(alert.reload.status).to eq("active")
-        expect(alert.begin_at).to be_within(5.seconds).of(now)
+        expect(alert.start_at).to be_within(5.seconds).of(now)
         expect(alert.end_at).to be_within(5.seconds).of(now + 1.day)
       end
 

--- a/spec/requests/admin/theft_alerts_request_spec.rb
+++ b/spec/requests/admin/theft_alerts_request_spec.rb
@@ -5,6 +5,8 @@ base_url = "/admin/theft_alerts"
 RSpec.describe Admin::TheftAlertsController, type: :request do
   context "given a logged-in superuser" do
     include_context :request_spec_logged_in_as_superuser
+    let(:stolen_record) { FactoryBot.create(:stolen_record, :with_alert_image, :in_vancouver, approved: true) }
+    let(:bike) { stolen_record.bike }
 
     describe "GET /admin/theft_alerts" do
       let!(:theft_alert) { FactoryBot.create(:theft_alert) }
@@ -56,9 +58,9 @@ RSpec.describe Admin::TheftAlertsController, type: :request do
 
     describe "GET /admin/theft_alerts/:id/edit" do
       it "responds with 200 and the edit template" do
-        alert = FactoryBot.create(:theft_alert)
+        theft_alert = FactoryBot.create(:theft_alert)
 
-        get "/admin/theft_alerts/#{alert.id}/edit"
+        get "/admin/theft_alerts/#{theft_alert.id}/edit"
 
         expect(response.status).to eq(200)
         expect(response).to render_template(:edit)
@@ -67,104 +69,18 @@ RSpec.describe Admin::TheftAlertsController, type: :request do
 
     describe "PATCH /admin/theft_alerts/:id" do
       it "redirects to the index route on update success" do
-        alert = FactoryBot.create(:theft_alert)
-        expect(alert.status).to eq("pending")
+        theft_alert = FactoryBot.create(:theft_alert)
+        expect(theft_alert.status).to eq("pending")
 
-        patch "/admin/theft_alerts/#{alert.id}",
+        patch "/admin/theft_alerts/#{theft_alert.id}",
           params: {
-            theft_alert: {
-              status: "active",
-              theft_alert_plan_id: alert.theft_alert_plan.id,
-              notes: "Some notes"
-            }
+            theft_alert: {update_theft_alert: true, notes: "Some notes"}
           }
 
         expect(response).to redirect_to(admin_theft_alerts_path)
         expect(flash[:success]).to match(/success/i)
         expect(flash[:errors]).to be_blank
-        expect(alert.reload.status).to eq("active")
-        expect(alert.notes).to eq("Some notes")
-      end
-
-      it "sets alert timestamps when beginning an alert" do
-        alert = FactoryBot.create(:theft_alert)
-        expect(alert.status).to eq("pending")
-        expect(alert.start_at).to eq(nil)
-        expect(alert.end_at).to eq(nil)
-
-        patch "/admin/theft_alerts/#{alert.id}",
-          params: {
-            theft_alert: {
-              status: "active",
-              theft_alert_plan_id: alert.theft_alert_plan.id
-            }
-          }
-
-        expect(response).to redirect_to(admin_theft_alerts_path)
-        expect(alert.reload.status).to eq("active")
-        expect(alert.start_at).to be_within(2.seconds).of(Time.current)
-        expect(alert.end_at).to be_within(2.seconds).of(Time.current + 7.days)
-      end
-
-      it "does not set alert timestamps when updating a pending alert" do
-        alert = FactoryBot.create(:theft_alert)
-        expect(alert.status).to eq("pending")
-        expect(alert.notes).to be_nil
-        expect(alert.start_at).to be_nil
-        expect(alert.end_at).to be_nil
-
-        patch "/admin/theft_alerts/#{alert.id}",
-          params: {
-            theft_alert: {
-              status: "pending",
-              theft_alert_plan_id: alert.theft_alert_plan.id,
-              notes: "updated note"
-            }
-          }
-
-        expect(response).to redirect_to(admin_theft_alerts_path)
-        expect(alert.reload.status).to eq("pending")
-        expect(alert.notes).to eq("updated note")
-        expect(alert.start_at).to be_nil
-        expect(alert.end_at).to be_nil
-      end
-
-      it "does not overwrite submitted timestamps when updating a non-pending alert" do
-        alert = FactoryBot.create(:theft_alert_begun)
-        now = Time.current
-        expect(alert.status).to eq("active")
-
-        patch "/admin/theft_alerts/#{alert.id}",
-          params: {
-            theft_alert: {
-              status: "active",
-              theft_alert_plan_id: alert.theft_alert_plan.id,
-              start_at: now,
-              end_at: now + 1.day
-            }
-          }
-
-        expect(response).to redirect_to(admin_theft_alerts_path)
-        expect(alert.reload.status).to eq("active")
-        expect(alert.start_at).to be_within(5.seconds).of(now)
-        expect(alert.end_at).to be_within(5.seconds).of(now + 1.day)
-      end
-
-      it "renders the edit template on update failure" do
-        alert = FactoryBot.create(:theft_alert, status: "pending")
-
-        patch "/admin/theft_alerts/#{alert.id}",
-          params: {
-            theft_alert: {
-              status: nil,
-              theft_alert_plan_id: alert.theft_alert_plan.id
-            }
-          }
-
-        expect(response.status).to eq(200)
-        expect(flash[:success]).to be_blank
-        expect(flash[:error]).to include("Status can't be blank")
-        expect(alert.reload.status).to eq("pending")
+        expect(theft_alert.reload.notes).to eq("Some notes")
       end
     end
 
@@ -188,6 +104,81 @@ RSpec.describe Admin::TheftAlertsController, type: :request do
           patch "/admin/theft_alerts/#{theft_alert.id}", params: {update_theft_alert: true}
           # expect(UpdateTheftAlertFacebookWorker.jobs.count).to eq 1
           expect(theft_alert.reload.activating_at).to be_blank
+        end
+      end
+    end
+
+    describe "new" do
+      let!(:theft_alert_plan) { FactoryBot.create(:theft_alert_plan) }
+      it "renders" do
+        expect(stolen_record).to be_present
+        get "#{base_url}/new?bike_id=#{bike.id}"
+        expect(assigns(:stolen_record)&.id).to eq stolen_record.id
+        expect(response).to be_ok
+        expect(response).to render_template(:new)
+        get "#{base_url}/new"
+        expect(response).to redirect_to admin_theft_alerts_path
+        expect(flash[:info]).to match "bike"
+      end
+    end
+
+    describe "create" do
+      let!(:theft_alert_plan) { FactoryBot.create(:theft_alert_plan) }
+      it "creates and activates" do
+        Sidekiq::Worker.clear_all
+        expect do
+          post "/admin/theft_alerts",
+            params: {
+              theft_alert: {
+                stolen_record_id: stolen_record.id,
+                theft_alert_plan_id: theft_alert_plan.id,
+                notes: "Some notes",
+                ad_radius_miles: 33
+              }
+            }
+        end.to change(TheftAlert, :count).by 1
+
+        expect(flash[:success]).to be_present
+        theft_alert = TheftAlert.last
+        expect(theft_alert.admin).to be_truthy
+        expect(theft_alert.user_id).to eq current_user.id
+        expect(theft_alert.stolen_record_id).to eq stolen_record.id
+        expect(theft_alert.bike_id).to eq bike.id
+        expect(theft_alert.ad_radius_miles).to eq 33
+        expect(theft_alert.notes).to eq "Some notes"
+        expect(theft_alert.status).to eq "pending"
+        expect(theft_alert.activateable?).to be_truthy
+        expect(ActivateTheftAlertWorker.jobs.count).to eq 1
+      end
+      context "not activateable" do
+        let(:stolen_record) { FactoryBot.create(:stolen_record, :with_alert_image, :in_vancouver) }
+        it "does not activate" do
+          Sidekiq::Worker.clear_all
+          expect(stolen_record.reload.approved?).to be_falsey
+          expect do
+            post "/admin/theft_alerts",
+              params: {
+                theft_alert: {
+                  stolen_record_id: stolen_record.id,
+                  theft_alert_plan_id: theft_alert_plan.id,
+                  notes: "Some notes",
+                  ad_radius_miles: 33
+                }
+              }
+          end.to change(TheftAlert, :count).by 1
+
+          expect(flash[:success]).to be_present
+          theft_alert = TheftAlert.last
+          expect(theft_alert.admin).to be_truthy
+          expect(theft_alert.user_id).to eq current_user.id
+          expect(theft_alert.stolen_record_id).to eq stolen_record.id
+          expect(theft_alert.bike_id).to eq bike.id
+          expect(theft_alert.ad_radius_miles).to eq 33
+          expect(theft_alert.notes).to eq "Some notes"
+          expect(theft_alert.status).to eq "pending"
+          expect(theft_alert.activateable?).to be_falsey
+          expect(theft_alert.activating?).to be_falsey
+          expect(ActivateTheftAlertWorker.jobs.count).to eq 0
         end
       end
     end

--- a/spec/workers/activate_theft_alert_worker_spec.rb
+++ b/spec/workers/activate_theft_alert_worker_spec.rb
@@ -33,7 +33,7 @@ if !ENV["CI"] && facebook_imported && Facebook::AdsIntegration::TOKEN.present?
       #   expect(theft_alert.missing_photo?).to be_falsey
       #   expect(theft_alert.activateable?).to be_truthy
       #   expect(theft_alert.status).to eq "pending"
-      #   expect(theft_alert.begin_at).to be_blank
+      #   expect(theft_alert.start_at).to be_blank
       #   expect(theft_alert.facebook_data).to be_blank
       #   Sidekiq::Worker.clear_all
       #   VCR.use_cassette("facebook/activate_theft_alert_worker-success", match_requests_on: [:method]) do
@@ -41,7 +41,7 @@ if !ENV["CI"] && facebook_imported && Facebook::AdsIntegration::TOKEN.present?
       #     theft_alert.reload
       #     expect(theft_alert.activateable?).to be_truthy
       #     expect(theft_alert.status).to eq "active"
-      #     expect(theft_alert.begin_at).to be_present
+      #     expect(theft_alert.start_at).to be_present
       #     expect(theft_alert.facebook_data.activating_at).to be_present
       #     # Somehow this doesn't show up, in requests after the first request
       #     # expect(theft_alert.facebook_post_url).to be_present

--- a/spec/workers/deactivate_expired_theft_alert_worker_spec.rb
+++ b/spec/workers/deactivate_expired_theft_alert_worker_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe DeactivateExpiredTheftAlertWorker, type: :job do
     it "deactivates expired theft alerts" do
       active = FactoryBot.create_list(:theft_alert_begun, 2)
       expired = FactoryBot.create_list(:theft_alert_begun, 2,
-        begin_at: Time.current - 2.days,
+        start_at: Time.current - 2.days,
         end_at: Time.current - 1.day)
       expect(TheftAlert.active.count).to eq(4)
       expect(TheftAlert.inactive.count).to eq(0)

--- a/spec/workers/update_theft_alert_facebook_worker_spec.rb
+++ b/spec/workers/update_theft_alert_facebook_worker_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe UpdateTheftAlertFacebookWorker, type: :job do
         theft_alert_plan: theft_alert_plan,
         stolen_record: stolen_record,
         facebook_data: facebook_data,
-        begin_at: Time.current - 1.minute,
+        start_at: Time.current - 1.minute,
         end_at: Time.current + theft_alert_plan.duration_days_facebook)
     end
     before { stub_const("Facebook::AdsIntegration", FakeIntegrationClass) }
@@ -40,7 +40,7 @@ RSpec.describe UpdateTheftAlertFacebookWorker, type: :job do
       expect(theft_alert.activateable?).to be_truthy
       expect(theft_alert.notify?).to be_truthy
       expect(theft_alert.status).to eq "pending"
-      expect(theft_alert.begin_at).to be_present
+      expect(theft_alert.start_at).to be_present
       expect(theft_alert.end_at).to be_present
       expect(theft_alert.facebook_post_url).to be_blank
       expect(theft_alert.facebook_updated_at).to be_blank
@@ -77,7 +77,7 @@ RSpec.describe UpdateTheftAlertFacebookWorker, type: :job do
         expect(theft_alert.activateable?).to be_truthy
         expect(theft_alert.notify?).to be_falsey
         expect(theft_alert.status).to eq "pending"
-        expect(theft_alert.begin_at).to be_present
+        expect(theft_alert.start_at).to be_present
         expect(theft_alert.end_at).to be_present
         expect(theft_alert.facebook_post_url).to be_blank
         expect(theft_alert.facebook_updated_at).to be_blank


### PR DESCRIPTION
- Allow admins to see all theft alerts in user bike view
- Rename `begin_at` to `start_at` for consistency with other attributes
- Admins can create new stolen alerts for arbitrary bikes