### PR TITLE
Force geocode job

### DIFF
--- a/app/jobs/backfills/address_record_force_geocode_job.rb
+++ b/app/jobs/backfills/address_record_force_geocode_job.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class Backfills::AddressRecordForceGeocodeJob < ApplicationJob
+  sidekiq_options queue: "low_priority", retry: false
+
+  def perform(id)
+    address_record = AddressRecord.find(id)
+
+    address_record.update(force_geocoding: true)
+  end
+end

--- a/spec/jobs/backfills/address_record_force_geocode_job_spec.rb
+++ b/spec/jobs/backfills/address_record_force_geocode_job_spec.rb
@@ -1,0 +1,34 @@
+require "rails_helper"
+
+RSpec.describe Backfills::AddressRecordForceGeocodeJob, type: :job do
+  let(:instance) { described_class.new }
+
+  describe "perform" do
+    let(:country_id) { Country.united_states.id }
+    let(:region_record_id) { FactoryBot.create(:state_california).id }
+    let!(:address_record) { AddressRecord.create(postal_code: "95616", region_record_id:, country_id:, skip_geocoding: true) }
+    let(:target_attrs) do
+      {
+        region_record_id:,
+        region_string: nil,
+        postal_code: "95616",
+        street: nil,
+        city: "Davis",
+        latitude: 38.5474428,
+        longitude: -121.7765309
+      }
+    end
+
+    include_context :geocoder_real
+
+    it "force geocodes address_record" do
+      expect(address_record.reload.city).to be_blank
+
+      VCR.use_cassette("address-record-assignment_geocode") do
+        instance.perform(address_record.id)
+
+        expect(address_record.reload).to match_hash_indifferently target_attrs
+      end
+    end
+  end
+end

--- a/spec/models/address_record_spec.rb
+++ b/spec/models/address_record_spec.rb
@@ -42,10 +42,10 @@ RSpec.describe AddressRecord, type: :model do
     let(:target_attrs) do
       {
         region_record_id:,
-        postal_code: "95616",
+        region_string: nil,
+        postal_code: postal_code.strip,
         street: nil,
         city: nil,
-        region_string: nil,
         latitude: nil,
         longitude: nil
       }
@@ -63,10 +63,10 @@ RSpec.describe AddressRecord, type: :model do
       let(:target_attrs) do
         {
           region_record_id:,
+          region_string: nil,
           postal_code: "95616",
           street: nil,
           city: "Davis",
-          region_string: nil,
           latitude: 38.5474428,
           longitude: -121.7765309
         }
@@ -88,16 +88,43 @@ RSpec.describe AddressRecord, type: :model do
             expect(address_record.reload).to match_hash_indifferently target_attrs
           end
 
-          address_record.reload
           # not wrapped in VCR, so will error if it attempts to geocode
-
-          address_record.update(kind: :marketplace_listing, publicly_visible_attribute: :city, user_id: 121212)
+          address_record.reload.update(kind: :marketplace_listing, publicly_visible_attribute: :city, user_id: 121212)
 
           VCR.use_cassette("address-record-assignment_geocode-again") do
             address_record.update(street: "100 Shields Ave")
 
             expect(address_record.reload.latitude).to_not eq target_attrs[:latitude]
           end
+        end
+      end
+    end
+
+    context "Canada, force geocoding" do
+      let(:region_string) { "  " }
+      let!(:region_record_id) { nil }
+      let(:postal_code) { "T4N4E4" }
+      let(:country_id) { Country.canada_id }
+      let(:target_attrs) do
+        {
+          region_record_id: nil,
+          region_string: "AB",
+          postal_code: "T4N 4E4",
+          street: nil,
+          city: "Red Deer",
+          latitude: 52.2977406,
+          longitude: -113.812812
+        }
+      end
+      it "updates with force update" do
+        expect(address_record).to be_valid
+        # postal_code is formatted by Geocodeable.format_postal_code
+        expect(address_record.reload).to match_hash_indifferently({postal_code: "T4N 4E4", region_string: nil, city: nil})
+
+        VCR.use_cassette("address-record-assignment_geocode-canada") do
+          address_record.update(force_geocoding: true)
+
+          expect(address_record.reload).to match_hash_indifferently target_attrs
         end
       end
     end

--- a/spec/vcr_cassettes/address-record-assignment_geocode-canada.yml
+++ b/spec/vcr_cassettes/address-record-assignment_geocode-canada.yml
@@ -1,0 +1,85 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://maps.googleapis.com/maps/api/geocode/json?address=T4N%204E4,%20Canada&key=<GOOGLE_GEOCODER>&language=en&sensor=false
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Wed, 11 Jun 2025 18:28:40 GMT
+      Pragma:
+      - no-cache
+      Expires:
+      - Fri, 01 Jan 1990 00:00:00 GMT
+      Cache-Control:
+      - no-cache, must-revalidate
+      Access-Control-Allow-Origin:
+      - "*"
+      Content-Security-Policy-Report-Only:
+      - script-src 'none'; form-action 'none'; frame-src 'none'; report-uri https://csp.withgoogle.com/csp/scaffolding/msaifdggmnwc:228:0
+      Cross-Origin-Opener-Policy-Report-Only:
+      - same-origin; report-to=msaifdggmnwc:228:0
+      Report-To:
+      - '{"group":"msaifdggmnwc:228:0","max_age":2592000,"endpoints":[{"url":"https://csp.withgoogle.com/csp/report-to/scaffolding/msaifdggmnwc:228:0"}],}'
+      Server:
+      - mafe
+      Content-Length:
+      - '2368'
+      X-Xss-Protection:
+      - '0'
+      X-Frame-Options:
+      - SAMEORIGIN
+      Server-Timing:
+      - gfet4t7; dur=98
+      Alt-Svc:
+      - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
+    body:
+      encoding: UTF-8
+      string: "{\n   \"results\" : \n   [\n      {\n         \"address_components\"
+        : \n         [\n            {\n               \"long_name\" : \"T4N 4E4\",\n
+        \              \"short_name\" : \"T4N 4E4\",\n               \"types\" : \n
+        \              [\n                  \"postal_code\"\n               ]\n            },\n
+        \           {\n               \"long_name\" : \"Red Deer\",\n               \"short_name\"
+        : \"Red Deer\",\n               \"types\" : \n               [\n                  \"locality\",\n
+        \                 \"political\"\n               ]\n            },\n            {\n
+        \              \"long_name\" : \"Red Deer County\",\n               \"short_name\"
+        : \"Red Deer County\",\n               \"types\" : \n               [\n                  \"administrative_area_level_2\",\n
+        \                 \"political\"\n               ]\n            },\n            {\n
+        \              \"long_name\" : \"Alberta\",\n               \"short_name\"
+        : \"AB\",\n               \"types\" : \n               [\n                  \"administrative_area_level_1\",\n
+        \                 \"political\"\n               ]\n            },\n            {\n
+        \              \"long_name\" : \"Canada\",\n               \"short_name\"
+        : \"CA\",\n               \"types\" : \n               [\n                  \"country\",\n
+        \                 \"political\"\n               ]\n            }\n         ],\n
+        \        \"formatted_address\" : \"Red Deer, AB T4N 4E4, Canada\",\n         \"geometry\"
+        : \n         {\n            \"bounds\" : \n            {\n               \"northeast\"
+        : \n               {\n                  \"lat\" : 52.2995248,\n                  \"lng\"
+        : -113.811914\n               },\n               \"southwest\" : \n               {\n
+        \                 \"lat\" : 52.295942,\n                  \"lng\" : -113.8143829\n
+        \              }\n            },\n            \"location\" : \n            {\n
+        \              \"lat\" : 52.2977406,\n               \"lng\" : -113.812812\n
+        \           },\n            \"location_type\" : \"APPROXIMATE\",\n            \"viewport\"
+        : \n            {\n               \"northeast\" : \n               {\n                  \"lat\"
+        : 52.2995248,\n                  \"lng\" : -113.8117994697085\n               },\n
+        \              \"southwest\" : \n               {\n                  \"lat\"
+        : 52.295942,\n                  \"lng\" : -113.8144974302915\n               }\n
+        \           }\n         },\n         \"place_id\" : \"ChIJlT7Osq5VdFMRxTPqe5pJufs\",\n
+        \        \"types\" : \n         [\n            \"postal_code\"\n         ]\n
+        \     }\n   ],\n   \"status\" : \"OK\"\n}"
+  recorded_at: Wed, 11 Jun 2025 18:28:40 GMT
+recorded_with: VCR 6.3.1


### PR DESCRIPTION
Address Records were backfilled from user records. Some of them are missing city and region, but have postal code.

Adds a `attr_accessor :force_geocoding` to AddressRecord so that these records can be geocoded, and a job to handle batching geocoding