### PR TITLE
Updates for Princeton landing page

### DIFF
--- a/app/assets/stylesheets/registrations.scss
+++ b/app/assets/stylesheets/registrations.scss
@@ -360,6 +360,9 @@ img {
   &.lapd .submit-wrapper .btn {
     background: #4062a8;
   }
+  &.princeton .submit-wrapper .btn {
+    background: #EE7F2D;
+  }
   &.uc-davis .submit-wrapper .btn, &.uc-davis-health .submit-wrapper .btn {
     background: #022851;
   }

--- a/app/assets/stylesheets/revised/pages/landing/_organizations.scss
+++ b/app/assets/stylesheets/revised/pages/landing/_organizations.scss
@@ -77,12 +77,12 @@
 }
 
 // Organization landing pages base styles
-.org-landing-icon-list {
+ul.org-landing-icon-list {
   @include list-unstyled;
 
   margin: 0;
 
-  li {
+  &>li {
     min-height: 96px;
 
     img {
@@ -93,7 +93,7 @@
   }
 
   @include media-breakpoint-up(md) {
-    li {
+    &>li {
       @include make-row;
 
       margin-top: 2 * $vertical-height;
@@ -122,7 +122,7 @@
   }
 
   @include media-breakpoint-down(md) {
-    li {
+    &>li {
       .org-landing-icon-list-icon {
         width: 16.66667%;
 


### PR DESCRIPTION
- Scope `.org-landing-icon-list` styles, so that a sublist isn't styled by them
- Add princeton registration button color.