### PR TITLE
Update duplicate bike functionality

### DIFF
--- a/app/models/bike.rb
+++ b/app/models/bike.rb
@@ -300,6 +300,11 @@ class Bike < ApplicationRecord
       current_ownership.status == "status_impounded"
   end
 
+  # Matches the current scope
+  def current?
+    deleted_at.blank? && !example && !user_hidden && !likely_spam
+  end
+
   # Abbreviation, checks if this is a bike_version
   def version?
     false

--- a/app/models/bike.rb
+++ b/app/models/bike.rb
@@ -38,7 +38,7 @@ class Bike < ApplicationRecord
   has_many :stolen_records, -> { current_and_not }
   has_many :impound_claims_submitting, through: :stolen_records, source: :impound_claims
   has_many :stolen_bike_listings
-  has_many :normalized_serial_segments, dependent: :destroy
+  has_many :normalized_serial_segments
   has_many :ownerships
   has_many :bike_versions
   has_many :bike_stickers
@@ -111,6 +111,7 @@ class Bike < ApplicationRecord
   default_scope -> { default_includes.current.order(listing_order: :desc) }
 
   before_validation :set_calculated_attributes
+  after_commit :enqueue_duplicate_bike_finder_worker, on: :destroy
 
   pg_search_scope :pg_search, against: {
     serial_number: "A",
@@ -298,11 +299,6 @@ class Bike < ApplicationRecord
     return false if current_ownership.blank?
     %w[unregistered_parking_notification impound_import].include?(current_ownership.origin) ||
       current_ownership.status == "status_impounded"
-  end
-
-  # Matches the current scope
-  def current?
-    deleted_at.blank? && !example && !user_hidden && !likely_spam
   end
 
   # Abbreviation, checks if this is a bike_version
@@ -792,6 +788,10 @@ class Bike < ApplicationRecord
     return "status_stolen" if current_stolen_record.present?
 
     "status_with_owner"
+  end
+
+  def enqueue_duplicate_bike_finder_worker
+    DuplicateBikeFinderWorker.perform_async(id)
   end
 
   private

--- a/app/models/concerns/bike_searchable.rb
+++ b/app/models/concerns/bike_searchable.rb
@@ -77,7 +77,7 @@ module BikeSearchable
     end
 
     # NOTE: This where query should exactly match not_matching_serial
-    # Also Called from OwnerDuplicateBikeFinder
+    # This method is also called from OwnerDuplicateBikeFinder
     def matching_serial(serial, serial_no_space = nil)
       return all unless serial.present?
       serial_no_space ||= SerialNormalizer.no_space(serial)
@@ -87,7 +87,6 @@ module BikeSearchable
 
     # TODO: actually make private?
     # Private (internal only) methods below here, as defined at the start
-    # private
 
     def non_serial_matches(interpreted_params)
       # For each of the of the colors, call searching_matching_color_ids with the color_id on the previous ;)

--- a/app/models/concerns/bike_searchable.rb
+++ b/app/models/concerns/bike_searchable.rb
@@ -76,6 +76,15 @@ module BikeSearchable
         :serial, :stolenness, colors: [], query_items: []].freeze
     end
 
+    # NOTE: This where query should exactly match not_matching_serial
+    # Also Called from OwnerDuplicateBikeFinder
+    def matching_serial(serial, serial_no_space = nil)
+      return all unless serial.present?
+      serial_no_space ||= SerialNormalizer.no_space(serial)
+      # Note: @@ is postgres fulltext search
+      where("serial_normalized @@ ? OR serial_normalized_no_space = ?", serial, serial_no_space)
+    end
+
     # TODO: actually make private?
     # Private (internal only) methods below here, as defined at the start
     # private
@@ -202,13 +211,6 @@ module BikeSearchable
 
     def search_matching_query(query)
       query.presence && pg_search(query) || all
-    end
-
-    # NOTE: This where query should exactly match not_matching_serial
-    def matching_serial(serial, serial_no_space)
-      return all unless serial.present?
-      # Note: @@ is postgres fulltext search
-      where("serial_normalized @@ ? OR serial_normalized_no_space = ?", serial, serial_no_space)
     end
 
     # TODO: Better way of matching this with matching_serial

--- a/app/services/owner_duplicate_bike_finder.rb
+++ b/app/services/owner_duplicate_bike_finder.rb
@@ -21,8 +21,8 @@ module OwnerDuplicateBikeFinder
 
     candidate_user_ids = find_matching_user_ids(email, phone)
     Bike.with_user_hidden
+      .matching_serial(serial_normalized)
       .joins("LEFT JOIN ownerships ON bikes.id = ownerships.bike_id")
-      .where("bikes.serial_normalized @@ ?", serial_normalized) # @@ is used in BikeSearchable, replicated here
       .where(
         "bikes.owner_email = ? OR bikes.owner_email = ? OR ownerships.owner_email = ? OR ownerships.owner_email = ? OR ownerships.user_id IN (?)",
         email,

--- a/app/services/serial_normalizer.rb
+++ b/app/services/serial_normalizer.rb
@@ -60,13 +60,16 @@ class SerialNormalizer
 
   def normalized_segments
     return [] if normalized.blank?
-    (normalized.split(" ").reject(&:empty?) + [SerialNormalizer.no_space(normalized)]).uniq
+    (normalized.split(" ") + [SerialNormalizer.no_space(normalized)])
+      .reject(&:empty?).uniq
   end
 
   def save_segments(bike_id)
     existing = NormalizedSerialSegment.where(bike_id: bike_id)
     existing.map(&:destroy) if existing.present?
-    return false if Bike.unscoped.where(deleted_at: nil).where(id: bike_id).limit(1).none?
+    # NOTE: save segments if user_hidden, but not if otherwise not current
+    return false if Bike.unscoped.where(example: false, likely_spam: false, deleted_at: nil)
+      .where(id: bike_id).limit(1).none?
     normalized_segments.each do |seg|
       NormalizedSerialSegment.create(bike_id: bike_id, segment: seg)
     end

--- a/app/services/serial_normalizer.rb
+++ b/app/services/serial_normalizer.rb
@@ -60,13 +60,13 @@ class SerialNormalizer
 
   def normalized_segments
     return [] if normalized.blank?
-    normalized.split(" ").reject(&:empty?).uniq
+    (normalized.split(" ").reject(&:empty?) + [SerialNormalizer.no_space(normalized)]).uniq
   end
 
   def save_segments(bike_id)
     existing = NormalizedSerialSegment.where(bike_id: bike_id)
     existing.map(&:destroy) if existing.present?
-    return false unless Bike.where(id: bike_id).present?
+    return false if Bike.unscoped.where(deleted_at: nil).where(id: bike_id).limit(1).none?
     normalized_segments.each do |seg|
       NormalizedSerialSegment.create(bike_id: bike_id, segment: seg)
     end

--- a/app/workers/duplicate_bike_finder_worker.rb
+++ b/app/workers/duplicate_bike_finder_worker.rb
@@ -1,7 +1,7 @@
 class DuplicateBikeFinderWorker < ApplicationWorker
   sidekiq_options retry: false
 
-  def perform(bike_id, bike)
+  def perform(bike_id, bike = nil)
     bike ||= Bike.unscoped.find_by_id(bike_id)
     return true if bike.blank?
 

--- a/app/workers/duplicate_bike_finder_worker.rb
+++ b/app/workers/duplicate_bike_finder_worker.rb
@@ -3,12 +3,18 @@ class DuplicateBikeFinderWorker < ApplicationWorker
 
   def perform(bike_id)
     bike = Bike.unscoped.find_by_id(bike_id)
-    return true unless bike.present?
-    serial_segments = bike.normalized_serial_segments
+    return true if bike.blank?
+
+    should_delete = bike.blank? || bike.deleted_at.present? || bike.example ||
+      bike.likely_spam
+
+    serial_segments = NormalizedSerialSegment.where(bike_id: bike_id)
 
     serial_segments.considered_for_duplicate.each do |serial_segment|
       existing_duplicate = DuplicateBikeGroup.matching_segment(serial_segment.segment)
-      if existing_duplicate.present?
+      if should_delete
+        remove_orphaned_duplicate(existing_duplicate, serial_segment) if existing_duplicate.present?
+      elsif existing_duplicate.present?
         serial_segment.update_attribute :duplicate_bike_group_id, existing_duplicate.id
         existing_duplicate.update_attribute :added_bike_at, Time.current
       else
@@ -23,5 +29,22 @@ class DuplicateBikeFinderWorker < ApplicationWorker
         end
       end
     end
+
+    serial_segments.destroy_all if should_delete
+  end
+
+  def remove_orphaned_duplicate(duplicate_bike_group, normalized_serial_segment)
+    other_segments = duplicate_bike_group.normalized_serial_segments.where.not(id: normalized_serial_segment.id)
+    not_orphaned = false
+    # Check the other segments to verify that *they* aren't orphans
+    other_segments.each do |other_segment|
+      bike = Bike.unscoped.find_by_id(other_segment.bike_id)
+      if bike.present? && bike.deleted_at.blank? && !bike.example && !bike.likely_spam
+        not_orphaned = true
+      else
+        other_segment.destroy
+      end
+    end
+    duplicate_bike_group.destroy if not_orphaned
   end
 end

--- a/app/workers/duplicate_bike_finder_worker.rb
+++ b/app/workers/duplicate_bike_finder_worker.rb
@@ -2,7 +2,7 @@ class DuplicateBikeFinderWorker < ApplicationWorker
   sidekiq_options retry: false
 
   def perform(bike_id)
-    bike = Bike.find_by_id(bike_id)
+    bike = Bike.unscoped.find_by_id(bike_id)
     return true unless bike.present?
     serial_segments = bike.normalized_serial_segments
 

--- a/app/workers/duplicate_bike_finder_worker.rb
+++ b/app/workers/duplicate_bike_finder_worker.rb
@@ -1,8 +1,8 @@
 class DuplicateBikeFinderWorker < ApplicationWorker
   sidekiq_options retry: false
 
-  def perform(bike_id)
-    bike = Bike.unscoped.find_by_id(bike_id)
+  def perform(bike_id, bike)
+    bike ||= Bike.unscoped.find_by_id(bike_id)
     return true if bike.blank?
 
     should_delete = bike.blank? || bike.deleted_at.present? || bike.example ||
@@ -31,6 +31,9 @@ class DuplicateBikeFinderWorker < ApplicationWorker
     end
 
     serial_segments.destroy_all if should_delete
+
+    # TODO: Remove after migration
+    bike.update_column :serial_segments_migrated_at, Time.current
   end
 
   def remove_orphaned_duplicate(duplicate_bike_group, normalized_serial_segment)

--- a/app/workers/migrate_normalized_serial_segments_worker.rb
+++ b/app/workers/migrate_normalized_serial_segments_worker.rb
@@ -1,0 +1,43 @@
+class MigrateNormalizedSerialSegmentsWorker < ApplicationWorker
+  prepend ScheduledWorkerRecorder
+
+  NUMBER_TO_ENQUEUE = ENV.fetch("SEGMENTS_WORKER_LIMIT", 1000).to_i.freeze
+
+  sidekiq_options retry: false
+
+  def self.frequency
+    4.minutes
+  end
+
+  def self.potential_bikes
+    Bike.where(serial_segments_migrated_at: nil)
+  end
+
+  def perform(bike_id = nil)
+    return enqueue_workers if bike_id.nil?
+
+    bike = Bike.unscoped.find_by_id(bike_id)
+    return true if bike.blank?
+
+    should_delete = bike.blank? || bike.deleted_at.present? || bike.example ||
+      bike.likely_spam
+
+    serial_segments = NormalizedSerialSegment.where(bike_id: bike_id)
+
+    unless should_delete
+      normalized_segments = SerialNormalizer.new(serial: bike.serial_normalized).normalized_segments
+      (normalized_segments - serial_segments.pluck(:segment)).each do |segment|
+        NormalizedSerialSegment.create(bike_id: bike_id, segment: segment)
+      end
+    end
+
+    # TODO: remove ability to pass in bike when removing migration
+    DuplicateBikeFinderWorker.new.perform(bike.id, bike)
+  end
+
+  def enqueue_workers
+    return if NUMBER_TO_ENQUEUE == 0
+    self.class.potential_bikes.limit(NUMBER_TO_ENQUEUE).pluck(:id)
+      .each { |id| self.class.perform_async(id) }
+  end
+end

--- a/db/migrate/20231012212343_add_serial_segments_migrated_to_bikes.rb
+++ b/db/migrate/20231012212343_add_serial_segments_migrated_to_bikes.rb
@@ -1,0 +1,5 @@
+class AddSerialSegmentsMigratedToBikes < ActiveRecord::Migration[6.1]
+  def change
+    add_column :bikes, :serial_segments_migrated_at, :datetime
+  end
+end

--- a/db/primary_replica_structure.sql
+++ b/db/primary_replica_structure.sql
@@ -506,7 +506,8 @@ CREATE TABLE public.bikes (
     occurred_at timestamp without time zone,
     serial_normalized_no_space character varying,
     credibility_score integer,
-    likely_spam boolean DEFAULT false
+    likely_spam boolean DEFAULT false,
+    serial_segments_migrated_at timestamp without time zone
 );
 
 
@@ -6423,6 +6424,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20230906180600'),
 ('20230906200524'),
 ('20230906203110'),
-('20231004171919');
+('20231004171919'),
+('20231012212343');
 
 

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -506,7 +506,8 @@ CREATE TABLE public.bikes (
     occurred_at timestamp without time zone,
     serial_normalized_no_space character varying,
     credibility_score integer,
-    likely_spam boolean DEFAULT false
+    likely_spam boolean DEFAULT false,
+    serial_segments_migrated_at timestamp without time zone
 );
 
 
@@ -6423,6 +6424,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20230906180600'),
 ('20230906200524'),
 ('20230906203110'),
-('20231004171919');
+('20231004171919'),
+('20231012212343');
 
 

--- a/spec/services/serial_normalizer_spec.rb
+++ b/spec/services/serial_normalizer_spec.rb
@@ -90,7 +90,7 @@ RSpec.describe SerialNormalizer do
   describe "normalized_segments" do
     it "makes normalized segments" do
       segments = SerialNormalizer.new(serial: "some + : serial").normalized_segments
-      expect(segments.count).to eq(2)
+      expect(segments.count).to eq(3)
       expect(segments[0]).to eq("50ME")
     end
     it "returns nil if serial is absent" do
@@ -103,7 +103,7 @@ RSpec.describe SerialNormalizer do
     it "saves normalized segments with the bike_id and not break if we resave" do
       bike = FactoryBot.create(:bike)
       SerialNormalizer.new(serial: "some + : serial").save_segments(bike.id)
-      expect(NormalizedSerialSegment.where(bike_id: bike.id).count).to eq(2)
+      expect(NormalizedSerialSegment.where(bike_id: bike.id).count).to eq(3)
     end
 
     it "does not save made_without_serial segments" do
@@ -121,10 +121,10 @@ RSpec.describe SerialNormalizer do
     it "rewrites the segments if we save them a second time" do
       bike = FactoryBot.create(:bike)
       SerialNormalizer.new(serial: "some + : serial").save_segments(bike.id)
-      expect(NormalizedSerialSegment.where(bike_id: bike.id).count).to eq(2)
+      expect(NormalizedSerialSegment.where(bike_id: bike.id).count).to eq(3)
       SerialNormalizer.new(serial: "another + : THING").save_segments(bike.id)
       segments = NormalizedSerialSegment.where(bike_id: bike.id)
-      expect(segments.count).to eq(2)
+      expect(segments.count).to eq(3)
       seg_strings = segments.map(&:segment)
       expect(seg_strings.include?("AN0THER")).to be_truthy
       expect(seg_strings.include?("TH1NG")).to be_truthy

--- a/spec/workers/migrate_normalized_serial_segments_worker_spec.rb
+++ b/spec/workers/migrate_normalized_serial_segments_worker_spec.rb
@@ -1,0 +1,39 @@
+require "rails_helper"
+
+RSpec.describe MigrateNormalizedSerialSegmentsWorker, type: :job do
+  let(:instance) { described_class.new }
+
+  it "adds the missing serial segments" do
+    bike = FactoryBot.create(:bike, serial_number: "applejacks cereal cross")
+    bike.create_normalized_serial_segments
+    expect(bike.reload.normalized_serial_segments.count).to eq 4
+    expect(bike.normalized_serial_segments.last.segment).to eq "APP1EJACK5CEREA1CR055"
+    bike.normalized_serial_segments.last.destroy
+    og_segment_ids = bike.normalized_serial_segments.pluck(:id)
+    instance.perform(bike.id)
+    expect(bike.reload.normalized_serial_segments.count).to eq 4
+    # Verify that it isn't deleting
+    expect((bike.normalized_serial_segments.pluck(:id) & og_segment_ids).count).to eq 3
+    expect(bike.serial_segments_migrated_at).to be_present
+  end
+
+  context "user_hidden" do
+    let!(:bike) { FactoryBot.create(:bike, serial_number: "Y0AASF FFFF", user_hidden: true) }
+    it "creates for user_hidden" do
+      instance.perform(bike.id)
+      expect(bike.reload.normalized_serial_segments.count).to eq 3
+    end
+  end
+
+  context "example" do
+    let!(:bike) { FactoryBot.create(:bike, serial_number: "Y0AAS FFFFF") }
+    it "deletes" do
+      bike.create_normalized_serial_segments
+      bike.update(example: true)
+      expect(bike.reload.normalized_serial_segments.count).to eq 3
+      instance.perform(bike.id)
+      expect(bike.reload.normalized_serial_segments.count).to eq 0
+      expect(bike.serial_segments_migrated_at).to be_present
+    end
+  end
+end


### PR DESCRIPTION
- Remove orphaned Duplicate Bike Groups and Normalized Serial Segments
- Create normalized serial segments for `serial_normalized_no_space`
- Add Migration to create `serial_normalized_no_space` serial segments and remove orphaned duplicate bike groups