### PR TITLE
Improve bike GeoJSON

### DIFF
--- a/app/services/bike_geojsoner.rb
+++ b/app/services/bike_geojsoner.rb
@@ -1,27 +1,8 @@
 class BikeGeojsoner
-  # Using an array of colors here to make it easier to copy, specifically for github.com/bikeindex/bike_thefts_map
-  COLORS = ["#BD1622", "#E74C3C", "#EB6759", "#EE8276", "#F29D94", "#F6B9B3"].freeze
-
-  def self.stolen_marker_color(date_stolen)
-    if date_stolen > Time.now - 1.day
-      COLORS[0]
-    elsif date_stolen > Time.now - 1.week
-      COLORS[1]
-    elsif date_stolen > Time.now - 1.month
-      COLORS[2]
-    elsif date_stolen > Time.now - 1.year
-      COLORS[3]
-    elsif date_stolen > Time.now - 5.years
-      COLORS[4]
-    else
-      COLORS[5]
-    end
-  end
-
   def self.feature(bike, extended_properties = false)
     return nil unless bike.status_stolen?
     date_stolen = bike.occurred_at || Time.current
-    properties = {id: bike.id, color: stolen_marker_color(date_stolen)}
+    properties = {id: bike.id, at: date_stolen.to_date.to_s}
     if extended_properties
       properties.merge!(kind: "theft",
         occurred_at: date_stolen.to_i,
@@ -43,7 +24,7 @@ class BikeGeojsoner
   def self.feature_from_plucked(id, occurred_at, latitude, longitude)
     {
       type: "Feature",
-      properties: {id: id, color: stolen_marker_color(occurred_at)},
+      properties: {id: id, at: occurred_at.to_date.to_s},
       geometry: {
         type: "Point",
         coordinates: [

--- a/spec/services/bike_geojsoner_spec.rb
+++ b/spec/services/bike_geojsoner_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe BikeGeojsoner do
           type: "Feature",
           properties: {
             id: bike.id,
-            color: "#BD1622"
+            at: date_stolen.strftime("%Y-%m-%d")
           },
           geometry: {
             type: "Point",


### PR DESCRIPTION
Previously, GeoJSON had a `color` key to represent when the bike was stolen - which was opaque and not that precise. This switches to including date, because it clears up what is going on.

```ruby
> puts Benchmark.measure { 1000.times { time.to_date.to_s } }
# =>  0.001318   0.000085   0.001403 (  0.001390)
> puts Benchmark.measure { 1000.times { time.strftime("%Y-%m-%d") } }
# =>  0.001731   0.000037   0.001768 (  0.001765)
```

... so sticking with `.to_date.to_s`