### PR TITLE
Fix: Remove overly-broad Universal Links exclusion

### DIFF
--- a/public/.well-known/apple-app-site-association
+++ b/public/.well-known/apple-app-site-association
@@ -6,11 +6,6 @@
          ],
          "components": [
             {
-               "/": "*",
-               "exclude": true,
-               "comment": "Defer all to the web (instead of app) for all links except those explicitly listed later"
-            },
-            {
                "/": "/bikes/scanned/*",
                "comment": "Example: bikeindex.org/bikes/scanned/A40340, open directly in-app for QR code scanning"
             }


### PR DESCRIPTION
# Description

1. AASA file from PR https://github.com/bikeindex/bike_index/pull/2756 is propagated 
    - See: https://app-site-association.cdn-apple.com/a/v1/bikeindex.org
2. Settings > Developer > Universal Links section > Associated Domains Development → ON
3. Settings > Developer > Universal Links section > Diagnostics > paste `https://bikeindex.org/bikes/scanned/A40340` URL for validation ✅ 
4. Branch.io's validator reports a misconfiguration https://branch.io/resources/aasa-validator/
- components declaring `bikes/scanned/*` should be sufficient alone