### PR TITLE
Fix Redis.current deprecation

### DIFF
--- a/app/integrations/file_cache_maintainer.rb
+++ b/app/integrations/file_cache_maintainer.rb
@@ -89,11 +89,8 @@ class FileCacheMaintainer
       "#{Rails.env[0..2]}_tsv"
     end
 
-    # Should be the new cannonical way of using redis
-    def self.redis
-      # Basically, crib what is done in sidekiq
-      raise ArgumentError, "requires a block" unless block_given?
-      redis_pool.with { |conn| yield conn }
+    def redis
+      @redis ||= Redis.new # TODO: Switch to connection pool, preferred way of accessing redis
     end
 
     def uploader_from_filename(filename)

--- a/app/workers/email_updated_terms_worker.rb
+++ b/app/workers/email_updated_terms_worker.rb
@@ -20,10 +20,7 @@ class EmailUpdatedTermsWorker < ApplicationWorker
     "#{Rails.env[0..2]}_email_updated_terms_user_ids"
   end
 
-  # Should be the new cannonical way of using redis
-  def self.redis
-    # Basically, crib what is done in sidekiq
-    raise ArgumentError, "requires a block" unless block_given?
-    redis_pool.with { |conn| yield conn }
+  def redis
+    @redis ||= Redis.new # TODO: Switch to connection pool, preferred way of accessing redis
   end
 end


### PR DESCRIPTION
Deprecation warning in tests:

```
`Redis.current=` is deprecated and will be removed in 5.0. (called from: /home/circleci/bikeindex/bike_index/app/integrations/file_cache_maintainer.rb:93:in `redis')
```