### PR TITLE
Graduated notification status improvement

### DIFF
--- a/app/helpers/organized_helper.rb
+++ b/app/helpers/organized_helper.rb
@@ -75,7 +75,7 @@ module OrganizedHelper
     case status.downcase
     when "current", "paging", "being_helped"
       content_tag(:span, status_str, class: "text-success")
-    when /retrieved/, "resolved_otherwise", "on_deck", /approved/
+    when "resolved_otherwise", "on_deck", /approved/, /retrieved/, "bike graduated"
       content_tag(:span, status_str.gsub("otherwise", ""), class: "text-info")
     when /removed/, "impounded", "trashed", "failed_to_find", /denied/
       content_tag(:span, status_str, class: "text-danger")

--- a/app/models/bike.rb
+++ b/app/models/bike.rb
@@ -399,7 +399,7 @@ class Bike < ApplicationRecord
   end
 
   def graduated?(org = nil)
-    graduated_notifications(org).active.any?
+    graduated_notifications(org).bike_graduated.any?
   end
 
   # check if this is the first ownership - or if no owner, which means testing probably

--- a/app/models/graduated_notification.rb
+++ b/app/models/graduated_notification.rb
@@ -1,5 +1,5 @@
 class GraduatedNotification < ApplicationRecord
-  STATUS_ENUM = {pending: 0, active: 1, marked_remaining: 2}.freeze
+  STATUS_ENUM = {pending: 0, bike_graduated: 1, marked_remaining: 2}.freeze
   PENDING_PERIOD = 24.hours
   belongs_to :bike
   belongs_to :bike_organization
@@ -38,7 +38,7 @@ class GraduatedNotification < ApplicationRecord
   end
 
   def self.processed_statuses
-    %w[active marked_remaining]
+    %w[bike_graduated marked_remaining]
   end
 
   def self.unprocessed_statuses
@@ -48,8 +48,8 @@ class GraduatedNotification < ApplicationRecord
   def self.status_humanized(str)
     return nil unless str.present?
     str = str.to_s
-    return "bike graduated" if str == "active"
-    str.humanize
+    return "marked not graduated" if str == "marked_remaining"
+    str.humanize.downcase
   end
 
   def self.user_or_email_query(graduated_notification)
@@ -229,7 +229,7 @@ class GraduatedNotification < ApplicationRecord
     bike_organization.update(deleted_at: nil)
     associated_notifications.each { |n| n.mark_remaining!(resolved_at: marked_remaining_at) } if primary_notification?
     # Long shot - but update any graduated notifications that might have been missed, just in case
-    organization.graduated_notifications.where(bike_id: bike_id).active.each do |pre_notification|
+    organization.graduated_notifications.where(bike_id: bike_id).bike_graduated.each do |pre_notification|
       if bike_organization.created_at.present? && pre_notification.bike_organization.created_at.present?
         # remove the newer bike_organization, keep the older one
         bike_organization.destroy if bike_organization.created_at > pre_notification.bike_organization.created_at
@@ -306,7 +306,7 @@ class GraduatedNotification < ApplicationRecord
     # Because prior to commit, the value for the current notification isn't set
     return "marked_remaining" if marked_remaining_at.present? || associated_notifications_including_self.marked_remaining.any?
     # Similar - if this is the primary_notification, we want to make sure it's marked processed during save
-    email_success? || primary_notification.present? && primary_notification.email_success? ? "active" : "pending"
+    email_success? || primary_notification.present? && primary_notification.email_success? ? "bike_graduated" : "pending"
   end
 
   def calculated_email

--- a/app/models/graduated_notification.rb
+++ b/app/models/graduated_notification.rb
@@ -45,6 +45,13 @@ class GraduatedNotification < ApplicationRecord
     statuses - processed_statuses
   end
 
+  def self.status_humanized(str)
+    return nil unless str.present?
+    str = str.to_s
+    return "bike graduated" if str == "active"
+    str.humanize
+  end
+
   def self.user_or_email_query(graduated_notification)
     if graduated_notification.user_id.present?
       {user_id: graduated_notification.user_id}
@@ -96,6 +103,10 @@ class GraduatedNotification < ApplicationRecord
 
   def message
     nil # for parity with parking_notifications
+  end
+
+  def status_humanized
+    self.class.status_humanized(status)
   end
 
   # Get it unscoped, because we really want it

--- a/app/views/admin/graduated_notifications/index.html.haml
+++ b/app/views/admin/graduated_notifications/index.html.haml
@@ -14,7 +14,7 @@
         .dropdown-menu
           - (["all"] + GraduatedNotification.statuses).each do |kind|
             - kind_active = @search_status == kind
-            - kind_display = "#{kind.humanize} notifications"
+            - kind_display = "#{GraduatedNotification.status_humanized(kind)} notifications"
             = link_to kind_display, url_for(sortable_search_params.merge(search_status: (kind_active ? nil : kind))), class: "dropdown-item #{kind_active ? 'active' : ''}"
             - if kind == "all" # Add a divider after all
               .dropdown-divider
@@ -76,7 +76,7 @@
             = link_to organized_bike_text(graduated_notification.bike), bike_path(graduated_notification.bike, organization_id: graduated_notification.organization_id)
         %td
           %em
-            = status_display(graduated_notification.status.humanize)
+            = status_display(graduated_notification.status_humanized)
         %td
           - if graduated_notification.user_id.present?
             = link_to graduated_notification.email, admin_user_path(graduated_notification.user_id)

--- a/app/views/bikes/_organized_access_panel.html.haml
+++ b/app/views/bikes/_organized_access_panel.html.haml
@@ -285,7 +285,7 @@
   - graduated_notifications = @bike.graduated_notifications(passive_organization).order(id: :desc)
   - if graduated_notifications.any?
     .parking-notifications-wrap
-      %h3.mt-2.mb-2 Graduated notifications
+      %h3.mt-2.mb-3 Graduated notifications
       = render partial: "/organized/graduated_notifications/table", locals: {graduated_notifications: graduated_notifications, skip_email: true, render_remaining_at: true}
 
 

--- a/app/views/organized/graduated_notifications/_table.html.haml
+++ b/app/views/organized/graduated_notifications/_table.html.haml
@@ -55,7 +55,7 @@
         - unless skip_status
           %td
             %em
-              = status_display(graduated_notification.status.humanize)
+              = status_display(graduated_notification.status_humanize)
         - unless skip_email
           %td
             = graduated_notification.email

--- a/app/views/organized/graduated_notifications/_table.html.haml
+++ b/app/views/organized/graduated_notifications/_table.html.haml
@@ -23,7 +23,7 @@
     - unless skip_email
       %td= sortable "email", render_sortable: render_sortable
     - if render_remaining_at
-      %td= sortable "marked_remaining_at", render_sortable: render_sortable
+      %td= sortable "marked_remaining_at", "Marked Not Graduated", render_sortable: render_sortable
 
   %tbody
     - graduated_notifications.each do |graduated_notification|
@@ -55,7 +55,7 @@
         - unless skip_status
           %td
             %em
-              = status_display(graduated_notification.status_humanize)
+              = status_display(graduated_notification.status_humanized&.titleize)
         - unless skip_email
           %td
             = graduated_notification.email

--- a/app/views/organized/graduated_notifications/index.html.haml
+++ b/app/views/organized/graduated_notifications/index.html.haml
@@ -35,15 +35,15 @@
       %span.only-dev-visible.mr-2.pl-1.pr-1.pt-1.pb-2
         = link_to "separate secondary", url_for(sortable_search_params.merge(search_secondary: !separate_secondary_notifications?)), class: (separate_secondary_notifications? ? "active btn btn-primary btn-sm" : "less-strong small")
     %a.dropdown-toggle.btn.btn-outline-primary{href: "#", role: "button", "data-toggle" => "dropdown", "aria-haspopup" => "true", "aria-expanded" => "false" }
-      = @search_status.humanize || "All statuses"
+      = GraduatedNotification.status_humanized(@search_status) || "All statuses"
     .dropdown-menu
       - (GraduatedNotification.statuses + %w[current all]).each do |status|
         - if status == "current" # Add a divider before all
           .dropdown-divider
         - status_active = @search_status == status
         - status_link_params = sortable_search_params.merge(organization_id: current_organization.id, search_status: (status_active ? nil : status))
-        - display_status = "Current (pending & active)" if status == "current"
-        - display_status ||= status.humanize || "All statuses"
+        - display_status = "Current (pending & graduated)" if status == "current"
+        - display_status ||= GraduatedNotification.status_humanized(status)&.titleize || "All statuses"
         = link_to display_status, organization_graduated_notifications_path(status_link_params), class: "dropdown-item #{status_active ? 'active' : ''}"
 
 

--- a/app/views/organized/graduated_notifications/show.html.haml
+++ b/app/views/organized/graduated_notifications/show.html.haml
@@ -20,7 +20,7 @@
               = l(@graduated_notification.created_at, format: :convert_time)
         %tr
           %td Status
-          %td= status_display(@graduated_notification.status.humanize)
+          %td= status_display(@graduated_notification.status_humanize)
 
         - if @graduated_notification.processed? && @graduated_notification.processed_at.present?
           %tr

--- a/app/views/organized/graduated_notifications/show.html.haml
+++ b/app/views/organized/graduated_notifications/show.html.haml
@@ -20,7 +20,7 @@
               = l(@graduated_notification.created_at, format: :convert_time)
         %tr
           %td Status
-          %td= status_display(@graduated_notification.status_humanize)
+          %td= status_display(@graduated_notification.status_humanized)
 
         - if @graduated_notification.processed? && @graduated_notification.processed_at.present?
           %tr

--- a/spec/factories/graduated_notifications.rb
+++ b/spec/factories/graduated_notifications.rb
@@ -31,7 +31,7 @@ FactoryBot.define do
       end
     end
 
-    factory :graduated_notification_active do
+    factory :graduated_notification_bike_graduated do
       transient do
         bike_created_at { Time.current - 1.day - graduated_notification_interval }
       end

--- a/spec/helpers/organized_helper_spec.rb
+++ b/spec/helpers/organized_helper_spec.rb
@@ -90,6 +90,13 @@ RSpec.describe OrganizedHelper, type: :helper do
         expect(status_display("claim_denied")).to eq "<span class=\"text-danger\">claim denied</span>"
       end
     end
+    context "graduated_notification" do
+      it "info for approved, red for denied" do
+        expect(status_display("marked not graduated")).to eq "<span class=\"less-strong\">marked not graduated</span>"
+        expect(status_display("Marked NOT Graduated")).to eq "<span class=\"less-strong\">Marked NOT Graduated</span>"
+        expect(status_display("bike Graduated")).to eq "<span class=\"text-info\">bike Graduated</span>"
+      end
+    end
   end
 
   describe "organized_container" do

--- a/spec/models/graduated_notification_spec.rb
+++ b/spec/models/graduated_notification_spec.rb
@@ -27,6 +27,7 @@ RSpec.describe GraduatedNotification, type: :model do
       expect(graduated_notification.bike_organization.deleted?).to be_truthy
       expect(graduated_notification.email_success?).to be_truthy
       expect(graduated_notification.status).to eq "active"
+      expect(graduated_notification.status_humanized).to eq "bike graduated"
       expect(graduated_notification.processed?).to be_truthy
       expect(graduated_notification.user).to be_blank
       expect(graduated_notification.email).to eq bike.owner_email
@@ -77,6 +78,7 @@ RSpec.describe GraduatedNotification, type: :model do
         graduated_notification.reload
         expect(graduated_notification).to be_valid
         expect(graduated_notification.status).to eq "marked_remaining"
+        expect(graduated_notification.status_humanized).to eq "marked not graduated"
         expect(graduated_notification.active?).to be_falsey
         expect(graduated_notification.processed?).to be_truthy
         expect(graduated_notification.user).to be_blank

--- a/spec/models/graduated_notification_spec.rb
+++ b/spec/models/graduated_notification_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe GraduatedNotification, type: :model do
       graduated_notification.reload
       expect(graduated_notification.bike_organization.deleted?).to be_truthy
       expect(graduated_notification.email_success?).to be_truthy
-      expect(graduated_notification.status).to eq "active"
+      expect(graduated_notification.status).to eq "bike_graduated"
       expect(graduated_notification.status_humanized).to eq "bike graduated"
       expect(graduated_notification.processed?).to be_truthy
       expect(graduated_notification.user).to be_blank
@@ -42,7 +42,7 @@ RSpec.describe GraduatedNotification, type: :model do
         graduated_notification.reload
         expect(organization.deliver_graduated_notifications?).to be_falsey
         expect(graduated_notification).to be_valid
-        expect(graduated_notification.active?).to be_falsey
+        expect(graduated_notification.bike_graduated?).to be_falsey
         expect(graduated_notification.processed?).to be_falsey
         expect(graduated_notification.user).to be_blank
         expect(graduated_notification.send_email?).to be_falsey
@@ -67,7 +67,7 @@ RSpec.describe GraduatedNotification, type: :model do
       end
     end
     context "manually marked_remaining" do
-      it "is not active" do
+      it "is not bike_graduated" do
         expect(graduated_notification.processed?).to be_falsey
         graduated_notification.process_notification
         graduated_notification.reload
@@ -79,7 +79,7 @@ RSpec.describe GraduatedNotification, type: :model do
         expect(graduated_notification).to be_valid
         expect(graduated_notification.status).to eq "marked_remaining"
         expect(graduated_notification.status_humanized).to eq "marked not graduated"
-        expect(graduated_notification.active?).to be_falsey
+        expect(graduated_notification.bike_graduated?).to be_falsey
         expect(graduated_notification.processed?).to be_truthy
         expect(graduated_notification.user).to be_blank
         expect(graduated_notification.send_email?).to be_truthy
@@ -91,8 +91,8 @@ RSpec.describe GraduatedNotification, type: :model do
     end
     context "marked_remaining" do
       let(:graduated_notification) { FactoryBot.create(:graduated_notification, :marked_remaining, organization: organization, bike_created_at: Time.current - 1.year) }
-      it "is not active" do
-        expect(graduated_notification.active?).to be_falsey
+      it "is not bike_graduated" do
+        expect(graduated_notification.bike_graduated?).to be_falsey
         expect(graduated_notification.processed?).to be_truthy
         expect(graduated_notification.email_success?).to be_truthy
         expect(graduated_notification.marked_remaining_at).to be < Time.current
@@ -153,7 +153,7 @@ RSpec.describe GraduatedNotification, type: :model do
       expect(graduated_notification1.created_at).to be < interval_start
       expect(graduated_notification1.marked_remaining_at).to be < interval_start
       expect(GraduatedNotification.count).to eq 1
-      expect(GraduatedNotification.active.count).to eq 0
+      expect(GraduatedNotification.bike_graduated.count).to eq 0
       expect(GraduatedNotification.bikes_to_notify_without_notifications(organization).pluck(:id)).to eq([bike2.id])
       expect(GraduatedNotification.bikes_to_notify_expired_notifications(organization).pluck(:id)).to match_array([bike1.id])
       expect(GraduatedNotification.bike_ids_to_notify(organization)).to match_array([bike1.id, bike2.id])
@@ -459,7 +459,7 @@ RSpec.describe GraduatedNotification, type: :model do
           expect(graduated_notification1.process_notification).to be_truthy
         }.to change(CreateGraduatedNotificationWorker.jobs, :count).by 0
         graduated_notification1.reload
-        expect(graduated_notification1.status).to eq "active"
+        expect(graduated_notification1.status).to eq "bike_graduated"
         expect(graduated_notification1.processed?).to be_truthy
         expect(graduated_notification1.send_email?).to be_truthy
         Sidekiq::Testing.inline! do
@@ -519,10 +519,10 @@ RSpec.describe GraduatedNotification, type: :model do
         expect(ActionMailer::Base.deliveries.count).to eq 1
         graduated_notification1.reload
         expect(graduated_notification1.processed?).to be_truthy
-        expect(graduated_notification1.active?).to be_truthy
+        expect(graduated_notification1.bike_graduated?).to be_truthy
         graduated_notification2.reload
         expect(graduated_notification2.processed?).to be_truthy
-        expect(graduated_notification2.active?).to be_truthy
+        expect(graduated_notification2.bike_graduated?).to be_truthy
 
         # And then we create another bike after the notification has been processed - it's no longer added in there
         _bike3 = FactoryBot.create(:bike_organized, :with_ownership_claimed, user: user, creation_organization: organization)
@@ -623,7 +623,7 @@ RSpec.describe GraduatedNotification, type: :model do
         expect(graduated_notification2.processable?).to be_truthy
         graduated_notification2.process_notification
         expect(graduated_notification2.reload.most_recent?).to be_truthy
-        expect(graduated_notification2.status).to eq "active"
+        expect(graduated_notification2.status).to eq "bike_graduated"
         expect(graduated_notification2.send(:existing_sent_notification)&.id).to eq graduated_notification2.id
 
         expect(graduated_notification.reload.most_recent?).to be_truthy

--- a/spec/requests/bikes/show_request_spec.rb
+++ b/spec/requests/bikes/show_request_spec.rb
@@ -250,7 +250,7 @@ RSpec.describe "BikesController#show", type: :request do
     end
   end
   describe "graduated_notification_remaining param" do
-    let(:graduated_notification) { FactoryBot.create(:graduated_notification_active) }
+    let(:graduated_notification) { FactoryBot.create(:graduated_notification_bike_graduated) }
     let!(:bike) { graduated_notification.bike }
     let(:ownership) { bike.current_ownership }
     let(:organization) { graduated_notification.organization }
@@ -301,7 +301,7 @@ RSpec.describe "BikesController#show", type: :request do
         bike.reload
         graduated_notification.reload
         expect(bike.graduated?(organization)).to be_truthy
-        expect(graduated_notification.status).to eq("active")
+        expect(graduated_notification.status).to eq("bike_graduated")
         expect(bike.bike_organizations.pluck(:organization_id)).to eq([])
       end
     end

--- a/spec/requests/bikes_request_spec.rb
+++ b/spec/requests/bikes_request_spec.rb
@@ -92,7 +92,7 @@ RSpec.describe BikesController, type: :request do
 
   describe "resolve_token" do
     context "graduated_notification" do
-      let(:graduated_notification) { FactoryBot.create(:graduated_notification_active) }
+      let(:graduated_notification) { FactoryBot.create(:graduated_notification_bike_graduated) }
       let!(:bike) { graduated_notification.bike }
       let(:ownership) { bike.current_ownership }
       let(:organization) { graduated_notification.organization }
@@ -186,7 +186,7 @@ RSpec.describe BikesController, type: :request do
           bike.reload
           graduated_notification.reload
           expect(bike.graduated?(organization)).to be_truthy
-          expect(graduated_notification.status).to eq("active")
+          expect(graduated_notification.status).to eq("bike_graduated")
           expect(bike.bike_organizations.pluck(:organization_id)).to eq([])
         end
       end

--- a/spec/requests/organized/graduated_notifications_request_spec.rb
+++ b/spec/requests/organized/graduated_notifications_request_spec.rb
@@ -9,8 +9,8 @@ RSpec.describe Organized::GraduatedNotificationsController, type: :request do
   let(:bike1) { FactoryBot.create(:bike_organized, :with_ownership, creation_organization: current_organization, serial_number: "sameserialnumber12111", owner_email: "testly@university.edu", created_at: earliest_time) }
 
   describe "index" do
-    let!(:graduated_notification_pending) { FactoryBot.create(:graduated_notification_active, organization: current_organization, bike: bike1) }
-    let!(:graduated_notification_active) { FactoryBot.create(:graduated_notification_active, organization: current_organization) }
+    let!(:graduated_notification_pending) { FactoryBot.create(:graduated_notification_bike_graduated, organization: current_organization, bike: bike1) }
+    let!(:graduated_notification_bike_graduated) { FactoryBot.create(:graduated_notification_bike_graduated, organization: current_organization) }
     let!(:graduated_notification_remaining) do
       FactoryBot.create(:graduated_notification,
         :marked_remaining,
@@ -18,20 +18,20 @@ RSpec.describe Organized::GraduatedNotificationsController, type: :request do
         marked_remaining_at: Time.current - current_organization.graduated_notification_interval + 2.days)
     end
     it "renders with correct things" do
-      expect(graduated_notification_pending.reload.status).to eq "active"
-      expect(GraduatedNotification.current.pluck(:id)).to match_array([graduated_notification_pending.id, graduated_notification_active.id])
+      expect(graduated_notification_pending.reload.status).to eq "bike_graduated"
+      expect(GraduatedNotification.current.pluck(:id)).to match_array([graduated_notification_pending.id, graduated_notification_bike_graduated.id])
 
       get base_url
       expect(response.status).to eq(200)
       expect(response).to render_template(:index)
       expect(assigns(:search_status)).to eq "current"
       expect(assigns(:separate_secondary_notifications)).to be_falsey
-      expect(assigns(:graduated_notifications).pluck(:id)).to match_array([graduated_notification_pending.id, graduated_notification_active.id])
+      expect(assigns(:graduated_notifications).pluck(:id)).to match_array([graduated_notification_pending.id, graduated_notification_bike_graduated.id])
 
       get "#{base_url}?search_status=all"
       expect(response.status).to eq(200)
       expect(response).to render_template(:index)
-      expect(assigns(:graduated_notifications).pluck(:id)).to match_array([graduated_notification_pending.id, graduated_notification_active.id, graduated_notification_remaining.id])
+      expect(assigns(:graduated_notifications).pluck(:id)).to match_array([graduated_notification_pending.id, graduated_notification_bike_graduated.id, graduated_notification_remaining.id])
 
       get "#{base_url}?search_email=testly%40univer"
       expect(response.status).to eq(200)
@@ -56,7 +56,7 @@ RSpec.describe Organized::GraduatedNotificationsController, type: :request do
   end
 
   describe "show" do
-    let!(:graduated_notification) { FactoryBot.create(:graduated_notification_active, organization: current_organization, bike: bike1) }
+    let!(:graduated_notification) { FactoryBot.create(:graduated_notification_bike_graduated, organization: current_organization, bike: bike1) }
     it "renders" do
       get "#{base_url}/#{graduated_notification.id}"
       expect(response.status).to eq(200)
@@ -64,7 +64,7 @@ RSpec.describe Organized::GraduatedNotificationsController, type: :request do
       expect(assigns(:graduated_notification)).to eq graduated_notification
     end
     context "different organization's" do
-      let!(:graduated_notification) { FactoryBot.create(:graduated_notification_active) }
+      let!(:graduated_notification) { FactoryBot.create(:graduated_notification_bike_graduated) }
       it "raises not found" do
         expect {
           get "#{base_url}/#{graduated_notification.id}"

--- a/spec/workers/after_user_create_worker_spec.rb
+++ b/spec/workers/after_user_create_worker_spec.rb
@@ -258,14 +258,14 @@ RSpec.describe AfterUserCreateWorker, type: :job do
   end
 
   describe "graduated_notification" do
-    let!(:graduated_notification) { FactoryBot.create(:graduated_notification_active) }
+    let!(:graduated_notification) { FactoryBot.create(:graduated_notification_bike_graduated) }
     let(:bike) { graduated_notification.bike }
     let(:user) { FactoryBot.create(:user_confirmed, email: bike.owner_email.upcase) }
 
     it "assigns any that match the user email" do
       expect(bike.reload.claimed?).to be_falsey
       expect(bike.current_ownership.user&.id).to be_blank
-      expect(graduated_notification.active?).to be_truthy
+      expect(graduated_notification.bike_graduated?).to be_truthy
       expect(graduated_notification.primary_notification?).to be_truthy
       expect(graduated_notification.user_id).to be_blank
       og_updated_at = graduated_notification.reload.updated_at

--- a/spec/workers/create_graduated_notification_worker_spec.rb
+++ b/spec/workers/create_graduated_notification_worker_spec.rb
@@ -77,7 +77,7 @@ RSpec.describe CreateGraduatedNotificationWorker, type: :lib do
     end
 
     context "with existing graduated_notification" do
-      let!(:graduated_notification_active) { FactoryBot.create(:graduated_notification_active, organization: organization) }
+      let!(:graduated_notification_bike_graduated) { FactoryBot.create(:graduated_notification_bike_graduated, organization: organization) }
 
       let!(:graduated_notification_remaining_expired) do
         FactoryBot.create(:graduated_notification,
@@ -98,8 +98,8 @@ RSpec.describe CreateGraduatedNotificationWorker, type: :lib do
         expect(graduated_notification_remaining_expired.created_at).to be < graduated_notification_remaining_expired.marked_remaining_at
         expect(graduated_notification_remaining_expired.most_recent?).to be_truthy
         expect(graduated_notification_remaining_expired.expired?).to be_truthy
-        expect(graduated_notification_active.processed_at).to be < Time.current
-        expect(graduated_notification_active.status).to eq("active")
+        expect(graduated_notification_bike_graduated.processed_at).to be < Time.current
+        expect(graduated_notification_bike_graduated.status).to eq("bike_graduated")
         # Really, testing bike_ids_to_notify ensures we're enqueueing the right things, but - just to be sure
         expect(GraduatedNotification.bike_ids_to_notify(organization)).to match_array([bike.id])
         expect(bike.organizations.pluck(:id)).to eq([organization.id])

--- a/spec/workers/process_graduated_notification_worker_spec.rb
+++ b/spec/workers/process_graduated_notification_worker_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe ProcessGraduatedNotificationWorker, type: :lib do
     let(:organization) { FactoryBot.create(:organization_with_organization_features, enabled_feature_slugs: ["graduated_notifications"], graduated_notification_interval: graduated_notification_interval) }
     let(:bike1) { FactoryBot.create(:bike_organized, :with_ownership, creation_organization: organization, owner_email: "notify@bike.com", created_at: Time.current - (2 * graduated_notification_interval)) }
     let!(:bike2) { FactoryBot.create(:bike_organized, :with_ownership, creation_organization: organization, owner_email: "notify@bike.com", created_at: Time.current - 1.week) }
-    let!(:graduated_notification_active) { FactoryBot.create(:graduated_notification_active, organization: organization) }
+    let!(:graduated_notification_bike_graduated) { FactoryBot.create(:graduated_notification_bike_graduated, organization: organization) }
     let!(:graduated_notification_processable) { FactoryBot.create(:graduated_notification, organization: organization, created_at: Time.current - GraduatedNotification::PENDING_PERIOD - 55.minutes) }
     let!(:graduated_notification_primary) { FactoryBot.create(:graduated_notification, organization: organization, bike: bike1, created_at: Time.current - 30.minutes) }
 


### PR DESCRIPTION
"active" was confusing, since it actually meant that the bike was not accessible for the university. Switched to "bike graduated" 