### PR TITLE
Add hotwire-livereload

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -132,8 +132,7 @@ group :development do
   gem "guard-rspec", require: false
   gem "letter_opener"
   gem "rerun" # restart sidekiq processes in development on app change
-  # Locked to 1.4.1, see kirillplatonov/hotwire-livereload/issues/73 - mainly because it double re-renders lookbook
-  gem "hotwire-livereload", "~> 1.4.1" # livereload pages in development
+  gem "hotwire-livereload", "~> 1.4.1" # See #2759 for reasoning on version
   gem "terminal-notifier"
   gem "annotate_rb", github: "sethherr/annotate_rb", branch: "rename-annotate_rb"
 end

--- a/Gemfile
+++ b/Gemfile
@@ -132,6 +132,8 @@ group :development do
   gem "guard-rspec", require: false
   gem "letter_opener"
   gem "rerun" # restart sidekiq processes in development on app change
+  # Locked to 1.4.1, see kirillplatonov/hotwire-livereload/issues/73 - mainly because it double re-renders lookbook
+  gem "hotwire-livereload", "~> 1.4.1" # livereload pages in development
   gem "terminal-notifier"
   gem "annotate_rb", github: "sethherr/annotate_rb", branch: "rename-annotate_rb"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -352,6 +352,10 @@ GEM
     honeybadger (5.27.0)
       logger
       ostruct
+    hotwire-livereload (1.4.1)
+      actioncable (>= 6.0.0)
+      listen (>= 3.0.0)
+      railties (>= 6.0.0)
     htmlbeautifier (1.4.3)
     htmlentities (4.3.4)
     http (4.4.1)
@@ -870,6 +874,7 @@ DEPENDENCIES
   guard-rspec
   haml
   honeybadger
+  hotwire-livereload (~> 1.4.1)
   htmlbeautifier
   httparty
   i18n-country-translations

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -4,11 +4,15 @@
     = render(HeaderTags::Component.new(**header_tags_component_options))
     -# TODO: Cache this ^
     = csrf_meta_tags
-    = stylesheet_link_tag 'revised'
+    = stylesheet_link_tag 'revised', "data-turbo-track": "reload"
     <link href='https://fonts.googleapis.com/css?family=Open+Sans:400,400italic,300italic,700' rel='stylesheet' type='text/css'>
     <link href='https://fonts.googleapis.com/css?family=Montserrat:400,700' rel='stylesheet' type='text/css'>
     <script src="https://kit.fontawesome.com/82eb17360c.js"></script>
     = javascript_include_tag 'application_revised'
+    - if @include_importmaps
+      = stylesheet_link_tag 'tailwind', "data-turbo-track": "reload"
+      = javascript_importmap_tags
+      = hotwire_livereload_tags if Rails.env.development?
     :javascript
       window.BikeIndex.translator = (keyspace) => {
         return (key, args={}) => I18n.t(`javascript.${keyspace}.${key}`, args);

--- a/config/cable.yml
+++ b/config/cable.yml
@@ -1,5 +1,7 @@
 development:
-  adapter: async
+  adapter: redis
+  url: <%= ENV.fetch("REDIS_URL") { "redis://localhost:6379/1" } %>
+  channel_prefix: bikeindex_development
 
 test:
   adapter: async


### PR DESCRIPTION
[hotwire-livereload](https://github.com/kirillplatonov/hotwire-livereload/) locked to version 1.4.1 - the last version prior to it auto injecting the code.

Specifically this is because it double renders lookbook and throws an error, but also other places in the app where Turbo isn't enabled.

See https://github.com/kirillplatonov/hotwire-livereload/issues/73 - hoping to figure out a way to disable for just some layouts.