### PR TITLE
Fix issues with hidden fields

### DIFF
--- a/app/assets/javascripts/revised/components/optional_form_update.coffee
+++ b/app/assets/javascripts/revised/components/optional_form_update.coffee
@@ -11,16 +11,13 @@ class BikeIndex.OptionalFormUpdate extends BikeIndex
     unless $target.is('a') # Ensure we aren't clicking on an interior element
       $target = $target.parents('.optional-form-block')
     $click_target = $($target.attr('data-target'))
-    $($target.attr('data-toggle')).slideDown 'fast', ->
-        $($target.attr('data-toggle')).removeClass('currently-hidden')
-    $target.slideUp 'fast', ->
-        $target.addClass('currently-hidden')
+    $($target.attr('data-toggle')).show().removeClass('currently-hidden')
+    $target.addClass('currently-hidden').hide()
     action = $target.attr('data-action')
 
     if action == 'rm-block'
       $click_target.slideUp 'fast', ->
         $click_target.removeClass('unhidden').addClass('currently-hidden')
-        $click_target.removeAttr('style')
         # FIX FIX FIX
         # THIS IS A TERRIBLE HACK
         setTimeout ->
@@ -29,10 +26,8 @@ class BikeIndex.OptionalFormUpdate extends BikeIndex
 
     else if action == 'swap'
       $swap = $($target.attr('data-swap'))
-      console.log('swap')
       $swap.slideUp 'fast', ->
-        console.log('here')
-        # $click_target.fadeIn()
+        $click_target.fadeIn()
         $click_target.slideDown().addClass('unhidden').removeClass('currently-hidden')
         $swap.addClass('currently-hidden').removeClass('unhidden')
 

--- a/app/assets/javascripts/revised/components/optional_form_update.coffee
+++ b/app/assets/javascripts/revised/components/optional_form_update.coffee
@@ -11,18 +11,28 @@ class BikeIndex.OptionalFormUpdate extends BikeIndex
     unless $target.is('a') # Ensure we aren't clicking on an interior element
       $target = $target.parents('.optional-form-block')
     $click_target = $($target.attr('data-target'))
-    $($target.attr('data-toggle')).show().removeClass('currently-hidden')
-    $target.addClass('currently-hidden').hide()
+    $($target.attr('data-toggle')).slideDown 'fast', ->
+        $($target.attr('data-toggle')).removeClass('currently-hidden')
+    $target.slideUp 'fast', ->
+        $target.addClass('currently-hidden')
     action = $target.attr('data-action')
 
     if action == 'rm-block'
       $click_target.slideUp 'fast', ->
         $click_target.removeClass('unhidden').addClass('currently-hidden')
+        $click_target.removeAttr('style')
+        # FIX FIX FIX
+        # THIS IS A TERRIBLE HACK
+        setTimeout ->
+          $click_target.css('display', 'none')
+        , 50
 
     else if action == 'swap'
       $swap = $($target.attr('data-swap'))
+      console.log('swap')
       $swap.slideUp 'fast', ->
-        $click_target.fadeIn()
+        console.log('here')
+        # $click_target.fadeIn()
         $click_target.slideDown().addClass('unhidden').removeClass('currently-hidden')
         $swap.addClass('currently-hidden').removeClass('unhidden')
 

--- a/app/assets/javascripts/revised/embed_script.coffee
+++ b/app/assets/javascripts/revised/embed_script.coffee
@@ -118,7 +118,7 @@ updateYear = ->
       $('#bike_unknown_year').prop('checked', false)
 
   slug = $('#bike_manufacturer_id').val()
-  if slug.length > 0
+  if slug and slug.length > 0
     getModelList(slug)
 
   else

--- a/app/assets/stylesheets/revised.scss
+++ b/app/assets/stylesheets/revised.scss
@@ -263,9 +263,6 @@ html {
   background: $black-off;
 }
 
-.currently-hidden {
-  display: none;
-}
 
 img {
   max-width: 100%;
@@ -394,4 +391,18 @@ $dev-color: #9400d3;
 
 .cursor-not-allowed {
   cursor: not-allowed;
+}
+
+// Fix collapse post tailwind
+.container {
+  .currently-hidden {
+    display: none;
+  }
+
+  .collapse {
+    display: none;
+    &.in {
+      display: block;
+    }
+  }
 }

--- a/app/components/pagination/component.rb
+++ b/app/components/pagination/component.rb
@@ -2,7 +2,7 @@
 
 module Pagination
   class Component < ApplicationComponent
-    def initialize(pagy:, page_params:, size: :md, data: {}, display_single: false)
+    def initialize(pagy:, page_params:, size: :md, data: {})
       @pagy = pagy
       @params = page_params.is_a?(Hash) ? page_params : page_params.permit!
       @size = size


### PR DESCRIPTION
Something in tailwind or JS vendoring overrode hiding fields, and they stopped working.

This fixes it. In a terrible gross hacky way for `BikeIndex.OptionalFormUpdate`, but it works better than it not working.