### PR TITLE
Prevent email previews from rendering links with tokens

### DIFF
--- a/app/controllers/organized/emails_controller.rb
+++ b/app/controllers/organized/emails_controller.rb
@@ -10,7 +10,7 @@ module Organized
     def show
       @email_preview = true
       # NOTE: This is a bad hack, but there isn't a good place to define this method
-      @email_preview_tokenized_url = "#"
+      @email_preview_tokenized_url = "/404"
       if ParkingNotification.kinds.include?(@kind)
         find_or_build_parking_notification
         render template: "/organized_mailer/parking_notification", layout: "email"

--- a/app/controllers/organized/emails_controller.rb
+++ b/app/controllers/organized/emails_controller.rb
@@ -9,6 +9,8 @@ module Organized
 
     def show
       @email_preview = true
+      # NOTE: This is a bad hack, but there isn't a good place to define this method
+      @email_preview_tokenized_url = "#"
       if ParkingNotification.kinds.include?(@kind)
         find_or_build_parking_notification
         render template: "/organized_mailer/parking_notification", layout: "email"

--- a/app/controllers/organized/emails_controller.rb
+++ b/app/controllers/organized/emails_controller.rb
@@ -146,7 +146,6 @@ module Organized
       @graduated_notification ||= graduated_notifications.last
       @graduated_notification ||= GraduatedNotification.new(organization_id: current_organization.id, bike: default_bike)
       @bike = @graduated_notification.bike || default_bike
-      @retrieval_link_url = "#"
       @graduated_notification
     end
 
@@ -176,7 +175,6 @@ module Organized
         @parking_notification.set_location_from_organization
       end
       @bike = @parking_notification.bike || default_bike
-      @retrieval_link_url = "#"
       @parking_notification
     end
   end

--- a/app/controllers/organized/emails_controller.rb
+++ b/app/controllers/organized/emails_controller.rb
@@ -9,7 +9,7 @@ module Organized
 
     def show
       @email_preview = true
-      # NOTE: This is a bad hack, but there isn't a good place to define this method
+      # NOTE: This is a bad hack, but there isn't a good place to define this
       @email_preview_tokenized_url = "/404"
       if ParkingNotification.kinds.include?(@kind)
         find_or_build_parking_notification

--- a/app/helpers/organized_helper.rb
+++ b/app/helpers/organized_helper.rb
@@ -92,6 +92,16 @@ module OrganizedHelper
     l datetime, format: :dotted
   end
 
+  def retrieval_link_url(obj)
+    if obj.is_a?(ParkingNotification)
+      return nil if obj.retrieval_link_token.blank?
+      bike_url(obj.bike.to_param, parking_notification_retrieved: obj.retrieval_link_token)
+    elsif obj.is_a?(GraduatedNotification)
+      return nil if obj.marked_remaining_link_token.blank?
+      bike_url(obj.bike.to_param, graduated_notification_remaining: obj.marked_remaining_link_token)
+    end
+  end
+
   def include_field_reg_extra_registration_number?(organization = nil, user = nil)
     organization.present? &&
       organization.additional_registration_fields.include?("reg_extra_registration_number")

--- a/app/mailers/organized_mailer.rb
+++ b/app/mailers/organized_mailer.rb
@@ -65,9 +65,6 @@ class OrganizedMailer < ApplicationMailer
     @organization = @parking_notification.organization
     @bike = @parking_notification.bike
     @sender = @parking_notification.user
-    @retrieval_link_url = if @parking_notification.retrieval_link_token.present?
-      bike_url(@bike.to_param, parking_notification_retrieved: @parking_notification.retrieval_link_token)
-    end
 
     I18n.with_locale(@sender&.preferred_language) do
       mail(reply_to: @parking_notification.reply_to_email,
@@ -84,9 +81,6 @@ class OrganizedMailer < ApplicationMailer
     @graduated_notification = graduated_notification
     @organization = @graduated_notification.organization
     @bike = @graduated_notification.bike
-    @retrieval_link_url = if @graduated_notification.marked_remaining_link_token.present?
-      bike_url(@bike.to_param, graduated_notification_remaining: @graduated_notification.marked_remaining_link_token)
-    end
 
     I18n.with_locale(@user&.preferred_language) do
       mail(reply_to: reply_to,

--- a/app/views/customer_mailer/additional_email_confirmation.html.haml
+++ b/app/views/customer_mailer/additional_email_confirmation.html.haml
@@ -7,7 +7,8 @@
 %p.center-text{ style: 'margin-bottom: 3em;' }
   = t(".html.user_would_like_to_merge", name: @user.display_name, email: @user.email)
 
-= link_to t(".html.verify_email"), confirm_user_email_url(id: @user_email.id, confirmation_token: @user_email.confirmation_token), "data-pm-no-track" => true, class: 'binx-button'
+- tokenized_url = @email_preview ? @email_preview_tokenized_url : confirm_user_email_url(id: @user_email.id, confirmation_token: @user_email.confirmation_token)
+= link_to t(".html.verify_email"), tokenized_url, "data-pm-no-track" => true, class: 'binx-button'
 
 %p.center-text.less-strong= t(".html.click_verify_email_html")
 

--- a/app/views/customer_mailer/confirmation_email.html.haml
+++ b/app/views/customer_mailer/confirmation_email.html.haml
@@ -5,7 +5,8 @@
 %h3.center-text{ style: "margin: 2rem 0 3rem;" }
   = t(".html.please_confirm_your_email_address")
 
-= link_to t(".html.verify_email"), confirm_users_url(id: @user.id, code: @user.confirmation_token, partner: @partner), "data-pm-no-track" => true, class: "binx-button"
+- tokenized_url = @email_preview ? @email_preview_tokenized_url : confirm_users_url(id: @user.id, code: @user.confirmation_token, partner: @partner)
+= link_to t(".html.verify_email"), tokenized_url, "data-pm-no-track" => true, class: "binx-button"
 
 - unless @partner
   %p.less-strong.center-text

--- a/app/views/customer_mailer/magic_login_link_email.html.haml
+++ b/app/views/customer_mailer/magic_login_link_email.html.haml
@@ -1,7 +1,8 @@
 %h4{ style: 'margin-bottom: 2em;' }
   = t(".html.click_the_button")
 
-= link_to t(".html.sign_in"), @url, "data-pm-no-track" => true, class: 'binx-button'
+- tokenized_url = @email_preview ? @email_preview_tokenized_url : @url
+= link_to t(".html.sign_in"), tokenized_url, "data-pm-no-track" => true, class: 'binx-button'
 
 %p
   %em.less-strong

--- a/app/views/customer_mailer/password_reset_email.html.haml
+++ b/app/views/customer_mailer/password_reset_email.html.haml
@@ -3,7 +3,8 @@
 %p{ style: 'margin-bottom: 2em;' }
   = t(".html.please_click_the_button_below_to_create_a")
 
-= link_to t(".html.reset_password"), @url, "data-pm-no-track" => true, class: 'binx-button'
+- tokenized_url = @email_preview ? @email_preview_tokenized_url : @url
+= link_to t(".html.reset_password"), tokenized_url, "data-pm-no-track" => true, class: 'binx-button'
 
 %hr{ style: 'margin-top: 40px;' }
 

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -88,7 +88,7 @@
               = active_link t(".blog"), news_index_path, class: 'nav-link', match_controller: true
             %li.primary-nav-item.d-none.d-lg-block
               = link_to t(".search_bikes"), default_bike_search_path, class: "nav-link defaultBikeSearchLink #{bike_search_active ? 'active' : ''}", match_controller: true
-    = render 'layouts/revised_messages'
+    = render "/layouts/revised_messages"
 
     - if current_page_skeleton.present?
       = render partial: "/shared/#{current_page_skeleton}"

--- a/app/views/layouts/email.html.haml
+++ b/app/views/layouts/email.html.haml
@@ -11,9 +11,6 @@
         .binx-wrapper { margin: 0; }
         html { background: #e6e6e6; }
 
-      -# NOTE: This is a bad hack, but there isn't a good place to define this method
-      @email_preview_tokenized_url = "#"
-
   %body
     .binx-wrapper
       %table.binx-header

--- a/app/views/layouts/email.html.haml
+++ b/app/views/layouts/email.html.haml
@@ -11,6 +11,9 @@
         .binx-wrapper { margin: 0; }
         html { background: #e6e6e6; }
 
+      -# NOTE: This is a bad hack, but there isn't a good place to define this method
+      @email_preview_tokenized_url = "#"
+
   %body
     .binx-wrapper
       %table.binx-header

--- a/app/views/organized/emails/edit.html.haml
+++ b/app/views/organized/emails/edit.html.haml
@@ -117,8 +117,8 @@
 - else
   #emailPreview.collapse.show.in
     %h3.uncap.mt-4 Preview of email sent:
-
     .email-preview.parking-notification-email-preview
+      .text-center.small.less-strong email for preview only
       <iframe src="#{organization_email_url(@kind, organization_id: current_organization.to_param)}"></iframe>
 
   #emailPreviewUpdated.collapse

--- a/app/views/organized/graduated_notifications/show.html.haml
+++ b/app/views/organized/graduated_notifications/show.html.haml
@@ -87,6 +87,7 @@
           not the version the user received.
 
   .email-preview.parking-notification-email-preview
+    .text-center.small.less-strong email for preview only
     <iframe src="#{organization_email_path("graduated_notification", graduated_notification_id: @graduated_notification.to_param, organization_id: current_organization.to_param)}"></iframe>
 
 - else

--- a/app/views/organized/parking_notifications/_show_details.html.haml
+++ b/app/views/organized/parking_notifications/_show_details.html.haml
@@ -231,6 +231,7 @@
 - if @parking_notification.send_email?
   %h2.uncap.mt-4 Preview of email sent:
   .email-preview.parking-notification-email-preview
+    .text-center.small.less-strong email for preview only
     <iframe src="#{organization_email_path(@parking_notification.kind, parking_notification_id: @parking_notification.id, organization_id: current_organization.to_param)}"></iframe>
 - else
   %p.text-warning.mt-4

--- a/app/views/organized_mailer/finished_registration.html.haml
+++ b/app/views/organized_mailer/finished_registration.html.haml
@@ -58,7 +58,8 @@
     - else
       = t(".html.hopefully_you_find_the_bike_html", bike_type: @bike.type)
       %strong
-        - mark_recovered_link = link_to(t(".html.mark_your_bike_recovered"), edit_bike_recovery_url(bike_id: @bike.id, token: @bike.fetch_current_stolen_record.find_or_create_recovery_link_token), "data-pm-no-track" => true)
+        - tokenized_url = @email_preview ? @email_preview_tokenized_url : edit_bike_recovery_url(bike_id: @bike.id, token: @bike.fetch_current_stolen_record.find_or_create_recovery_link_token)
+        - mark_recovered_link = link_to(t(".html.mark_your_bike_recovered"), tokenized_url, "data-pm-no-track" => true)
         = t(".html.mark_recovered_link_html", mark_recovered_link: mark_recovered_link)
 
 - if @vars[:donation_message]
@@ -72,9 +73,11 @@
 
 - unless @ownership.claimed?
   - if @vars[:registered_by_owner]
-    = link_to t(".html.claim_the_bike_type", bike_type: @bike.type), bike_url(@bike, email: @vars[:email]), "data-pm-no-track" => true, class: 'binx-button'
+    - tokenized_url = @email_preview ? @email_preview_tokenized_url : bike_url(@bike, t: @ownership.token, email: @vars[:email])
+    = link_to t(".html.claim_the_bike_type", bike_type: @bike.type), tokenized_url, "data-pm-no-track" => true, class: 'binx-button'
   - else
-    = link_to t(".html.confirm_this_bike_type", bike_type: @bike.type), bike_url(@bike, t: @ownership.token, email: @vars[:email]), "data-pm-no-track" => true, class: 'binx-button'
+    - tokenized_url = @email_preview ? @email_preview_tokenized_url : bike_url(@bike, t: @ownership.token, email: @vars[:email])
+    = link_to t(".html.confirm_this_bike_type", bike_type: @bike.type), tokenized_url, "data-pm-no-track" => true, class: 'binx-button'
 
   - if @bike.status_stolen?
     %p= t(".html.sign_up_on_bikeindexorg_to_claim_your_bik", bike_type: @bike.type)

--- a/app/views/organized_mailer/graduated_notification.html.haml
+++ b/app/views/organized_mailer/graduated_notification.html.haml
@@ -10,9 +10,10 @@
 - if bikes.count >= 1
   = render partial: "shared/email_bike_box"
 
-- if @retrieval_link_url.present?
+- tokenized_url = @email_preview ? @email_preview_tokenized_url : retrieval_link_url(@graduated_notification)
+- if tokenized_url.present?
   .mark-retrieved-box
-    = link_to @retrieval_link_url, "data-pm-no-track" => true, class: "binx-button" do
+    = link_to tokenized_url, "data-pm-no-track" => true, class: "binx-button" do
       Click to renew
     %p
       %em

--- a/app/views/organized_mailer/organization_invitation.html.haml
+++ b/app/views/organized_mailer/organization_invitation.html.haml
@@ -6,4 +6,5 @@
 - if @sender.present?
   %p= t(".html.you_are_a_member", sender_name: @sender.display_name, org_name: @organization.name)
 
-= link_to t(".html.join_org", org_name: @organization.short_name), new_user_url(email: @vars[:email]), "data-pm-no-track" => true, class: 'binx-button'
+- tokenized_url = @email_preview ? @email_preview_tokenized_url : new_user_url(email: @vars[:email])
+= link_to t(".html.join_org", org_name: @organization.short_name), tokenized_url, "data-pm-no-track" => true, class: 'binx-button'

--- a/app/views/organized_mailer/parking_notification.html.haml
+++ b/app/views/organized_mailer/parking_notification.html.haml
@@ -46,10 +46,10 @@
 
 <img class="geolocated-message-map" src="https://maps.googleapis.com/maps/api/staticmap?center=#{@parking_notification.latitude},#{@parking_notification.longitude}&zoom=13&size=640x400&maptype=roadmap&scale=2&markers=color:red%7C#{@parking_notification.latitude},#{@parking_notification.longitude}&key=#{ENV["GOOGLE_MAPS_STATIC"]}">
 
-
-- if @retrieval_link_url.present? && !@parking_notification.impound_notification?
+- tokenized_url = @email_preview ? @email_preview_tokenized_url : retrieval_link_url(@parking_notification)
+- if tokenized_url.present? && !@parking_notification.impound_notification?
   .mark-retrieved-box
-    = link_to "I picked up my #{@bike.type}", @retrieval_link_url, "data-pm-no-track" => true, class: "binx-button"
+    = link_to "I picked up my #{@bike.type}", tokenized_url, "data-pm-no-track" => true, class: "binx-button"
     %p
       %em
         Let

--- a/app/views/organized_mailer/partial_registration.html.haml
+++ b/app/views/organized_mailer/partial_registration.html.haml
@@ -12,4 +12,5 @@
 
 %p= t(".html.click_below_to_complete_your_registration")
 
-= link_to t(".html.finish_it"), new_bike_url(b_param_token: @b_param.id_token), "data-pm-no-track" => true, class: 'binx-button'
+- tokenized_url = @email_preview ? @email_preview_tokenized_url : new_bike_url(b_param_token: @b_param.id_token)
+= link_to t(".html.finish_it"), tokenized_url, "data-pm-no-track" => true, class: 'binx-button'

--- a/app/views/shared/_email_bike_box.html.haml
+++ b/app/views/shared/_email_bike_box.html.haml
@@ -1,6 +1,7 @@
 - @ownership ||= @bike.current_ownership
 - bike_url_path ||= bike_url(@bike, t: @ownership.token)
 - skip_link_tracking = bike_url_path.match?(/\?/) # Skip link tracking if there are query parameters - e.g. token
+- bike_url_path = @email_preview_tokenized_url if @email_preview
 - thumb_url = @bike.thumb_path || @bike.stock_photo_url
 
 - unless thumb_url.present?

--- a/spec/helpers/organized_helper_spec.rb
+++ b/spec/helpers/organized_helper_spec.rb
@@ -150,6 +150,28 @@ RSpec.describe OrganizedHelper, type: :helper do
     end
   end
 
+  describe "retrieval_link_url" do
+    let(:graduated_notification) { FactoryBot.create(:graduated_notification) }
+    it "is present" do
+      expect(graduated_notification.marked_remaining_link_token).to be_present
+      expect(retrieval_link_url(graduated_notification)).to match(graduated_notification.marked_remaining_link_token)
+    end
+    context "parking_notification" do
+      let(:parking_notification) { FactoryBot.create(:parking_notification) }
+      it "is present" do
+        expect(parking_notification.retrieval_link_token).to be_present
+        expect(retrieval_link_url(parking_notification)).to match(parking_notification.retrieval_link_token)
+      end
+      context "unregistered" do
+        let(:parking_notification) { FactoryBot.create(:parking_notification_unregistered) }
+        it "is nil" do
+          expect(parking_notification.retrieval_link_token).to be_blank
+          expect(retrieval_link_url(parking_notification)).to be_nil
+        end
+      end
+    end
+  end
+
   describe "include_fields" do
     let(:organization) { Organization.new }
     let(:user) { User.new }


### PR DESCRIPTION
So organization members don't accidentally do actions that they shouldn't do.

Also adds an alert to the email to make it clear that it's a preview.