### PR TITLE
2024-4 App Stats

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -180,3 +180,7 @@ group :test do
 end
 
 gem "dockerfile-rails", ">= 1.5", group: :development
+
+# Stats gems
+gem "bundler-stats"
+gem "rails_stats"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -142,6 +142,9 @@ GEM
     bullet (7.0.1)
       activesupport (>= 3.0.0)
       uniform_notifier (~> 1.11)
+    bundler-stats (2.4.0)
+      bundler (>= 1.9, < 3)
+      thor (>= 0.19.0, < 2.0)
     byebug (11.1.3)
     carrierwave (0.11.2)
       activemodel (>= 3.2.0)
@@ -561,6 +564,8 @@ GEM
     rails-i18n (7.0.8)
       i18n (>= 0.7, < 2)
       railties (>= 6.0.0, < 8)
+    rails_stats (1.0.2)
+      rake
     railties (6.1.7.6)
       actionpack (= 6.1.7.6)
       activesupport (= 6.1.7.6)
@@ -746,6 +751,7 @@ DEPENDENCIES
   bootsnap
   bootstrap (= 4.0.0.alpha4)
   bullet
+  bundler-stats
   carrierwave (~> 0.11.2)
   carrierwave_backgrounder
   chartkick
@@ -827,6 +833,7 @@ DEPENDENCIES
   rails-assets-waypoints (~> 3.1.1)!
   rails-controller-testing
   rails-i18n
+  rails_stats
   rb-fsevent (~> 0.10.3)
   redis
   redlock

--- a/lib/tasks/rake_tasks.rake
+++ b/lib/tasks/rake_tasks.rake
@@ -73,3 +73,6 @@ task database_vacuum: :environment do
 rescue
   Rails.logger.error("Database VACUUM error: #{exc.message}")
 end
+
+# Rakefile
+require "rails_stats"


### PR DESCRIPTION
Reference article: [How FastRuby.io Estimates The Size of a Rails Application](https://www.fastruby.io/blog/rails/code-quality/how-we-estimate-rails-application-size.html)

```
$ bundle-stats stats

+--------------------------------|------------|----------------+
|                           Name | Total Deps | 1st Level Deps |
+--------------------------------|------------|----------------+
|               dockerfile-rails | 47         | 1              |
|                          rails | 46         | 14             |
|                premailer-rails | 34         | 2              |
|                     i18n-tasks | 31         | 10             |
|                 postmark-rails | 31         | 2              |
|                     sass-rails | 28         | 1              |
|                    rspec-rails | 27         | 7              |
|                   coffee-rails | 25         | 2              |
|                i18n_generators | 24         | 2              |
|                    money-rails | 24         | 4              |
|                      webpacker | 24         | 4              |
|                doorkeeper-i18n | 23         | 1              |
|                   dotenv-rails | 23         | 2              |
|              factory_bot_rails | 23         | 2              |
|                        lograge | 23         | 4              |
|                     doorkeeper | 22         | 1              |
|      i18n-country-translations | 22         | 2              |
|                   jquery-rails | 22         | 3              |
|                     rails-i18n | 22         | 2              |
|                     responders | 22         | 2              |
|               facebookbusiness | 21         | 5              |
|                    guard-rspec | 21         | 3              |
|              omniauth-facebook | 21         | 1              |
|              omniauth-globalid | 21         | 4              |
|                omniauth-strava | 21         | 2              |
|                       kaminari | 20         | 4              |
|                        twitter | 20         | 10             |
|                  grape-swagger | 19         | 2              |
|                sprockets-rails | 19         | 3              |
|       rails-controller-testing | 18         | 3              |
|                  grape_logging | 17         | 2              |
|                          grape | 16         | 6              |
|                    twilio-ruby | 16         | 3              |
|       carrierwave_backgrounder | 15         | 1              |
|                    carrierwave | 14         | 5              |
|             faraday_middleware | 13         | 1              |
|                          guard | 13         | 8              |
|                       standard | 13         | 2              |
|                        fog-aws | 12         | 4              |
|          flipper-active_record | 9          | 2              |
|                       paranoia | 8          | 1              |
|                      pg_search | 8          | 2              |
|       active_model_serializers | 7          | 1              |
|                      bootstrap | 7          | 2              |
|                         bullet | 7          | 2              |
|                  rspec-sidekiq | 7          | 2              |
|                          axlsx | 6          | 4              |
|                      groupdate | 6          | 1              |
|                       skylight | 6          | 1              |
|               omniauth-twitter | 5          | 2              |
|                          rspec | 5          | 3              |
|               sidekiq-failures | 5          | 1              |
|                        webmock | 5          | 3              |
|                     flipper-ui | 4          | 4              |
|                     pry-byebug | 4          | 2              |
|                          rerun | 4          | 1              |
|                        sidekiq | 4          | 3              |
|                         hamlit | 3          | 3              |
|                  letter_opener | 3          | 1              |
|                      pry-rails | 3          | 1              |
|         rails-assets-selectize | 3          | 3              |
|                    translation | 3          | 1              |
|             MailchimpMarketing | 2          | 2              |
|                        i18n-js | 2          | 1              |
|            kramdown-parser-gfm | 2          | 1              |
|                       omniauth | 2          | 2              |
|                  rack-throttle | 2          | 2              |
|                          redis | 2          | 1              |
|                        redlock | 2          | 1              |
|                    rspec-retry | 2          | 1              |
|          rspec_junit_formatter | 2          | 1              |
|                      sprockets | 2          | 2              |
|                       bootsnap | 1          | 1              |
|                       httparty | 1          | 1              |
|                       kramdown | 1          | 1              |
|                       net-http | 1          | 1              |
|                             oj | 1          | 1              |
|                 parallel_tests | 1          | 1              |
|                           puma | 1          | 1              |
|             rack-mini-profiler | 1          | 1              |
| rails-assets-jquery.dirtyforms | 1          | 1              |
|   rails-assets-moment-timezone | 1          | 1              |
|                        rqrcode | 1          | 1              |
|                 secure_headers | 1          | 1              |
|              sitemap_generator | 1          | 1              |
|                       uglifier | 1          | 1              |
|                 api-pagination | 0          | 0              |
|                         bcrypt | 0          | 0              |
|                  bundler-stats | 0          | 0              |
|                      chartkick | 0          | 0              |
|                        coderay | 0          | 0              |
|               database_cleaner | 0          | 0              |
|                   eventmachine | 0          | 0              |
|                     fast_blank | 0          | 0              |
|                     flamegraph | 0          | 0              |
|                        flipper | 0          | 0              |
|                        foreman | 0          | 0              |
|                       geocoder | 0          | 0              |
|                         hashie | 0          | 0              |
|                    honeybadger | 0          | 0              |
|                 logstash-event | 0          | 0              |
|                memory_profiler | 0          | 0              |
|                    mini_magick | 0          | 0              |
|                     multi_json | 0          | 0              |
|                             pg | 0          | 0              |
|                           rack | 0          | 0              |
|        rails-assets-Stickyfill | 0          | 0              |
|            rails-assets-jquery | 0          | 0              |
|            rails-assets-lodash | 0          | 0              |
|         rails-assets-mailcheck | 0          | 0              |
|            rails-assets-moment | 0          | 0              |
|          rails-assets-mustache | 0          | 0              |
|           rails-assets-select2 | 0          | 0              |
|            rails-assets-tether | 0          | 0              |
|         rails-assets-waypoints | 0          | 0              |
|                    rails_stats | 0          | 0              |
|                     rb-fsevent | 0          | 0              |
|                      stackprof | 0          | 0              |
|                         stripe | 0          | 0              |
|               swagger-ui_rails | 0          | 0              |
|              terminal-notifier | 0          | 0              |
|                           thor | 0          | 0              |
|                            vcr | 0          | 0              |
+--------------------------------|------------|----------------+

      Declared Gems   123
         Total Gems   295
  Unpinned Versions   89
        Github Refs   3
```

```
$ rake stats\[./dash\]

Directory: /../bikeindex

+----------------------+-------+-------+---------+---------+-----+-------+
| Name                 | Lines |   LOC | Classes | Methods | M/C | LOC/M |
+----------------------+-------+-------+---------+---------+-----+-------+
| Uploaders            |   334 |   268 |      14 |      34 |   2 |     5 |
| Mailers              |   454 |   382 |       5 |      35 |   7 |     8 |
| Models               | 13770 | 10760 |     106 |    1646 |  15 |     4 |
| Integrations         |   856 |   680 |       8 |      78 |   9 |     6 |
| Serializers          |   655 |   552 |      27 |      96 |   3 |     3 |
| Workers              |  3218 |  2637 |      90 |     275 |   3 |     7 |
| Validators           |    31 |    25 |       1 |       2 |   2 |    10 |
| Javascripts          | 18021 | 10918 |      35 |    1119 |  31 |     7 |
| Controllers          | 11268 |  9529 |     150 |    1015 |   6 |     7 |
| Helpers              |  1214 |  1041 |       0 |     117 |   0 |     6 |
| Services             |  2559 |  2096 |      30 |     218 |   7 |     7 |
| Jests                |    76 |    62 |       0 |       0 |   0 |     0 |
| Configuration        |  1505 |   907 |       7 |      19 |   2 |    45 |
| Uploader Tests       |    85 |    58 |       0 |       0 |   0 |     0 |
| Spec Support         |  3423 |  2907 |       7 |      66 |   9 |    42 |
| Other Tests          |    39 |    27 |       0 |       0 |   0 |     0 |
| Mailer Tests         |   874 |   824 |       0 |       2 |   0 |   410 |
| Model Tests          | 14786 | 13500 |       0 |       3 |   0 |  4498 |
| Request Tests        | 18290 | 16941 |       0 |       7 |   0 |  2418 |
| Integration Tests    |   691 |   598 |       0 |       0 |   0 |     0 |
| Serializer Tests     |   292 |   269 |       0 |       0 |   0 |     0 |
| Worker Tests         |  7578 |  6873 |       1 |       9 |   9 |   761 |
| Validator Tests      |     0 |     0 |       0 |       0 |   0 |     0 |
| Routing Tests        |   283 |   269 |       0 |       1 |   0 |   267 |
| Controller Tests     |  5001 |  4658 |       0 |       4 |   0 |  1162 |
| Helper Tests         |  2044 |  1955 |       0 |       0 |   0 |     0 |
| Service Tests        |  4260 |  3926 |       0 |       2 |   0 |  1961 |
+----------------------+-------+-------+---------+---------+-----+-------+
| Total                | 111607 | 92662 |     481 |    4748 |   9 |    17 |
+----------------------+-------+-------+---------+---------+-----+-------+
  Code LOC: 39857     Test LOC: 52805     Code to Test Ratio: 1:1.3
```