### PR TITLE
use cache_key_with_version for serializers

### DIFF
--- a/app/serializers/application_serializer.rb
+++ b/app/serializers/application_serializer.rb
@@ -1,5 +1,7 @@
 class ApplicationSerializer < ActiveModel::Serializer
-  delegate :cache_key, to: :object
+  def cache_key
+    object.cache_key_with_version
+  end
 
   def perform_caching
     true

--- a/spec/serializers/bike_serializer_spec.rb
+++ b/spec/serializers/bike_serializer_spec.rb
@@ -34,9 +34,10 @@ RSpec.describe BikeSerializer, type: :lib do
   end
   describe "caching" do
     include_context :caching_basic
-    it "is not cached" do
+    it "is cached" do
       expect(serializer.perform_caching).to be_truthy
       expect(serializer.as_json.is_a?(Hash)).to be_truthy
+      expect(serializer.cache_key).to match bike.cache_key_with_version
     end
   end
 end


### PR DESCRIPTION
Fix #2326 

Serializers have been using a cache_key that doesn't include the `updated_at` timestamp for objects - [this honeybadger blog post](https://www.honeybadger.io/blog/rails-low-level-caching/) explains the difference between `cache_key` and `cache_key_with_version`.