### PR TITLE
Create record for invalid file type bulk_imports

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -179,4 +179,4 @@ group :test do
   gem "webmock" # mocking for VCR
 end
 
-gem "dockerfile-rails", ">= 1.5", :group => :development
+gem "dockerfile-rails", ">= 1.5", group: :development

--- a/app/controllers/admin/bulk_imports_controller.rb
+++ b/app/controllers/admin/bulk_imports_controller.rb
@@ -63,10 +63,21 @@ class Admin::BulkImportsController < Admin::BaseController
   def matching_bulk_imports
     return @matching_bulk_imports if defined?(@matching_bulk_imports)
     bulk_imports = BulkImport
-    if params[:ascend].present?
+    if params[:search_ascend].present?
       bulk_imports = bulk_imports.ascend
-    elsif params[:not_ascend].present?
+    elsif params[:search_not_ascend].present?
       bulk_imports = bulk_imports.not_ascend
+    end
+
+    if params[:search_errors].present?
+      @search_errors = %w[file_error line_error].include?(params[:search_errors]) ? params[:search_errors] : "any_error"
+      bulk_imports = if params[:search_errors] == "file_error"
+        bulk_imports.file_errors
+      elsif params[:search_errors] == "line_error"
+        bulk_imports.line_errors
+      else
+        bulk_imports.file_or_line_errors
+      end
     end
 
     if BulkImport.progresses.include?(params[:search_progress])

--- a/app/models/bulk_import.rb
+++ b/app/models/bulk_import.rb
@@ -1,7 +1,7 @@
 class BulkImport < ApplicationRecord
   PROGRESS_ENUM = {pending: 0, ongoing: 1, finished: 2}.freeze
   KIND_ENUM = {organization_import: 0, unorganized: 1, ascend: 2, impounded: 3, stolen: 4}.freeze
-  VALID_FILE_EXTENSIONS = %[csv tsv].freeze
+  VALID_FILE_EXTENSIONS = %(csv tsv).freeze
   mount_uploader :file, BulkImportUploader
 
   belongs_to :organization

--- a/app/models/bulk_import.rb
+++ b/app/models/bulk_import.rb
@@ -1,11 +1,13 @@
 class BulkImport < ApplicationRecord
   PROGRESS_ENUM = {pending: 0, ongoing: 1, finished: 2}.freeze
   KIND_ENUM = {organization_import: 0, unorganized: 1, ascend: 2, impounded: 3, stolen: 4}.freeze
+  VALID_FILE_EXTENSIONS = %[csv tsv].freeze
   mount_uploader :file, BulkImportUploader
 
   belongs_to :organization
   belongs_to :user
   validates_presence_of :file, unless: :file_cleaned
+  validate :ensure_valid_file_type
   has_many :ownerships
   has_many :bikes, through: :ownerships
 
@@ -14,6 +16,7 @@ class BulkImport < ApplicationRecord
 
   scope :file_errors, -> { where("(import_errors -> 'file') is not null") }
   scope :line_errors, -> { where("(import_errors -> 'line') is not null") }
+  scope :file_or_line_errors, -> { file_errors.or(line_errors) }
   scope :no_bikes, -> { where("(import_errors -> 'bikes') is not null") }
   scope :with_bikes, -> { where.not("(import_errors -> 'bikes') is not null") }
   scope :not_ascend, -> { where.not(kind: "ascend") }
@@ -161,6 +164,14 @@ class BulkImport < ApplicationRecord
       import_errors["bikes"] = "none_imported"
     end
     true
+  end
+
+  def ensure_valid_file_type
+    extension = (local_file? ? file.path : file.url)&.split(".")&.last
+    if extension.present?
+      return true if VALID_FILE_EXTENSIONS.include?(extension)
+      add_file_error("Invalid file extension, must be .csv or .tsv")
+    end
   end
 
   # Because the way we load the file is different if it's remote or local

--- a/app/uploaders/bulk_import_uploader.rb
+++ b/app/uploaders/bulk_import_uploader.rb
@@ -1,9 +1,9 @@
-class BulkImportUploader < ExportUploader
+class BulkImportUploader < ApplicationUploader
   def store_dir
     "#{base_store_dir}imports/#{model.id}"
   end
 
-  def extension_white_list
-    %w[csv tsv]
+  def base_store_dir
+    "uploads/"
   end
 end

--- a/app/views/admin/bulk_imports/index.html.haml
+++ b/app/views/admin/bulk_imports/index.html.haml
@@ -5,6 +5,16 @@
   .col-md-6
     %ul
       %li.nav-item.dropdown
+        - search_errors_text = @search_errors || "With and without error"
+        %a.nav-link.dropdown-toggle{ href: "#", role: "button", "data-toggle" => "dropdown", "aria-haspopup" => "true", "aria-expanded" => "false", class: (@search_errors != "all" ? "active" : "") }
+          #{search_errors_text.titleize}
+        .dropdown-menu
+          = link_to "With and without error", url_for(sortable_search_params.merge(search_errors: nil)), class: "dropdown-item #{@search_errors.blank? ? 'active' : ''}"
+          .dropdown-divider
+          = link_to "File Error (fully blocks import)", url_for(sortable_search_params.merge(search_errors: "file_error")), class: "dropdown-item #{@search_errors == 'file_error' ? 'active' : ''}"
+          = link_to "Line Error", url_for(sortable_search_params.merge(search_errors: "line_error")), class: "dropdown-item #{@search_errors == 'line_error' ? 'active' : ''}"
+          = link_to "Any Error", url_for(sortable_search_params.merge(search_errors: "any_error")), class: "dropdown-item #{@search_errors == 'any_error' ? 'active' : ''}"
+      %li.nav-item.dropdown
         %a.nav-link.dropdown-toggle{ href: "#", role: "button", "data-toggle" => "dropdown", "aria-haspopup" => "true", "aria-expanded" => "false", class: (@progress != "all" ? "active" : "") }
           #{@progress.titleize} #{@progress == "all" ? "progresses" : ""}
         .dropdown-menu
@@ -13,12 +23,12 @@
           - BulkImport.progresses.each do |progress|
             = link_to progress.humanize, url_for(sortable_search_params.merge(search_progress: progress)), class: "dropdown-item #{@progress == progress ? 'active' : '' }"
       %li.nav-item
-        - all_active = (params.keys & %w[ascend not_ascend organization_id]).blank?
+        - all_active = (params.keys & %w[search_ascend search_not_ascend organization_id search_errors]).blank?
         = link_to "All", admin_bulk_imports_path(sortable_search_params), class: "nav-link #{all_active ? 'active' : ''}"
       %li.nav-item
-        = link_to "Only Ascend", admin_bulk_imports_path(sortable_search_params.merge(ascend: true)), class: "nav-link #{params[:ascend].present? ? 'active' : ''}"
+        = link_to "Only Ascend", admin_bulk_imports_path(sortable_search_params.merge(search_ascend: true)), class: "nav-link #{params[:search_ascend].present? ? 'active' : ''}"
       %li.nav-item
-        = link_to "Not Ascend", admin_bulk_imports_path(sortable_search_params.merge(not_ascend: true)), class: "nav-link #{params[:not_ascend].present? ? 'active' : ''}"
+        = link_to "Not Ascend", admin_bulk_imports_path(sortable_search_params.merge(search_not_ascend: true)), class: "nav-link #{params[:search_not_ascend].present? ? 'active' : ''}"
       %li.nav-item
         = link_to "New bulk import", new_admin_bulk_import_url, class: "nav-link"
 

--- a/spec/requests/organized/bulk_imports_request_spec.rb
+++ b/spec/requests/organized/bulk_imports_request_spec.rb
@@ -373,6 +373,32 @@ RSpec.describe Organized::BulkImportsController, type: :request do
               expect(BulkImportWorker).to have_enqueued_sidekiq_job(bulk_import.id)
             end
           end
+          context "invalid file type" do
+            let(:file) { Rack::Test::UploadedFile.new(File.open(File.join("public", "powered-by-bike-index.png"))) }
+            it "creates but adds an error" do
+              Sidekiq::Worker.clear_all
+              expect {
+                post "/o/ascend/bulk_imports", params: {file: file}, headers: {"Authorization" => "XXXZZZ"}
+              }.to change(BulkImport, :count).by 1
+              expect(response.status).to eq(201)
+              expect(json_result["success"]).to be_present
+
+              bulk_import = BulkImport.last
+              expect(bulk_import.kind).to eq "ascend"
+              expect(bulk_import.import_errors?).to be_present
+              expect(bulk_import.file_import_errors.join).to match(/file extension/)
+              expect(bulk_import.user).to be_blank
+              expect(bulk_import.user).to be_blank
+              expect(bulk_import.file_url).to be_present
+              expect(bulk_import.progress).to eq "finished"
+              expect(bulk_import.organization).to be_blank
+              expect(bulk_import.send_email).to be_truthy # Because no_notify isn't permitted here, only in admin
+              expect(BulkImportWorker).to have_enqueued_sidekiq_job(bulk_import.id)
+              # Make sure that the worker doesn't explode
+              BulkImportWorker.drain
+              expect(bulk_import.file_import_errors.join).to match(/file extension/)
+            end
+          end
         end
       end
     end


### PR DESCRIPTION
Prior to this PR, to see file uploads that failed because of invalid file types required checking the logs.

To make this easier to investigate, create the import with an error (instead of blocking the creation with an error)