### PR TITLE
Rename user admin factory to superuser

### DIFF
--- a/spec/controllers/organized/bikes_controller_spec.rb
+++ b/spec/controllers/organized/bikes_controller_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe Organized::BikesController, type: :controller do
       expect(session[:passive_organization_id]).to eq "0" # sets it to zero so we don't look it up again
     end
     context "admin user" do
-      let(:user) { FactoryBot.create(:admin) }
+      let(:user) { FactoryBot.create(:superuser) }
       it "renders, doesn't reassign passive_organization_id" do
         session[:passive_organization_id] = organization.to_param # Admin, so user has access
         get :index, params: {organization_id: organization.to_param}

--- a/spec/controllers/sessions_controller_spec.rb
+++ b/spec/controllers/sessions_controller_spec.rb
@@ -313,7 +313,7 @@ RSpec.describe SessionsController, type: :controller do
         end
 
         context "admin" do
-          let(:user) { FactoryBot.create(:admin) }
+          let(:user) { FactoryBot.create(:superuser) }
           it "authenticates and redirects to admin" do
             expect(user).to receive(:authenticate).and_return(true)
             request.env["HTTP_REFERER"] = my_account_url

--- a/spec/factories/bike_sticker_batches.rb
+++ b/spec/factories/bike_sticker_batches.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :bike_sticker_batch do
-    user { FactoryBot.create(:admin) }
+    user { FactoryBot.create(:superuser) }
     sequence(:prefix) { |n| "G#{n}" }
   end
 end

--- a/spec/factories/email_domains.rb
+++ b/spec/factories/email_domains.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :email_domain do
-    creator { FactoryBot.create(:admin) }
+    creator { FactoryBot.create(:superuser) }
     sequence(:domain) { |n| "@fakedomain-#{n}.com" }
   end
 end

--- a/spec/factories/memberships.rb
+++ b/spec/factories/memberships.rb
@@ -3,7 +3,7 @@ FactoryBot.define do
     user { FactoryBot.create(:user_confirmed) }
     level { "basic" }
     start_at { Time.current - 1.hour }
-    creator { FactoryBot.create(:admin) }
+    creator { FactoryBot.create(:superuser) }
 
     trait :with_payment do
       after(:create) do |membership|

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -20,8 +20,6 @@ FactoryBot.define do
         factory :superuser_developer do
           developer { true }
         end
-        # TODO: replace all use of admin with superuser
-        factory :admin
       end
       factory :developer do
         developer { true }

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -14,12 +14,14 @@ FactoryBot.define do
       factory :user_bikehub_signup do
         partner_data { {sign_up: "bikehub"} }
       end
-      factory :admin do
+      factory :superuser do
         accepted_vendor_terms_of_service { true }
         superuser { true }
-        factory :admin_developer do
+        factory :superuser_developer do
           developer { true }
         end
+        # TODO: replace all use of admin with superuser
+        factory :admin
       end
       factory :developer do
         developer { true }

--- a/spec/jobs/admin_reassign_bike_sticker_codes_job_spec.rb
+++ b/spec/jobs/admin_reassign_bike_sticker_codes_job_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe AdminReassignBikeStickerCodesJob, type: :job do
   describe "perform" do
     let(:organization) { FactoryBot.create(:organization) }
     let(:organization2) { FactoryBot.create(:organization) }
-    let!(:user) { FactoryBot.create(:admin) }
+    let!(:user) { FactoryBot.create(:superuser) }
     let(:user2) { FactoryBot.create(:user) }
     let(:bike) { FactoryBot.create(:bike, :with_ownership_claimed) }
     let(:bike_sticker_batch) { FactoryBot.create(:bike_sticker_batch, prefix: "A", code_number_length: nil, organization: organization) }

--- a/spec/jobs/after_user_change_job_spec.rb
+++ b/spec/jobs/after_user_change_job_spec.rb
@@ -93,7 +93,7 @@ RSpec.describe AfterUserChangeJob, type: :job do
       expect(user.reload.superuser_abilities.count).to eq 0
     end
     context "user is superuser" do
-      let(:user) { FactoryBot.create(:admin) }
+      let(:user) { FactoryBot.create(:superuser) }
       it "does adds superuser_abilities" do
         expect(user.superuser).to be_truthy
         expect(user.superuser_abilities.count).to eq 0
@@ -152,7 +152,7 @@ RSpec.describe AfterUserChangeJob, type: :job do
   end
 
   describe "phone_waiting_confirmation" do
-    let(:user) { FactoryBot.create(:admin) } # Confirm that superadmins still get this alert, because we want them to
+    let(:user) { FactoryBot.create(:superuser) } # Confirm that superadmins still get this alert, because we want them to
     let!(:user_phone) { FactoryBot.create(:user_phone, user: user) }
     it "adds alert_slugs" do
       expect {

--- a/spec/jobs/email/stolen_notification_job_spec.rb
+++ b/spec/jobs/email/stolen_notification_job_spec.rb
@@ -134,7 +134,7 @@ RSpec.describe Email::StolenNotificationJob, type: :job do
       expect_notification_blocked(stolen_notification.sender.email)
     end
     context "admin" do
-      let(:user) { FactoryBot.create(:admin) }
+      let(:user) { FactoryBot.create(:superuser) }
       it "sends to customer" do
         instance.perform(stolen_notification.id)
         expect_notification_sent(stolen_notification.sender.email)

--- a/spec/jobs/organization_export_job_spec.rb
+++ b/spec/jobs/organization_export_job_spec.rb
@@ -58,7 +58,7 @@ RSpec.describe OrganizationExportJob, type: :job do
         end
       end
       context "avery export" do
-        let(:user) { FactoryBot.create(:admin) }
+        let(:user) { FactoryBot.create(:superuser) }
         let(:export) { FactoryBot.create(:export_avery, progress: "pending", file: nil, bike_code_start: "a1111 ", user: user) }
         let(:bike_for_avery_og) do
           FactoryBot.create(:bike_organized,

--- a/spec/jobs/process_logged_search_job_spec.rb
+++ b/spec/jobs/process_logged_search_job_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe ProcessLoggedSearchJob, type: :job do
       end
 
       context "user is superuser" do
-        let(:user) { FactoryBot.create(:admin, :with_organization) }
+        let(:user) { FactoryBot.create(:superuser, :with_organization) }
         it "doesn't associate" do
           expect(logged_search.user_id).to eq user.id
           expect(logged_search.organization_id).to be_nil

--- a/spec/jobs/remove_unconfirmed_users_job_spec.rb
+++ b/spec/jobs/remove_unconfirmed_users_job_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe RemoveUnconfirmedUsersJob, type: :job do
       let!(:user) { FactoryBot.create(:user_confirmed, created_at: Time.current - 1.week, email: "something@zzz.example.com") }
       let!(:user_not_domain) { FactoryBot.create(:user_confirmed, created_at: Time.current - 1.week, email: "other@example.org") }
       let!(:user_pending_domain) { FactoryBot.create(:user_confirmed, created_at: Time.current - 1.week, email: "other@stuff.stuff.com") }
-      let(:creator) { FactoryBot.create(:admin) }
+      let(:creator) { FactoryBot.create(:superuser) }
       let!(:email_domain_banned) { FactoryBot.create(:email_domain, status: "banned", domain: "example.com", creator:) }
       let!(:email_domain_pending) { FactoryBot.create(:email_domain, status: "provisional_ban", domain: "stuff.com", creator:) }
 

--- a/spec/jobs/user/create_or_update_membership_from_payment_job_spec.rb
+++ b/spec/jobs/user/create_or_update_membership_from_payment_job_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe User::CreateOrUpdateMembershipFromPaymentJob, type: :job do
   let(:user) { FactoryBot.create(:user_confirmed) }
   let(:amount_cents) { 999 }
   let(:payment) { FactoryBot.create(:payment, amount_cents:, user:, paid_at: Time.current - 1.day) }
-  let(:creator_id) { FactoryBot.create(:admin).id }
+  let(:creator_id) { FactoryBot.create(:superuser).id }
 
   let(:new_attrs) do
     {user_id: user.id, start_at: Time.current, end_at: Time.current + 3.month,

--- a/spec/mailers/customer_mailer_spec.rb
+++ b/spec/mailers/customer_mailer_spec.rb
@@ -137,7 +137,7 @@ RSpec.describe CustomerMailer, type: :mailer do
   describe "admin_contact_stolen_email" do
     let!(:ownership) { FactoryBot.create(:ownership, bike: bike) }
     let(:bike) { FactoryBot.create(:stolen_bike) }
-    let(:user) { FactoryBot.create(:admin, email: "something@stuff.com") }
+    let(:user) { FactoryBot.create(:superuser, email: "something@stuff.com") }
     let(:customer_contact) do
       CustomerContact.create(user_email: bike.owner_email,
         creator_email: user.email,

--- a/spec/models/bike_spec.rb
+++ b/spec/models/bike_spec.rb
@@ -773,7 +773,7 @@ RSpec.describe Bike, type: :model do
         end
       end
       context "claimed" do
-        let(:superuser) { FactoryBot.create(:admin) }
+        let(:superuser) { FactoryBot.create(:superuser) }
         let(:bike) { FactoryBot.create(:bike, :with_ownership_claimed, user: superuser, creator: FactoryBot.create(:user_confirmed)) }
         it "returns true for user, not creator" do
           expect(bike.reload.current_ownership.creator_id).to_not eq superuser.id

--- a/spec/models/bike_version_spec.rb
+++ b/spec/models/bike_version_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe BikeVersion, type: :model do
     let(:bike_version) { FactoryBot.create(:bike_version) }
     let(:owner) { bike_version.owner }
     let(:user) { FactoryBot.create(:user) }
-    let(:superuser) { FactoryBot.create(:admin) }
+    let(:superuser) { FactoryBot.create(:superuser) }
     it "is false for non-owner" do
       expect(bike_version.authorized?(nil)).to be_falsey
       expect(bike_version.authorized?(user)).to be_falsey

--- a/spec/models/membership_spec.rb
+++ b/spec/models/membership_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe Membership, type: :model do
   end
 
   describe "validations" do
-    let(:creator) { FactoryBot.create(:admin) }
+    let(:creator) { FactoryBot.create(:superuser) }
     let!(:membership_existing) { FactoryBot.create(:membership, start_at: Time.current - 2.months, end_at: end_at_existing, creator:) }
     let(:user) { membership_existing.user.reload }
     let(:membership_new) { FactoryBot.build(:membership, start_at: Time.current - 1.week, user:, creator:) }

--- a/spec/models/stripe_subscription_spec.rb
+++ b/spec/models/stripe_subscription_spec.rb
@@ -83,7 +83,7 @@ RSpec.describe StripeSubscription, type: :model do
     context "with existing admin_managed membership" do
       let!(:membership_existing) do
         FactoryBot.create(:membership, user:, start_at: start_at_existing, end_at: end_at_existing,
-          creator: FactoryBot.create(:admin))
+          creator: FactoryBot.create(:superuser))
       end
       let(:start_at_existing) { Time.current - 1.year }
       let(:end_at_existing) { nil }

--- a/spec/models/user_ban_spec.rb
+++ b/spec/models/user_ban_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 RSpec.describe UserBan, type: :model do
   describe "nested create" do
     let(:user) { FactoryBot.create(:user) }
-    let(:admin) { FactoryBot.create(:admin) }
+    let(:admin) { FactoryBot.create(:superuser) }
     it "is valid" do
       user.update(banned: true, user_ban_attributes: {creator: admin, reason: :abuse})
       expect(user.user_ban).to be_valid

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -212,7 +212,7 @@ RSpec.describe User, type: :model do
     end
 
     context "with superuser" do
-      let(:user) { FactoryBot.build(:admin) }
+      let(:user) { FactoryBot.build(:superuser) }
 
       it "is true for superuser attribute" do
         expect(user.superuser?).to be_truthy
@@ -807,7 +807,7 @@ RSpec.describe User, type: :model do
       end
     end
     context "superadmin" do
-      let(:user) { FactoryBot.create(:admin) }
+      let(:user) { FactoryBot.create(:superuser) }
       it "returns true" do
         expect(user.member_of?(organization)).to be_truthy
         expect(user.member_of?(organization, no_superuser_override: true)).to be_falsey
@@ -862,7 +862,7 @@ RSpec.describe User, type: :model do
       end
     end
     context "superadmin" do
-      let(:user) { FactoryBot.create(:admin) }
+      let(:user) { FactoryBot.create(:superuser) }
       it "returns true" do
         expect(user.admin_of?(organization)).to be_truthy
       end

--- a/spec/requests/admin/organization_features_request_spec.rb
+++ b/spec/requests/admin/organization_features_request_spec.rb
@@ -57,7 +57,7 @@ RSpec.describe Admin::OrganizationFeaturesController, type: :request do
         expect(subject.feature_slugs).to eq([])
       end
       context "developer" do
-        let(:current_user) { FactoryBot.create(:admin_developer) }
+        let(:current_user) { FactoryBot.create(:superuser_developer) }
         it "does not update feature_slugs" do
           put "#{base_url}/#{subject.to_param}", params: {organization_feature: passed_params.merge(feature_slugs_string: "csv_exports, ,pARKinG_notifications, blarg")}
           subject.reload
@@ -75,7 +75,7 @@ RSpec.describe Admin::OrganizationFeaturesController, type: :request do
         passed_params.each { |k, v| expect(subject.send(k)).to_not eq(v) }
       end
       context "developer" do
-        let(:current_user) { FactoryBot.create(:admin_developer) }
+        let(:current_user) { FactoryBot.create(:superuser_developer) }
         it "does not update feature_slugs" do
           patch "#{base_url}/#{subject.to_param}", params: {organization_feature: passed_params.merge(feature_slugs_string: "csv_exports, parkiNG_NOTifications, blarg")}
           subject.reload
@@ -96,7 +96,7 @@ RSpec.describe Admin::OrganizationFeaturesController, type: :request do
       expect(organization_feature.feature_slugs).to eq([])
     end
     context "developer" do
-      let(:current_user) { FactoryBot.create(:admin_developer) }
+      let(:current_user) { FactoryBot.create(:superuser_developer) }
       it "succeeds" do
         expect {
           post base_url, params: {organization_feature: passed_params.merge(feature_slugs_string: "csv_exports, show_bulk_import")}

--- a/spec/requests/admin/organizations/custom_layouts_request_spec.rb
+++ b/spec/requests/admin/organizations/custom_layouts_request_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe Admin::Organizations::CustomLayoutsController, type: :request do
 
   context "super admin and developer" do
     include_context :request_spec_logged_in_as_superuser
-    let(:current_user) { FactoryBot.create(:admin_developer) }
+    let(:current_user) { FactoryBot.create(:superuser_developer) }
 
     describe "index" do
       it "renders" do

--- a/spec/requests/admin/users_request_spec.rb
+++ b/spec/requests/admin/users_request_spec.rb
@@ -85,7 +85,7 @@ RSpec.describe Admin::UsersController, type: :request do
       end
     end
     context "developer" do
-      let(:current_user) { FactoryBot.create(:admin_developer) }
+      let(:current_user) { FactoryBot.create(:superuser_developer) }
       it "updates developer" do
         user_subject.reload
         og_auth_token = user_subject.auth_token

--- a/spec/requests/api/v3/bikes_request_spec.rb
+++ b/spec/requests/api/v3/bikes_request_spec.rb
@@ -466,7 +466,7 @@ RSpec.describe "Bikes API V3", type: :request do
           }
         end
         it "updates" do
-          bike_sticker.claim(bike: bike, user: FactoryBot.create(:admin))
+          bike_sticker.claim(bike: bike, user: FactoryBot.create(:superuser))
           expect(bike_sticker.reload.bike_sticker_updates.count).to eq 1
           expect(bike.year).to_not eq 2012
           expect {

--- a/spec/requests/bike_versions/edits_request_spec.rb
+++ b/spec/requests/bike_versions/edits_request_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe BikeVersions::EditsController, type: :request do
   end
   context "superadmin" do
     let!(:bike_version) { FactoryBot.create(:bike_version) }
-    let(:current_user) { FactoryBot.create(:admin) }
+    let(:current_user) { FactoryBot.create(:superuser) }
     it "renders" do
       expect(bike_version.authorized?(current_user)).to be_truthy
       expect(bike_version.owner_id).to_not eq current_user.id

--- a/spec/requests/bike_versions_request_spec.rb
+++ b/spec/requests/bike_versions_request_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe BikeVersionsController, type: :request do
       expect(response).to render_template(:show)
     end
     context "superadmin" do
-      let(:current_user) { FactoryBot.create(:admin) }
+      let(:current_user) { FactoryBot.create(:superuser) }
       it "renders" do
         get "#{base_url}/#{bike_version.to_param}"
         expect(response.code).to eq "200"

--- a/spec/requests/bikes/theft_alerts_request_spec.rb
+++ b/spec/requests/bikes/theft_alerts_request_spec.rb
@@ -52,7 +52,7 @@ RSpec.describe Bikes::TheftAlertsController, type: :request, vcr: true, match_re
           expect(assigns(:theft_alerts).pluck(:id)).to eq([])
         end
         context "superadmin" do
-          let(:current_user) { FactoryBot.create(:admin) }
+          let(:current_user) { FactoryBot.create(:superuser) }
           it "renders" do
             get "#{base_url}/new"
             expect(response.code).to eq("200")

--- a/spec/requests/dev_dashboards_request_spec.rb
+++ b/spec/requests/dev_dashboards_request_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe "Dev dashboards", type: :request do
     # IDK, doesn't render in test - most important to test that it doesn't render so ignoring for now
     # context "signed in as dev" do
     #   include_context :request_spec_logged_in_as_superuser
-    #   let(:current_user) { FactoryBot.create(:admin, developer: true) }
+    #   let(:current_user) { FactoryBot.create(:superuser, developer: true) }
 
     #   it "renders" do
     #     get "/sidekiq"
@@ -27,7 +27,7 @@ RSpec.describe "Dev dashboards", type: :request do
     # IDK, doesn't render in test - most important to test that it doesn't render so ignoring for now
     # context "signed in as dev" do
     #   include_context :request_spec_logged_in_as_superuser
-    #   let(:current_user) { FactoryBot.create(:admin, developer: true) }
+    #   let(:current_user) { FactoryBot.create(:superuser, developer: true) }
 
     #   it "renders" do
     #     get "/pghero"

--- a/spec/requests/oauth/applications_controller_spec.rb
+++ b/spec/requests/oauth/applications_controller_spec.rb
@@ -80,7 +80,7 @@ RSpec.describe Oauth::ApplicationsController, type: :request do
       end
 
       context "admin" do
-        let(:current_user) { FactoryBot.create(:admin) }
+        let(:current_user) { FactoryBot.create(:superuser) }
         it "renders if superuser" do
           expect(doorkeeper_app.owner_id).to_not eq current_user.id
           get "#{base_url}/#{doorkeeper_app.id}/edit"

--- a/spec/requests/organized/bulk_imports_request_spec.rb
+++ b/spec/requests/organized/bulk_imports_request_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe Organized::BulkImportsController, type: :request do
     end
 
     context "logged in as super admin" do
-      let(:current_user) { FactoryBot.create(:admin) }
+      let(:current_user) { FactoryBot.create(:superuser) }
       describe "index" do
         # Minor sanity check
         let!(:current_organization) { FactoryBot.create(:organization_with_organization_features, :with_auto_user, enabled_feature_slugs: ["impound_bikes"]) }

--- a/spec/requests/organized/exports_request_spec.rb
+++ b/spec/requests/organized/exports_request_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe Organized::ExportsController, type: :request do
     end
 
     context "logged in as super admin" do
-      let(:current_user) { FactoryBot.create(:admin) }
+      let(:current_user) { FactoryBot.create(:superuser) }
       describe "index" do
         it "renders" do
           expect(current_user.member_of?(current_organization, no_superuser_override: true)).to be_falsey

--- a/spec/requests/organized/model_audits_request_spec.rb
+++ b/spec/requests/organized/model_audits_request_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe Organized::ModelAuditsController, type: :request do
     end
 
     context "logged in as super admin" do
-      let(:current_user) { FactoryBot.create(:admin) }
+      let(:current_user) { FactoryBot.create(:superuser) }
       describe "index" do
         it "renders" do
           expect(current_user.member_of?(current_organization, no_superuser_override: true)).to be_falsey

--- a/spec/requests/public_images_request_spec.rb
+++ b/spec/requests/public_images_request_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe PublicImagesController, type: :request do
   let(:base_url) { "/public_images" }
 
   describe "create" do
-    let(:current_user) { FactoryBot.create(:admin) }
+    let(:current_user) { FactoryBot.create(:superuser) }
     context "bike" do
       let(:bike) { FactoryBot.create(:bike, :with_ownership_claimed) }
       let!(:current_user) { bike.current_ownership.creator }

--- a/spec/services/bike_displayer_spec.rb
+++ b/spec/services/bike_displayer_spec.rb
@@ -247,7 +247,7 @@ RSpec.describe BikeDisplayer do
   describe "user_edit_bike_address?, display_edit_address_fields? and edit_street_address?" do
     let(:bike) { FactoryBot.create(:bike) }
     let(:user) { FactoryBot.create(:user, :confirmed) }
-    let(:admin) { FactoryBot.create(:admin) }
+    let(:admin) { FactoryBot.create(:superuser) }
 
     it "is falsey" do
       expect(BikeDisplayer.display_edit_address_fields?(bike, user)).to be_falsey

--- a/spec/support/controller_spec_helpers.rb
+++ b/spec/support/controller_spec_helpers.rb
@@ -13,7 +13,7 @@ module ControllerSpecHelpers
   end
 
   RSpec.shared_context :logged_in_as_superuser do
-    let(:user) { FactoryBot.create(:admin) }
+    let(:user) { FactoryBot.create(:superuser) }
     before { set_current_user(user) }
   end
 

--- a/spec/support/request_spec_helpers.rb
+++ b/spec/support/request_spec_helpers.rb
@@ -24,7 +24,7 @@ module RequestSpecHelpers
   end
 
   RSpec.shared_context :request_spec_logged_in_as_superuser do
-    let(:current_user) { FactoryBot.create(:admin) }
+    let(:current_user) { FactoryBot.create(:superuser) }
     before { log_in(current_user) }
   end
 


### PR DESCRIPTION
`admin` is ambiguous (because e.g. organization admins). Switch to using superuser, which is the name of the actual attribute on user.