### PR TITLE
Email survey update

### DIFF
--- a/spec/workers/scheduled_email_survey_worker_spec.rb
+++ b/spec/workers/scheduled_email_survey_worker_spec.rb
@@ -12,14 +12,14 @@ RSpec.describe ScheduledEmailSurveyWorker, type: :job do
 
   describe "enqueue workers" do
     let(:user2) { FactoryBot.create(:user, no_non_theft_notification: true) }
-    let!(:bike2) { FactoryBot.create(:bike, :with_ownership_claimed, user: user2, creation_organization: organization) }
+    let(:bike2) { FactoryBot.create(:bike, :with_ownership_claimed, user: user2, creation_organization: organization) }
     let(:bike3) { FactoryBot.create(:bike, :with_ownership_claimed, creation_organization: organization, user: user) }
 
     let(:bike5) { FactoryBot.create(:bike, :with_ownership, creation_organization: organization, owner_email: "phoebe@example.com") }
 
     it "enqueues expected emails" do
-      expect(bike.reload.claimed?).to be_truthy
       expect(bike2.reload.claimed?).to be_truthy
+      expect(bike.reload.claimed?).to be_truthy
       expect(bike3.reload.claimed?).to be_truthy
       # Test that no_notify is the same for everyone
       expect(instance.send_survey?(bike)).to be_truthy

--- a/spec/workers/scheduled_email_survey_worker_spec.rb
+++ b/spec/workers/scheduled_email_survey_worker_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe ScheduledEmailSurveyWorker, type: :job do
       FactoryBot.create(:stolen_bike_in_amsterdam, :with_ownership, date_stolen: stolen_at)
     end
     let(:target_ids) { [bike1.id, bike_unclaimed.id, bike_recovered.id] }
-    let(:all_ids) { {bike1: bike1.id, bike_unclaimed: bike_unclaimed.id, bike2: bike2.id, bike3: bike3.id, bike_recovered: bike_recovered.id, bike_outside_survey_period: bike_outside_survey_period.id, bike_theft_survey_4_2022: bike_theft_survey_4_2022.id, bike_outside_us: bike_outside_us.id}}
+    let(:all_ids) { {bike1: bike1.id, bike_unclaimed: bike_unclaimed.id, bike2: bike2.id, bike3: bike3.id, bike_recovered: bike_recovered.id, bike_outside_survey_period: bike_outside_survey_period.id, bike_theft_survey_4_2022: bike_theft_survey_4_2022.id, bike_outside_us: bike_outside_us.id} }
 
     it "enqueues expected emails" do
       expect(bike1.reload.claimed?).to be_truthy

--- a/spec/workers/scheduled_email_survey_worker_spec.rb
+++ b/spec/workers/scheduled_email_survey_worker_spec.rb
@@ -8,9 +8,9 @@ RSpec.describe ScheduledEmailSurveyWorker, type: :job do
   let(:stolen_at) { Time.current - 2.weeks } # time in stolen_survey_period
   let(:organization) { FactoryBot.create(:organization, opted_into_theft_survey_2023: true) }
   let(:user) { FactoryBot.create(:user) }
-  let(:bike1) { FactoryBot.create(:bike, :with_ownership_claimed, user: user) }
+  let(:bike1) { FactoryBot.create(:bike, :with_ownership_claimed, user: user, creation_organization: organization) }
   let!(:stolen_record1) { FactoryBot.create(:stolen_record, bike: bike1, date_stolen: stolen_at) }
-  let(:bike_unclaimed) { FactoryBot.create(:bike, :with_ownership, owner_email: user.email) }
+  let(:bike_unclaimed) { FactoryBot.create(:bike, :with_ownership, owner_email: user.email, creation_organization: organization) }
   let!(:stolen_record_unclaimed) { FactoryBot.create(:stolen_record, :in_nyc, bike: bike_unclaimed, date_stolen: stolen_at) }
 
   describe "enqueue workers" do
@@ -57,19 +57,8 @@ RSpec.describe ScheduledEmailSurveyWorker, type: :job do
       expect(instance.send_survey?(bike_outside_us.reload)).to be_falsey
 
       expect(Bike.pluck(:id)).to match_array all_ids.values
-      pp all_ids
+      # pp all_ids
       expect(stolen_record_recovered.reload.current).to be_falsey
-      # pp Bike.unscoped.joins(:stolen_records).merge(StolenRecord.recovered).to_sql
-      # pp Bike.unscoped.joins(:stolen_records).merge(StolenRecord.recovered).pluck(:id)
-
-      # pp Bike.select("INNER JOINS stolen_records ON stolen_records.bike_id = bikes.id").merge(StolenRecord.recovered).to_sql
-      # pp Bike.joins(:all_stolen_records).merge(StolenRecord.recovered).pluck(:id)
-      # pp Bike.joins("INNER JOINS stolen_records ON stolen_records.bike_id = bikes.id").merge(StolenRecord.recovered).pluck(:id)
-
-      # pp Bike.select("INNER JOINS stolen_records ON stolen_records.bike_id = bikes.id").where(stolen_records: {id: stolen_record_recovered.id}).to_sql
-      # pp Bike.select("INNER JOINS stolen_records ON stolen_records.bike_id = bikes.id").where(stolen_records: {id: stolen_record_recovered.id}).pluck(:id)
-
-      # expect(instance.potential_bikes.pluck(:id)).to match_array target_ids
 
       Sidekiq::Worker.clear_all
       instance.perform
@@ -100,79 +89,79 @@ RSpec.describe ScheduledEmailSurveyWorker, type: :job do
     end
   end
 
-  # describe "perform" do
-  #   let!(:mail_snippet) { MailSnippet.create(kind: "theft_survey_2023", subject: "Survey!", body: "Bike Index Registrant,\na Bike Shop - view survey: https://example.com?respid=SURVEY_LINK_ID", is_enabled: true) }
-  #   it "sends a theft survey email" do
-  #     expect(mail_snippet).to be_valid
-  #     ActionMailer::Base.deliveries = []
-  #     expect(Notification.count).to eq 0
-  #     instance.perform(bike1.id)
-  #     expect(Notification.count).to eq 1
-  #     notification = Notification.last
-  #     expect(notification.kind).to eq "theft_survey_2023"
-  #     expect(notification.user_id).to eq user.id
-  #     expect(notification.bike_id).to eq bike1.id
-  #     expect(notification.notifiable).to be_blank
-  #     expect(notification.delivered?).to be_truthy
-  #     expect(notification.message_channel_target).to eq user.email
-  #     expect(ActionMailer::Base.deliveries.count).to eq 1
+  describe "perform" do
+    let!(:mail_snippet) { MailSnippet.create(kind: "theft_survey_2023", subject: "Survey!", body: "Bike Index Registrant,\na Bike Shop - view survey: https://example.com?respid=SURVEY_LINK_ID", is_enabled: true) }
+    it "sends a theft survey email" do
+      expect(mail_snippet).to be_valid
+      ActionMailer::Base.deliveries = []
+      expect(Notification.count).to eq 0
+      instance.perform(bike1.id)
+      expect(Notification.count).to eq 1
+      notification = Notification.last
+      expect(notification.kind).to eq "theft_survey_2023"
+      expect(notification.user_id).to eq user.id
+      expect(notification.bike_id).to eq bike1.id
+      expect(notification.notifiable).to be_blank
+      expect(notification.delivered?).to be_truthy
+      expect(notification.message_channel_target).to eq user.email
+      expect(ActionMailer::Base.deliveries.count).to eq 1
 
-  #     mail = ActionMailer::Base.deliveries.last
-  #     expect(mail.subject).to eq("Survey!")
-  #     expect(mail.from).to eq(["gavin@bikeindex.org"])
-  #     expect(mail.to).to eq([user.email])
-  #     expect(mail.tag).to eq "theft_survey_2023"
-  #     expect(mail.body.encoded.strip).to eq "#{user.name},\r\n#{organization.name} - view survey: https://example.com?respid=1"
-  #     expect(mail.body.encoded).to_not match "supported by"
-  #     # Doing it again doesn't send it
-  #     instance.perform(bike1.id)
-  #     expect(Notification.count).to eq 1
-  #     expect(ActionMailer::Base.deliveries.count).to eq 1
-  #     # And it doesn't send to the unclaimed bike
-  #     instance.perform(bike_unclaimed.id)
-  #     expect(Notification.count).to eq 1
-  #     expect(ActionMailer::Base.deliveries.count).to eq 1
-  #     # But - with force_send, it sends!
-  #     instance.perform(bike.id, true)
-  #     expect(Notification.count).to eq 2
-  #     expect(ActionMailer::Base.deliveries.count).to eq 2
-  #   end
-  #   context "unclaimed bikes" do
-  #     it "sends a theft survey email" do
-  #       expect(mail_snippet).to be_valid
-  #       ActionMailer::Base.deliveries = []
-  #       expect(Notification.count).to eq 0
-  #       instance.perform(bike_unclaimed.id)
-  #       expect(Notification.count).to eq 1
-  #       notification = Notification.last
-  #       expect(notification.kind).to eq "theft_survey_2023"
-  #       expect(notification.user_id).to be_blank
-  #       expect(notification.bike_id).to eq bike_unclaimed.id
-  #       expect(notification.notifiable).to be_blank
-  #       expect(notification.delivered?).to be_truthy
-  #       expect(notification.message_channel_target).to eq user.email
-  #       expect(ActionMailer::Base.deliveries.count).to eq 1
+      mail = ActionMailer::Base.deliveries.last
+      expect(mail.subject).to eq("Survey!")
+      expect(mail.from).to eq(["gavin@bikeindex.org"])
+      expect(mail.to).to eq([user.email])
+      expect(mail.tag).to eq "theft_survey_2023"
+      expect(mail.body.encoded.strip).to eq "#{user.name},\r\n#{organization.name} - view survey: https://example.com?respid=1"
+      expect(mail.body.encoded).to_not match "supported by"
+      # Doing it again doesn't send it
+      instance.perform(bike1.id)
+      expect(Notification.count).to eq 1
+      expect(ActionMailer::Base.deliveries.count).to eq 1
+      # And it doesn't send to the unclaimed bike
+      instance.perform(bike_unclaimed.id)
+      expect(Notification.count).to eq 1
+      expect(ActionMailer::Base.deliveries.count).to eq 1
+      # But - with force_send, it sends!
+      instance.perform(bike1.id, true)
+      expect(Notification.count).to eq 2
+      expect(ActionMailer::Base.deliveries.count).to eq 2
+    end
+    context "unclaimed bikes" do
+      it "sends a theft survey email" do
+        expect(mail_snippet).to be_valid
+        ActionMailer::Base.deliveries = []
+        expect(Notification.count).to eq 0
+        instance.perform(bike_unclaimed.id)
+        expect(Notification.count).to eq 1
+        notification = Notification.last
+        expect(notification.kind).to eq "theft_survey_2023"
+        expect(notification.user_id).to be_blank
+        expect(notification.bike_id).to eq bike_unclaimed.id
+        expect(notification.notifiable).to be_blank
+        expect(notification.delivered?).to be_truthy
+        expect(notification.message_channel_target).to eq user.email
+        expect(ActionMailer::Base.deliveries.count).to eq 1
 
-  #       mail = ActionMailer::Base.deliveries.last
-  #       expect(mail.subject).to eq("Survey!")
-  #       expect(mail.from).to eq(["gavin@bikeindex.org"])
-  #       expect(mail.to).to eq([user.email])
-  #       expect(mail.tag).to eq "theft_survey_2023"
-  #       expect(mail.body.encoded.strip).to eq "Bike Index Registrant,\r\n#{organization.name} - view survey: https://example.com?respid=1"
-  #       expect(mail.body.encoded).to_not match "supported by"
-  #       # Doing it again doesn't send it
-  #       instance.perform(bike_unclaimed.id)
-  #       expect(Notification.count).to eq 1
-  #       expect(ActionMailer::Base.deliveries.count).to eq 1
-  #       # And it doesn't send to the claimed bike
-  #       instance.perform(bike1.id)
-  #       expect(Notification.count).to eq 1
-  #       expect(ActionMailer::Base.deliveries.count).to eq 1
-  #       # But - with force_send, it sends!
-  #       instance.perform(bike1.id, true)
-  #       expect(Notification.count).to eq 2
-  #       expect(ActionMailer::Base.deliveries.count).to eq 2
-  #     end
-  #   end
-  # end
+        mail = ActionMailer::Base.deliveries.last
+        expect(mail.subject).to eq("Survey!")
+        expect(mail.from).to eq(["gavin@bikeindex.org"])
+        expect(mail.to).to eq([user.email])
+        expect(mail.tag).to eq "theft_survey_2023"
+        expect(mail.body.encoded.strip).to eq "Bike Index Registrant,\r\n#{organization.name} - view survey: https://example.com?respid=1"
+        expect(mail.body.encoded).to_not match "supported by"
+        # Doing it again doesn't send it
+        instance.perform(bike_unclaimed.id)
+        expect(Notification.count).to eq 1
+        expect(ActionMailer::Base.deliveries.count).to eq 1
+        # And it doesn't send to the claimed bike
+        instance.perform(bike1.id)
+        expect(Notification.count).to eq 1
+        expect(ActionMailer::Base.deliveries.count).to eq 1
+        # But - with force_send, it sends!
+        instance.perform(bike1.id, true)
+        expect(Notification.count).to eq 2
+        expect(ActionMailer::Base.deliveries.count).to eq 2
+      end
+    end
+  end
 end

--- a/spec/workers/scheduled_email_survey_worker_spec.rb
+++ b/spec/workers/scheduled_email_survey_worker_spec.rb
@@ -5,42 +5,69 @@ RSpec.describe ScheduledEmailSurveyWorker, type: :job do
   include_context :scheduled_worker
   include_examples :scheduled_worker_tests
 
+  let(:stolen_at) { Time.current - 2.weeks } # time in stolen_survey_period
   let(:organization) { FactoryBot.create(:organization, opted_into_theft_survey_2023: true) }
   let(:user) { FactoryBot.create(:user) }
-  let(:bike) { FactoryBot.create(:bike, :with_ownership_claimed, user: user, creation_organization: organization) }
-  let(:bike_unclaimed) { FactoryBot.create(:bike, :with_ownership, creation_organization: organization, owner_email: user.email) }
+  let(:bike1) { FactoryBot.create(:bike, :with_ownership_claimed, user: user) }
+  let!(:stolen_record1) { FactoryBot.create(:stolen_record, bike: bike1, date_stolen: stolen_at) }
+  let(:bike_unclaimed) { FactoryBot.create(:bike, :with_ownership, owner_email: user.email) }
+  let!(:stolen_record_unclaimed) { FactoryBot.create(:stolen_record_recovered, bike: bike_unclaimed, date_stolen: stolen_at) }
 
   describe "enqueue workers" do
     let(:user2) { FactoryBot.create(:user, no_non_theft_notification: true) }
-    let(:bike2) { FactoryBot.create(:bike, :with_ownership_claimed, user: user2, creation_organization: organization) }
-    let(:bike3) { FactoryBot.create(:bike, :with_ownership_claimed, creation_organization: organization, user: user) }
-
-    let(:bike5) { FactoryBot.create(:bike, :with_ownership, creation_organization: organization, owner_email: "phoebe@example.com") }
+    let(:bike2) do
+      FactoryBot.create(:bike, :with_stolen_record, :with_ownership_claimed,
+        date_stolen: stolen_at, user: user2, creation_organization: organization)
+    end
+    let(:bike3) do
+      FactoryBot.create(:bike, :with_stolen_record, :with_ownership_claimed,
+        date_stolen: stolen_at, user: user)
+    end
+    let(:bike5) do
+      FactoryBot.create(:bike, :with_stolen_record, :with_ownership,
+        owner_email: "phoebe@example.com", date_stolen: stolen_at)
+    end
+    let!(:bike_outside_survey_period) do
+      FactoryBot.create(:bike, :with_stolen_record, :with_ownership, date_stolen: Time.current)
+    end
+    let(:bike_theft_survey_4_2022) { FactoryBot.create(:stolen_bike, :with_ownership, date_stolen: stolen_at) }
+    let!(:theft_survey_4_2022) do
+      Notification.create(kind: "theft_survey_4_2022", bike_id: bike_theft_survey_4_2022.id,
+        notifiable: bike_theft_survey_4_2022.current_stolen_record, delivery_status: "email_success",
+        message_channel: :email)
+    end
+    let!(:bike_outside_us) do
+      FactoryBot.create(:stolen_bike_in_amsterdam, :with_ownership, date_stolen: stolen_at)
+    end
 
     it "enqueues expected emails" do
       expect(bike2.reload.claimed?).to be_truthy
-      expect(bike.reload.claimed?).to be_truthy
+      expect(bike1.reload.claimed?).to be_truthy
       expect(bike3.reload.claimed?).to be_truthy
       # Test that no_notify is the same for everyone
-      expect(instance.send_survey?(bike)).to be_truthy
+      expect(instance.send_survey?(bike1)).to be_truthy
       expect(instance.send_survey?(bike3)).to be_truthy
       expect(instance.send_survey?(bike2)).to be_falsey
+      expect(instance.send_survey?(bike_outside_survey_period.reload)).to be_falsey
+      expect(Bike.unscoped.left_joins(:theft_surveys).where.not(notifications: {bike_id: nil}).pluck(:id)).to eq([bike_theft_survey_4_2022.id])
+      expect(instance.send_survey?(bike_theft_survey_4_2022.reload)).to be_falsey
+      expect(instance.send_survey?(bike_outside_us.reload)).to be_falsey
 
       expect(bike_unclaimed.reload.claimed?).to be_falsey
+      expect(instance.send_survey?(bike_unclaimed)).to be_truthy # recovered
       expect(bike5.reload.claimed?).to be_falsey
-      expect(instance.send_survey?(bike_unclaimed)).to be_truthy
       expect(instance.send_survey?(bike5)).to be_truthy
 
       Sidekiq::Worker.clear_all
       instance.perform
       # It enqueues the bikes that we want - even though some won't be surveyed
       enqueued_ids = ScheduledEmailSurveyWorker.jobs.map { |j| j["args"] }.flatten || []
-      expect(enqueued_ids).to match_array([bike.id, bike3.id, bike_unclaimed.id, bike5.id])
+      expect(enqueued_ids).to match_array([bike1.id, bike3.id, bike_unclaimed.id, bike5.id])
 
       # Test notification creation
       notification = Notification.create(kind: "theft_survey_2023",
         user: user,
-        bike: bike,
+        bike: bike1,
         delivery_status: "email_success",
         message_channel: :email)
       expect(notification).to be_valid
@@ -60,79 +87,79 @@ RSpec.describe ScheduledEmailSurveyWorker, type: :job do
     end
   end
 
-  describe "perform" do
-    let!(:mail_snippet) { MailSnippet.create(kind: "theft_survey_2023", subject: "Survey!", body: "Bike Index Registrant,\na Bike Shop - view survey: https://example.com?respid=SURVEY_LINK_ID", is_enabled: true) }
-    it "sends a theft survey email" do
-      expect(mail_snippet).to be_valid
-      ActionMailer::Base.deliveries = []
-      expect(Notification.count).to eq 0
-      instance.perform(bike.id)
-      expect(Notification.count).to eq 1
-      notification = Notification.last
-      expect(notification.kind).to eq "theft_survey_2023"
-      expect(notification.user_id).to eq user.id
-      expect(notification.bike_id).to eq bike.id
-      expect(notification.notifiable).to be_blank
-      expect(notification.delivered?).to be_truthy
-      expect(notification.message_channel_target).to eq user.email
-      expect(ActionMailer::Base.deliveries.count).to eq 1
+  # describe "perform" do
+  #   let!(:mail_snippet) { MailSnippet.create(kind: "theft_survey_2023", subject: "Survey!", body: "Bike Index Registrant,\na Bike Shop - view survey: https://example.com?respid=SURVEY_LINK_ID", is_enabled: true) }
+  #   it "sends a theft survey email" do
+  #     expect(mail_snippet).to be_valid
+  #     ActionMailer::Base.deliveries = []
+  #     expect(Notification.count).to eq 0
+  #     instance.perform(bike1.id)
+  #     expect(Notification.count).to eq 1
+  #     notification = Notification.last
+  #     expect(notification.kind).to eq "theft_survey_2023"
+  #     expect(notification.user_id).to eq user.id
+  #     expect(notification.bike_id).to eq bike1.id
+  #     expect(notification.notifiable).to be_blank
+  #     expect(notification.delivered?).to be_truthy
+  #     expect(notification.message_channel_target).to eq user.email
+  #     expect(ActionMailer::Base.deliveries.count).to eq 1
 
-      mail = ActionMailer::Base.deliveries.last
-      expect(mail.subject).to eq("Survey!")
-      expect(mail.from).to eq(["gavin@bikeindex.org"])
-      expect(mail.to).to eq([user.email])
-      expect(mail.tag).to eq "theft_survey_2023"
-      expect(mail.body.encoded.strip).to eq "#{user.name},\r\n#{organization.name} - view survey: https://example.com?respid=1"
-      expect(mail.body.encoded).to_not match "supported by"
-      # Doing it again doesn't send it
-      instance.perform(bike.id)
-      expect(Notification.count).to eq 1
-      expect(ActionMailer::Base.deliveries.count).to eq 1
-      # And it doesn't send to the unclaimed bike
-      instance.perform(bike_unclaimed.id)
-      expect(Notification.count).to eq 1
-      expect(ActionMailer::Base.deliveries.count).to eq 1
-      # But - with force_send, it sends!
-      instance.perform(bike.id, true)
-      expect(Notification.count).to eq 2
-      expect(ActionMailer::Base.deliveries.count).to eq 2
-    end
-    context "unclaimed bikes" do
-      it "sends a theft survey email" do
-        expect(mail_snippet).to be_valid
-        ActionMailer::Base.deliveries = []
-        expect(Notification.count).to eq 0
-        instance.perform(bike_unclaimed.id)
-        expect(Notification.count).to eq 1
-        notification = Notification.last
-        expect(notification.kind).to eq "theft_survey_2023"
-        expect(notification.user_id).to be_blank
-        expect(notification.bike_id).to eq bike_unclaimed.id
-        expect(notification.notifiable).to be_blank
-        expect(notification.delivered?).to be_truthy
-        expect(notification.message_channel_target).to eq user.email
-        expect(ActionMailer::Base.deliveries.count).to eq 1
+  #     mail = ActionMailer::Base.deliveries.last
+  #     expect(mail.subject).to eq("Survey!")
+  #     expect(mail.from).to eq(["gavin@bikeindex.org"])
+  #     expect(mail.to).to eq([user.email])
+  #     expect(mail.tag).to eq "theft_survey_2023"
+  #     expect(mail.body.encoded.strip).to eq "#{user.name},\r\n#{organization.name} - view survey: https://example.com?respid=1"
+  #     expect(mail.body.encoded).to_not match "supported by"
+  #     # Doing it again doesn't send it
+  #     instance.perform(bike1.id)
+  #     expect(Notification.count).to eq 1
+  #     expect(ActionMailer::Base.deliveries.count).to eq 1
+  #     # And it doesn't send to the unclaimed bike
+  #     instance.perform(bike_unclaimed.id)
+  #     expect(Notification.count).to eq 1
+  #     expect(ActionMailer::Base.deliveries.count).to eq 1
+  #     # But - with force_send, it sends!
+  #     instance.perform(bike.id, true)
+  #     expect(Notification.count).to eq 2
+  #     expect(ActionMailer::Base.deliveries.count).to eq 2
+  #   end
+  #   context "unclaimed bikes" do
+  #     it "sends a theft survey email" do
+  #       expect(mail_snippet).to be_valid
+  #       ActionMailer::Base.deliveries = []
+  #       expect(Notification.count).to eq 0
+  #       instance.perform(bike_unclaimed.id)
+  #       expect(Notification.count).to eq 1
+  #       notification = Notification.last
+  #       expect(notification.kind).to eq "theft_survey_2023"
+  #       expect(notification.user_id).to be_blank
+  #       expect(notification.bike_id).to eq bike_unclaimed.id
+  #       expect(notification.notifiable).to be_blank
+  #       expect(notification.delivered?).to be_truthy
+  #       expect(notification.message_channel_target).to eq user.email
+  #       expect(ActionMailer::Base.deliveries.count).to eq 1
 
-        mail = ActionMailer::Base.deliveries.last
-        expect(mail.subject).to eq("Survey!")
-        expect(mail.from).to eq(["gavin@bikeindex.org"])
-        expect(mail.to).to eq([user.email])
-        expect(mail.tag).to eq "theft_survey_2023"
-        expect(mail.body.encoded.strip).to eq "Bike Index Registrant,\r\n#{organization.name} - view survey: https://example.com?respid=1"
-        expect(mail.body.encoded).to_not match "supported by"
-        # Doing it again doesn't send it
-        instance.perform(bike_unclaimed.id)
-        expect(Notification.count).to eq 1
-        expect(ActionMailer::Base.deliveries.count).to eq 1
-        # And it doesn't send to the claimed bike
-        instance.perform(bike.id)
-        expect(Notification.count).to eq 1
-        expect(ActionMailer::Base.deliveries.count).to eq 1
-        # But - with force_send, it sends!
-        instance.perform(bike.id, true)
-        expect(Notification.count).to eq 2
-        expect(ActionMailer::Base.deliveries.count).to eq 2
-      end
-    end
-  end
+  #       mail = ActionMailer::Base.deliveries.last
+  #       expect(mail.subject).to eq("Survey!")
+  #       expect(mail.from).to eq(["gavin@bikeindex.org"])
+  #       expect(mail.to).to eq([user.email])
+  #       expect(mail.tag).to eq "theft_survey_2023"
+  #       expect(mail.body.encoded.strip).to eq "Bike Index Registrant,\r\n#{organization.name} - view survey: https://example.com?respid=1"
+  #       expect(mail.body.encoded).to_not match "supported by"
+  #       # Doing it again doesn't send it
+  #       instance.perform(bike_unclaimed.id)
+  #       expect(Notification.count).to eq 1
+  #       expect(ActionMailer::Base.deliveries.count).to eq 1
+  #       # And it doesn't send to the claimed bike
+  #       instance.perform(bike1.id)
+  #       expect(Notification.count).to eq 1
+  #       expect(ActionMailer::Base.deliveries.count).to eq 1
+  #       # But - with force_send, it sends!
+  #       instance.perform(bike1.id, true)
+  #       expect(Notification.count).to eq 2
+  #       expect(ActionMailer::Base.deliveries.count).to eq 2
+  #     end
+  #   end
+  # end
 end


### PR DESCRIPTION
Send to stolen recipients.

Uses some of the functionality from `theft_survey_4_2022` (see [the worker](https://github.com/bikeindex/bike_index/blob/e5fde657080dc4e53c682fbae6ff1a154e0b9d88/app/workers/scheduled_email_survey_worker.rb) and [spec](https://github.com/bikeindex/bike_index/blob/e5fde657080dc4e53c682fbae6ff1a154e0b9d88/spec/workers/scheduled_email_survey_worker_spec.rb) from then)