### PR TITLE
Additional update to graduated_notification status

### DIFF
--- a/app/helpers/organized_helper.rb
+++ b/app/helpers/organized_helper.rb
@@ -69,21 +69,26 @@ module OrganizedHelper
     ].include?([controller_name, action_name])
   end
 
-  # This is duplicated in parking_notifications.js
-  def status_display(status)
-    status_str = status.tr("_", " ")
+  def status_display_class(status)
     case status.downcase
     when "current", "paging", "being_helped"
-      content_tag(:span, status_str, class: "text-success")
+      "text-success"
     when "resolved_otherwise", "on_deck", /approved/, /retrieved/, "bike graduated"
-      content_tag(:span, status_str.gsub("otherwise", ""), class: "text-info")
+      "text-info"
     when /removed/, "impounded", "trashed", "failed_to_find", /denied/
-      content_tag(:span, status_str, class: "text-danger")
+      "text-danger"
     when "stolen"
-      content_tag(:span, status_str, class: "text-warning")
+      "text-warning"
     else
-      content_tag(:span, status_str, class: "less-strong")
+      "less-strong"
     end
+  end
+
+  # This is (roughly) duplicated in parking_notifications.js
+  def status_display(status)
+    status_str = status.tr("_", " ")
+    status_str.gsub!(/ otherwise/i, "") if status_str.match?(/resolved otherwise/i)
+    content_tag(:span, status_str, class: status_display_class(status))
   end
 
   # Might make this more fancy sometime, but... for now, good enough

--- a/app/models/bike.rb
+++ b/app/models/bike.rb
@@ -399,7 +399,8 @@ class Bike < ApplicationRecord
   end
 
   def graduated?(org = nil)
-    graduated_notifications(org).bike_graduated.any?
+    g_notifications = org.present? ? graduated_notifications(org) : GraduatedNotification.where(bike_id: id)
+    g_notifications.bike_graduated.any?
   end
 
   # check if this is the first ownership - or if no owner, which means testing probably

--- a/app/models/graduated_notification.rb
+++ b/app/models/graduated_notification.rb
@@ -26,7 +26,6 @@ class GraduatedNotification < ApplicationRecord
   scope :current, -> { where(status: current_statuses) }
   scope :processed, -> { where(status: processed_statuses) }
   scope :unprocessed, -> { where(status: unprocessed_statuses) }
-  scope :not_marked_remaining, -> { where.not(status: "marked_remaining") }
   scope :primary_notification, -> { where("primary_notification_id = id") }
   scope :secondary_notification, -> { where.not("primary_notification_id  = id") }
   scope :email_success, -> { where(delivery_status: "email_success") }
@@ -50,7 +49,7 @@ class GraduatedNotification < ApplicationRecord
   def self.status_humanized(str)
     return nil unless str.present?
     str = str.to_s
-    return "remains registered" if str == "marked_remaining"
+    return "marked not graduated" if str == "marked_remaining"
     str.humanize.downcase
   end
 
@@ -262,6 +261,7 @@ class GraduatedNotification < ApplicationRecord
 
   def update_associated_notifications
     return true if skip_update
+    pp "update_associated_notifications #{id} - '#{@skip_update}'"
     mark_previous_notifications_not_most_recent if most_recent?
     return unless primary_notification?
     self.class.associated_notifications(self)
@@ -289,16 +289,24 @@ class GraduatedNotification < ApplicationRecord
     return true if email_success?
     return false unless processable?
 
-    user_registration_organization&.destroy!
+    pp "destroying! #{id}"
+    user_registration_organization&.destroy_for_graduated_notification!
     bike_organization&.destroy!
 
     # deliver email before everything, so if fails, we send when we try again
     OrganizedMailer.graduated_notification(self).deliver_now if send_email?
-    update(processed_at: Time.current, delivery_status: "email_success", skip_update: true)
 
+    pp "----"
+    @skip_update = true
+    update(processed_at: Time.current, delivery_status: "email_success", skip_update: true)
+    pp "vvvv"
     return true unless primary_notification?
+    pp "cccc"
     # Update the associated notifications after updating the primary notification, so if we fail, they can be updated by the worker
-    associated_notifications.each { |notification| notification.process_notification }
+    associated_notifications.each do |notification|
+      pp "notification: #{notification.id}"
+      notification.process_notification
+    end
     true
   end
 

--- a/app/models/graduated_notification.rb
+++ b/app/models/graduated_notification.rb
@@ -50,7 +50,7 @@ class GraduatedNotification < ApplicationRecord
   def self.status_humanized(str)
     return nil unless str.present?
     str = str.to_s
-    return "marked not graduated" if str == "marked_remaining"
+    return "remains registered" if str == "marked_remaining"
     str.humanize.downcase
   end
 

--- a/app/models/user_registration_organization.rb
+++ b/app/models/user_registration_organization.rb
@@ -78,11 +78,19 @@ class UserRegistrationOrganization < ApplicationRecord
     self.can_not_edit_claimed = !val
   end
 
+  def destroy_for_graduated_notification!
+    @skip_update_associations = true
+    destroy!
+  end
+
   def set_calculated_attributes
     self.registration_info ||= {}
   end
 
   def update_associations
+    pp "update_associations skip: '#{@skip_update_associations}', persist: #{persisted?} #{deleted_at}"
+    return true if @skip_update_associations
+    pp "below"
     create_or_update_bike_organizations
     return true if skip_after_user_change_worker
     AfterUserChangeWorker.perform_async(user_id)

--- a/app/models/user_registration_organization.rb
+++ b/app/models/user_registration_organization.rb
@@ -88,9 +88,7 @@ class UserRegistrationOrganization < ApplicationRecord
   end
 
   def update_associations
-    pp "update_associations skip: '#{@skip_update_associations}', persist: #{persisted?} #{deleted_at}"
     return true if @skip_update_associations
-    pp "below"
     create_or_update_bike_organizations
     return true if skip_after_user_change_worker
     AfterUserChangeWorker.perform_async(user_id)

--- a/app/views/bikes/_organized_access_panel.html.haml
+++ b/app/views/bikes/_organized_access_panel.html.haml
@@ -1,5 +1,11 @@
 - show_sticker_modal = false
-
+- if passive_organization.enabled?("graduated_notifications") && @bike.graduated?(passive_organization)
+  %h5.mt-4
+    %strong.text-warning This is a graduated #{@bike.type}
+    %span.text-dark
+      \- it is no longer registered with #{passive_organization.short_name}
+    %em.small.less-strong
+      it was registered with #{passive_organization.short_name} previously
 .card.organized-access-panel
   .card-block
     .card-title
@@ -280,7 +286,6 @@
           %strong Previously impounded
           \- #{link_to "view impound records", organization_impound_records_path(organization_id: passive_organization.to_param, search_bike_id: @bike.id, search_status: "all")}!
 
-- # TODO: add translations
 - if passive_organization.enabled?("graduated_notifications")
   - graduated_notifications = @bike.graduated_notifications(passive_organization).order(id: :desc)
   - if graduated_notifications.any?

--- a/app/views/organized/graduated_notifications/_table.html.haml
+++ b/app/views/organized/graduated_notifications/_table.html.haml
@@ -54,8 +54,7 @@
                 = link_to organized_bike_text(associated_notification.bike), bike_path(associated_notification.bike, organization_id: associated_notification.organization_id)
         - unless skip_status
           %td
-            %em
-              = status_display(graduated_notification.status_humanized&.titleize)
+            = status_display(graduated_notification.status_humanized&.titleize)
         - unless skip_email
           %td
             = graduated_notification.email

--- a/app/views/organized/graduated_notifications/show.html.haml
+++ b/app/views/organized/graduated_notifications/show.html.haml
@@ -24,7 +24,7 @@
             %span{class: status_display_class(@graduated_notification.status_humanized)}
               = @graduated_notification.status_humanized.titleize
               - if @graduated_notification.status == "marked_remaining"
-                with #{@graduated_notification.organization&.short_name || "organization"}
+                \- remained registered with #{@graduated_notification.organization&.short_name || "organization"}
             - if @graduated_notification.status == "bike_graduated"
               %small.less-strong
                 no longer registered with #{@graduated_notification.organization&.short_name || "organization"}

--- a/app/views/organized/graduated_notifications/show.html.haml
+++ b/app/views/organized/graduated_notifications/show.html.haml
@@ -20,7 +20,14 @@
               = l(@graduated_notification.created_at, format: :convert_time)
         %tr
           %td Status
-          %td= status_display(@graduated_notification.status_humanized)
+          %td
+            %span{class: status_display_class(@graduated_notification.status_humanized)}
+              = @graduated_notification.status_humanized.titleize
+              - if @graduated_notification.status == "marked_remaining"
+                with #{@graduated_notification.organization&.short_name || "organization"}
+            - if @graduated_notification.status == "bike_graduated"
+              %small.less-strong
+                no longer registered with #{@graduated_notification.organization&.short_name || "organization"}
 
         - if @graduated_notification.processed? && @graduated_notification.processed_at.present?
           %tr

--- a/app/workers/after_bike_save_worker.rb
+++ b/app/workers/after_bike_save_worker.rb
@@ -80,15 +80,8 @@ class AfterBikeSaveWorker < ApplicationWorker
 
   def create_user_registration_organizations(bike)
     return if bike.reload.user.blank?
-    # P SURE THIS ISN'T NEEDED:
-    graduated_grad_notifications = GraduatedNotification.where(user_id: user_id).bike_graduated
     bike.bike_organizations.each do |bike_organization|
       # If there is notification that is graduated for the organization, don't create new reg organizations
-      if graduated_grad_notifications.where(organization_id: bike_organization.organization_id)
-        pp "FOUND IT"
-        next
-      end
-      pp "create_user_registration_organizations"
       organization = bike_organization.organization
       next if organization.blank? || UserRegistrationOrganization.unscoped
         .where(user_id: bike.user.id, organization_id: organization.id).any?

--- a/app/workers/after_bike_save_worker.rb
+++ b/app/workers/after_bike_save_worker.rb
@@ -79,8 +79,16 @@ class AfterBikeSaveWorker < ApplicationWorker
   end
 
   def create_user_registration_organizations(bike)
-    return unless bike.reload.user.present?
+    return if bike.reload.user.blank?
+    # P SURE THIS ISN'T NEEDED:
+    graduated_grad_notifications = GraduatedNotification.where(user_id: user_id).bike_graduated
     bike.bike_organizations.each do |bike_organization|
+      # If there is notification that is graduated for the organization, don't create new reg organizations
+      if graduated_grad_notifications.where(organization_id: bike_organization.organization_id)
+        pp "FOUND IT"
+        next
+      end
+      pp "create_user_registration_organizations"
       organization = bike_organization.organization
       next if organization.blank? || UserRegistrationOrganization.unscoped
         .where(user_id: bike.user.id, organization_id: organization.id).any?

--- a/app/workers/after_user_change_worker.rb
+++ b/app/workers/after_user_change_worker.rb
@@ -104,6 +104,7 @@ class AfterUserChangeWorker < ApplicationWorker
   def process_user_registration_organizations(user)
     # Process user_registration_organizations
     user.user_registration_organizations.order(:id).each do |u|
+      pp "heeeee"
       # Delete dupe user_registration_organizations
       user.user_registration_organizations
         .where(organization_id: u.organization_id).where("id > ?", u.id)

--- a/app/workers/after_user_change_worker.rb
+++ b/app/workers/after_user_change_worker.rb
@@ -104,7 +104,6 @@ class AfterUserChangeWorker < ApplicationWorker
   def process_user_registration_organizations(user)
     # Process user_registration_organizations
     user.user_registration_organizations.order(:id).each do |u|
-      pp "heeeee"
       # Delete dupe user_registration_organizations
       user.user_registration_organizations
         .where(organization_id: u.organization_id).where("id > ?", u.id)

--- a/spec/helpers/organized_helper_spec.rb
+++ b/spec/helpers/organized_helper_spec.rb
@@ -92,8 +92,8 @@ RSpec.describe OrganizedHelper, type: :helper do
     end
     context "graduated_notification" do
       it "info for approved, red for denied" do
-        expect(status_display("marked not graduated")).to eq "<span class=\"less-strong\">marked not graduated</span>"
-        expect(status_display("Marked NOT Graduated")).to eq "<span class=\"less-strong\">Marked NOT Graduated</span>"
+        expect(status_display("remains registered")).to eq "<span class=\"less-strong\">remains registered</span>"
+        expect(status_display("REMAINS registered")).to eq "<span class=\"less-strong\">REMAINS registered</span>"
         expect(status_display("bike Graduated")).to eq "<span class=\"text-info\">bike Graduated</span>"
       end
     end

--- a/spec/helpers/organized_helper_spec.rb
+++ b/spec/helpers/organized_helper_spec.rb
@@ -59,6 +59,7 @@ RSpec.describe OrganizedHelper, type: :helper do
     it "renders text-success" do
       expect(status_display("current")).to eq "<span class=\"text-success\">current</span>"
       expect(status_display("Current")).to eq "<span class=\"text-success\">Current</span>"
+      expect(status_display_class("Current")).to eq "text-success"
     end
     it "renders text-warning" do
       expect(status_display("stolen")).to eq "<span class=\"text-warning\">stolen</span>"
@@ -67,7 +68,7 @@ RSpec.describe OrganizedHelper, type: :helper do
       it "is blue" do
         expect(status_display("retrieved_by_owner")).to eq "<span class=\"text-info\">retrieved by owner</span>"
         expect(status_display("Retrieved")).to eq "<span class=\"text-info\">Retrieved</span>"
-        expect(status_display("resolved_otherwise")).to eq "<span class=\"text-info\">resolved </span>"
+        expect(status_display("resolved_otherwise")).to eq "<span class=\"text-info\">resolved</span>"
       end
     end
     context "removed_from_bike_index, trashed or Removed from Bike Index" do
@@ -95,6 +96,7 @@ RSpec.describe OrganizedHelper, type: :helper do
         expect(status_display("remains registered")).to eq "<span class=\"less-strong\">remains registered</span>"
         expect(status_display("REMAINS registered")).to eq "<span class=\"less-strong\">REMAINS registered</span>"
         expect(status_display("bike Graduated")).to eq "<span class=\"text-info\">bike Graduated</span>"
+        expect(status_display_class("bike Graduated")).to eq "text-info"
       end
     end
   end

--- a/spec/models/graduated_notification_spec.rb
+++ b/spec/models/graduated_notification_spec.rb
@@ -78,7 +78,7 @@ RSpec.describe GraduatedNotification, type: :model do
         graduated_notification.reload
         expect(graduated_notification).to be_valid
         expect(graduated_notification.status).to eq "marked_remaining"
-        expect(graduated_notification.status_humanized).to eq "marked not graduated"
+        expect(graduated_notification.status_humanized).to eq "remains registered"
         expect(graduated_notification.bike_graduated?).to be_falsey
         expect(graduated_notification.processed?).to be_truthy
         expect(graduated_notification.user).to be_blank

--- a/spec/models/graduated_notification_spec.rb
+++ b/spec/models/graduated_notification_spec.rb
@@ -78,7 +78,7 @@ RSpec.describe GraduatedNotification, type: :model do
         graduated_notification.reload
         expect(graduated_notification).to be_valid
         expect(graduated_notification.status).to eq "marked_remaining"
-        expect(graduated_notification.status_humanized).to eq "remains registered"
+        expect(graduated_notification.status_humanized).to eq "marked not graduated"
         expect(graduated_notification.bike_graduated?).to be_falsey
         expect(graduated_notification.processed?).to be_truthy
         expect(graduated_notification.user).to be_blank
@@ -452,6 +452,7 @@ RSpec.describe GraduatedNotification, type: :model do
         expect(graduated_notification1.processed?).to be_falsey
         expect(graduated_notification1.send_email?).to be_truthy
         expect(graduated_notification1.user_registration_organization&.id).to eq user_registration_organization.id
+        expect(bike1.reload.bike_organizations.count).to eq 1
         Sidekiq::Worker.clear_all
         ActionMailer::Base.deliveries = []
         expect(GraduatedNotification.count).to eq 1
@@ -478,6 +479,53 @@ RSpec.describe GraduatedNotification, type: :model do
         expect(bike1.reload.bike_organizations.count).to eq 1
         expect(UserRegistrationOrganization.count).to eq 1
         expect(UserRegistrationOrganization.unscoped.count).to eq 1
+      end
+      context "two bikes" do
+        let!(:bike2) { FactoryBot.create(:bike_organized, :with_ownership_claimed, user: user, creation_organization: organization, created_at: bike1.created_at + 1.hour) }
+        it "removes all_bikes" do
+          expect(user_registration_organization.reload.bikes.pluck(:id)).to eq([bike1.id, bike2.id])
+          AfterUserChangeWorker.new.perform(user.id)
+          graduated_notification1.save
+          # Manually create graduated_notification2 because whateves
+          graduated_notification2 = GraduatedNotification.create(bike_id: bike2.id, organization_id: organization.id)
+          expect(graduated_notification1.reload.user).to be_present
+          expect(graduated_notification1.processed?).to be_falsey
+          expect(graduated_notification1.primary_notification?).to be_truthy
+          expect(graduated_notification1.send_email?).to be_truthy
+          expect(graduated_notification1.user_registration_organization&.id).to eq user_registration_organization.id
+          expect(graduated_notification2.reload.primary_notification?).to be_falsey
+          expect(graduated_notification2.user_registration_organization&.id).to eq user_registration_organization.id
+          expect(bike1.reload.bike_organizations.count).to eq 1
+          expect(bike2.reload.bike_organizations.count).to eq 1
+          Sidekiq::Worker.clear_all
+          ActionMailer::Base.deliveries = []
+          expect(GraduatedNotification.count).to eq 2
+          Sidekiq::Testing.inline! do
+            pp "HEEEEERRRREEEEEEEE"
+            expect(graduated_notification1.process_notification).to be_truthy
+          end
+          graduated_notification1.reload
+          expect(graduated_notification1.status).to eq "bike_graduated"
+          expect(graduated_notification1.processed?).to be_truthy
+          expect(graduated_notification1.send_email?).to be_truthy
+          # This was failing, fixed in #2346
+          expect(bike1.reload.bike_organizations.count).to eq 0
+          expect(bike1.graduated?(organization)).to be_truthy
+          expect(bike2.reload.bike_organizations.count).to eq 0
+          expect(bike2.graduated?(organization)).to be_truthy
+          expect(UserRegistrationOrganization.count).to eq 0
+          expect(graduated_notification1.user_registration_organization&.id).to eq user_registration_organization.id
+          graduated_notification1.mark_remaining!
+          Sidekiq::Testing.inline! do
+            graduated_notification1.mark_remaining!
+          end
+          expect(bike1.reload.bike_organizations.count).to eq 1
+          expect(bike1.graduated?(organization)).to be_falsey
+          expect(bike2.reload.bike_organizations.count).to eq 1
+          expect(bike2.graduated?(organization)).to be_falsey
+          expect(UserRegistrationOrganization.count).to eq 1
+          expect(UserRegistrationOrganization.unscoped.count).to eq 1
+        end
       end
     end
     context "bike created inside of notification interval" do
@@ -517,6 +565,9 @@ RSpec.describe GraduatedNotification, type: :model do
         expect(graduated_notification2.user_id).to eq user.id
         expect(graduated_notification2.status).to eq "pending"
         expect(graduated_notification2.processed?).to be_falsey
+        expect(graduated_notification1.user_registration_organization&.id).to be_blank
+        expect(bike1.reload.bike_organizations.count).to eq 1
+        expect(bike2.reload.bike_organizations.count).to eq 1
 
         graduated_notification1.process_notification
         expect(ActionMailer::Base.deliveries.count).to eq 1
@@ -526,6 +577,8 @@ RSpec.describe GraduatedNotification, type: :model do
         graduated_notification2.reload
         expect(graduated_notification2.processed?).to be_truthy
         expect(graduated_notification2.bike_graduated?).to be_truthy
+        expect(bike1.reload.bike_organizations.count).to eq 0
+        expect(bike2.reload.bike_organizations.count).to eq 0
 
         # And then we create another bike after the notification has been processed - it's no longer added in there
         _bike3 = FactoryBot.create(:bike_organized, :with_ownership_claimed, user: user, creation_organization: organization)

--- a/spec/models/graduated_notification_spec.rb
+++ b/spec/models/graduated_notification_spec.rb
@@ -501,7 +501,6 @@ RSpec.describe GraduatedNotification, type: :model do
           ActionMailer::Base.deliveries = []
           expect(GraduatedNotification.count).to eq 2
           Sidekiq::Testing.inline! do
-            pp "HEEEEERRRREEEEEEEE"
             expect(graduated_notification1.process_notification).to be_truthy
           end
           graduated_notification1.reload

--- a/spec/models/graduated_notification_spec.rb
+++ b/spec/models/graduated_notification_spec.rb
@@ -466,6 +466,9 @@ RSpec.describe GraduatedNotification, type: :model do
           AfterUserChangeWorker.new.perform(user.id)
         end
         expect(bike1.reload.bike_organizations.count).to eq 0
+        expect(bike1.graduated?).to be_truthy
+        expect(bike1.graduated?(organization)).to be_truthy
+        expect(bike1.graduated?(Organization.new)).to be_falsey
         expect(UserRegistrationOrganization.count).to eq 0
         expect(graduated_notification1.user_registration_organization&.id).to eq user_registration_organization.id
         graduated_notification1.mark_remaining!


### PR DESCRIPTION
Follows #2343 - further attempts to clarify what it means when a bike is "graduated" and "marked not graduated"

Now it shows "remains registered" and additional clarification on the `organized_access_panel`.

This also fixes an issue where bikes with multiple graduated notifications weren't correctly disassociating from organizations.