### PR TITLE
Update email domain spam score

### DIFF
--- a/app/helpers/admin_helper.rb
+++ b/app/helpers/admin_helper.rb
@@ -124,6 +124,16 @@ module AdminHelper
     content_tag(:span, number_with_delimiter(number), class: ((number == 0) ? "less-less-strong" : ""))
   end
 
+  def admin_email_domain_spam_color(spam_score)
+    if spam_score > 9
+      "text-danger"
+    elsif spam_score < EmailDomain::SPAM_SCORE_AUTO_BAN
+      "text-info"
+    else
+      ""
+    end
+  end
+
   def user_icon_hash(user = nil)
     icon_hash = {tags: []}
     return icon_hash if user&.id.blank?
@@ -143,6 +153,7 @@ module AdminHelper
     icon_hash
   end
 
+  # Add icon for unconfirmed, email banned
   def user_icon(user = nil, full_text: false)
     icon_hash = user_icon_hash(user)
     return "" if icon_hash[:tags].empty?

--- a/app/jobs/merge_additional_email_job.rb
+++ b/app/jobs/merge_additional_email_job.rb
@@ -27,6 +27,7 @@ class MergeAdditionalEmailJob < ApplicationJob
     old_user.received_stolen_notifications.update_all(receiver_id: user_id)
     old_user.theft_alerts.update_all(user_id:)
     old_user.bike_sticker_updates.update_all(user_id:)
+    old_user.email_bans.each { |eb| eb.update(user_id:) }
 
     BikeVersion.unscoped.where(owner_id: old_user.id).each { |i| i.update(owner_id: user_id) }
     Doorkeeper::Application.where(owner_id: old_user.id).each { |i| i.update_attribute(:owner_id, user_id) }

--- a/app/models/email_ban.rb
+++ b/app/models/email_ban.rb
@@ -2,19 +2,17 @@
 #
 # Table name: email_bans
 #
-#  id            :bigint           not null, primary key
-#  end_at        :datetime
-#  reason        :integer
-#  start_at      :datetime
-#  created_at    :datetime         not null
-#  updated_at    :datetime         not null
-#  user_email_id :bigint
-#  user_id       :bigint
+#  id         :bigint           not null, primary key
+#  end_at     :datetime
+#  reason     :integer
+#  start_at   :datetime
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#  user_id    :bigint
 #
 # Indexes
 #
-#  index_email_bans_on_user_email_id  (user_email_id)
-#  index_email_bans_on_user_id        (user_id)
+#  index_email_bans_on_user_id  (user_id)
 #
 class EmailBan < ApplicationRecord
   include ActivePeriodable
@@ -93,6 +91,16 @@ class EmailBan < ApplicationRecord
 
       User.where("email ~ ?", "^#{email_start}(\\+.*)?@#{email_end}").where.not(email:)
     end
+  end
+
+  def email
+    user&.email
+  end
+
+  def email_domain
+    return nil if email.blank?
+
+    EmailDomain.find_or_create_for(email, skip_processing: true)
   end
 
   def reason_humanized

--- a/app/models/email_domain.rb
+++ b/app/models/email_domain.rb
@@ -52,6 +52,7 @@ class EmailDomain < ApplicationRecord
   scope :tld_matches_subdomains, -> { tld.where.not("domain ILIKE ?", "@%") }
   scope :subdomain, -> { where("(data -> 'is_tld')::text = ?", "false") }
   scope :with_bikes, -> { where("COALESCE((data -> 'bike_count')::integer, 0) > 0") }
+  scope :no_auto_assign_status, -> { where("(data -> 'no_auto_assign_status')::text =?", "true") }
 
   attr_accessor :skip_processing
 

--- a/app/models/email_domain.rb
+++ b/app/models/email_domain.rb
@@ -175,8 +175,7 @@ class EmailDomain < ApplicationRecord
 
     s_score = (10 - spam_score_domain_resolution - spam_score_our_records - spam_score_sendgrid_validations)
       .clamp(1, 10)
-    s_score == 1 ? score_zero_if_allowed : s_score
-
+    (s_score == 1) ? score_zero_if_allowed : s_score
   end
 
   def spam_score_domain_resolution
@@ -263,7 +262,7 @@ class EmailDomain < ApplicationRecord
   private
 
   def score_zero_if_allowed
-    data["bike_count_pos"]&.to_i > 1 && user_count > 5 ? 0 : 1
+    ((data["bike_count_pos"]&.to_i&.> 1) && user_count > 5) ? 0 : 1
   end
 
   def domain_is_expected_format

--- a/app/views/admin/email_domains/_data_details.html.haml
+++ b/app/views/admin/email_domains/_data_details.html.haml
@@ -4,8 +4,6 @@
   %a.small.text-info.text-underline.mr-1{href: admin_email_domains_path(query: email_domain.tld) }
     = admin_number_display(subdomain_count)
     %em subs
-- if email_domain&.no_auto_assign_status?
-  %small.text-info.mr-1 no auto status
 - if email_domain&.broader_domain_exists?
   %a.small.text-danger.text-underline.mr-1{href: admin_email_domains_path(query: email_domain.tld) }
     broader exists

--- a/app/views/admin/email_domains/_table.html.haml
+++ b/app/views/admin/email_domains/_table.html.haml
@@ -54,7 +54,7 @@
             = admin_number_display(email_domain.notification_count)
           %td
             - spam_score = email_domain.spam_score.round(0)
-            %span{class: (spam_score < EmailDomain::SPAM_SCORE_AUTO_BAN ? "text-info" : "")}
+            %span{class: admin_email_domain_spam_color(spam_score)}
               = email_domain.spam_score.round(0)
           %td
             = render partial: "data_details", locals: {email_domain:}

--- a/app/views/admin/email_domains/_table.html.haml
+++ b/app/views/admin/email_domains/_table.html.haml
@@ -54,7 +54,7 @@
             = admin_number_display(email_domain.notification_count)
           %td
             - spam_score = email_domain.spam_score.round(0)
-            %span{class: (spam_score > EmailDomain::SPAM_SCORE_AUTO_BAN ? "text-info" : "")}
+            %span{class: (spam_score < EmailDomain::SPAM_SCORE_AUTO_BAN ? "text-info" : "")}
               = email_domain.spam_score.round(0)
           %td
             = render partial: "data_details", locals: {email_domain:}

--- a/app/views/admin/email_domains/_table.html.haml
+++ b/app/views/admin/email_domains/_table.html.haml
@@ -41,6 +41,8 @@
             - status_class = "text-warning font-weight-bold" if email_domain.ignored?
             %span{class: status_class}
               = email_domain.status_humanized
+            - if email_domain&.no_auto_assign_status?
+              %small{class: "tw:ml-1 tw:text-sky-400"} no auto status
           %td
             = render partial: "/shared/admin/user_cell", locals: {user: email_domain.creator, user_id: email_domain.creator_id, cache: false}
           %td

--- a/app/views/admin/email_domains/show.html.haml
+++ b/app/views/admin/email_domains/show.html.haml
@@ -56,6 +56,8 @@
               = @email_domain.status_humanized
             - if @email_domain.ignored?
               %small.less-strong will not match any new users
+            - if @email_domain&.no_auto_assign_status?
+              %small{class: "tw:ml-1 tw:text-sky-400"} no auto status
 
   .col-md-6
     %table.table-list

--- a/app/views/admin/email_domains/show.html.haml
+++ b/app/views/admin/email_domains/show.html.haml
@@ -91,13 +91,13 @@
             %small.less-strong above #{EmailDomain::SPAM_SCORE_AUTO_BAN} is auto-bannable (with no blockers)
             %small.d-block
               %span
-                %strong= admin_number_display(@email_domain.spam_score_our_records)
+                %strong= admin_number_display(- @email_domain.spam_score_our_records)
                 our records,
               %span.ml-2
-                %strong= admin_number_display(@email_domain.spam_score_domain_resolution)
+                %strong= admin_number_display(- @email_domain.spam_score_domain_resolution)
                 domain resolution,
               %span.ml-2
-                %strong= admin_number_display(@email_domain.spam_score_sendgrid_validations)
+                %strong= admin_number_display(- @email_domain.spam_score_sendgrid_validations)
                 sendgrid
 
         %tr

--- a/app/views/admin/email_domains/show.html.haml
+++ b/app/views/admin/email_domains/show.html.haml
@@ -65,28 +65,35 @@
           %td
             Ban Blockers
           %td
-            = @email_domain.ban_blockers.any? ? check_mark : cross_mark
+            - ban_blockers = @email_domain.ban_blockers.any?
+            = ban_blockers ? check_mark : cross_mark
             %small.ml-2
               - if @email_domain.auto_bannable?
                 %span.text-warning auto bannable
               - else
                 not auto banable
-                -# duplicates the logic from ban_blockers to make it more readable
-                - if @email_domain.below_email_count_blocker?
-                  %em.ml-2{title: "NOTE: this also checks against notifications / 10"}
-                    Below email min count (#{EmailDomain::EMAIL_MIN_COUNT})
-                - if @email_domain.bike_count_blocker?
-                  %em.ml-2 Bike count
-                - if @email_domain.organization_role_blocker?
-                  %em.ml-2 Org Roles
-                - if @email_domain.calculated_subdomains.permitted.count > 0
-                  %em.ml-2 Permitted subdomains
+                - if ban_blockers
+                  %ul.mb-0
+                    -# duplicates the logic from ban_blockers to make it more readable
+                    - if @email_domain.below_email_count_blocker?
+                      %li
+                        %em.ml-2{title: "NOTE: this also checks against notifications / 10"}
+                          Below email min count (#{EmailDomain::EMAIL_MIN_COUNT})
+                    - if @email_domain.bike_count_blocker?
+                      %li
+                        %em.ml-2 Bike count
+                    - if @email_domain.organization_role_blocker?
+                      %li
+                        %em.ml-2 Org Roles
+                    - if @email_domain.calculated_subdomains.permitted.count > 0
+                      %li
+                        %em.ml-2 Permitted subdomains
 
 
         %tr
           %td Spam score
           %td
-            %strong
+            %strong{class: admin_email_domain_spam_color(@email_domain.spam_score)}
               #{@email_domain.spam_score} / 10
             %small.less-strong above #{EmailDomain::SPAM_SCORE_AUTO_BAN} is auto-bannable (with no blockers)
             %small.d-block

--- a/app/views/admin/email_domains/show.html.haml
+++ b/app/views/admin/email_domains/show.html.haml
@@ -88,7 +88,7 @@
           %td
             %strong
               #{@email_domain.spam_score} / 10
-            %small.less-strong below #{EmailDomain::SPAM_SCORE_AUTO_BAN} is auto-bannable (with no blockers)
+            %small.less-strong above #{EmailDomain::SPAM_SCORE_AUTO_BAN} is auto-bannable (with no blockers)
             %small.d-block
               %span
                 %strong= admin_number_display(@email_domain.spam_score_our_records)

--- a/app/views/admin/marketplace_listings/_table.html.haml
+++ b/app/views/admin/marketplace_listings/_table.html.haml
@@ -54,7 +54,7 @@
           %td
             = "#{marketplace_listing.currency_symbol}#{admin_number_display(marketplace_listing.amount)}"
           %td
-            = marketplace_listing.status_humanized
+            = marketplace_listing.condition
           %td
             = render partial: "/shared/admin/user_cell", locals: {user: marketplace_listing.seller, render_search: true, cache: true}
           %td

--- a/app/views/admin/marketplace_messages/show.html.haml
+++ b/app/views/admin/marketplace_messages/show.html.haml
@@ -77,6 +77,9 @@
           %td
             = "#{@marketplace_listing.currency_symbol}#{admin_number_display(@marketplace_listing.amount)}"
         %tr
+          %td Condition
+          %td= @marketplace_listing.condition
+        %tr
           %td Item
           %td
             = render partial: "/shared/admin/bike_cell", locals: {bike: @marketplace_listing.item, bike_id: @marketplace_listing.item_id, bike_link_path: bike_path(@marketplace_listing.item_id, show_marketplace_preview: true) }

--- a/app/views/admin/users/edit.html.haml
+++ b/app/views/admin/users/edit.html.haml
@@ -43,15 +43,15 @@
         .alert.alert-danger.mb-4
           %h4.text-danger User's email banned (not delivered)
           Reasons:
-          - @user.email_bans_active.pluck(:reason).each do |reason|
-            = EmailBan.reason_humanized(reason)
+          - @user.email_bans_active.each do |email_ban|
+            = email_ban.reason_humanized
             %small.less-strong
-              - if reason == "email_domain"
-                The email domain was banned
-              - elsif reason == "email_duplicate"
-                The email looks like a duplicate of another email. In 2025, we were getting a lot of user sign up spam with emails that just had extra periods added in (which still deliver to gmail)
-              - elsif reason == "delivery_failure"
-                A recent email to them failed to be delivered. Have them check their spam folder!
+              - if email_ban.reason == "email_domain"
+                \- the #{link_to "email domain", admin_email_domain_path(email_ban.email_domain)} was banned.
+              - elsif email_ban.reason == "email_duplicate"
+                \- the email looks like a duplicate of another email. In 2025, we were getting a lot of user sign up spam with emails that just had extra periods added in (which still deliver to gmail)
+              - elsif email_ban.reason == "delivery_failure"
+                \- a recent email to them failed to be delivered. Have them check their spam folder!
 .row
   .col-md-6
     %h1

--- a/db/migrate/20250519154506_remove_user_email_id_from_email_bans.rb
+++ b/db/migrate/20250519154506_remove_user_email_id_from_email_bans.rb
@@ -1,0 +1,5 @@
+class RemoveUserEmailIdFromEmailBans < ActiveRecord::Migration[8.0]
+  def change
+    remove_column :email_bans, :user_email_id, :bigint
+  end
+end

--- a/db/primary_replica_structure.sql
+++ b/db/primary_replica_structure.sql
@@ -1100,7 +1100,6 @@ ALTER SEQUENCE public.duplicate_bike_groups_id_seq OWNED BY public.duplicate_bik
 CREATE TABLE public.email_bans (
     id bigint NOT NULL,
     user_id bigint,
-    user_email_id bigint,
     start_at timestamp(6) without time zone,
     end_at timestamp(6) without time zone,
     reason integer,
@@ -5891,13 +5890,6 @@ CREATE INDEX index_components_on_manufacturer_id ON public.components USING btre
 
 
 --
--- Name: index_email_bans_on_user_email_id; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX index_email_bans_on_user_email_id ON public.email_bans USING btree (user_email_id);
-
-
---
 -- Name: index_email_bans_on_user_id; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -7047,6 +7039,7 @@ ALTER TABLE ONLY public.ambassador_task_assignments
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20250519154506'),
 ('20250515190821'),
 ('20250508151610'),
 ('20250508151602'),

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -1100,7 +1100,6 @@ ALTER SEQUENCE public.duplicate_bike_groups_id_seq OWNED BY public.duplicate_bik
 CREATE TABLE public.email_bans (
     id bigint NOT NULL,
     user_id bigint,
-    user_email_id bigint,
     start_at timestamp(6) without time zone,
     end_at timestamp(6) without time zone,
     reason integer,
@@ -5891,13 +5890,6 @@ CREATE INDEX index_components_on_manufacturer_id ON public.components USING btre
 
 
 --
--- Name: index_email_bans_on_user_email_id; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX index_email_bans_on_user_email_id ON public.email_bans USING btree (user_email_id);
-
-
---
 -- Name: index_email_bans_on_user_id; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -7047,6 +7039,7 @@ ALTER TABLE ONLY public.ambassador_task_assignments
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20250519154506'),
 ('20250515190821'),
 ('20250508151610'),
 ('20250508151602'),

--- a/spec/jobs/merge_additional_email_job_spec.rb
+++ b/spec/jobs/merge_additional_email_job_spec.rb
@@ -206,6 +206,14 @@ RSpec.describe MergeAdditionalEmailJob, type: :job do
       end
     end
 
+    context "email_ban" do
+      let!(:email_ban) { FactoryBot.create(:email_ban, user: old_user) }
+      it "updates the email_ban" do
+        instance.perform(user_email.id)
+        expect(email_ban.reload.user_id).to eq user.id
+      end
+    end
+
     context "multi merging" do
       let(:older_user) { FactoryBot.create(:user_confirmed) }
       let!(:older_user_email) { FactoryBot.create(:user_email, email: older_user.email, user: old_user) }

--- a/spec/jobs/update_email_domain_job_spec.rb
+++ b/spec/jobs/update_email_domain_job_spec.rb
@@ -178,7 +178,7 @@ RSpec.describe UpdateEmailDomainJob, type: :lib do
           expect(email_domain.data.except("spam_score")).to match_hash_indifferently target_data
           expect(email_domain.status).to eq "provisional_ban"
           expect(described_class).to_not have_enqueued_sidekiq_job
-          expect(email_domain.spam_score).to be >9
+          expect(email_domain.spam_score).to be > 9
         end
       end
 

--- a/spec/jobs/update_email_domain_job_spec.rb
+++ b/spec/jobs/update_email_domain_job_spec.rb
@@ -91,7 +91,7 @@ RSpec.describe UpdateEmailDomainJob, type: :lib do
           expect(email_domain.ban_blockers.any?).to be_truthy
           expect(email_domain.data.except("spam_score")).to match_hash_indifferently target_data
           expect(email_domain.status).to eq "permitted"
-          expect(email_domain.spam_score).to be > 5
+          expect(email_domain.spam_score).to be < 3
         end
       end
       context "with domain starting out provisional_ban" do
@@ -106,7 +106,7 @@ RSpec.describe UpdateEmailDomainJob, type: :lib do
             expect(email_domain.ban_blockers.any?).to be_truthy
             expect(email_domain.data.except("spam_score")).to match_hash_indifferently target_data
             expect(email_domain.status).to eq "permitted"
-            expect(email_domain.spam_score).to be > 5
+            expect(email_domain.spam_score).to be < 3
           end
         end
       end
@@ -127,7 +127,7 @@ RSpec.describe UpdateEmailDomainJob, type: :lib do
           expect(email_domain.data.except("sendgrid_validations", "spam_score"))
             .to match_hash_indifferently valid_data.merge(domain_resolves: false, tld_resolves: false)
           expect(email_domain.data.dig("sendgrid_validations", user2.email).keys.sort).to eq target_sendgrid_keys
-          expect(email_domain.spam_score).to be < 2
+          expect(email_domain.spam_score).to be > 9
           expect(email_domain.status).to eq "provisional_ban"
         end
       end
@@ -178,7 +178,7 @@ RSpec.describe UpdateEmailDomainJob, type: :lib do
           expect(email_domain.data.except("spam_score")).to match_hash_indifferently target_data
           expect(email_domain.status).to eq "provisional_ban"
           expect(described_class).to_not have_enqueued_sidekiq_job
-          expect(email_domain.spam_score).to be < 2
+          expect(email_domain.spam_score).to be >9
         end
       end
 

--- a/spec/models/email_ban_spec.rb
+++ b/spec/models/email_ban_spec.rb
@@ -132,4 +132,12 @@ RSpec.describe EmailBan, type: :model do
       end
     end
   end
+
+  describe "email and email_domain" do
+    let(:email_ban) { FactoryBot.create(:email_ban) }
+    it "returns the user's email" do
+      expect(email_ban.email).to eq email_ban.user.email
+      expect(email_ban.email_domain&.id).to be_present
+    end
+  end
 end

--- a/spec/requests/api/v3/bikes_request_spec.rb
+++ b/spec/requests/api/v3/bikes_request_spec.rb
@@ -860,7 +860,7 @@ RSpec.describe "Bikes API V3", type: :request do
 
         context "non-matching email" do
           let(:email) { "another_email@example.com" }
-          it "creates a bike for organization with v3_accessor, doesn't send email because skip_email" do
+          it "creates a bike for organization with v3_accessor, doesn't send email because skip_email", :flaky do
             organization.update_attribute :enabled_feature_slugs, ["skip_ownership_email"]
             bike = FactoryBot.create(:bike, serial_number: bike_attrs[:serial], owner_email: email)
             ownership = FactoryBot.create(:ownership, bike: bike, owner_email: email)


### PR DESCRIPTION
Follow up to #2751

- [x] Invert `EmailDomain` "spam score" (10 should be most suspicious) 
  - [x] Only give a spam score of 0 for domains with multiple confirmed
users and multiple non-spammy bikes

In separate PR:

- [ ] conditionally choose email delivery provider