### PR TITLE
Admin theft alert fixes

### DIFF
--- a/app/controllers/admin/stolen_bikes_controller.rb
+++ b/app/controllers/admin/stolen_bikes_controller.rb
@@ -16,7 +16,7 @@ class Admin::StolenBikesController < Admin::BaseController
         stolen_record_ids.each do |id|
           stolen_record = StolenRecord.unscoped.find(id)
           stolen_record.update_attribute :approved, true
-          ApproveStolenListingJob.perform_async(stolen_record.bike_id)
+          StolenBike::ApproveStolenListingJob.perform_async(stolen_record.bike_id)
         end
         # Lazy pluralize hack
         flash[:success] = "#{stolen_record_ids.count} stolen #{(stolen_record_ids.count == 1) ? "bike" : "bikes"} approved!"
@@ -27,7 +27,7 @@ class Admin::StolenBikesController < Admin::BaseController
     else
       find_bike
       @bike.current_stolen_record.update_attribute :approved, true
-      ApproveStolenListingJob.perform_async(@bike.id)
+      StolenBike::ApproveStolenListingJob.perform_async(@bike.id)
       flash[:success] = "Stolen Bike was approved"
       redirect_to edit_admin_stolen_bike_url(@bike)
     end

--- a/app/controllers/admin/theft_alerts_controller.rb
+++ b/app/controllers/admin/theft_alerts_controller.rb
@@ -108,7 +108,7 @@ class Admin::TheftAlertsController < Admin::BaseController
   end
 
   def available_statuses
-    TheftAlert.statuses + ["posted"]
+    TheftAlert.statuses + %w[posted failed_to_activate]
   end
 
   def available_paid_admin
@@ -136,10 +136,10 @@ class Admin::TheftAlertsController < Admin::BaseController
     theft_alerts = theft_alerts.facebook_updateable if @search_facebook_data
     if available_statuses.include?(params[:search_status])
       @status = params[:search_status]
-      theft_alerts = if @status == "posted"
-        theft_alerts.posted
-      else
+      theft_alerts = if TheftAlert.available_statuses.include?(@status)
         theft_alerts.where(status: @status)
+      else # It must be one of the special statuses - which must be valid to send!
+        theft_alerts.send(@status)
       end
     else
       @status = "all"

--- a/app/controllers/admin/theft_alerts_controller.rb
+++ b/app/controllers/admin/theft_alerts_controller.rb
@@ -23,11 +23,11 @@ class Admin::TheftAlertsController < Admin::BaseController
     if InputNormalizer.boolean(params[:activate_theft_alert])
       new_data = @theft_alert.facebook_data || {}
       @theft_alert.update(facebook_data: new_data.merge(activating_at: Time.current.to_i))
-      ActivateTheftAlertJob.perform_async(@theft_alert.id, true)
+      StolenBike::ActivateTheftAlertJob.perform_async(@theft_alert.id, true)
       flash[:success] = "Activating, please wait"
       redirect_to admin_theft_alert_path(@theft_alert)
     elsif InputNormalizer.boolean(params[:update_theft_alert])
-      UpdateTheftAlertFacebookJob.new.perform(@theft_alert.id)
+      StolenBike::UpdateTheftAlertFacebookJob.new.perform(@theft_alert.id)
       flash[:success] = "Updating Facebook data"
       redirect_to admin_theft_alerts_path
     elsif @theft_alert.update(permitted_update_params)
@@ -64,7 +64,7 @@ class Admin::TheftAlertsController < Admin::BaseController
   def create
     @theft_alert = TheftAlert.new(permitted_create_params)
     if @theft_alert.save
-      ActivateTheftAlertJob.perform_async(@theft_alert.id) if @theft_alert.activateable?
+      StolenBike::ActivateTheftAlertJob.perform_async(@theft_alert.id) if @theft_alert.activateable?
       flash[:success] = "Promoted alert created!"
       redirect_to edit_admin_theft_alert_path(@theft_alert)
     else

--- a/app/controllers/admin/theft_alerts_controller.rb
+++ b/app/controllers/admin/theft_alerts_controller.rb
@@ -112,7 +112,7 @@ class Admin::TheftAlertsController < Admin::BaseController
   end
 
   def available_paid_admin
-    %w[paid admin paid_or_admin]
+    %w[paid_or_admin paid admin unpaid paid_and_unpaid]
   end
 
   def searched_theft_alerts
@@ -124,8 +124,13 @@ class Admin::TheftAlertsController < Admin::BaseController
     else
       TheftAlert
     end
-    @search_paid_admin = available_paid_admin.include?(params[:search_paid_admin]) ? params[:search_paid_admin] : nil
-    theft_alerts = theft_alerts.public_send(@search_paid_admin) if @search_paid_admin.present?
+    @search_paid_admin = if available_paid_admin.include?(params[:search_paid_admin])
+      params[:search_paid_admin]
+    else
+      available_paid_admin.first
+    end
+    # paid_and_unpaid is "all"
+    theft_alerts = theft_alerts.public_send(@search_paid_admin) if @search_paid_admin != "paid_and_unpaid"
 
     @search_facebook_data = InputNormalizer.boolean(params[:search_facebook_data])
     theft_alerts = theft_alerts.facebook_updateable if @search_facebook_data

--- a/app/controllers/admin/theft_alerts_controller.rb
+++ b/app/controllers/admin/theft_alerts_controller.rb
@@ -136,7 +136,7 @@ class Admin::TheftAlertsController < Admin::BaseController
     theft_alerts = theft_alerts.facebook_updateable if @search_facebook_data
     if available_statuses.include?(params[:search_status])
       @status = params[:search_status]
-      theft_alerts = if TheftAlert.available_statuses.include?(@status)
+      theft_alerts = if TheftAlert.statuses.include?(@status)
         theft_alerts.where(status: @status)
       else # It must be one of the special statuses - which must be valid to send!
         theft_alerts.send(@status)

--- a/app/jobs/activate_theft_alert_job.rb
+++ b/app/jobs/activate_theft_alert_job.rb
@@ -14,7 +14,7 @@ class ActivateTheftAlertJob < ApplicationJob
     Facebook::AdsIntegration.new.create_for(theft_alert)
     theft_alert.reload
     # And mark the theft alert active
-    theft_alert.update(start_at: theft_alert.calculated_start_at,
+    theft_alert.update(start_at: theft_alert.start_at_with_fallback,
       end_at: theft_alert.calculated_end_at,
       status: "active")
     # Generally, there is information that didn't get saved when the ad was created, so enqueue update

--- a/app/jobs/after_user_change_job.rb
+++ b/app/jobs/after_user_change_job.rb
@@ -36,7 +36,7 @@ class AfterUserChangeJob < ApplicationJob
     # Activate activateable theft alerts!
     user.theft_alerts.paid.where(start_at: nil).each do |theft_alert|
       next unless theft_alert.activateable?
-      ActivateTheftAlertJob.perform_async(theft_alert.id)
+      StolenBike::ActivateTheftAlertJob.perform_async(theft_alert.id)
     end
 
     process_user_registration_organizations(user)

--- a/app/jobs/scheduled_job_runner.rb
+++ b/app/jobs/scheduled_job_runner.rb
@@ -39,7 +39,7 @@ class ScheduledJobRunner < ScheduledJob
       CreateGraduatedNotificationJob,
       CreateStolenGeojsonJob,
       CreateUserAlertNotificationJob,
-      DeactivateExpiredTheftAlertJob,
+      StolenBike::DeactivateExpiredTheftAlertJob,
       FetchProject529BikesJob,
       FileCacheMaintenanceJob,
       ImpoundExpirationJob,
@@ -58,7 +58,7 @@ class ScheduledJobRunner < ScheduledJob
       UpdateInvoiceJob,
       UpdateManufacturerLogoAndPriorityJob,
       UpdateOrganizationPosKindJob,
-      UpdateTheftAlertFacebookJob,
+      StolenBike::UpdateTheftAlertFacebookJob,
       self
     ].freeze
   end

--- a/app/jobs/scheduled_job_runner.rb
+++ b/app/jobs/scheduled_job_runner.rb
@@ -39,7 +39,6 @@ class ScheduledJobRunner < ScheduledJob
       CreateGraduatedNotificationJob,
       CreateStolenGeojsonJob,
       CreateUserAlertNotificationJob,
-      StolenBike::DeactivateExpiredTheftAlertJob,
       FetchProject529BikesJob,
       FileCacheMaintenanceJob,
       ImpoundExpirationJob,
@@ -51,6 +50,8 @@ class ScheduledJobRunner < ScheduledJob
       ScheduledEmailSurveyJob,
       ScheduledSearchForExternalRegistryBikesJob,
       ScheduledStoreLogSearchesJob,
+      StolenBike::DeactivateExpiredTheftAlertJob,
+      StolenBike::UpdateTheftAlertFacebookJob,
       TsvCreatorJob,
       # UnusedOwnershipRemovalJob,
       UpdateCountsJob,
@@ -58,7 +59,6 @@ class ScheduledJobRunner < ScheduledJob
       UpdateInvoiceJob,
       UpdateManufacturerLogoAndPriorityJob,
       UpdateOrganizationPosKindJob,
-      StolenBike::UpdateTheftAlertFacebookJob,
       self
     ].freeze
   end

--- a/app/jobs/stolen_bike/activate_theft_alert_job.rb
+++ b/app/jobs/stolen_bike/activate_theft_alert_job.rb
@@ -4,14 +4,15 @@ class StolenBike::ActivateTheftAlertJob < ApplicationJob
   def perform(theft_alert_id, force_activate = false)
     theft_alert = TheftAlert.find(theft_alert_id)
     return false unless theft_alert.pending?
-    unless force_activate
-      return false unless theft_alert.activateable?
-    end
+    return false unless theft_alert.activateable? || force_activate
+
     if theft_alert.activating_at.blank?
       new_data = theft_alert.facebook_data || {}
       theft_alert.update(facebook_data: new_data.merge(activating_at: Time.current.to_i))
     end
+
     Facebook::AdsIntegration.new.create_for(theft_alert)
+
     theft_alert.reload
     # And mark the theft alert active
     theft_alert.update(start_at: theft_alert.start_at_with_fallback,

--- a/app/jobs/stolen_bike/activate_theft_alert_job.rb
+++ b/app/jobs/stolen_bike/activate_theft_alert_job.rb
@@ -1,5 +1,5 @@
-class ActivateTheftAlertJob < ApplicationJob
-  sidekiq_options retry: 4 # It will retry because of UpdateTheftAlertFacebookJob
+class StolenBike::ActivateTheftAlertJob < ApplicationJob
+  sidekiq_options retry: 4 # It will retry because of StolenBike::UpdateTheftAlertFacebookJob
 
   def perform(theft_alert_id, force_activate = false)
     theft_alert = TheftAlert.find(theft_alert_id)
@@ -18,6 +18,6 @@ class ActivateTheftAlertJob < ApplicationJob
       end_at: theft_alert.calculated_end_at,
       status: "active")
     # Generally, there is information that didn't get saved when the ad was created, so enqueue update
-    UpdateTheftAlertFacebookJob.perform_in(15.seconds, theft_alert.id)
+    StolenBike::UpdateTheftAlertFacebookJob.perform_in(15.seconds, theft_alert.id)
   end
 end

--- a/app/jobs/stolen_bike/after_stolen_record_save_job.rb
+++ b/app/jobs/stolen_bike/after_stolen_record_save_job.rb
@@ -1,4 +1,4 @@
-class AfterStolenRecordSaveJob < ApplicationJob
+class StolenBike::AfterStolenRecordSaveJob < ApplicationJob
   sidekiq_options retry: false
 
   def perform(stolen_record_id, remove_alert_image = false)

--- a/app/jobs/stolen_bike/approve_stolen_listing_job.rb
+++ b/app/jobs/stolen_bike/approve_stolen_listing_job.rb
@@ -1,4 +1,4 @@
-class ApproveStolenListingJob < ApplicationJob
+class StolenBike::ApproveStolenListingJob < ApplicationJob
   sidekiq_options queue: "notify", retry: 1
 
   TWEETING_DISABLED = ENV["TWITTER_IS_FUCKED"].present?

--- a/app/jobs/stolen_bike/deactivate_expired_theft_alert_job.rb
+++ b/app/jobs/stolen_bike/deactivate_expired_theft_alert_job.rb
@@ -1,4 +1,4 @@
-class DeactivateExpiredTheftAlertJob < ScheduledJob
+class StolenBike::DeactivateExpiredTheftAlertJob < ScheduledJob
   prepend ScheduledJobRecorder
 
   def self.frequency

--- a/app/jobs/stolen_bike/update_theft_alert_facebook_job.rb
+++ b/app/jobs/stolen_bike/update_theft_alert_facebook_job.rb
@@ -1,9 +1,9 @@
 class StolenBike::UpdateTheftAlertFacebookJob < ScheduledJob
   prepend ScheduledJobRecorder
-  sidekiq_options queue: "low_priority", retry: 4 # It will retry because of scheduling
+  sidekiq_options queue: "low_priority", retry: 3 # It will retry because of scheduling
 
   def self.frequency
-    62.minutes
+    34.minutes
   end
 
   def perform(theft_alert_id = nil)
@@ -24,9 +24,14 @@ class StolenBike::UpdateTheftAlertFacebookJob < ScheduledJob
 
   def enqueue_workers
     TheftAlert.should_update_facebook.where(facebook_updated_at: nil).pluck(:id)
-      .each { |i| StolenBike::UpdateTheftAlertFacebookJob.perform_async(i) }
+      .each { |i| self.class.perform_async(i) }
+
     # Try to avoid overrunning our rate limits
-    TheftAlert.should_update_facebook.where.not(facebook_updated_at: nil).order(:facebook_updated_at).limit(10).pluck(:id)
-      .each { |i| StolenBike::UpdateTheftAlertFacebookJob.perform_async(i) }
+    TheftAlert.failed_to_activate.pluck(:id)
+      .each { |i| self.class.perform_in(2.minutes, i) }
+
+    TheftAlert.should_update_facebook.where.not(facebook_updated_at: nil)
+      .order(:facebook_updated_at).limit(20).pluck(:id)
+      .each_with_index { |i, inx| self.class.perform_async(3.minutes + inx.minutes, i) }
   end
 end

--- a/app/jobs/stolen_bike/update_theft_alert_facebook_job.rb
+++ b/app/jobs/stolen_bike/update_theft_alert_facebook_job.rb
@@ -1,4 +1,4 @@
-class UpdateTheftAlertFacebookJob < ScheduledJob
+class StolenBike::UpdateTheftAlertFacebookJob < ScheduledJob
   prepend ScheduledJobRecorder
   sidekiq_options queue: "low_priority", retry: 4 # It will retry because of scheduling
 
@@ -12,7 +12,7 @@ class UpdateTheftAlertFacebookJob < ScheduledJob
     theft_alert = TheftAlert.find(theft_alert_id)
     # If the ad_id is blank, we need to activate the ad
     if theft_alert.facebook_data&.dig("ad_id").blank?
-      return ActivateTheftAlertJob.perform_async(theft_alert_id)
+      return StolenBike::ActivateTheftAlertJob.perform_async(theft_alert_id)
     end
     Facebook::AdsIntegration.new.update_facebook_data(theft_alert)
 
@@ -24,9 +24,9 @@ class UpdateTheftAlertFacebookJob < ScheduledJob
 
   def enqueue_workers
     TheftAlert.should_update_facebook.where(facebook_updated_at: nil).pluck(:id)
-      .each { |i| UpdateTheftAlertFacebookJob.perform_async(i) }
+      .each { |i| StolenBike::UpdateTheftAlertFacebookJob.perform_async(i) }
     # Try to avoid overrunning our rate limits
     TheftAlert.should_update_facebook.where.not(facebook_updated_at: nil).order(:facebook_updated_at).limit(10).pluck(:id)
-      .each { |i| UpdateTheftAlertFacebookJob.perform_async(i) }
+      .each { |i| StolenBike::UpdateTheftAlertFacebookJob.perform_async(i) }
   end
 end

--- a/app/models/stolen_record.rb
+++ b/app/models/stolen_record.rb
@@ -404,7 +404,7 @@ class StolenRecord < ApplicationRecord
     if current || bike&.current_stolen_record_id == id
       bike&.update(manual_csr: true, current_stolen_record: (current ? self : nil))
     end
-    AfterStolenRecordSaveJob.perform_async(id, @alert_location_changed)
+    StolenBike::AfterStolenRecordSaveJob.perform_async(id, @alert_location_changed)
     AfterUserChangeJob.perform_async(bike.user_id) if bike&.user_id.present?
   end
 
@@ -412,7 +412,7 @@ class StolenRecord < ApplicationRecord
 
   # The read replica can't make database changes, but can enqueue the worker - which will make the changes
   def enqueue_worker
-    AfterStolenRecordSaveJob.perform_async(id)
+    StolenBike::AfterStolenRecordSaveJob.perform_async(id)
   end
 
   def notify_of_promoted_alert_recovery

--- a/app/models/theft_alert.rb
+++ b/app/models/theft_alert.rb
@@ -181,6 +181,11 @@ class TheftAlert < ApplicationRecord
   # Simplistic, can be improved
   def failed_to_activate?
     return false unless activating?
+    failed_to_activate_data?
+  end
+
+  # Separate so that we can manually set alerts to be inactive, but still show that they failed to activate
+  def failed_to_activate_data?
     activating_at < Time.current - FAILED_DELAY
   end
 

--- a/app/models/theft_alert.rb
+++ b/app/models/theft_alert.rb
@@ -64,8 +64,10 @@ class TheftAlert < ApplicationRecord
   before_validation :set_calculated_attributes
 
   scope :should_expire, -> { active.where('"theft_alerts"."end_at" <= ?', Time.current) }
-  scope :paid, -> { joins(:payment).where.not(payments: {paid_at: nil}) }
+  scope :paid, -> { joins(:payment).merge(Payment.paid) }
   scope :admin, -> { where(admin: true) }
+  scope :not_admin, -> { where(admin: false) }
+  scope :unpaid, -> { not_admin.joins(:payment).merge(Payment.incomplete) }
   scope :paid_or_admin, -> { paid.or(admin) }
   scope :posted, -> { where.not(start_at: nil) }
   scope :creation_ordered_desc, -> { order(created_at: :desc) }

--- a/app/models/theft_alert.rb
+++ b/app/models/theft_alert.rb
@@ -73,12 +73,6 @@ class TheftAlert < ApplicationRecord
   scope :posted, -> { where.not(start_at: nil) }
   scope :activating, -> { pending.where(start_at: nil).where("(facebook_data -> 'activating_at') IS NOT NULL") }
   scope :failed_to_activate, -> { activating.where("(facebook_data -> 'activating_at')::integer < ?", Time.current.to_i - FAILED_DELAY) }
-
-  # return false unless activating?
-  #   activating_at < Time.current - 5.minutes
-  #   t = facebook_data&.dig("activating_at")
-  #   t.present? ? TimeParser.parse(t) : nil
-
   scope :creation_ordered_desc, -> { order(created_at: :desc) }
   scope :facebook_updateable, -> { where("(facebook_data -> 'campaign_id') IS NOT NULL") }
   scope :should_update_facebook, -> { facebook_updateable.where("theft_alerts.end_at > ?", update_end_buffer) }

--- a/app/models/theft_alert.rb
+++ b/app/models/theft_alert.rb
@@ -41,6 +41,7 @@
 class TheftAlert < ApplicationRecord
   # NOTE: TheftAlert is called "Promoted alert" on the frontend
 
+  FAILED_DELAY = 5.minutes.to_i.freeze
   STATUS_ENUM = {pending: 0, active: 1, inactive: 2}.freeze
   # Timestamp 1s before first alert was automated
   AUTOMATION_START = 1625586988 # 2021-7-6
@@ -70,6 +71,14 @@ class TheftAlert < ApplicationRecord
   scope :unpaid, -> { not_admin.joins(:payment).merge(Payment.incomplete) }
   scope :paid_or_admin, -> { paid.or(admin) }
   scope :posted, -> { where.not(start_at: nil) }
+  scope :activating, -> { pending.where(start_at: nil).where("(facebook_data -> 'activating_at') IS NOT NULL") }
+  scope :failed_to_activate, -> { activating.where("(facebook_data -> 'activating_at')::integer < ?", Time.current.to_i - FAILED_DELAY) }
+
+  # return false unless activating?
+  #   activating_at < Time.current - 5.minutes
+  #   t = facebook_data&.dig("activating_at")
+  #   t.present? ? TimeParser.parse(t) : nil
+
   scope :creation_ordered_desc, -> { order(created_at: :desc) }
   scope :facebook_updateable, -> { where("(facebook_data -> 'campaign_id') IS NOT NULL") }
   scope :should_update_facebook, -> { facebook_updateable.where("theft_alerts.end_at > ?", update_end_buffer) }
@@ -178,7 +187,7 @@ class TheftAlert < ApplicationRecord
   # Simplistic, can be improved
   def failed_to_activate?
     return false unless activating?
-    activating_at < Time.current - 5.minutes
+    activating_at < Time.current - FAILED_DELAY
   end
 
   def recovered?
@@ -264,13 +273,13 @@ class TheftAlert < ApplicationRecord
     "#{stolen_record&.city}: Keep an eye out for this stolen #{bike.mnfg_name}. If you see it, let the owner know on Bike Index!"
   end
 
-  def calculated_start_at
+  def start_at_with_fallback
     start_at.present? ? start_at : Time.current
   end
 
   # Default to 3 days, because something
   def calculated_end_at
-    calculated_start_at + (duration_days_facebook || 3).days
+    start_at_with_fallback + (duration_days_facebook || 3).days
   end
 
   def set_calculated_attributes

--- a/app/views/admin/theft_alerts/edit.html.haml
+++ b/app/views/admin/theft_alerts/edit.html.haml
@@ -12,7 +12,7 @@
       Facebook Activation failed
     %small
       this alert has be marked inactive, but it never ran.
-      %span.less-strong This happened either because something is broken with this alert, or because it was one of the original ~80 that Seth updated when he enabled automated fixing of failed activations on 2024-2-23.
+      %span.less-strong This happened either because something is broken with this alert, or because it was one of the original ~90 that Seth updated when he enabled automated fixing of failed activations on 2024-2-23.
 %h4
   - if @theft_alert.facebook_updateable?
     = link_to "Update Facebook data", admin_theft_alert_path(@theft_alert.id, update_theft_alert: true), method: :patch, action: "update", class: "btn btn-outline-success btn-sm"

--- a/app/views/admin/theft_alerts/edit.html.haml
+++ b/app/views/admin/theft_alerts/edit.html.haml
@@ -6,6 +6,13 @@
     alert status:
     %span{class: theft_alert_status_class(@theft_alert)}
       = @theft_alert.status
+- if @theft_alert.inactive? && @theft_alert.failed_to_activate_data?
+  %p.pt-2.pb-2
+    %span.text-danger
+      Facebook Activation failed
+    %small
+      this alert has be marked inactive, but it never ran.
+      %span.less-strong This happened either because something is broken with this alert, or because it was one of the original ~80 that Seth updated when he enabled automated fixing of failed activations on 2024-2-23.
 %h4
   - if @theft_alert.facebook_updateable?
     = link_to "Update Facebook data", admin_theft_alert_path(@theft_alert.id, update_theft_alert: true), method: :patch, action: "update", class: "btn btn-outline-success btn-sm"

--- a/app/views/admin/theft_alerts/index.html.haml
+++ b/app/views/admin/theft_alerts/index.html.haml
@@ -21,14 +21,11 @@
               = link_to "#{status.humanize} alerts", url_for(sortable_search_params.merge(search_status: status)), class: "dropdown-item #{@status == status ? 'active' : '' }"
         %li.nav-item.dropdown
           %a.nav-link.dropdown-toggle{ href: "#", role: "button", "data-toggle" => "dropdown", "aria-haspopup" => "true", "aria-expanded" => "false", class: (@search_paid_admin.present? ? "active" : "") }
-            - if @search_paid_admin.present?
-              = @search_paid_admin.humanize
-            - else
-              Any paid/admin
+            = @search_paid_admin.humanize
           .dropdown-menu
-            = link_to "Any paid/admin", url_for(sortable_search_params.merge(search_paid_admin: nil)), class: "dropdown-item #{@search_paid_admin == 'all' ? 'active' : '' }"
-            .dropdown-divider
             - available_paid_admin.each do |paid_admin|
+              - if paid_admin == "paid_and_unpaid"
+                .dropdown-divider
               = link_to paid_admin.humanize, url_for(sortable_search_params.merge(search_paid_admin: paid_admin)), class: "dropdown-item #{@search_paid_admin == paid_admin ? 'active' : '' }"
         %li.nav-item
           = link_to "fbook data", url_for(sortable_search_params.merge(search_facebook_data: !@search_facebook_data)), class: "nav-link #{@search_facebook_data ? 'active' : ''}"

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -256,7 +256,7 @@
       "check_name": "Render",
       "message": "Render path contains parameter value",
       "file": "app/views/my_accounts/edit.html.haml",
-      "line": 25,
+      "line": 27,
       "link": "https://brakemanscanner.org/docs/warning_types/dynamic_render_path/",
       "code": "render(partial => (params[:edit_template] or edit_templates.keys.first), { :locals => ({ :f => FormBuilder.new }) })",
       "render_path": [
@@ -313,6 +313,29 @@
       "confidence": "Medium",
       "cwe_id": [
         79
+      ],
+      "note": ""
+    },
+    {
+      "warning_type": "Dangerous Send",
+      "warning_code": 23,
+      "fingerprint": "27893a57cea7b1d22ce67ff0eb87c14ee97190f330ff3c7fbe4c632842b6056c",
+      "check_name": "Send",
+      "message": "User controlled method execution",
+      "file": "app/controllers/admin/theft_alerts_controller.rb",
+      "line": 133,
+      "link": "https://brakemanscanner.org/docs/warning_types/dangerous_send/",
+      "code": "(if InputNormalizer.boolean(params[:search_recovered]) then\n  stolen_record_ids = StolenRecord.recovered.with_theft_alerts.where(:theft_alerts => ({ :created_at => (@time_range) })).pluck(:id)\n  TheftAlert.where(:stolen_record_id => StolenRecord.recovered.with_theft_alerts.where(:theft_alerts => ({ :created_at => (@time_range) })).pluck(:id))\nelse\n  TheftAlert\nend).public_send((params[:search_paid_admin] or available_paid_admin.first))",
+      "render_path": null,
+      "location": {
+        "type": "method",
+        "class": "Admin::TheftAlertsController",
+        "method": "searched_theft_alerts"
+      },
+      "user_input": "params[:search_paid_admin]",
+      "confidence": "High",
+      "cwe_id": [
+        77
       ],
       "note": ""
     },
@@ -443,6 +466,29 @@
       "note": "@sethherr: All these sends are for allowlisted methods (from https://github.com/bikeindex/bike_index/pull/2560)"
     },
     {
+      "warning_type": "Dangerous Send",
+      "warning_code": 23,
+      "fingerprint": "4042ee974c4be89e69767715766963cb9e215f86867d62a579ceaf391602c24e",
+      "check_name": "Send",
+      "message": "User controlled method execution",
+      "file": "app/controllers/admin/theft_alerts_controller.rb",
+      "line": 142,
+      "link": "https://brakemanscanner.org/docs/warning_types/dangerous_send/",
+      "code": "(if InputNormalizer.boolean(params[:search_recovered]) then\n  stolen_record_ids = StolenRecord.recovered.with_theft_alerts.where(:theft_alerts => ({ :created_at => (@time_range) })).pluck(:id)\n  TheftAlert.where(:stolen_record_id => StolenRecord.recovered.with_theft_alerts.where(:theft_alerts => ({ :created_at => (@time_range) })).pluck(:id))\nelse\n  TheftAlert\nend).public_send((params[:search_paid_admin] or available_paid_admin.first)).facebook_updateable.send(params[:search_status])",
+      "render_path": null,
+      "location": {
+        "type": "method",
+        "class": "Admin::TheftAlertsController",
+        "method": "searched_theft_alerts"
+      },
+      "user_input": "params[:search_status]",
+      "confidence": "High",
+      "cwe_id": [
+        77
+      ],
+      "note": ""
+    },
+    {
       "warning_type": "Cross-Site Scripting",
       "warning_code": 2,
       "fingerprint": "41a1fefb45b009c5feb4331dccc7615e5175863357cc0b6750da62e07437e05c",
@@ -530,40 +576,6 @@
       "confidence": "Medium",
       "cwe_id": [
         89
-      ],
-      "note": ""
-    },
-    {
-      "warning_type": "Cross-Site Scripting",
-      "warning_code": 4,
-      "fingerprint": "4b22877587bddcd02107e977eced9d582540249cca162af37c1a2fc4a5c610df",
-      "check_name": "LinkToHref",
-      "message": "Potentially unsafe model attribute in `link_to` href",
-      "file": "app/views/admin/memberships/show.html.haml",
-      "line": 68,
-      "link": "https://brakemanscanner.org/docs/warning_types/link_to_href",
-      "code": "link_to(\"manage on stripe\", Membership.find(params[:id]).stripe_admin_url)",
-      "render_path": [
-        {
-          "type": "controller",
-          "class": "Admin::MembershipsController",
-          "method": "show",
-          "line": 38,
-          "file": "app/controllers/admin/memberships_controller.rb",
-          "rendered": {
-            "name": "admin/memberships/show",
-            "file": "app/views/admin/memberships/show.html.haml"
-          }
-        }
-      ],
-      "location": {
-        "type": "template",
-        "template": "admin/memberships/show"
-      },
-      "user_input": "Membership.find(params[:id]).stripe_admin_url",
-      "confidence": "Weak",
-      "cwe_id": [
-        79
       ],
       "note": ""
     },
@@ -721,29 +733,6 @@
         "method": "matching_organization_statuses"
       },
       "user_input": "params[:search_kind]",
-      "confidence": "High",
-      "cwe_id": [
-        77
-      ],
-      "note": "@sethherr: All these sends are for allowlisted methods (from https://github.com/bikeindex/bike_index/pull/2560)"
-    },
-    {
-      "warning_type": "Dangerous Send",
-      "warning_code": 23,
-      "fingerprint": "93147b3c27356f6e72390dad6da70126a62760f224ca6532210de0fef6bf0222",
-      "check_name": "Send",
-      "message": "User controlled method execution",
-      "file": "app/controllers/admin/theft_alerts_controller.rb",
-      "line": 128,
-      "link": "https://brakemanscanner.org/docs/warning_types/dangerous_send/",
-      "code": "(if InputNormalizer.boolean(params[:search_recovered]) then\n  stolen_record_ids = StolenRecord.recovered.with_theft_alerts.where(:theft_alerts => ({ :created_at => (@time_range) })).pluck(:id)\n  TheftAlert.where(:stolen_record_id => StolenRecord.recovered.with_theft_alerts.where(:theft_alerts => ({ :created_at => (@time_range) })).pluck(:id))\nelse\n  TheftAlert\nend).public_send((params[:search_paid_admin] or nil))",
-      "render_path": null,
-      "location": {
-        "type": "method",
-        "class": "Admin::TheftAlertsController",
-        "method": "searched_theft_alerts"
-      },
-      "user_input": "params[:search_paid_admin]",
       "confidence": "High",
       "cwe_id": [
         77
@@ -934,7 +923,7 @@
       "check_name": "Redirect",
       "message": "Possible unprotected redirect",
       "file": "app/controllers/memberships_controller.rb",
-      "line": 12,
+      "line": 20,
       "link": "https://brakemanscanner.org/docs/warning_types/redirect/",
       "code": "redirect_to(StripeSubscription.create_for(:stripe_price => StripePrice.where(stripe_price_parameters).first, :user => current_user).stripe_checkout_session_url, :allow_other_host => true)",
       "render_path": null,

--- a/spec/jobs/stolen_bike/activate_theft_alert_job_spec.rb
+++ b/spec/jobs/stolen_bike/activate_theft_alert_job_spec.rb
@@ -14,7 +14,7 @@ if !ENV["CI"] && facebook_imported && Facebook::AdsIntegration::TOKEN.present?
       let(:theft_alert_plan) { FactoryBot.create(:theft_alert_plan, amount_cents_facebook: 3999) }
       let(:manufacturer) { FactoryBot.create(:manufacturer, name: "Salsa") }
       let(:bike) { FactoryBot.create(:bike, manufacturer: manufacturer) }
-      let(:stolen_record) { FactoryBot.create(:stolen_record, :with_alert_image, :in_vancouver, bike: bike) }
+      let(:stolen_record) { FactoryBot.create(:stolen_record, :with_alert_image, :in_vancouver, bike: bike, approved: true) }
       let(:theft_alert) { FactoryBot.create(:theft_alert, :paid, theft_alert_plan: theft_alert_plan, stolen_record: stolen_record) }
       before do
         allow_any_instance_of(TheftAlert).to receive(:facebook_name) { "Test Theft Alert (worker)" }
@@ -48,6 +48,27 @@ if !ENV["CI"] && facebook_imported && Facebook::AdsIntegration::TOKEN.present?
       #   end
       #   expect(StolenBike::UpdateTheftAlertFacebookJob.jobs.count).to eq 1
       # end
+
+      describe "failed to activate" do
+        let(:timestamp) { (Time.current - 10.minutes).to_i }
+
+        it "doesn't update the activating_at time" do
+          stolen_record.reload
+          theft_alert.reload.update(facebook_data: {activating_at: timestamp})
+          expect(theft_alert.reload.failed_to_activate?).to be_truthy
+          expect(theft_alert.activateable_except_approval?).to be_truthy
+          expect(theft_alert.activateable?).to be_truthy
+
+          allow_any_instance_of(Facebook::AdsIntegration).to receive(:create_for).and_raise(StandardError)
+
+          expect {
+            instance.perform(theft_alert.id)
+          }.to raise_error(StandardError)
+
+          expect(theft_alert.reload.failed_to_activate?).to be_truthy
+          expect(theft_alert.facebook_data["activating_at"]).to be_within(1).of timestamp
+        end
+      end
     end
   end
 end

--- a/spec/jobs/stolen_bike/activate_theft_alert_job_spec.rb
+++ b/spec/jobs/stolen_bike/activate_theft_alert_job_spec.rb
@@ -7,7 +7,7 @@ rescue
 end
 
 if !ENV["CI"] && facebook_imported && Facebook::AdsIntegration::TOKEN.present?
-  RSpec.describe ActivateTheftAlertJob, type: :job do
+  RSpec.describe StolenBike::ActivateTheftAlertJob, type: :job do
     let(:instance) { described_class.new }
 
     describe "perform" do
@@ -46,7 +46,7 @@ if !ENV["CI"] && facebook_imported && Facebook::AdsIntegration::TOKEN.present?
       #     # Somehow this doesn't show up, in requests after the first request
       #     # expect(theft_alert.facebook_post_url).to be_present
       #   end
-      #   expect(UpdateTheftAlertFacebookJob.jobs.count).to eq 1
+      #   expect(StolenBike::UpdateTheftAlertFacebookJob.jobs.count).to eq 1
       # end
     end
   end

--- a/spec/jobs/stolen_bike/after_stolen_record_save_job_spec.rb
+++ b/spec/jobs/stolen_bike/after_stolen_record_save_job_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
-RSpec.describe AfterStolenRecordSaveJob, type: :job do
-  let(:subject) { AfterStolenRecordSaveJob }
+RSpec.describe StolenBike::AfterStolenRecordSaveJob, type: :job do
+  let(:subject) { StolenBike::AfterStolenRecordSaveJob }
   let(:instance) { subject.new }
   before { Sidekiq::Job.clear_all }
 

--- a/spec/jobs/stolen_bike/approve_stolen_listing_job_spec.rb
+++ b/spec/jobs/stolen_bike/approve_stolen_listing_job_spec.rb
@@ -1,16 +1,16 @@
 require "rails_helper"
 
-RSpec.describe ApproveStolenListingJob, type: :job, vcr: true do
+RSpec.describe StolenBike::ApproveStolenListingJob, type: :job, vcr: true do
   it "enqueues another awesome job" do
     bike = FactoryBot.create(:bike)
-    ApproveStolenListingJob.perform_async(bike.id)
-    expect(ApproveStolenListingJob).to have_enqueued_sidekiq_job(bike.id)
+    StolenBike::ApproveStolenListingJob.perform_async(bike.id)
+    expect(StolenBike::ApproveStolenListingJob).to have_enqueued_sidekiq_job(bike.id)
   end
 
   context "given a bike with no current stolen record" do
     it "raises ArgumentError" do
       bike = FactoryBot.create(:bike)
-      job = -> { ApproveStolenListingJob.new.perform(bike.id) }
+      job = -> { StolenBike::ApproveStolenListingJob.new.perform(bike.id) }
       expect { job.call }.to raise_error(ArgumentError)
     end
   end
@@ -18,7 +18,7 @@ RSpec.describe ApproveStolenListingJob, type: :job, vcr: true do
   context "given no twitter client" do
     it "raises ArgumentError" do
       bike = FactoryBot.create(:stolen_bike)
-      job = -> { ApproveStolenListingJob.new.perform(bike.id) }
+      job = -> { StolenBike::ApproveStolenListingJob.new.perform(bike.id) }
       expect { job.call }.to raise_error(ArgumentError)
     end
   end
@@ -30,13 +30,13 @@ RSpec.describe ApproveStolenListingJob, type: :job, vcr: true do
   #   let!(:bike) { FactoryBot.create(:stolen_bike) }
   #   it "creates twitter stolen bike alert" do
   #     expect {
-  #       ApproveStolenListingJob.new.perform(bike.id)
+  #       StolenBike::ApproveStolenListingJob.new.perform(bike.id)
   #     }.to change(Tweet, :count).by 1
   #   end
   #   it "skips if tweeting disabled" do
-  #     stub_const("ApproveStolenListingJob::TWEETING_DISABLED", true)
+  #     stub_const("StolenBike::ApproveStolenListingJob::TWEETING_DISABLED", true)
   #     expect {
-  #       ApproveStolenListingJob.new.perform(bike.id)
+  #       StolenBike::ApproveStolenListingJob.new.perform(bike.id)
   #     }.to change(Tweet, :count).by 0
   #   end
   # end

--- a/spec/jobs/stolen_bike/deactivate_expired_theft_alert_job_spec.rb
+++ b/spec/jobs/stolen_bike/deactivate_expired_theft_alert_job_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe DeactivateExpiredTheftAlertJob, type: :job do
+RSpec.describe StolenBike::DeactivateExpiredTheftAlertJob, type: :job do
   include_context :scheduled_job
   include_examples :scheduled_job_tests
 

--- a/spec/jobs/stolen_bike/update_theft_alert_facebook_job_spec.rb
+++ b/spec/jobs/stolen_bike/update_theft_alert_facebook_job_spec.rb
@@ -19,13 +19,15 @@ RSpec.describe StolenBike::UpdateTheftAlertFacebookJob, type: :job do
     let(:bike) { FactoryBot.create(:bike, manufacturer: manufacturer) }
     let(:stolen_record) { FactoryBot.create(:stolen_record, :with_alert_image, :in_vancouver, bike: bike, approved: true) }
     let(:facebook_data) { {campaign_id: "222", adset_id: "333", ad_id: "444", activating_at: Time.current.to_i} }
+    let(:start_at) { Time.current - 1.minute }
+    let(:end_at) { Time.current + theft_alert_plan.duration_days_facebook }
     let(:theft_alert) do
       FactoryBot.create(:theft_alert, :paid,
-        theft_alert_plan: theft_alert_plan,
-        stolen_record: stolen_record,
-        facebook_data: facebook_data,
-        start_at: Time.current - 1.minute,
-        end_at: Time.current + theft_alert_plan.duration_days_facebook)
+        theft_alert_plan:,
+        stolen_record:,
+        facebook_data:,
+        start_at:,
+        end_at:)
     end
     before { stub_const("Facebook::AdsIntegration", FakeIntegrationClass) }
 
@@ -99,9 +101,34 @@ RSpec.describe StolenBike::UpdateTheftAlertFacebookJob, type: :job do
       it "enqueues activate theft worker and exits" do
         theft_alert.reload
         expect(theft_alert.status).to eq "pending"
+        expect(theft_alert.should_update_facebook?).to be_falsey
+        # It's isn't enqueued
+        expect {
+          instance.perform
+        }.to change(StolenBike::UpdateTheftAlertFacebookJob.jobs, :count).by 0
+        # But if it's processed, it runs activate
         expect {
           instance.perform(theft_alert.id)
         }.to change(StolenBike::ActivateTheftAlertJob.jobs, :count).by 1
+      end
+      context "failed_to_activate" do
+        let(:start_at) { nil }
+        let(:end_at) { nil }
+        let(:facebook_data) { {activating_at: (Time.current - 6.minutes).to_i} }
+        it "enqueues activate theft worker and exits" do
+          theft_alert.reload
+          expect(theft_alert.failed_to_activate?).to be_truthy
+          expect(theft_alert.should_update_facebook?).to be_falsey
+          expect(TheftAlert.failed_to_activate.pluck(:id)).to eq([theft_alert.id])
+          # It's enqueued
+          expect {
+            instance.perform
+          }.to change(StolenBike::UpdateTheftAlertFacebookJob.jobs, :count).by 1
+          # when processed, it runs activate
+          expect {
+            instance.perform(theft_alert.id)
+          }.to change(StolenBike::ActivateTheftAlertJob.jobs, :count).by 1
+        end
       end
     end
     context "receive_notifications? false" do

--- a/spec/jobs/stolen_bike/update_theft_alert_facebook_job_spec.rb
+++ b/spec/jobs/stolen_bike/update_theft_alert_facebook_job_spec.rb
@@ -8,7 +8,7 @@ class FakeIntegrationClass
   end
 end
 
-RSpec.describe UpdateTheftAlertFacebookJob, type: :job do
+RSpec.describe StolenBike::UpdateTheftAlertFacebookJob, type: :job do
   let(:instance) { described_class.new }
   include_context :scheduled_job
   include_examples :scheduled_job_tests
@@ -101,7 +101,7 @@ RSpec.describe UpdateTheftAlertFacebookJob, type: :job do
         expect(theft_alert.status).to eq "pending"
         expect {
           instance.perform(theft_alert.id)
-        }.to change(ActivateTheftAlertJob.jobs, :count).by 1
+        }.to change(StolenBike::ActivateTheftAlertJob.jobs, :count).by 1
       end
     end
     context "receive_notifications? false" do

--- a/spec/models/bike_spec.rb
+++ b/spec/models/bike_spec.rb
@@ -87,7 +87,7 @@ RSpec.describe Bike, type: :model do
       let!(:stolen_record3) { FactoryBot.create(:stolen_record, phone: "2223334444", secondary_phone: "111222333") }
       let(:bike2) { stolen_record3.bike }
       it "finds by stolen_record" do
-        AfterStolenRecordSaveJob.new.perform(stolen_record2.id)
+        StolenBike::AfterStolenRecordSaveJob.new.perform(stolen_record2.id)
         expect(stolen_record1.reload.current?).to be_falsey
         stolen_record1.update_column :current, true
         bike1.reload

--- a/spec/requests/admin/stolen_bikes_request_spec.rb
+++ b/spec/requests/admin/stolen_bikes_request_spec.rb
@@ -84,8 +84,8 @@ RSpec.describe Admin::StolenBikesController, type: :request do
           expect(AfterUserChangeJob.jobs.count).to eq 1
           AfterUserChangeJob.drain
 
-          expect(ActivateTheftAlertJob.jobs.count).to eq 1
-          expect(ActivateTheftAlertJob.jobs.map { |j| j["args"] }.last.flatten).to eq([theft_alert.id])
+          expect(StolenBike::ActivateTheftAlertJob.jobs.count).to eq 1
+          expect(StolenBike::ActivateTheftAlertJob.jobs.map { |j| j["args"] }.last.flatten).to eq([theft_alert.id])
         end
       end
       context "multi_approve" do

--- a/spec/requests/admin/stolen_bikes_request_spec.rb
+++ b/spec/requests/admin/stolen_bikes_request_spec.rb
@@ -57,8 +57,8 @@ RSpec.describe Admin::StolenBikesController, type: :request do
         expect(stolen_record.approved).to be_truthy
         expect(flash[:success]).to be_present
         expect(response).to redirect_to(:edit_admin_stolen_bike)
-        expect(ApproveStolenListingJob.jobs.count).to eq 1
-        expect(ApproveStolenListingJob.jobs.map { |j| j["args"] }.last.flatten).to eq([bike.id])
+        expect(StolenBike::ApproveStolenListingJob.jobs.count).to eq 1
+        expect(StolenBike::ApproveStolenListingJob.jobs.map { |j| j["args"] }.last.flatten).to eq([bike.id])
       end
       context "with a theft_alert" do
         let!(:alert_image) { FactoryBot.create(:alert_image, :with_image, stolen_record: stolen_record) }
@@ -78,8 +78,8 @@ RSpec.describe Admin::StolenBikesController, type: :request do
           expect(stolen_record.approved).to be_truthy
           expect(flash[:success]).to be_present
           expect(response).to redirect_to(:edit_admin_stolen_bike)
-          expect(ApproveStolenListingJob.jobs.count).to eq 1
-          expect(ApproveStolenListingJob.jobs.map { |j| j["args"] }.last.flatten).to eq([bike.id])
+          expect(StolenBike::ApproveStolenListingJob.jobs.count).to eq 1
+          expect(StolenBike::ApproveStolenListingJob.jobs.map { |j| j["args"] }.last.flatten).to eq([bike.id])
 
           expect(AfterUserChangeJob.jobs.count).to eq 1
           AfterUserChangeJob.drain
@@ -107,8 +107,8 @@ RSpec.describe Admin::StolenBikesController, type: :request do
           # Sanity check!
           expect(stolen_record3.reload.approved).to be_falsey
           expect(flash[:success]).to be_present
-          expect(ApproveStolenListingJob.jobs.count).to eq 2
-          expect(ApproveStolenListingJob.jobs.map { |j| j["args"] }.flatten).to eq([bike.id, stolen_record2.bike_id])
+          expect(StolenBike::ApproveStolenListingJob.jobs.count).to eq 2
+          expect(StolenBike::ApproveStolenListingJob.jobs.map { |j| j["args"] }.flatten).to eq([bike.id, stolen_record2.bike_id])
         end
       end
     end

--- a/spec/requests/admin/theft_alerts_request_spec.rb
+++ b/spec/requests/admin/theft_alerts_request_spec.rb
@@ -92,7 +92,7 @@ RSpec.describe Admin::TheftAlertsController, type: :request do
           expect(theft_alert.activating?).to be_falsey
           Sidekiq::Job.clear_all
           patch "/admin/theft_alerts/#{theft_alert.id}", params: {activate_theft_alert: 1}
-          expect(ActivateTheftAlertJob.jobs.count).to eq 1
+          expect(StolenBike::ActivateTheftAlertJob.jobs.count).to eq 1
           expect(theft_alert.reload.activating_at).to be_present
           expect(theft_alert.activating?).to be_truthy
         end
@@ -102,7 +102,7 @@ RSpec.describe Admin::TheftAlertsController, type: :request do
           expect(theft_alert.reload.activating_at).to be_blank
           Sidekiq::Job.clear_all
           patch "/admin/theft_alerts/#{theft_alert.id}", params: {update_theft_alert: true}
-          # expect(UpdateTheftAlertFacebookJob.jobs.count).to eq 1
+          # expect(StolenBike::UpdateTheftAlertFacebookJob.jobs.count).to eq 1
           expect(theft_alert.reload.activating_at).to be_blank
         end
       end
@@ -148,7 +148,7 @@ RSpec.describe Admin::TheftAlertsController, type: :request do
         expect(theft_alert.notes).to eq "Some notes"
         expect(theft_alert.status).to eq "pending"
         expect(theft_alert.activateable?).to be_truthy
-        expect(ActivateTheftAlertJob.jobs.count).to eq 1
+        expect(StolenBike::ActivateTheftAlertJob.jobs.count).to eq 1
       end
       context "not activateable" do
         let(:stolen_record) { FactoryBot.create(:stolen_record, :with_alert_image, :in_vancouver) }
@@ -178,7 +178,7 @@ RSpec.describe Admin::TheftAlertsController, type: :request do
           expect(theft_alert.status).to eq "pending"
           expect(theft_alert.activateable?).to be_falsey
           expect(theft_alert.activating?).to be_falsey
-          expect(ActivateTheftAlertJob.jobs.count).to eq 0
+          expect(StolenBike::ActivateTheftAlertJob.jobs.count).to eq 0
         end
       end
     end

--- a/spec/requests/bikes/show_request_spec.rb
+++ b/spec/requests/bikes/show_request_spec.rb
@@ -155,11 +155,11 @@ RSpec.describe "BikesController#show", type: :request do
         get "#{base_url}/#{bike.id}"
         expect(assigns(:bike).id).to eq bike.id
         expect(response).to render_template(:show)
-      }.to change(AfterStolenRecordSaveJob.jobs, :count).by 1
+      }.to change(StolenBike::AfterStolenRecordSaveJob.jobs, :count).by 1
       expect(stolen_record.reload.alert_image).to be_blank
       expect {
-        AfterStolenRecordSaveJob.new.perform(stolen_record.id)
-      }.to change(AfterStolenRecordSaveJob.jobs, :count).by 0
+        StolenBike::AfterStolenRecordSaveJob.new.perform(stolen_record.id)
+      }.to change(StolenBike::AfterStolenRecordSaveJob.jobs, :count).by 0
       expect(stolen_record.reload.alert_image).to be_present
       expect(stolen_record.recovery_link_token).to be_present
     end

--- a/spec/requests/organized/bulk_imports_request_spec.rb
+++ b/spec/requests/organized/bulk_imports_request_spec.rb
@@ -207,7 +207,7 @@ RSpec.describe Organized::BulkImportsController, type: :request do
             let(:file) { Rack::Test::UploadedFile.new(File.open(File.join("public", "import_impounded_only_required.csv"))) }
             let!(:color_purple) { FactoryBot.create(:color, name: "Purple") }
             let!(:color_pink) { FactoryBot.create(:color, name: "Pink") }
-            it "imports impounded bikes" do
+            it "imports impounded bikes", :flaky do
               Sidekiq::Job.clear_all
               expect {
                 post base_url, params: {bulk_import: {file: file, kind: "impounded"}}


### PR DESCRIPTION
- Default view shows only paid (and admin activated)
- Create a `jobs/stolen_bike` subfolder and put jobs for stolen bikes in there
- Enable sorting by _failed to activate_
- Automatically retry activating _failed to activate_ alerts