### PR TITLE
Fix: Universal Links > AASA > Details needs to be an array of objects

### DIFF
--- a/public/.well-known/apple-app-site-association
+++ b/public/.well-known/apple-app-site-association
@@ -1,16 +1,18 @@
 {
    "applinks": {
-      "details": {
-         "appIDs": [
-            "8ZM5ZL6ABT.org.bikeindex.app"
-         ],
-         "components": [
-            {
-               "/": "/bikes/scanned/*",
-               "comment": "Example: bikeindex.org/bikes/scanned/A40340, open directly in-app for QR code scanning"
-            }
-         ]
-      }
+      "details": [
+         {
+            "appIDs": [
+               "8ZM5ZL6ABT.org.bikeindex.app"
+            ],
+            "components": [
+               {
+                  "/": "/bikes/scanned/*",
+                  "comment": "Example: bikeindex.org/bikes/scanned/A40340, open directly in-app for QR code scanning"
+               }
+            ]
+         }
+      ]
    },
    "webcredentials": {
       "apps": [


### PR DESCRIPTION
# Description

- Change `applinks > details > { appIDs, components }` to `[{ appIDs, components }]`
- Follow format at https://developer.apple.com/documentation/xcode/supporting-associated-domains
- https://github.com/bikeindex/bike_index/pull/2806
- https://github.com/bikeindex/bike_index/pull/2756