### PR TITLE
Update partial registration email placeholder

### DIFF
--- a/app/views/registrations/embed.html.haml
+++ b/app/views/registrations/embed.html.haml
@@ -1,7 +1,7 @@
 = form_for @b_param, { url: registrations_path, action: "create" } do |f|
   .form-group
     - email_placeholder = registration_field_label(current_organization, "owner_email", strip_tags: true)
-    - email_placeholder ||= t(".owner_email", owner: current_organization&.school? ? current_organization.slug : t(".your"))
+    - email_placeholder ||= t(".owner_email", owner: current_organization&.school? ? current_organization.short_name : t(".your"))
     = f.email_field :owner_email, required: true, value: @owner_email, placeholder: email_placeholder, class: "form-control"
 
   .form-group

--- a/spec/requests/api/v2/bikes_search_request_spec.rb
+++ b/spec/requests/api/v2/bikes_search_request_spec.rb
@@ -63,7 +63,6 @@ RSpec.describe "Bikes API V2", type: :request do
       FactoryBot.create(:bike, serial_number: "awesome")
       FactoryBot.create(:bike)
       get "/api/v2/bikes_search/count?query=awesome", params: {format: :json}
-      pp json_result
       result = JSON.parse(response.body)
       expect(result["non_stolen"]).to eq(1)
       expect(result["stolen"]).to eq(0)

--- a/spec/workers/organization_export_worker_spec.rb
+++ b/spec/workers/organization_export_worker_spec.rb
@@ -203,9 +203,6 @@ RSpec.describe OrganizationExportWorker, type: :job do
         generated_csv_string = export.file.read
         # NOTE: this only seems to fail on the mac version of nokogiri, see PR#2366
         # Ensure we actually match the exact thing with correct escaping
-        pp "HERHERHER"
-        pp generated_csv_string.split("\n").last
-        pp target_csv_line
         expect(generated_csv_string.split("\n").last).to eq target_csv_line
         # And matching the whole thing
         expect(generated_csv_string).to eq(csv_string)


### PR DESCRIPTION
Use `short_name` rather than `slug`

I have no idea why it was slug before, so I wanted to comment about it

(also, remove some unnecessary spec `pp`s)