### PR TITLE
range.include? to range.cover

### DIFF
--- a/app/workers/email_donation_worker.rb
+++ b/app/workers/email_donation_worker.rb
@@ -67,7 +67,7 @@ class EmailDonationWorker < ApplicationWorker
   def matching_stolen_bikes(payment)
     return [] if payment.user.blank?
     payment.user.bikes.status_stolen.map(&:current_stolen_record).reject(&:blank?)
-      .select { |s| relevant_period(payment).include?(s.date_stolen) }
+      .select { |s| relevant_period(payment).cover?(s.date_stolen) }
       .sort_by(&:date_stolen) # most recent stolen
       .map(&:bike)
   end


### PR DESCRIPTION
```
DEPRECATION WARNING: Using `Range#include?` to check the inclusion of a value in a date time range is deprecated. It is recommended to use `Range#cover?` instead of `Range#include?` to check the inclusion of a value in a date time range. (called from block in matching_stolen_bikes at /home/circleci/bikeindex/bike_index/app/workers/email_donation_worker.rb:70)
```