### PR TITLE
Translation methods backward compatibility, part 2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -210,9 +210,9 @@ jobs:
         paths:
           - ~/.cache/bundle
 
-      - run:
-          name: Sync translations (only on main by default)
-          command: bin/check_translations
+      # - run:
+      #     name: Sync translations (only on main by default)
+      #     command: bin/check_translations
 
       - restore_cache:
           name: "Node dependencies: cache restore"

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -5,12 +5,6 @@ module ApplicationHelper
     super([key, locale: I18n.locale], options, &block)
   end
 
-  # TODO: remove after updating to Ruby 3.1 - #2605
-  # translate_with_args( replaced t(
-  def translate_with_args(key, ...)
-    t(key, ...)
-  end
-
   def check_mark
     "&#x2713;".html_safe
   end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -5,6 +5,12 @@ module ApplicationHelper
     super([key, locale: I18n.locale], options, &block)
   end
 
+  # TODO: remove after updating to Ruby 3.1 - #2605
+  # translate_with_args( replaced t(
+  def translate_with_args(key, ...)
+    t(key, ...)
+  end
+
   def check_mark
     "&#x2713;".html_safe
   end

--- a/app/helpers/localization_helper.rb
+++ b/app/helpers/localization_helper.rb
@@ -1,4 +1,10 @@
 module LocalizationHelper
+  # TODO: remove after updating to Ruby 3.1 - #2605
+  # translate_with_args( replaced t(
+  def translate_with_args(key, ...)
+    t(key, ...)
+  end
+
   def theft_alert_plan_title(plan)
     duration = [
       plan.duration_days,

--- a/app/mailers/customer_mailer.rb
+++ b/app/mailers/customer_mailer.rb
@@ -1,4 +1,6 @@
 class CustomerMailer < ApplicationMailer
+  helper LocalizationHelper
+
   default content_type: "multipart/alternative",
     parts_order: ["text/calendar", "text/plain", "text/html", "text/enriched"]
 

--- a/app/mailers/donation_mailer.rb
+++ b/app/mailers/donation_mailer.rb
@@ -1,5 +1,6 @@
 # Does not inheriting from normal base class
 class DonationMailer < ActionMailer::Base
+  helper LocalizationHelper
   layout false
   default content_type: "multipart/alternative",
     parts_order: ["text/calendar", "text/plain", "text/html", "text/enriched"]

--- a/app/mailers/organized_mailer.rb
+++ b/app/mailers/organized_mailer.rb
@@ -1,6 +1,7 @@
 # Every email in here has the potential to be owned by an organization -
 # but they aren't necessarily
 class OrganizedMailer < ApplicationMailer
+  helper LocalizationHelper
   default content_type: "multipart/alternative",
     parts_order: ["text/calendar", "text/plain", "text/html", "text/enriched"]
 
@@ -35,7 +36,7 @@ class OrganizedMailer < ApplicationMailer
     }
     @organization = @ownership.organization
     @vars[:donation_message] = @bike.status_stolen? && !(@organization && !@organization.paid?)
-    subject = translate_with_args("organized_mailer.finished#{finished_registration_type}_registration.subject", default_subject_vars)
+    subject = translation_with_args("organized_mailer.finished#{finished_registration_type}_registration.subject", default_subject_vars)
     tag = __callee__
     tag = "#{tag}_pos" if @ownership.pos? && @ownership.new_registration?
     I18n.with_locale(@user&.preferred_language) do

--- a/config/initializers/translation.rb
+++ b/config/initializers/translation.rb
@@ -15,18 +15,22 @@ TranslationIO.configure do |config|
   # https://github.com/translation/rails#readme
 end
 
-
 #
 # TODO: remove after updating to Ruby 3.1 - #2605
-# added these methods in #2608 to make the update backward compatible
+# added these methods in #2609 to make the update backward compatible
 # (See also spec/i18n_spec.rb)
 #
 # translate_with_args( replaced t(
 def translate_with_args(key, ...)
-  t(key, ...)
+  I18n.t(key, ...)
+end
+
+# i18n_translate_with_args( replaced ti18n_translate_with_args(
+def i18n_translate_with_args(key, ...)
+  translate_with_args(key, ...)
 end
 
 # translation_with_args( replaced translation(
 def translation_with_args(key, ...)
-  t(key, ...)
+  translate_with_args(key, ...)
 end

--- a/config/initializers/translation.rb
+++ b/config/initializers/translation.rb
@@ -18,19 +18,14 @@ end
 #
 # TODO: remove after updating to Ruby 3.1 - #2605
 # added these methods in #2609 to make the update backward compatible
-# (See also spec/i18n_spec.rb)
+# (See also i18n_spec.rb and application_helper.rb)
 #
-# translate_with_args( replaced t(
-def translate_with_args(key, ...)
-  I18n.t(key, ...)
-end
-
-# i18n_translate_with_args( replaced ti18n_translate_with_args(
+# i18n_translate_with_args( replaced I18n.t(
 def i18n_translate_with_args(key, ...)
-  translate_with_args(key, ...)
+  I18n.t(key, ...)
 end
 
 # translation_with_args( replaced translation(
 def translation_with_args(key, ...)
-  translate_with_args(key, ...)
+  I18n.t(key, ...)
 end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -1,13 +1,6 @@
 require "rails_helper"
 
 RSpec.describe ApplicationHelper, type: :helper do
-  describe "translate_with_args" do
-    let(:target) { "User Settings" }
-    it "translates" do
-      expect(translate_with_args(:user_settings, scope: [:controllers, :my_accounts, :edit])).to eq target
-    end
-  end
-
   describe "phone_link and phone_display" do
     it "displays phone with an area code and country code" do
       expect(phone_display("999 999 9999")).to eq("999-999-9999")

--- a/spec/helpers/localization_helper_spec.rb
+++ b/spec/helpers/localization_helper_spec.rb
@@ -1,6 +1,13 @@
 require "rails_helper"
 
 RSpec.describe LocalizationHelper, type: :helper do
+  describe "translate_with_args" do
+    let(:target) { "User Settings" }
+    it "translates" do
+      expect(translate_with_args(:user_settings, scope: [:controllers, :my_accounts, :edit])).to eq target
+    end
+  end
+
   describe "#language_choices" do
     context "in English" do
       it "returns the language choices with english included" do

--- a/spec/i18n_spec.rb
+++ b/spec/i18n_spec.rb
@@ -2,7 +2,7 @@
 
 #
 # TODO: uncomment after updating to Ruby 3.1 - #2605
-# replaced translation methods in #2608 to make upgrade backward compatible
+# replaced translation methods in #2609 to make upgrade backward compatible
 # It broke these specs.
 # (See also config/initializers/translation.rb)
 #


### PR DESCRIPTION
Fixes changes from #2609

These are the updates that will need to be reverted after shipping Ruby 3.1 in #2605