### PR TITLE
BIB-67: ActionView::Template::Error:   undefined method `valid_encoding?'

### DIFF
--- a/config/initializers/kramdown.rb
+++ b/config/initializers/kramdown.rb
@@ -1,0 +1,37 @@
+module Kramdown
+
+  module Parser
+    class Base
+      def adapt_source(source)
+        # We added this monkeypatch because we had 2 tests in spec/requests/documentation_request_spec.rb 
+        # failing in Rails 7.1 with the following error:
+        #    ActionView::Template::Error:undefined method `valid_encoding?' 
+        #    for #<ActionView::OutputBuffer:0x000056417815bbb0>
+        #
+        # We believe we need to upgrade grape-swagger, but this would require us to upgrade grape, which 
+        # requires us to upgrade to Ruby 3.0.
+        # We will keep this monkey patch until we can finish the Ruby 3.0 upgrade and the tests pass 
+        # without this patch.
+        # 
+        # See these links for more information:
+        # https://github.com/gettalong/kramdown/blob/0b0a9e072f9a76e59fe2bbafdf343118fb27c3fa/lib/kramdown/parser/base.rb#L91-L92
+        # https://github.com/rails/rails/pull/51023
+        # https://github.com/gettalong/kramdown/pull/807
+
+        
+
+        if source.respond_to?(:to_s)
+          source = source.to_s
+        end
+
+        unless source.valid_encoding?
+          raise "The source text contains invalid characters for the used encoding #{source.encoding}"
+        end
+        source = source.encode('UTF-8')
+        source.gsub!(/\r\n?/, "\n")
+        source.chomp!
+        source << "\n"
+      end
+    end
+  end
+end


### PR DESCRIPTION
This PR fixes the following error:

```
Failure/Error: The Bike Index is open source. You can [view the source code on GitHub](https://github.com/bikeindex/bike_index)&mdash;the API is in [app/controllers/api/v2](https://github.com/bikeindex/bike_index/tree/main/app/controllers/api/v2) and the tests for it are in [spec/api/v2](https://github.com/bikeindex/bike_index/tree/main/spec/api/v2).

ActionView::Template::Error:
  undefined method `valid_encoding?' for #<ActionView::OutputBuffer:0x000055c40084d950>
```

We were getting similar errors in `spec/requests/documentation_request_spec.rb`. 

We investigated this error and it's due to a [change in Rails 7.1 that allows ActionView to render non-strings](https://github.com/rails/rails/pull/51023). We tried to update `grape-swagger` and `grape` for Rails 7.1 support, but we were unable to update either gem without upgrading to Ruby 3.0. In the meantime, we added a monkeypatch to convert the source into a string as per Kramdown documentation. See https://github.com/gettalong/kramdown/pull/807.

This change is backwards-compatible and can be merged in to Rails 7.0.