### PR TITLE
Remove and rename columns in payment model

### DIFF
--- a/app/controllers/admin/payments_controller.rb
+++ b/app/controllers/admin/payments_controller.rb
@@ -33,7 +33,7 @@ class Admin::PaymentsController < Admin::BaseController
 
   def create
     @payment = Payment.new(permitted_create_parameters)
-    @payment.first_payment_date = @payment.created_at
+    @payment.paid_at = @payment.created_at
     valid_method = Payment.admin_creatable_payment_methods.include?(permitted_create_parameters[:payment_method])
 
     if valid_method && valid_invoice_parameters? && @payment.save

--- a/app/controllers/bikes/theft_alerts_controller.rb
+++ b/app/controllers/bikes/theft_alerts_controller.rb
@@ -54,7 +54,6 @@ class Bikes::TheftAlertsController < Bikes::BaseController
     {
       kind: "theft_alert",
       payment_method: "stripe",
-      stripe_kind: "stripe_session",
       theft_alert: theft_alert,
       amount_cents: theft_alert.amount_cents,
       user_id: current_user.id,

--- a/app/controllers/payments_controller.rb
+++ b/app/controllers/payments_controller.rb
@@ -40,6 +40,6 @@ class PaymentsController < ApplicationController
   def permitted_create_parameters
     params.require(:payment)
       .permit(:kind, :amount_cents, :email, :currency, :referral_source)
-      .merge(user_id: current_user&.id, stripe_kind: "stripe_session")
+      .merge(user_id: current_user&.id)
   end
 end

--- a/app/models/theft_alert.rb
+++ b/app/models/theft_alert.rb
@@ -56,7 +56,7 @@ class TheftAlert < ApplicationRecord
   before_validation :set_calculated_attributes
 
   scope :should_expire, -> { active.where('"theft_alerts"."end_at" <= ?', Time.current) }
-  scope :paid, -> { joins(:payment).where.not(payments: {first_payment_date: nil}) }
+  scope :paid, -> { joins(:payment).where.not(payments: {paid_at: nil}) }
   scope :admin, -> { where(admin: true) }
   scope :paid_or_admin, -> { paid.or(admin) }
   scope :posted, -> { where.not(start_at: nil) }
@@ -180,7 +180,7 @@ class TheftAlert < ApplicationRecord
   end
 
   def paid_at
-    payment&.first_payment_date
+    payment&.paid_at
   end
 
   def address_string

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -75,7 +75,6 @@ class User < ApplicationRecord
   has_many :ambassador_task_assignments
   has_many :ambassador_tasks, through: :ambassador_task_assignments
   has_many :payments
-  has_many :subscriptions, -> { subscription }, class_name: "Payment"
   has_many :notifications
   has_many :memberships
   has_many :sent_memberships, class_name: "Membership", foreign_key: :sender_id

--- a/app/views/admin/payments/_display.html.haml
+++ b/app/views/admin/payments/_display.html.haml
@@ -6,7 +6,7 @@
       %tr
         %td Method
         %td
-          %span.less-strong= payment.payment_method
+          %span.less-strong= payment.stripe_or_check
       %tr
         %td Amount
         %td= payment.amount_formatted
@@ -18,7 +18,7 @@
             - if display_dev_info?
               %small.less-strong.only-dev-visible
                 Kind:
-                %code= payment.stripe_kind
+                %code= payment.payment_method
       %tr
         %td For
         %td

--- a/app/views/admin/payments/_display.html.haml
+++ b/app/views/admin/payments/_display.html.haml
@@ -6,7 +6,7 @@
       %tr
         %td Method
         %td
-          %span.less-strong= payment.stripe_or_check
+          %span.less-strong= payment.payment_method
       %tr
         %td Amount
         %td= payment.amount_formatted
@@ -15,10 +15,6 @@
           %td Stripe ID
           %td
             = link_to payment.stripe_id.truncate(20), "https://dashboard.stripe.com/payments/#{payment.stripe_id}", title: payment.stripe_id
-            - if display_dev_info?
-              %small.less-strong.only-dev-visible
-                Kind:
-                %code= payment.payment_method
       %tr
         %td For
         %td

--- a/app/views/admin/payments/_display.html.haml
+++ b/app/views/admin/payments/_display.html.haml
@@ -38,7 +38,7 @@
         %td
           - if payment.paid?
             %span.convertTime.preciseTime
-              = l payment.first_payment_date, format: :convert_time
+              = l payment.paid_at, format: :convert_time
           - else
             %span.text-danger Incomplete!
       %tr

--- a/app/views/admin/payments/_display_table.html.haml
+++ b/app/views/admin/payments/_display_table.html.haml
@@ -15,10 +15,7 @@
           %td Stripe ID
           %td
             = link_to payment.stripe_id, "https://dashboard.stripe.com/payments/#{payment.stripe_id}"
-            - if display_dev_info?
-              %small.less-strong.only-dev-visible
-                Kind:
-                %code= payment.stripe_kind
+
       %tr
         %td For
         %td

--- a/app/views/admin/payments/_display_table.html.haml
+++ b/app/views/admin/payments/_display_table.html.haml
@@ -38,7 +38,7 @@
         %td
           - if payment.paid?
             %span.convertTime.preciseTime
-              = l payment.first_payment_date, format: :convert_time
+              = l payment.paid_at, format: :convert_time
           - else
             %span.text-danger Incomplete!
       %tr

--- a/app/views/admin/payments/_table.html.haml
+++ b/app/views/admin/payments/_table.html.haml
@@ -11,7 +11,7 @@
         = sortable "created_at", render_sortable: render_sortable
       - unless skip_paid_at
         %th.small
-          = sortable "first_payment_date", "Paid", render_sortable: render_sortable
+          = sortable "paid_at", "Paid", render_sortable: render_sortable
       - unless skip_user
         %th= sortable "user_id", render_sortable: render_sortable
       %th= sortable "referral_source", render_sortable: render_sortable
@@ -36,9 +36,9 @@
               = l payment.created_at, format: :convert_time
           - unless skip_paid_at
             %td
-              - if payment.first_payment_date.present?
+              - if payment.paid_at.present?
                 %small.convertTime
-                  = l payment.first_payment_date, format: :convert_time
+                  = l payment.paid_at, format: :convert_time
           - unless skip_user
             %td
               = render partial: "/shared/admin_user_cell", locals: {email: payment.email, user: payment.user, render_search: render_sortable, cache: true}

--- a/app/views/customer_mailer/invoice_email.html.haml
+++ b/app/views/customer_mailer/invoice_email.html.haml
@@ -4,8 +4,6 @@
 %p
   = t(".html.we_really_appreciate_your_support")
 
-- if @payment.is_recurring
-  %p= t(".html.thanks_for_signing_up")
 %p
   - if @payment.donation?
     = t(".html.donation_will_help", amount: @payment.amount_formatted)

--- a/config/locales/.translation_io
+++ b/config/locales/.translation_io
@@ -1,2 +1,2 @@
 ---
-timestamp: 1738546007
+timestamp: 1738548555

--- a/config/locales/.translation_io
+++ b/config/locales/.translation_io
@@ -1,2 +1,2 @@
 ---
-timestamp: 1738539846
+timestamp: 1738546007

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -501,7 +501,6 @@ en:
       payment:
         amount_cents: Amount cents
         email: Email
-        first_payment_date: First payment date
         invoice: :activerecord.models.invoice
         is_current: Is current
         is_payment: Is payment
@@ -509,6 +508,7 @@ en:
         kind: Kind
         last_payment_date: Last payment date
         organization: :activerecord.models.organization
+        paid_at: First payment date
         theft_alert: :activerecord.models.theft_alert
         user: :activerecord.models.user
       public_image:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -502,11 +502,8 @@ en:
         amount_cents: Amount cents
         email: Email
         invoice: :activerecord.models.invoice
-        is_current: Is current
         is_payment: Is payment
-        is_recurring: Is recurring
         kind: Kind
-        last_payment_date: Last payment date
         organization: :activerecord.models.organization
         paid_at: First payment date
         theft_alert: :activerecord.models.theft_alert

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2006,9 +2006,6 @@ en:
           more bikes.
         payment_received: Your payment of %{amount} has been received.
         thank_you_so_much: Thank you so much!
-        thanks_for_signing_up: >-
-          Thank you for signing up to be a member of Bike Index. We'll send you invoices
-          every month to this email address
         we_really_appreciate_your_support: We really appreciate your support of Bike
           Index!
       subject: Thank you for supporting Bike Index!

--- a/config/locales/translation.es.yml
+++ b/config/locales/translation.es.yml
@@ -664,12 +664,12 @@ es:
       payment:
         amount_cents:
         email: Email
-        first_payment_date:
         is_current:
         is_payment:
         is_recurring:
         kind:
         last_payment_date:
+        paid_at:
       public_image:
         external_image_url:
         image:
@@ -2513,7 +2513,6 @@ es:
         donation_will_help:
         payment_received:
         thank_you_so_much:
-        thanks_for_signing_up:
         we_really_appreciate_your_support:
       subject:
     magic_login_link_email:

--- a/config/locales/translation.es.yml
+++ b/config/locales/translation.es.yml
@@ -664,11 +664,8 @@ es:
       payment:
         amount_cents:
         email: Email
-        is_current:
         is_payment:
-        is_recurring:
         kind:
-        last_payment_date:
         paid_at:
       public_image:
         external_image_url:

--- a/config/locales/translation.it.yml
+++ b/config/locales/translation.it.yml
@@ -668,12 +668,12 @@ it:
       payment:
         amount_cents: Importo in centesimi
         email: Email
-        first_payment_date: Prima data di pagamento
         is_current: È attuale
         is_payment: È pagamento
         is_recurring: È ricorrente
         kind: Tipo
         last_payment_date: Data dell'ultimo pagamento
+        paid_at: Prima data di pagamento
       public_image:
         external_image_url: URL dell'immagine esterna
         image: Immagine
@@ -2530,7 +2530,6 @@ it:
         donation_will_help:
         payment_received:
         thank_you_so_much:
-        thanks_for_signing_up:
         we_really_appreciate_your_support:
       subject:
     magic_login_link_email:

--- a/config/locales/translation.it.yml
+++ b/config/locales/translation.it.yml
@@ -668,11 +668,8 @@ it:
       payment:
         amount_cents: Importo in centesimi
         email: Email
-        is_current: È attuale
         is_payment: È pagamento
-        is_recurring: È ricorrente
         kind: Tipo
-        last_payment_date: Data dell'ultimo pagamento
         paid_at: Prima data di pagamento
       public_image:
         external_image_url: URL dell'immagine esterna

--- a/config/locales/translation.nb.yml
+++ b/config/locales/translation.nb.yml
@@ -675,12 +675,12 @@ nb:
       payment:
         amount_cents: Beløp cent
         email: E-post
-        first_payment_date: Første betalingsdato
         is_current: Er aktuell
         is_payment: Er betaling
         is_recurring: Er tilbakevendende
         kind: Snill
         last_payment_date: Siste betalingsdato
+        paid_at: Første betalingsdato
       public_image:
         external_image_url: Ekstern bildenettadresse
         image: Bilde
@@ -2699,8 +2699,6 @@ nb:
           å redde flere sykler.
         payment_received: Din betaling på %{amount} er mottatt.
         thank_you_so_much: Tusen takk!
-        thanks_for_signing_up: Takk for at du registrerte deg som medlem av Bike Index.
-          Vi sender deg fakturaer hver måned til denne e-postadressen
         we_really_appreciate_your_support: Vi setter stor pris på din støtte til Bike
           Index!
       subject: Takk for at du støtter Bike Index!

--- a/config/locales/translation.nb.yml
+++ b/config/locales/translation.nb.yml
@@ -675,11 +675,8 @@ nb:
       payment:
         amount_cents: Beløp cent
         email: E-post
-        is_current: Er aktuell
         is_payment: Er betaling
-        is_recurring: Er tilbakevendende
         kind: Snill
-        last_payment_date: Siste betalingsdato
         paid_at: Første betalingsdato
       public_image:
         external_image_url: Ekstern bildenettadresse

--- a/config/locales/translation.nl.yml
+++ b/config/locales/translation.nl.yml
@@ -654,12 +654,12 @@ nl:
       payment:
         amount_cents: Bedrag centen
         email: E-mailadres
-        first_payment_date: Eerste betalingsdatum
         is_current: Is momenteel
         is_payment: Is betaling
         is_recurring: Komt terug
         kind: Soort
         last_payment_date: Laatste betalingsdatum
+        paid_at: Eerste betalingsdatum
       public_image:
         external_image_url: Externe afbeeldings-URL
         image: afbeelding
@@ -2483,8 +2483,6 @@ nl:
           te redden.
         payment_received: Uw betaling van %{amount} is ontvangen.
         thank_you_so_much: Heel erg bedankt!
-        thanks_for_signing_up: Bedankt voor het aanmelden als lid van Bike Index.
-          We sturen u elke maand facturen naar dit e-mailadres
         we_really_appreciate_your_support: We stellen uw steun aan Bike Index zeer
           op prijs!
       subject: Bedankt voor het ondersteunen van Bike Index!

--- a/config/locales/translation.nl.yml
+++ b/config/locales/translation.nl.yml
@@ -654,11 +654,8 @@ nl:
       payment:
         amount_cents: Bedrag centen
         email: E-mailadres
-        is_current: Is momenteel
         is_payment: Is betaling
-        is_recurring: Komt terug
         kind: Soort
-        last_payment_date: Laatste betalingsdatum
         paid_at: Eerste betalingsdatum
       public_image:
         external_image_url: Externe afbeeldings-URL

--- a/db/migrate/20250203011709_drop_deprecated_payment_columns.rb
+++ b/db/migrate/20250203011709_drop_deprecated_payment_columns.rb
@@ -2,6 +2,7 @@ class DropDeprecatedPaymentColumns < ActiveRecord::Migration[8.0]
   def change
     remove_column :payments, :is_current, :boolean, default: true
     remove_column :payments, :is_recurring, :boolean, default: false
+    remove_column :payments, :stripe_kind, :integer
     remove_column :payments, :last_payment_date, :datetime
     rename_column :payments, :first_payment_date, :paid_at
   end

--- a/db/migrate/20250203011709_drop_deprecated_payment_columns.rb
+++ b/db/migrate/20250203011709_drop_deprecated_payment_columns.rb
@@ -1,0 +1,8 @@
+class DropDeprecatedPaymentColumns < ActiveRecord::Migration[8.0]
+  def change
+    remove_column :payments, :is_current, :boolean, default: true
+    remove_column :payments, :is_recurring, :boolean, default: false
+    remove_column :payments, :last_payment_date, :datetime
+    rename_column :payments, :first_payment_date, :paid_at
+  end
+end

--- a/db/primary_replica_structure.sql
+++ b/db/primary_replica_structure.sql
@@ -2652,11 +2652,8 @@ ALTER SEQUENCE public.parking_notifications_id_seq OWNED BY public.parking_notif
 CREATE TABLE public.payments (
     id integer NOT NULL,
     user_id integer,
-    is_current boolean DEFAULT true,
-    is_recurring boolean DEFAULT false NOT NULL,
     stripe_id character varying(255),
-    last_payment_date timestamp without time zone,
-    first_payment_date timestamp without time zone,
+    paid_at timestamp without time zone,
     amount_cents integer,
     created_at timestamp without time zone NOT NULL,
     updated_at timestamp without time zone NOT NULL,
@@ -6209,6 +6206,7 @@ ALTER TABLE ONLY public.ambassador_task_assignments
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20250203011709'),
 ('20250130185756'),
 ('20250127224140'),
 ('20250127223414'),

--- a/db/primary_replica_structure.sql
+++ b/db/primary_replica_structure.sql
@@ -2663,7 +2663,6 @@ CREATE TABLE public.payments (
     invoice_id integer,
     currency character varying DEFAULT 'USD'::character varying NOT NULL,
     kind integer,
-    stripe_kind integer,
     referral_source text
 );
 

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -2652,11 +2652,8 @@ ALTER SEQUENCE public.parking_notifications_id_seq OWNED BY public.parking_notif
 CREATE TABLE public.payments (
     id integer NOT NULL,
     user_id integer,
-    is_current boolean DEFAULT true,
-    is_recurring boolean DEFAULT false NOT NULL,
     stripe_id character varying(255),
-    last_payment_date timestamp without time zone,
-    first_payment_date timestamp without time zone,
+    paid_at timestamp without time zone,
     amount_cents integer,
     created_at timestamp without time zone NOT NULL,
     updated_at timestamp without time zone NOT NULL,
@@ -6209,6 +6206,7 @@ ALTER TABLE ONLY public.ambassador_task_assignments
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20250203011709'),
 ('20250130185756'),
 ('20250127224140'),
 ('20250127223414'),

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -2663,7 +2663,6 @@ CREATE TABLE public.payments (
     invoice_id integer,
     currency character varying DEFAULT 'USD'::character varying NOT NULL,
     kind integer,
-    stripe_kind integer,
     referral_source text
 );
 

--- a/spec/factories/payments.rb
+++ b/spec/factories/payments.rb
@@ -3,7 +3,7 @@ FactoryBot.define do
     user { FactoryBot.create(:user) }
     amount_cents { 999 }
     payment_method { "stripe" }
-    first_payment_date { Time.current }
+    paid_at { Time.current }
     factory :payment_check do
       payment_method { "check" }
     end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -704,14 +704,6 @@ RSpec.describe User, type: :model do
     end
   end
 
-  describe "subscriptions" do
-    it "returns the payment if payment is subscription" do
-      user = FactoryBot.create(:user)
-      Payment.create(is_recurring: true, user_id: user)
-      expect(user.subscriptions).to eq(user.payments.where(is_recurring: true))
-    end
-  end
-
   describe "userlink" do
     it "is nil" do
       expect(User.new.userlink).to be_nil

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -108,7 +108,7 @@ if ENV["RETRY_FLAKY"]
 
     config.around(:each) do |ex|
       if ex.metadata[:flaky]
-        ex.run_with_retry retry: 1
+        ex.run_with_retry retry: 2
       else
         ex.run
       end

--- a/spec/requests/admin/payments_request_spec.rb
+++ b/spec/requests/admin/payments_request_spec.rb
@@ -154,7 +154,7 @@ RSpec.describe Admin::PaymentsController, type: :request do
           expect(payment.payment_method).to eq "check"
           expect(payment.created_at).to be_within(1.minute).of create_time
           expect(payment.paid?).to be_truthy
-          expect(payment.first_payment_date).to be_within(1.minute).of create_time
+          expect(payment.paid_at).to be_within(1.minute).of create_time
         end
       end
     end

--- a/spec/requests/bikes/theft_alerts_request_spec.rb
+++ b/spec/requests/bikes/theft_alerts_request_spec.rb
@@ -162,7 +162,7 @@ RSpec.describe Bikes::TheftAlertsController, type: :request, vcr: true, match_re
   describe "show" do
     let(:stripe_id) { "cs_test_a11HYkpTmOUEdKM02Xx8zlX7pqUFhXW1P6CBRVhm09l3BCiFs0MxBs7NIY" }
     let(:theft_alert) { FactoryBot.create(:theft_alert, theft_alert_plan: theft_alert_plan, stolen_record: bike.current_stolen_record) }
-    let(:payment) { Payment.create(stripe_id: stripe_id, user: current_user, payment_method: "stripe_session", amount: nil, kind: "theft_alert", theft_alert: theft_alert) }
+    let(:payment) { Payment.create(stripe_id: stripe_id, user: current_user, payment_method: "stripe", amount: nil, kind: "theft_alert", theft_alert: theft_alert) }
     it "marks as paid" do
       expect(payment.reload.paid?).to be_falsey
       expect(payment.amount_cents).to eq 0

--- a/spec/requests/bikes/theft_alerts_request_spec.rb
+++ b/spec/requests/bikes/theft_alerts_request_spec.rb
@@ -101,7 +101,6 @@ RSpec.describe Bikes::TheftAlertsController, type: :request, vcr: true, match_re
       expect(payment.currency).to eq "USD"
       expect(payment.amount_cents).to eq theft_alert_plan.amount_cents
       expect(payment.paid_at).to be_blank # Ensure this gets set
-      expect(payment.last_payment_date).to be_blank
       expect(payment.paid?).to be_falsey
     end
 

--- a/spec/requests/bikes/theft_alerts_request_spec.rb
+++ b/spec/requests/bikes/theft_alerts_request_spec.rb
@@ -101,7 +101,7 @@ RSpec.describe Bikes::TheftAlertsController, type: :request, vcr: true, match_re
       expect(payment.stripe_kind).to eq "stripe_session"
       expect(payment.currency).to eq "USD"
       expect(payment.amount_cents).to eq theft_alert_plan.amount_cents
-      expect(payment.first_payment_date).to be_blank # Ensure this gets set
+      expect(payment.paid_at).to be_blank # Ensure this gets set
       expect(payment.last_payment_date).to be_blank
       expect(payment.paid?).to be_falsey
     end

--- a/spec/requests/bikes/theft_alerts_request_spec.rb
+++ b/spec/requests/bikes/theft_alerts_request_spec.rb
@@ -98,7 +98,6 @@ RSpec.describe Bikes::TheftAlertsController, type: :request, vcr: true, match_re
       expect(payment.user_id).to eq current_user.id
       expect(payment.stripe_id).to be_present
       expect(payment.kind).to eq "theft_alert"
-      expect(payment.stripe_kind).to eq "stripe_session"
       expect(payment.currency).to eq "USD"
       expect(payment.amount_cents).to eq theft_alert_plan.amount_cents
       expect(payment.paid_at).to be_blank # Ensure this gets set
@@ -164,7 +163,7 @@ RSpec.describe Bikes::TheftAlertsController, type: :request, vcr: true, match_re
   describe "show" do
     let(:stripe_id) { "cs_test_a11HYkpTmOUEdKM02Xx8zlX7pqUFhXW1P6CBRVhm09l3BCiFs0MxBs7NIY" }
     let(:theft_alert) { FactoryBot.create(:theft_alert, theft_alert_plan: theft_alert_plan, stolen_record: bike.current_stolen_record) }
-    let(:payment) { Payment.create(stripe_id: stripe_id, user: current_user, payment_method: "stripe", amount: nil, kind: "theft_alert", theft_alert: theft_alert) }
+    let(:payment) { Payment.create(stripe_id: stripe_id, user: current_user, payment_method: "stripe_session", amount: nil, kind: "theft_alert", theft_alert: theft_alert) }
     it "marks as paid" do
       expect(payment.reload.paid?).to be_falsey
       expect(payment.amount_cents).to eq 0

--- a/spec/requests/payments_request_spec.rb
+++ b/spec/requests/payments_request_spec.rb
@@ -137,7 +137,6 @@ RSpec.describe PaymentsController, type: :request do
         expect(payment.currency).to eq "USD"
         expect(payment.amount_cents).to eq 4000
         expect(payment.paid_at).to be_blank # Ensure this gets set
-        expect(payment.last_payment_date).to be_blank
         expect(payment.paid?).to be_falsey
         expect(payment.referral_source).to eq "stuffffffff"
 
@@ -202,7 +201,6 @@ RSpec.describe PaymentsController, type: :request do
           expect(payment.currency).to eq "USD"
           expect(payment.amount_cents).to eq 4000
           expect(payment.paid_at).to be_blank # Ensure this gets set
-          expect(payment.last_payment_date).to be_blank
           expect(payment.paid?).to be_falsey
           expect(payment.stripe_customer).to be_blank
         end
@@ -230,7 +228,6 @@ RSpec.describe PaymentsController, type: :request do
             expect(payment.currency).to eq "USD"
             expect(payment.amount_cents).to eq 7500
             expect(payment.paid_at).to be_blank # Ensure this gets set
-            expect(payment.last_payment_date).to be_blank
             expect(payment.paid?).to be_falsey
             expect(payment.stripe_customer).to be_present
             expect(payment.stripe_customer.id).to eq customer_stripe_id

--- a/spec/requests/payments_request_spec.rb
+++ b/spec/requests/payments_request_spec.rb
@@ -134,7 +134,6 @@ RSpec.describe PaymentsController, type: :request do
         expect(payment.user_id).to be_blank
         expect(payment.stripe_id).to be_present
         expect(payment.kind).to eq "payment"
-        expect(payment.stripe_kind).to eq "stripe_session"
         expect(payment.currency).to eq "USD"
         expect(payment.amount_cents).to eq 4000
         expect(payment.paid_at).to be_blank # Ensure this gets set

--- a/spec/requests/payments_request_spec.rb
+++ b/spec/requests/payments_request_spec.rb
@@ -137,7 +137,7 @@ RSpec.describe PaymentsController, type: :request do
         expect(payment.stripe_kind).to eq "stripe_session"
         expect(payment.currency).to eq "USD"
         expect(payment.amount_cents).to eq 4000
-        expect(payment.first_payment_date).to be_blank # Ensure this gets set
+        expect(payment.paid_at).to be_blank # Ensure this gets set
         expect(payment.last_payment_date).to be_blank
         expect(payment.paid?).to be_falsey
         expect(payment.referral_source).to eq "stuffffffff"
@@ -202,7 +202,7 @@ RSpec.describe PaymentsController, type: :request do
           expect(payment.kind).to eq "donation"
           expect(payment.currency).to eq "USD"
           expect(payment.amount_cents).to eq 4000
-          expect(payment.first_payment_date).to be_blank # Ensure this gets set
+          expect(payment.paid_at).to be_blank # Ensure this gets set
           expect(payment.last_payment_date).to be_blank
           expect(payment.paid?).to be_falsey
           expect(payment.stripe_customer).to be_blank
@@ -230,7 +230,7 @@ RSpec.describe PaymentsController, type: :request do
             expect(payment.kind).to eq "donation"
             expect(payment.currency).to eq "USD"
             expect(payment.amount_cents).to eq 7500
-            expect(payment.first_payment_date).to be_blank # Ensure this gets set
+            expect(payment.paid_at).to be_blank # Ensure this gets set
             expect(payment.last_payment_date).to be_blank
             expect(payment.paid?).to be_falsey
             expect(payment.stripe_customer).to be_present


### PR DESCRIPTION
NOTE: the final Stripe charge was created on 2021-08-04 - after which only stripe sessions were created.

There were briefly both Sessions and Charges being created.

I don't know this actually could matter in the future, but this is removing the column that tracks that, so I figure it should be noted.