### PR TITLE
Ignore false positives in brakeman security warnings

### DIFF
--- a/.config/brakeman.ignore
+++ b/.config/brakeman.ignore
@@ -1,0 +1,98 @@
+{
+  "ignored_warnings": [
+    {
+      "warning_type": "Command Injection",
+      "warning_code": 14,
+      "fingerprint": "a434fb9e854f608ed5dc1c4e1750bb35561f5fbdbd315e95e6581113638b074a",
+      "check_name": "Execute",
+      "message": "Possible command injection",
+      "file": "app/workers/listicle_image_size_worker.rb",
+      "line": 8,
+      "link": "https://brakemanscanner.org/docs/warning_types/command_injection/",
+      "code": "`identify -format \"%wx%h\" #{Listicle.find(id).image_url}`",
+      "render_path": null,
+      "location": {
+        "type": "method",
+        "class": "ListicleImageSizeWorker",
+        "method": "perform"
+      },
+      "user_input": "Listicle.find(id).image_url",
+      "confidence": "High",
+      "cwe_id": [
+        77
+      ],
+      "note": ""
+    },
+    {
+      "warning_type": "Command Injection",
+      "warning_code": 14,
+      "fingerprint": "b97c32bd1f9691044a8c08a94654b3ed612af82a25060f834a8d121ac2086e0e",
+      "check_name": "Execute",
+      "message": "Possible command injection",
+      "file": "app/uploaders/circular_image_uploader.rb",
+      "line": 42,
+      "link": "https://brakemanscanner.org/docs/warning_types/command_injection/",
+      "code": "system(\"convert #{\"-size #{width}x#{height}\"} xc:transparent #{\"-fill #{img.path}\"} #{\"-draw 'circle #{(width / 2)},#{(height / 2)} #{((width > height) ? ([(width / 2), height]) : ([width, (height / 2)])).join(\",\")}'\"} #{\"+repage #{File.join(cache_dir, \"round_#{File.basename(img.path)}\")}\"}\")",
+      "render_path": null,
+      "location": {
+        "type": "method",
+        "class": "CircularImageUploader",
+        "method": "round_image"
+      },
+      "user_input": "width",
+      "confidence": "Medium",
+      "cwe_id": [
+        77
+      ],
+      "note": ""
+    },
+    {
+      "warning_type": "Command Injection",
+      "warning_code": 14,
+      "fingerprint": "c0f1fcb420f4dd6336fc424ef1bccad4e49fb195b5ed27497995993f4f7afede",
+      "check_name": "Execute",
+      "message": "Possible command injection",
+      "file": "app/models/export.rb",
+      "line": 225,
+      "link": "https://brakemanscanner.org/docs/warning_types/command_injection/",
+      "code": "`wc -l \"#{tmp_file.path}\"`",
+      "render_path": null,
+      "location": {
+        "type": "method",
+        "class": "Export",
+        "method": "tmp_file_rows"
+      },
+      "user_input": "tmp_file.path",
+      "confidence": "Medium",
+      "cwe_id": [
+        77
+      ],
+      "note": ""
+    },
+    {
+      "warning_type": "Command Injection",
+      "warning_code": 14,
+      "fingerprint": "d8da8ee7a70773f264d1ee33b44fd664227586cbd3b7ca689811909da303a313",
+      "check_name": "Execute",
+      "message": "Possible command injection",
+      "file": "app/services/log_searcher/reader.rb",
+      "line": 35,
+      "link": "https://brakemanscanner.org/docs/warning_types/command_injection/",
+      "code": "`#{rgrep_command_str(time, :log_path => log_path)} | wc -l`",
+      "render_path": null,
+      "location": {
+        "type": "method",
+        "class": "LogSearcher::Reader",
+        "method": "rgrep_log_lines_count"
+      },
+      "user_input": "rgrep_command_str(time, :log_path => log_path)",
+      "confidence": "Medium",
+      "cwe_id": [
+        77
+      ],
+      "note": ""
+    }
+  ],
+  "updated": "2024-08-19 15:11:37 -0300",
+  "brakeman_version": "5.4.1"
+}


### PR DESCRIPTION
Brakeman is currently reporting 4 command injection vulnerabilities which we know are false positives. This PR merely adds a `.config/brakeman.ignore` ignoring these 4 warnings