### PR TITLE
Rename User.password_reset_token

### DIFF
--- a/app/controllers/concerns/sessionable.rb
+++ b/app/controllers/concerns/sessionable.rb
@@ -58,7 +58,7 @@ module Sessionable
 
   def update_user_authentication_for_new_password
     @user.generate_auth_token("auth_token") # Doesn't save user
-    @user.update_auth_token("password_reset_token") # saves users
+    @user.update_auth_token("token_for_password_reset") # saves users
     @user.reload
   end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,7 +1,7 @@
 class UsersController < ApplicationController
   include Sessionable
   before_action :skip_if_signed_in, only: %i[new]
-  before_action :find_user_from_password_reset_token!, only: %i[update_password_form_with_reset_token update_password_with_reset_token]
+  before_action :find_user_from_token_for_password_reset!, only: %i[update_password_form_with_reset_token update_password_with_reset_token]
 
   def new
     @user ||= User.new(email: params[:email])
@@ -183,10 +183,10 @@ class UsersController < ApplicationController
     params.require(:user).permit(:password, :password_confirmation)
   end
 
-  def find_user_from_password_reset_token!
+  def find_user_from_token_for_password_reset!
     @token = params[:token]
-    @user = User.find_by_password_reset_token(@token) if @token.present?
-    return true if @user.present? && !@user.auth_token_expired?("password_reset_token")
+    @user = User.find_by_token_for_password_reset(@token) if @token.present?
+    return true if @user.present? && !@user.auth_token_expired?("token_for_password_reset")
     remove_session
     flash[:error] = @user.blank? ? translation_with_args(:does_not_match_token) : translation_with_args(:token_expired)
     redirect_to(request_password_reset_form_users_path) && return

--- a/app/mailers/customer_mailer.rb
+++ b/app/mailers/customer_mailer.rb
@@ -25,7 +25,7 @@ class CustomerMailer < ApplicationMailer
 
   def password_reset_email(user)
     @user = user
-    @url = update_password_form_with_reset_token_users_url(token: @user.password_reset_token)
+    @url = update_password_form_with_reset_token_users_url(token: @user.token_for_password_reset)
 
     I18n.with_locale(@user&.preferred_language) do
       mail(to: @user.email, tag: __callee__)

--- a/app/models/ambassador.rb
+++ b/app/models/ambassador.rb
@@ -33,7 +33,7 @@
 #  partner_data                       :jsonb
 #  password                           :text
 #  password_digest                    :string(255)
-#  password_reset_token               :text
+#  token_for_password_reset           :text
 #  phone                              :string(255)
 #  preferred_language                 :string
 #  show_bikes                         :boolean          default(FALSE), not null

--- a/app/workers/email_reset_password_worker.rb
+++ b/app/workers/email_reset_password_worker.rb
@@ -3,8 +3,8 @@ class EmailResetPasswordWorker < ApplicationWorker
 
   def perform(user_id)
     user = User.find(user_id)
-    unless user.password_reset_token.present?
-      raise StandardError, "User #{user_id} does not have a password_reset_token"
+    unless user.token_for_password_reset.present?
+      raise StandardError, "User #{user_id} does not have a token_for_password_reset"
     end
     CustomerMailer.password_reset_email(user).deliver_now
   end

--- a/config/initializers/filter_parameter_logging.rb
+++ b/config/initializers/filter_parameter_logging.rb
@@ -4,6 +4,6 @@
 # Use this to limit dissemination of sensitive information.
 # See the ActiveSupport::ParameterFilter documentation for supported notations and behaviors.
 Rails.application.config.filter_parameters += [
-  :password, :passw, :email, :secret, :token, :_key, :crypt, :salt, :certificate, :otp, :ssn,
+  :password, :passw, :secret, :token, :_key, :crypt, :salt, :certificate, :otp, :ssn,
   :file
 ]

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -48,7 +48,7 @@ en:
         partner_data: Partner data
         password: Password
         password_digest: Password digest
-        password_reset_token: Password reset token
+        token_for_password_reset: Password reset token
         payments: Payments
         phone: Phone
         preferred_language: Preferred language
@@ -652,7 +652,7 @@ en:
         partner_data: Partner data
         password: Password
         password_digest: Password digest
-        password_reset_token: Password reset token
+        token_for_password_reset: Password reset token
         payments: Payments
         phone: Phone
         preferred_language: Preferred language
@@ -1917,7 +1917,7 @@ en:
     users:
       confirm:
         already_confirmed: Your user account is already confirmed. Please log in.
-      find_user_from_password_reset_token!:
+      find_user_from_token_for_password_reset!:
         does_not_match_token: Doesn't match user's password reset token
         token_expired: Password reset token expired, try resetting password again.
       resend_confirmation_email:

--- a/config/locales/translation.es.yml
+++ b/config/locales/translation.es.yml
@@ -299,7 +299,7 @@ es:
         partner_data:
         password: Contraseña
         password_digest:
-        password_reset_token:
+        token_for_password_reset:
         payments:
         phone:
         preferred_language:
@@ -793,7 +793,7 @@ es:
         partner_data:
         password: Contraseña
         password_digest:
-        password_reset_token:
+        token_for_password_reset:
         payments:
         phone:
         preferred_language:
@@ -2447,7 +2447,7 @@ es:
     users:
       confirm:
         already_confirmed:
-      find_user_from_password_reset_token!:
+      find_user_from_token_for_password_reset!:
         does_not_match_token:
         token_expired:
       resend_confirmation_email:

--- a/config/locales/translation.it.yml
+++ b/config/locales/translation.it.yml
@@ -299,7 +299,7 @@ it:
         partner_data: Dati dei partner
         password: Password
         password_digest: Digest della password
-        password_reset_token: Token per la reimpostazione della password
+        token_for_password_reset: Token per la reimpostazione della password
         payments: Pagamenti
         phone: Telefono
         preferred_language: Lingua preferita
@@ -794,7 +794,7 @@ it:
         partner_data:
         password: Password
         password_digest:
-        password_reset_token:
+        token_for_password_reset:
         payments:
         phone:
         preferred_language:
@@ -2445,7 +2445,7 @@ it:
     users:
       confirm:
         already_confirmed:
-      find_user_from_password_reset_token!:
+      find_user_from_token_for_password_reset!:
         does_not_match_token:
         token_expired:
       resend_confirmation_email:

--- a/config/locales/translation.nb.yml
+++ b/config/locales/translation.nb.yml
@@ -309,7 +309,7 @@ nb:
         partner_data: Partnerdata
         password: Passord
         password_digest: Passordsammendrag
-        password_reset_token: Token for tilbakestilling av passord
+        token_for_password_reset: Token for tilbakestilling av passord
         payments: Betalinger
         phone: Telefon
         preferred_language: Foretrukket Språk
@@ -804,7 +804,7 @@ nb:
         partner_data: Partnerdata
         password: Passord
         password_digest: Passordsammendrag
-        password_reset_token: Token for tilbakestilling av passord
+        token_for_password_reset: Token for tilbakestilling av passord
         payments: Betalinger
         phone: Telefon
         preferred_language: Foretrukket Språk
@@ -2620,7 +2620,7 @@ nb:
       confirm:
         already_confirmed: Brukerkontoen din er allerede bekreftet. Vennligst Logg
           inn.
-      find_user_from_password_reset_token!:
+      find_user_from_token_for_password_reset!:
         does_not_match_token: Tilsvarer ikke brukerens tilbakestillingstoken for passord
         token_expired: Token for tilbakestilling av passord er utløpt. Prøv å tilbakestille
           passordet på nytt.

--- a/config/locales/translation.nl.yml
+++ b/config/locales/translation.nl.yml
@@ -308,7 +308,7 @@ nl:
         partner_data: Partner gegevens
         password: Wachtwoord
         password_digest: Wachtwoord samenvatting
-        password_reset_token: Wachtwoord reset token
+        token_for_password_reset: Wachtwoord reset token
         payments: Betalingen
         phone: Telefoon
         preferred_language: Voorkeurstaal
@@ -783,7 +783,7 @@ nl:
         partner_data: Partner gegevens
         password: Wachtwoord
         password_digest: Wachtwoord samenvatting
-        password_reset_token: Wachtwoord reset token
+        token_for_password_reset: Wachtwoord reset token
         payments: Betalingen
         phone: Telefoon
         preferred_language: Voorkeurstaal
@@ -2291,7 +2291,7 @@ nl:
       resend_confirmation_email:
         please_sign_in: Log in om de bevestiging opnieuw te verzenden
         resending_email: E-mailbevestiging opnieuw verzonden
-      find_user_from_password_reset_token!:
+      find_user_from_token_for_password_reset!:
         does_not_match_token: Komt niet overeen met het wachtwoord-reset-token van
           de gebruiker
         token_expired: Wachtwoord-reset-token is verlopen, probeer het wachtwoord

--- a/db/migrate/20250130185756_rename_user_password_reset_token.rb
+++ b/db/migrate/20250130185756_rename_user_password_reset_token.rb
@@ -1,0 +1,9 @@
+# Rename User.password_reset_token because has_secure_password update in Rails 8
+# Now, it generates password_reset_token on initialize
+# See https://github.com/rails/rails/pull/52483
+# So switch to an unused attribute
+class RenameUserPasswordResetToken < ActiveRecord::Migration[7.2]
+  def change
+    rename_column :users, :password_reset_token, :token_for_password_reset
+  end
+end

--- a/db/migrate/20250130185756_rename_user_password_reset_token.rb
+++ b/db/migrate/20250130185756_rename_user_password_reset_token.rb
@@ -1,7 +1,6 @@
 # Rename User.password_reset_token because has_secure_password update in Rails 8
-# Now, it generates password_reset_token on initialize
 # See https://github.com/rails/rails/pull/52483
-# So switch to an unused attribute
+# And https://github.com/bikeindex/bike_index/pull/2659
 class RenameUserPasswordResetToken < ActiveRecord::Migration[7.2]
   def change
     rename_column :users, :password_reset_token, :token_for_password_reset

--- a/db/primary_replica_structure.sql
+++ b/db/primary_replica_structure.sql
@@ -3441,7 +3441,7 @@ CREATE TABLE public.users (
     password text,
     last_login_at timestamp without time zone,
     superuser boolean DEFAULT false NOT NULL,
-    password_reset_token text,
+    token_for_password_reset text,
     created_at timestamp without time zone NOT NULL,
     updated_at timestamp without time zone NOT NULL,
     password_digest character varying(255),
@@ -6125,10 +6125,10 @@ CREATE INDEX index_users_on_auth_token ON public.users USING btree (auth_token);
 
 
 --
--- Name: index_users_on_password_reset_token; Type: INDEX; Schema: public; Owner: -
+-- Name: index_users_on_token_for_password_reset; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_users_on_password_reset_token ON public.users USING btree (password_reset_token);
+CREATE INDEX index_users_on_token_for_password_reset ON public.users USING btree (token_for_password_reset);
 
 
 --
@@ -6208,6 +6208,7 @@ ALTER TABLE ONLY public.ambassador_task_assignments
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20250130185756'),
 ('20250127224140'),
 ('20250127223414'),
 ('20250125023931'),

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -3441,7 +3441,7 @@ CREATE TABLE public.users (
     password text,
     last_login_at timestamp without time zone,
     superuser boolean DEFAULT false NOT NULL,
-    password_reset_token text,
+    token_for_password_reset text,
     created_at timestamp without time zone NOT NULL,
     updated_at timestamp without time zone NOT NULL,
     password_digest character varying(255),
@@ -6125,10 +6125,10 @@ CREATE INDEX index_users_on_auth_token ON public.users USING btree (auth_token);
 
 
 --
--- Name: index_users_on_password_reset_token; Type: INDEX; Schema: public; Owner: -
+-- Name: index_users_on_token_for_password_reset; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_users_on_password_reset_token ON public.users USING btree (password_reset_token);
+CREATE INDEX index_users_on_token_for_password_reset ON public.users USING btree (token_for_password_reset);
 
 
 --
@@ -6208,6 +6208,7 @@ ALTER TABLE ONLY public.ambassador_task_assignments
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20250130185756'),
 ('20250127224140'),
 ('20250127223414'),
 ('20250125023931'),

--- a/spec/mailers/customer_mailer_spec.rb
+++ b/spec/mailers/customer_mailer_spec.rb
@@ -37,13 +37,13 @@ RSpec.describe CustomerMailer, type: :mailer do
 
   describe "password_reset_email" do
     it "renders email" do
-      user.update_auth_token("password_reset_token")
+      user.update_auth_token("token_for_password_reset")
       mail = CustomerMailer.password_reset_email(user)
       expect(mail.subject).to eq("Instructions to reset your password")
       expect(mail.from).to eq(["contact@bikeindex.org"])
-      expect(mail.body.encoded).to match(user.password_reset_token)
+      expect(mail.body.encoded).to match(user.token_for_password_reset)
       # And just to be sure, test the route a little more
-      expect(mail.body.encoded).to match(/users\/update_password_form_with_reset_token\?token=#{user.password_reset_token}/)
+      expect(mail.body.encoded).to match(/users\/update_password_form_with_reset_token\?token=#{user.token_for_password_reset}/)
       expect(mail.tag).to eq "password_reset_email"
     end
   end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -493,25 +493,26 @@ RSpec.describe User, type: :model do
   end
 
   describe "auth_token_time" do
-    context "password_reset_token" do
-      it "gets long time ago if not there" do
-        user = User.new(password_reset_token: "c7c3b99a319ac09e2b0080a8s89asd89afsd6734n")
-        expect(user.auth_token_time("password_reset_token")).to eq(Time.at(SecurityTokenizer::EARLIEST_TOKEN_TIME))
+    let(:user) { FactoryBot.create(:user) }
+    context "token_for_password_reset" do
+      context "not there" do
+        let(:user) { User.new(token_for_password_reset: "c7c3b99a319ac09e2b0080a8s89asd89afsd6734n") }
+        it "gets long time ago if not there" do
+          expect(user.auth_token_time("token_for_password_reset")).to eq(Time.at(SecurityTokenizer::EARLIEST_TOKEN_TIME))
+        end
       end
       it "gets the time" do
-        user = FactoryBot.create(:user)
-        expect(user.password_reset_token).to be_blank
-        user.update_auth_token("password_reset_token")
+        user.update_auth_token("token_for_password_reset")
         user.reload
-        expect(user.password_reset_token).to be_present
-        expect(user.auth_token_time("password_reset_token")).to be > Time.current - 2.seconds
-        expect(user.auth_token_expired?("password_reset_token")).to be_falsey
+        expect(user.token_for_password_reset).to be_present
+        expect(user.auth_token_time("token_for_password_reset")).to be > Time.current - 2.seconds
+        expect(user.auth_token_expired?("token_for_password_reset")).to be_falsey
       end
       it "input time" do
         user = FactoryBot.create(:user)
-        user.update_auth_token("password_reset_token", (Time.current - 121.minutes).to_i)
-        expect(user.reload.auth_token_time("password_reset_token")).to be < (Time.current - 1.hours)
-        expect(user.auth_token_expired?("password_reset_token")).to be_truthy
+        user.update_auth_token("token_for_password_reset", (Time.current - 121.minutes).to_i)
+        expect(user.reload.auth_token_time("token_for_password_reset")).to be < (Time.current - 1.hours)
+        expect(user.auth_token_expired?("token_for_password_reset")).to be_truthy
       end
     end
 
@@ -539,23 +540,23 @@ RSpec.describe User, type: :model do
   describe "send_password_reset_email" do
     it "enqueues sending the password reset" do
       user = FactoryBot.create(:user)
-      expect(user.password_reset_token).to be_nil
       expect {
         expect(user.send_password_reset_email).to be_truthy
       }.to change(EmailResetPasswordWorker.jobs, :size).by(1)
-      expect(user.reload.password_reset_token).not_to be_nil
+      expect(user.reload.token_for_password_reset).not_to be_nil
     end
 
     it "doesn't send another one immediately" do
       user = FactoryBot.create(:user)
       expect(user.send_password_reset_email).to be_truthy
-      current_token = user.password_reset_token
+      user.reload
+      current_token = user.token_for_password_reset
       expect {
         expect(user.send_password_reset_email).to be_falsey
         expect(user.send_password_reset_email).to be_falsey
       }.to change(EmailResetPasswordWorker.jobs, :size).by(0)
       user.reload
-      expect(user.password_reset_token).to eq current_token
+      expect(user.token_for_password_reset).to eq current_token
     end
   end
 

--- a/spec/requests/users_request_spec.rb
+++ b/spec/requests/users_request_spec.rb
@@ -167,7 +167,7 @@ RSpec.describe UsersController, type: :request do
   describe "send_password_reset_email" do
     let(:user) { FactoryBot.create(:user_confirmed) }
     it "enqueues a password reset email job" do
-      expect(user.password_reset_token).to be_blank
+      expect(user.token_for_password_reset).to be_blank
       ActionMailer::Base.deliveries = []
       Sidekiq::Worker.clear_all
       Sidekiq::Testing.inline! do
@@ -181,7 +181,7 @@ RSpec.describe UsersController, type: :request do
       expect(mail.subject).to eq("Instructions to reset your password")
 
       user.reload
-      expect(user.password_reset_token).to be_present
+      expect(user.token_for_password_reset).to be_present
     end
     context "unknown user" do
       it "redirects back and flash errors if unable to find user" do
@@ -203,7 +203,7 @@ RSpec.describe UsersController, type: :request do
         }.to change(EmailResetPasswordWorker.jobs, :size).by(1)
         expect(EmailResetPasswordWorker).to have_enqueued_sidekiq_job(user.id)
         user.reload
-        expect(user.password_reset_token).to be_present
+        expect(user.token_for_password_reset).to be_present
       end
     end
     context "unconfirmed user" do
@@ -217,14 +217,14 @@ RSpec.describe UsersController, type: :request do
           expect(flash).to be_blank
         }.to change(EmailResetPasswordWorker.jobs, :size).by(1)
         user.reload
-        expect(user.password_reset_token).to be_present
+        expect(user.token_for_password_reset).to be_present
         expect(user.confirmed?).to be_falsey
       end
     end
     context "existing password reset token" do
       it "does not resend if just sent" do
         user.send_password_reset_email
-        og_token = user.password_reset_token
+        og_token = user.token_for_password_reset
         expect {
           post "#{base_url}/send_password_reset_email", params: {email: user.email}
           expect(response.code).to eq("200")
@@ -232,12 +232,12 @@ RSpec.describe UsersController, type: :request do
           expect(flash).to be_present
         }.to_not change(EmailResetPasswordWorker.jobs, :size)
         user.reload
-        expect(user.password_reset_token).to eq og_token
+        expect(user.token_for_password_reset).to eq og_token
       end
       context "older token" do
         it "updates token and sends" do
-          user.update_auth_token("password_reset_token", Time.current - 5.minutes)
-          og_token = user.password_reset_token
+          user.update_auth_token("token_for_password_reset", Time.current - 5.minutes)
+          og_token = user.token_for_password_reset
           expect(og_token).to be_present
           expect {
             post "#{base_url}/send_password_reset_email", params: {email: user.email}
@@ -246,7 +246,7 @@ RSpec.describe UsersController, type: :request do
             expect(flash).to be_blank
           }.to change(EmailResetPasswordWorker.jobs, :size).by(1)
           user.reload
-          expect(user.password_reset_token).to_not eq og_token
+          expect(user.token_for_password_reset).to_not eq og_token
         end
       end
     end
@@ -256,17 +256,17 @@ RSpec.describe UsersController, type: :request do
     let(:user) { FactoryBot.create(:user) }
     it "renders" do
       user.send_password_reset_email
-      og_token = user.password_reset_token
+      og_token = user.token_for_password_reset
       get "#{base_url}/update_password_form_with_reset_token?token=#{og_token}"
       expect(response.code).to eq("200")
       expect(response).to render_template(:update_password_form_with_reset_token)
       expect(flash).to be_blank
       user.reload
-      expect(user.password_reset_token).to eq og_token
+      expect(user.token_for_password_reset).to eq og_token
     end
     context "nil token" do
       it "redirects" do
-        expect(user.password_reset_token).to be_blank # technically, this matches the pasesd token
+        expect(user.token_for_password_reset).to be_blank # technically, this matches the pasesd token
         get "#{base_url}/update_password_form_with_reset_token", params: {token: ""}
         expect(response).to redirect_to request_password_reset_form_users_path
         expect(flash[:error]).to be_present
@@ -281,13 +281,13 @@ RSpec.describe UsersController, type: :request do
     end
     context "auth token expired" do
       it "redirects" do
-        user.update_auth_token("password_reset_token", Time.current - 121.minutes)
-        og_token = user.password_reset_token
-        get "#{base_url}/update_password_form_with_reset_token", params: {token: user.password_reset_token}
+        user.update_auth_token("token_for_password_reset", Time.current - 121.minutes)
+        og_token = user.token_for_password_reset
+        get "#{base_url}/update_password_form_with_reset_token", params: {token: user.token_for_password_reset}
         expect(response).to redirect_to request_password_reset_form_users_path
         expect(flash[:error]).to match "expired"
         user.reload
-        expect(user.password_reset_token).to eq og_token
+        expect(user.token_for_password_reset).to eq og_token
       end
     end
   end
@@ -296,18 +296,18 @@ RSpec.describe UsersController, type: :request do
     let(:user) { FactoryBot.create(:user_confirmed) }
     let(:valid_params) do
       {
-        token: user.password_reset_token,
+        token: user.token_for_password_reset,
         user: {password: "b79xzcvb9xcvbzaxcvvvcvqwerwe7823412/`!", password_confirmation: "b79xzcvb9xcvbzaxcvvvcvqwerwe7823412/`!"}
       }
     end
     it "updates user and signs in" do
       user.send_password_reset_email
       og_auth = user.auth_token
-      og_token = user.password_reset_token
+      og_token = user.token_for_password_reset
       post "#{base_url}/update_password_with_reset_token", params: valid_params
       expect(response).to redirect_to my_account_url
       user.reload
-      expect(user.password_reset_token).to_not eq og_token
+      expect(user.token_for_password_reset).to_not eq og_token
       expect(user.auth_token).to_not eq og_auth
       expect(user.authenticate(valid_params.dig(:user, :password))).to be_truthy
       jar = ActionDispatch::Cookies::CookieJar.build(request, cookies.to_hash)
@@ -319,12 +319,12 @@ RSpec.describe UsersController, type: :request do
         user.send_password_reset_email
         user.reload
         og_auth = user.auth_token
-        og_token = user.password_reset_token
+        og_token = user.token_for_password_reset
         expect(user.confirmed?).to be_falsey
         post "#{base_url}/update_password_with_reset_token", params: valid_params
         expect(response).to redirect_to my_account_url
         user.reload
-        expect(user.password_reset_token).to_not eq og_token
+        expect(user.token_for_password_reset).to_not eq og_token
         expect(user.auth_token).to_not eq og_auth
         expect(user.authenticate(valid_params.dig(:user, :password))).to be_truthy
         jar = ActionDispatch::Cookies::CookieJar.build(request, cookies.to_hash)
@@ -337,7 +337,7 @@ RSpec.describe UsersController, type: :request do
       it "redirects to terms" do
         user.send_password_reset_email
         user.reload
-        og_token = user.password_reset_token
+        og_token = user.token_for_password_reset
         expect(user.confirmed?).to be_truthy
         expect(user.terms_of_service).to be_falsey
         post "#{base_url}/update_password_with_reset_token", params: valid_params
@@ -346,7 +346,7 @@ RSpec.describe UsersController, type: :request do
         get "/my_account"
         expect(response).to redirect_to accept_terms_url
         user.reload
-        expect(user.password_reset_token).to_not eq og_token
+        expect(user.token_for_password_reset).to_not eq og_token
         expect(user.authenticate(valid_params.dig(:user, :password))).to be_truthy
         jar = ActionDispatch::Cookies::CookieJar.build(request, cookies.to_hash)
         expect(jar.signed["auth"]).to eq([user.id, user.auth_token])
@@ -359,12 +359,12 @@ RSpec.describe UsersController, type: :request do
       it "redirects back, doesn't sign in" do
         user.send_password_reset_email
         og_auth = user.auth_token
-        og_token = user.password_reset_token
+        og_token = user.token_for_password_reset
         post "#{base_url}/update_password_with_reset_token", params: invalid_params
         expect(assigns(:page_errors)).to be_present
         expect(response).to render_template(:update_password_form_with_reset_token)
         user.reload
-        expect(user.password_reset_token).to eq og_token
+        expect(user.token_for_password_reset).to eq og_token
         expect(user.auth_token).to eq og_auth
         expect(user.authenticate(valid_params.dig(:user, :password))).to be_falsey
         expect(response.cookies[:auth]).to be_blank
@@ -374,12 +374,12 @@ RSpec.describe UsersController, type: :request do
       let(:invalid_params) { valid_params.merge(user: {password: "validvalidvalid", password_confirmation: "invalidvalidvalid"}) }
       it "redirects back, doesn't sign in" do
         user.send_password_reset_email
-        og_token = user.password_reset_token
+        og_token = user.token_for_password_reset
         post "#{base_url}/update_password_with_reset_token", params: invalid_params
         expect(assigns(:page_errors)).to be_present
         expect(response).to render_template(:update_password_form_with_reset_token)
         user.reload
-        expect(user.password_reset_token).to eq og_token
+        expect(user.token_for_password_reset).to eq og_token
         expect(user.authenticate(valid_params.dig(:user, :password))).to be_falsey
         expect(response.cookies[:auth]).to be_blank
       end
@@ -387,7 +387,7 @@ RSpec.describe UsersController, type: :request do
     context "nil token" do
       it "redirects" do
         user.reload
-        expect(user.password_reset_token).to be_blank
+        expect(user.token_for_password_reset).to be_blank
         post "#{base_url}/update_password_with_reset_token", params: valid_params.merge(token: "")
         expect(response).to redirect_to request_password_reset_form_users_path
         expect(flash[:error]).to be_present
@@ -406,14 +406,14 @@ RSpec.describe UsersController, type: :request do
     end
     context "auth token expired" do
       it "redirects" do
-        user.update_auth_token("password_reset_token", Time.current - 3.hours)
+        user.update_auth_token("token_for_password_reset", Time.current - 3.hours)
         user.reload
-        og_token = user.password_reset_token
+        og_token = user.token_for_password_reset
         post "#{base_url}/update_password_with_reset_token", params: valid_params
         expect(response).to redirect_to request_password_reset_form_users_path
         expect(flash[:error]).to match "expired"
         user.reload
-        expect(user.password_reset_token).to eq og_token
+        expect(user.token_for_password_reset).to eq og_token
         expect(user.authenticate(valid_params.dig(:user, :password))).to be_falsey
         expect(response.cookies[:auth]).to be_blank
       end

--- a/spec/services/credibility_scorer_spec.rb
+++ b/spec/services/credibility_scorer_spec.rb
@@ -185,7 +185,7 @@ RSpec.describe CredibilityScorer do
     context "registered 2 years ago" do
       let(:created_at) { Time.current - 1.day - 2.years }
       let!(:ownership) { FactoryBot.create(:ownership, created_at: created_at, bike: bike) }
-      it "returns long_time_registration" do
+      it "returns long_time_registration", :flaky do
         bike.reload
         expect(subject.creation_age_badge(ownership)).to eq :long_time_registration
         expect(subject.creation_badges(ownership)).to eq([:long_time_registration])

--- a/spec/workers/email_reset_password_worker_spec.rb
+++ b/spec/workers/email_reset_password_worker_spec.rb
@@ -3,22 +3,22 @@ require "rails_helper"
 RSpec.describe EmailResetPasswordWorker, type: :job do
   it "sends a password_reset email" do
     user = FactoryBot.build(:user)
-    user.update_auth_token("password_reset_token")
-    token = user.password_reset_token
+    user.update_auth_token("token_for_password_reset")
+    token = user.token_for_password_reset
     ActionMailer::Base.deliveries = []
     EmailResetPasswordWorker.new.perform(user.id)
     expect(ActionMailer::Base.deliveries.empty?).to be_falsey
     user.reload
-    expect(user.password_reset_token).to eq token
+    expect(user.token_for_password_reset).to eq token
   end
   context "user doesn't have token" do
     it "raises an error" do
       user = FactoryBot.create(:user)
-      expect(user.password_reset_token).to be_blank
+      expect(user.token_for_password_reset).to be_blank
       ActionMailer::Base.deliveries = []
       expect {
         described_class.new.perform(user.id)
-      }.to raise_error(/#{user.id}.*password_reset_token/)
+      }.to raise_error(/#{user.id}.*token_for_password_reset/)
       user.reload
       expect(user.magic_link_token).to be_blank
       expect(ActionMailer::Base.deliveries.empty?).to be_truthy


### PR DESCRIPTION
There is a `has_secure_password` update in Rails 8 - which now generates `password_reset_token` on initialize - see https://github.com/rails/rails/pull/52483

Rather than override that functionality, switch to a different attribute name to make things less surprising.

This rename `User.password_reset_token` to `token_for_password_reset`

(related to the Rails 8 upgrade, #2655)
