### PR TITLE
Show location only on search proximity

### DIFF
--- a/app/components/search/registration_fields/component.html.erb
+++ b/app/components/search/registration_fields/component.html.erb
@@ -3,7 +3,7 @@
   data-search--registration-fields--component-api-count-url-value="<%= API_COUNT_URL %>">
 
   <div
-    class="tw:mt-5 tw:sm:mt-2 tw:flex tw:flex-wrap tw:sm:flex-nowrap tw:w-full tw:sm:w-min tw:ml-auto"
+    class="tw:mt-5 tw:sm:mt-2 tw:flex tw:flex-wrap tw:sm:flex-nowrap tw:w-full tw:sm:w-min tw:ml-auto <%= location_wrap_hidden? ? 'tw:hidden' : '' %>"
     data-search--registration-fields--component-target="locationWrap">
 
     <span class="tw:flex tw:flex-nowrap">
@@ -34,7 +34,8 @@
           <%= radio_button_tag(:stolenness, opt, @stolenness == opt,
             class: "tw:w-4 tw:h-4 tw:text-blue-600 tw:bg-gray-100 tw:border-gray-300 tw:focus:ring-blue-500 " \
               ":tw:dark:focus:ring-blue-600 tw:dark:ring-offset-gray-700 tw:dark:focus:ring-offset-gray-700 " \
-              "tw:focus:ring-2 tw:dark:bg-gray-600 tw:dark:border-gray-500")
+              "tw:focus:ring-2 tw:dark:bg-gray-600 tw:dark:border-gray-500",
+              "data-action" => "change->search--registration-fields--component#updateLocationVisibility")
           %>
 
           <%= label_tag("stolenness_#{opt}", class: "tw:w-full tw:py-3 tw:ms-2 tw:cursor-pointer") do %>

--- a/app/components/search/registration_fields/component.rb
+++ b/app/components/search/registration_fields/component.rb
@@ -21,6 +21,10 @@ module Search::RegistrationFields
 
     private
 
+    def location_wrap_hidden?
+      @stolenness != "proximity" # also true for marketplace
+    end
+
     def include_stolenness?
       true # will be false for versions and marketplace
     end

--- a/app/components/search/registration_fields/component_controller.js
+++ b/app/components/search/registration_fields/component_controller.js
@@ -1,4 +1,5 @@
 import { Controller } from '@hotwired/stimulus'
+import { collapse } from 'utils/collapse_utils'
 
 /* global localStorage  */
 
@@ -30,6 +31,16 @@ export default class extends Controller {
     if (!this.form) return
 
     this.form.addEventListener('turbo:submit-end', this.setStolennessCounts.bind(this))
+  }
+
+  updateLocationVisibility () {
+    const selectedValue = this.element.querySelector('input[name="stolenness"]:checked')?.value
+
+    if (selectedValue === 'proximity') {
+      collapse('show', this.locationWrapTarget)
+    } else {
+      collapse('hide', this.locationWrapTarget)
+    }
   }
 
   // TODO: make this location be controller specific

--- a/app/javascript/utils/collapse_utils.js
+++ b/app/javascript/utils/collapse_utils.js
@@ -49,6 +49,8 @@ export class CollapseUtils {
    * @param {number} duration - Animation duration in milliseconds
    */
   static show (element, duration) {
+    // Return early if already visible
+    if (this.isVisible(element)) return
     // Remove the hidden
     element.classList.remove('tw:hidden!')
     // First, ensure the hidden attributes are set
@@ -73,6 +75,9 @@ export class CollapseUtils {
    * @param {number} duration - Animation duration in milliseconds
    */
   static hide (element, duration) {
+    // Return early if already hidden
+    if (!this.isVisible(element)) return
+
     // Always add transition classes (moving toward a more generalizable collapse method)
     element.classList.add('tw:transition-all', `tw:duration-${duration}`)
     // Add the tailwind class to shrink
@@ -86,6 +91,20 @@ export class CollapseUtils {
     setTimeout(() => {
       element.classList.add('tw:hidden!')
     }, duration)
+  }
+
+  /**
+   * Checks if an element is visible in the viewport
+   * @param {HTMLElement} element - The element to check
+   * @return {boolean} - True if element is visible
+   */
+  static isVisible (element) {
+    // check display, visibility and opacity
+    if (window.getComputedStyle(element).display === 'none') return false
+    if (window.getComputedStyle(element).visibility === 'hidden') return false
+    if (window.getComputedStyle(element).opacity === '0') return false
+
+    return true
   }
 }
 

--- a/app/javascript/utils/collapse_utils.js
+++ b/app/javascript/utils/collapse_utils.js
@@ -39,7 +39,7 @@ export class CollapseUtils {
   static toggle (element, duration) {
     if (!element) return
 
-    const isHidden = element.classList.contains('tw:hidden!')
+    const isHidden = element.classList.contains('tw:hidden!') || element.classList.contains('tw:hidden')
     this.collapse(isHidden ? 'show' : 'hide', element, duration)
   }
 
@@ -52,7 +52,7 @@ export class CollapseUtils {
     // Return early if already visible
     if (this.isVisible(element)) return
     // Remove the hidden
-    element.classList.remove('tw:hidden!')
+    element.classList.remove('tw:hidden!', 'tw:hidden')
     // First, ensure the hidden attributes are set
     element.classList.add('tw:scale-y-0')
     element.style.height = 0


### PR DESCRIPTION
Based on feedback, revert #2773. Once again, only show location fields when "stolen in search area" is selected