### PR TITLE
Theft alert fixes

### DIFF
--- a/app/jobs/stolen_bike/update_theft_alert_facebook_job.rb
+++ b/app/jobs/stolen_bike/update_theft_alert_facebook_job.rb
@@ -11,7 +11,7 @@ class StolenBike::UpdateTheftAlertFacebookJob < ScheduledJob
 
     theft_alert = TheftAlert.find(theft_alert_id)
     # If the ad_id is blank, we need to activate the ad
-    if theft_alert.facebook_data&.dig("ad_id").blank?
+    if theft_alert.facebook_data&.dig("ad_id").blank? || theft_alert.failed_to_activate?
       return StolenBike::ActivateTheftAlertJob.perform_async(theft_alert_id)
     end
     Facebook::AdsIntegration.new.update_facebook_data(theft_alert)

--- a/app/views/admin/theft_alerts/edit.html.haml
+++ b/app/views/admin/theft_alerts/edit.html.haml
@@ -102,8 +102,9 @@
                 = l @theft_alert.facebook_updated_at, format: :convert_time
               %small.ml-2.less-strong
                 = @theft_alert.live? ? "alert ends" : "alert ended"
-                %span.convertTime
-                  = l @theft_alert.end_at, format: :convert_time
+                - if @theft_alert.end_at.present?
+                  %span.convertTime
+                    = l @theft_alert.end_at, format: :convert_time
         %tr
           %td Notify?
           %td


### PR DESCRIPTION
- Ensure failed to activate alerts actually get re-activated
- Fix a nil bug in admin theft alerts