### PR TITLE
Feat: Add applinks for bikes/scanned/:id to support QR code scans

### DIFF
--- a/public/.well-known/apple-app-site-association
+++ b/public/.well-known/apple-app-site-association
@@ -1,5 +1,25 @@
 {
-   "webcredentials": {
-      "apps": [ "8ZM5ZL6ABT.org.bikeindex.app" ]
+   "applinks": {
+      "details": {
+         "appIDs": [
+            "8ZM5ZL6ABT.org.bikeindex.app"
+         ],
+         "components": [
+            {
+               "/": "*",
+               "exclude": true,
+               "comment": "Defer all to the web (instead of app) for all links except those explicitly listed later"
+            },
+            {
+               "/": "/bikes/scanned/*",
+               "comment": "Example: bikeindex.org/bikes/scanned/A40340, open directly in-app for QR code scanning"
+            }
+         ]
+      }
    },
+   "webcredentials": {
+      "apps": [
+         "8ZM5ZL6ABT.org.bikeindex.app"
+      ]
+   }
 }


### PR DESCRIPTION
# Description

Update app site association to add:
1. Defer to bikeindex.org for all URLs
2. **Except** `/bikes/scanned/:id` URLs _should_ open the app for the app to display.
    - Guests (aka unauthenticated / new users) who have the app should be able to view the bike
    - Guests who don't have the app yet _should_ be directed to the App Store to download it and then open the app to the bikes/scanned/:id deeplink automatically.

### App support

- QR code handling is not built in the app yet and will need to handle:
    - Displaying a scanned bike for authenticated users
    - Displaying a scanned bike for guest users and allow them to 
         - View a bike
         - Create an account and then continue to interact with that bike

## Resources

- Public AASA file: https://bikeindex.org/.well-known/apple-app-site-association
- https://developer.apple.com/documentation/xcode/supporting-associated-domains
- https://stackoverflow.com/questions/74866698/how-do-i-access-apples-aasa-validator-app-search-api-validation-tool
	- Including iOS device validation in Settings > Developer > Associated Domains Development > Diagnostics
- https://brunoscheufler.com/blog/2020-12-13-supporting-universal-links-with-swiftui