### PR TITLE
Switch to a shared bike search form

### DIFF
--- a/app/assets/javascripts/revised/sections/bike_search_bar.coffee
+++ b/app/assets/javascripts/revised/sections/bike_search_bar.coffee
@@ -89,8 +89,7 @@ class BikeIndex.BikeSearchBar extends BikeIndex
       placeholder: $query_field.attr('placeholder') # Pull placeholder from HTML
       dropdownParent: $('.bikes-search-form') # Append to search for for easier css access
       templateResult: formatSearchText # let custom formatter work
-      # Turned off selectOnClose because it made it so that you couldn't select nothing
-      # selectOnClose: true # Select the options when the dropdown is closed (e.g. clicked outside)
+      # selectOnClose: true # Turned off in PR#2325
       escapeMarkup: (markup) -> markup # Allow our fancy display of options
       ajax:
         url: '/api/autocomplete'

--- a/app/assets/javascripts/revised/sections/bike_search_bar.coffee
+++ b/app/assets/javascripts/revised/sections/bike_search_bar.coffee
@@ -89,7 +89,8 @@ class BikeIndex.BikeSearchBar extends BikeIndex
       placeholder: $query_field.attr('placeholder') # Pull placeholder from HTML
       dropdownParent: $('.bikes-search-form') # Append to search for for easier css access
       templateResult: formatSearchText # let custom formatter work
-      selectOnClose: true # Select the options when the dropdown is closed (e.g. clicked outside)
+      # Turned off selectOnClose because it made it so that you couldn't select nothing
+      # selectOnClose: true # Select the options when the dropdown is closed (e.g. clicked outside)
       escapeMarkup: (markup) -> markup # Allow our fancy display of options
       ajax:
         url: '/api/autocomplete'

--- a/app/assets/stylesheets/revised.scss
+++ b/app/assets/stylesheets/revised.scss
@@ -12,7 +12,7 @@
  */
 
 // Core variables and mixins
-@import "bootstrap/variables";
+@import 'bootstrap/variables';
 
 $enable-flex: true;
 
@@ -25,22 +25,22 @@ $border-radius: 1px;
 $border-radius-lg: 1px;
 $border-radius-sm: 1px;
 
-@import "revised/mixins/colors";
+@import 'revised/mixins/colors';
 
 //
 // More bootstrap
-@import "bootstrap/mixins";
+@import 'bootstrap/mixins';
 
 // Reset and dependencies
-@import "bootstrap/normalize";
-@import "bootstrap/print";
+@import 'bootstrap/normalize';
+@import 'bootstrap/print';
 
 // Core CSS
-@import "bootstrap/reboot";
+@import 'bootstrap/reboot';
 
 // @import "bootstrap/type";
-@import "bootstrap/images";
-@import "bootstrap/code";
+@import 'bootstrap/images';
+@import 'bootstrap/code';
 
 .code {
   .code-label {
@@ -63,38 +63,38 @@ $border-radius-sm: 1px;
   }
 }
 
-@import "bootstrap/grid";
-@import "bootstrap/tables";
+@import 'bootstrap/grid';
+@import 'bootstrap/tables';
 
 .table-compact-long {
   line-height: 1.2em;
 }
 
-@import "bootstrap/forms";
+@import 'bootstrap/forms';
 
 // @import "bootstrap/buttons"; // Override buttons with our own buttons
 
 // Components
-@import "bootstrap/animation";
-@import "bootstrap/dropdown";
-@import "bootstrap/button-group";
-@import "bootstrap/input-group";
-@import "bootstrap/custom-forms";
-@import "bootstrap/nav";
-@import "bootstrap/navbar";
-@import "bootstrap/card";
-@import "bootstrap/breadcrumb";
+@import 'bootstrap/animation';
+@import 'bootstrap/dropdown';
+@import 'bootstrap/button-group';
+@import 'bootstrap/input-group';
+@import 'bootstrap/custom-forms';
+@import 'bootstrap/nav';
+@import 'bootstrap/navbar';
+@import 'bootstrap/card';
+@import 'bootstrap/breadcrumb';
 
 // @import "bootstrap/pagination"; // Overriden with our own
 // @import "bootstrap/tags";
-@import "bootstrap/jumbotron";
+@import 'bootstrap/jumbotron';
 
 // @import "bootstrap/alert"; // Overriden with our own
-@import "bootstrap/progress";
-@import "bootstrap/media";
-@import "bootstrap/list-group";
-@import "bootstrap/responsive-embed";
-@import "bootstrap/close";
+@import 'bootstrap/progress';
+@import 'bootstrap/media';
+@import 'bootstrap/list-group';
+@import 'bootstrap/responsive-embed';
+@import 'bootstrap/close';
 
 // Components w/ JavaScript
 $modal-backdrop-bg: $blue-dark;
@@ -105,20 +105,20 @@ $modal-backdrop-opacity: 0.8;
   margin-bottom: 20px;
 }
 
-@import "bootstrap/modal";
-@import "bootstrap/tooltip";
-@import "bootstrap/popover";
-@import "bootstrap/carousel";
+@import 'bootstrap/modal';
+@import 'bootstrap/tooltip';
+@import 'bootstrap/popover';
+@import 'bootstrap/carousel';
 
 // Utility classes
-@import "bootstrap/utilities";
+@import 'bootstrap/utilities';
 
 //
 // Other (non-bootstrap) external styles
-@import "legacy_includes/zoom.scss";
+@import 'legacy_includes/zoom.scss';
 
 // Backport of future bootstrap utilities
-@import "revised/mixins/bootstrap_utilities";
+@import 'revised/mixins/bootstrap_utilities';
 
 $zoom-img-wrap-z-index: $zindex-navbar-fixed + 100;
 
@@ -136,132 +136,132 @@ $zoom-img-wrap-z-index: $zindex-navbar-fixed + 100;
  */
 
 // Settings
-@import "revised/vars";
-@import "revised/fonts";
+@import 'revised/vars';
+@import 'revised/fonts';
 
 // Bootstrap overrides
-@import "revised/mixins/buttons";
-@import "revised/sections/modals";
-@import "revised/sections/alerts";
-@import "revised/sections/forms";
-@import "revised/sections/custom_selects";
+@import 'revised/mixins/buttons';
+@import 'revised/sections/modals';
+@import 'revised/sections/alerts';
+@import 'revised/sections/forms';
+@import 'revised/sections/custom_selects';
 
 // Bike Index mixins
-@import "revised/mixins/trash_can_icon";
-@import "revised/mixins/textoverflow";
-@import "revised/mixins/nav_tabs";
+@import 'revised/mixins/trash_can_icon';
+@import 'revised/mixins/textoverflow';
+@import 'revised/mixins/nav_tabs';
 
 // Shared styles
-@import "revised/sections/primary_header_nav";
-@import "revised/sections/primary_footer";
-@import "revised/sections/content_menu";
-@import "revised/sections/form_well";
-@import "revised/sections/form_well_additional_field";
-@import "revised/sections/form_well_menu";
-@import "revised/sections/form_well_header";
-@import "revised/sections/pagination";
-@import "revised/sections/horizontal_lines";
-@import "revised/sections/legal";
-@import "revised/sections/sharing";
-@import "revised/sections/attr_list";
-@import "revised/sections/sign_in_up";
-@import "revised/sections/bikehub_sign_in_up";
-@import "revised/sections/sign_out";
-@import "revised/sections/ad_blocks";
-@import "revised/sections/bike_search_form";
-@import "revised/sections/bike_boxes";
-@import "revised/sections/side_boxes";
-@import "../../javascript/stylesheets/table_extensions"; // Import from new scss files!
-@import "revised/sections/embeded_tweet";
-@import "revised/sections/general_alerts";
+@import 'revised/sections/primary_header_nav';
+@import 'revised/sections/primary_footer';
+@import 'revised/sections/content_menu';
+@import 'revised/sections/form_well';
+@import 'revised/sections/form_well_additional_field';
+@import 'revised/sections/form_well_menu';
+@import 'revised/sections/form_well_header';
+@import 'revised/sections/pagination';
+@import 'revised/sections/horizontal_lines';
+@import 'revised/sections/legal';
+@import 'revised/sections/sharing';
+@import 'revised/sections/attr_list';
+@import 'revised/sections/sign_in_up';
+@import 'revised/sections/bikehub_sign_in_up';
+@import 'revised/sections/sign_out';
+@import 'revised/sections/ad_blocks';
+@import 'revised/sections/bike_search_form';
+@import 'revised/sections/bike_boxes';
+@import 'revised/sections/side_boxes';
+@import '../../javascript/stylesheets/table_extensions'; // Import from new scss files!
+@import 'revised/sections/embeded_tweet';
+@import 'revised/sections/general_alerts';
 
 // Shared organized styles
-@import "revised/pages/organized/forms";
-@import "revised/pages/organized/shared";
-@import "revised/pages/organized/parking_notifications";
-@import "revised/pages/organized/exports";
-@import "revised/pages/organized/bikes";
-@import "revised/pages/organized/dashboard";
-@import "revised/pages/organized/hot_sheet";
-@import "revised/sections/organized_menu"; // left hand organized menu
-@import "revised/sections/period_selection"; // mostly copies pack styles
+@import 'revised/pages/organized/forms';
+@import 'revised/pages/organized/shared';
+@import 'revised/pages/organized/parking_notifications';
+@import 'revised/pages/organized/exports';
+@import 'revised/pages/organized/bikes';
+@import 'revised/pages/organized/dashboard';
+@import 'revised/pages/organized/hot_sheet';
+@import 'revised/sections/organized_menu'; // left hand organized menu
+@import 'revised/sections/period_selection'; // mostly copies pack styles
 
 // Organization public
-@import "revised/pages/organized/impounded_bikes";
+@import 'revised/pages/organized/impounded_bikes';
 
 //
 // Page styles
 //
 // Bike form pages
-@import "revised/pages/bikes/new";
-@import "revised/pages/bikes/edit_bike_details";
-@import "revised/pages/bikes/edit_bike_groups";
-@import "revised/pages/bikes/edit_remove";
-@import "revised/pages/bikes/edit_accessories";
-@import "revised/pages/bikes/edit_photos";
-@import "revised/pages/bikes/stolen_checklist";
-@import "revised/pages/bikes/edit_publicize";
-@import "revised/pages/bikes/edit_alert";
+@import 'revised/pages/bikes/new';
+@import 'revised/pages/bikes/edit_bike_details';
+@import 'revised/pages/bikes/edit_bike_groups';
+@import 'revised/pages/bikes/edit_remove';
+@import 'revised/pages/bikes/edit_accessories';
+@import 'revised/pages/bikes/edit_photos';
+@import 'revised/pages/bikes/stolen_checklist';
+@import 'revised/pages/bikes/edit_publicize';
+@import 'revised/pages/bikes/edit_alert';
 
 // Bike registration page styles
-@import "revised/pages/bikes/choose_registration";
+@import 'revised/pages/bikes/choose_registration';
 
 // Bike show & search pages
-@import "revised/pages/bikes/index";
-@import "revised/pages/bikes/show";
-@import "revised/pages/bikes/show_photo";
-@import "revised/pages/bikes/stolen_bike_listings"; // Sorta fits here...
+@import 'revised/pages/bikes/index';
+@import 'revised/pages/bikes/show';
+@import 'revised/pages/bikes/show_photo';
+@import 'revised/pages/bikes/stolen_bike_listings'; // Sorta fits here...
 
 // separated because it's a lot
-@import "revised/pages/bikes/multi_serial_search";
+@import 'revised/pages/bikes/multi_serial_search';
 
 // My Account pages
-@import "revised/pages/my_accounts/show";
-@import "revised/pages/my_accounts/edit";
+@import 'revised/pages/my_accounts/show';
+@import 'revised/pages/my_accounts/edit';
 
 // public user show page
-@import "revised/pages/user/show";
+@import 'revised/pages/user/show';
 
 // Error pages
-@import "revised/pages/errors";
+@import 'revised/pages/errors';
 
 // Info pages
-@import "revised/pages/info/where";
-@import "revised/pages/info/about";
-@import "revised/pages/info/protect_your_bike";
-@import "revised/pages/payments/payments";
+@import 'revised/pages/info/where';
+@import 'revised/pages/info/about';
+@import 'revised/pages/info/protect_your_bike';
+@import 'revised/pages/payments/payments';
 
 // Support pages
-@import "revised/pages/support/faq";
+@import 'revised/pages/support/faq';
 
 // Locks pages
-@import "revised/pages/locks/lock_styles";
+@import 'revised/pages/locks/lock_styles';
 
 // News pages
-@import "revised/pages/news/index";
-@import "revised/pages/news/show";
+@import 'revised/pages/news/index';
+@import 'revised/pages/news/show';
 
 // Landing page styles
-@import "revised/pages/landing/organizations";
-@import "revised/pages/landing/signup";
-@import "revised/pages/landing/ambassadors";
-@import "revised/pages/landing/point_of_sale";
-@import "revised/pages/landing/packages";
-@import "revised/pages/landing/footer";
+@import 'revised/pages/landing/organizations';
+@import 'revised/pages/landing/signup';
+@import 'revised/pages/landing/ambassadors';
+@import 'revised/pages/landing/point_of_sale';
+@import 'revised/pages/landing/packages';
+@import 'revised/pages/landing/footer';
 
 // Home styles
-@import "legacy_includes/slick.scss";
-@import "revised/pages/landing/home";
-@import "revised/pages/landing/recoveries";
+@import 'legacy_includes/slick.scss';
+@import 'revised/pages/landing/home';
+@import 'revised/pages/landing/recoveries';
 
 // LEGACY PAGES general styles - replace as soon as all pages have been restyled
-@import "revised/sections/legacy_content";
+@import 'revised/sections/legacy_content';
 
 // general legacy content styles
-@import "revised/pages/legacy_stolen";
+@import 'revised/pages/legacy_stolen';
 
 // legacy stolen page - including multi-serial search
-@import "revised/sections/oauth";
+@import 'revised/sections/oauth';
 
 html {
   background: $black-off;
@@ -352,6 +352,11 @@ body {
   &.form-control:focus {
     opacity: 1;
   }
+}
+
+.less-less-strong {
+  @extend .less-strong;
+  opacity: 0.4;
 }
 
 .gray-link {

--- a/app/assets/stylesheets/revised/pages/organized/parking_notifications.scss
+++ b/app/assets/stylesheets/revised/pages/organized/parking_notifications.scss
@@ -66,6 +66,7 @@
   #placeSearch {
     max-width: 60%;
     display: none;
+    position: absolute;
 
     &.searchOnMap {
       display: block;

--- a/app/assets/stylesheets/revised/sections/bike_boxes.scss
+++ b/app/assets/stylesheets/revised/sections/bike_boxes.scss
@@ -1,3 +1,10 @@
+.bike-serial {
+  color: $body-font-color;
+  background: none;
+  padding: 0;
+  border-radius: none;
+}
+
 $bike-box-bg: $gray-lighter;
 
 .bike-boxes {

--- a/app/helpers/bike_helper.rb
+++ b/app/helpers/bike_helper.rb
@@ -3,16 +3,16 @@ module BikeHelper
   def render_serial_display(bike, user = nil, skip_explanation: false)
     serial_text = bike.serial_display(user).downcase
     serial_html = if ["hidden", "unknown", "made without serial"].include?(serial_text)
-      content_tag(:span, serial_text, class: "less-strong")
+      content_tag(:span,
+        I18n.t(serial_text.tr(" ", "_"), scope: %i[helpers bike_helper]),
+        class: "less-strong")
     else
       content_tag(:code, bike.serial_display(user), class: "bike-serial")
     end
     return serial_html unless bike.serial_hidden? && !skip_explanation
     serial_html << " "
-    serial_html << content_tag(:em, class: "small less-strong") do
+    serial_html << content_tag(:em, class: "small less-less-strong") do
       if bike.authorized?(user)
-        # t(".hidden_for_unauthorized_users")
-        # I18n.t(key, **kwargs, scope: scope.compact)
         I18n.t("hidden_for_unauthorized_users", scope: %i[helpers bike_helper])
       else
         I18n.t("hidden_because_status",

--- a/app/helpers/bike_helper.rb
+++ b/app/helpers/bike_helper.rb
@@ -1,5 +1,27 @@
 # There is also BikeDisplayer for things that aren't only used in view files
 module BikeHelper
+  def render_serial_display(bike, user = nil, skip_explanation: false)
+    serial_text = bike.serial_display(user).downcase
+    serial_html = if ["hidden", "unknown", "made without serial"].include?(serial_text)
+      content_tag(:span, serial_text, class: "less-strong")
+    else
+      content_tag(:code, bike.serial_display(user), class: "bike-serial")
+    end
+    return serial_html unless bike.serial_hidden? && !skip_explanation
+    serial_html << " "
+    serial_html << content_tag(:em, class: "small less-strong") do
+      if bike.authorized?(user)
+        # t(".hidden_for_unauthorized_users")
+        # I18n.t(key, **kwargs, scope: scope.compact)
+        I18n.t("hidden_for_unauthorized_users", scope: %i[helpers bike_helper])
+      else
+        I18n.t("hidden_because_status",
+          bike_type: bike.type, status: bike.status_humanized_translated,
+          scope: %i[helpers bike_helper])
+      end
+    end
+  end
+
   def bike_status_span(bike)
     return "" if bike.status_with_owner?
     content_tag(:strong,

--- a/app/helpers/bike_helper.rb
+++ b/app/helpers/bike_helper.rb
@@ -1,7 +1,8 @@
 # There is also BikeDisplayer for things that aren't only used in view files
 module BikeHelper
   def render_serial_display(bike, user = nil, skip_explanation: false)
-    serial_text = bike.serial_display(user).downcase
+    serial_text = bike.serial_display(user)&.downcase
+    return "" if serial_text.blank?
     serial_html = if ["hidden", "unknown", "made without serial"].include?(serial_text)
       content_tag(:span,
         I18n.t(serial_text.tr(" ", "_"), scope: %i[helpers bike_helper]),

--- a/app/javascript/scripts/pages/binx_mapping.js
+++ b/app/javascript/scripts/pages/binx_mapping.js
@@ -1,266 +1,266 @@
-import log from "../utils/log";
-import _ from "lodash";
+import log from '../utils/log'
+import _ from 'lodash'
 
 export default class BinxMapping {
   // The page instance of this class is modified to store the current list of points for rendering
-  constructor(kind) {
-    this.kind = kind;
-    this.searchBox = null;
-    this.searchMarkers = [];
-    this.markerPointsToRender = [];
-    this.markersRendered = [];
-    this.mapRendered = false;
+  constructor (kind) {
+    this.kind = kind
+    this.searchBox = null
+    this.searchMarkers = []
+    this.markerPointsToRender = []
+    this.markersRendered = []
+    this.mapRendered = false
   }
 
-  loadMap(callback) {
+  loadMap (callback) {
     if (window.googleMapInjected || this.googleMapsLoaded()) {
-      return true;
+      return true
     }
     // Add google maps script
-    var js_file = document.createElement("script");
-    js_file.type = "text/javascript";
-    js_file.src = `https://maps.googleapis.com/maps/api/js?callback=${callback}&key=${window.pageInfo.google_maps_key}&libraries=places`;
-    document.getElementsByTagName("head")[0].appendChild(js_file);
-    window.googleMapInjected = true;
+    var js_file = document.createElement('script')
+    js_file.type = 'text/javascript'
+    js_file.src = `https://maps.googleapis.com/maps/api/js?callback=${callback}&key=${window.pageInfo.google_maps_key}&libraries=places`
+    document.getElementsByTagName('head')[0].appendChild(js_file)
+    window.googleMapInjected = true
   }
 
-  render(lat, lng, zoom = null) {
+  render (lat, lng, zoom = null) {
     if (zoom == null) {
-      zoom = 13;
+      zoom = 13
     }
-    this.zoom = zoom;
+    this.zoom = zoom
     let myOptions = {
       zoom: zoom,
       center: new google.maps.LatLng(lat, lng),
-      gestureHandling: "cooperative",
-      mapTypeId: google.maps.MapTypeId.ROADMAP,
-    };
+      gestureHandling: 'cooperative',
+      mapTypeId: google.maps.MapTypeId.ROADMAP
+    }
     if (!window.infoWindow) {
-      window.infoWindow = new google.maps.InfoWindow();
+      window.infoWindow = new google.maps.InfoWindow()
     }
     window.binxMap = new google.maps.Map(
-      document.getElementById("map"),
+      document.getElementById('map'),
       myOptions
-    );
+    )
   }
 
-  googleMapsLoaded() {
-    return typeof google === "object" && typeof google.maps === "object";
+  googleMapsLoaded () {
+    return typeof google === 'object' && typeof google.maps === 'object'
   }
 
-  fitMap() {
-    let bounds = new google.maps.LatLngBounds();
+  fitMap () {
+    let bounds = new google.maps.LatLngBounds()
     // Fit to markers
     for (let marker of Array.from(this.markersRendered)) {
       if (marker) {
-        bounds.extend(marker.getPosition());
+        bounds.extend(marker.getPosition())
       }
     }
-    binxMap.fitBounds(bounds);
+    binxMap.fitBounds(bounds)
 
     // Finish rendering map, then check - if too zoomed in (e.g. on one point), zoom out
     window.setTimeout(function () {
       if (binxMap.zoom > 16) {
-        binxMap.setZoom(16);
+        binxMap.setZoom(16)
       }
-    }, 500);
+    }, 500)
   }
 
-  boundingBoxParams() {
+  boundingBoxParams () {
     if (!binxMapping.mapRendered) {
-      return [];
+      return []
     }
-    let bounds = binxMap.getBounds();
+    let bounds = binxMap.getBounds()
     return [
-      ["search_southwest_coords", bounds.getSouthWest().toUrlValue()],
-      ["search_northeast_coords", bounds.getNorthEast().toUrlValue()],
-    ];
+      ['search_southwest_coords', bounds.getSouthWest().toUrlValue()],
+      ['search_northeast_coords', bounds.getNorthEast().toUrlValue()]
+    ]
   }
 
-  renderAddressSearch() {
+  renderAddressSearch () {
     if (this.searchBox != null) {
-      return true;
+      return true
     }
-    $("#map").before(
+    $('#map').before(
       '<input id="placeSearch" class="controls form-control" type="text" placeholder="Search map">'
-    );
-    let input = document.getElementById("placeSearch");
-    this.searchBox = new google.maps.places.SearchBox(input);
-    window.binxMap.controls[google.maps.ControlPosition.TOP_RIGHT].push(input);
-    $(input).addClass("searchOnMap"); // search box is initially hidden - display it when rendered on map
+    )
+    let input = document.getElementById('placeSearch')
+    this.searchBox = new google.maps.places.SearchBox(input)
+    window.binxMap.controls[google.maps.ControlPosition.TOP_RIGHT].push(input)
     // Bias SearchBox results towards current map's viewport.
-    binxMap.addListener("bounds_changed", () =>
+    binxMap.addListener('bounds_changed', () =>
       binxMapping.searchBox.setBounds(binxMap.getBounds())
-    );
+    )
 
-    this.searchBox.addListener("places_changed", function () {
-      let places = binxMapping.searchBox.getPlaces();
+    this.searchBox.addListener('places_changed', function () {
+      let places = binxMapping.searchBox.getPlaces()
       if (places.length === 0) {
-        log.debug("Unable to find that address");
+        log.debug('Unable to find that address')
       }
       // For each place, get the icon, name and location.
-      let bounds = new google.maps.LatLngBounds();
+      let bounds = new google.maps.LatLngBounds()
       places.forEach(function (place) {
         if (!place.geometry) {
-          log.debug("Returned place contains no geometry");
+          log.debug('Returned place contains no geometry')
         }
         // Create a marker for each place
         binxMapping.searchMarkers.push(
           new google.maps.Marker({
             map: binxMap,
             icon:
-              "http://maps.google.com/mapfiles/ms/micons/purple-pushpin.png",
+              'http://maps.google.com/mapfiles/ms/micons/purple-pushpin.png',
             title: place.name,
-            position: place.geometry.location,
+            position: place.geometry.location
           })
-        );
-        bounds.extend(place.geometry.location);
-      });
-      binxMap.fitBounds(bounds);
-    });
+        )
+        bounds.extend(place.geometry.location)
+      })
+      binxMap.fitBounds(bounds)
+    })
+    $(input).addClass('searchOnMap') // search box is initially hidden - display it when rendered on map
   }
 
-  removeMarkersWithoutMatchingIds(markers) {
+  removeMarkersWithoutMatchingIds (markers) {
     if (!binxMapping.markersRendered) {
-      binxMapping.markersRendered = [];
+      binxMapping.markersRendered = []
     }
 
-    const newIds = markers.map((m) => m.id);
+    const newIds = markers.map(m => m.id)
 
     if (window.infoWindow != null) {
-      window.infoWindow.close();
+      window.infoWindow.close()
     }
 
-    let markersToKeep = [];
+    let markersToKeep = []
 
     while (binxMapping.markersRendered.length > 0) {
-      const marker = binxMapping.markersRendered.pop();
+      const marker = binxMapping.markersRendered.pop()
       // If marker isn't around, ignore it
       if (marker != null) {
         // If the id is a match, move it to the new array, otherwise remove it from the map
         if (
-          typeof marker.binxId != "undefined" &&
+          typeof marker.binxId != 'undefined' &&
           newIds.includes(marker.binxId)
         ) {
-          markersToKeep.push(marker);
+          markersToKeep.push(marker)
         } else {
-          marker.setMap(null);
+          marker.setMap(null)
         }
       }
     }
-    binxMapping.markersRendered = markersToKeep;
+    binxMapping.markersRendered = markersToKeep
 
     // Ids make sure we aren't double rendering
-    return (window.renderedMarkerIds = newIds);
+    return (window.renderedMarkerIds = newIds)
   }
 
-  clearMarkers() {
+  clearMarkers () {
     if (!binxMapping.markersRendered) {
-      binxMapping.markersRendered = [];
+      binxMapping.markersRendered = []
     }
 
     if (window.infoWindow != null) {
-      window.infoWindow.close();
+      window.infoWindow.close()
     }
     // Useful when the page reloads without fully reloading
     if (binxMapping.markersRendered.length) {
       for (let i of Array.from(binxMapping.markersRendered)) {
-        i != null && i.setMap(null);
+        i != null && i.setMap(null)
       }
     }
     // Empty the array
-    binxMapping.markersRendered = [];
+    binxMapping.markersRendered = []
     // Ids make sure we aren't double rendering
-    return (window.renderedMarkerIds = []);
+    return (window.renderedMarkerIds = [])
   }
 
-  markersInViewport() {
-    let bounds = binxMap.getBounds();
+  markersInViewport () {
+    let bounds = binxMap.getBounds()
     return _.filter(binxMapping.markersRendered, function (m) {
-      return bounds.contains(m.getPosition());
-    });
+      return bounds.contains(m.getPosition())
+    })
   }
 
-  renderMarker(point) {
-    let popupContent = "";
-    if (binxMapping.kind == "parking_notifications") {
-      popupContent = binxAppOrgParkingNotificationMapping.mapPopup(point);
+  renderMarker (point) {
+    let popupContent = ''
+    if (binxMapping.kind == 'parking_notifications') {
+      popupContent = binxAppOrgParkingNotificationMapping.mapPopup(point)
     } else {
-      log.debug(binxMapping.kind);
-      popupContent = "Missing template!";
+      log.debug(binxMapping.kind)
+      popupContent = 'Missing template!'
     }
-    window.infoWindow.setContent(popupContent);
+    window.infoWindow.setContent(popupContent)
     // Ensure things are rendered before setting times, pause for a hot sec
-    window.setTimeout(() => window.timeParser.localize(), 50);
+    window.setTimeout(() => window.timeParser.localize(), 50)
   }
 
-  openInfoWindow(marker, markerId, point) {
-    window.infoWindow.setContent("");
-    window.infoWindow.open(window.binxMap, marker);
-    binxMapping.enableEscapeForInfoWindows();
+  openInfoWindow (marker, markerId, point) {
+    window.infoWindow.setContent('')
+    window.infoWindow.open(window.binxMap, marker)
+    binxMapping.enableEscapeForInfoWindows()
     // For an unclear reason, this needs to return the rendered marker
-    return binxMapping.renderMarker(point);
+    return binxMapping.renderMarker(point)
   }
 
-  enableEscapeForInfoWindows() {
+  enableEscapeForInfoWindows () {
     // Enable using escape key to close info windows
     // Make sure we aren't adding duplicate handlers, sometimes we don't catch the close event
-    $(window).off("keyup");
+    $(window).off('keyup')
     // Add the trigger for the escape closing the window
-    $(window).on("keyup", function (e) {
+    $(window).on('keyup', function (e) {
       if (e.keyCode === 27) {
-        window.infoWindow.close();
+        window.infoWindow.close()
         // Escape was pressed, infoWindow is closed, so remove the keyup handler
-        $(window).off("keyup");
+        $(window).off('keyup')
       }
-      return true; // allow bubbling up
-    });
+      return true // allow bubbling up
+    })
     // on infowindow close, remove keyup handler - aka clean up after yourself
-    google.maps.event.addListener(window.infoWindow, "closeclick", function () {
-      $(window).off("keyup");
-    });
+    google.maps.event.addListener(window.infoWindow, 'closeclick', function () {
+      $(window).off('keyup')
+    })
   }
 
-  addMarkers({ fitMap = false, renderAddressSearch = true }) {
-    log.debug(`adding markers - fitMap: ${fitMap}`);
+  addMarkers ({ fitMap = false, renderAddressSearch = true }) {
+    log.debug(`adding markers - fitMap: ${fitMap}`)
     while (binxMapping.markerPointsToRender.length > 0) {
-      let point = binxMapping.markerPointsToRender.shift();
-      let markerId = point.id;
-      let markerOpacity = binxMapping.kind == "parking_notifications" ? 0.6 : 1;
+      let point = binxMapping.markerPointsToRender.shift()
+      let markerId = point.id
+      let markerOpacity = binxMapping.kind == 'parking_notifications' ? 0.6 : 1
       // Only render if the point isn't already rendered
-      if (!_.find(binxMapping.markersRendered, ["binxId", point.id])) {
+      if (!_.find(binxMapping.markersRendered, ['binxId', point.id])) {
         let marker = new google.maps.Marker({
           position: new google.maps.LatLng(point.lat, point.lng),
           map: window.binxMap,
           binxId: markerId,
-          opacity: markerOpacity,
-        });
+          opacity: markerOpacity
+        })
 
         google.maps.event.addListener(
           marker,
-          "click",
+          'click',
           ((marker, markerId) =>
             function () {
-              return binxMapping.openInfoWindow(marker, markerId, point);
+              return binxMapping.openInfoWindow(marker, markerId, point)
             })(marker, markerId)
-        );
-        binxMapping.markersRendered.push(marker);
+        )
+        binxMapping.markersRendered.push(marker)
       }
     }
     // If we're suppose to fit the map to the markers - and if there are markers that have been rendered - fit it
     if (fitMap == true && binxMapping.markersRendered.length > 0) {
-      binxMapping.fitMap();
+      binxMapping.fitMap()
     }
     // If we're suppose to include the address search, do it
     if (renderAddressSearch == true) {
-      binxMapping.renderAddressSearch();
+      binxMapping.renderAddressSearch()
     }
     if (binxMapping.mapRendered) {
-      return true;
+      return true
     }
     // If map isn't rendered, give the page a second to catch up
     window.setTimeout(function () {
-      binxMapping.mapRendered = true;
-    }, 1000);
+      binxMapping.mapRendered = true
+    }, 1000)
   }
 }

--- a/app/javascript/stylesheets/admin/_bikes.scss
+++ b/app/javascript/stylesheets/admin/_bikes.scss
@@ -4,6 +4,13 @@
   font-style: italic;
 }
 
+.bike-serial {
+  color: #212529; // body font color
+  background: none;
+  padding: 0;
+  border-radius: none;
+}
+
 .admin-bike-tabs {
   margin: -1.5rem -15px 0;
   padding: 1.5rem 15px 0;

--- a/app/mailers/customer_mailer.rb
+++ b/app/mailers/customer_mailer.rb
@@ -2,6 +2,8 @@ class CustomerMailer < ApplicationMailer
   default content_type: "multipart/alternative",
     parts_order: ["text/calendar", "text/plain", "text/html", "text/enriched"]
 
+  helper :bike
+
   def welcome_email(user)
     @user = user
 

--- a/app/mailers/organized_mailer.rb
+++ b/app/mailers/organized_mailer.rb
@@ -6,6 +6,7 @@ class OrganizedMailer < ApplicationMailer
 
   helper :organized
   helper :money # Required to render currency for bike recoveries
+  helper :bike
 
   def partial_registration(b_param)
     @b_param = b_param

--- a/app/views/admin/bikes/_bike_tabs.html.haml
+++ b/app/views/admin/bikes/_bike_tabs.html.haml
@@ -49,7 +49,7 @@
                 %td
                   Serial number
                 %td
-                  %code= bike.serial_display(current_user)
+                  = render_serial_display(@bike, current_user, skip_explanation: true)
               %tr
                 %td
                   Colors

--- a/app/views/bike_versions/index.html.haml
+++ b/app/views/bike_versions/index.html.haml
@@ -8,16 +8,7 @@
 
   .row
     .col-md-12
-      = form_tag bike_versions_path, id: 'bikes_search_form', class: 'bikes-search-form', enforce_utf8: false, method: :get do
-        .query-field-wrap.nojs
-          = hidden_field_tag :locale, params[:locale] if params[:locale].present?
-          - opt_vals = @selected_query_items_options.map { |i| i.is_a?(String) ? [i, i] : [i['text'], i['search_id']]  }
-          = select_tag :query_items, options_for_select(opt_vals, selected: opt_vals.map(&:last)), placeholder: t(".search_bike_descriptions"), title: t(".search_bike_descriptions"), class: 'form-control query-field', multiple: true
-          = text_field_tag :query, params[:query], placeholder: t(".search_bike_descriptions"), title: t(".search_bike_descriptions"), class: 'form-control query-field'
-        .search-button-wrap
-          = button_tag(type: "submit", class: 'searchit btn btn-primary') do
-            :plain
-              <svg id="search-button" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 29 29"><defs><style>.cls-1,.cls-2{fill:none;stroke:#fff;stroke-miterlimit:10;stroke-width:2px;}.cls-2{stroke-linecap:round;}</style></defs><title>searcher</title><circle class="cls-1" cx="10.39" cy="10.39" r="9.39"/><line class="cls-2" x1="17.03" y1="17.03" x2="28" y2="28"/></svg>
+      = render partial: "/shared/bike_search_form", locals: {search_path: bike_versions_path, skip_serial_field: true}
 
   .row
     .col-md-12

--- a/app/views/bike_versions/index.html.haml
+++ b/app/views/bike_versions/index.html.haml
@@ -6,9 +6,8 @@
       %h1
         Search for bike versions
 
-  .row
-    .col-md-12
-      = render partial: "/shared/bike_search_form", locals: {search_path: bike_versions_path, skip_serial_field: true}
+  .mt-3.mb-4
+    = render partial: "/shared/bike_search_form", locals: {search_path: bike_versions_path, skip_serial_field: true}
 
   .row
     .col-md-12

--- a/app/views/bikes/_bike.html.haml
+++ b/app/views/bikes/_bike.html.haml
@@ -15,14 +15,9 @@
       %li
         %strong.attr-title #{t(".serial")}:
         - if !skip_cache
-          = bike.serial_display
+          = render_serial_display(bike)
         - else # Show the user specific info
-          = bike.serial_display(current_user)
-          - if bike.serial_hidden?
-            %em.small.less-strong
-              - if bike.authorized?(current_user)
-                = t(".hidden_for_unauthorized_users")
-              = t(".hidden_because_status", bike_type: bike.type, status: bike.status_humanized_translated)
+          = render_serial_display(bike, current_user)
       = attr_list_item(bike.frame_colors.to_sentence, t(".primary_colors"))
     - if bike.occurred_at.present?
       %ul.attr-list

--- a/app/views/bikes/_main_show_block.html.haml
+++ b/app/views/bikes/_main_show_block.html.haml
@@ -34,12 +34,7 @@
       - unless @bike.version?
         %li
           %strong.attr-title #{t(".serial")}:
-          = @bike.serial_display(current_user)
-          - if @bike.serial_hidden?
-            %em.small.less-strong
-              - if @bike.authorized?(current_user)
-                = t(".hidden_for_unauthorized_users")
-              = t(".hidden_because_status", bike_type: @bike.type, status: @bike.status_humanized_translated)
+          = render_serial_display(@bike, current_user)
         - unless @bike.serial_hidden?
           = attr_list_item(@bike.extra_registration_number, t(".other_serial"))
       - unless @bike.type == "bike"

--- a/app/views/bikes/index.html.haml
+++ b/app/views/bikes/index.html.haml
@@ -10,28 +10,7 @@
 
   .row
     .col-md-12
-      = form_tag bikes_path, id: 'bikes_search_form', class: 'bikes-search-form', enforce_utf8: false, method: :get do
-        .query-field-wrap.nojs
-          = hidden_field_tag :locale, params[:locale] if params[:locale].present?
-          - opt_vals = @selected_query_items_options.map { |i| i.is_a?(String) ? [i, i] : [i['text'], i['search_id']]  }
-          = select_tag :query_items, options_for_select(opt_vals, selected: opt_vals.map(&:last)), placeholder: t(".search_bike_descriptions"), title: t(".search_bike_descriptions"), class: 'form-control query-field', multiple: true
-          = text_field_tag :query, params[:query], placeholder: t(".search_bike_descriptions"), title: t(".search_bike_descriptions"), class: 'form-control query-field'
-          = text_field_tag :serial, params[:serial], placeholder: t(".search_for_serial_number"), title: t(".search_for_serial_number"), class: 'form-control query-field'
-        .search-button-wrap
-          = button_tag(type: t(".submit"), class: 'searchit btn btn-primary') do
-            :plain
-              <svg id="search-button" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 29 29"><defs><style>.cls-1,.cls-2{fill:none;stroke:#fff;stroke-miterlimit:10;stroke-width:2px;}.cls-2{stroke-linecap:round;}</style></defs><title>searcher</title><circle class="cls-1" cx="10.39" cy="10.39" r="9.39"/><line class="cls-2" x1="17.03" y1="17.03" x2="28" y2="28"/></svg>
-        .stolen-search-fields{ class: ('currently-hidden' unless params[:stolenness] == 'proximity') }
-          = text_field_tag :location, params[:location], placeholder: t(".anywhere"), title: "Search location", class: 'form-control stolen-proximity'
-          %span
-            = t(".miles_of")
-          = number_field_tag :distance, @interpreted_params[:distance] || 100, placeholder: '100', min: 1, title: "Search distance", class: 'form-control stolen-radius'
-          %span
-            = t(".within")
-          = hidden_field_tag :stolenness, params[:stolenness]
-      - if @interpreted_params[:raw_serial].present? && @interpreted_params[:serial].blank?
-        .alert.alert-warning.mt-4
-          = t(".doesnt_look_like_serial")
+      = render partial: "/shared/bike_search_form"
 
       .search-type-tabs
         %ul#stolenness_tabs.nav.nav-tabs{ role: 'tablist' }

--- a/app/views/bikes/index.html.haml
+++ b/app/views/bikes/index.html.haml
@@ -10,7 +10,7 @@
 
   .row
     .col-md-12
-      = render partial: "/shared/bike_search_form"
+      = render partial: "/shared/bike_search_form", locals: {include_location_search: true}
 
       .search-type-tabs
         %ul#stolenness_tabs.nav.nav-tabs{ role: 'tablist' }

--- a/app/views/my_accounts/show.html.haml
+++ b/app/views/my_accounts/show.html.haml
@@ -35,7 +35,9 @@
                       %h5.title-link
                         = link_to bike_title_html(bike, include_status: true), bike_path(bike)
                       %ul.attr-list
-                        = attr_list_item(bike.serial_display(current_user), t(".serial"))
+                        %li
+                          %strong.attr-title #{t(".serial")}:
+                          = render_serial_display(bike, current_user, skip_explanation: true)
                         = attr_list_item(bike.frame_colors.to_sentence, t(".primary_colors"))
                         %li.less-strong
                           %strong.attr-title #{t(".registered")}:

--- a/app/views/org_public/impounded_bikes/index.html.haml
+++ b/app/views/org_public/impounded_bikes/index.html.haml
@@ -7,27 +7,10 @@
     %strong.uncap= current_organization.name
     Impounded bikes
 
-  = render partial: "/shared/period_select", locals: { prepend_text: "Impounded during:" }
+  = render partial: "/shared/period_select", locals: {prepend_text: "Impounded during:"}
 
   .mt-4
-    = form_tag organization_impounded_bikes_path(organization_id: current_organization.to_param), id: "bikes_search_form", class: "bikes-search-form", method: :get do
-      .query-field-wrap.nojs
-        - opt_vals = @selected_query_items_options.map { |i| i.is_a?(String) ? [i, i] : [i["text"], i["search_id"]]  }
-        = select_tag :query_items,                                      |
-          options_for_select(opt_vals, selected: opt_vals.map(&:last)), |
-          placeholder: t(".search_bike_descriptions"),                  |
-          class: "form-control query-field",                            |
-          multiple: true
-
-        = text_field_tag :query, params[:query], placeholder: t(".search_bike_descriptions"), class: "form-control query-field"
-        = text_field_tag :serial, params[:serial], placeholder: t(".search_for_serial_number"), class: "form-control query-field"
-
-      .search-button-wrap
-        = button_tag(type: "submit", class: "searchit btn btn-primary") do
-          :plain
-            <svg id="search-button" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 29 29"><defs><style>.cls-1,.cls-2{fill:none;stroke:#fff;stroke-miterlimit:10;stroke-width:2px;}.cls-2{stroke-linecap:round;}</style></defs><title>searcher</title><circle class="cls-1" cx="10.39" cy="10.39" r="9.39"/><line class="cls-2" x1="17.03" y1="17.03" x2="28" y2="28"/></svg>
-
-      = render partial: "/shared/hidden_search_fields", locals: {kind: "organized_bike_search"}
+    = render partial: "/shared/bike_search_form", locals: {include_hidden_search_fields: true, search_path: organization_impounded_bikes_path(organization_id: current_organization.to_param)}
 
   .mt-4.mb-4
     = pluralize(number_with_delimiter(@impound_records.total_count), "matching impound record")

--- a/app/views/organized/bikes/_search.html.haml
+++ b/app/views/organized/bikes/_search.html.haml
@@ -1,31 +1,7 @@
--# If no url_for_search passed in, default to organization bike search
-
-- path_for_search ||= organization_bikes_path(organization_id: current_organization.to_param)
 - skip_view_just_stolen ||= @bike_sticker.present?
 
 .mb-4
-  = form_tag path_for_search, id: 'bikes_search_form', class: 'bikes-search-form', method: :get do
-    .query-field-wrap.nojs
-      - opt_vals = @selected_query_items_options.map { |i| i.is_a?(String) ? [i, i] : [i['text'], i['search_id']]  }
-      = select_tag :query_items,                                      |
-        options_for_select(opt_vals, selected: opt_vals.map(&:last)), |
-        placeholder: t(".search_bike_descriptions"),                  |
-        class: 'form-control query-field',                            |
-        multiple: true
-
-      = text_field_tag :query, params[:query], placeholder: t(".search_bike_descriptions"), class: 'form-control query-field'
-      .sidebyside-queries
-        = text_field_tag :search_email, params[:search_email], placeholder: t(".search_owner_email"), class: 'form-control query-field email-field-too'
-        = text_field_tag :serial, params[:serial], placeholder: t(".search_for_serial_number"), class: 'form-control query-field email-field-too'
-
-    .search-button-wrap
-      = button_tag(type: 'submit', class: 'searchit btn btn-primary') do
-        :plain
-          <svg id="search-button" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 29 29"><defs><style>.cls-1,.cls-2{fill:none;stroke:#fff;stroke-miterlimit:10;stroke-width:2px;}.cls-2{stroke-linecap:round;}</style></defs><title>searcher</title><circle class="cls-1" cx="10.39" cy="10.39" r="9.39"/><line class="cls-2" x1="17.03" y1="17.03" x2="28" y2="28"/></svg>
-
-    = render partial: "/shared/hidden_search_fields", locals: {kind: "organized_bike_search"}
-    = hidden_field_tag :search_stickers, params[:search_stickers]
-    = hidden_field_tag :search_address, params[:search_address]
+  = render partial: "/shared/bike_search_form", locals: {include_organized_search_fields: true, search_path: organization_bikes_path(organization_id: current_organization.to_param)}
 
 %hr{style: "opacity: .3;"}
 

--- a/app/views/organized/graduated_notifications/index.html.haml
+++ b/app/views/organized/graduated_notifications/index.html.haml
@@ -17,27 +17,7 @@
 = render partial: "/shared/period_select"
 
 .mt-4
-  = form_tag organization_graduated_notifications_path(organization_id: current_organization.to_param), id: 'bikes_search_form', class: 'bikes-search-form', method: :get do
-    .query-field-wrap.nojs
-      - opt_vals = @selected_query_items_options.map { |i| i.is_a?(String) ? [i, i] : [i['text'], i['search_id']]  }
-      = select_tag :query_items,                                      |
-        options_for_select(opt_vals, selected: opt_vals.map(&:last)), |
-        placeholder: t(".search_bike_descriptions"),                  |
-        class: 'form-control query-field',                            |
-        multiple: true
-
-      = text_field_tag :query, params[:query], placeholder: t(".search_bike_descriptions"), class: 'form-control query-field'
-      .sidebyside-queries
-        = text_field_tag :search_email, params[:search_email], placeholder: t(".search_owner_email"), class: 'form-control query-field email-field-too'
-        = text_field_tag :serial, params[:serial], placeholder: t(".search_for_serial_number"), class: 'form-control query-field email-field-too'
-
-    .search-button-wrap
-      = button_tag(type: 'submit', class: 'searchit btn btn-primary') do
-        :plain
-          <svg id="search-button" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 29 29"><defs><style>.cls-1,.cls-2{fill:none;stroke:#fff;stroke-miterlimit:10;stroke-width:2px;}.cls-2{stroke-linecap:round;}</style></defs><title>searcher</title><circle class="cls-1" cx="10.39" cy="10.39" r="9.39"/><line class="cls-2" x1="17.03" y1="17.03" x2="28" y2="28"/></svg>
-
-    = hidden_field :search_secondary, params[:search_secondary]
-    = render partial: "/shared/hidden_search_fields", locals: {kind: "organized_bike_search"}
+  = render partial: "/shared/bike_search_form", locals: {include_organized_search_fields: true, search_path: organization_graduated_notifications_path(organization_id: current_organization.to_param)}
 
 .row.mt-4.mb-4
   .col-sm-6
@@ -52,7 +32,7 @@
         for searched bike
   .col-sm-6.text-right
     - if display_dev_info?
-      %span.only-dev-visible.mr-2.pl-1.pr-1
+      %span.only-dev-visible.mr-2.pl-1.pr-1.pt-1.pb-2
         = link_to "separate secondary", url_for(sortable_search_params.merge(search_secondary: !separate_secondary_notifications?)), class: (separate_secondary_notifications? ? "active btn btn-primary btn-sm" : "less-strong small")
     %a.dropdown-toggle.btn.btn-outline-primary{href: "#", role: "button", "data-toggle" => "dropdown", "aria-haspopup" => "true", "aria-expanded" => "false" }
       = @search_status.humanize || "All statuses"

--- a/app/views/organized/hot_sheets/show.html.haml
+++ b/app/views/organized/hot_sheets/show.html.haml
@@ -82,7 +82,7 @@
                       = link_to organized_bike_text(bike, skip_creation: true), bike_link
                   %tr
                     %td Serial
-                    %td= bike.serial_display(current_user)
+                    %td= render_serial_display(bike, current_user)
                   - if stolen_record.recovered?
                     %tr
                       %td

--- a/app/views/organized/impound_records/_table.html.haml
+++ b/app/views/organized/impound_records/_table.html.haml
@@ -73,7 +73,7 @@
               = link_to organized_bike_text(impound_record.bike), bike_path(impound_record.bike, organization_id: current_organization.id)
               -# Only show the serial if there is a serial. Because PSU asked for this
               - if !impound_record.bike.no_serial?
-                %small #{impound_record.bike.serial_display(current_user)}
+                %small= render_serial_display(impound_record.bike, current_user)
         - unless skip_status
           %td
             %em

--- a/app/views/organized/impound_records/index.html.haml
+++ b/app/views/organized/impound_records/index.html.haml
@@ -12,27 +12,7 @@
 = render partial: "/shared/period_select"
 
 .mt-4
-  = form_tag organization_impound_records_path(organization_id: current_organization.to_param), id: 'bikes_search_form', class: 'bikes-search-form', method: :get do
-    .query-field-wrap.nojs
-      - opt_vals = @selected_query_items_options.map { |i| i.is_a?(String) ? [i, i] : [i['text'], i['search_id']]  }
-      = select_tag :query_items,                                      |
-        options_for_select(opt_vals, selected: opt_vals.map(&:last)), |
-        placeholder: t(".search_bike_descriptions"),                  |
-        class: 'form-control query-field',                            |
-        multiple: true
-
-      = text_field_tag :query, params[:query], placeholder: t(".search_bike_descriptions"), class: 'form-control query-field'
-      .sidebyside-queries
-        = text_field_tag :search_email, params[:search_email], placeholder: t(".search_owner_email"), class: 'form-control query-field email-field-too'
-        = text_field_tag :serial, params[:serial], placeholder: t(".search_for_serial_number"), class: 'form-control query-field email-field-too'
-
-    .search-button-wrap
-      = button_tag(type: 'submit', class: 'searchit btn btn-primary') do
-        :plain
-          <svg id="search-button" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 29 29"><defs><style>.cls-1,.cls-2{fill:none;stroke:#fff;stroke-miterlimit:10;stroke-width:2px;}.cls-2{stroke-linecap:round;}</style></defs><title>searcher</title><circle class="cls-1" cx="10.39" cy="10.39" r="9.39"/><line class="cls-2" x1="17.03" y1="17.03" x2="28" y2="28"/></svg>
-
-    = render partial: "/shared/hidden_search_fields", locals: {kind: "organized_bike_search"}
-    = hidden_field_tag :search_status, @search_status
+  = render partial: "/shared/bike_search_form", locals: {include_organized_search_fields: true, search_path: organization_impound_records_path(organization_id: current_organization.to_param)}
 
 .row.mt-4.mb-4
   .col-sm-9

--- a/app/views/organized/parking_notifications/index.html.haml
+++ b/app/views/organized/parking_notifications/index.html.haml
@@ -98,28 +98,7 @@
   = render partial: "/shared/period_select", locals: { skip_submission: true }
 
   .mt-4
-    = form_tag organization_parking_notifications_path(organization_id: current_organization.to_param), id: 'bikes_search_form', class: 'bikes-search-form', method: :get do
-      .query-field-wrap.nojs
-        - opt_vals = @selected_query_items_options.map { |i| i.is_a?(String) ? [i, i] : [i['text'], i['search_id']]  }
-        = select_tag :query_items,                                      |
-          options_for_select(opt_vals, selected: opt_vals.map(&:last)), |
-          placeholder: t(".search_bike_descriptions"),                  |
-          class: 'form-control query-field',                            |
-          multiple: true
-
-        = text_field_tag :query, params[:query], placeholder: t(".search_bike_descriptions"), class: 'form-control query-field'
-        .sidebyside-queries
-          = text_field_tag :search_email, params[:search_email], placeholder: t(".search_owner_email"), class: 'form-control query-field email-field-too'
-          = text_field_tag :serial, params[:serial], placeholder: t(".search_for_serial_number"), class: 'form-control query-field email-field-too'
-
-      .search-button-wrap
-        = button_tag(type: 'submit', class: 'searchit btn btn-primary') do
-          :plain
-            <svg id="search-button" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 29 29"><defs><style>.cls-1,.cls-2{fill:none;stroke:#fff;stroke-miterlimit:10;stroke-width:2px;}.cls-2{stroke-linecap:round;}</style></defs><title>searcher</title><circle class="cls-1" cx="10.39" cy="10.39" r="9.39"/><line class="cls-2" x1="17.03" y1="17.03" x2="28" y2="28"/></svg>
-
-      = render partial: "/shared/hidden_search_fields", locals: {kind: "organized_bike_search"}
-      = hidden_field_tag :search_status, @search_status
-      = hidden_field_tag :search_kind, @search_kind
+    = render partial: "/shared/bike_search_form", locals: {include_organized_search_fields: true, search_path: organization_parking_notifications_path(organization_id: current_organization.to_param)}
 
   .row.mt-4.mb-2
     .col-sm-6

--- a/app/views/shared/_bike_search_form.html.haml
+++ b/app/views/shared/_bike_search_form.html.haml
@@ -3,33 +3,47 @@
 - include_location_search ||= false
 
 - include_organized_search_fields ||= false
+- include_hidden_search_fields ||= include_organized_search_fields
 
 
-= form_tag search_path, id: 'bikes_search_form', class: 'bikes-search-form', enforce_utf8: false, method: :get do
+- search_form_class = "bikes-search-form"
+- search_form_class += " single-search-input " if skip_serial_field
+
+= form_tag search_path, id: "bikes_search_form", class: search_form_class, enforce_utf8: false, method: :get do
   .query-field-wrap.nojs
     = hidden_field_tag :locale, params[:locale] if params[:locale].present?
-    - opt_vals = @selected_query_items_options.map { |i| i.is_a?(String) ? [i, i] : [i['text'], i['search_id']]  }
-    = select_tag :query_items, options_for_select(opt_vals, selected: opt_vals.map(&:last)), placeholder: t(".search_bike_descriptions"), title: t(".search_bike_descriptions"), class: 'form-control query-field', multiple: true
-    = text_field_tag :query, params[:query], placeholder: t(".search_bike_descriptions"), title: t(".search_bike_descriptions"), class: 'form-control query-field'
+    - opt_vals = @selected_query_items_options.map { |i| i.is_a?(String) ? [i, i] : [i["text"], i["search_id"]]  }
+    = select_tag :query_items,                                      |
+      options_for_select(opt_vals, selected: opt_vals.map(&:last)), |
+      placeholder: t(".search_bike_descriptions"),                  |
+      class: "form-control query-field",                            |
+      multiple: true
+    = text_field_tag :query, params[:query], placeholder: t(".search_bike_descriptions"), title: t(".search_bike_descriptions"), class: "form-control query-field"
     - if include_organized_search_fields
       .sidebyside-queries
-        = text_field_tag :search_email, params[:search_email], placeholder: t(".search_owner_email"), class: 'form-control query-field email-field-too'
-        = text_field_tag :serial, params[:serial], placeholder: t(".search_for_serial_number"), class: 'form-control query-field email-field-too'
+        = text_field_tag :search_email, params[:search_email], placeholder: t(".search_owner_email"), class: "form-control query-field email-field-too"
+        = text_field_tag :serial, params[:serial], placeholder: t(".search_for_serial_number"), class: "form-control query-field email-field-too"
     - elsif !skip_serial_field
-      = text_field_tag :serial, params[:serial], placeholder: t(".search_for_serial_number"), title: t(".search_for_serial_number"), class: 'form-control query-field'
+      = text_field_tag :serial, params[:serial], placeholder: t(".search_for_serial_number"), title: t(".search_for_serial_number"), class: "form-control query-field"
   .search-button-wrap
-    = button_tag(type: t(".submit"), class: 'searchit btn btn-primary') do
+    = button_tag(type: t(".submit"), class: "searchit btn btn-primary") do
       :plain
         <svg id="search-button" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 29 29"><defs><style>.cls-1,.cls-2{fill:none;stroke:#fff;stroke-miterlimit:10;stroke-width:2px;}.cls-2{stroke-linecap:round;}</style></defs><title>searcher</title><circle class="cls-1" cx="10.39" cy="10.39" r="9.39"/><line class="cls-2" x1="17.03" y1="17.03" x2="28" y2="28"/></svg>
   - if include_location_search
-    .stolen-search-fields{ class: ('currently-hidden' unless params[:stolenness] == 'proximity') }
-      = text_field_tag :location, params[:location], placeholder: t(".anywhere"), title: "Search location", class: 'form-control stolen-proximity'
+    .stolen-search-fields{ class: ("currently-hidden" unless params[:stolenness] == "proximity") }
+      = text_field_tag :location, params[:location], placeholder: t(".anywhere"), title: "Search location", class: "form-control stolen-proximity"
       %span
         = t(".miles_of")
-      = number_field_tag :distance, @interpreted_params[:distance] || 100, placeholder: '100', min: 1, title: "Search distance", class: 'form-control stolen-radius'
+      = number_field_tag :distance, @interpreted_params[:distance] || 100, placeholder: "100", min: 1, title: "Search distance", class: "form-control stolen-radius"
       %span
         = t(".within")
       = hidden_field_tag :stolenness, params[:stolenness]
+
+  - if include_organized_search_fields
+    = render partial: "/shared/hidden_search_fields", locals: {kind: "organized_bike_search"}
+    = hidden_field_tag :search_stickers, params[:search_stickers]
+    = hidden_field_tag :search_address, params[:search_address]
+
 - if @interpreted_params[:raw_serial].present? && @interpreted_params[:serial].blank?
   .alert.alert-warning.mt-4
     = t(".doesnt_look_like_serial")

--- a/app/views/shared/_bike_search_form.html.haml
+++ b/app/views/shared/_bike_search_form.html.haml
@@ -1,0 +1,27 @@
+- search_path ||= bikes_path
+- include_email_field ||= false
+- skip_serial_field ||= false
+
+= form_tag search_path, id: 'bikes_search_form', class: 'bikes-search-form', enforce_utf8: false, method: :get do
+  .query-field-wrap.nojs
+    = hidden_field_tag :locale, params[:locale] if params[:locale].present?
+    - opt_vals = @selected_query_items_options.map { |i| i.is_a?(String) ? [i, i] : [i['text'], i['search_id']]  }
+    = select_tag :query_items, options_for_select(opt_vals, selected: opt_vals.map(&:last)), placeholder: t(".search_bike_descriptions"), title: t(".search_bike_descriptions"), class: 'form-control query-field', multiple: true
+    = text_field_tag :query, params[:query], placeholder: t(".search_bike_descriptions"), title: t(".search_bike_descriptions"), class: 'form-control query-field'
+    - unless skip_serial_field
+      = text_field_tag :serial, params[:serial], placeholder: t(".search_for_serial_number"), title: t(".search_for_serial_number"), class: 'form-control query-field'
+  .search-button-wrap
+    = button_tag(type: t(".submit"), class: 'searchit btn btn-primary') do
+      :plain
+        <svg id="search-button" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 29 29"><defs><style>.cls-1,.cls-2{fill:none;stroke:#fff;stroke-miterlimit:10;stroke-width:2px;}.cls-2{stroke-linecap:round;}</style></defs><title>searcher</title><circle class="cls-1" cx="10.39" cy="10.39" r="9.39"/><line class="cls-2" x1="17.03" y1="17.03" x2="28" y2="28"/></svg>
+  .stolen-search-fields{ class: ('currently-hidden' unless params[:stolenness] == 'proximity') }
+    = text_field_tag :location, params[:location], placeholder: t(".anywhere"), title: "Search location", class: 'form-control stolen-proximity'
+    %span
+      = t(".miles_of")
+    = number_field_tag :distance, @interpreted_params[:distance] || 100, placeholder: '100', min: 1, title: "Search distance", class: 'form-control stolen-radius'
+    %span
+      = t(".within")
+    = hidden_field_tag :stolenness, params[:stolenness]
+- if @interpreted_params[:raw_serial].present? && @interpreted_params[:serial].blank?
+  .alert.alert-warning.mt-4
+    = t(".doesnt_look_like_serial")

--- a/app/views/shared/_bike_search_form.html.haml
+++ b/app/views/shared/_bike_search_form.html.haml
@@ -1,6 +1,9 @@
 - search_path ||= bikes_path
-- include_email_field ||= false
 - skip_serial_field ||= false
+- include_location_search ||= false
+
+- include_organized_search_fields ||= false
+
 
 = form_tag search_path, id: 'bikes_search_form', class: 'bikes-search-form', enforce_utf8: false, method: :get do
   .query-field-wrap.nojs
@@ -8,20 +11,25 @@
     - opt_vals = @selected_query_items_options.map { |i| i.is_a?(String) ? [i, i] : [i['text'], i['search_id']]  }
     = select_tag :query_items, options_for_select(opt_vals, selected: opt_vals.map(&:last)), placeholder: t(".search_bike_descriptions"), title: t(".search_bike_descriptions"), class: 'form-control query-field', multiple: true
     = text_field_tag :query, params[:query], placeholder: t(".search_bike_descriptions"), title: t(".search_bike_descriptions"), class: 'form-control query-field'
-    - unless skip_serial_field
+    - if include_organized_search_fields
+      .sidebyside-queries
+        = text_field_tag :search_email, params[:search_email], placeholder: t(".search_owner_email"), class: 'form-control query-field email-field-too'
+        = text_field_tag :serial, params[:serial], placeholder: t(".search_for_serial_number"), class: 'form-control query-field email-field-too'
+    - elsif !skip_serial_field
       = text_field_tag :serial, params[:serial], placeholder: t(".search_for_serial_number"), title: t(".search_for_serial_number"), class: 'form-control query-field'
   .search-button-wrap
     = button_tag(type: t(".submit"), class: 'searchit btn btn-primary') do
       :plain
         <svg id="search-button" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 29 29"><defs><style>.cls-1,.cls-2{fill:none;stroke:#fff;stroke-miterlimit:10;stroke-width:2px;}.cls-2{stroke-linecap:round;}</style></defs><title>searcher</title><circle class="cls-1" cx="10.39" cy="10.39" r="9.39"/><line class="cls-2" x1="17.03" y1="17.03" x2="28" y2="28"/></svg>
-  .stolen-search-fields{ class: ('currently-hidden' unless params[:stolenness] == 'proximity') }
-    = text_field_tag :location, params[:location], placeholder: t(".anywhere"), title: "Search location", class: 'form-control stolen-proximity'
-    %span
-      = t(".miles_of")
-    = number_field_tag :distance, @interpreted_params[:distance] || 100, placeholder: '100', min: 1, title: "Search distance", class: 'form-control stolen-radius'
-    %span
-      = t(".within")
-    = hidden_field_tag :stolenness, params[:stolenness]
+  - if include_location_search
+    .stolen-search-fields{ class: ('currently-hidden' unless params[:stolenness] == 'proximity') }
+      = text_field_tag :location, params[:location], placeholder: t(".anywhere"), title: "Search location", class: 'form-control stolen-proximity'
+      %span
+        = t(".miles_of")
+      = number_field_tag :distance, @interpreted_params[:distance] || 100, placeholder: '100', min: 1, title: "Search distance", class: 'form-control stolen-radius'
+      %span
+        = t(".within")
+      = hidden_field_tag :stolenness, params[:stolenness]
 - if @interpreted_params[:raw_serial].present? && @interpreted_params[:serial].blank?
   .alert.alert-warning.mt-4
     = t(".doesnt_look_like_serial")

--- a/app/views/shared/_bike_search_form.html.haml
+++ b/app/views/shared/_bike_search_form.html.haml
@@ -43,6 +43,7 @@
     = render partial: "/shared/hidden_search_fields", locals: {kind: "organized_bike_search"}
     = hidden_field_tag :search_stickers, params[:search_stickers]
     = hidden_field_tag :search_address, params[:search_address]
+    = hidden_field :search_secondary, params[:search_secondary]
 
 - if @interpreted_params[:raw_serial].present? && @interpreted_params[:serial].blank?
   .alert.alert-warning.mt-4

--- a/app/views/shared/_email_bike_box.html.haml
+++ b/app/views/shared/_email_bike_box.html.haml
@@ -22,7 +22,7 @@
 
           %li
             %strong= t(".serial")
-            = @bike.serial_display
+            = render_serial_display(@bike, skip_explanation: true)
 
           %li
             %strong

--- a/app/views/stolen_bike_listings/index.html.haml
+++ b/app/views/stolen_bike_listings/index.html.haml
@@ -27,24 +27,8 @@
 
 .container
   .mt-4
-    = form_tag stolen_bike_listings_path, id: "bikes_search_form", class: "bikes-search-form single-search-input", method: :get do
-      .query-field-wrap.nojs
-        - opt_vals = @selected_query_items_options.map { |i| i.is_a?(String) ? [i, i] : [i["text"], i["search_id"]]  }
-        = select_tag :query_items,                                      |
-          options_for_select(opt_vals, selected: opt_vals.map(&:last)), |
-          placeholder: t(".search_bike_descriptions"),                  |
-          class: 'form-control query-field',                            |
-          multiple: true
+    = render partial: "/shared/bike_search_form", locals: {search_path: bike_versions_path, skip_serial_field: true, include_hidden_search_fields: true}
 
-        = text_field_tag :query, params[:query], placeholder: t(".search_bike_descriptions"), class: "form-control query-field"
-
-      .search-button-wrap
-        = button_tag(type: t(".submit"), class: 'searchit btn btn-primary') do
-          :plain
-            <svg id="search-button" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 29 29"><defs><style>.cls-1,.cls-2{fill:none;stroke:#fff;stroke-miterlimit:10;stroke-width:2px;}.cls-2{stroke-linecap:round;}</style></defs><title>searcher</title><circle class="cls-1" cx="10.39" cy="10.39" r="9.39"/><line class="cls-2" x1="17.03" y1="17.03" x2="28" y2="28"/></svg>
-
-      -# Skipping rendering these for now - they aren't strictly necessary
-      = render partial: "/shared/hidden_search_fields", locals: {kind: "stolen_bike_listings"}
 
 
   #timeSelectionBtnGroup.mt-4.text-right{ role: "group", class: @period == "custom" ? "custom-period-selected" : "", "data-nosubmit" => "#{false}" }

--- a/config/i18n-tasks.yml
+++ b/config/i18n-tasks.yml
@@ -123,9 +123,11 @@ ignore_unused:
   - "meta_titles.*"
   - "meta_descriptions.*"
   - "helpers.page_entries_info.*"
+  - "helpers.bike_helper.*"
   - "locales.*"
   - "money.*"
   - "javascript.*"
+
 ## Exclude these keys from the `i18n-tasks eq-base' report:
 # ignore_eq_base:
 #   all:

--- a/config/locales/.translation_io
+++ b/config/locales/.translation_io
@@ -1,2 +1,2 @@
 ---
-timestamp: 1666546832
+timestamp: 1666631789

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -979,8 +979,6 @@ en:
       primary_colors: Primary colors
   bikes:
     bike:
-      hidden_because_status: because %{bike_type} is %{status}
-      hidden_for_unauthorized_users: hidden for unauthorized users
       location: Location
       primary_colors: Primary colors
       serial: Serial
@@ -1050,8 +1048,6 @@ en:
       front_rear: Front & rear
       front_wheel_diameter: Front wheel diameter
       handlebar_type: Handlebar type
-      hidden_because_status: because %{bike_type} is %{status}
-      hidden_for_unauthorized_users: hidden for unauthorized users
       impounded_at: Impounded
       location: Location
       locking_circumvented: Locking circumvented
@@ -2337,6 +2333,9 @@ en:
           one: Displaying <b>1</b> %{entry_name}
           other: Displaying <b>all %{count}</b> %{entry_name}
           zero: No %{entry_name} found
+    bike_helper:
+        hidden_because_status: because %{bike_type} is %{status}
+        hidden_for_unauthorized_users: hidden for unauthorized users
   info:
     about:
       about_bike_index: About Bike Index
@@ -5013,7 +5012,7 @@ en:
       stolen_anywhere: Stolen anywhere
       submit: submit
       within: within
-      you: you
+      search_owner_email: Search owner email and name
     claim_message:
       public_resource_reunited_value_html: >-
         Bike Index is a public resource for registering bikes. We've reunited over

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2334,8 +2334,11 @@ en:
           other: Displaying <b>all %{count}</b> %{entry_name}
           zero: No %{entry_name} found
     bike_helper:
-        hidden_because_status: because %{bike_type} is %{status}
-        hidden_for_unauthorized_users: hidden for unauthorized users
+      hidden: hidden
+      unknown: unknown
+      made_without_serial: made without serial
+      hidden_because_status: because %{bike_type} is %{status}
+      hidden_for_unauthorized_users: hidden for unauthorized users
   info:
     about:
       about_bike_index: About Bike Index

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2323,6 +2323,12 @@ en:
       you_can_reach_us_at_contact_html: You can reach us at %{contact_link}, or send
         your message right here.
   helpers:
+    bike_helper:
+      hidden: hidden
+      hidden_because_status: because %{bike_type} is %{status}
+      hidden_for_unauthorized_users: hidden for unauthorized users
+      made_without_serial: made without serial
+      unknown: unknown
     page_entries_info:
       more_pages:
         display_entries: >-
@@ -2333,12 +2339,6 @@ en:
           one: Displaying <b>1</b> %{entry_name}
           other: Displaying <b>all %{count}</b> %{entry_name}
           zero: No %{entry_name} found
-    bike_helper:
-      hidden: hidden
-      unknown: unknown
-      made_without_serial: made without serial
-      hidden_because_status: because %{bike_type} is %{status}
-      hidden_for_unauthorized_users: hidden for unauthorized users
   info:
     about:
       about_bike_index: About Bike Index
@@ -4191,11 +4191,6 @@ en:
     precision:
       format:
         delimiter: ''
-  org_public:
-    impounded_bikes:
-      index:
-        search_bike_descriptions: Search bike descriptions
-        search_for_serial_number: Search for serial number
   organization_invitations:
     not_available:
       contact_us: Contact us
@@ -4485,9 +4480,6 @@ en:
         owner_name: Owner name
         registered: Registered
         registered_bikes_html: "<strong>%{bikes}</strong> matching for %{org_name}"
-        search_bike_descriptions: Search bike descriptions
-        search_for_serial_number: Search for serial number
-        search_owner_email: Search owner email and name
         sent_to: Sent to
         settings: settings
         status: 'Status:'
@@ -4620,14 +4612,6 @@ en:
         unable_to_export: Unable to export, not part of your organization
         unassign_stickers: Unassign stickers
         view_avery_labels: View Avery Labels
-    graduated_notifications:
-      index:
-        search_owner_email: Search owner email and name
-    impound_records:
-      index:
-        search_bike_descriptions: Search bike descriptions
-        search_for_serial_number: Search for serial number
-        search_owner_email: Search owner email and name
     manage_impoundings:
       edit:
         impound_settings_html: Manage <em>%{org_name}</em> impound settings
@@ -4684,9 +4668,6 @@ en:
       index:
         matches_visible: visible
         parking_notifications: Parking notifications
-        search_bike_descriptions: Search bike descriptions
-        search_for_serial_number: Search for serial number
-        search_owner_email: Search owner email and name
       show_details:
         address: Address
         bike: Bike
@@ -5011,11 +4992,9 @@ en:
       miles_of: miles of
       search_bike_descriptions: Search bike descriptions
       search_for_serial_number: Search for serial number
-      search_for_stolenness_desc_bikes: Search for %{stolenness_desc} bikes
-      stolen_anywhere: Stolen anywhere
+      search_owner_email: Search owner email and name
       submit: submit
       within: within
-      search_owner_email: Search owner email and name
     claim_message:
       public_resource_reunited_value_html: >-
         Bike Index is a public resource for registering bikes. We've reunited over
@@ -5404,10 +5383,6 @@ en:
       your_local_police_department_will_do_what: >-
         Your local police department will do what it does to help recover your bike.
         Stay in communication with them.
-  stolen_bike_listings:
-    index:
-      search_bike_descriptions: Search bike descriptions
-      submit: Submit
   support:
     array:
       last_word_connector: ", and "

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -977,7 +977,6 @@ en:
   bike_versions:
     index:
       primary_colors: Primary colors
-      search_bike_descriptions: Search bike descriptions
   bikes:
     bike:
       hidden_because_status: because %{bike_type} is %{status}
@@ -1029,20 +1028,12 @@ en:
       your_bike: Your %{bike_type}
     index:
       all: All
-      anywhere: Anywhere
-      doesnt_look_like_serial: >-
-        The serial you entered doesn't look like a serial number, so it isn't being
-        used to search.
       miles_of: miles of
       no_bikes_matched: No bikes exactly matched your search
       not_marked_stolen: Not marked stolen
-      search_bike_descriptions: Search bike descriptions
-      search_for_serial_number: Search for serial number
       search_for_stolenness_desc_bikes: Search for %{stolenness_desc} bikes
       stolen_anywhere: Stolen anywhere
       stolen_within: Stolen within
-      submit: submit
-      within: within
       you: you
     main_show_block:
       bike_photo: "%{bike_type} photo"
@@ -4629,8 +4620,6 @@ en:
         view_avery_labels: View Avery Labels
     graduated_notifications:
       index:
-        search_bike_descriptions: Search bike descriptions
-        search_for_serial_number: Search for serial number
         search_owner_email: Search owner email and name
     impound_records:
       index:
@@ -5012,6 +5001,19 @@ en:
       sign_in_using_strava: Sign in using Strava
       sign_up: sign up
   shared:
+    bike_search_form:
+      anywhere: Anywhere
+      doesnt_look_like_serial: >-
+        The serial you entered doesn't look like a serial number, so it isn't being
+        used to search.
+      miles_of: miles of
+      search_bike_descriptions: Search bike descriptions
+      search_for_serial_number: Search for serial number
+      search_for_stolenness_desc_bikes: Search for %{stolenness_desc} bikes
+      stolen_anywhere: Stolen anywhere
+      submit: submit
+      within: within
+      you: you
     claim_message:
       public_resource_reunited_value_html: >-
         Bike Index is a public resource for registering bikes. We've reunited over

--- a/config/locales/translation.nl.yml
+++ b/config/locales/translation.nl.yml
@@ -1097,6 +1097,12 @@ nl:
       more_pages:
         display_entries: "%{entry_name} <b>%{first}&nbsp;-&nbsp;%{last}</b> van de
           <b>%{total}</b> getoond"
+    bike_helper:
+      hidden: verborgen
+      hidden_because_status: omdat %{bike_type} %{status} is
+      hidden_for_unauthorized_users: verborgen voor onbevoegde gebruikers
+      made_without_serial: gemaakt zonder serie
+      unknown: Onbekend
   i18n_tasks:
     add_missing:
       added:
@@ -1709,8 +1715,6 @@ nl:
       location: Plaats
       primary_colors: Primaire kleuren
       serial: Serie
-      hidden_because_status: omdat %{bike_type} %{status} is
-      hidden_for_unauthorized_users: verborgen voor onbevoegde gebruikers
     bike_show_overlays:
       add_a_picture_of_it: Voeg er een foto van toe, zodat iedereen de schoonheid
         ervan kan bewonderen!
@@ -1757,20 +1761,13 @@ nl:
       whoa_this_awesome_version_is_yours: Wauw, %{version_name} is van jou!
     index:
       all: Alle
-      anywhere: Overal
       miles_of: mijl van
       no_bikes_matched: Er zijn geen serienummers die exact overeenkomen met uw zoekopdracht
       not_marked_stolen: Niet gemarkeerd als gestolen
-      search_bike_descriptions: Zoek fietsbeschrijvingen
-      search_for_serial_number: Zoek naar framenummer
       search_for_stolenness_desc_bikes: Zoek naar %{stolenness_desc} fietsen
       stolen_anywhere: Overal gestolen
       stolen_within: Gestolen binnen
-      submit: Voorleggen
-      within: binnen
       you: jou
-      doesnt_look_like_serial: Het serienummer dat je hebt ingevoerd, lijkt niet op
-        een serienummer en wordt dus niet gebruikt om te zoeken.
     new:
       additional_serial_sticker_number: Extra framenummer / stickernummer
       affiliation: "%{org_name} aansluiting"
@@ -2054,8 +2051,6 @@ nl:
       front_rear: Voor en achter
       front_wheel_diameter: Diameter voorwiel
       handlebar_type: Type stuur
-      hidden_because_status: omdat %{bike_type} %{status} is
-      hidden_for_unauthorized_users: verborgen voor onbevoegde gebruikers
       impounded_at: In beslag genomen bij
       location: Plaats
       locking_circumvented: Vergrendeling omzeild
@@ -4291,9 +4286,6 @@ nl:
         owner_name: Eigenaar naam
         registered: Geregistreerd
         registered_bikes_html: "<strong>%{bikes}</strong> geregistreerd bij %{org_name}"
-        search_bike_descriptions: Zoek fietsbeschrijvingen
-        search_for_serial_number: Zoek naar framenummer
-        search_owner_email: Zoek eigenaar e-mail
         sent_to: Verzonden naar
         settings: Instellingen
         sticker: Sticker
@@ -4528,9 +4520,6 @@ nl:
       index:
         parking_notifications: Verlaten records
         matches_visible: Zichtbaar
-        search_bike_descriptions: Zoek fietsbeschrijvingen
-        search_for_serial_number: Zoek naar framenummer
-        search_owner_email: Zoek eigenaar e-mail
       table:
         bike: Fiets
         by: Door
@@ -4594,16 +4583,6 @@ nl:
         why_no_direct_by_default: Standaard worden e-mails naar niet-geclaimde fietsen
           naar uw organisatie verzonden om te bekijken en door te sturen naar de eindgebruiker,
           omdat die gebruikers zich niet hebben aangemeld voor Bike Index-meldingen.
-    impound_records:
-      index:
-        search_bike_descriptions: Zoek fietsbeschrijvingen
-        search_for_serial_number: Zoek naar framenummer
-        search_owner_email: Zoek eigenaar e-mail
-    graduated_notifications:
-      index:
-        search_bike_descriptions: Zoek fietsbeschrijvingen
-        search_for_serial_number: Zoek naar framenummer
-        search_owner_email: Zoek eigenaar e-mail
     manage_impoundings:
       edit:
         impound_settings_html: Beheer <em>%{org_name}</em> inbeslagname-instellingen
@@ -5065,6 +5044,16 @@ nl:
       stolen_hot_sheet_configuration: Stolen Bike Hot Sheet-configuratie
       super_admin_view: Superbeheerder voor %{org_name}
       stolen_message: Gestolen bericht
+    bike_search_form:
+      anywhere: Overal
+      doesnt_look_like_serial: Het serienummer dat je hebt ingevoerd, lijkt niet op
+        een serienummer en wordt dus niet gebruikt om te zoeken.
+      miles_of: mijl van
+      search_bike_descriptions: Zoek fietsbeschrijvingen
+      search_for_serial_number: Zoek naar framenummer
+      search_owner_email: Zoek eigenaar e-mail
+      submit: Voorleggen
+      within: binnen
   users:
     accept_terms:
       i_agree_to_tos_html: Ik ga akkoord met de <strong>Servicevoorwaarden van</strong>
@@ -5701,15 +5690,6 @@ nl:
       update_your_phone_on_html: Update je telefoon in %{user_settings_link}
       when_not_selected: Indien niet aangevinkt, beheer via de pagina "Groepen en
         organisaties" van elke fiets.
-  org_public:
-    impounded_bikes:
-      index:
-        search_bike_descriptions: Zoek fietsbeschrijvingen
-        search_for_serial_number: Zoek naar framenummer
-  stolen_bike_listings:
-    index:
-      search_bike_descriptions: Zoek fietsbeschrijvingen
-      submit: Voorleggen
   bikes_edit:
     accessories:
       add_a_component: Voeg een component toe
@@ -5926,4 +5906,3 @@ nl:
   bike_versions:
     index:
       primary_colors: Primaire kleuren
-      search_bike_descriptions: Zoek fietsbeschrijvingen

--- a/spec/helpers/bike_helper_spec.rb
+++ b/spec/helpers/bike_helper_spec.rb
@@ -7,10 +7,16 @@ RSpec.describe BikeHelper, type: :helper do
     it "is in a code element" do
       expect(render_serial_display(bike)).to eq("<code class=\"bike-serial\">fff333</code>")
     end
+    context "unknown" do
+      let(:serial_number) { "unknown" }
+      it "is in a span element" do
+        expect(render_serial_display(bike)).to eq("<span class=\"less-strong\">unknown</span>")
+      end
+    end
     context "hidden" do
-      let(:target) { "<span class=\"less-strong\">hidden</span> <em class=\"small less-strong\">because tandem is impounded</em>" }
-      let(:target_authorized) { "<code class=\"bike-serial\">fff333</code> <em class=\"small less-strong\">hidden for unauthorized users</em>" }
-      it "returns hidden" do
+      let(:target) { "<span class=\"less-strong\">hidden</span> <em class=\"small less-less-strong\">because tandem is impounded</em>" }
+      let(:target_authorized) { "<code class=\"bike-serial\">fff333</code> <em class=\"small less-less-strong\">hidden for unauthorized users</em>" }
+      it "returns target" do
         bike.status = "status_impounded"
         expect(render_serial_display(bike)).to eq target
         expect(render_serial_display(bike, skip_explanation: true)).to eq "<span class=\"less-strong\">hidden</span>"

--- a/spec/helpers/bike_helper_spec.rb
+++ b/spec/helpers/bike_helper_spec.rb
@@ -1,6 +1,26 @@
 require "rails_helper"
 
 RSpec.describe BikeHelper, type: :helper do
+  describe "render_serial_display" do
+    let(:bike) { Bike.new(serial_number: serial_number, cycle_type: "tandem") }
+    let(:serial_number) { "fff333" }
+    it "is in a code element" do
+      expect(render_serial_display(bike)).to eq("<code class=\"bike-serial\">fff333</code>")
+    end
+    context "hidden" do
+      let(:target) { "<span class=\"less-strong\">hidden</span> <em class=\"small less-strong\">because tandem is impounded</em>" }
+      let(:target_authorized) { "<code class=\"bike-serial\">fff333</code> <em class=\"small less-strong\">hidden for unauthorized users</em>" }
+      it "returns hidden" do
+        bike.status = "status_impounded"
+        expect(render_serial_display(bike)).to eq target
+        expect(render_serial_display(bike, skip_explanation: true)).to eq "<span class=\"less-strong\">hidden</span>"
+        expect(render_serial_display(bike, User.new)).to eq target
+        expect(render_serial_display(bike, User.new(superuser: true))).to eq target_authorized
+        expect(render_serial_display(bike, User.new(superuser: true), skip_explanation: true)).to eq "<code class=\"bike-serial\">fff333</code>"
+      end
+    end
+  end
+
   describe "bike_thumb_image" do
     context "bike photo exists" do
       it "returns the thumb path if one exists" do


### PR DESCRIPTION
- Add `/shared/_bike_search_form.html.haml` and use it instead of the 7 separate versions of it.
  - _Partially motivated by #2324, which added an alert for serial number search queries that are normalized to `unknown` or `made_without_serial` - rather than adding that alert on all 7 pages_
- Turned off `selectOnClose` in `bike_search_bar.coffee` - it prevented selecting nothing (unless you hit escape a lot, or were on a slow connection). Ideally it would be on for custom entries, not sure how to do that though.
- Added a `render_serial_display` to `BikeHelper` to make bike serials render better