### PR TITLE
Improve unknown model matcher

### DIFF
--- a/app/controllers/organized/model_audits_controller.rb
+++ b/app/controllers/organized/model_audits_controller.rb
@@ -19,7 +19,7 @@ module Organized
       @model_attestations = @model_audit.model_attestations
       @model_attestation ||= ModelAttestation.new
       @organization_model_audit = @model_audit.organization_model_audits.where(organization_id: current_organization.id).first
-      bikes = @organization_model_audit&.bikes
+      bikes = @organization_model_audit&.bikes&.reorder(created_at: :desc)
       @bikes_count = @organization_model_audit&.bikes_count || 0
       @per_page = 10
       @bikes = bikes&.page(1)&.per(@per_page) || Bike.none

--- a/app/models/cycle_type.rb
+++ b/app/models/cycle_type.rb
@@ -79,7 +79,7 @@ class CycleType
   end
 
   def self.front_and_rear_wheels?(slug)
-    (PEDAL - %i[unicycle trail-behind trailer] + %i[e-scooter non-e-scooter])
+    (PEDAL - %i[unicycle trail-behind trailer] + %i[e-scooter non-e-scooter e-motorcycle])
       .include?(slug&.to_sym)
   end
 

--- a/app/models/cycle_type.rb
+++ b/app/models/cycle_type.rb
@@ -22,7 +22,8 @@ class CycleType
     "e-scooter": 16,
     "personal-mobility": 18,
     "non-e-scooter": 19,
-    "non-e-skateboard": 20
+    "non-e-skateboard": 20,
+    "e-motorcycle": 21
   }.freeze
 
   NAMES = {
@@ -42,19 +43,20 @@ class CycleType
     "cargo-trike-rear": "Cargo Tricycle (rear storage)",
     "trail-behind": "Trail behind (half bike)",
     "pedi-cab": "Pedi Cab (rickshaw)",
-    "e-scooter": "E-Scooter",
-    "personal-mobility": "E-Skateboard (E-Unicycle, Personal mobility device, etc)",
+    "e-scooter": "e-Scooter",
+    "personal-mobility": "e-Skateboard (e-Unicycle, Personal mobility device, etc)",
     "non-e-scooter": "Scooter (Not electric)",
-    "non-e-skateboard": "Skateboard (Not electric)"
+    "non-e-skateboard": "Skateboard (Not electric)",
+    "e-motorcycle": "e-Motorcycle (or e-Dirtbike)"
   }.freeze
 
   MODEST_PRIORITY = %i[personal-mobility recumbent tandem tricycle].freeze
 
   PEDAL = %i[bike cargo cargo-rear cargo-trike cargo-trike-rear pedi-cab penny-farthing
     recumbent tall-bike tandem trail-behind tricycle unicycle].freeze
-  ALWAYS_MOTORIZED = %i[e-scooter personal-mobility].freeze
+  ALWAYS_MOTORIZED = %i[e-scooter personal-mobility e-motorcycle].freeze
   NEVER_MOTORIZED = %i[non-e-scooter non-e-skateboard trail-behind].freeze
-  NOT_CYCLE_TYPE = %i[e-scooter non-e-skateboard personal-mobility stroller wheelchair].freeze
+  NOT_CYCLE_TYPE = %i[e-scooter non-e-skateboard personal-mobility stroller wheelchair e-motorcycle].freeze
 
   def self.searchable_names
     slugs

--- a/app/models/model_audit.rb
+++ b/app/models/model_audit.rb
@@ -170,7 +170,7 @@ class ModelAudit < ApplicationRecord
   end
 
   def matching_bike?(bike)
-    same_frame_model = if self.class.unknown_model?(bike.frame_model, manufacturer_id: manufacturer_id)
+    same_frame_model = if self.class.unknown_model?(bike.frame_model, manufacturer_id: bike.manufacturer_id)
       unknown_model?
     else
       frame_model&.downcase == bike.frame_model&.downcase
@@ -185,6 +185,11 @@ class ModelAudit < ApplicationRecord
 
   def unknown_model?
     frame_model.blank?
+  end
+
+  def should_be_unknown_model?
+    frame_model.present? &&
+      self.class.unknown_model?(frame_model, manufacturer_id: manufacturer_id)
   end
 
   def certification_status_humanized

--- a/app/models/model_audit.rb
+++ b/app/models/model_audit.rb
@@ -19,7 +19,7 @@ class ModelAudit < ApplicationRecord
   ADDITIONAL_CYCLE_TYPES = %w[bicycle dirtbike trike three-wheeler].freeze
   VARIETIES_MATCHERS = %w[
     men.?s male female lady.?s? ladies women.?s
-    sm(all)? me?d(ium)? l(ar)?ge? xx?s xx?l regular
+    sm(all)? me?d(ium)? l(ar)?ge? xx?s xx?l regular traditional
     bmx city commuter cruiser fat(.?tire)? foldable folding hybrid mtb mountain utility
     electric full.suspension frame step.?through step.?thru mid.?step long.?tail mid.?tail
   ].freeze

--- a/app/models/model_audit.rb
+++ b/app/models/model_audit.rb
@@ -16,7 +16,7 @@
 #
 class ModelAudit < ApplicationRecord
   UNKNOWN_STRINGS = %w[na idk no none nomodel tbd unknown unkown].freeze
-  ADDITIONAL_CYCLE_TYPES = %w[bicycle trike dirtbike].freeze
+  ADDITIONAL_CYCLE_TYPES = %w[bicycle dirtbike trike three-wheeler].freeze
   VARIETIES_MATCHERS = %w[
     full.suspension frame step.?through step.?thru
     men.?s male female lady.?s? ladies women.?s sm(all)? me?d(ium)? l(ar)?ge?

--- a/app/models/model_audit.rb
+++ b/app/models/model_audit.rb
@@ -16,12 +16,13 @@
 #
 class ModelAudit < ApplicationRecord
   UNKNOWN_STRINGS = %w[na idk no none nomodel tbd unknown unkown].freeze
-  ADDITIONAL_CYCLE_TYPES = %w[bicycle dirtbike trike three-wheeler].freeze
+  ADDITIONAL_CYCLE_TYPES = %w[bicycle dirtbike trike three-wheeler 3-wheeler].freeze
   VARIETIES_MATCHERS = %w[
     men.?s male female lady.?s? ladies women.?s
-    sm(all)? me?d(ium)? l(ar)?ge? xx?s xx?l regular traditional
-    bmx city commuter cruiser fat(.?tire)? foldable folding hybrid mtb mountain utility
-    electric full.suspension frame step.?through step.?thru mid.?step long.?tail mid.?tail
+    sm(all)? me?d(ium)? l(ar)?ge? xx?s xx?l regular
+    bmx city commuter cruiser hybrid mtb mountain road utility traditional
+    aluminum electric fat(.?tire)? foldable folding frame full.suspension
+    long.?tail mid.?tail high.?step mid.?step step.?through step.?thru step.?in
   ].freeze
 
   enum certification_status: ModelAttestation::CERTIFICATION_KIND_ENUM

--- a/app/models/model_audit.rb
+++ b/app/models/model_audit.rb
@@ -98,9 +98,10 @@ class ModelAudit < ApplicationRecord
       if manufacturer_id != Manufacturer.other.id
         bikes = bikes.or(Bike.unscoped.where(manufacturer_id: manufacturer_id))
       end
-
-      matching_bikes_for_frame_model(bikes, manufacturer_id: manufacturer_id, frame_model: frame_model || bike&.frame_model)
-        .reorder(id: :desc)
+      bikes = matching_bikes_for_frame_model(bikes, manufacturer_id: manufacturer_id, frame_model: frame_model || bike&.frame_model)
+      # Include bike if it was passed
+      bikes = bikes.or(Bike.unscoped.where(id: bike.id)) if bike&.id.present?
+      bikes.reorder(id: :desc)
     end
 
     def counted_matching_bikes(bikes)

--- a/app/models/model_audit.rb
+++ b/app/models/model_audit.rb
@@ -18,10 +18,10 @@ class ModelAudit < ApplicationRecord
   UNKNOWN_STRINGS = %w[na idk no none nomodel tbd unknown unkown].freeze
   ADDITIONAL_CYCLE_TYPES = %w[bicycle dirtbike trike three-wheeler].freeze
   VARIETIES_MATCHERS = %w[
-    full.suspension frame step.?through step.?thru electric
+    full.suspension frame step.?through step.?thru electric long.?tail
     men.?s male female lady.?s? ladies women.?s
-    sm(all)? me?d(ium)? l(ar)?ge? xx?s xx?l
-    bmx city commuter cruiser folding hybrid mtb mountain utility
+    sm(all)? me?d(ium)? l(ar)?ge? xx?s xx?l black
+    bmx city commuter cruiser fat(.?tire)? folding hybrid mtb mountain utility
   ].freeze
 
   enum certification_status: ModelAttestation::CERTIFICATION_KIND_ENUM

--- a/app/models/model_audit.rb
+++ b/app/models/model_audit.rb
@@ -19,8 +19,8 @@ class ModelAudit < ApplicationRecord
   ADDITIONAL_CYCLE_TYPES = %w[bicycle dirtbike trike three-wheeler].freeze
   VARIETIES_MATCHERS = %w[
     men.?s male female lady.?s? ladies women.?s
-    sm(all)? me?d(ium)? l(ar)?ge? xx?s xx?l
-    bmx city commuter cruiser fat(.?tire)? folding hybrid mtb mountain utility
+    sm(all)? me?d(ium)? l(ar)?ge? xx?s xx?l regular
+    bmx city commuter cruiser fat(.?tire)? foldable folding hybrid mtb mountain utility
     electric full.suspension frame step.?through step.?thru mid.?step long.?tail mid.?tail
   ].freeze
 

--- a/app/models/model_audit.rb
+++ b/app/models/model_audit.rb
@@ -19,7 +19,7 @@ class ModelAudit < ApplicationRecord
   ADDITIONAL_CYCLE_TYPES = %w[bicycle dirtbike trike three-wheeler].freeze
   VARIETIES_MATCHERS = %w[
     men.?s male female lady.?s? ladies women.?s
-    sm(all)? me?d(ium)? l(ar)?ge? xx?s xx?l black
+    sm(all)? me?d(ium)? l(ar)?ge? xx?s xx?l
     bmx city commuter cruiser fat(.?tire)? folding hybrid mtb mountain utility
     electric full.suspension frame step.?through step.?thru mid.?step long.?tail mid.?tail
   ].freeze
@@ -145,7 +145,8 @@ class ModelAudit < ApplicationRecord
     def model_without_varieties(frame_model)
       match_string = frame_model.downcase.strip.gsub(/\W|_/, " ")
       # Replace all varities with a space
-      VARIETIES_MATCHERS.each { |v| match_string.gsub!(/(\A| )#{v}( |\z)/, " ") }
+      (VARIETIES_MATCHERS + Color::ALL_NAMES.map { |c| c.split(/\W/).first.downcase })
+        .each { |v| match_string.gsub!(/(\A| )#{v}( |\z)/, " ") }
       # remove cargo (which is often compounded with other types) and convert spaces to dashes
       match_string.gsub("cargo", " ").strip.gsub(/ +/, "-")
         .gsub(/\A(electric|e)-?/, "") # remove leading e/electric ("electric" not leading removed by variety)

--- a/app/models/model_audit.rb
+++ b/app/models/model_audit.rb
@@ -18,8 +18,9 @@ class ModelAudit < ApplicationRecord
   UNKNOWN_STRINGS = %w[na idk no none nomodel tbd unknown unkown].freeze
   ADDITIONAL_CYCLE_TYPES = %w[bicycle dirtbike trike three-wheeler].freeze
   VARIETIES_MATCHERS = %w[
-    full.suspension frame step.?through step.?thru
-    men.?s male female lady.?s? ladies women.?s sm(all)? me?d(ium)? l(ar)?ge?
+    full.suspension frame step.?through step.?thru electric
+    men.?s male female lady.?s? ladies women.?s
+    sm(all)? me?d(ium)? l(ar)?ge? xx?s xx?l
     bmx city commuter cruiser folding hybrid mtb mountain utility
   ].freeze
 
@@ -142,12 +143,12 @@ class ModelAudit < ApplicationRecord
     end
 
     def model_without_varieties(frame_model)
-      # remove leading e/electric
       match_string = frame_model.downcase.strip.gsub(/\W|_/, " ")
       # Replace all varities with a space
       VARIETIES_MATCHERS.each { |v| match_string.gsub!(/(\A| )#{v}( |\z)/, " ") }
       # remove cargo (which is often compounded with other types) and convert spaces to dashes
-      match_string.gsub("cargo", " ").strip.gsub(/ +/, "-").gsub(/\A(electric|e)-?/, "")
+      match_string.gsub("cargo", " ").strip.gsub(/ +/, "-")
+        .gsub(/\A(electric|e)-?/, "") # remove leading e/electric ("electric" not leading removed by variety)
     end
 
     def vehicle_type_strings

--- a/app/models/model_audit.rb
+++ b/app/models/model_audit.rb
@@ -18,10 +18,10 @@ class ModelAudit < ApplicationRecord
   UNKNOWN_STRINGS = %w[na idk no none nomodel tbd unknown unkown].freeze
   ADDITIONAL_CYCLE_TYPES = %w[bicycle dirtbike trike three-wheeler].freeze
   VARIETIES_MATCHERS = %w[
-    full.suspension frame step.?through step.?thru electric long.?tail
     men.?s male female lady.?s? ladies women.?s
     sm(all)? me?d(ium)? l(ar)?ge? xx?s xx?l black
     bmx city commuter cruiser fat(.?tire)? folding hybrid mtb mountain utility
+    electric full.suspension frame step.?through step.?thru mid.?step long.?tail mid.?tail
   ].freeze
 
   enum certification_status: ModelAttestation::CERTIFICATION_KIND_ENUM

--- a/app/models/model_audit.rb
+++ b/app/models/model_audit.rb
@@ -15,7 +15,8 @@
 #  manufacturer_id      :bigint
 #
 class ModelAudit < ApplicationRecord
-  UNKNOWN_STRINGS = %w[na idk no unknown unkown none tbd no\ model].freeze
+  UNKNOWN_STRINGS = %w[na idk no unknown unkown none tbd nomodel].freeze
+  VEHICLE_TYPE_STRINGS = %w[scooter bike bicycle mtb cargobike trike unicycle].freeze
 
   enum certification_status: ModelAttestation::CERTIFICATION_KIND_ENUM
   enum propulsion_type: PropulsionType::SLUGS
@@ -66,9 +67,15 @@ class ModelAudit < ApplicationRecord
     not_other.present? ? not_other.first : matching_audits.first
   end
 
+  def self.normalized_frame_model(frame_model)
+    frame_model.downcase.gsub(/\W|_|\s/, "") # remove everything but numbers and letters
+    # remove leading e/electric
+  end
+
   def self.unknown_model?(frame_model)
     return true if frame_model.blank?
-    UNKNOWN_STRINGS.include?(frame_model.downcase)
+    normed_frame_model = normed_frame_model(frame_model)
+    UNKNOWN_STRINGS.include?(normed_frame_model)
   end
 
   def self.audit?(bike)

--- a/app/views/organized/model_audits/show.html.haml
+++ b/app/views/organized/model_audits/show.html.haml
@@ -55,7 +55,8 @@
               Org Model Audit ID
               %code.mr-2= @organization_model_audit&.id
               Model Audit ID
-              %code= @model_audit.id
+              %code
+                = link_to @model_audit&.id, admin_bikes_path(search_model_audit_id: @model_audit&.id)
 
 %h2.uncap.mt-4
   Attestations

--- a/app/workers/find_or_create_model_audit_worker.rb
+++ b/app/workers/find_or_create_model_audit_worker.rb
@@ -54,7 +54,11 @@ class FindOrCreateModelAuditWorker < ApplicationWorker
     propulsion_type ||= matching_bikes.first&.propulsion_type
     cycle_type = matching_bikes.detect { |b| b.cycle_type != "bike" }&.cycle_type
     cycle_type ||= matching_bikes.first&.cycle_type
-    frame_model = ModelAudit.unknown_model?(bike.frame_model) ? nil : bike.frame_model
+    frame_model = if ModelAudit.unknown_model?(bike.frame_model, bike.manufacturer_id)
+      nil
+    else
+      bike.frame_model
+    end
     ModelAudit.create!(manufacturer_id: bike.manufacturer_id,
       manufacturer_other: bike.manufacturer_other,
       frame_model: frame_model,

--- a/app/workers/find_or_create_model_audit_worker.rb
+++ b/app/workers/find_or_create_model_audit_worker.rb
@@ -54,7 +54,7 @@ class FindOrCreateModelAuditWorker < ApplicationWorker
     propulsion_type ||= matching_bikes.first&.propulsion_type
     cycle_type = matching_bikes.detect { |b| b.cycle_type != "bike" }&.cycle_type
     cycle_type ||= matching_bikes.first&.cycle_type
-    frame_model = if ModelAudit.unknown_model?(bike.frame_model, bike.manufacturer_id)
+    frame_model = if ModelAudit.unknown_model?(bike.frame_model, manufacturer_id: bike.manufacturer_id)
       nil
     else
       bike.frame_model

--- a/config/locales/.translation_io
+++ b/config/locales/.translation_io
@@ -1,2 +1,2 @@
 ---
-timestamp: 1721237508
+timestamp: 1722664478

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -694,6 +694,7 @@ en:
         cargo_rear: Cargo Bike (rear storage)
         cargo_trike: Cargo Tricycle (front storage)
         cargo_trike_rear: Cargo Tricycle (rear storage)
+        e_motorcycle: e-Motorcycle (or e-Dirtbike)
         e_scooter: e-Scooter
         e_skateboard: e-Skateboard
         non_e_scooter: Scooter (not electric)
@@ -710,7 +711,6 @@ en:
         tricycle: Tricycle
         unicycle: Unicycle
         wheelchair: Wheelchair
-        e_motorcycle: e-Motorcycle (or e-Dirtbike)
       frame_material:
         aluminum: Aluminum
         composite: Carbon or composite

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -694,13 +694,13 @@ en:
         cargo_rear: Cargo Bike (rear storage)
         cargo_trike: Cargo Tricycle (front storage)
         cargo_trike_rear: Cargo Tricycle (rear storage)
-        e_scooter: E-Scooter
-        e_skateboard: E-Skateboard
+        e_scooter: e-Scooter
+        e_skateboard: e-Skateboard
         non_e_scooter: Scooter (not electric)
         non_e_skateboard: Skateboard (Not electric)
         pedi_cab: Pedi Cab (rickshaw)
         penny_farthing: Penny Farthing
-        personal_mobility: E-Skateboard (E-Unicycle, Personal mobility device, etc)
+        personal_mobility: e-Skateboard (e-Unicycle, Personal mobility device, etc)
         recumbent: Recumbent
         stroller: Stroller
         tall_bike: Tall Bike
@@ -710,6 +710,7 @@ en:
         tricycle: Tricycle
         unicycle: Unicycle
         wheelchair: Wheelchair
+        e_motorcycle: e-Motorcycle (or e-Dirtbike)
       frame_material:
         aluminum: Aluminum
         composite: Carbon or composite

--- a/config/locales/translation.es.yml
+++ b/config/locales/translation.es.yml
@@ -844,6 +844,7 @@ es:
         tricycle:
         unicycle:
         wheelchair:
+        e_motorcycle:
       frame_material:
         aluminum:
         composite:

--- a/config/locales/translation.nb.yml
+++ b/config/locales/translation.nb.yml
@@ -854,6 +854,7 @@ nb:
         tricycle: Trehjulssykkel
         unicycle: Enhjuling
         wheelchair: Rullestol
+        e_motorcycle: e-motorsykkel (eller e-Dirtbike)
       frame_material:
         aluminum: Aluminium
         composite: Karbon eller kompositt

--- a/config/locales/translation.nl.yml
+++ b/config/locales/translation.nl.yml
@@ -853,6 +853,7 @@ nl:
         e_skateboard: E-skateboard
         non_e_scooter: Scooter (niet elektrisch)
         non_e_skateboard: Skateboard (niet elektrisch)
+        e_motorcycle: e-motorfiets (of e-dirtbike)
       frame_material:
         aluminum: Aluminium
         composite: Koolstof of composiet

--- a/spec/models/model_audit_spec.rb
+++ b/spec/models/model_audit_spec.rb
@@ -101,7 +101,7 @@ RSpec.describe ModelAudit, type: :model do
         expect(ModelAudit.unknown_model?(bike_known.frame_model, manufacturer_id: 42)).to be_falsey
         expect(ModelAudit.matching_bikes_for(bike1).pluck(:id)).to match_array([bike1.id, bike5.id])
         # TODO: This seems weird - it probably should return empty...
-        expect(ModelAudit.matching_bikes_for(bike2).pluck(:id)).to match_array([bike1.id, bike5.id])
+        expect(ModelAudit.matching_bikes_for(bike2).pluck(:id)).to match_array([bike1.id, bike2.id, bike5.id])
         # But - if you update to be motorized, it's all the bikes
         manufacturer.update(motorized_only: true)
         expect(ModelAudit.matching_bikes_for(bike1).pluck(:id)).to match_array([bike1.id, bike2.id, bike3.id, bike4.id, bike5.id])

--- a/spec/models/model_audit_spec.rb
+++ b/spec/models/model_audit_spec.rb
@@ -238,8 +238,8 @@ RSpec.describe ModelAudit, type: :model do
         expect(described_class.send(:model_bare_vehicle_type?, "silver  Men's bike")).to be_truthy
         expect(described_class.send(:model_bare_vehicle_type?, "\ngreen ladies unicycle")).to be_truthy
         expect(described_class.send(:model_bare_vehicle_type?, " stepthru folding bike frame\n")).to be_truthy
-        expect(described_class.send(:model_bare_vehicle_type?, " ladies step through frame\n")).to be_truthy
-        expect(described_class.send(:model_bare_vehicle_type?, " ladies step-thru frame\n")).to be_truthy
+        expect(described_class.send(:model_bare_vehicle_type?, " ladies step through regular frame\n")).to be_truthy
+        expect(described_class.send(:model_bare_vehicle_type?, " ladies step-thru foldable frame\n")).to be_truthy
         expect(described_class.send(:model_bare_vehicle_type?, " XP Step-Thru 3.0\n")).to be_falsey
 
         expect(described_class.send(:model_bare_vehicle_type?, " Full Suspension e-bike\n")).to be_truthy

--- a/spec/models/model_audit_spec.rb
+++ b/spec/models/model_audit_spec.rb
@@ -237,7 +237,7 @@ RSpec.describe ModelAudit, type: :model do
         expect(described_class.send(:model_bare_vehicle_type?, "electric-utility-trike")).to be_truthy
         expect(described_class.send(:model_bare_vehicle_type?, "silver  Men's bike")).to be_truthy
         expect(described_class.send(:model_bare_vehicle_type?, "\ngreen ladies unicycle")).to be_truthy
-        expect(described_class.send(:model_bare_vehicle_type?, " stepthru bike frame\n")).to be_truthy
+        expect(described_class.send(:model_bare_vehicle_type?, " stepthru folding bike frame\n")).to be_truthy
         expect(described_class.send(:model_bare_vehicle_type?, " ladies step through frame\n")).to be_truthy
         expect(described_class.send(:model_bare_vehicle_type?, " ladies step-thru frame\n")).to be_truthy
         expect(described_class.send(:model_bare_vehicle_type?, " XP Step-Thru 3.0\n")).to be_falsey

--- a/spec/models/model_audit_spec.rb
+++ b/spec/models/model_audit_spec.rb
@@ -207,6 +207,7 @@ RSpec.describe ModelAudit, type: :model do
         expect(described_class.send(:model_bare_vehicle_type?, "electric_cargobike")).to be_truthy
         expect(described_class.send(:model_bare_vehicle_type?, "motorcycle")).to be_truthy
         expect(described_class.send(:model_bare_vehicle_type?, "dirtbike")).to be_truthy
+        expect(described_class.send(:model_bare_vehicle_type?, "e-Three Wheeler")).to be_truthy
       end
 
       it "matches vehicle varieties combined with vehicle types" do

--- a/spec/models/model_audit_spec.rb
+++ b/spec/models/model_audit_spec.rb
@@ -220,13 +220,11 @@ RSpec.describe ModelAudit, type: :model do
         expect(described_class.send(:model_without_varieties, "ladys MeDium\t")).to eq ""
         expect(described_class.send(:model_without_varieties, "male lag longtail")).to eq "lag"
         expect(described_class.send(:model_without_varieties, "male fat tire")).to eq ""
-        expect(described_class.send(:model_without_varieties, "black xl mountain bike")).to eq "bike"
+        expect(described_class.send(:model_bare_vehicle_type?, " Women's lg frame")).to be_truthy
 
         expect(described_class.send(:model_without_varieties, "folding large cargo electricdd")).to eq "dd"
         expect(described_class.send(:model_without_varieties, "utility xxl cargo electric X.X_2")).to eq "x-x-2"
 
-        expect(described_class.send(:model_bare_vehicle_type?, "Men's")).to be_truthy
-        expect(described_class.send(:model_bare_vehicle_type?, " Women's lg frame")).to be_truthy
         expect(described_class.send(:model_bare_vehicle_type?, "city bike")).to be_truthy
         expect(described_class.send(:model_bare_vehicle_type?, "commuter trike")).to be_truthy
         expect(described_class.send(:model_bare_vehicle_type?, "folding bike")).to be_truthy
@@ -237,8 +235,8 @@ RSpec.describe ModelAudit, type: :model do
         expect(described_class.send(:model_bare_vehicle_type?, "xs mtb ")).to be_truthy
         expect(described_class.send(:model_bare_vehicle_type?, "bmx\tbike")).to be_truthy
         expect(described_class.send(:model_bare_vehicle_type?, "electric-utility-trike")).to be_truthy
-        expect(described_class.send(:model_bare_vehicle_type?, " Men's bike")).to be_truthy
-        expect(described_class.send(:model_bare_vehicle_type?, " ladies unicycle")).to be_truthy
+        expect(described_class.send(:model_bare_vehicle_type?, "silver  Men's bike")).to be_truthy
+        expect(described_class.send(:model_bare_vehicle_type?, "\ngreen ladies unicycle")).to be_truthy
         expect(described_class.send(:model_bare_vehicle_type?, " stepthru bike frame\n")).to be_truthy
         expect(described_class.send(:model_bare_vehicle_type?, " ladies step through frame\n")).to be_truthy
         expect(described_class.send(:model_bare_vehicle_type?, " ladies step-thru frame\n")).to be_truthy
@@ -262,7 +260,8 @@ RSpec.describe ModelAudit, type: :model do
     it "matches cycle types" do
       expect(described_class.unknown_model?("eScooter", manufacturer_id: 42)).to be_truthy
       expect(described_class.unknown_model?("electric-mens MTB", manufacturer_id: 42)).to be_truthy
-      expect(described_class.unknown_model?("cargo-bike", manufacturer_id: 42)).to be_truthy
+      expect(described_class.unknown_model?("purple small cargo-bike", manufacturer_id: 42)).to be_truthy
+      expect(described_class.unknown_model?("RED XXL electric Mountain", manufacturer_id: 42)).to be_truthy
     end
     context "when named the same as the manufacturer" do
       let!(:manufacturer) { FactoryBot.create(:manufacturer, name: "Salsa") }

--- a/spec/models/model_audit_spec.rb
+++ b/spec/models/model_audit_spec.rb
@@ -192,6 +192,7 @@ RSpec.describe ModelAudit, type: :model do
         expect(described_class.send(:model_bare_vehicle_type?, "\nbicycle ")).to be_truthy
         expect(described_class.send(:model_bare_vehicle_type?, "tandem")).to be_truthy
         expect(described_class.send(:model_bare_vehicle_type?, "e-bike ")).to be_truthy
+        expect(described_class.send(:model_bare_vehicle_type?, "e-fat bike ")).to be_truthy
         expect(described_class.send(:model_bare_vehicle_type?, " electricbicycle ")).to be_truthy
         expect(described_class.send(:model_bare_vehicle_type?, "TRIcycle ")).to be_truthy
         expect(described_class.send(:model_bare_vehicle_type?, "e-trike ")).to be_truthy
@@ -217,7 +218,9 @@ RSpec.describe ModelAudit, type: :model do
         expect(described_class.send(:model_without_varieties, "lady sm cargo electric")).to eq ""
         expect(described_class.send(:model_without_varieties, "ladys MD")).to eq ""
         expect(described_class.send(:model_without_varieties, "ladys MeDium\t")).to eq ""
-        expect(described_class.send(:model_without_varieties, "male lag")).to eq "lag"
+        expect(described_class.send(:model_without_varieties, "male lag longtail")).to eq "lag"
+        expect(described_class.send(:model_without_varieties, "male fat tire")).to eq ""
+        expect(described_class.send(:model_without_varieties, "black xl mountain bike")).to eq "bike"
 
         expect(described_class.send(:model_without_varieties, "folding large cargo electricdd")).to eq "dd"
         expect(described_class.send(:model_without_varieties, "utility xxl cargo electric X.X_2")).to eq "x-x-2"

--- a/spec/models/model_audit_spec.rb
+++ b/spec/models/model_audit_spec.rb
@@ -217,29 +217,29 @@ RSpec.describe ModelAudit, type: :model do
         expect(described_class.send(:model_without_varieties, "mens electric CARGO")).to eq ""
         expect(described_class.send(:model_without_varieties, "lady sm cargo electric")).to eq ""
         expect(described_class.send(:model_without_varieties, "ladys MD")).to eq ""
-        expect(described_class.send(:model_without_varieties, "ladys MeDium\t")).to eq ""
+        expect(described_class.send(:model_without_varieties, "ladys MeDium\t road bike")).to eq "bike"
         expect(described_class.send(:model_without_varieties, "male lag longtail")).to eq "lag"
         expect(described_class.send(:model_without_varieties, "male fat tire")).to eq ""
-        expect(described_class.send(:model_bare_vehicle_type?, " Women's lg frame")).to be_truthy
+        expect(described_class.send(:model_bare_vehicle_type?, " Women's lg frame step in")).to be_truthy
 
         expect(described_class.send(:model_without_varieties, "folding large cargo electricdd")).to eq "dd"
         expect(described_class.send(:model_without_varieties, "utility xxl cargo electric X.X_2")).to eq "x-x-2"
 
-        expect(described_class.send(:model_bare_vehicle_type?, "city bike")).to be_truthy
+        expect(described_class.send(:model_bare_vehicle_type?, "high.step city bike")).to be_truthy
         expect(described_class.send(:model_bare_vehicle_type?, "commuter trike")).to be_truthy
-        expect(described_class.send(:model_bare_vehicle_type?, "folding bike")).to be_truthy
-        expect(described_class.send(:model_bare_vehicle_type?, "cruiser mtb")).to be_truthy
-        expect(described_class.send(:model_bare_vehicle_type?, "Mountain-bicycle")).to be_truthy
-        expect(described_class.send(:model_bare_vehicle_type?, "hybrid electric-bike")).to be_truthy
+        expect(described_class.send(:model_bare_vehicle_type?, "traditional folding bike")).to be_truthy
+        expect(described_class.send(:model_bare_vehicle_type?, "mtb (yellow)")).to be_truthy
+        expect(described_class.send(:model_bare_vehicle_type?, "Aluminum Mountain-bicycle")).to be_truthy
+        expect(described_class.send(:model_bare_vehicle_type?, "hybrid electric-cruiser bike")).to be_truthy
         expect(described_class.send(:model_bare_vehicle_type?, "electric-step-through")).to be_truthy
-        expect(described_class.send(:model_bare_vehicle_type?, "xs mtb ")).to be_truthy
+        expect(described_class.send(:model_bare_vehicle_type?, "xs mtb 3_wheeler")).to be_truthy
         expect(described_class.send(:model_bare_vehicle_type?, "bmx\tbike")).to be_truthy
         expect(described_class.send(:model_bare_vehicle_type?, "electric-utility-trike")).to be_truthy
         expect(described_class.send(:model_bare_vehicle_type?, "silver  Men's bike")).to be_truthy
         expect(described_class.send(:model_bare_vehicle_type?, "\ngreen ladies unicycle")).to be_truthy
         expect(described_class.send(:model_bare_vehicle_type?, " stepthru folding bike frame\n")).to be_truthy
         expect(described_class.send(:model_bare_vehicle_type?, " ladies step through regular frame\n")).to be_truthy
-        expect(described_class.send(:model_bare_vehicle_type?, " ladies step-thru foldable frame\n")).to be_truthy
+        expect(described_class.send(:model_bare_vehicle_type?, " ladies step-thru foldable\ntrike ")).to be_truthy
         expect(described_class.send(:model_bare_vehicle_type?, " XP Step-Thru 3.0\n")).to be_falsey
 
         expect(described_class.send(:model_bare_vehicle_type?, " Full Suspension e-bike\n")).to be_truthy

--- a/spec/models/model_audit_spec.rb
+++ b/spec/models/model_audit_spec.rb
@@ -174,4 +174,38 @@ RSpec.describe ModelAudit, type: :model do
       end
     end
   end
+
+  describe "unknown_model" do
+    it "is false" do
+      expect(described_class.unknown_model?("bike 200")).to be_falsey
+    end
+    it "matches na" do
+      expect(described_class.unknown_model?("na")).to be_truthy
+      expect(described_class.unknown_model?("N/A")).to be_truthy
+      expect(described_class.unknown_model?("N A")).to be_truthy
+      expect(described_class.unknown_model?("N-A ")).to be_truthy
+    end
+    context "cycle type" do
+      it "is truthy for scooter" do
+        expect(described_class.unknown_model?("Scooter")).to be_truthy
+        expect(described_class.unknown_model?("eScooter")).to be_truthy
+        expect(described_class.unknown_model?("e-Scooter")).to be_truthy
+        expect(described_class.unknown_model?("Scooter ?")).to be_truthy
+        expect(described_class.unknown_model?("e-Scooter ?")).to be_truthy
+      end
+      it "is truthy for bikes" do
+        expect(described_class.unknown_model?("Bike")).to be_truthy
+        expect(described_class.unknown_model?("bicycle")).to be_truthy
+        expect(described_class.unknown_model?("e-bicycle")).to be_truthy
+        expect(described_class.unknown_model?("e-MTB")).to be_truthy
+        expect(described_class.unknown_model?("e-cargobike")).to be_truthy
+        expect(described_class.unknown_model?("trike")).to be_truthy
+      end
+    end
+    context "matching mnfg_name" do
+      it "is truthy" do
+
+      end
+    end
+  end
 end

--- a/spec/models/model_audit_spec.rb
+++ b/spec/models/model_audit_spec.rb
@@ -192,7 +192,7 @@ RSpec.describe ModelAudit, type: :model do
         expect(described_class.send(:model_bare_vehicle_type?, "\nbicycle ")).to be_truthy
         expect(described_class.send(:model_bare_vehicle_type?, "tandem")).to be_truthy
         expect(described_class.send(:model_bare_vehicle_type?, "e-bike ")).to be_truthy
-        expect(described_class.send(:model_bare_vehicle_type?, " electric bicycle ")).to be_truthy
+        expect(described_class.send(:model_bare_vehicle_type?, " electricbicycle ")).to be_truthy
         expect(described_class.send(:model_bare_vehicle_type?, "TRIcycle ")).to be_truthy
         expect(described_class.send(:model_bare_vehicle_type?, "e-trike ")).to be_truthy
         expect(described_class.send(:model_bare_vehicle_type?, "electric cargo trike")).to be_truthy
@@ -200,7 +200,7 @@ RSpec.describe ModelAudit, type: :model do
         expect(described_class.send(:model_bare_vehicle_type?, "cargo")).to be_truthy
         expect(described_class.send(:model_bare_vehicle_type?, "cargod")).to be_falsey
         expect(described_class.send(:model_bare_vehicle_type?, "cargo-tricycle")).to be_truthy
-        expect(described_class.send(:model_bare_vehicle_type?, "tandem")).to be_truthy
+        expect(described_class.send(:model_bare_vehicle_type?, "tandem electric")).to be_truthy
         expect(described_class.send(:model_bare_vehicle_type?, "unicycle")).to be_truthy
         expect(described_class.send(:model_bare_vehicle_type?, "wheelchair")).to be_truthy
         expect(described_class.send(:model_bare_vehicle_type?, "estroller")).to be_truthy
@@ -220,7 +220,7 @@ RSpec.describe ModelAudit, type: :model do
         expect(described_class.send(:model_without_varieties, "male lag")).to eq "lag"
 
         expect(described_class.send(:model_without_varieties, "folding large cargo electricdd")).to eq "dd"
-        expect(described_class.send(:model_without_varieties, "utility cargo electric X.X_2")).to eq "x-x-2"
+        expect(described_class.send(:model_without_varieties, "utility xxl cargo electric X.X_2")).to eq "x-x-2"
 
         expect(described_class.send(:model_bare_vehicle_type?, "Men's")).to be_truthy
         expect(described_class.send(:model_bare_vehicle_type?, " Women's lg frame")).to be_truthy
@@ -231,7 +231,7 @@ RSpec.describe ModelAudit, type: :model do
         expect(described_class.send(:model_bare_vehicle_type?, "Mountain-bicycle")).to be_truthy
         expect(described_class.send(:model_bare_vehicle_type?, "hybrid electric-bike")).to be_truthy
         expect(described_class.send(:model_bare_vehicle_type?, "electric-step-through")).to be_truthy
-        expect(described_class.send(:model_bare_vehicle_type?, "mtb ")).to be_truthy
+        expect(described_class.send(:model_bare_vehicle_type?, "xs mtb ")).to be_truthy
         expect(described_class.send(:model_bare_vehicle_type?, "bmx\tbike")).to be_truthy
         expect(described_class.send(:model_bare_vehicle_type?, "electric-utility-trike")).to be_truthy
         expect(described_class.send(:model_bare_vehicle_type?, " Men's bike")).to be_truthy

--- a/spec/models/model_audit_spec.rb
+++ b/spec/models/model_audit_spec.rb
@@ -193,12 +193,12 @@ RSpec.describe ModelAudit, type: :model do
         expect(described_class.send(:model_bare_vehicle_type?, "tandem")).to be_truthy
         expect(described_class.send(:model_bare_vehicle_type?, "e-bike ")).to be_truthy
         expect(described_class.send(:model_bare_vehicle_type?, "e-fat bike ")).to be_truthy
-        expect(described_class.send(:model_bare_vehicle_type?, " electricbicycle ")).to be_truthy
+        expect(described_class.send(:model_bare_vehicle_type?, " midstep electricbicycle ")).to be_truthy
         expect(described_class.send(:model_bare_vehicle_type?, "TRIcycle ")).to be_truthy
         expect(described_class.send(:model_bare_vehicle_type?, "e-trike ")).to be_truthy
         expect(described_class.send(:model_bare_vehicle_type?, "electric cargo trike")).to be_truthy
         expect(described_class.send(:model_bare_vehicle_type?, "electric cargoite")).to be_falsey
-        expect(described_class.send(:model_bare_vehicle_type?, "cargo")).to be_truthy
+        expect(described_class.send(:model_bare_vehicle_type?, "cargo midtail bike")).to be_truthy
         expect(described_class.send(:model_bare_vehicle_type?, "cargod")).to be_falsey
         expect(described_class.send(:model_bare_vehicle_type?, "cargo-tricycle")).to be_truthy
         expect(described_class.send(:model_bare_vehicle_type?, "tandem electric")).to be_truthy

--- a/spec/models/propulsion_type_spec.rb
+++ b/spec/models/propulsion_type_spec.rb
@@ -83,7 +83,7 @@ RSpec.describe PropulsionType, type: :model do
         expect(PropulsionType.for_vehicle(:stroller, :"pedal-assist")).to eq :throttle
         expect(PropulsionType.for_vehicle(:"personal-mobility", :"pedal-assist")).to eq :throttle
         expect(PropulsionType.for_vehicle(:"e-scooter", :"pedal-assist-and-throttle")).to eq :throttle
-        expect(PropulsionType.for_vehicle(:"e-motorcycle", :"hand-pedal")).to eq :trottle
+        expect(PropulsionType.for_vehicle(:"e-motorcycle", :"hand-pedal")).to eq :throttle
         (CycleType.slugs_sym - CycleType::PEDAL - CycleType::NEVER_MOTORIZED).each do |cycle_type|
           expect(PropulsionType.for_vehicle(cycle_type, :motorized)).to eq :throttle
         end

--- a/spec/models/propulsion_type_spec.rb
+++ b/spec/models/propulsion_type_spec.rb
@@ -83,6 +83,7 @@ RSpec.describe PropulsionType, type: :model do
         expect(PropulsionType.for_vehicle(:stroller, :"pedal-assist")).to eq :throttle
         expect(PropulsionType.for_vehicle(:"personal-mobility", :"pedal-assist")).to eq :throttle
         expect(PropulsionType.for_vehicle(:"e-scooter", :"pedal-assist-and-throttle")).to eq :throttle
+        expect(PropulsionType.for_vehicle(:"e-motorcycle", :"hand-pedal")).to eq :trottle
         (CycleType.slugs_sym - CycleType::PEDAL - CycleType::NEVER_MOTORIZED).each do |cycle_type|
           expect(PropulsionType.for_vehicle(cycle_type, :motorized)).to eq :throttle
         end

--- a/spec/services/autocomplete/loader_spec.rb
+++ b/spec/services/autocomplete/loader_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Autocomplete::Loader do
     let!(:color) { Color.black }
     let!(:manufacturer) { Manufacturer.other }
     it "stores" do
-      expect(CycleType.all.count).to eq 20
+      expect(CycleType.all.count).to eq 21
       expect(Manufacturer.count).to eq 1
       expect(Color.count).to eq 1
       expect(PropulsionType.autocomplete_hashes.count).to eq 1
@@ -26,7 +26,7 @@ RSpec.describe Autocomplete::Loader do
 
     context "passing individual types" do
       it "stores the passed kind" do
-        expect(CycleType.all.count).to eq 20
+        expect(CycleType.all.count).to eq 21
         expect(Manufacturer.count).to eq 1
         expect(Color.count).to eq 1
         subject.clear_redis

--- a/spec/services/autocomplete/loader_spec.rb
+++ b/spec/services/autocomplete/loader_spec.rb
@@ -17,10 +17,10 @@ RSpec.describe Autocomplete::Loader do
       expect(PropulsionType.autocomplete_hashes.count).to eq 1
       subject.clear_redis
       total_count = subject.load_all
-      expect(total_count).to eq 23 * category_count_for_1_item
+      expect(total_count).to eq 24 * category_count_for_1_item
       info = subject.info
       expect(info.keys).to match_array(%i[category_keys cache_keys db0 used_memory used_memory_peak])
-      expect(info[:category_keys]).to eq 3152
+      expect(info[:category_keys]).to eq 3464
       expect(info[:cache_keys]).to eq 0
     end
 
@@ -37,7 +37,7 @@ RSpec.describe Autocomplete::Loader do
         expect(manufacturer_count).to eq category_count_for_1_item
 
         cycle_type_count = subject.load_all(["CycleType"])
-        expect(cycle_type_count).to eq 20 * category_count_for_1_item
+        expect(cycle_type_count).to eq 21 * category_count_for_1_item
       end
     end
   end

--- a/spec/workers/find_or_create_model_audit_worker_spec.rb
+++ b/spec/workers/find_or_create_model_audit_worker_spec.rb
@@ -73,8 +73,8 @@ RSpec.describe FindOrCreateModelAuditWorker, type: :job do
       expect(bike1.model_audit_id).to be_blank
       expect(bike2.model_audit_id).to be_blank
       Sidekiq::Worker.clear_all
+      expect(ModelAudit.matching_bikes_for(bike1).pluck(:id)).to match_array([bike1.id, bike2.id])
       expect {
-        expect(ModelAudit.matching_bikes_for(bike1).pluck(:id)).to match_array([bike1.id, bike2.id])
         instance.perform(bike1.id)
       }.to change(ModelAudit, :count).by 1
       new_model_audit = bike1.reload.model_audit
@@ -85,14 +85,14 @@ RSpec.describe FindOrCreateModelAuditWorker, type: :job do
       expect(UpdateModelAuditWorker.jobs.map { |j| j["args"] }.flatten).to eq([new_model_audit.id])
     end
     context "unknown frame_model" do
-      let(:frame_model1) { "no model" }
+      let(:frame_model1) { "idk" }
       let(:frame_model2) { "unknown" }
       it "creates a model_audit" do
         expect(bike1.model_audit_id).to be_blank
         expect(bike2.model_audit_id).to be_blank
         Sidekiq::Worker.clear_all
+        expect(ModelAudit.matching_bikes_for(bike1).pluck(:id)).to match_array([bike1.id])
         expect {
-          expect(ModelAudit.matching_bikes_for(bike1).pluck(:id)).to match_array([bike1.id])
           instance.perform(bike1.id)
         }.to change(ModelAudit, :count).by 1
         new_model_audit = bike1.reload.model_audit
@@ -103,8 +103,8 @@ RSpec.describe FindOrCreateModelAuditWorker, type: :job do
         expect(UpdateModelAuditWorker.jobs.map { |j| j["args"] }.flatten).to eq([new_model_audit.id])
       end
       context "bike2 is motorized" do
-        xit "matches" do
-          bike2.update(propulsion_type: "pedal-assist")
+        before { bike2.update(propulsion_type: "pedal-assist") }
+        it "matches" do
           Sidekiq::Worker.clear_all
           expect {
             expect(ModelAudit.matching_bikes_for(bike1).pluck(:id)).to match_array([bike1.id, bike2.id])
@@ -115,6 +115,28 @@ RSpec.describe FindOrCreateModelAuditWorker, type: :job do
           # NOTE: this uses the cycle_type of bike2
           expect_attrs_to_match_hash(new_model_audit, basic_target_attributes.merge(frame_model: nil, propulsion_type: "pedal-assist"))
           expect(UpdateModelAuditWorker.jobs.map { |j| j["args"] }.flatten).to eq([new_model_audit.id])
+        end
+        context "frame model is a model_bare_vehicle_type" do
+          let(:frame_model1) { "ladies BIKE" }
+          let(:frame_model2) { "medium Men's folding utility bicycle" }
+          it "creates a model_audit" do
+            expect(ModelAudit.unknown_model?(bike1.frame_model, manufacturer_id: bike1.manufacturer_id)).to be_truthy
+            expect(ModelAudit.unknown_model?(bike2.frame_model, manufacturer_id: bike2.manufacturer_id)).to be_truthy
+            Sidekiq::Worker.clear_all
+            expect(ModelAudit.matching_bikes_for(bike1).pluck(:id)).to eq([bike1.id])
+            expect(ModelAudit.matching_bikes_for(bike2).pluck(:id)).to eq([bike2.id])
+            expect { instance.perform(bike1.id) }.to change(ModelAudit, :count).by 1
+            new_model_audit = bike1.reload.model_audit
+            expect(bike2.reload.model_audit_id).to be_blank # This worker doesn't update other bikes
+            expect_attrs_to_match_hash(new_model_audit, basic_target_attributes.merge(frame_model: nil, cycle_type: "bike"))
+            # Organization model audits are created by UpdateModelAuditWorker
+            expect(new_model_audit.organization_model_audits.count).to eq 0
+            expect(UpdateModelAuditWorker.jobs.map { |j| j["args"] }.flatten).to eq([new_model_audit.id])
+            # Should bikes with unknown models, which are marked e-vehicle be grouped together with non-e-vehicles?
+            # Currently they do, which seems likely to get false positives
+            expect { instance.perform(bike2.id) }.to change(ModelAudit, :count).by 0
+            expect(bike2.reload.model_audit_id).to eq new_model_audit.id
+          end
         end
       end
     end

--- a/spec/workers/find_or_create_model_audit_worker_spec.rb
+++ b/spec/workers/find_or_create_model_audit_worker_spec.rb
@@ -134,6 +134,7 @@ RSpec.describe FindOrCreateModelAuditWorker, type: :job do
             expect(UpdateModelAuditWorker.jobs.map { |j| j["args"] }.flatten).to eq([new_model_audit.id])
             # Should bikes with unknown models, which are marked e-vehicle be grouped together with non-e-vehicles?
             # Currently they do, which seems likely to get false positives
+            # THIS IS A PROBLEM. Someone marks a rockhopper as an e-vehicle, and then all orgs have all their rockhopper in model audits
             expect { instance.perform(bike2.id) }.to change(ModelAudit, :count).by 0
             expect(bike2.reload.model_audit_id).to eq new_model_audit.id
           end

--- a/spec/workers/find_or_create_model_audit_worker_spec.rb
+++ b/spec/workers/find_or_create_model_audit_worker_spec.rb
@@ -103,7 +103,7 @@ RSpec.describe FindOrCreateModelAuditWorker, type: :job do
         expect(UpdateModelAuditWorker.jobs.map { |j| j["args"] }.flatten).to eq([new_model_audit.id])
       end
       context "bike2 is motorized" do
-        it "matches" do
+        xit "matches" do
           bike2.update(propulsion_type: "pedal-assist")
           Sidekiq::Worker.clear_all
           expect {


### PR DESCRIPTION
- [x] Match more unknown strings
- [x] Match when model is some variety of the vehicle type
- [x] Match when model is the manufacturer name
- [x] Add job to reprocess model audits and handle ones that are now `unknown_model`
  - Verify that if there are no longer any matching models, the model audit is deleted

Also - reseed autocomplete hash after shipping