### PR TITLE
Display marketplace listing location in admin, job namespacing

### DIFF
--- a/app/controllers/admin/marketplace_listings_controller.rb
+++ b/app/controllers/admin/marketplace_listings_controller.rb
@@ -4,7 +4,8 @@ class Admin::MarketplaceListingsController < Admin::BaseController
   def index
     @per_page = params[:per_page] || 50
     @pagy, @collection = pagy(
-      matching_marketplace_listings.includes(:seller, :item, :buyer).reorder("marketplace_listings.#{sort_column} #{sort_direction}"),
+      matching_marketplace_listings.includes(:seller, :item, :buyer, :address_record)
+        .reorder("marketplace_listings.#{sort_column} #{sort_direction}"),
       limit: @per_page
     )
   end

--- a/app/controllers/admin/payments_controller.rb
+++ b/app/controllers/admin/payments_controller.rb
@@ -23,7 +23,7 @@ class Admin::PaymentsController < Admin::BaseController
   def update
     if assign_to_membership_param?
       if @payment.can_assign_to_membership?
-        User::CreateOrUpdateMembershipFromPaymentJob.new.perform(@payment.id, current_user.id)
+        Users::CreateOrUpdateMembershipFromPaymentJob.new.perform(@payment.id, current_user.id)
         flash[:success] = "Payment updated"
       else
         flash[:error] = "This payment can't be assigned to a membership - maybe it already has been?"

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -96,7 +96,7 @@ class Admin::UsersController < Admin::BaseController
       # Manually confirm the user
       user_email.update(confirmation_token: nil) if user_email&.unconfirmed?
       user_email ||= @user.user_emails.create(email: email)
-      if MergeAdditionalEmailJob.new.perform(user_email.id)
+      if Users::MergeAdditionalEmailJob.new.perform(user_email.id)
         flash[:success] = "User #{@user.display_name} merged with '#{email}'"
       else
         flash[:error] = "Unable to merge users!"

--- a/app/controllers/my_accounts_controller.rb
+++ b/app/controllers/my_accounts_controller.rb
@@ -51,7 +51,7 @@ class MyAccountsController < ApplicationController
 
   def destroy
     if current_user.deletable?
-      UserDeleteJob.new.perform(current_user.id, user: current_user)
+      Users::DeleteJob.new.perform(current_user.id, user: current_user)
       remove_session
       redirect_to goodbye_url, notice: "Account deleted!"
     else

--- a/app/jobs/callbacks/after_user_create_job.rb
+++ b/app/jobs/callbacks/after_user_create_job.rb
@@ -73,12 +73,12 @@ class Callbacks::AfterUserCreateJob < ApplicationJob
     return false unless organization_roles.any?
 
     first, *rest = organization_roles.pluck(:id)
-    ProcessOrganizationRoleJob.new.perform(first, user.id)
+    Users::ProcessOrganizationRoleJob.new.perform(first, user.id)
 
     # We want to do the first one inline so we can redirect
     # the user to the org page
     rest.each do |organization_role_id|
-      ProcessOrganizationRoleJob.perform_async(organization_role_id, user.id)
+      Users::ProcessOrganizationRoleJob.perform_async(organization_role_id, user.id)
     end
 
     user.confirm(user.confirmation_token) unless skip_confirm

--- a/app/jobs/email/additional_email_confirmation_job.rb
+++ b/app/jobs/email/additional_email_confirmation_job.rb
@@ -2,7 +2,9 @@ class Email::AdditionalEmailConfirmationJob < ApplicationJob
   sidekiq_options queue: "notify"
 
   def perform(user_email_id)
-    user_email = UserEmail.find(user_email_id)
+    user_email = UserEmail.find_by(id: user_email_id)
+    return if user_email.blank?
+
     CustomerMailer.additional_email_confirmation(user_email).deliver_now
   end
 end

--- a/app/jobs/images/associator_job.rb
+++ b/app/jobs/images/associator_job.rb
@@ -1,4 +1,4 @@
-class ImageAssociatorJob < ApplicationJob
+class Images::AssociatorJob < ApplicationJob
   sidekiq_options queue: "high_priority"
 
   def perform

--- a/app/jobs/images/external_url_store_job.rb
+++ b/app/jobs/images/external_url_store_job.rb
@@ -1,8 +1,8 @@
-class ExternalImageUrlStoreJob < ApplicationJob
+class Images::ExternalUrlStoreJob < ApplicationJob
   sidekiq_options queue: "med_priority"
 
   def perform(public_image_id)
-    public_image = PublicImage.find(public_image_id)
+    public_image = PublicImage.unscoped.find(public_image_id)
     return true if public_image.image.present? || public_image.external_image_url.blank?
     public_image.update(remote_image_url: public_image.external_image_url)
   end

--- a/app/jobs/images/external_url_store_job.rb
+++ b/app/jobs/images/external_url_store_job.rb
@@ -2,8 +2,9 @@ class Images::ExternalUrlStoreJob < ApplicationJob
   sidekiq_options queue: "med_priority"
 
   def perform(public_image_id)
-    public_image = PublicImage.unscoped.find(public_image_id)
-    return true if public_image.image.present? || public_image.external_image_url.blank?
+    public_image = PublicImage.unscoped.find_by(id: public_image_id)
+    return if public_image.blank? || public_image.image.present? || public_image.external_image_url.blank?
+
     public_image.update(remote_image_url: public_image.external_image_url)
   end
 end

--- a/app/jobs/process_organization_role_job.rb
+++ b/app/jobs/process_organization_role_job.rb
@@ -2,7 +2,8 @@ class ProcessOrganizationRoleJob < ApplicationJob
   sidekiq_options queue: "high_priority"
 
   def perform(organization_role_id, user_id = nil)
-    organization_role = OrganizationRole.find(organization_role_id)
+    organization_role = OrganizationRole.find_by(id: organization_role_id)
+    return if organization_role.blank?
 
     assign_organization_role_user(organization_role, user_id) if organization_role.user.blank?
     return false if remove_duplicated_organization_role!(organization_role)

--- a/app/jobs/scheduled_job_runner.rb
+++ b/app/jobs/scheduled_job_runner.rb
@@ -45,7 +45,6 @@ class ScheduledJobRunner < ScheduledJob
       ImpoundExpirationJob,
       ProcessGraduatedNotificationJob,
       ProcessHotSheetJob,
-      RemoveUnconfirmedUsersJob,
       ScheduledAutocompleteCheckJob,
       ScheduledBikePossiblyFoundNotificationJob,
       ScheduledSearchForExternalRegistryBikesJob,
@@ -61,6 +60,7 @@ class ScheduledJobRunner < ScheduledJob
       UpdateInvoiceJob,
       UpdateManufacturerLogoAndPriorityJob,
       UpdateOrganizationPosKindJob,
+      Users::RemoveUnconfirmedJob,
       self
     ].freeze
   end

--- a/app/jobs/update_organization_associations_job.rb
+++ b/app/jobs/update_organization_associations_job.rb
@@ -5,7 +5,9 @@ class UpdateOrganizationAssociationsJob < ApplicationJob
     organization_ids_for_update = associated_organization_ids(org_ids)
 
     organization_ids_for_update.each do |id|
-      organization = Organization.find(id)
+      organization = Organization.find_by(id: id)
+      next if organization.blank?
+
       # Critical that locations skip_update, so we don't loop
       organization.locations.each { |l| l.update(updated_at: Time.current, skip_update: true) }
       organization.reload # Just in case default location has changed

--- a/app/jobs/users/create_or_update_membership_from_payment_job.rb
+++ b/app/jobs/users/create_or_update_membership_from_payment_job.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 # NOTE: This job creates admin managed memberships
-class User::CreateOrUpdateMembershipFromPaymentJob < ApplicationJob
+class Users::CreateOrUpdateMembershipFromPaymentJob < ApplicationJob
   def perform(payment_id, admin_id = nil)
     payment = Payment.find(payment_id)
     return if payment.membership_id.present?

--- a/app/jobs/users/delete_job.rb
+++ b/app/jobs/users/delete_job.rb
@@ -1,4 +1,4 @@
-class UserDeleteJob < ApplicationJob
+class Users::DeleteJob < ApplicationJob
   # This is called inline - so it makes sense to pass in the user rather than just the user_id
   def perform(user_id, user: nil)
     user ||= User.find(user_id)

--- a/app/jobs/users/merge_additional_email_job.rb
+++ b/app/jobs/users/merge_additional_email_job.rb
@@ -1,4 +1,4 @@
-class MergeAdditionalEmailJob < ApplicationJob
+class Users::MergeAdditionalEmailJob < ApplicationJob
   sidekiq_options queue: "high_priority"
 
   def perform(user_email_id)

--- a/app/jobs/users/process_organization_role_job.rb
+++ b/app/jobs/users/process_organization_role_job.rb
@@ -1,4 +1,4 @@
-class ProcessOrganizationRoleJob < ApplicationJob
+class Users::ProcessOrganizationRoleJob < ApplicationJob
   sidekiq_options queue: "high_priority"
 
   def perform(organization_role_id, user_id = nil)

--- a/app/jobs/users/remove_unconfirmed_job.rb
+++ b/app/jobs/users/remove_unconfirmed_job.rb
@@ -1,4 +1,4 @@
-class RemoveUnconfirmedUsersJob < ScheduledJob
+class Users::RemoveUnconfirmedJob < ScheduledJob
   prepend ScheduledJobRecorder
 
   REMOVE_DELAY = 2.days

--- a/app/models/b_param.rb
+++ b/app/models/b_param.rb
@@ -603,8 +603,8 @@ class BParam < ApplicationRecord
 
   def process_image_if_required
     return true if image_processed || image.blank?
-    ImageAssociatorJob.perform_in(5.seconds)
-    ImageAssociatorJob.perform_in(1.minutes)
+    Images::AssociatorJob.perform_in(5.seconds)
+    Images::AssociatorJob.perform_in(1.minutes)
   end
 
   def set_color_key(key = nil)

--- a/app/models/organization_role.rb
+++ b/app/models/organization_role.rb
@@ -61,9 +61,9 @@ class OrganizationRole < ApplicationRecord
       return existing_organization_role if existing_organization_role.present?
     end
     organization_role = create!(new_passwordless_attrs.merge(create_attrs))
-    # ProcessOrganizationRoleJob creates a user if the user doesn't exist, for passwordless organizations
+    # Users::ProcessOrganizationRoleJob creates a user if the user doesn't exist, for passwordless organizations
     # because of that, we want to process this inline
-    ProcessOrganizationRoleJob.new.perform(organization_role.id)
+    Users::ProcessOrganizationRoleJob.new.perform(organization_role.id)
     organization_role.reload
     organization_role
   end
@@ -99,11 +99,11 @@ class OrganizationRole < ApplicationRecord
 
   def enqueue_processing_worker
     return true if skip_processing
-    # We manually update the user, because ProcessOrganizationRoleJob won't find this organization_role
+    # We manually update the user, because Users::ProcessOrganizationRoleJob won't find this organization_role
     if deleted? && user_id.present?
       ::Callbacks::AfterUserChangeJob.perform_async(user_id)
     else
-      ProcessOrganizationRoleJob.perform_async(id)
+      Users::ProcessOrganizationRoleJob.perform_async(id)
     end
   end
 

--- a/app/models/public_image.rb
+++ b/app/models/public_image.rb
@@ -71,7 +71,7 @@ class PublicImage < ApplicationRecord
     return if skip_update
 
     if external_image_url.present? && image.blank?
-      return ExternalImageUrlStoreJob.perform_async(id)
+      return Images::ExternalUrlStoreJob.perform_async(id)
     end
     imageable&.update(updated_at: Time.current)
     return true unless bike?

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -69,7 +69,7 @@ class User < ApplicationRecord
   include AddressRecorded
 
   EMAIL_REGEX = /\A(\S+)@(.+)\.(\S+)\z/
-  MARKETPLACE_FREE_UNTIL = 1750452905 # 2025-06-20 15:55 CST
+  MARKETPLACE_FREE_UNTIL = 1750787705 # 2025-06-24 10:55 CST
 
   cattr_accessor :current_user
 

--- a/app/models/user_email.rb
+++ b/app/models/user_email.rb
@@ -97,7 +97,7 @@ class UserEmail < ActiveRecord::Base
   def confirm(token)
     return false if token != confirmation_token
     update_attribute :confirmation_token, nil
-    MergeAdditionalEmailJob.perform_async(id)
+    Users::MergeAdditionalEmailJob.perform_async(id)
     true
   end
 

--- a/app/views/admin/marketplace_listings/_table.html.haml
+++ b/app/views/admin/marketplace_listings/_table.html.haml
@@ -19,44 +19,50 @@
       %th
         = sortable "condition", render_sortable: render_sortable
       %th
+        City
+      %th
         = sortable "seller_id", render_sortable: render_sortable
       %th
         = sortable "buyer_id", render_sortable: render_sortable
     %tbody
       - collection.each do |marketplace_listing|
-        %tr
-          %td
-            .less-strong-hold
-              %span.convertTime
-                = l marketplace_listing.created_at, format: :convert_time
-              - if display_dev_info?
-                %span.less-strong-right.d-none.d-md-block.only-dev-visible
-                  = marketplace_listing.id
-          - if display_dev_info?
+        - cache(marketplace_listing) do
+          %tr
             %td
-              %small.convertTime
-                = l marketplace_listing.updated_at, format: :convert_time
-          %td
-            - status_class = "text-info" if marketplace_listing.for_sale?
-            - status_class = "text-success" if marketplace_listing.sold?
-            %span{class: status_class}
-              = marketplace_listing.status_humanized
-          %td
-            - if marketplace_listing.published_at.present?
-              %span.convertTime
-                = l marketplace_listing.published_at, format: :convert_time
-          %td
-            - if marketplace_listing.end_at.present?
-              %span.convertTime
-                = l marketplace_listing.end_at, format: :convert_time
-          %td
-            = render partial: "/shared/admin/bike_cell", locals: {bike: marketplace_listing.item, bike_id: marketplace_listing.item_id, bike_link_path: bike_path(marketplace_listing.item_id, show_marketplace_preview: true) }
-          %td
-            = "#{marketplace_listing.currency_symbol}#{admin_number_display(marketplace_listing.amount)}"
-          %td
-            = marketplace_listing.condition
-          %td
-            = render partial: "/shared/admin/user_cell", locals: {user: marketplace_listing.seller, render_search: true, cache: true}
-          %td
-            - if marketplace_listing.buyer_id.present?
-              = render partial: "/shared/admin/user_cell", locals: {user: marketplace_listing.buyer_id, render_search: true, cache: true}
+              .less-strong-hold
+                %span.convertTime
+                  = l marketplace_listing.created_at, format: :convert_time
+                - if display_dev_info?
+                  %span.less-strong-right.d-none.d-md-block.only-dev-visible
+                    = marketplace_listing.id
+            - if display_dev_info?
+              %td
+                %small.convertTime
+                  = l marketplace_listing.updated_at, format: :convert_time
+            %td
+              - status_class = "text-info" if marketplace_listing.for_sale?
+              - status_class = "text-success" if marketplace_listing.sold?
+              %span{class: status_class}
+                = marketplace_listing.status_humanized
+            %td
+              - if marketplace_listing.published_at.present?
+                %span.convertTime
+                  = l marketplace_listing.published_at, format: :convert_time
+            %td
+              - if marketplace_listing.end_at.present?
+                %span.convertTime
+                  = l marketplace_listing.end_at, format: :convert_time
+            %td
+              = render partial: "/shared/admin/bike_cell", locals: {bike: marketplace_listing.item, bike_id: marketplace_listing.item_id, bike_link_path: bike_path(marketplace_listing.item_id, show_marketplace_preview: true) }
+            %td
+              = "#{marketplace_listing.currency_symbol}#{admin_number_display(marketplace_listing.amount)}"
+            %td
+              = marketplace_listing.condition
+            %td
+              - if marketplace_listing.address_record
+                = render partial: "/shared/admin/address_record_cell", locals: {address_record: marketplace_listing.address_record}
+            %td
+              = render partial: "/shared/admin/user_cell", locals: {user: marketplace_listing.seller, render_search: true, cache: true}
+            %td
+              - if marketplace_listing.buyer_id.present?
+                = render partial: "/shared/admin/user_cell", locals: {user: marketplace_listing.buyer_id, render_search: true, cache: true}

--- a/app/views/shared/_claim_message.html.haml
+++ b/app/views/shared/_claim_message.html.haml
@@ -11,7 +11,7 @@
     - elsif ownership.creator&.name.present?
       = ownership.creator.name
     - else
-      = EmailNormalizer.obfuscate(ownership&.creator.email)
+      = EmailNormalizer.obfuscate(ownership&.creator&.email)
   = t(".registered_your_bike_on_index", bike_type: bike.type)
 
 

--- a/app/views/shared/admin/_address_record_cell.html.haml
+++ b/app/views/shared/admin/_address_record_cell.html.haml
@@ -1,0 +1,6 @@
+= address_record.city
+%small.less-strong
+  - if address_record.region.present?
+    = address_record.region
+  - elsif address_record.country.present? && address_record.country != Country.united_states
+    = address_record.country.abbreviation

--- a/bin/knapsack_pro_tests
+++ b/bin/knapsack_pro_tests
@@ -6,7 +6,7 @@ if [ "$KNAPSACK_PRO_TEST_SUITE_TOKEN_RSPEC" = "" ]; then
   KNAPSACK_PRO_TEST_SUITE_TOKEN_RSPEC=disabled-for-fork \
   KNAPSACK_PRO_MAX_REQUEST_RETRIES=0 \
   KNAPSACK_PRO_CI_NODE_RETRY_COUNT=0 \
-  bundle exec rake knapsack_pro:queue:rspec[--format documentation --format RSpec::Github::Formatter]
+  bundle exec rake "knapsack_pro:queue:rspec[--format documentation --format RSpec::Github::Formatter]"
 else
-  bundle exec rake knapsack_pro:queue:rspec[--format documentation --format RSpec::Github::Formatter]
+  bundle exec rake "knapsack_pro:queue:rspec[--format documentation --format RSpec::Github::Formatter]"
 fi

--- a/bin/knapsack_pro_tests
+++ b/bin/knapsack_pro_tests
@@ -6,7 +6,7 @@ if [ "$KNAPSACK_PRO_TEST_SUITE_TOKEN_RSPEC" = "" ]; then
   KNAPSACK_PRO_TEST_SUITE_TOKEN_RSPEC=disabled-for-fork \
   KNAPSACK_PRO_MAX_REQUEST_RETRIES=0 \
   KNAPSACK_PRO_CI_NODE_RETRY_COUNT=0 \
-  bundle exec rake knapsack_pro:queue:rspec
+  bundle exec rake knapsack_pro:queue:rspec[--format documentation --format RSpec::Github::Formatter]
 else
-  bundle exec rake knapsack_pro:queue:rspec
+  bundle exec rake knapsack_pro:queue:rspec[--format documentation --format RSpec::Github::Formatter]
 fi

--- a/spec/controllers/bikes_controller_spec.rb
+++ b/spec/controllers/bikes_controller_spec.rb
@@ -571,7 +571,7 @@ RSpec.describe BikesController, type: :controller do
             expect(assigns[:persist_email]).to be_falsey
             expect(response).to redirect_to(embed_extended_organization_url(organization))
             # Have to do after, because inline sidekiq ignores delays and created_bike isn't present when it's run
-            ImageAssociatorJob.new.perform
+            Images::AssociatorJob.new.perform
             bike = Bike.last
             expect(bike.owner_email).to eq bike_params[:owner_email].downcase
             expect(bike.current_ownership.origin).to eq "embed_extended"

--- a/spec/jobs/callbacks/after_bike_save_job_spec.rb
+++ b/spec/jobs/callbacks/after_bike_save_job_spec.rb
@@ -42,6 +42,7 @@ RSpec.describe Callbacks::AfterBikeSaveJob, type: :job do
 
     context "with marketplace_listing" do
       let!(:marketplace_listing) { FactoryBot.create(:marketplace_listing, item: bike) }
+
       it "updates the marketplace_listing updated_at" do
         marketplace_listing.update_column :updated_at, Time.current - 1.hour
         expect(marketplace_listing.reload.updated_at).to be < Time.current - 50.minutes

--- a/spec/jobs/callbacks/after_bike_save_job_spec.rb
+++ b/spec/jobs/callbacks/after_bike_save_job_spec.rb
@@ -59,7 +59,7 @@ RSpec.describe Callbacks::AfterBikeSaveJob, type: :job do
       expect(bike.public_images.pluck(:external_image_url)).to match_array external_image_urls.uniq
       # Processing occurs in the processing job - not inline
       expect(bike.public_images.any? { |i| i.image.present? }).to be_falsey
-      expect(ExternalImageUrlStoreJob.jobs.count).to eq 2
+      expect(Images::ExternalUrlStoreJob.jobs.count).to eq 2
     end
     context "images already exist, passed some blank values" do
       let(:passed_external_image_urls) { external_image_urls + [nil, ""] }

--- a/spec/jobs/callbacks/after_bike_save_job_spec.rb
+++ b/spec/jobs/callbacks/after_bike_save_job_spec.rb
@@ -22,8 +22,9 @@ RSpec.describe Callbacks::AfterBikeSaveJob, type: :job do
   end
 
   describe "update listing order and credibility score" do
+    let(:bike) { FactoryBot.create(:bike) }
+
     it "updates the listing order" do
-      bike = FactoryBot.create(:bike)
       bike.update_attribute :listing_order, -22
       instance.perform(bike.id)
       bike.reload
@@ -33,10 +34,19 @@ RSpec.describe Callbacks::AfterBikeSaveJob, type: :job do
 
     context "unchanged listing order" do
       it "does not update the listing order or enqueue afterbikesave" do
-        bike = FactoryBot.create(:bike)
         bike.update_attribute :listing_order, bike.calculated_listing_order
         expect_any_instance_of(Bike).to_not receive(:update_attribute)
         instance.perform(bike.id)
+      end
+    end
+
+    context "with marketplace_listing" do
+      let!(:marketplace_listing) { FactoryBot.create(:marketplace_listing, item: bike) }
+      it "updates the marketplace_listing updated_at" do
+        marketplace_listing.update_column :updated_at, Time.current - 1.hour
+        expect(marketplace_listing.reload.updated_at).to be < Time.current - 50.minutes
+        instance.perform(bike.id)
+        expect(marketplace_listing.reload.updated_at).to be_within(1).of Time.current
       end
     end
   end

--- a/spec/jobs/images/associator_job_spec.rb
+++ b/spec/jobs/images/associator_job_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe ImageAssociatorJob, type: :job do
+RSpec.describe Images::AssociatorJob, type: :job do
   it "is the correct queue" do
     expect(described_class.sidekiq_options["queue"]).to eq "high_priority"
   end

--- a/spec/jobs/images/external_url_store_job_spec.rb
+++ b/spec/jobs/images/external_url_store_job_spec.rb
@@ -1,14 +1,14 @@
 require "rails_helper"
 
-RSpec.describe ExternalImageUrlStoreJob, type: :job do
-  let(:subject) { ExternalImageUrlStoreJob }
-  let(:instance) { subject.new }
+RSpec.describe Images::ExternalUrlStoreJob, type: :job do
+  let(:instance) { described_class.new }
 
   context "valid performance" do
     let(:bike) { FactoryBot.create(:bike) }
+    let(:is_private) { false }
     let(:public_image) do
       # Use the email logo url - since that file it should never be removed
-      PublicImage.create(imageable: bike,
+      PublicImage.create(imageable: bike, is_private:,
         external_image_url: "https://files.bikeindex.org/email_assets/logo.png")
     end
     it "downloads and processes the image" do
@@ -22,6 +22,21 @@ RSpec.describe ExternalImageUrlStoreJob, type: :job do
       end
       expect(Sidekiq::Job.jobs.count).to eq 1
       expect(::Callbacks::AfterBikeSaveJob).to have_enqueued_sidekiq_job(bike.id, false, true)
+    end
+    context "is_private true" do
+      let(:is_private) { true }
+      it "downloads and processes" do
+        expect(public_image.id).to be_present
+        Sidekiq::Job.clear_all
+        expect(public_image.image).to_not be_present
+        VCR.use_cassette("external_image_url_store_worker") do
+          instance.perform(public_image.id)
+          public_image.reload
+          expect(public_image.image).to be_present
+        end
+        expect(Sidekiq::Job.jobs.count).to eq 1
+        expect(::Callbacks::AfterBikeSaveJob).to have_enqueued_sidekiq_job(bike.id, false, true)
+      end
     end
   end
   context "already has an image" do

--- a/spec/jobs/users/create_or_update_membership_from_payment_job_spec.rb
+++ b/spec/jobs/users/create_or_update_membership_from_payment_job_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe User::CreateOrUpdateMembershipFromPaymentJob, type: :job do
+RSpec.describe Users::CreateOrUpdateMembershipFromPaymentJob, type: :job do
   let(:instance) { described_class.new }
 
   let(:user) { FactoryBot.create(:user_confirmed) }

--- a/spec/jobs/users/delete_job_spec.rb
+++ b/spec/jobs/users/delete_job_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe UserDeleteJob, type: :job do
+RSpec.describe Users::DeleteJob, type: :job do
   let(:instance) { described_class.new }
 
   let!(:user) { FactoryBot.create(:user_confirmed, email: "owner1@A.COM") }

--- a/spec/jobs/users/merge_additional_email_job_spec.rb
+++ b/spec/jobs/users/merge_additional_email_job_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe MergeAdditionalEmailJob, type: :job do
+RSpec.describe Users::MergeAdditionalEmailJob, type: :job do
   let(:instance) { described_class.new }
 
   it "is the correct queue" do

--- a/spec/jobs/users/process_organization_role_job_spec.rb
+++ b/spec/jobs/users/process_organization_role_job_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe ProcessOrganizationRoleJob, type: :job do
+RSpec.describe Users::ProcessOrganizationRoleJob, type: :job do
   let(:instance) { described_class.new }
   before { ActionMailer::Base.deliveries = [] }
 

--- a/spec/jobs/users/remove_unconfirmed_job_spec.rb
+++ b/spec/jobs/users/remove_unconfirmed_job_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe RemoveUnconfirmedUsersJob, type: :job do
+RSpec.describe Users::RemoveUnconfirmedJob, type: :job do
   let(:instance) { described_class.new }
   include_context :scheduled_job
   include_examples :scheduled_job_tests

--- a/spec/models/organization_role_spec.rb
+++ b/spec/models/organization_role_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe OrganizationRole, type: :model do
         Sidekiq::Job.clear_all
         expect {
           FactoryBot.create(:organization_role_claimed, organization: org, user: user)
-        }.to change(ProcessOrganizationRoleJob.jobs, :count).by 1
+        }.to change(Users::ProcessOrganizationRoleJob.jobs, :count).by 1
         Sidekiq::Job.drain_all
 
         expect(AmbassadorTaskAssignment.count).to eq(2)

--- a/spec/models/public_image_spec.rb
+++ b/spec/models/public_image_spec.rb
@@ -52,7 +52,7 @@ RSpec.describe PublicImage, type: :model do
           expect {
             public_image.enqueue_after_commit_jobs
           }.to change(::Callbacks::AfterBikeSaveJob.jobs, :size).by(1)
-        }.to_not change(ExternalImageUrlStoreJob.jobs, :size)
+        }.to_not change(Images::ExternalUrlStoreJob.jobs, :size)
       end
     end
     context "remote_image_url" do
@@ -64,7 +64,7 @@ RSpec.describe PublicImage, type: :model do
         expect(public_image.bike_type).to eq "bike"
         expect {
           expect(public_image.save).to be_truthy
-        }.to change(ExternalImageUrlStoreJob.jobs, :size).by(1)
+        }.to change(Images::ExternalUrlStoreJob.jobs, :size).by(1)
       end
       context "image present" do
         let(:public_image) { PublicImage.new(imageable: bike, external_image_url: "http://example.com/image.png", image: File.open(Rails.root.join("spec", "fixtures", "bike.jpg"))) }
@@ -73,7 +73,7 @@ RSpec.describe PublicImage, type: :model do
             expect {
               expect(public_image.save).to be_truthy
             }.to change(::Callbacks::AfterBikeSaveJob.jobs, :size).by(1)
-          }.to_not change(ExternalImageUrlStoreJob.jobs, :size)
+          }.to_not change(Images::ExternalUrlStoreJob.jobs, :size)
         end
       end
     end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -849,10 +849,13 @@ RSpec.describe User, type: :model do
 
   describe "can_create_listing?" do
     let(:user) { FactoryBot.create(:user_confirmed) }
-    it "is true" do
+    it "is false if past MARKETPLACE_FREE_UNTIL" do
       # TODO: update when MARKETPLACE_FREE_UNTIL changes
-      expect(user.reload.can_create_listing?).to be_truthy
-      # expect(user.reload.can_create_listing?).to be_falsey
+      if Time.current.to_i < User::MARKETPLACE_FREE_UNTIL
+        expect(user.reload.can_create_listing?).to be_truthy
+      else
+        expect(user.reload.can_create_listing?).to be_falsey
+      end
     end
     context "superuser" do
       let(:user) { User.new(superuser: true) }

--- a/spec/requests/admin/organization_roles_request_spec.rb
+++ b/spec/requests/admin/organization_roles_request_spec.rb
@@ -45,8 +45,8 @@ RSpec.describe Admin::OrganizationRolesController, type: :request do
         expect(organization.organization_roles.count).to eq 1
         existing_user.reload
         organization_role = OrganizationRole.last
-        expect(ProcessOrganizationRoleJob.jobs.count).to eq 1
-        ProcessOrganizationRoleJob.drain
+        expect(Users::ProcessOrganizationRoleJob.jobs.count).to eq 1
+        Users::ProcessOrganizationRoleJob.drain
         organization.reload
         organization_role.reload
         expect(existing_user.organization_roles.count).to eq 1

--- a/spec/requests/api/v2/bikes_search_request_spec.rb
+++ b/spec/requests/api/v2/bikes_search_request_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe "Bikes API V2", type: :request do
+RSpec.describe "BikesSearch API V2", type: :request do
   describe "bike search" do
     before :each do
       FactoryBot.create(:bike)
@@ -70,12 +70,13 @@ RSpec.describe "Bikes API V2", type: :request do
       expect(response.code).to eq("200")
     end
 
-    it "proximity square does not overwrite the proximity_radius" do
-      opts = {proximity_square: 100, proximity_radius: "10"}
-      target = opts.merge(proximity: "ip")
-      expect_any_instance_of(BikeSearcher).to receive(:initialize).with(target)
-      get "/api/v2/bikes_search/count", params: opts.merge(format: :json)
-    end
+    # Stubbing initialize prints out a warning. I don't really care about this test, who's using V2 anyway?
+    # it "proximity square does not overwrite the proximity_radius" do
+    #   opts = {proximity_square: 100, proximity_radius: "10"}
+    #   target = opts.merge(proximity: "ip")
+    #   expect_any_instance_of(BikeSearcher).to receive(:initialize).with(target)
+    #   get "/api/v2/bikes_search/count", params: opts.merge(format: :json)
+    # end
   end
 
   describe "all_stolen" do

--- a/spec/requests/organized/bikes_request_spec.rb
+++ b/spec/requests/organized/bikes_request_spec.rb
@@ -221,7 +221,7 @@ RSpec.describe Organized::BikesController, type: :request do
           expect(ActionMailer::Base.deliveries.count).to eq 0
         end
         # Have to do after, because inline sidekiq ignores delays and created_bike isn't present when it's run
-        ImageAssociatorJob.new.perform
+        Images::AssociatorJob.new.perform
 
         b_param.reload
         expect(b_param.creation_organization).to eq current_organization

--- a/spec/requests/user_emails_request_spec.rb
+++ b/spec/requests/user_emails_request_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe UserEmailsController, type: :request do
         it "confirms and enqueues merge job" do
           expect {
             get "#{base_url}/#{user_email.id}/confirm", params: {confirmation_token: user_email.confirmation_token}
-          }.to change(MergeAdditionalEmailJob.jobs, :size).by 1
+          }.to change(Users::MergeAdditionalEmailJob.jobs, :size).by 1
           user_email.reload
           expect(user_email.confirmed?).to be_truthy
           expect(flash[:success]).to be_present
@@ -59,7 +59,7 @@ RSpec.describe UserEmailsController, type: :request do
           user_email.confirm(user_email.confirmation_token)
           expect {
             get "#{base_url}/#{user_email.id}/confirm", params: {confirmation_token: "sometoken-or-something"}
-          }.to change(MergeAdditionalEmailJob.jobs, :size).by 0
+          }.to change(Users::MergeAdditionalEmailJob.jobs, :size).by 0
           expect(flash[:info]).to be_present
         end
       end
@@ -67,7 +67,7 @@ RSpec.describe UserEmailsController, type: :request do
         it "sets flash error and does not add job" do
           expect {
             get "#{base_url}/#{user_email.id}/confirm", params: {confirmation_token: "somethingelse-"}
-          }.to change(MergeAdditionalEmailJob.jobs, :size).by 0
+          }.to change(Users::MergeAdditionalEmailJob.jobs, :size).by 0
           expect(flash[:error]).to be_present
         end
       end


### PR DESCRIPTION
- Extend `User::MARKETPLACE_FREE_UNTIL` time to match the time the final newsletter was sent
- Display city of listing in `admin/marketplace_listings`
- Namespace users and images jobs
- Fix nil issue for `Images::ExternalUrlStoreJob` and `Users::ProcessOrganizationRoleJob` (previously `ExternalImageUrlStoreJob` and `ProcessOrganizationRoleJob`)
