### PR TITLE
Add AASA file for web credential sharing with iOS app for easier auth

### DIFF
--- a/public/.well-known/apple-app-site-association
+++ b/public/.well-known/apple-app-site-association
@@ -1,0 +1,5 @@
+{
+   "webcredentials": {
+      "apps": [ "8ZM5ZL6ABT.org.bikeindex.app" ]
+   },
+}

--- a/public/apple-app-site-association
+++ b/public/apple-app-site-association
@@ -1,5 +1,0 @@
-{
-   "webcredentials": {
-      "apps": [ "8ZM5ZL6ABT.org.bikeindex.app" ]
-   },
-}

--- a/public/apple-app-site-association
+++ b/public/apple-app-site-association
@@ -1,0 +1,5 @@
+{
+   "webcredentials": {
+      "apps": [ "8ZM5ZL6ABT.org.bikeindex.app" ]
+   },
+}


### PR DESCRIPTION
# Description

- AASA = apple-app-site-association file, without extension, of type JSON
- Stored in `public/.well-known` for access in bikeindex.org/.well-known/apple-app-site-association URL

### Resources

- Documentation for webcredentials: https://developer.apple.com/documentation/xcode/supporting-associated-domains

## Requirements

- Requires iOS app to acknowledge associated domains entitlement in PR https://github.com/bikeindex/bike_index_ios/pull/1