### PR TITLE
Fix issue with duplicated graduated notifications

### DIFF
--- a/app/workers/process_graduated_notification_worker.rb
+++ b/app/workers/process_graduated_notification_worker.rb
@@ -7,7 +7,6 @@ class ProcessGraduatedNotificationWorker < ScheduledWorker
   end
 
   def perform(graduated_notification_id = nil)
-    return if ENV["BLOCK_GRADUATION_NOTIFICATIONS"].present? # Block process graduated notification worker temporarily
     return enqueue_workers unless graduated_notification_id.present?
 
     graduated_notification = GraduatedNotification.find(graduated_notification_id)


### PR DESCRIPTION
Fix issue causing multiple renewal emails/duplicate graduated notifications

Also, revert #2254 (which temporarily blocked sending graduation notifications)