### PR TITLE
Serial search matches with whitespace removed

### DIFF
--- a/app/javascript/scripts/api.js
+++ b/app/javascript/scripts/api.js
@@ -48,26 +48,9 @@ const request = async url => {
   return result
 }
 
-const queryString = ({ serial, stolenness, location, query, query_items }) => {
-  const params = {}
-  if (serial) {
-    params.serial = serial
-  }
-  if (stolenness) {
-    params.stolenness = stolenness
-  }
-  if (location) {
-    params.location = location
-  }
-  if (query) {
-    params.query = query
-  }
-  if (query_items) {
-    params.query_items = query_items
-  }
-
-  return Object.keys(params)
-    .map(k => `${k}=${params[k]}`)
+const queryString = (passedParams = {}) => {
+  return Object.keys(passedParams)
+    .map(k => `${k}=${passedParams[k]}`)
     .join('&')
 }
 

--- a/app/javascript/scripts/bikes_search/BikeSearch.jsx
+++ b/app/javascript/scripts/bikes_search/BikeSearch.jsx
@@ -22,7 +22,6 @@ class BikeSearch extends Component {
 
   componentDidMount () {
     this.resultsBeingFetched()
-    console.log(this.props.interpretedParams)
     this.props
       .fetchBikes(this.props.interpretedParams)
       .then(this.resultsFetched)

--- a/app/javascript/scripts/bikes_search/BikeSearch.jsx
+++ b/app/javascript/scripts/bikes_search/BikeSearch.jsx
@@ -22,6 +22,7 @@ class BikeSearch extends Component {
 
   componentDidMount () {
     this.resultsBeingFetched()
+    console.log(this.props.interpretedParams)
     this.props
       .fetchBikes(this.props.interpretedParams)
       .then(this.resultsFetched)
@@ -91,7 +92,7 @@ class BikeSearch extends Component {
       return (
         <div className={wrapperClassName}>
           <div className='col-md-12'>
-            <h3 className='secondary-matches'>
+            <h3 className='secondary-matches uncap'>
               {this.props.t('searching_html', { serial })}
             </h3>
             <Loading />

--- a/app/javascript/scripts/bikes_search/SecondarySearches.jsx
+++ b/app/javascript/scripts/bikes_search/SecondarySearches.jsx
@@ -28,7 +28,7 @@ const MultipleSerialSearchHeader = ({ serial, queriesCount }) =>
   queriesCount === 1 ? (
     <Fragment />
   ) : (
-    <h2 className='secondary-matches'>{t('serial_search', { serial })}</h2>
+    <h2 className='secondary-matches uncap'>{t('serial_search', { serial })}</h2>
   )
 
 const SecondarySearches = ({ interpretedParams }) =>

--- a/app/models/concerns/bike_searchable.rb
+++ b/app/models/concerns/bike_searchable.rb
@@ -212,12 +212,11 @@ module BikeSearchable
     def search_matching_serial(serial, serial_no_space)
       return all unless serial.present?
       # Note: @@ is postgres fulltext search
-      where("serial_normalized @@ ? OR serial_normalized_no_space @@ ?", serial, serial_no_space)
+      where("serial_normalized @@ ? OR serial_normalized_no_space LIKE ?", serial, serial_no_space)
     end
 
     def serials_containing(interpreted_params)
       non_serial_matches(interpreted_params)
-        # .where("serial_normalized LIKE ?", "%#{interpreted_params[:serial]}%")
         .where("serial_normalized_no_space LIKE ?", "%#{interpreted_params[:serial_no_space]}%")
     end
 

--- a/app/models/concerns/bike_searchable.rb
+++ b/app/models/concerns/bike_searchable.rb
@@ -35,7 +35,7 @@ module BikeSearchable
     end
 
     def search(interpreted_params)
-      search_matching_serial(interpreted_params[:serial])
+      search_matching_serial(interpreted_params[:serial], interpreted_params[:serial_no_space])
         .non_serial_matches(interpreted_params)
     end
 
@@ -209,10 +209,10 @@ module BikeSearchable
       query.presence && pg_search(query) || all
     end
 
-    def search_matching_serial(serial)
+    def search_matching_serial(serial, serial_no_space)
       return all unless serial.present?
       # Note: @@ is postgres fulltext search
-      where("serial_normalized @@ ?", serial)
+      where("serial_normalized @@ ? OR serial_normalized_no_space @@ ?", serial, serial_no_space)
     end
 
     def serials_containing(interpreted_params)

--- a/spec/support/shared_examples/bike_searchable.rb
+++ b/spec/support/shared_examples/bike_searchable.rb
@@ -404,9 +404,10 @@ RSpec.shared_examples "bike_searchable" do
     end
   end
 
-  describe "search_close_serials" do
+  describe "search_close_serials and serials_containing" do
     let!(:stolen_bike) { FactoryBot.create(:stolen_bike, serial_number: "O|ILSZB-111JJJG8", manufacturer: manufacturer) }
-    let!(:non_stolen_bike) { FactoryBot.create(:bike, serial_number: "O|ILSZB-111JJJJJ") }
+    let(:blue) { FactoryBot.create(:color, name: "Blue") }
+    let!(:non_stolen_bike) { FactoryBot.create(:bike, serial_number: "O|ILSZB-111JJJJJ", primary_frame_color: blue) }
     context "no serial param" do
       let(:query_params) { {query_items: [manufacturer.search_id], stolenness: "non"} }
       it "returns nil" do
@@ -416,7 +417,27 @@ RSpec.shared_examples "bike_searchable" do
     context "exact normalized serial" do
       let(:query_params) { {serial: "11I528-111JJJJJ", stolenness: "all"} } # Because drops leading zeros
       it "matches only non-exact" do
+        expect(Bike.search(interpreted_params).pluck(:id)).to eq([non_stolen_bike.id])
         expect(Bike.search_close_serials(interpreted_params).pluck(:id)).to eq([stolen_bike.id])
+      end
+    end
+    context "passing color" do
+      let(:q_blue) { {colors: [blue.id]} }
+      let(:q_black) { {colors: [color.id]} }
+      let(:s_contain) { "011 I528-111J J" }
+      let(:s_nearby) { "011 I528-111J v" }
+      it "matches by color as well" do
+        # Sanity check
+        expect(Bike.serials_containing(i_params(s_contain)).pluck(:id)).to match_array([stolen_bike.id, non_stolen_bike.id])
+        # expect(Bike.search_close_serials(i_params(s_nearby)).pluck(:id)).to match_array([stolen_bike.id, non_stolen_bike.id])
+        expect(Bike.search(i_params(nil, query_items: q_blue)).pluck(:id)).to eq([stolen_bike.id])
+        expect(Bike.search(i_params(nil, query_items: q_black)).pluck(:id)).to eq([non_stolen_bike.id])
+        # serials_containing matches by color
+        expect(Bike.serials_containing(i_params(s_contain, query_items: q_blue)).pluck(:id)).to eq([non_stolen_bike.id])
+        expect(Bike.serials_containing(i_params(s_contain, query_items: q_black)).pluck(:id)).to eq([stolen_bike.id])
+        # search_close_serials matches by color too
+        expect(Bike.search_close_serials(i_params(s_contain, query_items: q_blue)).pluck(:id)).to eq([non_stolen_bike.id])
+        expect(Bike.search_close_serials(i_params(s_contain, query_items: q_black)).pluck(:id)).to eq([stolen_bike.id])
       end
     end
     context "serial with spaces rather than dashes" do
@@ -429,7 +450,7 @@ RSpec.shared_examples "bike_searchable" do
       let!(:non_stolen_bike_n) { FactoryBot.create(:bike, serial_number: "O|ILSZB-111JJJN") }
       let(:query_params) { {serial: "011-I528-111J-J", stolenness: "all"} }
       let(:interpreted_params_g) { i_params("011 I528-111J JJg") }
-      let(:interpreted_params_n) { i_params("111528 11 1JJ Jn") } # just segment 2
+      let(:interpreted_params_n) { i_params("11528 11 1JJ Jn") } # just segment 2
       let(:interpreted_params_no_space) { i_params("011I528111JJ") }
       let(:interpreted_params_first_segment) { i_params("111529") }
       let(:all_ids) { [stolen_bike.id, non_stolen_bike.id, non_stolen_bike_n.id] }
@@ -452,6 +473,13 @@ RSpec.shared_examples "bike_searchable" do
         expect(non_stolen_bike.serial_normalized_no_space).to match interpreted_params_no_space[:serial_no_space]
         expect(Bike.serials_containing(interpreted_params_no_space).pluck(:id)).to match_array(all_ids)
         expect(Bike.search_close_serials(interpreted_params_no_space).pluck(:id)).to eq([])
+        # Exact match, no whitespace
+        pp non_stolen_bike_n.serial_normalized_no_space
+        expect(Bike.serials_containing(i_params("0111528111JJJN")).pluck(:id)).to eq([])
+        # expect(Bike.search_close_serials(i_params("O11LSZB111JJJN")).pluck(:id)).to eq([])
+        # Exact match, extra whitespace - doesn't match
+        expect(Bike.serials_containing(i_params("O11 LSZB 111 JJJN")).pluck(:id)).to eq([])
+        # expect(Bike.search_close_serials(i_params("O11 LSZB 111 JJJN")).pluck(:id)).to eq([])
         # first segment mismatch. NOTE: This doesn't work!
         expect(Bike.serials_containing(interpreted_params_first_segment).pluck(:id)).to match_array([])
         # TODO: Make this actually work - Levenshtein match against different serial segments, separated by space

--- a/spec/support/shared_examples/bike_searchable.rb
+++ b/spec/support/shared_examples/bike_searchable.rb
@@ -303,6 +303,10 @@ RSpec.shared_examples "bike_searchable" do
           let(:query_params) { {serial: "STood ffer", stolenness: "all"} }
           it "finds matching bikes" do
             expect(Bike.search(interpreted_params).pluck(:id)).to eq([bike.id])
+            # It finds without spaces
+            expect(Bike.search(interpreted_params.merge(serial: "SToodffer")).pluck(:id)).to eq([bike.id])
+            # And with extra spaces
+            expect(Bike.search(interpreted_params.merge(serial: "ST ood ffer")).pluck(:id)).to eq([bike.id])
           end
         end
         context "partial homoglyph match" do

--- a/spec/support/shared_examples/bike_searchable.rb
+++ b/spec/support/shared_examples/bike_searchable.rb
@@ -319,7 +319,7 @@ RSpec.shared_examples "bike_searchable" do
       context "reversed serial" do
         let(:bike) { FactoryBot.create(:bike, serial_number: "K10DY00047-bkd") }
         let(:query_params) { {serial: "bkd-K1oDYooo47", stolenness: "all"} }
-        it "fulls text search" do
+        it "full text search" do
           expect(Bike.search(interpreted_params).pluck(:id)).to eq([bike.id])
         end
       end


### PR DESCRIPTION
Given a bike with serial `"XXX XXX"`, searches for `"XXXXXX"` and `"XX XX XX"` should both match the bike.