### PR TITLE
Remove dev's nonfunctional file update checker for api

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -98,28 +98,5 @@ Rails.application.configure do
 
   # Use an evented file watcher to asynchronously detect changes in source code,
   # routes, locales, etc. This feature depends on the listen gem.
-
-  # Make sure we reload the API after every request!
-  @last_api_change = Time.current
-  api_reloader = ActiveSupport::FileUpdateChecker.new(Dir["#{Rails.root}/app/controllers/api/**/**/*.rb"]) { |reloader|
-    times = Dir["#{Rails.root}/app/api/**/*.rb"].map { |f| File.mtime(f) }
-    files = Dir["#{Rails.root}/app/api/**/*.rb"].map { |f| f }
-
-    Rails.logger.debug "! Change detected: reloading following files:"
-    files.each_with_index do |s, i|
-      if times[i] > @last_api_change
-        Rails.logger.debug " - #{s}"
-        load s
-      end
-    end
-
-    Rails.application.reload_routes!
-    Rails.application.routes_reloader.reload!
-    Rails.application.eager_load!
-  }
-
-  ActiveSupport::Reloader.to_prepare do
-    api_reloader.execute_if_updated
-  end
   config.file_watcher = ActiveSupport::EventedFileUpdateChecker
 end


### PR DESCRIPTION
Sorry for the random drive-by PR. I was searching for examples of FileUpdateChecker usage and saw yours and went "hmmmm".

I believe this code to be probably non-functional and definitely slowing down your development experience.

For the code being removed, every time a file in `app/controllers/api/*` is modified, it will:
- Do some logic on `app/api` which is a directory that doesn't exist
- Eager-load the entire application (which likely pauses everything for several seconds)

I say "probably non-functional" because I could imagine the situation where files in `app/controllers/api/*` need to be eager-loaded specifically (rather than lazy/auto loaded)... but I didn't see other logic in your application that would do that _at development boot_. 

So if your application currently has a weird errata like "doesn't work quite right when you first boot the development environment until you touch a file in `app/controllers/api/*` then I guess it's necessary, but could probably be done a little more targetted (lemme know and I could propose a fix for that).

Again, sorry for the drive-by, but seemed like maybe a source of weird/annoying development friction that maybe I could help with ❤️ 