### PR TITLE
Add Mastodon/Fediverse to site footer icons

### DIFF
--- a/app/views/shared/_footer_revised.html.haml
+++ b/app/views/shared/_footer_revised.html.haml
@@ -46,6 +46,10 @@
         %nav.col-md-2.social-nav
           %ul
             %li
+              = link_to "https://universeodon.com/@bikeindex", :rel => 'me' do
+                %span.sr-only Bike Index Fediverse
+                %i.fab.fa-mastodon.fa-3x
+            %li
               = link_to "https://facebook.com/bikeindex" do
                 %span.sr-only Bike Index Facebook
                 %i.fab.fa-facebook-square.fa-3x


### PR DESCRIPTION
Add a Mastodon icon with the `rel=me` attribute set. This is what Mastodon will look for to show the green verification box, per our discussion on fedi.

I have not tested this as I don't know anything about Ruby or HAML, not having worked with them in years. I'm also not sure if the FontAwesome version is high enough for this icon to exist, so apologies for not finishing the job; if anyone who knows what they're doing wants to take a quick look to make sure this works before deploying, that would be great!