### PR TITLE
Update organization affiliation to specify undergraduate

### DIFF
--- a/app/views/admin/ownerships/edit.html.haml
+++ b/app/views/admin/ownerships/edit.html.haml
@@ -64,4 +64,17 @@
       %tr
         %td Claim message
         %td= @ownership.claim_message&.humanize
+      %tr
+        %td Pre-registration?
+        %td= check_mark if @ownership.organization_pre_registration
+      %tr
+        %td Origin
+        %td
+          %code= @ownership.origin
 
+
+- if display_dev_info?
+  .row
+    .col-md-6
+      %h4.only-dev-visible Registration info
+      = pretty_print_json(@ownership.registration_info, true)

--- a/app/views/admin/users/edit.html.haml
+++ b/app/views/admin/users/edit.html.haml
@@ -236,7 +236,12 @@
 
 %h4.mt-4
   Memberships
-  %small.less-strong= admin_number_display(@user.memberships.count)
+  %small.less-strong.mr-3= admin_number_display(@user.memberships.count)
+  %small.d-inline-block.less-strong
+    - reg_orgs_count = @user.user_registration_organizations.count
+    = link_to admin_user_registration_organizations_path(user_id: @user.id) do
+      = admin_number_display(reg_orgs_count)
+    = "registration org".pluralize(reg_orgs_count)
 - if @user.memberships.count > 0
   = render partial: "/admin/memberships/table", locals: {memberships: @user.memberships}
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -950,7 +950,7 @@ en:
           community_member: Community Member
           employee: Employee
           graduate_student: Graduate Student
-          student: Student
+          student: Student (Undergraduate)
       stolen_record:
         bike_was_not_locked: Bike was not locked
         cable_lock: Cable lock

--- a/spec/models/bike_spec.rb
+++ b/spec/models/bike_spec.rb
@@ -368,6 +368,23 @@ RSpec.describe Bike, type: :model do
             expect(bike.organization_affiliation).to eq "student"
             expect(bike.registration_info).to eq target_registration_info.merge(organization_affiliation: "student").as_json
           end
+          context "multiple organizations" do
+            # Look in user_registration_organization_spec
+            let(:organization1) { FactoryBot.create(:organization) }
+            let(:organization2) { FactoryBot.create(:organization) }
+            let(:registration_info) do
+              {"organization_affiliation_#{organization1.id}" => "graduate_student",
+                "organization_affiliation_#{organization2.id}" => "community_member"}
+            end
+            it "uses correct values" do
+              bike.reload
+              # expect(bike.registration_info).to eq target_registration_info
+              expect(bike.organization_affiliation(organization1)).to eq "graduate_student"
+              expect(bike.organization_affiliation(organization2.id)).to eq "community_member"
+              expect(bike.registration_info).to eq registration_info
+            end
+
+          end
         end
       end
 

--- a/spec/models/organization_spec.rb
+++ b/spec/models/organization_spec.rb
@@ -706,7 +706,7 @@ RSpec.describe Organization, type: :model do
         expect(organization.additional_registration_fields.include?("reg_student_id")).to be_truthy
         expect(organization.additional_registration_fields.include?("reg_bike_sticker")).to be_truthy
 
-        expect(organization.organization_affiliation_options).to eq([["Student", "student"], ["Graduate Student", "graduate_student"], ["Employee", "employee"], ["Community Member", "community_member"]])
+        expect(organization.organization_affiliation_options).to eq([["Student (Undergraduate)", "student"], ["Graduate Student", "graduate_student"], ["Employee", "employee"], ["Community Member", "community_member"]])
       end
     end
   end


### PR DESCRIPTION
- Rename `Student` organization affiliation to `Student (Undergraduate)`
- Pass organization into `bike.organization_affiliation` and `bike.student_id` in a few places that it was missing
