### PR TITLE
Protect from organization nils in embed bike create

### DIFF
--- a/app/controllers/bikes_controller.rb
+++ b/app/controllers/bikes_controller.rb
@@ -111,7 +111,9 @@ class BikesController < Bikes::BaseController
 
   def create
     find_or_new_b_param
-    if params[:bike][:embeded] # NOTE: if embeded, doesn't verify csrf token
+    # Protect from missing organization errors. Seems to come mainly from fuzzing tho
+    org_param = (@b_param.organization || current_organization)&.slug
+    if params[:bike][:embeded].present? && org_param.present? # NOTE: if embeded, doesn't verify csrf token
       if @b_param.created_bike.present?
         redirect_to edit_bike_url(@b_param.created_bike)
       end
@@ -123,8 +125,6 @@ class BikesController < Bikes::BaseController
       @bike = BikeCreator.new(location: request.safe_location).create_bike(@b_param)
       if @bike.errors.any?
         flash[:error] = @b_param.bike_errors.to_sentence
-        # Protect from nil errors.
-        org_param = (@bike.creation_organization || current_organization || @b_param.organization)&.slug
         if params[:bike][:embeded_extended]
           redirect_to(embed_extended_organization_url(id: org_param, b_param_id_token: @b_param.id_token)) && return
         else
@@ -133,9 +133,9 @@ class BikesController < Bikes::BaseController
       elsif params[:bike][:embeded_extended]
         flash[:success] = translation(:bike_was_sent_to, bike_type: @bike.type, owner_email: @bike.owner_email)
         @persist_email = ParamsNormalizer.boolean(params[:persist_email])
-        redirect_to(embed_extended_organization_url(@bike.creation_organization, email: @persist_email ? @bike.owner_email : nil)) && return
+        redirect_to(embed_extended_organization_url(org_param, email: @persist_email ? @bike.owner_email : nil)) && return
       else
-        redirect_to(controller: :organizations, action: :embed_create_success, id: @bike.creation_organization.slug, bike_id: @bike.id) && return
+        redirect_to(controller: :organizations, action: :embed_create_success, id: org_param, bike_id: @bike.id) && return
       end
     elsif verified_request?
       if @b_param.created_bike.present?

--- a/app/controllers/bikes_controller.rb
+++ b/app/controllers/bikes_controller.rb
@@ -123,10 +123,12 @@ class BikesController < Bikes::BaseController
       @bike = BikeCreator.new(location: request.safe_location).create_bike(@b_param)
       if @bike.errors.any?
         flash[:error] = @b_param.bike_errors.to_sentence
+        # Protect from nil errors.
+        org_param = (@bike.creation_organization || current_organization || @b_param.organization)&.slug
         if params[:bike][:embeded_extended]
-          redirect_to(embed_extended_organization_url(id: @bike.creation_organization.slug, b_param_id_token: @b_param.id_token)) && return
+          redirect_to(embed_extended_organization_url(id: org_param, b_param_id_token: @b_param.id_token)) && return
         else
-          redirect_to(embed_organization_url(id: @bike.creation_organization.slug, b_param_id_token: @b_param.id_token)) && return
+          redirect_to(embed_organization_url(id: org_param, b_param_id_token: @b_param.id_token)) && return
         end
       elsif params[:bike][:embeded_extended]
         flash[:success] = translation(:bike_was_sent_to, bike_type: @bike.type, owner_email: @bike.owner_email)

--- a/app/controllers/bikes_controller.rb
+++ b/app/controllers/bikes_controller.rb
@@ -111,8 +111,7 @@ class BikesController < Bikes::BaseController
 
   def create
     find_or_new_b_param
-    # Protect from missing organization errors. Seems to come mainly from fuzzing tho
-    org_param = (@b_param.organization || current_organization)&.slug
+    org_param = (@b_param.organization || current_organization)&.slug # Protect from nil - see #2308
     if params[:bike][:embeded].present? && org_param.present? # NOTE: if embeded, doesn't verify csrf token
       if @b_param.created_bike.present?
         redirect_to edit_bike_url(@b_param.created_bike)

--- a/spec/requests/bikes/create_request_spec.rb
+++ b/spec/requests/bikes/create_request_spec.rb
@@ -447,10 +447,9 @@ RSpec.describe "BikesController#create", type: :request do
         expect(new_bike.current_ownership.organization&.id).to be_blank
         expect(new_bike.current_ownership.origin).to eq "embed_extended"
 
-        expect(new_bike.bike_stickers.pluck(:id)).to eq([bike_sticker.id])
-        expect(bike_sticker.reload.claimed?).to be_truthy
-        expect(bike_sticker.bike&.id).to eq new_bike.id
-        expect(bike_sticker.bike_sticker_updates.count).to eq 1
+        expect(new_bike.bike_stickers.pluck(:id)).to eq([])
+        expect(bike_sticker.bike&.id).to eq bike.id
+        expect(bike_sticker.bike_sticker_updates.count).to eq 0
       end
     end
   end

--- a/spec/requests/bikes/create_request_spec.rb
+++ b/spec/requests/bikes/create_request_spec.rb
@@ -381,28 +381,29 @@ RSpec.describe "BikesController#create", type: :request do
     let!(:bike_sticker) { FactoryBot.create(:bike_sticker, organization: organization, bike: bike, code: "ED00001") }
     # Created the same way that organizations controller creates a b_param
     let(:b_param) { BParam.create(creator_id: organization.auto_user.id, params: {creation_organization_id: organization.id, embeded: true, bike: {}}) }
+    let(:bike_params) do
+      {
+        b_param_id_token: b_param.id_token,
+        embeded: "true",
+        creation_organization_id: organization.id,
+        embeded_extended: true,
+        serial_number: "example serial",
+        manufacturer_id: manufacturer.slug,
+        manufacturer_other: "",
+        primary_frame_color_id: color.id.to_s,
+        secondary_frame_color_id: "",
+        tertiary_frame_color_id: "",
+        owner_email: "something@stuff.COM   ",
+        phone: "312.379.9513",
+        student_id: " ",
+        bike_code: "ed001"
+      }
+    end
     it "creates and adds the bike code" do
       b_param.reload
       expect(b_param.created_bike_id).to be_blank
       expect {
-        post base_url, params: {
-          bike: {
-            b_param_id_token: b_param.id_token,
-            embeded: "true",
-            creation_organization_id: organization.id,
-            embeded_extended: true,
-            serial_number: "example serial",
-            manufacturer_id: manufacturer.slug,
-            manufacturer_other: "",
-            primary_frame_color_id: color.id.to_s,
-            secondary_frame_color_id: "",
-            tertiary_frame_color_id: "",
-            owner_email: "something@stuff.COM   ",
-            phone: "312.379.9513",
-            student_id: " ",
-            bike_code: "ed001"
-          }
-        }
+        post base_url, params: {bike: bike_params}
       }.to change(Bike, :count).by(1)
       expect(flash[:success]).to be_present
 
@@ -423,6 +424,34 @@ RSpec.describe "BikesController#create", type: :request do
       expect(bike_sticker.reload.claimed?).to be_truthy
       expect(bike_sticker.bike&.id).to eq new_bike.id
       expect(bike_sticker.bike_sticker_updates.count).to eq 1
+    end
+    context "no organization" do
+      it "registers" do
+        b_param.reload
+        expect(b_param.created_bike_id).to be_blank
+        expect {
+          post base_url, params: {bike: bike_params.merge(creation_organization_id: nil)}
+        }.to change(Bike, :count).by(1)
+        expect(flash[:success]).to be_present
+
+        b_param.reload
+        expect(b_param.bike_sticker_code).to eq "ed001"
+        expect(b_param.created_bike_id).to be_present
+        new_bike = b_param.created_bike
+        expect(new_bike.owner_email).to eq "something@stuff.com"
+        expect(new_bike.user).to be_blank
+        expect(new_bike.status).to eq "status_with_owner"
+        expect(new_bike.phone).to eq "3123799513"
+        expect(new_bike.student_id).to eq nil
+
+        expect(new_bike.current_ownership.organization&.id).to be_blank
+        expect(new_bike.current_ownership.origin).to eq "embed_extended"
+
+        expect(new_bike.bike_stickers.pluck(:id)).to eq([bike_sticker.id])
+        expect(bike_sticker.reload.claimed?).to be_truthy
+        expect(bike_sticker.bike&.id).to eq new_bike.id
+        expect(bike_sticker.bike_sticker_updates.count).to eq 1
+      end
     end
   end
   context "existing b_param, no bike" do


### PR DESCRIPTION
Seems like it's mainly happening from illegitimate registrations, but still should protect