### PR TITLE
Organization stolen message report_url

### DIFF
--- a/app/assets/stylesheets/revised/emails/email_components.scss
+++ b/app/assets/stylesheets/revised/emails/email_components.scss
@@ -90,7 +90,7 @@ $alert-warning-color: #ffc107;
   }
 }
 
-.organization-stolen-message {
+.organization-stolen-message-alert {
   margin: 2 * $vertical-height 0;
   padding: $vertical-height;
   border: 2px solid $alert-warning-color;

--- a/app/assets/stylesheets/revised/mixins/_colors.scss
+++ b/app/assets/stylesheets/revised/mixins/_colors.scss
@@ -58,3 +58,8 @@ $unregistered-color: #f0ad4e; // text-warning color
 .unregistered-color {
   color: $unregistered-color;
 }
+
+// current boostrap has this class, do something similar
+.text-dark {
+  color: $body-font-color !important;
+}

--- a/app/controllers/admin/organizations_controller.rb
+++ b/app/controllers/admin/organizations_controller.rb
@@ -166,9 +166,8 @@ class Admin::OrganizationsController < Admin::BaseController
     message_params = {search_radius_miles: params[:organization_stolen_message_search_radius_miles],
                       kind: params[:organization_stolen_message_kind],
                       search_radius_kilometers: params[:organization_stolen_message_search_radius_kilometers]}
-    return unless @organization.organization_stolen_message.present? &&
-      message_params.values.present?
-    @organization.organization_stolen_message.update(message_params)
+    return unless message_params.values.reject(&:blank?).any?
+    OrganizationStolenMessage.for(@organization).update(message_params)
   end
 
   def find_organization

--- a/app/controllers/organized/emails_controller.rb
+++ b/app/controllers/organized/emails_controller.rb
@@ -77,7 +77,9 @@ module Organized
         bike = default_bike
         bike.current_stolen_record = StolenRecord.new(date_stolen: Time.current - 1.day)
       end
-      bike.current_stolen_record.organization_stolen_message = current_organization.organization_stolen_message
+      if current_organization.organization_stolen_message&.body.present?
+        bike.current_stolen_record.organization_stolen_message = current_organization.organization_stolen_message
+      end
       bike
     end
 
@@ -115,8 +117,7 @@ module Organized
 
     def permitted_parameters
       if params[:organization_stolen_message].present?
-        params.require(:organization_stolen_message).permit(:body, :is_enabled,
-          :report_url, :report_phone)
+        params.require(:organization_stolen_message).permit(:body, :is_enabled, :report_url)
       else
         params.require(:mail_snippet).permit(:body, :is_enabled, :subject)
       end

--- a/app/controllers/organized/emails_controller.rb
+++ b/app/controllers/organized/emails_controller.rb
@@ -115,7 +115,8 @@ module Organized
 
     def permitted_parameters
       if params[:organization_stolen_message].present?
-        params.require(:organization_stolen_message).permit(:body, :is_enabled, :report_url)
+        params.require(:organization_stolen_message).permit(:body, :is_enabled,
+          :report_url, :report_phone)
       else
         params.require(:mail_snippet).permit(:body, :is_enabled, :subject)
       end

--- a/app/controllers/organized/emails_controller.rb
+++ b/app/controllers/organized/emails_controller.rb
@@ -77,8 +77,8 @@ module Organized
         bike = default_bike
         bike.current_stolen_record = StolenRecord.new(date_stolen: Time.current - 1.day)
       end
-      if current_organization.organization_stolen_message&.body.present?
-        bike.current_stolen_record.organization_stolen_message = current_organization.organization_stolen_message
+      if OrganizationStolenMessage.for(current_organization).is_enabled
+        bike.current_stolen_record.organization_stolen_message = OrganizationStolenMessage.for(current_organization)
       end
       bike
     end
@@ -108,7 +108,7 @@ module Organized
       @can_edit = !%w[finished_registration partial_registration].include?(@kind)
       return unless @can_edit
       if @kind == "organization_stolen_message"
-        @object = current_organization.organization_stolen_message
+        @object = OrganizationStolenMessage.for(current_organization)
       else
         @object = mail_snippets.where(kind: @kind).first
         @object ||= current_organization.mail_snippets.build(kind: @kind)

--- a/app/models/concerns/search_radius_metricable.rb
+++ b/app/models/concerns/search_radius_metricable.rb
@@ -27,7 +27,7 @@ module SearchRadiusMetricable
     @search_radius_metric_units ||= metric_units? # assign because through multiple tables
   end
 
-  def initial_search_radius_miles
+  def default_search_radius_miles
     search_rad = organization&.search_radius_miles if self.class != Organization
     search_rad || DEFAULT_RADIUS_MILES
   end
@@ -50,9 +50,9 @@ module SearchRadiusMetricable
 
   def set_search_radius
     if search_radius_miles.blank? || search_radius_miles < 1
-      self.search_radius_miles = initial_search_radius_miles
+      self.search_radius_miles = default_search_radius_miles
       # switch km default to 100
-      self.search_radius_kilometers = 100 if search_radius_metric_units? && search_radius_miles == DEFAULT_RADIUS_MILES
+      self.search_radius_kilometers = 100 if search_radius_metric_units? && search_radius_miles == default_search_radius_miles
     end
   end
 end

--- a/app/models/organization_stolen_message.rb
+++ b/app/models/organization_stolen_message.rb
@@ -2,6 +2,7 @@ class OrganizationStolenMessage < ApplicationRecord
   MAX_BODY_LENGTH = 400
   KIND_ENUM = {area: 0, association: 1}
   MAX_SEARCH_RADIUS = 1000
+  DEFAULT_RADIUS_MILES = 10
 
   include SearchRadiusMetricable
 
@@ -72,6 +73,10 @@ class OrganizationStolenMessage < ApplicationRecord
 
   def editable_subject?
     false # match mail_snippet method
+  end
+
+  def default_search_radius_miles
+    DEFAULT_RADIUS_MILES
   end
 
   def max_body_length

--- a/app/models/organization_stolen_message.rb
+++ b/app/models/organization_stolen_message.rb
@@ -30,6 +30,10 @@ class OrganizationStolenMessage < ApplicationRecord
     miles_to_kilometers(MAX_SEARCH_RADIUS)
   end
 
+  def self.for(organization)
+    where(organization_id: organization.id).first_or_create
+  end
+
   def self.for_stolen_record(stolen_record)
     return stolen_record.organization_stolen_message if stolen_record.organization_stolen_message.present?
     area_result = for_coordinates(stolen_record.to_coordinates)

--- a/app/models/organization_stolen_message.rb
+++ b/app/models/organization_stolen_message.rb
@@ -34,7 +34,9 @@ class OrganizationStolenMessage < ApplicationRecord
     return stolen_record.organization_stolen_message if stolen_record.organization_stolen_message.present?
     area_result = for_coordinates(stolen_record.to_coordinates)
     return area_result if area_result.present?
-    stolen_record.bike.bike_organizations.includes(:organization).order(:id)
+    bike = Bike.unscoped.find_by_id(stolen_record.bike_id)
+    return nil if bike.blank?
+    bike.bike_organizations.includes(:organization).order(:id)
       .detect { |bo| bo.organization.organization_stolen_message&.is_enabled? }
       &.organization&.organization_stolen_message
   end

--- a/app/models/stolen_record.rb
+++ b/app/models/stolen_record.rb
@@ -316,15 +316,8 @@ class StolenRecord < ApplicationRecord
     if current || bike&.current_stolen_record_id == id
       bike&.update(manual_csr: true, current_stolen_record: (current ? self : nil))
     end
-    AfterStolenRecordSaveWorker.perform_async(id)
+    AfterStolenRecordSaveWorker.perform_async(id, @alert_location_changed)
     AfterUserChangeWorker.perform_async(bike.user_id) if bike&.user_id.present?
-  end
-
-  # If the bike has been recovered, remove the alert_image
-  def remove_outdated_alert_images
-    no_longer_around = bike.blank? || !bike.status_stolen? || recovered?
-    return true unless no_longer_around || @alert_location_changed
-    alert_image&.destroy
   end
 
   private

--- a/app/models/stolen_record.rb
+++ b/app/models/stolen_record.rb
@@ -310,17 +310,21 @@ class StolenRecord < ApplicationRecord
     end
   end
 
-  # TODO: maybe background some of this stuff?
   def update_associations
     return true if skip_update
-    remove_outdated_alert_images
     # Bump bike only if it looks like this is bike's current_stolen_record
     if current || bike&.current_stolen_record_id == id
-      update_not_current_records
       bike&.update(manual_csr: true, current_stolen_record: (current ? self : nil))
     end
-    theft_alerts.each { |t| t.update(updated_at: Time.current) }
+    AfterStolenRecordSaveWorker.perform_async(id)
     AfterUserChangeWorker.perform_async(bike.user_id) if bike&.user_id.present?
+  end
+
+  # If the bike has been recovered, remove the alert_image
+  def remove_outdated_alert_images
+    no_longer_around = bike.blank? || !bike.status_stolen? || recovered?
+    return true unless no_longer_around || @alert_location_changed
+    alert_image&.destroy
   end
 
   private
@@ -332,19 +336,7 @@ class StolenRecord < ApplicationRecord
       .perform_async(theft_alerts.last.id, "theft_alert_recovered")
   end
 
-  # If the bike has been recovered, remove the alert_image
-  def remove_outdated_alert_images
-    no_longer_around = bike.blank? || !bike.status_stolen? || recovered?
-    return true unless no_longer_around || @alert_location_changed
-    alert_image&.destroy
-  end
-
   def fix_date
     self.date_stolen = self.class.corrected_date_stolen(date_stolen)
-  end
-
-  def update_not_current_records
-    StolenRecord.unscoped.where(bike_id: bike_id).where.not(id: id)
-      .each { |s| s.update(current: false, skip_update: true) }
   end
 end

--- a/app/views/admin/organizations/_form.html.haml
+++ b/app/views/admin/organizations/_form.html.haml
@@ -205,8 +205,8 @@
                     leave blank unless it's <strong>absolutely</strong> required - default behavior is preferred
                 = text_field_tag "reg_label-#{reg_field}", registration_field_label(@organization, reg_field), {class: "form-control"}
 
-          - if @organization.enabled?("organization_stolen_message") && @organization.organization_stolen_message.present?
-            - organization_stolen_message = @organization.organization_stolen_message
+          - if @organization.enabled?("organization_stolen_message")
+            - organization_stolen_message = OrganizationStolenMessage.for(@organization)
             .form-group.mt-4
               = label_tag :organization_stolen_message_kind do
                 Stolen Message type

--- a/app/views/admin/organizations/custom_layouts/index.html.haml
+++ b/app/views/admin/organizations/custom_layouts/index.html.haml
@@ -35,14 +35,16 @@
         %td.table-cell-check
           = check_mark if LandingPages::ORGANIZATIONS.include?(@organization.slug)
       %tr
+        -# If there is a message, or organization_stolen_message is enabled, grab it. But don't create one otherwise
+        - organization_stolen_message = @organization.enabled?("organization_stolen_message") ? OrganizationStolenMessage.for(@organization) : @organization.organization_stolen_message
         %td
           = link_to "Organization Stolen Message", edit_organization_email_path("organization_stolen_message", organization_id: @organization.to_param)
         %td.small
           = link_to "preview message", edit_organization_email_path("organization_stolen_message", organization_id: @organization.to_param)
         %td.table-cell-check
-          = check_mark if @organization.organization_stolen_message&.body.present?
+          = check_mark if organization_stolen_message&.body.present?
         %td.table-cell-check
-          = check_mark if @organization.organization_stolen_message&.is_enabled
+          = check_mark if organization_stolen_message&.is_enabled
       - MailSnippet.organization_snippets.each do |kind, snippet_attrs|
         - snippet = @organization.mail_snippets.where(kind: kind).first
         %tr

--- a/app/views/admin/organizations/show.html.haml
+++ b/app/views/admin/organizations/show.html.haml
@@ -188,7 +188,7 @@
                 %strong.text-warning Previously paid!
               - else
                 False
-            %em.less-strong
+            %em.small.less-strong
               Set this via #{link_to "invoices", admin_organization_invoices_path(organization_id: @organization.to_param)}
 
         - if @organization.paid?
@@ -199,7 +199,7 @@
                 Yes
               - else
                 %small.less-strong
-                  No
+                  no
           %tr
             %td Templates
             %td
@@ -207,7 +207,7 @@
                 = @organization.mail_snippets.pluck(:kind).to_sentence
               - else
                 %small.less-strong
-                  None
+                  none
           %tr
             %td Landing Page
             %td
@@ -218,13 +218,13 @@
                   landing page is not public - #{ link_to 'landing page', organization_landing_path(organization_id: @organization.to_param) }
               - else
                 %small.less-strong
-                  no landing page
+                  no
           %tr
             %td Additional Fields
             %td
               - additional_fields = @organization.additional_registration_fields.map { |i| OrganizationFeature.reg_field_to_bike_attrs(i)&.titleize(keep_id_suffix: true) }
               - if additional_fields.none?
-                %small.less-strong None
+                %small.less-strong none
               - else
                 %small= additional_fields.join(", ")
                 %br
@@ -246,9 +246,22 @@
                   %em.less-strong
                     = "recipient".pluralize(@organization.hot_sheet_configuration.current_recipients.count)
                 - else
-                  %span.less-strong not enabled
+                  %small.less-strong not enabled
                 %small
                   = link_to "configuration", edit_organization_hot_sheet_path(organization_id: @organization.to_param)
+          - if @organization.enabled?("organization_stolen_message")
+            - organization_stolen_message = @organization.organization_stolen_message
+            %tr
+              %td Stolen Message
+              %td
+                - if organization_stolen_message.is_enabled
+                  %strong Enabled
+                - elsif organization_stolen_message.body.present?
+                  has content, not enabled
+                - else
+                  %small.less-strong no
+                - if organization_stolen_message.report_url.present?
+                  %strong Report URL present
           %tr
             %td Stickers
             %td

--- a/app/views/admin/organizations/show.html.haml
+++ b/app/views/admin/organizations/show.html.haml
@@ -250,7 +250,7 @@
                 %small
                   = link_to "configuration", edit_organization_hot_sheet_path(organization_id: @organization.to_param)
           - if @organization.enabled?("organization_stolen_message")
-            - organization_stolen_message = @organization.organization_stolen_message
+            - organization_stolen_message = OrganizationStolenMessage.for(@organization)
             %tr
               %td Stolen Message
               %td

--- a/app/views/admin/organizations/show.html.haml
+++ b/app/views/admin/organizations/show.html.haml
@@ -255,13 +255,13 @@
               %td Stolen Message
               %td
                 - if organization_stolen_message.is_enabled
-                  %strong Enabled
+                  = link_to "Enabled", edit_organization_email_path("organization_stolen_message", organization_id: @organization.to_param)
                 - elsif organization_stolen_message.body.present?
                   has content, not enabled
                 - else
                   %small.less-strong no
                 - if organization_stolen_message.report_url.present?
-                  %strong Report URL present
+                  %small Report URL present
           %tr
             %td Stickers
             %td

--- a/app/views/bikes/_organization_stolen_message.html.haml
+++ b/app/views/bikes/_organization_stolen_message.html.haml
@@ -1,0 +1,11 @@
+- organization_stolen_message = stolen_record.organization_stolen_message
+- shown_report_url = stolen_record.police_report_number.blank? && organization_stolen_message.report_url.present?
+.alert.alert-warning.text-dark.organization-stolen-message-alert
+  - if organization_stolen_message.body.present?
+    %span.d-block{style: "line-height: 1.2;"}
+      = organization_stolen_message.body
+    - if shown_report_url
+      .mb-2
+  - if shown_report_url
+    - report_link = link_to(t(".report_link_text"), organization_stolen_message.report_url, target: "_blank")
+    %span.d-block= t(".report_the_theft_to_the_organization_html", organization: organization_stolen_message.organization.name, report_link: report_link)

--- a/app/views/bikes/_stolen_checklist.html.haml
+++ b/app/views/bikes/_stolen_checklist.html.haml
@@ -1,4 +1,9 @@
 - if stolen_record&.display_checklist?
+  - police_report_present = stolen_record.police_report_number.present?
+
+  - if stolen_record.organization_stolen_message&.shown_to?(stolen_record)
+    .pl-1.pr-1= render partial: "/bikes/organization_stolen_message", locals: {stolen_record: stolen_record}
+
   %ul.stolen-checklist
     %li.completed-item
       %span.checklist-checkbox
@@ -31,7 +36,7 @@
         = link_to t(".a_photo_of_your_bike_type", bike_type: @bike.type),
           edit_bike_url(id: @bike.to_param, edit_template: "photos")
 
-    - police_report_present = stolen_record.police_report_number.present?
+
     - submitted_to_police_services = police_report_present && !serial_unknown
 
     -# We only have recommendations for reporting your theft to police if your bike is reported stolen in the Netherlands
@@ -61,7 +66,6 @@
                 = t(".nl_person")
               = t(".nl_person_report")
               = link_to "www.politie.nl/mijn-buurt/politiebureaus", "https://www.politie.nl/mijn-buurt/politiebureaus"
-
     %li{ class: police_report_present ? "completed-item" : "" }
       %span.checklist-checkbox
         = "&#10003;".html_safe if police_report_present

--- a/app/views/organized/emails/index.html.haml
+++ b/app/views/organized/emails/index.html.haml
@@ -37,25 +37,19 @@
             %small
               = truncate(mail_snippets.first.body, length: 100)
     - if current_organization.enabled?("organization_stolen_message")
+      - organization_stolen_message = OrganizationStolenMessage.for(current_organization)
       %tr
         %td
           = link_to "Organization Stolen Message", edit_organization_email_path("organization_stolen_message", organization_id: current_organization.to_param)
-        - if current_organization.organization_stolen_message.present?
-          - organization_stolen_message = current_organization.organization_stolen_message
-          %td= check_mark if organization_stolen_message.is_enabled
-          %td
-            - if organization_stolen_message.content_added_at.present?
-              %span.convertTime
-                = l(organization_stolen_message.content_added_at, format: :convert_time)
-          %td
-            - if organization_stolen_message.content_added_at.present?
-              %span.convertTime
-                = l(organization_stolen_message.updated_at, format: :convert_time)
-          %td
-            %small
-              = truncate(organization_stolen_message.body, length: 100)
-        - else
-          %td
-          %td
-          %td
-          %td
+        %td= check_mark if organization_stolen_message.is_enabled
+        %td
+          - if organization_stolen_message.content_added_at.present?
+            %span.convertTime
+              = l(organization_stolen_message.content_added_at, format: :convert_time)
+        %td
+          - if organization_stolen_message.content_added_at.present?
+            %span.convertTime
+              = l(organization_stolen_message.updated_at, format: :convert_time)
+        %td
+          %small
+            = truncate(organization_stolen_message.body, length: 100)

--- a/app/views/organized_mailer/finished_registration.html.haml
+++ b/app/views/organized_mailer/finished_registration.html.haml
@@ -2,9 +2,10 @@
 - if @organization&.mail_snippet_body('welcome').present?
   = @organization.mail_snippet_body('welcome').html_safe
 
+
 - if @ownership.claim_message.present?
-  - if @bike.current_stolen_record&.organization_stolen_message.present? # NOTE: duplicates in claim message
-    .organization-stolen-message= @bike.current_stolen_record.organization_stolen_message.body
+  - if OrganizationStolenMessage.shown_to?(@bike.current_stolen_record)
+    = render partial: "/bikes/organization_stolen_message", locals: {stolen_record: @bike.current_stolen_record}
   = render partial: "/shared/claim_message", locals: {bike: @bike, skip_to_see: true}
 
 - else
@@ -17,8 +18,8 @@
     %h1= t(".html.thanks_for_adding_this_bike_type_you_found", bike_type: @bike.type)
   - elsif @bike.status_stolen?
     %h1= t(".html.bike_type_thieves_are_jerks", bike_type: @bike.type)
-    - if @bike.current_stolen_record&.organization_stolen_message.present? # NOTE: duplicates in claim message
-      .organization-stolen-message= @bike.current_stolen_record.organization_stolen_message.body
+    - if OrganizationStolenMessage.shown_to?(@bike.current_stolen_record)
+      = render partial: "/bikes/organization_stolen_message", locals: {stolen_record: @bike.current_stolen_record}
     %p= t(".html.were_sorry_your_bike_type_was_stolen", bike_type: @bike.type)
   - else
     %h1.uncap

--- a/app/views/shared/_organized_menu_items.html.haml
+++ b/app/views/shared/_organized_menu_items.html.haml
@@ -116,6 +116,11 @@
     - if passed_organization.enabled?("customize_emails")
       %li
         = active_link t(".custom_emails"), organization_emails_path(organization_id: passed_organization.to_param), match_controller: true, class: "nav-link"
+    - elsif passed_organization.enabled?("organization_stolen_message")
+      -# Show organization stolen message link, even if custom emails aren't enabled
+      %li
+        = active_link t(".stolen_message"), edit_organization_email_path("organization_stolen_message", organization_id: passed_organization.to_param), class: "nav-link"
+
     - if passed_organization.enabled?("hot_sheet")
       %li
         = active_link t(".stolen_hot_sheet_configuration"), edit_organization_hot_sheet_path(organization_id: passed_organization.to_param), class: "nav-link"

--- a/app/workers/after_stolen_record_save_worker.rb
+++ b/app/workers/after_stolen_record_save_worker.rb
@@ -1,0 +1,24 @@
+# This will replace WebhookRunner - which is brittle and not flexible enough for what I'm looking for now
+# I need to refactor that, but I don't want to right now because I don't want to break existing stuff yet
+
+class AfterStolenRecordSaveWorker < ApplicationWorker
+  sidekiq_options retry: false
+
+  def perform(stolen_record_id)
+    stolen_record = StolenRecord.unscoped.find_by_id(stolen_record_id)
+    return if stolen_record.blank?
+    stolen_record.remove_outdated_alert_images
+    stolen_record.theft_alerts.each { |t| t.update(updated_at: Time.current) }
+    if stolen_record.current
+      StolenRecord.unscoped.where(bike_id: stolen_record.bike_id).where.not(id: stolen_record.id)
+        .each { |s| s.update(current: false, skip_update: true) }
+    end
+
+    if stolen_record.organization_stolen_message.blank?
+      stolen_message = OrganizationStolenMessage.for_stolen_record(stolen_record)
+      if stolen_message.present?
+        stolen_record.update(organization_stolen_message_id: stolen_message.id, skip_update: true)
+      end
+    end
+  end
+end

--- a/app/workers/after_stolen_record_save_worker.rb
+++ b/app/workers/after_stolen_record_save_worker.rb
@@ -1,12 +1,10 @@
-# This will replace WebhookRunner - which is brittle and not flexible enough for what I'm looking for now
-# I need to refactor that, but I don't want to right now because I don't want to break existing stuff yet
-
 class AfterStolenRecordSaveWorker < ApplicationWorker
   sidekiq_options retry: false
 
   def perform(stolen_record_id)
     stolen_record = StolenRecord.unscoped.find_by_id(stolen_record_id)
     return if stolen_record.blank?
+    pp "fasdfasdfs"
     stolen_record.remove_outdated_alert_images
     stolen_record.theft_alerts.each { |t| t.update(updated_at: Time.current) }
     if stolen_record.current

--- a/app/workers/email_ownership_invitation_worker.rb
+++ b/app/workers/email_ownership_invitation_worker.rb
@@ -6,14 +6,6 @@ class EmailOwnershipInvitationWorker < ApplicationWorker
     return true unless ownership.present? && ownership.bike.present?
     ownership.bike&.update(updated_at: Time.current)
     ownership.reload
-    if ownership.bike.current_stolen_record.present?
-      stolen_record = ownership.bike.current_stolen_record
-      stolen_record.organization_stolen_message ||= OrganizationStolenMessage.for_stolen_record(stolen_record)
-      if stolen_record.changed?
-        stolen_record.save!
-        ownership.reload
-      end
-    end
     unless ownership.calculated_send_email
       # Update the ownership to have send email set
       return ownership.update_attribute(:send_email, ownership.calculated_send_email)

--- a/app/workers/update_organization_associations_worker.rb
+++ b/app/workers/update_organization_associations_worker.rb
@@ -67,9 +67,7 @@ class UpdateOrganizationAssociationsWorker < ApplicationWorker
 
   def update_organization_stolen_message(organization)
     if organization.enabled?("organization_stolen_message")
-      if organization.organization_stolen_message.blank?
-        OrganizationStolenMessage.create!(organization: organization)
-      end
+      OrganizationStolenMessage.for(organization) # Create if it doesn't exist
     elsif organization.organization_stolen_message&.is_enabled?
       organization.organization_stolen_message.update(is_enabled: false)
     end

--- a/config/locales/.translation_io
+++ b/config/locales/.translation_io
@@ -1,2 +1,2 @@
 ---
-timestamp: 1660330443
+timestamp: 1660334231

--- a/config/locales/.translation_io
+++ b/config/locales/.translation_io
@@ -1,2 +1,2 @@
 ---
-timestamp: 1659211128
+timestamp: 1660330443

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -5235,7 +5235,6 @@ en:
       ascend_imports: Ascend Imports
       bulk_imports: Bulk Imports
       custom_emails: Custom emails
-      stolen_message: Stolen Message
       discuss: Discuss
       exports: Exports
       getting_started: Getting started
@@ -5258,6 +5257,7 @@ en:
       resources: Resources
       stolen_hot_sheet: Stolen Bike Hot Sheet
       stolen_hot_sheet_configuration: Stolen Bike Hot Sheet configuration
+      stolen_message: Stolen Message
       super_admin_view: Super Admin for %{org_name}
     organized_skeleton:
       additional_features_html: >-

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1279,6 +1279,9 @@ en:
       you_scanned_this_sticker_html: >-
         You scanned the sticker <strong>%{pretty_code}</strong>, which is assigned
         to this %{bike_type}.
+    organization_stolen_message:
+      report_link_text: at this link
+      report_the_theft_to_the_organization_html: <span class="text-warning">Report the theft</span> to %{organization} <strong>%{report_link}</strong> to get a police report number
     stolen_checklist:
       a_photo_of_your_bike_type: a photo of your %{bike_type}
       add: Add

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1125,6 +1125,11 @@ en:
       without_serial_number: This %{bike_type} was made without a serial number
       your_full_address_is_required: Your full address is required by %{org_name}
       zipcode: Postal code
+    organization_stolen_message:
+      report_link_text: at this link
+      report_the_theft_to_the_organization_html: >-
+        <span class="text-warning">Report the theft</span> to %{organization} <strong>%{report_link}</strong>
+        to get a police report number
     organized_access_panel:
       access_panel: Access Panel
       added_to_track_parking_notification: >-
@@ -1279,9 +1284,6 @@ en:
       you_scanned_this_sticker_html: >-
         You scanned the sticker <strong>%{pretty_code}</strong>, which is assigned
         to this %{bike_type}.
-    organization_stolen_message:
-      report_link_text: at this link
-      report_the_theft_to_the_organization_html: <span class="text-warning">Report the theft</span> to %{organization} <strong>%{report_link}</strong> to get a police report number
     stolen_checklist:
       a_photo_of_your_bike_type: a photo of your %{bike_type}
       add: Add

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -5235,6 +5235,7 @@ en:
       ascend_imports: Ascend Imports
       bulk_imports: Bulk Imports
       custom_emails: Custom emails
+      stolen_message: Stolen Message
       discuss: Discuss
       exports: Exports
       getting_started: Getting started

--- a/config/locales/translation.nl.yml
+++ b/config/locales/translation.nl.yml
@@ -5040,6 +5040,7 @@ nl:
       stolen_hot_sheet: Stolen Bike Hot Sheet
       stolen_hot_sheet_configuration: Stolen Bike Hot Sheet-configuratie
       super_admin_view: Superbeheerder voor %{org_name}
+      stolen_message: Gestolen bericht
   users:
     accept_terms:
       i_agree_to_tos_html: Ik ga akkoord met de <strong>Servicevoorwaarden van</strong>

--- a/config/locales/translation.nl.yml
+++ b/config/locales/translation.nl.yml
@@ -2071,6 +2071,11 @@ nl:
       stolen_details: Diefstal details
       wheel_diameter: Wiel diameter
       year: jaar
+    organization_stolen_message:
+      report_link_text: op deze link
+      report_the_theft_to_the_organization_html: <span class="text-warning">Meld de
+        diefstal</span> bij %{organization} <strong>%{report_link}</strong> om een
+        politierapportnummer te krijgen
   controllers:
     bikes:
       edit:

--- a/db/migrate/20220811174115_remove_report_phone_from_organization_stolen_message.rb
+++ b/db/migrate/20220811174115_remove_report_phone_from_organization_stolen_message.rb
@@ -1,0 +1,5 @@
+class RemoveReportPhoneFromOrganizationStolenMessage < ActiveRecord::Migration[6.1]
+  def change
+    remove_column :organization_stolen_messages, :report_phone, :string
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -2235,7 +2235,6 @@ CREATE TABLE public.organization_stolen_messages (
     is_enabled boolean DEFAULT false,
     content_added_at timestamp without time zone,
     report_url character varying,
-    report_phone character varying,
     created_at timestamp(6) without time zone NOT NULL,
     updated_at timestamp(6) without time zone NOT NULL
 );
@@ -6328,6 +6327,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20220622004930'),
 ('20220627165205'),
 ('20220730171652'),
-('20220801162511');
+('20220801162511'),
+('20220811174115');
 
 

--- a/spec/models/bike_spec.rb
+++ b/spec/models/bike_spec.rb
@@ -87,6 +87,7 @@ RSpec.describe Bike, type: :model do
       let!(:stolen_record3) { FactoryBot.create(:stolen_record, phone: "2223334444", secondary_phone: "111222333") }
       let(:bike2) { stolen_record3.bike }
       it "finds by stolen_record" do
+        AfterStolenRecordSaveWorker.new.perform(stolen_record2.id)
         expect(stolen_record1.reload.current?).to be_falsey
         stolen_record1.update_column :current, true
         bike1.reload

--- a/spec/models/organization_stolen_message_spec.rb
+++ b/spec/models/organization_stolen_message_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe OrganizationStolenMessage, type: :model do
 
   describe "calculated_attributes" do
     let(:organization) { FactoryBot.create(:organization, kind: "law_enforcement") }
-    let(:organization_stolen_message) { OrganizationStolenMessage.create(organization_id: organization.id) }
+    let(:organization_stolen_message) { OrganizationStolenMessage.for(organization) }
     it "uses attributes" do
       expect(organization.search_radius_miles).to eq 50
       expect(organization_stolen_message.reload.organization_id).to eq organization.id
@@ -40,6 +40,17 @@ RSpec.describe OrganizationStolenMessage, type: :model do
         organization_stolen_message.update(is_enabled: true, body: " #{target} i officia deserunt mollit anim id est laborum.")
         expect(organization_stolen_message.reload.is_enabled).to be_falsey
         expect(organization_stolen_message.body).to eq target
+      end
+    end
+    context "report_url present" do
+      let(:organization_stolen_message) { OrganizationStolenMessage.create!(organization_id: organization.id, report_url: "https://example.com", kind: "association") }
+      it "also can enable" do
+        expect(organization_stolen_message).to be_valid
+        expect(organization_stolen_message.can_enable?).to be_truthy
+        organization_stolen_message.update(is_enabled: true)
+        expect(organization_stolen_message.reload.is_enabled).to be_truthy
+        organization_stolen_message.update(is_enabled: false)
+        expect(organization_stolen_message.reload.is_enabled).to be_falsey
       end
     end
     context "max search_radius" do

--- a/spec/models/organization_stolen_message_spec.rb
+++ b/spec/models/organization_stolen_message_spec.rb
@@ -7,8 +7,10 @@ RSpec.describe OrganizationStolenMessage, type: :model do
     let(:organization) { FactoryBot.create(:organization, kind: "law_enforcement") }
     let(:organization_stolen_message) { OrganizationStolenMessage.create(organization_id: organization.id) }
     it "uses attributes" do
+      expect(organization.search_radius_miles).to eq 50
       expect(organization_stolen_message.reload.organization_id).to eq organization.id
       expect(organization_stolen_message.kind).to eq "area"
+      expect(organization_stolen_message.search_radius_miles).to eq OrganizationStolenMessage::DEFAULT_RADIUS_MILES
       organization_stolen_message.update(is_enabled: true, body: "  ", kind: "association")
       expect(organization_stolen_message.is_enabled).to be_falsey
       expect(organization_stolen_message.body).to eq nil
@@ -20,7 +22,7 @@ RSpec.describe OrganizationStolenMessage, type: :model do
       it "uses location" do
         expect(organization_stolen_message.reload.latitude).to eq organization.location_latitude
         expect(organization_stolen_message.longitude).to eq organization.location_longitude
-        expect(organization_stolen_message.search_radius_miles).to eq 94
+        expect(organization_stolen_message.search_radius_miles).to eq 10
         expect(organization_stolen_message.kind).to eq "association"
         expect(organization_stolen_message.is_enabled).to be_falsey
         organization_stolen_message.update(is_enabled: true, body: "  Something\n<strong> PARTy</strong>  ", search_radius_miles: 12, latitude: 22, longitude: 22)

--- a/spec/models/stolen_record_spec.rb
+++ b/spec/models/stolen_record_spec.rb
@@ -10,7 +10,9 @@ RSpec.describe StolenRecord, type: :model do
       it "removes alert_image" do
         expect(stolen_record.alert_image).to be_present
 
-        stolen_record.update_attribute(:bike, nil)
+        Sidekiq::Testing.inline! do
+          stolen_record.update_attribute(:bike, nil)
+        end
 
         stolen_record.reload
         expect(stolen_record.bike).to be_blank
@@ -28,7 +30,9 @@ RSpec.describe StolenRecord, type: :model do
         expect(bike.current_stolen_record_id).to eq stolen_record.id
         expect(bike.occurred_at).to be_present
 
-        stolen_record.add_recovery_information
+        Sidekiq::Testing.inline! do
+          stolen_record.add_recovery_information
+        end
         stolen_record.reload
         bike.reload
 
@@ -47,7 +51,9 @@ RSpec.describe StolenRecord, type: :model do
       it "does not removes alert_image" do
         expect(stolen_record.alert_image).to be_present
 
-        stolen_record.run_callbacks(:commit)
+        Sidekiq::Testing.inline! do
+          stolen_record.run_callbacks(:commit)
+        end
 
         expect(stolen_record.alert_image).to be_present
       end

--- a/spec/models/stolen_record_spec.rb
+++ b/spec/models/stolen_record_spec.rb
@@ -61,13 +61,15 @@ RSpec.describe StolenRecord, type: :model do
     describe "update_not_current_records" do
       it "marks all the records that are not current, not current" do
         bike = FactoryBot.create(:bike)
-        stolen_record1 = FactoryBot.create(:stolen_record, bike: bike)
-        bike.reload
-        expect(bike.current_stolen_record_id).to eq(stolen_record1.id)
-        stolen_record2 = FactoryBot.create(:stolen_record, bike: bike)
-        expect(stolen_record1.reload.current).to be_falsey
-        expect(stolen_record2.reload.current).to be_truthy
-        expect(bike.reload.current_stolen_record_id).to eq stolen_record2.id
+        Sidekiq::Testing.inline! do
+          stolen_record1 = FactoryBot.create(:stolen_record, bike: bike)
+          bike.reload
+          expect(bike.current_stolen_record_id).to eq(stolen_record1.id)
+          stolen_record2 = FactoryBot.create(:stolen_record, bike: bike)
+          expect(stolen_record1.reload.current).to be_falsey
+          expect(stolen_record2.reload.current).to be_truthy
+          expect(bike.reload.current_stolen_record_id).to eq stolen_record2.id
+        end
       end
     end
   end

--- a/spec/requests/admin/invoices_request_spec.rb
+++ b/spec/requests/admin/invoices_request_spec.rb
@@ -19,12 +19,12 @@ RSpec.describe Admin::InvoicesController, type: :request do
         expect(assigns(:time_range).last).to be_within(1.day).of(Time.current)
         expect(assigns(:time_range).first).to be_within(1.day).of(Time.current - 1.year)
         expect(assigns(:invoices).pluck(:id)).to eq([invoice.id])
-        get "/admin/invoices?direction=desc&period=custom&start_time=#{(Time.current - 1.year).to_s}&sort=subscription_start_at"
+        get "/admin/invoices?direction=desc&period=custom&start_time=#{Time.current - 1.year}&sort=subscription_start_at"
         expect(response).to render_template(:index)
         expect(assigns(:time_range).last).to be_within(1.day).of(end_at)
         expect(assigns(:time_range).first).to be_within(1.day).of(Time.current - 1.year)
         expect(assigns(:invoices).pluck(:id)).to eq([invoice.id])
-        get "/admin/invoices?direction=desc&period=custom&start_time=#{(Time.current - 1.year).to_s}&end_time=#{Time.current.to_s}&sort=subscription_start_at"
+        get "/admin/invoices?direction=desc&period=custom&start_time=#{Time.current - 1.year}&end_time=#{Time.current}&sort=subscription_start_at"
         expect(response).to render_template(:index)
         expect(assigns(:time_range).last).to be_within(1.day).of(Time.current)
       end

--- a/spec/requests/admin/organizations_request_spec.rb
+++ b/spec/requests/admin/organizations_request_spec.rb
@@ -236,7 +236,7 @@ RSpec.describe Admin::OrganizationsController, type: :request do
       it "updates the organization attributes" do
         expect(organization_stolen_message).to be_present # Because of organization feature
         expect(organization_stolen_message.kind).to eq "area"
-        expect(organization_stolen_message.search_radius_miles).to eq 50.0
+        expect(organization_stolen_message.search_radius_miles).to eq 10.0
         put "#{base_url}/#{organization.to_param}", params: {
           organization: update_params,
           organization_stolen_message_search_radius_miles: 44,

--- a/spec/requests/bikes/create_request_spec.rb
+++ b/spec/requests/bikes/create_request_spec.rb
@@ -100,7 +100,7 @@ RSpec.describe "BikesController#create", type: :request do
       let(:organization) { FactoryBot.create(:organization_with_organization_features, enabled_feature_slugs: ["organization_stolen_message"], search_radius_miles: search_radius_miles) }
       let!(:organization_default_location) { FactoryBot.create(:location_chicago, organization: organization) }
       let(:organization_stolen_message) { OrganizationStolenMessage.where(organization_id: organization.id).first_or_create }
-      let(:organization_stolen_message_attrs) { {is_enabled: true, kind: "area", body: "Something cool"} }
+      let(:organization_stolen_message_attrs) { {is_enabled: true, kind: "area", body: "Something cool", search_radius_miles: search_radius_miles} }
       let(:search_radius_miles) { 5 }
       before { organization_stolen_message.update(organization_stolen_message_attrs) }
       def expect_created_stolen_bike(bike_params: nil, stolen_params: {})
@@ -154,7 +154,7 @@ RSpec.describe "BikesController#create", type: :request do
           expect(organization_stolen_message.reload.stolen_records.count).to eq 0
         end
         context "association message" do
-          let(:organization_stolen_message_attrs) { {is_enabled: true, kind: "association", body: "Something cool"} }
+          let(:organization_stolen_message_attrs) { {is_enabled: true, kind: "association", body: "Something cool", search_radius_miles: search_radius_miles} }
           it "it assigns organization_stolen_message" do
             expect(organization_stolen_message.reload.kind).to eq "association"
             expect_created_stolen_bike(bike_params: bike_params.merge(creation_organization_id: organization.id), stolen_params: chicago_stolen_params.merge(show_address: true))

--- a/spec/requests/bikes/create_request_spec.rb
+++ b/spec/requests/bikes/create_request_spec.rb
@@ -114,14 +114,15 @@ RSpec.describe "BikesController#create", type: :request do
           # This is also where we're testing bikebook assignment
           expect_any_instance_of(BikeBookIntegration).to receive(:get_model) { bb_data }
           ActionMailer::Base.deliveries = []
+          Sidekiq::Worker.clear_all
           expect {
-            # Test that we can still pass show_address - because API backward compatibility
-            post base_url, params: {bike: bike_params, stolen_record: stolen_params}
+            Sidekiq::Testing.inline! do
+              # Test that we can still pass show_address - because API backward compatibility
+              post base_url, params: {bike: bike_params, stolen_record: stolen_params}
+            end
           }.to change(Bike, :count).by(1)
           expect(flash[:success]).to be_present
           expect(BParam.all.count).to eq 0
-          expect(ActionMailer::Base.deliveries.count).to eq 0
-          EmailOwnershipInvitationWorker.drain
           expect(ActionMailer::Base.deliveries.count).to eq 1
           bike = Bike.last
           bike_params.except(:manufacturer_id, :phone, :date_stolen).each { |k, v| expect(bike.send(k).to_s).to eq v.to_s }

--- a/spec/requests/organized/emails_request_spec.rb
+++ b/spec/requests/organized/emails_request_spec.rb
@@ -156,7 +156,7 @@ RSpec.describe Organized::EmailsController, type: :request do
       end
       context "organization_stolen_message" do
         let(:enabled_feature_slugs) { %w[customize_emails organization_stolen_message] }
-        let(:organization_stolen_message) { current_organization.organization_stolen_message }
+        let(:organization_stolen_message) { OrganizationStolenMessage.for(current_organization) }
         it "renders" do
           expect(organization_stolen_message.id).to be_present
           expect(organization_stolen_message.body).to be_blank
@@ -172,7 +172,7 @@ RSpec.describe Organized::EmailsController, type: :request do
         context "with a stolen bike" do
           let!(:stolen_record) { FactoryBot.create(:stolen_record, bike: bike) }
           it "renders that bike" do
-            organization_stolen_message.update(body: "something here", is_enabled: false)
+            organization_stolen_message.update(body: "something here", is_enabled: true)
             expect(bike.reload.status).to eq "status_stolen"
             expect(current_organization.bikes.pluck(:id)).to eq([bike.id])
             get "#{base_url}/organization_stolen_message"
@@ -181,7 +181,6 @@ RSpec.describe Organized::EmailsController, type: :request do
             expect(assigns(:viewable_email_kinds)).to match_array(%w[finished_registration organization_stolen_message])
             expect(assigns(:bike).id).to eq bike.id
             expect(assigns(:bike).current_stolen_record).to be_present
-            # Still shown even though it isn't enabled
             expect(assigns(:bike).current_stolen_record.organization_stolen_message_id).to eq organization_stolen_message.id
           end
         end
@@ -289,7 +288,7 @@ RSpec.describe Organized::EmailsController, type: :request do
     end
     describe "update" do
       context "organization_stolen_message" do
-        let(:organization_stolen_message) { current_organization.organization_stolen_message }
+        let(:organization_stolen_message) { OrganizationStolenMessage.for(current_organization) }
         let(:update_params) do
           {
             organization_stolen_message: {

--- a/spec/requests/organized/emails_request_spec.rb
+++ b/spec/requests/organized/emails_request_spec.rb
@@ -294,7 +294,7 @@ RSpec.describe Organized::EmailsController, type: :request do
               organization_id: 844,
               is_enabled: true,
               report_url: "something.com/stuff=true?utm=fffff",
-              report_phone: "111222333"
+              report_phone: "1112223333"
             }
           }
         end
@@ -316,6 +316,7 @@ RSpec.describe Organized::EmailsController, type: :request do
           expect(organization_stolen_message.organization_id).to eq current_organization.id
           expect(organization_stolen_message.is_enabled).to be_truthy
           expect(organization_stolen_message.report_url).to eq "http://something.com/stuff=true?utm=fffff"
+          expect(organization_stolen_message.report_phone).to eq "1112223333"
         end
       end
     end

--- a/spec/requests/organized/emails_request_spec.rb
+++ b/spec/requests/organized/emails_request_spec.rb
@@ -296,7 +296,7 @@ RSpec.describe Organized::EmailsController, type: :request do
               body: "text for stolen message",
               organization_id: 844,
               is_enabled: true,
-              report_url: "something.com/stuff=true?utm=fffff",
+              report_url: "something.com/stuff=true?utm=fffff"
             }
           }
         end

--- a/spec/workers/after_stolen_record_save_worker_spec.rb
+++ b/spec/workers/after_stolen_record_save_worker_spec.rb
@@ -31,5 +31,15 @@ RSpec.describe AfterStolenRecordSaveWorker, type: :job do
       mail = ActionMailer::Base.deliveries.last
       expect(mail.body.encoded).to match "Alert numbers! 222"
     end
+    context "hidden bike" do
+      it "updates" do
+        bike.update(marked_user_hidden: true)
+        expect(bike.reload.user_hidden).to be_truthy
+        expect(Bike.pluck(:id)).to eq([])
+        expect(OrganizationStolenMessage.for_stolen_record(stolen_record)&.id).to eq organization_stolen_message.id
+        instance.perform(stolen_record.id)
+        expect(stolen_record.reload.organization_stolen_message_id).to eq organization_stolen_message.id
+      end
+    end
   end
 end

--- a/spec/workers/after_stolen_record_save_worker_spec.rb
+++ b/spec/workers/after_stolen_record_save_worker_spec.rb
@@ -1,0 +1,35 @@
+require "rails_helper"
+
+RSpec.describe AfterStolenRecordSaveWorker, type: :job do
+  let(:subject) { AfterStolenRecordSaveWorker }
+  let(:instance) { subject.new }
+  before { Sidekiq::Worker.clear_all }
+
+  context "organization_stolen_message" do
+    let(:organization) { FactoryBot.create(:organization_with_organization_features, kind: "bike_shop", enabled_feature_slugs: ["organization_stolen_message"]) }
+    let!(:organization_stolen_message) { OrganizationStolenMessage.where(organization_id: organization.id).first_or_create }
+    let(:bike) { FactoryBot.create(:bike_organized, :with_stolen_record, creation_organization: organization) }
+    let(:stolen_record) { bike.reload.current_stolen_record }
+    let(:ownership) { bike.ownerships.first }
+    before { organization_stolen_message.update(is_enabled: true, kind: "association", body: "Alert numbers! 222") }
+    it "includes organization_stolen_message" do
+      expect(stolen_record.organization_stolen_message_id).to be_blank
+      expect(organization_stolen_message.reload.kind).to eq "association"
+      expect(organization_stolen_message.id).to be_present
+      expect(organization_stolen_message.is_enabled).to be_truthy
+      expect(OrganizationStolenMessage.for_stolen_record(stolen_record)&.id).to eq organization_stolen_message.id
+      instance.perform(stolen_record.id)
+      expect(stolen_record.reload.organization_stolen_message_id).to eq organization_stolen_message.id
+      ActionMailer::Base.deliveries = []
+      expect {
+        EmailOwnershipInvitationWorker.new.perform(ownership.id)
+        EmailOwnershipInvitationWorker.new.perform(ownership.id)
+      }.to change(Notification, :count).by(1)
+      expect(ActionMailer::Base.deliveries.count).to eq 1
+      ownership.reload
+      expect(ownership.notifications.count).to eq 1
+      mail = ActionMailer::Base.deliveries.last
+      expect(mail.body.encoded).to match "Alert numbers! 222"
+    end
+  end
+end


### PR DESCRIPTION
- Associate `organization_stolen_message` with stolen records as soon as the are created
- Make `report_url` show up on the bike form and stolen checklist
