### PR TITLE
Update to use time_parser.js in coffeescript

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -117,6 +117,8 @@ source "https://rails-assets.org" do # JS land is crazy, so lock everything
   gem "rails-assets-jquery.dirtyforms", "~> 2.0.0" # Alert on attempts to leave with dirt on forms
   gem "rails-assets-lodash", "~> 4.9.0"
   gem "rails-assets-mailcheck", "~> 1.1.2" # Check for common email errors
+  gem "rails-assets-moment", "~> 2.18.1" # Javascript Time - localizing :)
+  gem "rails-assets-moment-timezone", "~> 0.5.13" # Timezones for moment
   gem "rails-assets-mustache", "~> 2.2.1"
   gem "rails-assets-select2", "~> 4.0.3" # Use select2 for a few things, it's a bit better sometimes
   gem "rails-assets-selectize", "~> 0.12.1" # Manually configured scss

--- a/Gemfile
+++ b/Gemfile
@@ -117,8 +117,6 @@ source "https://rails-assets.org" do # JS land is crazy, so lock everything
   gem "rails-assets-jquery.dirtyforms", "~> 2.0.0" # Alert on attempts to leave with dirt on forms
   gem "rails-assets-lodash", "~> 4.9.0"
   gem "rails-assets-mailcheck", "~> 1.1.2" # Check for common email errors
-  gem "rails-assets-moment", "~> 2.18.1" # Javascript Time - localizing :)
-  gem "rails-assets-moment-timezone", "~> 0.5.13" # Timezones for moment
   gem "rails-assets-mustache", "~> 2.2.1"
   gem "rails-assets-select2", "~> 4.0.3" # Use select2 for a few things, it's a bit better sometimes
   gem "rails-assets-selectize", "~> 0.12.1" # Manually configured scss

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -53,9 +53,6 @@ GEM
     rails-assets-lodash (4.9.0)
     rails-assets-mailcheck (1.1.2)
     rails-assets-microplugin (0.0.3)
-    rails-assets-moment (2.18.1)
-    rails-assets-moment-timezone (0.5.25)
-      rails-assets-moment (>= 2.9.0)
     rails-assets-mustache (2.2.1)
     rails-assets-select2 (4.0.8)
     rails-assets-selectize (0.12.6)
@@ -811,8 +808,6 @@ DEPENDENCIES
   rails-assets-jquery.dirtyforms (~> 2.0.0)!
   rails-assets-lodash (~> 4.9.0)!
   rails-assets-mailcheck (~> 1.1.2)!
-  rails-assets-moment (~> 2.18.1)!
-  rails-assets-moment-timezone (~> 0.5.13)!
   rails-assets-mustache (~> 2.2.1)!
   rails-assets-select2 (~> 4.0.3)!
   rails-assets-selectize (~> 0.12.1)!

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -53,6 +53,9 @@ GEM
     rails-assets-lodash (4.9.0)
     rails-assets-mailcheck (1.1.2)
     rails-assets-microplugin (0.0.3)
+    rails-assets-moment (2.18.1)
+    rails-assets-moment-timezone (0.5.25)
+      rails-assets-moment (>= 2.9.0)
     rails-assets-mustache (2.2.1)
     rails-assets-select2 (4.0.8)
     rails-assets-selectize (0.12.6)
@@ -808,6 +811,8 @@ DEPENDENCIES
   rails-assets-jquery.dirtyforms (~> 2.0.0)!
   rails-assets-lodash (~> 4.9.0)!
   rails-assets-mailcheck (~> 1.1.2)!
+  rails-assets-moment (~> 2.18.1)!
+  rails-assets-moment-timezone (~> 0.5.13)!
   rails-assets-mustache (~> 2.2.1)!
   rails-assets-select2 (~> 4.0.3)!
   rails-assets-selectize (~> 0.12.1)!

--- a/app/assets/javascripts/application_revised.js
+++ b/app/assets/javascripts/application_revised.js
@@ -35,6 +35,7 @@
 //= require external_scripts/jquery.ui.widget.js
 //= require external_scripts/jquery.iframe-transport.js
 //= require external_scripts/jquery.fileupload.js
+//= require external_scripts/time_parser-coffeeimport.js
 
 // Our actual scripts:
 //= require init

--- a/app/assets/javascripts/external_scripts/time_parser-coffeeimport.js
+++ b/app/assets/javascripts/external_scripts/time_parser-coffeeimport.js
@@ -1,29 +1,17 @@
-// 2023-7-30 - Added setDateInputField
-
-import moment from "moment-timezone";
-
-// TimeParser updates all HTML elements with class '.convertTime', making them:
-// - Human readable
-// - Displayed with time in provided timezone
-// - With context relevant data (e.g. today shows hour, last month just date)
-// - Gives the element a title of the precise time with seconds (so hovering shows it)
-// - If elements have classes '.preciseTime' or '.preciseTimeSeconds', includes extra specificity in output
-// - If elements have class '.withPreposition' it includes preposition (to make time fit better in a sentence)
-// - Requires elements have HTML content of a time string (e.g. a unix timestamp)
-// - if the window has timeParserSingleFormat truthy, all times are a single format, for consistency
-//   ... except elements that have classes '.variableFormat'
+// This COPIES app/javascript/scripts/utils/time_parser.js
+// ... with a two modifications:
 //
-// Imported and initialized like this:
-// if (!window.timeParser) { window.timeParser = new TimeParser() }
-// window.timeParser.localize() // updates all the elements on the page with the localized time
+// - It relies on rails-assets-moment-timezone (not package.js)
+// - It doesn't use 'export default' (not supported by sprockets)
 //
-// To get span with the localized time:
-// localizedTimeHtml("1604337131", {})
 //
-// You can add this to a react component:
-// componentDidUpdate() { window.timeParser.localize() }
+// To import time_parser.js:
+//
+// 1. Copy the contents of that file
+// 2. Delete everything before "class TimeParser"
+//
 
-export default class TimeParser {
+class TimeParser {
   constructor() {
     if (!window.localTimezone) {
       window.localTimezone = moment.tz.guess();

--- a/app/assets/javascripts/external_scripts/time_parser-coffeeimport.js
+++ b/app/assets/javascripts/external_scripts/time_parser-coffeeimport.js
@@ -5,10 +5,11 @@
 // - It doesn't use 'export default' (not supported by sprockets)
 //
 //
-// To import time_parser.js:
+// To re-import time_parser.js:
 //
-// 1. Copy the contents of that file
+// 1. Copy the contents of that file below
 // 2. Delete everything before "class TimeParser"
+//    (specifically "import ..." and "export default")
 //
 
 class TimeParser {

--- a/app/assets/javascripts/init.coffee
+++ b/app/assets/javascripts/init.coffee
@@ -125,37 +125,38 @@ class BikeIndex.Init extends BikeIndex
     if withPreposition then "on #{str}" else str
 
   localizeTimes: ->
-    window.localTimezone ||= moment.tz.guess()
-    moment.tz.setDefault(window.localTimezone)
-    window.yesterday = moment().subtract(1, "day").startOf("day")
-    window.today = moment().startOf("day")
-    window.tomorrow = moment().endOf("day")
-    # Update any hidden fields with current timezone
-    $(".hiddenFieldTimezone").val(window.localTimezone)
+    console.log("LOCALIZING!")
+  #   window.localTimezone ||= moment.tz.guess()
+  #   moment.tz.setDefault(window.localTimezone)
+  #   window.yesterday = moment().subtract(1, "day").startOf("day")
+  #   window.today = moment().startOf("day")
+  #   window.tomorrow = moment().endOf("day")
+  #   # Update any hidden fields with current timezone
+  #   $(".hiddenFieldTimezone").val(window.localTimezone)
 
-    displayLocalDate = @displayLocalDate
+  #   displayLocalDate = @displayLocalDate
 
-    # Write local time (format: 2018-07-14T01:00:00-0500)
-    $(".convertTime").each ->
-      $this = $(this)
-      $this.removeClass("convertTime")
-      text = $this.text().trim()
-      return unless text.length > 0
-      time = moment(text, moment.ISO_8601)
-      return unless time.isValid
-      $this.text(displayLocalDate(time, $this.hasClass("preciseTime"), $this.hasClass("withPreposition")))
+  #   # Write local time (format: 2018-07-14T01:00:00-0500)
+  #   $(".convertTime").each ->
+  #     $this = $(this)
+  #     $this.removeClass("convertTime")
+  #     text = $this.text().trim()
+  #     return unless text.length > 0
+  #     time = moment(text, moment.ISO_8601)
+  #     return unless time.isValid
+  #     $this.text(displayLocalDate(time, $this.hasClass("preciseTime"), $this.hasClass("withPreposition")))
 
-    # Write timezone
-    $(".convertTimezone").each ->
-      $this = $(this)
-      $this.text(moment().format("z"))
-      $this.removeClass("convertTimezone")
+  #   # Write timezone
+  #   $(".convertTimezone").each ->
+  #     $this = $(this)
+  #     $this.text(moment().format("z"))
+  #     $this.removeClass("convertTimezone")
 
-    # Write local time in fields
-    $(".dateInputUpdateZone").each ->
-      $this = $(this)
-      time = moment($this.attr("data-initialtime"), moment.ISO_8601)
-      $this.val(time.format("YYYY-MM-DDTHH:mm")) # Format that at least Chrome expects for field
+  #   # Write local time in fields
+  #   $(".dateInputUpdateZone").each ->
+  #     $this = $(this)
+  #     time = moment($this.attr("data-initialtime"), moment.ISO_8601)
+  #     $this.val(time.format("YYYY-MM-DDTHH:mm")) # Format that at least Chrome expects for field
 
   # copy of bike_index_utilities.js function
   enableFullscreenOverflow: ->

--- a/app/assets/javascripts/init.coffee
+++ b/app/assets/javascripts/init.coffee
@@ -125,38 +125,8 @@ class BikeIndex.Init extends BikeIndex
     if withPreposition then "on #{str}" else str
 
   localizeTimes: ->
-    console.log("LOCALIZING!")
-  #   window.localTimezone ||= moment.tz.guess()
-  #   moment.tz.setDefault(window.localTimezone)
-  #   window.yesterday = moment().subtract(1, "day").startOf("day")
-  #   window.today = moment().startOf("day")
-  #   window.tomorrow = moment().endOf("day")
-  #   # Update any hidden fields with current timezone
-  #   $(".hiddenFieldTimezone").val(window.localTimezone)
-
-  #   displayLocalDate = @displayLocalDate
-
-  #   # Write local time (format: 2018-07-14T01:00:00-0500)
-  #   $(".convertTime").each ->
-  #     $this = $(this)
-  #     $this.removeClass("convertTime")
-  #     text = $this.text().trim()
-  #     return unless text.length > 0
-  #     time = moment(text, moment.ISO_8601)
-  #     return unless time.isValid
-  #     $this.text(displayLocalDate(time, $this.hasClass("preciseTime"), $this.hasClass("withPreposition")))
-
-  #   # Write timezone
-  #   $(".convertTimezone").each ->
-  #     $this = $(this)
-  #     $this.text(moment().format("z"))
-  #     $this.removeClass("convertTimezone")
-
-  #   # Write local time in fields
-  #   $(".dateInputUpdateZone").each ->
-  #     $this = $(this)
-  #     time = moment($this.attr("data-initialtime"), moment.ISO_8601)
-  #     $this.val(time.format("YYYY-MM-DDTHH:mm")) # Format that at least Chrome expects for field
+    window.timeParser ||= new TimeParser()
+    window.timeParser.localize()
 
   # copy of bike_index_utilities.js function
   enableFullscreenOverflow: ->

--- a/app/assets/javascripts/init.coffee
+++ b/app/assets/javascripts/init.coffee
@@ -125,6 +125,7 @@ class BikeIndex.Init extends BikeIndex
     if withPreposition then "on #{str}" else str
 
   localizeTimes: ->
+    # NOTE: This uses time_parser-coffeeimport.js - not time_parser.js
     window.timeParser ||= new TimeParser()
     window.timeParser.localize()
 

--- a/app/javascript/scripts/pages/initializer.js
+++ b/app/javascript/scripts/pages/initializer.js
@@ -15,8 +15,8 @@ window.binxApp || (window.binxApp = {});
 // and make the instance of class (which I'm storing on window) the same name without the first letter capitalized
 // I'm absolutely sure there is a best practice that I'm ignoring, but just doing it for now.
 $(document).ready(function () {
-  window.timeParser = new TimeParser();
-  window.timeParser.localize();
+  if (!window.timeParser) { window.timeParser = new TimeParser() }
+  window.timeParser.localize()
   // Period selector
   if ($("#timeSelectionBtnGroup").length) {
     window.periodSelector = PeriodSelector();


### PR DESCRIPTION
Figured out a good enough solution!

Copy `time_parser.js` into a file in the rails asset pipeline - `time_parser-coffeeimport.js` !

Now rather than having a hacky script to do time localizing (a script which was the inspiration for `time_parser.js` but doesn't take advantage of a bunch of nice additions) we get have the same time localizing everywhere 😄 