### PR TITLE
BIB-32: Upgrade rack to fix security vulnerabilities

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,7 @@ git_source(:gitlab) { |repo| "https://gitlab.com/#{repo}.git" }
 
 # Update CircleCI config if Ruby version is bumped
 ruby "2.7.8"
-gem "rack", "2.2.3"
+gem "rack", "~> 2.2.3"
 gem "rails", "~> 6.0"
 
 gem "puma" # App server

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -520,7 +520,7 @@ GEM
     puma (6.3.1)
       nio4r (~> 2.0)
     racc (1.7.3)
-    rack (2.2.3)
+    rack (2.2.9)
     rack-accept (0.4.5)
       rack (>= 0.4)
     rack-mini-profiler (2.3.1)
@@ -817,7 +817,7 @@ DEPENDENCIES
   pry-byebug
   pry-rails
   puma
-  rack (= 2.2.3)
+  rack (~> 2.2.3)
   rack-mini-profiler
   rack-throttle
   rails (~> 6.0)


### PR DESCRIPTION
This PR fixes the following 'High' and 'Critical' security vulnerabilities found in the current version of `rack` (2.2.3):

```
Name: rack
Version: 2.2.3
CVE: CVE-2022-30123
GHSA: GHSA-wq4h-7r42-5hrr
Criticality: Critical
URL: https://groups.google.com/g/ruby-security-ann/c/LWB10kWzag8
Title: Possible shell escape sequence injection vulnerability in Rack
Solution: upgrade to '~> 2.0.9, >= 2.0.9.1', '~> 2.1.4, >= 2.1.4.1', '>= 2.2.3.1'

Name: rack
Version: 2.2.3
CVE: CVE-2022-30122
GHSA: GHSA-hxqx-xwvh-44m2
Criticality: High
URL: https://groups.google.com/g/ruby-security-ann/c/L2Axto442qk
Title: Denial of Service Vulnerability in Rack Multipart Parsing
Solution: upgrade to '~> 2.0.9, >= 2.0.9.1', '~> 2.1.4, >= 2.1.4.1', '>= 2.2.3.1'

Name: rack
Version: 2.2.3
CVE: CVE-2022-44570
GHSA: GHSA-65f5-mfpf-vfhj
Criticality: High
URL: https://github.com/rack/rack/releases/tag/v3.0.4.1
Title: Denial of service via header parsing in Rack
Solution: upgrade to '~> 2.0.9, >= 2.0.9.2', '~> 2.1.4, >= 2.1.4.2', '~> 2.2.6, >= 2.2.6.2', '>= 3.0.4.1'

Name: rack
Version: 2.2.3
CVE: CVE-2023-27530
GHSA: GHSA-3h57-hmj3-gj3p
Criticality: High
URL: https://discuss.rubyonrails.org/t/cve-2023-27530-possible-dos-vulnerability-in-multipart-mime-parsing/82388
Title: Possible DoS Vulnerability in Multipart MIME parsing
Solution: upgrade to '~> 2.0.9, >= 2.0.9.3', '~> 2.1.4, >= 2.1.4.3', '~> 2.2.6, >= 2.2.6.3', '>= 3.0.4.2'
```

QA Notes:
1. Run `bin/parallel_rspec` to ensure there are no spec failures related to the update.
2. Install `bundler-audit` if it's not already installed: `gem install bundler-audit`.
3. Run `bundler-audit` and ensure that `rack` is not included in the list of vulnerabilties.