### PR TITLE
Make marketplace messages thread email replies

### DIFF
--- a/app/components/definition_list/row/component.html.erb
+++ b/app/components/definition_list/row/component.html.erb
@@ -10,7 +10,7 @@
         <%= l @value, format: :convert_time %>
       </span>
       <% if @include_time_zone %>
-        <span class="convertTimezone"></span>
+        <span class="localizeTimezone"></span>
       <% end %>
     <% elsif @value.present? %>
       <%= @value %>

--- a/app/components/definition_list/row/component.rb
+++ b/app/components/definition_list/row/component.rb
@@ -49,7 +49,7 @@ module DefinitionList::Row
 
     def time_localizer_classes(time_localizer_settings)
       time_localizer_settings ||= []
-      time_localizer_settings << "convertTime"
+      time_localizer_settings << "localizeTime"
       time_localizer_settings.join(" ")
     end
   end

--- a/app/components/messages/thread/component.html.erb
+++ b/app/components/messages/thread/component.html.erb
@@ -2,7 +2,7 @@
   <span class="tw:lg:min-w-40 tw:col-span-3 tw:lg:col-auto tw:truncate" title="<%= translation(".from") %>: <%= sender_full_text %>">
     <%= sender_display_html %>
   </span>
-  <div class="tw:w-28 tw:text-right tw:lg:order-last">
+  <div class=" tw:text-right tw:lg:order-last tw:grow">
     <span class="convertTime">
       <%= l @marketplace_message.created_at, format: :convert_time %>
     </span>
@@ -11,6 +11,10 @@
     <span class="tw:absolute tw:inset-0 tw:z-10"></span>
     <strong class="tw:opacity-65 tw:mr-2"><%= item_title %></strong>
 
-    <span title="<%= @marketplace_message.body %>"><%= message_display %></span>
+    <span title="<%= @marketplace_message.body %>">
+      <%= message_display %>
+      <%# This is a gross hack to make this the full width, TODO: fix! %>
+      <span class="tw:opacity-0 tw:hidden tw:lg:inline"><%= message_display_filler %></span>
+    </span>
   </a>
 </div>

--- a/app/components/messages/thread/component.html.erb
+++ b/app/components/messages/thread/component.html.erb
@@ -1,5 +1,7 @@
-<div class="tw:w-full tw:py-2 tw:px-3 tw:border-t tw:last:border-b tw:border-gray-200 tw:dark:border-gray-700 tw:flex tw:max-lg:flex-wrap tw:relative tw:hover:shadow-md tw:dark:hover:shadow-slate-300/10">
-  <span class="tw:max-lg:grow tw:lg:w-40 tw:lg:min-w-40 tw:truncate" title="<%= translation(".from") %>: <%= sender_full_text %>">
+<a
+  href="<%= message_path %>"
+  class="tw:w-full tw:py-2 tw:px-3 tw:border-t tw:last:border-b tw:border-gray-200 tw:dark:border-gray-700 tw:flex tw:max-lg:flex-wrap tw:hover:shadow-md tw:dark:hover:shadow-slate-300/10">
+  <span class="tw:max-lg:grow tw:lg:w-60 tw:lg:min-w-60 tw:truncate" title="<%= translation(".from") %>: <%= sender_full_text %>">
     <%= sender_display_html %>
   </span>
   <div class="tw:w-30 tw:text-right tw:lg:order-last">
@@ -7,12 +9,11 @@
       <%= l @marketplace_message.created_at, format: :convert_time %>
     </span>
   </div>
-  <a href="<%= message_path %>" class="tw:max-lg:min-w-full tw:lg:grow tw:lg:truncate">
-    <span class="tw:absolute tw:inset-0 tw:z-10"></span>
+  <span class="tw:max-lg:min-w-full tw:lg:grow tw:lg:truncate">
     <strong class="tw:opacity-65 tw:mr-2"><%= item_title %></strong>
 
     <span title="<%= @marketplace_message.body %>">
       <%= message_display %>
     </span>
-  </a>
-</div>
+  </span>
+</a>

--- a/app/components/messages/thread/component.html.erb
+++ b/app/components/messages/thread/component.html.erb
@@ -1,9 +1,9 @@
-<div class="tw:w-full tw:py-2 tw:px-3 tw:border-b tw:first:border-t tw:border-gray-200 tw:dark:border-gray-700 tw:flex tw:max-lg:flex-wrap tw:relative tw:hover:shadow-md tw:dark:hover:shadow-slate-300/10">
+<div class="tw:w-full tw:py-2 tw:px-3 tw:border-t tw:last:border-b tw:border-gray-200 tw:dark:border-gray-700 tw:flex tw:max-lg:flex-wrap tw:relative tw:hover:shadow-md tw:dark:hover:shadow-slate-300/10">
   <span class="tw:max-lg:grow tw:lg:w-40 tw:lg:min-w-40 tw:truncate" title="<%= translation(".from") %>: <%= sender_full_text %>">
     <%= sender_display_html %>
   </span>
   <div class="tw:w-30 tw:text-right tw:lg:order-last">
-    <span class="convertTime">
+    <span class="localizeTime">
       <%= l @marketplace_message.created_at, format: :convert_time %>
     </span>
   </div>

--- a/app/components/messages/thread/component.html.erb
+++ b/app/components/messages/thread/component.html.erb
@@ -1,20 +1,18 @@
-<div class="tw:w-full tw:py-2 tw:px-3 tw:border-b tw:first:border-t tw:border-gray-200 tw:dark:border-gray-700 tw:gap-x-6 tw:grid tw:grid-cols-max tw:max-md:grid-cols-4 tw:lg:grid-flow-col tw:relative tw:hover:shadow-sm tw:dark:hover:shadow-white/10">
-  <span class="tw:lg:min-w-40 tw:col-span-3 tw:lg:col-auto tw:truncate" title="<%= translation(".from") %>: <%= sender_full_text %>">
+<div class="tw:w-full tw:py-2 tw:px-3 tw:border-b tw:first:border-t tw:border-gray-200 tw:dark:border-gray-700 tw:flex tw:max-lg:flex-wrap tw:relative tw:hover:shadow-md tw:dark:hover:shadow-slate-300/10">
+  <span class="tw:max-lg:grow tw:lg:w-40 tw:lg:min-w-40 tw:truncate" title="<%= translation(".from") %>: <%= sender_full_text %>">
     <%= sender_display_html %>
   </span>
-  <div class="tw:text-right tw:lg:order-last ">
+  <div class="tw:w-30 tw:text-right tw:lg:order-last">
     <span class="convertTime">
       <%= l @marketplace_message.created_at, format: :convert_time %>
     </span>
   </div>
-  <a href="<%= message_path %>" class="tw:col-span-4 tw:lg:truncate tw:lg:col-auto tw:lg:w-full tw:grow">
+  <a href="<%= message_path %>" class="tw:max-lg:min-w-full tw:lg:grow tw:lg:truncate">
     <span class="tw:absolute tw:inset-0 tw:z-10"></span>
     <strong class="tw:opacity-65 tw:mr-2"><%= item_title %></strong>
 
     <span title="<%= @marketplace_message.body %>">
       <%= message_display %>
-      <%# This is a gross hack to make this the full width, TODO: fix! %>
-      <span class="tw:opacity-0 tw:hidden tw:lg:inline"><%= message_display_filler %></span>
     </span>
   </a>
 </div>

--- a/app/components/messages/thread/component.html.erb
+++ b/app/components/messages/thread/component.html.erb
@@ -2,12 +2,12 @@
   <span class="tw:lg:min-w-40 tw:col-span-3 tw:lg:col-auto tw:truncate" title="<%= translation(".from") %>: <%= sender_full_text %>">
     <%= sender_display_html %>
   </span>
-  <div class=" tw:text-right tw:lg:order-last tw:grow">
+  <div class="tw:text-right tw:lg:order-last ">
     <span class="convertTime">
       <%= l @marketplace_message.created_at, format: :convert_time %>
     </span>
   </div>
-  <a href="<%= message_path %>" class="tw:col-span-4 tw:lg:truncate tw:lg:col-auto tw:lg:w-full">
+  <a href="<%= message_path %>" class="tw:col-span-4 tw:lg:truncate tw:lg:col-auto tw:lg:w-full tw:grow">
     <span class="tw:absolute tw:inset-0 tw:z-10"></span>
     <strong class="tw:opacity-65 tw:mr-2"><%= item_title %></strong>
 

--- a/app/components/messages/thread/component.html.erb
+++ b/app/components/messages/thread/component.html.erb
@@ -1,4 +1,4 @@
-<div class="tw:w-full tw:py-2 tw:px-3 tw:border-y tw:border-gray-200 tw:dark:border-gray-700 tw:gap-x-6 tw:grid tw:grid-cols-max tw:max-md:grid-cols-4 tw:lg:grid-flow-col tw:relative tw:hover:shadow-md">
+<div class="tw:w-full tw:py-2 tw:px-3 tw:border-b tw:first:border-t tw:border-gray-200 tw:dark:border-gray-700 tw:gap-x-6 tw:grid tw:grid-cols-max tw:max-md:grid-cols-4 tw:lg:grid-flow-col tw:relative tw:hover:shadow-sm tw:dark:hover:shadow-white/10">
   <span class="tw:lg:min-w-40 tw:col-span-3 tw:lg:col-auto tw:truncate" title="<%= translation(".from") %>: <%= sender_full_text %>">
     <%= sender_display_html %>
   </span>

--- a/app/components/messages/thread/component.rb
+++ b/app/components/messages/thread/component.rb
@@ -36,7 +36,7 @@ module Messages::Thread
     def message_display_filler
       return "" unless message_display.length < TRUNCATED_MESSAGE_LENGTH
 
-      TRUNCATED_MESSAGE_LENGTH.times.map { |_i| "&nbsp;" }.join.html_safe
+      (TRUNCATED_MESSAGE_LENGTH * 2).times.map { |_i| "&nbsp;" }.join.html_safe
     end
 
     def sender_display_html

--- a/app/components/messages/thread/component.rb
+++ b/app/components/messages/thread/component.rb
@@ -17,7 +17,7 @@ module Messages::Thread
     private
 
     def message_path
-      my_account_message_path(id: @initial_record.id)
+      my_account_message_path(id: @initial_record.id, anchor: "message-#{@marketplace_message.id}")
     end
 
     def item_title

--- a/app/components/messages/thread/component.rb
+++ b/app/components/messages/thread/component.rb
@@ -3,6 +3,8 @@
 # NOTE: This component makes a number of DB calls - so rendering of this should be cached!
 module Messages::Thread
   class Component < ApplicationComponent
+    TRUNCATED_MESSAGE_LENGTH = 120
+
     def initialize(marketplace_message:, current_user:)
       @marketplace_message = marketplace_message
       @messages_prior_arr = @marketplace_message.messages_prior.pluck(:kind, :sender_id)
@@ -25,10 +27,16 @@ module Messages::Thread
 
     def message_display
       if @marketplace_message.initial_message?
-        "#{@initial_record.subject} - #{@marketplace_message.body}".truncate(100)
+        "#{@initial_record.subject} - #{@marketplace_message.body}".truncate(TRUNCATED_MESSAGE_LENGTH)
       else
-        @marketplace_message.body.truncate(100)
+        @marketplace_message.body.truncate(TRUNCATED_MESSAGE_LENGTH)
       end
+    end
+
+    def message_display_filler
+      return "" unless message_display.length < TRUNCATED_MESSAGE_LENGTH
+
+      TRUNCATED_MESSAGE_LENGTH.times.map { |_i| "&nbsp;" }.join.html_safe
     end
 
     def sender_display_html

--- a/app/components/messages/thread/component.rb
+++ b/app/components/messages/thread/component.rb
@@ -33,12 +33,6 @@ module Messages::Thread
       end
     end
 
-    def message_display_filler
-      return "" unless message_display.length < TRUNCATED_MESSAGE_LENGTH
-
-      (TRUNCATED_MESSAGE_LENGTH * 2).times.map { |_i| "&nbsp;" }.join.html_safe
-    end
-
     def sender_display_html
       if @marketplace_message.initial_message?
         if @marketplace_message.sender_id == @current_user.id

--- a/app/components/messages/thread/component_preview.rb
+++ b/app/components/messages/thread/component_preview.rb
@@ -3,8 +3,13 @@
 module Messages::Thread
   class ComponentPreview < ApplicationComponentPreview
     def default
-      marketplace_message = built_marketplace_message(default_marketplace_message_attrs)
-      render(Messages::Thread::Component.new(marketplace_message:, current_user:))
+      # marketplace_message_1 = built_marketplace_message(default_marketplace_message_attrs)
+      # marketplace_message_2 = built_marketplace_message(default_marketplace_message_attrs.merge(body: "yes"))
+      # # marketplace_message_3 = built_marketplace_message(default_marketplace_message_attrs.merge(messages_prior_count: 3))
+      # render do
+      #   Messages::Thread::Component.new(marketplace_message: marketplace_message_1, current_user:))
+      #   Messages::Thread::Component.new(marketplace_message: marketplace_message_2, current_user:))
+      # end
     end
 
     private

--- a/app/components/messages/thread/component_preview.rb
+++ b/app/components/messages/thread/component_preview.rb
@@ -3,16 +3,19 @@
 module Messages::Thread
   class ComponentPreview < ApplicationComponentPreview
     def default
-      # marketplace_message_1 = built_marketplace_message(default_marketplace_message_attrs)
-      # marketplace_message_2 = built_marketplace_message(default_marketplace_message_attrs.merge(body: "yes"))
-      # # marketplace_message_3 = built_marketplace_message(default_marketplace_message_attrs.merge(messages_prior_count: 3))
-      # render do
-      #   Messages::Thread::Component.new(marketplace_message: marketplace_message_1, current_user:))
-      #   Messages::Thread::Component.new(marketplace_message: marketplace_message_2, current_user:))
-      # end
+      {template: "messages/thread/component_preview/default", locals: {current_user:, marketplace_messages:}}
     end
 
     private
+
+    def marketplace_messages
+      [
+        built_marketplace_message(default_marketplace_message_attrs),
+        built_marketplace_message(default_marketplace_message_attrs.merge(body: "yes")),
+        built_marketplace_message(default_marketplace_message_attrs.merge(body: long_body)),
+        built_marketplace_message(default_marketplace_message_attrs.merge(created_at: Time.current - 6.months))
+      ]
+    end
 
     def current_user
       @current_user ||= User.find(ENV.fetch("LOOKBOOK_USER_ID", 1))
@@ -32,7 +35,7 @@ module Messages::Thread
         marketplace_listing: marketplace_listing,
         receiver: current_user,
         sender: other_user,
-        created_at: Time.current - 2.hours - 6.months
+        created_at: Time.current - 2.hours
       }
     end
 
@@ -45,6 +48,11 @@ module Messages::Thread
       message = MarketplaceMessage.new(attrs)
       message.send(:set_calculated_attributes)
       message
+    end
+
+    def long_body
+      "Cred poutine 8-bit, put a bird on it iceland tofu knausgaard craft beer fingerstache distillery pitchfork authentic master cleanse jawn banjo.\n\n" \
+      "Mixtape distillery raw denim four loko dreamcatcher. Celiac schlitz mlkshk whatever, gochujang chia disrupt actually lomo distillery."
     end
   end
 end

--- a/app/components/messages/thread/component_preview.rb
+++ b/app/components/messages/thread/component_preview.rb
@@ -12,8 +12,7 @@ module Messages::Thread
       [
         built_marketplace_message(default_marketplace_message_attrs),
         built_marketplace_message(default_marketplace_message_attrs.merge(body: "yes")),
-        built_marketplace_message(default_marketplace_message_attrs.merge(body: long_body)),
-        built_marketplace_message(default_marketplace_message_attrs.merge(created_at: Time.current - 6.months))
+        built_marketplace_message(default_marketplace_message_attrs.merge(body: long_body, created_at: Time.current - 6.months))
       ]
     end
 

--- a/app/components/messages/thread/component_preview/default.html.erb
+++ b/app/components/messages/thread/component_preview/default.html.erb
@@ -1,0 +1,3 @@
+<% marketplace_messages.each do |marketplace_message| %>
+  <%= render(Messages::Thread::Component.new(marketplace_message:, current_user: current_user)) %>
+<% end %>

--- a/app/components/messages/thread_show/component.html.erb
+++ b/app/components/messages/thread_show/component.html.erb
@@ -5,10 +5,12 @@
 
   <% if @marketplace_messages.any? %>
     <% @marketplace_messages.each do |marketplace_message| %>
-      <div class="tw:p-4 tw:bg-white tw:border tw:border-gray-200 tw:rounded-sm tw:dark:bg-gray-800 tw:dark:border-gray-700 tw:mt-4">
+      <div
+        id="message-<%= marketplace_message.id %>"
+        class="tw:p-4 tw:bg-white tw:border tw:border-gray-200 tw:rounded-sm tw:dark:bg-gray-800 tw:dark:border-gray-700 tw:mt-4">
         <div class="tw:w-full tw:mb-2 tw:gap-x-6 tw:flex tw:flex-nowrap">
           <span class="tw:block tw:grow"><%= user_display(marketplace_message.sender_id) %></span>
-          <span class="tw:block convertTime">
+          <span class="tw:block localizeTime preciseTime">
             <%= l marketplace_message.created_at, format: :convert_time %>
           </span>
         </div>

--- a/app/components/search/bike_box/component.html.erb
+++ b/app/components/search/bike_box/component.html.erb
@@ -25,7 +25,7 @@
       <ul class="attr-list">
         <li>
           <%= bike_status_span(@bike) %>:
-          <span class="convertTime">
+          <span class="localizeTime">
             <%= l @bike.occurred_at, format: :convert_time %>
           </span>
         </li>

--- a/app/controllers/admin/marketplace_listings_controller.rb
+++ b/app/controllers/admin/marketplace_listings_controller.rb
@@ -1,0 +1,33 @@
+class Admin::MarketplaceListingsController < Admin::BaseController
+  include SortableTable
+
+  def index
+    @per_page = params[:per_page] || 50
+    @pagy, @collection = pagy(
+      matching_marketplace_listings.includes(:seller, :item, :buyer).reorder("marketplace_listings.#{sort_column} #{sort_direction}"),
+      limit: @per_page
+    )
+  end
+
+  helper_method :matching_marketplace_listings, :searchable_statuses
+
+  protected
+
+  def sortable_columns
+    %w[created_at updated_at published_at end_at item_id amount_cents condition status seller_id buyer_id]
+  end
+
+  def searchable_statuses
+    MarketplaceListing.statuses.keys.map(&:to_s)
+  end
+
+  def matching_marketplace_listings
+    marketplace_listings = MarketplaceListing
+    @status = searchable_statuses.include?(params[:search_status]) ? params[:search_status] : nil
+    marketplace_listings = marketplace_listings.send(@status) if @status.present?
+
+    @time_range_column = sort_column if %w[updated_at published_at end_at].include?(sort_column)
+    @time_range_column ||= "created_at"
+    marketplace_listings.where(@time_range_column => @time_range)
+  end
+end

--- a/app/controllers/admin/marketplace_messages_controller.rb
+++ b/app/controllers/admin/marketplace_messages_controller.rb
@@ -1,0 +1,30 @@
+class Admin::MarketplaceMessagesController < Admin::BaseController
+  include SortableTable
+
+  def index
+    @per_page = params[:per_page] || 50
+    @pagy, @collection = pagy(
+      matching_marketplace_messages.includes(:marketplace_listing, :sender, :receiver).reorder("marketplace_messages.#{sort_column} #{sort_direction}"),
+      limit: @per_page
+    )
+  end
+
+  def show
+    @marketplace_message = MarketplaceMessage.find(params[:id])
+    @marketplace_listing = @marketplace_message.marketplace_listing
+  end
+
+  helper_method :matching_marketplace_messages
+
+  protected
+
+  def sortable_columns
+    %w[created_at marketplace_listing kind initial_record_id sender_id receiver_id]
+  end
+
+  def matching_marketplace_messages
+    marketplace_messages = MarketplaceMessage
+
+    marketplace_messages.where(created_at: @time_range)
+  end
+end

--- a/app/helpers/admin_helper.rb
+++ b/app/helpers/admin_helper.rb
@@ -63,6 +63,8 @@ module AdminHelper
       {title: "Bulk Imports", path: admin_bulk_imports_path, match_controller: true},
       {title: "Duplicate Bikes", path: duplicates_admin_bikes_path, match_controller: false},
       {title: "Model Audits", path: admin_model_audits_path, match_controller: true},
+      {title: "Marketplace Listings", path: admin_marketplace_listings_path, match_controller: true},
+      {title: "Marketplace Messages", path: admin_marketplace_messages_path, match_controller: true},
       {title: "Logged bike searches", path: admin_logged_searches_path, match_controller: true},
       {title: "Organization statuses", path: admin_organization_statuses_path, match_controller: true},
       {title: "Config: Email Domains", path: admin_email_domains_path, match_controller: true},

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -24,9 +24,5 @@ function localizeTime () {
   window.timeLocalizer.localize()
 }
 
-// Set window.importmapLocalizeTime on pages without application_revised.js
-// so time localization still happens (e.g. lookbook)
-if (window.importmapLocalizeTime) {
-  document.addEventListener('DOMContentLoaded', localizeTime)
-  document.addEventListener('turbo:frame-render', localizeTime)
-}
+document.addEventListener('DOMContentLoaded', localizeTime)
+document.addEventListener('turbo:render', localizeTime)

--- a/app/javascript/utils/time_localizer.js
+++ b/app/javascript/utils/time_localizer.js
@@ -1,4 +1,5 @@
 // TODO: add ability to show in og time zone
+// 2025-5-15 - switch to using .localizeTime class (instead of .convertTime)
 // 2025-5-12 - add onlyTodayWithoutDate option
 // 2024-11-24 - refactor code to better take advantage of luxon
 // 2024-11-13 - switch moment to luxon!

--- a/app/javascript/utils/time_localizer.js
+++ b/app/javascript/utils/time_localizer.js
@@ -7,7 +7,7 @@
 
 import { DateTime } from 'luxon'
 
-// TimeLocalizer updates all HTML elements with class '.convertTime', making them:
+// TimeLocalizer updates all HTML elements with class '.localizeTime', making them:
 // - Human readable
 // - Displayed with time in provided timezone
 // - With context relevant data (e.g. today shows hour, last month just date)
@@ -74,13 +74,13 @@ export default class TimeLocalizer {
   // Removes the classes that trigger localization, so it doesn't reupdate the times
   localize () {
     // Write times
-    Array.from(document.getElementsByClassName('convertTime')).forEach((el) =>
+    Array.from(document.getElementsByClassName('localizeTime')).forEach((el) =>
       this.writeTime(el)
     )
 
     // Write timezones
     Array.from(
-      document.getElementsByClassName('convertTimezone')
+      document.getElementsByClassName('localizeTimezone')
     ).forEach((el) => this.writeTimezone(el))
 
     // Write hidden timezone fields - so if we're submitting a form, it includes the current timezone
@@ -104,9 +104,9 @@ export default class TimeLocalizer {
     const text = el.textContent.trim()
     const time = this.parse(text)
     // So running this again doesn't reapply to this element
-    el.classList.remove('convertTime')
+    el.classList.remove('localizeTime')
     // So we know which were updated (for styling, future updates, etc)
-    el.classList.add('convertedTime')
+    el.classList.add('localizedTime')
 
     // If we couldn't parse the time, exit
     if (!(text.length > 0) || time === null) {
@@ -226,6 +226,6 @@ export default class TimeLocalizer {
 
   writeTimezone (el) {
     el.textContent = this.now.toFormat('z')
-    el.classList.remove('convertTimezone')
+    el.classList.remove('localizeTimezone')
   }
 }

--- a/app/jobs/email/marketplace_message_job.rb
+++ b/app/jobs/email/marketplace_message_job.rb
@@ -22,6 +22,6 @@ class Email::MarketplaceMessageJob < ApplicationJob
     marketplace_message.sender&.update(updated_at: Time.current)
     marketplace_message.receiver&.update(updated_at: Time.current)
 
-    delivery # so that we can check the actual email response
+    delivery # so that we can check the actual email response in tests
   end
 end

--- a/app/jobs/email/marketplace_message_job.rb
+++ b/app/jobs/email/marketplace_message_job.rb
@@ -13,13 +13,15 @@ class Email::MarketplaceMessageJob < ApplicationJob
 
     # track_email_delivery returns if delivery_success, but return early here to prevent updating the cache
     return if notification.delivery_success?
-
+    delivery = nil
     notification.track_email_delivery do
-      CustomerMailer.marketplace_message_notification(marketplace_message).deliver_now
+      delivery = CustomerMailer.marketplace_message_notification(marketplace_message).deliver_now
     end
 
     # Bust caches on the associations
     marketplace_message.sender&.update(updated_at: Time.current)
     marketplace_message.receiver&.update(updated_at: Time.current)
+
+    delivery # so that we can check the actual email response
   end
 end

--- a/app/mailers/customer_mailer.rb
+++ b/app/mailers/customer_mailer.rb
@@ -209,7 +209,12 @@ class CustomerMailer < ApplicationMailer
     @skip_header = true
 
     I18n.with_locale(@user&.preferred_language) do
-      mail(to: @user.email, subject: @marketplace_message.subject, tag: __callee__)
+      mail(
+        to: @user.email,
+        subject: @marketplace_message.subject,
+        references: @marketplace_message.email_references_id,
+        tag: __callee__
+      )
     end
   end
 end

--- a/app/models/marketplace_listing.rb
+++ b/app/models/marketplace_listing.rb
@@ -79,7 +79,7 @@ class MarketplaceListing < ApplicationRecord
     end
 
     def status_humanized(str)
-      str&.to_s&.gsub("_", " ")
+      str&.to_s&.tr("_", " ")
     end
 
     private

--- a/app/models/marketplace_listing.rb
+++ b/app/models/marketplace_listing.rb
@@ -78,12 +78,20 @@ class MarketplaceListing < ApplicationRecord
       ].freeze
     end
 
+    def status_humanized(str)
+      str&.to_s&.gsub("_", " ")
+    end
+
     private
 
     def item_address_record(item)
       item.user&.address_record ||
         AddressRecord.new(user: item.user, kind: :marketplace_listing)
     end
+  end
+
+  def status_humanized
+    self.class.status_humanized(status)
   end
 
   def current?

--- a/app/models/marketplace_message.rb
+++ b/app/models/marketplace_message.rb
@@ -186,6 +186,14 @@ class MarketplaceMessage < ApplicationRecord
     [sender_id, receiver_id]
   end
 
+  def email_references_id
+    return nil if initial_message?
+
+    er_id = Notification.where(notifiable_type: "MarketplaceMessage", notifiable_id: messages_prior.pluck(:id))
+      .with_message_id.order(:id).limit(1).pluck(:message_id).first
+    er_id.present? ? "<#{er_id}>" : nil
+  end
+
   private
 
   def users_match_initial_record

--- a/app/models/marketplace_message.rb
+++ b/app/models/marketplace_message.rb
@@ -47,8 +47,8 @@ class MarketplaceMessage < ApplicationRecord
   scope :reply_message, -> { where.not("id = initial_record_id") }
   scope :buyer_seller_message, -> { where(kind: BUYER_SELLER_MESSAGE_KINDS) }
   scope :distinct_threads, -> {
-    select("DISTINCT ON (initial_record_id) *")
-      .order(:initial_record_id, id: :desc)
+    select("DISTINCT ON (marketplace_messages.initial_record_id) *")
+      .order("marketplace_messages.initial_record_id, marketplace_messages.id desc")
   }
 
   delegate :seller_id, :seller, :item, :item_id, :item_type,

--- a/app/models/marketplace_message.rb
+++ b/app/models/marketplace_message.rb
@@ -122,6 +122,10 @@ class MarketplaceMessage < ApplicationRecord
 
       Rails.cache.fetch(["any_marketplace_messages", user]) { for_user(user).any? }
     end
+
+    def kind_humanized(str)
+      str&.to_s&.gsub("sender_", "")
+    end
   end
 
   # Should be called before creation
@@ -192,6 +196,10 @@ class MarketplaceMessage < ApplicationRecord
     er_id = Notification.where(notifiable_type: "MarketplaceMessage", notifiable_id: messages_prior.pluck(:id))
       .with_message_id.order(:id).limit(1).pluck(:message_id).first
     er_id.present? ? "<#{er_id}>" : nil
+  end
+
+  def kind_humanized
+    self.class.kind_humanized(kind)
   end
 
   private

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -15,6 +15,7 @@
 #  created_at             :datetime         not null
 #  updated_at             :datetime         not null
 #  bike_id                :bigint
+#  message_id             :string
 #  notifiable_id          :bigint
 #  user_id                :bigint
 #
@@ -222,8 +223,9 @@ class Notification < ApplicationRecord
   def track_email_delivery
     return if delivery_success?
 
-    yield
+    delivery = yield
 
+    self.message_id ||= message_id_from_delivery(delivery)
     update(delivery_status: "delivery_success")
     user_email&.update_last_email_errored!(email_errored: false)
   rescue => e
@@ -242,6 +244,10 @@ class Notification < ApplicationRecord
   end
 
   private
+
+  def message_id_from_delivery(delivery)
+    defined?(delivery.message_id) ? delivery.message_id : nil
+  end
 
   def calculated_phone
     notifiable&.phone

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -56,6 +56,7 @@ class Notification < ApplicationRecord
   scope :customer_contact, -> { where(kind: customer_contact_kinds) }
   scope :theft_survey, -> { where(kind: theft_survey_kinds) }
   scope :admin, -> { where(kind: admin_kinds) }
+  scope :with_message_id, -> { where.not(message_id: nil) }
 
   class << self
     def kinds

--- a/app/views/admin/marketplace_listings/_table.html.haml
+++ b/app/views/admin/marketplace_listings/_table.html.haml
@@ -46,9 +46,9 @@
               %span.convertTime
                 = l marketplace_listing.published_at, format: :convert_time
           %td
-            - if marketplace_listing.published_at.present?
+            - if marketplace_listing.end_at.present?
               %span.convertTime
-                = l marketplace_listing.published_at, format: :convert_time
+                = l marketplace_listing.end_at, format: :convert_time
           %td
             = render partial: "/shared/admin/bike_cell", locals: {bike: marketplace_listing.item, bike_id: marketplace_listing.item_id, bike_link_path: bike_path(marketplace_listing.item_id, show_marketplace_preview: true) }
           %td

--- a/app/views/admin/marketplace_listings/_table.html.haml
+++ b/app/views/admin/marketplace_listings/_table.html.haml
@@ -1,0 +1,62 @@
+.full-screen-table
+  %table.table.table-striped.table-bordered.table-sm
+    %thead.thead-light
+      %th
+        = sortable "created_at", render_sortable: render_sortable
+      - if display_dev_info?
+        %th.only-dev-visible.small
+          = sortable "updated_at", render_sortable: render_sortable
+      %th
+        = sortable "status", render_sortable: render_sortable
+      %th
+        = sortable "published_at", render_sortable: render_sortable
+      %th
+        = sortable "end_at", render_sortable: render_sortable
+      %th
+        Item
+      %th
+        = sortable "amount_cents", "amount", render_sortable: render_sortable
+      %th
+        = sortable "condition", render_sortable: render_sortable
+      %th
+        = sortable "seller_id", render_sortable: render_sortable
+      %th
+        = sortable "buyer_id", render_sortable: render_sortable
+    %tbody
+      - collection.each do |marketplace_listing|
+        %tr
+          %td
+            .less-strong-hold
+              %span.convertTime
+                = l marketplace_listing.created_at, format: :convert_time
+              - if display_dev_info?
+                %span.less-strong-right.d-none.d-md-block.only-dev-visible
+                  = marketplace_listing.id
+          - if display_dev_info?
+            %td
+              %small.convertTime
+                = l marketplace_listing.updated_at, format: :convert_time
+          %td
+            - status_class = "text-info" if marketplace_listing.for_sale?
+            - status_class = "text-success" if marketplace_listing.sold?
+            %span{class: status_class}
+              = marketplace_listing.status_humanized
+          %td
+            - if marketplace_listing.published_at.present?
+              %span.convertTime
+                = l marketplace_listing.published_at, format: :convert_time
+          %td
+            - if marketplace_listing.published_at.present?
+              %span.convertTime
+                = l marketplace_listing.published_at, format: :convert_time
+          %td
+            = render partial: "/shared/admin/bike_cell", locals: {bike: marketplace_listing.item, bike_id: marketplace_listing.item_id, bike_link_path: bike_path(marketplace_listing.item_id, show_marketplace_preview: true) }
+          %td
+            = "#{marketplace_listing.currency_symbol}#{admin_number_display(marketplace_listing.amount)}"
+          %td
+            = marketplace_listing.status_humanized
+          %td
+            = render partial: "/shared/admin/user_cell", locals: {user: marketplace_listing.seller, render_search: true, cache: true}
+          %td
+            - if marketplace_listing.buyer_id.present?
+              = render partial: "/shared/admin/user_cell", locals: {user: marketplace_listing.buyer_id, render_search: true, cache: true}

--- a/app/views/admin/marketplace_listings/index.html.haml
+++ b/app/views/admin/marketplace_listings/index.html.haml
@@ -1,0 +1,14 @@
+- nav_header_list_items = capture_haml do
+  %li.nav-item.dropdown
+    %a.nav-link.dropdown-toggle{href: "#", role: "button", "data-toggle" => "dropdown", "aria-haspopup" => "true", "aria-expanded" => "false", class: (@status.present? ? "active" : "")}
+      - if @status.blank?
+        All statuses
+      - else
+        #{@status.titleize} only
+    .dropdown-menu
+      = link_to "All statuses", url_for(sortable_search_params.merge(search_status: nil)), class: "dropdown-item #{@status.present? ? '' : 'active'}"
+      .dropdown-divider
+      - searchable_statuses.each do |kind|
+        = link_to "#{kind.titleize} only", url_for(sortable_search_params.merge(search_status: kind)), class: "dropdown-item #{@status == kind ? 'active' : ''}"
+
+= render partial: "/shared/admin/index_skeleton", locals: {chart_collection: @render_chart && matching_marketplace_listings, nav_header_list_items:}

--- a/app/views/admin/marketplace_messages/_table.html.haml
+++ b/app/views/admin/marketplace_messages/_table.html.haml
@@ -1,0 +1,38 @@
+.full-screen-table
+  %table.table.table-striped.table-bordered.table-sm
+    %thead.thead-light
+      %th
+        = sortable "created_at", render_sortable: render_sortable
+      %th
+        = sortable "kind", render_sortable: render_sortable
+      %th
+        = sortable "marketplace_listing", render_sortable: render_sortable
+      %th
+        Body
+      %th
+        = sortable "sender_id", render_sortable: render_sortable
+      -# I don't think this is necessary...
+      -# %th
+      -#   = sortable "receiver_id", render_sortable: render_sortable
+    %tbody
+      - collection.each do |marketplace_message|
+        %tr
+          %td
+            .less-strong-hold
+              %a.convertTime{href: admin_marketplace_message_path(marketplace_message)}
+                = l marketplace_message.created_at, format: :convert_time
+              - if display_dev_info?
+                %span.less-strong-right.d-none.d-md-block.only-dev-visible
+                  = marketplace_message.id
+          %td
+            = marketplace_message.kind_humanized
+          %td
+            %small.less-strong= "#{marketplace_message.marketplace_listing.currency_symbol}#{admin_number_display(marketplace_message.marketplace_listing.amount)}"
+
+            = render partial: "/shared/admin/bike_cell", locals: {bike: marketplace_message.item, bike_link_path: bike_path(marketplace_message.item_id, show_marketplace_preview: true) }
+          %td
+            = marketplace_message.body.truncate(100)
+          %td
+            = render partial: "/shared/admin/user_cell", locals: {user: marketplace_message.sender, render_search: true, cache: true}
+          -# %td
+          -#   = render partial: "/shared/admin/user_cell", locals: {user: marketplace_message.receiver, render_search: true, cache: true}

--- a/app/views/admin/marketplace_messages/index.html.haml
+++ b/app/views/admin/marketplace_messages/index.html.haml
@@ -1,0 +1,1 @@
+= render partial: "/shared/admin/index_skeleton", locals: {chart_collection: @render_chart && matching_marketplace_messages}

--- a/app/views/admin/marketplace_messages/show.html.haml
+++ b/app/views/admin/marketplace_messages/show.html.haml
@@ -1,0 +1,89 @@
+.admin-subnav
+  .col-md-12
+    %h1
+      Marketplace Message
+
+.row.mt-4
+  .col-md-6
+    %table.table-list
+      %tbody
+        - if display_dev_info?
+          %tr
+            %td.only-dev-visible ID
+            %td
+              %code=@marketplace_message.id
+        %tr
+          %td
+            Sender
+          %td
+            = render partial: "/shared/admin/user_cell", locals: {user: @marketplace_message.sender, user_id: @marketplace_message.sender_id}
+        %tr
+          %td
+            Receiver
+          %td
+            = render partial: "/shared/admin/user_cell", locals: {user: @marketplace_message.receiver, user_id: @marketplace_message.receiver_id}
+        %tr.small
+          %td
+            Created
+          %td
+            %span.convertTime.preciseTime
+              = l @marketplace_message.created_at, format: :convert_time
+        %tr.small
+          %td
+            Updated
+          %td
+            %span.convertTime.preciseTime
+              = l @marketplace_message.updated_at, format: :convert_time
+        %tr
+          %td
+            Status
+          %td
+            = @marketplace_message.kind_humanized
+
+  .col-md-6
+    %table.table-list
+      %tbody
+
+        %tr
+          %td Marketplace Listing
+          %td
+            %span.convertTime
+              = l @marketplace_listing.created_at, format: :convert_time
+            - if display_dev_info?
+              %code.only-dev-visible
+                = @marketplace_listing.id
+
+        %tr
+          %td Listing status
+          %td
+            - status_class = "text-info" if @marketplace_listing.for_sale?
+            - status_class = "text-success" if @marketplace_listing.sold?
+            %span{class: status_class}
+              = @marketplace_listing.status_humanized
+        %tr
+          %td Listing published
+          %td
+            - if @marketplace_listing.published_at.present?
+              %span.convertTime
+                = l @marketplace_listing.published_at, format: :convert_time
+        %tr
+          %td Listing end
+          %td
+            - if @marketplace_listing.end_at.present?
+              %span.convertTime
+                = l @marketplace_listing.end_at, format: :convert_time
+        %tr
+          %td price
+          %td
+            = "#{@marketplace_listing.currency_symbol}#{admin_number_display(@marketplace_listing.amount)}"
+        %tr
+          %td Item
+          %td
+            = render partial: "/shared/admin/bike_cell", locals: {bike: @marketplace_listing.item, bike_id: @marketplace_listing.item_id, bike_link_path: bike_path(@marketplace_listing.item_id, show_marketplace_preview: true) }
+.mt-4
+  = render(Card::Component.new(shadow: true)) do
+    %p
+      %strong subject:
+      = @marketplace_message.subject
+
+    = render(UserTextBlockDisplay::Component.new(text: @marketplace_message.body, max_height_class: ""))

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -12,7 +12,6 @@
     - if @include_importmaps
       = javascript_importmap_tags
       = hotwire_livereload_tags if Rails.env.development?
-      <script>window.importmapLocalizeTime = true</script>
     :javascript
       window.BikeIndex.translator = (keyspace) => {
         return (key, args={}) => I18n.t(`javascript.${keyspace}.${key}`, args);

--- a/app/views/layouts/component_preview.html.erb
+++ b/app/views/layouts/component_preview.html.erb
@@ -6,7 +6,6 @@
     <link href="https://fonts.googleapis.com/css?family=Montserrat:400,700" rel="stylesheet" type="text/css">
     <%= stylesheet_link_tag "tailwind" %>
     <%= javascript_importmap_tags %>
-    <script>window.importmapLocalizeTime = true</script>
   </head>
   <%# NOTE: This sets the theme %>
   <body class="<%= params.dig(:lookbook, :display, :theme) %>">

--- a/app/views/layouts/component_preview_form_wrap.html.erb
+++ b/app/views/layouts/component_preview_form_wrap.html.erb
@@ -6,7 +6,6 @@
     <link href="https://fonts.googleapis.com/css?family=Montserrat:400,700" rel="stylesheet" type="text/css">
     <%= stylesheet_link_tag "tailwind", "revised" %>
     <%= javascript_importmap_tags %>
-    <script>window.importmapLocalizeTime = true</script>
   </head>
   <%# NOTE: inline styles to override revised styles and make the form-well show up in the top right %>
   <body class="<%= params.dig(:lookbook, :display, :theme) %>" style="min-height: auto; padding: 1rem 0;">

--- a/app/views/my_accounts/messages/_form.html.erb
+++ b/app/views/my_accounts/messages/_form.html.erb
@@ -14,14 +14,14 @@
     <% if marketplace_message.initial_message? %>
       <div class="tw:mb-3">
         <%= f.label :subject, class: "twlabel" %>
-        <%= f.text_field :subject, maxlength: 180, class: "twinput" %>
+        <%= f.text_field :subject, maxlength: 180, required: true, class: "twinput" %>
       </div>
     <% end %>
 
 
     <div class="tw:mt-3">
       <%= f.label :body, class: "twlabel tw:sr-only" %>
-      <%= f.text_area :body, rows: 5, placeholder: t(".body_placeholder"), class: "twinput" %>
+      <%= f.text_area :body, rows: 5, placeholder: t(".body_placeholder"), required: true, class: "twinput" %>
     </div>
 
     <div class="tw:mt-3 tw:flex tw:items-center tw:justify-end">

--- a/app/views/my_accounts/messages/show.html.erb
+++ b/app/views/my_accounts/messages/show.html.erb
@@ -1,8 +1,11 @@
 <div class="twbootcontainer">
   <%= render(Messages::ThreadShow::Component.new(current_user:, marketplace_messages: @marketplace_messages, marketplace_listing: @marketplace_listing)) %>
-  <% if @can_send_message %>
-    <%= render partial: "form", locals: {marketplace_message: @marketplace_message} %>
-  <% else %>
-    <%= t(".can_not_send_new_message") %>
-  <% end %>
+
+  <div id="reply-form">
+    <% if @can_send_message %>
+      <%= render partial: "form", locals: {marketplace_message: @marketplace_message} %>
+    <% else %>
+      <%= t(".can_not_send_new_message") %>
+    <% end %>
+  </div>
 </div>

--- a/app/views/my_accounts/messages/show.html.erb
+++ b/app/views/my_accounts/messages/show.html.erb
@@ -5,7 +5,9 @@
     <% if @can_send_message %>
       <%= render partial: "form", locals: {marketplace_message: @marketplace_message} %>
     <% else %>
-      <%= t(".can_not_send_new_message") %>
+      <div class="tw:mt-10">
+        <%= render(Alert::Component.new(text: t(".can_not_send_new_message"), kind: :error)) %>
+      </div>
     <% end %>
   </div>
 </div>

--- a/app/views/shared/admin/_bike_cell.html.haml
+++ b/app/views/shared/admin/_bike_cell.html.haml
@@ -1,0 +1,26 @@
+- bike_link_path ||= nil
+- search_url ||= nil
+- render_search ||= search_url.present?
+- bike ||= nil
+- bike_id ||= bike&.id
+
+- if bike.blank? && bike_id.present?
+  %small.text-danger{title: bike_id} Missing bike
+  - unless email.present? # If email is present, the email will be shown
+    %code.small= bike_id
+
+
+- if bike.present?
+  - bike_content = capture_haml do
+    = bike.title_string
+    - if bike.thumb_path.present?
+      %small 📷
+  - if bike_link_path.present?
+    = link_to bike_content, bike_link_path
+  - else
+    = bike_content
+
+- if render_search && (email.present? || bike_id.present?)
+  - search_url ||= bike_id.present? ? url_for(sortable_search_params.merge(bike_id: bike_id)) : url_for(sortable_search_params.merge(search_email: email))
+
+  = link_to search_emoji, search_url, class: "display-sortable-link small"

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -165,7 +165,7 @@
       "check_name": "FileAccess",
       "message": "Model attribute used in file name",
       "file": "app/controllers/bikes_controller.rb",
-      "line": 61,
+      "line": 62,
       "link": "https://brakemanscanner.org/docs/warning_types/file_access/",
       "code": "File.open(\"#{Rails.root}/tmp/#{(\"Registration_\" + Bike.unscoped.find((params[:bike_id] or params[:id])).updated_at.strftime(\"%m%d_%H%M\")[(0..)])}.pdf\", \"wb\")",
       "render_path": null,
@@ -256,7 +256,7 @@
       "check_name": "Render",
       "message": "Render path contains parameter value",
       "file": "app/views/my_accounts/edit.html.haml",
-      "line": 27,
+      "line": 30,
       "link": "https://brakemanscanner.org/docs/warning_types/dynamic_render_path/",
       "code": "render(partial => (params[:edit_template] or edit_templates.keys.first), { :locals => ({ :f => FormBuilder.new }) })",
       "render_path": [
@@ -264,7 +264,7 @@
           "type": "controller",
           "class": "MyAccountsController",
           "method": "edit",
-          "line": 18,
+          "line": 20,
           "file": "app/controllers/my_accounts_controller.rb",
           "rendered": {
             "name": "my_accounts/edit",
@@ -323,7 +323,7 @@
       "check_name": "Send",
       "message": "User controlled method execution",
       "file": "app/controllers/admin/theft_alerts_controller.rb",
-      "line": 133,
+      "line": 130,
       "link": "https://brakemanscanner.org/docs/warning_types/dangerous_send/",
       "code": "(if InputNormalizer.boolean(params[:search_recovered]) then\n  stolen_record_ids = StolenRecord.recovered.with_theft_alerts.where(:theft_alerts => ({ :created_at => (@time_range) })).pluck(:id)\n  TheftAlert.where(:stolen_record_id => StolenRecord.recovered.with_theft_alerts.where(:theft_alerts => ({ :created_at => (@time_range) })).pluck(:id))\nelse\n  TheftAlert\nend).public_send((params[:search_paid_admin] or available_paid_admin.first))",
       "render_path": null,
@@ -346,7 +346,7 @@
       "check_name": "Redirect",
       "message": "Possible unprotected redirect",
       "file": "app/controllers/bikes/theft_alerts_controller.rb",
-      "line": 40,
+      "line": 41,
       "link": "https://brakemanscanner.org/docs/warning_types/redirect/",
       "code": "redirect_to(Payment.new(create_parameters(TheftAlert.create!(:stolen_record => Bike.unscoped.find((params[:bike_id] or params[:id])).current_stolen_record, :theft_alert_plan => TheftAlertPlan.find(params[:theft_alert_plan_id]), :user => current_user))).stripe_checkout_session.url, :allow_other_host => true)",
       "render_path": null,
@@ -369,7 +369,7 @@
       "check_name": "SQL",
       "message": "Possible SQL injection",
       "file": "app/controllers/admin/email_domains_controller.rb",
-      "line": 78,
+      "line": 79,
       "link": "https://brakemanscanner.org/docs/warning_types/sql_injection/",
       "code": "Arel.sql(\"REVERSE(domain) #{sort_direction}\")",
       "render_path": null,
@@ -518,7 +518,7 @@
       "check_name": "Send",
       "message": "User controlled method execution",
       "file": "app/controllers/admin/theft_alerts_controller.rb",
-      "line": 142,
+      "line": 139,
       "link": "https://brakemanscanner.org/docs/warning_types/dangerous_send/",
       "code": "(if InputNormalizer.boolean(params[:search_recovered]) then\n  stolen_record_ids = StolenRecord.recovered.with_theft_alerts.where(:theft_alerts => ({ :created_at => (@time_range) })).pluck(:id)\n  TheftAlert.where(:stolen_record_id => StolenRecord.recovered.with_theft_alerts.where(:theft_alerts => ({ :created_at => (@time_range) })).pluck(:id))\nelse\n  TheftAlert\nend).public_send((params[:search_paid_admin] or available_paid_admin.first)).facebook_updateable.send(params[:search_status])",
       "render_path": null,
@@ -790,7 +790,7 @@
       "check_name": "SQL",
       "message": "Possible SQL injection",
       "file": "app/controllers/admin/email_domains_controller.rb",
-      "line": 74,
+      "line": 75,
       "link": "https://brakemanscanner.org/docs/warning_types/sql_injection/",
       "code": "Arel.sql(\"COALESCE((data -> 'bike_count')::integer, 0) #{sort_direction}\")",
       "render_path": null,
@@ -803,6 +803,29 @@
       "confidence": "Medium",
       "cwe_id": [
         89
+      ],
+      "note": ""
+    },
+    {
+      "warning_type": "Dangerous Send",
+      "warning_code": 23,
+      "fingerprint": "7e76033efdc3fd033fc62a7360eb95ff695c36087e35565d2854ec4374d7b29a",
+      "check_name": "Send",
+      "message": "User controlled method execution",
+      "file": "app/controllers/admin/marketplace_listings_controller.rb",
+      "line": 27,
+      "link": "https://brakemanscanner.org/docs/warning_types/dangerous_send/",
+      "code": "MarketplaceListing.send((params[:search_status] or nil))",
+      "render_path": null,
+      "location": {
+        "type": "method",
+        "class": "Admin::MarketplaceListingsController",
+        "method": "matching_marketplace_listings"
+      },
+      "user_input": "params[:search_status]",
+      "confidence": "High",
+      "cwe_id": [
+        77
       ],
       "note": ""
     },
@@ -1173,7 +1196,7 @@
       "check_name": "LinkToHref",
       "message": "Potentially unsafe model attribute in `link_to` href",
       "file": "app/views/admin/theft_alerts/edit.html.haml",
-      "line": 86,
+      "line": 88,
       "link": "https://brakemanscanner.org/docs/warning_types/link_to_href",
       "code": "link_to(\"Facebook post\", TheftAlert.find(params[:id]).facebook_post_url, :target => \"_blank\")",
       "render_path": [
@@ -1524,7 +1547,7 @@
       "check_name": "SQL",
       "message": "Possible SQL injection",
       "file": "app/controllers/admin/email_domains_controller.rb",
-      "line": 76,
+      "line": 77,
       "link": "https://brakemanscanner.org/docs/warning_types/sql_injection/",
       "code": "Arel.sql(\"COALESCE((data -> 'spam_score')::integer, 0) #{sort_direction}\")",
       "render_path": null,
@@ -1547,7 +1570,7 @@
       "check_name": "Send",
       "message": "User controlled method execution",
       "file": "app/controllers/admin/email_domains_controller.rb",
-      "line": 92,
+      "line": 95,
       "link": "https://brakemanscanner.org/docs/warning_types/dangerous_send/",
       "code": "EmailDomain.send((params[:search_status] or nil))",
       "render_path": null,
@@ -1682,7 +1705,7 @@
       "check_name": "FileAccess",
       "message": "Model attribute used in file name",
       "file": "app/controllers/bikes_controller.rb",
-      "line": 65,
+      "line": 66,
       "link": "https://brakemanscanner.org/docs/warning_types/file_access/",
       "code": "File.open(\"#{Rails.root}/tmp/#{(\"Registration_\" + Bike.unscoped.find((params[:bike_id] or params[:id])).updated_at.strftime(\"%m%d_%H%M\")[(0..)])}.pdf\")",
       "render_path": null,
@@ -1699,5 +1722,5 @@
       "note": ""
     }
   ],
-  "brakeman_version": "7.0.0"
+  "brakeman_version": "7.0.2"
 }

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -228,8 +228,9 @@ Rails.application.routes.draw do
 
     %i[
       bike_sticker_updates email_bans exports graduated_notifications invoices logged_searches
-      mailchimp_data model_attestations model_audits notifications organization_statuses
-      parking_notifications stripe_prices stripe_subscriptions user_alerts user_registration_organizations
+      mailchimp_data marketplace_listings marketplace_messages model_attestations model_audits
+      notifications organization_statuses parking_notifications stripe_prices stripe_subscriptions
+      user_alerts user_registration_organizations
     ].each { resources _1, only: %i[index] }
 
     resources :bike_stickers do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -228,10 +228,12 @@ Rails.application.routes.draw do
 
     %i[
       bike_sticker_updates email_bans exports graduated_notifications invoices logged_searches
-      mailchimp_data marketplace_listings marketplace_messages model_attestations model_audits
+      mailchimp_data marketplace_listings model_attestations model_audits
       notifications organization_statuses parking_notifications stripe_prices stripe_subscriptions
       user_alerts user_registration_organizations
     ].each { resources _1, only: %i[index] }
+
+    resources :marketplace_messages, only: %i[index show]
 
     resources :bike_stickers do
       collection { get :reassign }

--- a/db/migrate/20250515190821_add_message_id_to_notifications.rb
+++ b/db/migrate/20250515190821_add_message_id_to_notifications.rb
@@ -1,0 +1,5 @@
+class AddMessageIdToNotifications < ActiveRecord::Migration[8.0]
+  def change
+    add_column :notifications, :message_id, :string
+  end
+end

--- a/db/primary_replica_structure.sql
+++ b/db/primary_replica_structure.sql
@@ -2413,7 +2413,8 @@ CREATE TABLE public.notifications (
     bike_id bigint,
     message_channel_target character varying,
     delivery_status integer,
-    delivery_error character varying
+    delivery_error character varying,
+    message_id character varying
 );
 
 
@@ -7046,6 +7047,7 @@ ALTER TABLE ONLY public.ambassador_task_assignments
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20250515190821'),
 ('20250508151610'),
 ('20250508151602'),
 ('20250421153929'),

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -2413,7 +2413,8 @@ CREATE TABLE public.notifications (
     bike_id bigint,
     message_channel_target character varying,
     delivery_status integer,
-    delivery_error character varying
+    delivery_error character varying,
+    message_id character varying
 );
 
 
@@ -7046,6 +7047,7 @@ ALTER TABLE ONLY public.ambassador_task_assignments
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20250515190821'),
 ('20250508151610'),
 ('20250508151602'),
 ('20250421153929'),

--- a/spec/jobs/email/marketplace_message_job_spec.rb
+++ b/spec/jobs/email/marketplace_message_job_spec.rb
@@ -23,6 +23,28 @@ RSpec.describe Email::MarketplaceMessageJob, type: :job do
     notification = Notification.last
     expect(notification).to have_attributes target_notification_attrs
   end
+  context "reply to" do
+    let(:marketplace_message_reply) { FactoryBot.create(:marketplace_message_reply, initial_record: marketplace_message) }
+    it "uses the reference id" do
+      ActionMailer::Base.deliveries = []
+      expect(Notification.count).to eq 0
+      expect {
+        described_class.new.perform(marketplace_message.id)
+      }.to change(described_class.jobs, :count).by(0).and change(Notification, :count).by(1)
+      expect(marketplace_message.reload.email_references_id).to be_nil
+      notification = Notification.order(:id).last
+      expect(notification.message_id).to be_present
+
+      expect(marketplace_message_reply.reload.email_references_id).to eq "<#{notification.message_id}>"
+      result = described_class.new.perform(marketplace_message_reply.id)
+      expect(ActionMailer::Base.deliveries.count).to eq 2
+      expect(Notification.count).to eq 2
+      expect(Notification.order(:id).last.message_id).to be_present
+      expect(result.references).to eq notification.message_id
+      # sanity check - still choosing the first message id
+      expect(marketplace_message_reply.reload.email_references_id).to eq "<#{notification.message_id}>"
+    end
+  end
   context "donation, existing notification" do
     let!(:notification) do
       Notification.create(notifiable: marketplace_message, kind: "marketplace_message", delivery_status: "delivery_success")

--- a/spec/jobs/email/marketplace_message_job_spec.rb
+++ b/spec/jobs/email/marketplace_message_job_spec.rb
@@ -8,7 +8,8 @@ RSpec.describe Email::MarketplaceMessageJob, type: :job do
       kind: "marketplace_message",
       delivery_status: "delivery_success",
       notifiable: marketplace_message,
-      user_id: marketplace_message.receiver_id
+      user_id: marketplace_message.receiver_id,
+      message_id: be_present
     }
   end
   it "sends an email" do
@@ -19,7 +20,8 @@ RSpec.describe Email::MarketplaceMessageJob, type: :job do
     }.to change(described_class.jobs, :count).by 0
     expect(ActionMailer::Base.deliveries.empty?).to be_falsey
     expect(Notification.count).to eq 1
-    expect(Notification.last).to have_attributes target_notification_attrs
+    notification = Notification.last
+    expect(notification).to have_attributes target_notification_attrs
   end
   context "donation, existing notification" do
     let!(:notification) do
@@ -33,6 +35,7 @@ RSpec.describe Email::MarketplaceMessageJob, type: :job do
       }.to change(described_class.jobs, :count).by 0
       expect(ActionMailer::Base.deliveries.empty?).to be_truthy
       expect(Notification.count).to eq 1
+      expect(notification.reload.message_id).to be_blank
     end
   end
 end

--- a/spec/mailers/customer_mailer_spec.rb
+++ b/spec/mailers/customer_mailer_spec.rb
@@ -235,4 +235,15 @@ RSpec.describe CustomerMailer, type: :mailer do
       end
     end
   end
+
+  describe "marketplace_message_notification" do
+    let(:marketplace_message) { FactoryBot.create(:marketplace_message) }
+    it "delivers" do
+      mail = CustomerMailer.marketplace_message_notification(marketplace_message)
+      expect(mail.from).to eq(["contact@bikeindex.org"])
+      expect(mail.to).to eq([marketplace_message.receiver.email])
+      expect(mail.body.encoded.strip).to match marketplace_message.body
+      expect(mail.message_stream).to eq "outbound"
+    end
+  end
 end

--- a/spec/requests/admin/marketplace_listings_request_spec.rb
+++ b/spec/requests/admin/marketplace_listings_request_spec.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Admin::MarketplaceListingsController, type: :request do
+  include_context :request_spec_logged_in_as_superuser
+
+  base_url = "/admin/marketplace_listings"
+
+  describe "#index" do
+    let!(:marketplace_listing) { FactoryBot.create(:marketplace_listing) }
+
+    it "responds with ok" do
+      get base_url
+      expect(response.status).to eq(200)
+      expect(response).to render_template(:index)
+      expect(flash).to_not be_present
+      expect(assigns(:collection).pluck(:id)).to eq([marketplace_listing.id])
+    end
+  end
+end

--- a/spec/requests/admin/marketplace_messages_request_spec.rb
+++ b/spec/requests/admin/marketplace_messages_request_spec.rb
@@ -4,7 +4,7 @@ require "rails_helper"
 
 RSpec.describe Admin::MarketplaceMessagesController, type: :request do
   include_context :request_spec_logged_in_as_superuser
-  let!(:marketplace_messages) { FactoryBot.create(:marketplace_message) }
+  let!(:marketplace_message) { FactoryBot.create(:marketplace_message) }
 
   base_url = "/admin/marketplace_messages"
 
@@ -14,7 +14,7 @@ RSpec.describe Admin::MarketplaceMessagesController, type: :request do
       expect(response.status).to eq(200)
       expect(response).to render_template(:index)
       expect(flash).to_not be_present
-      expect(assigns(:collection).pluck(:id)).to eq([marketplace_listing.id])
+      expect(assigns(:collection).pluck(:id)).to eq([marketplace_message.id])
     end
   end
 

--- a/spec/requests/admin/marketplace_messages_request_spec.rb
+++ b/spec/requests/admin/marketplace_messages_request_spec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Admin::MarketplaceMessagesController, type: :request do
+  include_context :request_spec_logged_in_as_superuser
+  let!(:marketplace_messages) { FactoryBot.create(:marketplace_message) }
+
+  base_url = "/admin/marketplace_messages"
+
+  describe "#index" do
+    it "responds with ok" do
+      get base_url
+      expect(response.status).to eq(200)
+      expect(response).to render_template(:index)
+      expect(flash).to_not be_present
+      expect(assigns(:collection).pluck(:id)).to eq([marketplace_listing.id])
+    end
+  end
+
+  describe "#show" do
+    it "responds with ok" do
+      get "#{base_url}/#{marketplace_message.id}"
+      expect(response.status).to eq(200)
+      expect(response).to render_template(:show)
+      expect(flash).to_not be_present
+    end
+  end
+end


### PR DESCRIPTION
Add `message_id` to `Notification` so that it can be used for marketplace messages

Use things from [this article](https://flexport.engineering/sending-threaded-emails-using-rails-actionmailer-8549bd246283) to set the reply.