### PR TITLE
Add location parsing from Cloudflare headers

### DIFF
--- a/app/controllers/admin/dashboard_controller.rb
+++ b/app/controllers/admin/dashboard_controller.rb
@@ -59,4 +59,10 @@ class Admin::DashboardController < Admin::BaseController
     FileCacheMaintainer.reset_blocklist_ids(new_blocklist)
     redirect_to admin_tsvs_path
   end
+
+  def ip_location
+    @cloudflare_hash = IpAddressParser.location_hash(request)
+    @geocoder_hash = IpAddressParser.location_hash_geocoder(forwarded_ip_address, new_attrs: true)
+    @headers = request.headers.to_h.select { |k, _v| k.start_with?("HTTP_") }.to_h
+  end
 end

--- a/app/controllers/api/base.rb
+++ b/app/controllers/api/base.rb
@@ -7,7 +7,7 @@ module GrapeLogging
   module Loggers
     class BinxLogger < GrapeLogging::Loggers::Base
       def parameters(request, _)
-        {remote_ip: ForwardedIpAddress.parse(request), format: "json"}
+        {remote_ip: IpAddressParser.forwarded_address(request), format: "json"}
       end
     end
   end

--- a/app/controllers/concerns/controller_helpers.rb
+++ b/app/controllers/concerns/controller_helpers.rb
@@ -34,7 +34,7 @@ module ControllerHelpers
   end
 
   def forwarded_ip_address
-    @forwarded_ip_address ||= ForwardedIpAddress.parse(request)
+    @forwarded_ip_address ||= IpAddressParser.forwarded_address(request)
   end
 
   def enable_rack_profiler

--- a/app/helpers/admin_helper.rb
+++ b/app/helpers/admin_helper.rb
@@ -16,7 +16,8 @@ module AdminHelper
       {title: "Dev: Autocomplete Status", path: admin_autocomplete_status_path, match_controller: false},
       {title: "Dev: Notifications", path: admin_notifications_path, match_controller: true},
       {title: "Dev: Superuser Abilities", path: admin_superuser_abilities_path, match_controller: true},
-      {title: "Dev: Model Attestations", path: admin_model_attestations_path, match_controller: true}
+      {title: "Dev: Model Attestations", path: admin_model_attestations_path, match_controller: true},
+      {title: "Dev: IP Location", path: admin_ip_location_path, match_controller: false}
     ]
   end
 

--- a/app/models/concerns/bike_searchable.rb
+++ b/app/models/concerns/bike_searchable.rb
@@ -157,7 +157,7 @@ module BikeSearchable
 
       distance = query_params[:distance]&.to_i
       bounding_box = if ["", "ip", "you"].include?(location.strip.downcase)
-        address_hash = GeocodeHelper.address_hash_for(ip_address)
+        address_hash = IpAddressParser.location_hash_geocoder(ip_address)
         location = address_hash[:formatted_address]
         GeocodeHelper.bounding_box([address_hash[:latitude], address_hash[:longitude]], distance)
       else

--- a/app/models/country.rb
+++ b/app/models/country.rb
@@ -28,9 +28,16 @@ class Country < ApplicationRecord
     def friendly_find(name_or_iso)
       name_or_iso = name_or_iso.to_s.strip.downcase
       return if name_or_iso.blank?
-      return united_states if name_or_iso.in? %w[us usa]
+      return united_states if %w[us usa].include?(name_or_iso)
 
       find_by("lower(name) = ? or lower(iso) = ?", name_or_iso, name_or_iso)
+    end
+
+    def friendly_find_id(name_or_iso)
+      name_or_iso = name_or_iso.to_s.strip.downcase
+      return united_states_id if %w[us usa].include?(name_or_iso)
+
+      friendly_find(name_or_iso)
     end
 
     def united_states

--- a/app/models/country.rb
+++ b/app/models/country.rb
@@ -26,7 +26,7 @@ class Country < ApplicationRecord
     end
 
     def friendly_find(name_or_iso)
-      name_or_iso = name_or_iso.to_s.strip.downcase
+      name_or_iso = name_or_iso&.to_s&.strip&.downcase
       return if name_or_iso.blank?
       return united_states if %w[us usa].include?(name_or_iso)
 
@@ -34,8 +34,9 @@ class Country < ApplicationRecord
     end
 
     def friendly_find_id(name_or_iso)
-      name_or_iso = name_or_iso.to_s.strip.downcase
+      name_or_iso = name_or_iso&.to_s&.strip&.downcase
       return united_states_id if %w[us usa].include?(name_or_iso)
+      return canada_id if name_or_iso == "ca"
 
       friendly_find(name_or_iso)
     end

--- a/app/views/admin/dashboard/ip_location.html.haml
+++ b/app/views/admin/dashboard/ip_location.html.haml
@@ -1,0 +1,18 @@
+.admin-subnav
+  .col-12
+    %h1
+      IP Location
+
+%p
+  Compare cloudflare headers vs geocoder results
+
+.row
+  .col-md-6
+    %h4 Cloudflare
+    = pretty_print_json(@cloudflare_hash)
+  .col-md-6
+    %h4 Geocoder
+    = pretty_print_json(@geocoder_hash)
+  .col-md-6
+    %h4 Raw Headers
+    = pretty_print_json(@headers)

--- a/config/initializers/ip_address_parser.rb
+++ b/config/initializers/ip_address_parser.rb
@@ -9,11 +9,11 @@ class IpAddressParser
     def location_hash(request)
       # Additional CF headers that we're ignoring: timezone, continent, region-code, and metro-code
       {
-        city: request.env["HTTP_CF_IP_CITY"],
-        latitude: request.env["HTTP_CF_IP_LATITUDE"],
-        longitude: request.env["HTTP_CF_IP_LONGITUDE"],
+        city: request.env["HTTP_CF_IPCITY"],
+        latitude: request.env["HTTP_CF_IPLATITUDE"],
+        longitude: request.env["HTTP_CF_IPLONGITUDE"],
         formatted_address: nil, # could build this, ignoring for now
-        country_id: request.env["HTTP_CF_IP_COUNTRY"],
+        country_id: Country.friendly_find_id(request.env["HTTP_CF_IPCOUNTRY"]),
         neighborhood: request.env["HTTP_CF_METRO"],
         street: nil,
         postal_code: request.env["HTTP_CF_POSTAL_CODE"],

--- a/config/initializers/ip_address_parser.rb
+++ b/config/initializers/ip_address_parser.rb
@@ -7,11 +7,12 @@ class IpAddressParser
     end
 
     def location_hash(request)
-      # Additional CF headers that we're ignoring: timezone, continent, region-code, and metro-code
+      # CF headers that we're ignoring (but might be nice someday):
+      #   timezone, continent, region-code
       {
         city: request.env["HTTP_CF_IPCITY"],
-        latitude: request.env["HTTP_CF_IPLATITUDE"],
-        longitude: request.env["HTTP_CF_IPLONGITUDE"],
+        latitude: request.env["HTTP_CF_IPLATITUDE"]&.to_f,
+        longitude: request.env["HTTP_CF_IPLONGITUDE"]&.to_f,
         formatted_address: nil, # could build this, ignoring for now
         country_id: Country.friendly_find_id(request.env["HTTP_CF_IPCOUNTRY"]),
         neighborhood: request.env["HTTP_CF_METRO"],

--- a/config/initializers/ip_address_parser.rb
+++ b/config/initializers/ip_address_parser.rb
@@ -1,7 +1,28 @@
 class IpAddressParser
-  def self.forwarded_address(request)
-    addy = request.env["HTTP_CF_CONNECTING_IP"]
-    addy ||= request.env["HTTP_X_FORWARDED_FOR"].split(",").last if request.env["HTTP_X_FORWARDED_FOR"].present?
-    addy || request.env["REMOTE_ADDR"] || request.env["ip"]
+  class << self
+    def forwarded_address(request)
+      addy = request.env["HTTP_CF_CONNECTING_IP"]
+      addy ||= request.env["HTTP_X_FORWARDED_FOR"].split(",").last if request.env["HTTP_X_FORWARDED_FOR"].present?
+      addy || request.env["REMOTE_ADDR"] || request.env["ip"]
+    end
+
+    def location_hash(request)
+      # Additional CF headers that we're ignoring: timezone, continent, region-code, and metro-code
+      {
+        city: request.env["HTTP_CF_IP_CITY"],
+        latitude: request.env["HTTP_CF_IP_LATITUDE"],
+        longitude: request.env["HTTP_CF_IP_LONGITUDE"],
+        formatted_address: nil, # could build this, ignoring for now
+        country_id: request.env["HTTP_CF_IP_COUNTRY"],
+        neighborhood: request.env["HTTP_CF_METRO"],
+        street: nil,
+        postal_code: request.env["HTTP_CF_POSTAL_CODE"],
+        region_string: request.env["HTTP_CF_REGION"]
+      }
+    end
+
+    def location_hash_geocoder(ip_address, new_attrs: false)
+      GeocodeHelper.address_hash_for(ip_address, new_attrs:)
+    end
   end
 end

--- a/config/initializers/ip_address_parser.rb
+++ b/config/initializers/ip_address_parser.rb
@@ -1,5 +1,5 @@
-class ForwardedIpAddress
-  def self.parse(request)
+class IpAddressParser
+  def self.forwarded_address(request)
     addy = request.env["HTTP_CF_CONNECTING_IP"]
     addy ||= request.env["HTTP_X_FORWARDED_FOR"].split(",").last if request.env["HTTP_X_FORWARDED_FOR"].present?
     addy || request.env["REMOTE_ADDR"] || request.env["ip"]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -203,6 +203,7 @@ Rails.application.routes.draw do
     get "tsvs", to: "dashboard#tsvs"
     get "bust_z_cache", to: "dashboard#bust_z_cache"
     get "destroy_example_bikes", to: "dashboard#destroy_example_bikes"
+    get "ip_location", to: "dashboard#ip_location"
     resources :ads,
       :bulk_imports,
       :content_tags,

--- a/spec/requests/admin/dashboard_request_spec.rb
+++ b/spec/requests/admin/dashboard_request_spec.rb
@@ -116,5 +116,13 @@ RSpec.describe Admin::DashboardController, type: :request do
         expect(FileCacheMaintainer.blocklist).to eq([1, 2, 69, 200, 22222].map(&:to_s))
       end
     end
+
+    describe "ip_location" do
+      it "renders" do
+        get "/admin/ip_location"
+        expect(response.code).to eq "200"
+        expect(response).to render_template(:ip_location)
+      end
+    end
   end
 end


### PR DESCRIPTION
This will enable passing country id to address record building (to initialize with the correct country) and membership (for currency)

Also added `/admin/ip_location` to compare the results from Cloudflare against the results from Geocoder