### PR TITLE
slugifyer update

### DIFF
--- a/app/models/concerns/friendly_slug_findable.rb
+++ b/app/models/concerns/friendly_slug_findable.rb
@@ -27,6 +27,7 @@ module FriendlySlugFindable
   end
 
   def set_slug
+    self.name = name&.strip
     self.slug ||= Slugifyer.slugify(name)
   end
 end

--- a/app/services/slugifyer.rb
+++ b/app/services/slugifyer.rb
@@ -1,28 +1,43 @@
 class Slugifyer
-  def self.slugify(string)
-    slug = I18n.transliterate(string.to_s.downcase).strip
-    slug.gsub("%20", " ").gsub(/\s/, "-")
-      .gsub("-&-", "-amp-") # Replace singular & with amp - since we permit & in names
-      .gsub(/([^A-Za-z0-9_\-]+)/, "") # Remove any weird characters
-      .downcase
-  end
-
-  def self.book_slug(string)
-    slug = I18n.transliterate(string.to_s.downcase)
-    key_hash = {
-      '\s((bi)?cycles?|bikes?)' => " ",
-      '\+' => "plus",
-      "([^A-Za-z0-9])" => " "
-    }
-    key_hash.keys.each do |k|
-      slug.gsub!(/#{k}/i, key_hash[k])
+  class << self
+    def slugify(string)
+      transliterate(remove_parens(string))
+        .gsub("%20", " ").gsub(/\s/, "-")
+        .gsub("-&-", "-amp-") # Replace singular & with amp - since we permit & in names
+        .gsub(/([^A-Za-z0-9_\-]+)/, "") # Remove any weird characters
     end
-    slug.strip.gsub(/\s+/, "_") # strip and then turn any length of spaces into underscores
-  end
 
-  def self.manufacturer(string)
-    return nil unless string
-    book_slug(string.gsub(/\sco(\.|mpany)/i, " ")
-      .gsub(/\s(frame)?works/i, " ").gsub(/\([^)]*\)/i, ""))
+    def manufacturer(string)
+      return nil unless string
+      book_slug(
+        remove_parens(string).gsub(/\sco(\.|mpany)/i, " ").gsub(/\s(frame)?works/i, " ")
+      )
+    end
+
+    # underscores, also removes some extra stuff
+    def book_slug(string)
+      slug = transliterate(string)
+      key_hash = {
+        "%20" => " ",
+        '\s((bi)?cycles?|bikes?)' => " ",
+        '\+' => "plus",
+        "&" => "amp",
+        "([^A-Za-z0-9])" => " "
+      }
+      key_hash.keys.each do |k|
+        slug.gsub!(/#{k}/i, key_hash[k])
+      end
+      slug.strip.gsub(/\s+/, "_") # strip and then turn any length of spaces into underscores
+    end
+
+    private
+
+    def remove_parens(string)
+      string&.to_s&.gsub(/\([^)]*\)/i, "")
+    end
+
+    def transliterate(string)
+      I18n.transliterate(string.to_s.downcase).strip
+    end
   end
 end

--- a/spec/models/organization_spec.rb
+++ b/spec/models/organization_spec.rb
@@ -509,7 +509,7 @@ RSpec.describe Organization, type: :model do
         expect(organization.name).to eq "Bikes (& Trikes)"
         expect(organization.short_name).to eq "Bikes (& Trikes)"
         # only ampersands surrounded by spaces are kept
-        expect(organization.slug).to eq "bikes--trikes"
+        expect(organization.slug).to eq "bikes"
       end
     end
 

--- a/spec/services/slugifyer_spec.rb
+++ b/spec/services/slugifyer_spec.rb
@@ -1,6 +1,21 @@
 require "rails_helper"
 
 RSpec.describe Slugifyer do
+  describe "slugify" do
+    it "handles &" do
+      expect(Slugifyer.slugify("Bikes &amp; Trikes")).to eq "bikes-amp-trikes"
+      expect(Slugifyer.slugify("Bikes & Trikes")).to eq "bikes-amp-trikes"
+    end
+    it "handles é" do
+      expect(Slugifyer.slugify("paké rum runner")).to eq("pake-rum-runner")
+      expect(Slugifyer.slugify("pañe rum runner")).to eq("pane-rum-runner")
+    end
+
+    it "removes parens" do
+      expect(Slugifyer.slugify(" Some Cool NAMe (additional info)")).to eq("some-cool-name")
+    end
+  end
+
   describe "book_slug" do
     it "removes special characters and downcase" do
       slug = Slugifyer.book_slug("Surly's Cross-check bike (small wheel)")
@@ -20,17 +35,6 @@ RSpec.describe Slugifyer do
     it "changes + to plus for URL safety, and Trek uses + to differentiate" do
       slug = Slugifyer.book_slug("L100+ Lowstep BLX")
       expect(slug).to eq("l100plus_lowstep_blx")
-    end
-  end
-
-  describe "slugify" do
-    it "handles &" do
-      expect(Slugifyer.slugify("Bikes &amp; Trikes")).to eq "bikes-amp-trikes"
-      expect(Slugifyer.slugify("Bikes & Trikes")).to eq "bikes-amp-trikes"
-    end
-    it "handles é" do
-      expect(Slugifyer.slugify("paké rum runner")).to eq("pake-rum-runner")
-      expect(Slugifyer.slugify("pañe rum runner")).to eq("pane-rum-runner")
     end
   end
 
@@ -62,6 +66,10 @@ RSpec.describe Slugifyer do
     it "removes parens from EAI" do
       slug = Slugifyer.manufacturer("EAI (Euro Asia Imports)")
       expect(slug).to eq("eai")
+    end
+    it "handles Riese & Müller (Riese and Muller)" do
+      slug = Slugifyer.manufacturer("Riese & Müller (Riese and Muller)")
+      expect(slug).to eq "riese_amp_muller"
     end
   end
 end

--- a/spec/support/shared_examples/friendly_slug_findable.rb
+++ b/spec/support/shared_examples/friendly_slug_findable.rb
@@ -4,29 +4,19 @@ RSpec.shared_examples "friendly_slug_findable" do
   let(:model_sym) { subject.class.name.underscore.to_sym }
   let(:instance) { FactoryBot.create model_sym }
 
-  describe "callbacks" do
-    it "calls set slug before create" do
-      obj = FactoryBot.build(model_sym, name: "something cool and things&")
-      expect(obj).to receive :set_slug
-      obj.save
+  describe "sets slug" do
+    let(:instance) { FactoryBot.create(model_sym, name:) }
+    let(:name) { "Some Cool NAMe " }
+    it "assigns slug on create" do
+      expect(instance.reload.name).to eq "Some Cool NAMe"
+      expect(instance.slug).to eq "some-cool-name"
     end
-  end
 
-  describe "set_slug" do
-    context "name" do
-      it "slugs it" do
-        obj = FactoryBot.build(model_sym, name: "something cool and things&")
-        obj.slug = nil
-        obj.set_slug
-        expect(obj.slug).to eq Slugifyer.slugify("something cool and things&")
-      end
-    end
-    context "existing" do
-      it "doesn't overwrite" do
-        obj = FactoryBot.build model_sym
-        obj.slug = "something cool"
-        obj.set_slug
-        expect(obj.slug).to eq "something cool"
+    context "with parens" do
+      let(:name) { "Some Cool NAMe (additional info)" }
+      it "assigns slug without parens" do
+        expect(instance.reload.name).to eq name
+        expect(instance.slug).to eq "some-cool-name"
       end
     end
   end


### PR DESCRIPTION
Strip parentheses from slugs by default (for consistency between different slugifyer formats)