### PR TITLE
Download tempfile when processing remote bulk import, fix a bug causing AfterBikeSaveJob to hang

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -69,6 +69,7 @@ gem "axlsx", "~> 3.0.0.pre" # Write Excel files (OrganizationExports), on pre b/
 # gem "wkhtmltopdf-binary" # TODO: PDFs are broken right now - commented out because they're unused
 gem "rqrcode", "0.10.1" # QR Codes
 gem "inline_svg" # render SVGs inline and give them classes
+gem "down" # used to generate a local tempfile
 
 # API wrappers
 gem "twitter" # Twitter. For rendering tweets

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -210,6 +210,8 @@ GEM
     dotenv-rails (2.7.6)
       dotenv (= 2.7.6)
       railties (>= 3.2)
+    down (5.4.2)
+      addressable (~> 2.8)
     drb (2.2.3)
     dry-core (1.1.0)
       concurrent-ruby (~> 1.0)
@@ -876,6 +878,7 @@ DEPENDENCIES
   doorkeeper
   doorkeeper-i18n
   dotenv-rails
+  down
   erb-formatter
   facebookbusiness!
   factory_bot_rails

--- a/app/components/pagination/component.rb
+++ b/app/components/pagination/component.rb
@@ -25,9 +25,9 @@ module Pagination
 
     def pagy_series_link(item)
       if item.is_a?(Integer)
-        link_to(item, @params.merge(page: item), class: active_classes, data: @data)
+        link_to(number_display(item), @params.merge(page: item), class: active_classes, data: @data)
       elsif item.is_a?(String) # it's the current page
-        content_tag(:a, item, role: "link", class: current_link_class, disabled: true, "aria-disabled": "true")
+        content_tag(:a, number_display(item), role: "link", class: current_link_class, disabled: true, "aria-disabled": "true")
       else
         content_tag(:a, pagy_t("pagy.gap").html_safe, role: "link", class: "px-2", disabled: true, "aria-disabled": "true")
       end

--- a/app/jobs/bulk_import_job.rb
+++ b/app/jobs/bulk_import_job.rb
@@ -20,6 +20,7 @@ class BulkImportJob < ApplicationJob
     end
 
     process_csv(open_file)
+
     @bulk_import.unlink_tempfile
     @bulk_import.progress = "finished"
     return @bulk_import.save unless @line_errors.any?

--- a/app/jobs/bulk_import_job.rb
+++ b/app/jobs/bulk_import_job.rb
@@ -20,7 +20,7 @@ class BulkImportJob < ApplicationJob
     end
 
     process_csv(open_file)
-
+    @bulk_import.unlink_tempfile
     @bulk_import.progress = "finished"
     return @bulk_import.save unless @line_errors.any?
 

--- a/app/models/bulk_import.rb
+++ b/app/models/bulk_import.rb
@@ -20,7 +20,7 @@ class BulkImport < ApplicationRecord
   PROGRESS_ENUM = {pending: 0, ongoing: 1, finished: 2}.freeze
   KIND_ENUM = {organization_import: 0, unorganized: 1, ascend: 2, impounded: 3, stolen: 4}.freeze
   VALID_FILE_EXTENSIONS = %(csv tsv).freeze
-  FAILED_TIMEOUT = 20.minutes
+  TIMEOUT_FAILURE_DELAY = 20.minutes.freeze
   mount_uploader :file, BulkImportUploader
 
   belongs_to :organization
@@ -36,9 +36,9 @@ class BulkImport < ApplicationRecord
   scope :file_errors, -> { where("(import_errors -> 'file') IS NOT NULL") }
   scope :line_errors, -> { where("(import_errors -> 'line') IS NOT NULL") }
   scope :ascend_errors, -> { where("(import_errors -> 'ascend') IS NOT NULL") }
-  # NOTE: the failed_timeout? method is slightly different - it has a shorter timeout for pending status
-  scope :failed_timeout, -> { not_finished.where("created_at < ?", FAILED_TIMEOUT) }
-  scope :import_errors, -> { file_errors.or(line_errors).or(failed_timeout) }
+  # NOTE: the timeout_failure? method is slightly different - it has a shorter timeout for pending status
+  scope :timeout_failure, -> { not_finished.where("created_at < ?", Time.current - TIMEOUT_FAILURE_DELAY) }
+  scope :import_errors, -> { file_errors.or(line_errors).or(timeout_failure) }
   scope :no_import_errors, -> { where("(import_errors -> 'line') IS NULL").where("(import_errors -> 'file') IS NULL") }
   scope :no_bikes, -> { where("(import_errors -> 'bikes') IS NOT NULL") }
   scope :with_bikes, -> { where.not("(import_errors -> 'bikes') IS NOT NULL") }
@@ -94,16 +94,16 @@ class BulkImport < ApplicationRecord
     line_errors.present? || file_errors.present? || ascend_errors.present?
   end
 
-  def failed_timeout?
+  def timeout_failure?
     return false if finished? || created_at.blank?
     # If pending, fail if older than 5 minutes (it should have started processing by then!)
-    # Doesn't match the scope exactly, which just uses FAILED_TIMEOUT
-    timeout = pending? ? 5.minutes : FAILED_TIMEOUT
+    # Doesn't match the scope exactly, which just uses TIMEOUT_FAILURE_DELAY
+    timeout = pending? ? 5.minutes : TIMEOUT_FAILURE_DELAY
     created_at < Time.current - timeout
   end
 
   def blocking_error?
-    ascend_errors.present? || file_errors.present? || failed_timeout?
+    ascend_errors.present? || file_errors.present? || timeout_failure?
   end
 
   def no_bikes?

--- a/app/models/bulk_import.rb
+++ b/app/models/bulk_import.rb
@@ -20,7 +20,7 @@ class BulkImport < ApplicationRecord
   PROGRESS_ENUM = {pending: 0, ongoing: 1, finished: 2}.freeze
   KIND_ENUM = {organization_import: 0, unorganized: 1, ascend: 2, impounded: 3, stolen: 4}.freeze
   VALID_FILE_EXTENSIONS = %(csv tsv).freeze
-  PENDING_TIMEOUT = 15.minutes
+  FAILED_TIMEOUT = 20.minutes
   mount_uploader :file, BulkImportUploader
 
   belongs_to :organization
@@ -36,8 +36,9 @@ class BulkImport < ApplicationRecord
   scope :file_errors, -> { where("(import_errors -> 'file') IS NOT NULL") }
   scope :line_errors, -> { where("(import_errors -> 'line') IS NOT NULL") }
   scope :ascend_errors, -> { where("(import_errors -> 'ascend') IS NOT NULL") }
-  scope :pending_timeout, -> { pending.where("created_at < ?", Time.current - PENDING_TIMEOUT) }
-  scope :import_errors, -> { file_errors.or(line_errors).or(pending_timeout) }
+  # NOTE: the failed_timeout? method is slightly different - it has a shorter timeout for pending status
+  scope :failed_timeout, -> { not_finished.where("created_at < ?", FAILED_TIMEOUT) }
+  scope :import_errors, -> { file_errors.or(line_errors).or(failed_timeout) }
   scope :no_import_errors, -> { where("(import_errors -> 'line') IS NULL").where("(import_errors -> 'file') IS NULL") }
   scope :no_bikes, -> { where("(import_errors -> 'bikes') IS NOT NULL") }
   scope :with_bikes, -> { where.not("(import_errors -> 'bikes') IS NOT NULL") }
@@ -93,16 +94,16 @@ class BulkImport < ApplicationRecord
     line_errors.present? || file_errors.present? || ascend_errors.present?
   end
 
-  def pending_timeout?
-    return false unless pending? && created_at.present?
-    # If there are some ownerships created, give it more time before pronouncing timed out
-    # doesn't match the scope exactly, the scope just matches PENDING_TIMEOUT
-    timeout = ownerships.any? ? PENDING_TIMEOUT : 5.minutes
+  def failed_timeout?
+    return false if finished? || created_at.blank?
+    # If pending, fail if older than 5 minutes (it should have started processing by then!)
+    # Doesn't match the scope exactly, which just uses FAILED_TIMEOUT
+    timeout = pending? ? 5.minutes : FAILED_TIMEOUT
     created_at < Time.current - timeout
   end
 
   def blocking_error?
-    ascend_errors.present? || file_errors.present? || pending_timeout?
+    ascend_errors.present? || file_errors.present? || failed_timeout?
   end
 
   def no_bikes?

--- a/app/models/bulk_import.rb
+++ b/app/models/bulk_import.rb
@@ -166,9 +166,10 @@ class BulkImport < ApplicationRecord
   end
 
   def unlink_tempfile
-    return if tempfile.blank?
+    return if @tempfile.blank?
 
-    tempfile.close && tempfile.unlink
+    @tempfile.close && @tempfile.unlink && @tempfile = nil
+    true
   end
 
   def check_ascend_import_processable!
@@ -237,10 +238,6 @@ class BulkImport < ApplicationRecord
 
   def fetch_tempfile
     @tempfile ||= Down.download(file.url)
-  end
-
-  def tempfile
-    @tempfile
   end
 
   def calculated_kind

--- a/app/models/user_registration_organization.rb
+++ b/app/models/user_registration_organization.rb
@@ -116,9 +116,11 @@ class UserRegistrationOrganization < ApplicationRecord
   # Manually called from ::Callbacks::AfterUserChangeJob
   def create_or_update_bike_organizations
     return true unless all_bikes # only overrides bike_organizations if all_bikes is checked
-    bikes.each do |bike|
+    # Only update the most recent bikes.
+    # This is particularly important when bulk importing a bunch of bikes to a single user
+    bikes.order(id: :desc).limit(100).pluck(:id).each do |bike_id|
       bike_organization = BikeOrganization.unscoped
-        .where(organization_id: organization_id, bike_id: bike.id)
+        .where(organization_id: organization_id, bike_id: bike_id)
         .first_or_initialize
       bike_organization.update(deleted_at: nil, can_not_edit_claimed: can_not_edit_claimed)
     end

--- a/app/models/user_registration_organization.rb
+++ b/app/models/user_registration_organization.rb
@@ -117,7 +117,7 @@ class UserRegistrationOrganization < ApplicationRecord
   def create_or_update_bike_organizations
     return true unless all_bikes # only overrides bike_organizations if all_bikes is checked
     # Only update the most recent bikes.
-    # This is particularly important when bulk importing a bunch of bikes to a single user
+    # This is particularly important when bulk importing thousands of bikes to a single user
     bikes.order(id: :desc).limit(100).pluck(:id).each do |bike_id|
       BikeOrganization.unscoped
         .where(organization_id:, bike_id:).first_or_initialize

--- a/app/models/user_registration_organization.rb
+++ b/app/models/user_registration_organization.rb
@@ -119,10 +119,9 @@ class UserRegistrationOrganization < ApplicationRecord
     # Only update the most recent bikes.
     # This is particularly important when bulk importing a bunch of bikes to a single user
     bikes.order(id: :desc).limit(100).pluck(:id).each do |bike_id|
-      bike_organization = BikeOrganization.unscoped
-        .where(organization_id: organization_id, bike_id: bike_id)
-        .first_or_initialize
-      bike_organization.update(deleted_at: nil, can_not_edit_claimed: can_not_edit_claimed)
+      BikeOrganization.unscoped
+        .where(organization_id:, bike_id:).first_or_initialize
+        .update(deleted_at: nil, can_not_edit_claimed:)
     end
   end
 end

--- a/app/views/admin/bulk_imports/index.html.haml
+++ b/app/views/admin/bulk_imports/index.html.haml
@@ -94,7 +94,7 @@
                   = link_to "org view", organization_bulk_import_path(bulk_import, organization_id: bulk_import.organization.to_param), class: "em less-strong"
             %td
               = render partial: "/organized/bulk_imports/progress_display", locals: {bulk_import: bulk_import}
-              - if bulk_import.failed_timeout?
+              - if bulk_import.timeout_failure?
                 %em.small import failed to process
                 %small.only-dev-visible still pending
             %td

--- a/app/views/admin/bulk_imports/index.html.haml
+++ b/app/views/admin/bulk_imports/index.html.haml
@@ -94,7 +94,7 @@
                   = link_to "org view", organization_bulk_import_path(bulk_import, organization_id: bulk_import.organization.to_param), class: "em less-strong"
             %td
               = render partial: "/organized/bulk_imports/progress_display", locals: {bulk_import: bulk_import}
-              - if bulk_import.pending_timeout?
+              - if bulk_import.failed_timeout?
                 %em.small import failed to process
                 %small.only-dev-visible still pending
             %td

--- a/app/views/organized/bulk_imports/_progress_display.html.haml
+++ b/app/views/organized/bulk_imports/_progress_display.html.haml
@@ -4,7 +4,7 @@
     Failed
   - if show_extended
     %em.small.less-strong
-      - if bulk_import.pending_timeout?
+      - if bulk_import.failed_timeout?
         Processing failed
         - if display_dev_info?
           %small.only-dev-visible still pending

--- a/app/views/organized/bulk_imports/_progress_display.html.haml
+++ b/app/views/organized/bulk_imports/_progress_display.html.haml
@@ -6,10 +6,12 @@
     %em.small.less-strong
       - if bulk_import.failed_timeout?
         Processing timed out
-        - if display_dev_info?
-          %small.only-dev-visible currently #{bulk_import.progress}
       - else
         could not import, blocking error
+    - if bulk_import.failed_timeout? && display_dev_info?
+      %small.only-dev-visible
+        currently
+        %code= bulk_import.progress
 - else
   - bulk_import_progress_class = bulk_import.progress == "finished" ? "text-success" : ""
   %span{class: bulk_import_progress_class}

--- a/app/views/organized/bulk_imports/_progress_display.html.haml
+++ b/app/views/organized/bulk_imports/_progress_display.html.haml
@@ -4,11 +4,11 @@
     Failed
   - if show_extended
     %em.small.less-strong
-      - if bulk_import.failed_timeout?
+      - if bulk_import.timeout_failure?
         Processing timed out
       - else
         could not import, blocking error
-    - if bulk_import.failed_timeout? && display_dev_info?
+    - if bulk_import.timeout_failure? && display_dev_info?
       %small.only-dev-visible
         currently
         %code= bulk_import.progress

--- a/app/views/organized/bulk_imports/_progress_display.html.haml
+++ b/app/views/organized/bulk_imports/_progress_display.html.haml
@@ -5,9 +5,9 @@
   - if show_extended
     %em.small.less-strong
       - if bulk_import.failed_timeout?
-        Processing failed
+        Processing timed out
         - if display_dev_info?
-          %small.only-dev-visible still pending
+          %small.only-dev-visible currently #{bulk_import.progress}
       - else
         could not import, blocking error
 - else

--- a/app/views/organized/bulk_imports/index.html.haml
+++ b/app/views/organized/bulk_imports/index.html.haml
@@ -55,17 +55,13 @@
           %td
             = bulk_import.kind_humanized
         %td
-          - if bulk_import.blocking_error?
-            %span.text-danger
-              = t(".unable_to_process")
-          - else
-            = render partial: "/organized/bulk_imports/progress_display", locals: {bulk_import: bulk_import}
+          = render partial: "/organized/bulk_imports/progress_display", locals: {bulk_import: bulk_import}
         %td
           = render partial: "/organized/bulk_imports/error_type", locals: {bulk_import: bulk_import}
         %td
           = bulk_import.user.display_name if bulk_import.user_id.present?
         %td
-          = bulk_import.ownerships.count # Don't need to do bikes through ownerships
+          = admin_number_display(bulk_import.ownerships.count) # Don't need to do bikes through ownerships
 
 .pb-4.pt-4
   = render(Pagination::Component.new(pagy: @pagy, page_params: params, size: :lg))

--- a/app/views/organized/bulk_imports/index.html.haml
+++ b/app/views/organized/bulk_imports/index.html.haml
@@ -44,7 +44,7 @@
     %th= t(".errors")
     %th
       = sortable "user_id", t(".creator")
-    %th= t(".bikes")
+    %th= t(".registrations")
   %tbody
     - @bulk_imports.each do |bulk_import|
       %tr

--- a/app/views/organized/bulk_imports/show.html.haml
+++ b/app/views/organized/bulk_imports/show.html.haml
@@ -42,6 +42,12 @@
       %tr
         %td Kind
         %td= @bulk_import.kind_humanized
+    - if @bulk_import.no_notify
+      %tr
+        %td notes
+        %td
+          This import did <strong>not</strong> send emails
+
 
 
 

--- a/app/views/organized/bulk_imports/show.html.haml
+++ b/app/views/organized/bulk_imports/show.html.haml
@@ -7,7 +7,7 @@
     - else
       = t(".bulk_import")
     = link_to "superadmin", admin_bulk_import_path(@bulk_import.to_param), class: "btn btn-outline-info less-strong float-right"
-%table.table-list
+%table.table-list.mb-4
   %tbody
     %tr
       %td
@@ -44,20 +44,19 @@
         %td= @bulk_import.kind_humanized
 
 
-%hr{ style: "margin: 15px 0;" }
+
 - if @bulk_import.import_errors?
-  %h2= t(".errors")
+  %h2.mt-2.mb-2= t(".errors")
   - if @bulk_import.import_errors.present?
     = render partial: "/organized/bulk_imports/error_display", locals: {bulk_import: @bulk_import}
   %hr.tw:mt-4
 
-.tw:flex.tw:flex-wrap.tw:justify-between.tw:mt-4.tw:mb-4
-  %h2.uncap
+.tw:flex.tw:flex-wrap.tw:justify-between.tw:mt-8.tw:mb-4
+  %h2.uncap.mt-0.mb-0
     = t(".bikes")
     %small
       = admin_number_display @pagy.count
-  .pt-4.pb-4
-    = render(Pagination::Component.new(pagy: @pagy, page_params: params, size: :lg))
+  %div= render(Pagination::Component.new(pagy: @pagy, page_params: params, size: :lg))
 
 - show_impounded_id = @bulk_import.impounded? && @bulk_import.headers.present? && @bulk_import.headers.include?("impounded_id")
 

--- a/app/views/organized/bulk_imports/show.html.haml
+++ b/app/views/organized/bulk_imports/show.html.haml
@@ -59,7 +59,7 @@
 
 .tw:flex.tw:flex-wrap.tw:justify-between.tw:mt-8.tw:mb-4
   %h2.uncap.mt-0.mb-0
-    = t(".bikes")
+    = t(".registrations")
     %small
       = admin_number_display @pagy.count
   %div= render(Pagination::Component.new(pagy: @pagy, page_params: params, size: :lg))

--- a/config/locales/.translation_io
+++ b/config/locales/.translation_io
@@ -1,2 +1,2 @@
 ---
-timestamp: 1754968245
+timestamp: 1755020650

--- a/config/locales/.translation_io
+++ b/config/locales/.translation_io
@@ -1,2 +1,2 @@
 ---
-timestamp: 1752793987
+timestamp: 1754968245

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -4705,7 +4705,7 @@ en:
         sent_to_a_new_owner: "(sent to a new owner)"
     exports:
       index:
-        bikes_in_export: Registrations in export
+        bikes_in_export: Bikes in export
         created: Created
         creator: Creator
         delete: Delete

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -4629,7 +4629,6 @@ en:
         line: Line
       index:
         added: Added
-        bikes: Bikes
         creator: Creator
         errors: Errors
         exclude_empty_imports: Exclude Empty imports
@@ -4639,6 +4638,7 @@ en:
         org_ascend_imports_html: "<em>%{org_name}</em> Ascend Imports"
         org_bulk_imports_html: "<em>%{org_name}</em> Bulk Imports"
         progress: Progress
+        registrations: Registrations
       new:
         choose_file: Choose file...
         correct_actual_image_url_html: '<span class="text-success">Correct</span>:
@@ -4685,7 +4685,6 @@ en:
           have 'serial #' as a header, the import will not work.
       show:
         ascend_import: Ascend import
-        bikes: Bikes
         bulk_import: Bulk import
         bulk_import_impounded: Impounded bulk import
         color: Color
@@ -4701,11 +4700,12 @@ en:
         manufacturer: Manufacturer
         model: Model
         progress: Progress
+        registrations: Registrations
         sent_to: Sent to
         sent_to_a_new_owner: "(sent to a new owner)"
     exports:
       index:
-        bikes_in_export: Bikes in export
+        bikes_in_export: Registrations in export
         created: Created
         creator: Creator
         delete: Delete

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -4639,7 +4639,6 @@ en:
         org_ascend_imports_html: "<em>%{org_name}</em> Ascend Imports"
         org_bulk_imports_html: "<em>%{org_name}</em> Bulk Imports"
         progress: Progress
-        unable_to_process: Unable to process
       new:
         choose_file: Choose file...
         correct_actual_image_url_html: '<span class="text-success">Correct</span>:

--- a/config/locales/translation.es.yml
+++ b/config/locales/translation.es.yml
@@ -3833,7 +3833,6 @@ es:
         line:
       index:
         added:
-        bikes:
         creator:
         errors:
         exclude_empty_imports:
@@ -3843,6 +3842,7 @@ es:
         org_ascend_imports_html:
         org_bulk_imports_html:
         progress:
+        registrations:
       new:
         choose_file:
         correct_actual_image_url_html:
@@ -3868,7 +3868,6 @@ es:
         your_headers_must_match_html:
       show:
         ascend_import:
-        bikes:
         bulk_import:
         bulk_import_impounded:
         color:
@@ -3885,6 +3884,7 @@ es:
         progress:
         sent_to:
         sent_to_a_new_owner:
+        registrations:
     exports:
       index:
         bikes_in_export:

--- a/config/locales/translation.es.yml
+++ b/config/locales/translation.es.yml
@@ -3843,7 +3843,6 @@ es:
         org_ascend_imports_html:
         org_bulk_imports_html:
         progress:
-        unable_to_process:
       new:
         choose_file:
         correct_actual_image_url_html:

--- a/config/locales/translation.it.yml
+++ b/config/locales/translation.it.yml
@@ -3849,7 +3849,6 @@ it:
         line:
       index:
         added:
-        bikes:
         creator:
         errors:
         exclude_empty_imports:
@@ -3859,6 +3858,7 @@ it:
         org_ascend_imports_html:
         org_bulk_imports_html:
         progress:
+        registrations:
       new:
         choose_file:
         correct_actual_image_url_html:
@@ -3884,7 +3884,6 @@ it:
         your_headers_must_match_html:
       show:
         ascend_import:
-        bikes:
         bulk_import:
         bulk_import_impounded:
         color:
@@ -3901,6 +3900,7 @@ it:
         progress:
         sent_to:
         sent_to_a_new_owner:
+        registrations:
     exports:
       index:
         bikes_in_export:

--- a/config/locales/translation.it.yml
+++ b/config/locales/translation.it.yml
@@ -3859,7 +3859,6 @@ it:
         org_ascend_imports_html:
         org_bulk_imports_html:
         progress:
-        unable_to_process:
       new:
         choose_file:
         correct_actual_image_url_html:

--- a/config/locales/translation.nb.yml
+++ b/config/locales/translation.nb.yml
@@ -4921,7 +4921,6 @@ nb:
         org_ascend_imports_html: "<em>%{org_name}</em> Stigende import"
         org_bulk_imports_html: "<em>%{org_name}</em> Bulkimport"
         progress: Framgang
-        unable_to_process: Kan ikke behandle
       new:
         choose_file: Velg Fil...
         correct_actual_image_url_html: '<span class="text-success">Riktig</span> :

--- a/config/locales/translation.nb.yml
+++ b/config/locales/translation.nb.yml
@@ -4911,7 +4911,6 @@ nb:
         line: Linje
       index:
         added: La til
-        bikes: Sykler
         creator: Skaper
         errors: Feil
         exclude_empty_imports: Ekskluder tom import
@@ -4921,6 +4920,7 @@ nb:
         org_ascend_imports_html: "<em>%{org_name}</em> Stigende import"
         org_bulk_imports_html: "<em>%{org_name}</em> Bulkimport"
         progress: Framgang
+        registrations: Registreringer
       new:
         choose_file: Velg Fil...
         correct_actual_image_url_html: '<span class="text-success">Riktig</span> :
@@ -4962,7 +4962,6 @@ nb:
           vil ikke importen fungere.
       show:
         ascend_import: Ascend import
-        bikes: Sykler
         bulk_import: Masseimport
         bulk_import_impounded: Beslaglagt bulkimport
         color: Farge
@@ -4980,6 +4979,7 @@ nb:
         progress: Framgang
         sent_to: Sendt til
         sent_to_a_new_owner: "(sendt til ny eier)"
+        registrations: Registreringer
     exports:
       index:
         bikes_in_export: Sykler på eksport

--- a/config/locales/translation.nl.yml
+++ b/config/locales/translation.nl.yml
@@ -4397,7 +4397,6 @@ nl:
         org_ascend_imports_html: "<em>%{org_name}</em> Importeren <em>ascenderen</em>"
         org_bulk_imports_html: "<em>%{org_name} Bulkimport</em>"
         progress: Vooruitgang
-        unable_to_process: Niet in staat te verwerken
         kind: Soort
       new:
         choose_file: Kies bestand...

--- a/config/locales/translation.nl.yml
+++ b/config/locales/translation.nl.yml
@@ -4388,7 +4388,6 @@ nl:
     bulk_imports:
       index:
         added: Toegevoegd
-        bikes: Bikes
         creator: Schepper
         errors: fouten
         exclude_empty_imports: Lege invoer uitsluiten
@@ -4398,6 +4397,7 @@ nl:
         org_bulk_imports_html: "<em>%{org_name} Bulkimport</em>"
         progress: Vooruitgang
         kind: Soort
+        registrations: Registraties
       new:
         choose_file: Kies bestand...
         correct_actual_image_url_html: '<span class="text-success">Juist</span> :
@@ -4443,7 +4443,6 @@ nl:
           toegewezen.
       show:
         ascend_import: Ascending importeren
-        bikes: Bikes
         bulk_import: Bulk import
         color: Kleur
         created: Gemaakt
@@ -4461,6 +4460,7 @@ nl:
         bulk_import_impounded: In beslag genomen bulkimport
         impounded_at: In beslag genomen bij
         impounded_id: In beslag genomen identiteitsbewijs
+        registrations: Registraties
       error_type:
         file: file
         line: Lijn

--- a/spec/models/bulk_import_spec.rb
+++ b/spec/models/bulk_import_spec.rb
@@ -50,18 +50,29 @@ RSpec.describe BulkImport, type: :model do
     let(:bulk_import) { BulkImport.new(import_errors: {line: [2, "dddd"]}.as_json, progress: "finished", created_at: Time.current - 1.month) }
     it "is be_falsey" do
       expect(bulk_import.blocking_error?).to be_falsey
+      expect(bulk_import.failed_timeout?).to be_falsey
     end
     context "file error" do
       let(:bulk_import) { BulkImport.new(import_errors: {file: "dddd"}.as_json) }
       it "is be_falsey" do
         expect(bulk_import.blocking_error?).to be_truthy
+        expect(bulk_import.failed_timeout?).to be_falsey
       end
     end
-    context "pending and more than a minute old" do
+    context "pending and more than a few minutes old" do
       let(:bulk_import) { BulkImport.new(created_at: Time.current - 10.minutes, progress: "pending") }
       it "is truthy" do
         # Fallback because we failed to parse it
         expect(bulk_import.blocking_error?).to be_truthy
+        expect(bulk_import.failed_timeout?).to be_truthy
+      end
+    end
+    context "ongoing and more than 20 minutes old" do
+      let(:bulk_import) { BulkImport.new(created_at: Time.current - 30.minutes, progress: "ongoing") }
+      it "is truthy" do
+        # Fallback because we failed to parse it
+        expect(bulk_import.blocking_error?).to be_truthy
+        expect(bulk_import.failed_timeout?).to be_truthy
       end
     end
   end

--- a/spec/models/bulk_import_spec.rb
+++ b/spec/models/bulk_import_spec.rb
@@ -159,7 +159,7 @@ RSpec.describe BulkImport, type: :model do
       VCR.use_cassette("bulk_import-open_file") do
         tempfile = bulk_import.open_file
         expect(tempfile).to be_an_instance_of(Tempfile)
-        expect(bulk_import.tempfile).to eq tempfile
+        expect(bulk_import.unlink_tempfile).to be_truthy
       end
     end
   end

--- a/spec/models/bulk_import_spec.rb
+++ b/spec/models/bulk_import_spec.rb
@@ -145,4 +145,22 @@ RSpec.describe BulkImport, type: :model do
       end
     end
   end
+
+  describe "open_file" do
+    let(:bulk_import) { BulkImport.new }
+    let(:url) { "https://raw.githubusercontent.com/bikeindex/bike_index/main/public/import_all_optional_fields.csv" }
+    let(:file_stub) { Struct.new(:url, keyword_init: true).new(url:) }
+    before do
+      allow(bulk_import).to receive(:local_file?).and_return(false)
+      allow(bulk_import).to receive(:file).and_return(file_stub)
+    end
+
+    it "downloads a tempfile" do
+      VCR.use_cassette("bulk_import-open_file") do
+        tempfile = bulk_import.open_file
+        expect(tempfile).to be_an_instance_of(Tempfile)
+        expect(bulk_import.tempfile).to eq tempfile
+      end
+    end
+  end
 end

--- a/spec/models/bulk_import_spec.rb
+++ b/spec/models/bulk_import_spec.rb
@@ -50,13 +50,13 @@ RSpec.describe BulkImport, type: :model do
     let(:bulk_import) { BulkImport.new(import_errors: {line: [2, "dddd"]}.as_json, progress: "finished", created_at: Time.current - 1.month) }
     it "is be_falsey" do
       expect(bulk_import.blocking_error?).to be_falsey
-      expect(bulk_import.failed_timeout?).to be_falsey
+      expect(bulk_import.timeout_failure?).to be_falsey
     end
     context "file error" do
       let(:bulk_import) { BulkImport.new(import_errors: {file: "dddd"}.as_json) }
       it "is be_falsey" do
         expect(bulk_import.blocking_error?).to be_truthy
-        expect(bulk_import.failed_timeout?).to be_falsey
+        expect(bulk_import.timeout_failure?).to be_falsey
       end
     end
     context "pending and more than a few minutes old" do
@@ -64,7 +64,7 @@ RSpec.describe BulkImport, type: :model do
       it "is truthy" do
         # Fallback because we failed to parse it
         expect(bulk_import.blocking_error?).to be_truthy
-        expect(bulk_import.failed_timeout?).to be_truthy
+        expect(bulk_import.timeout_failure?).to be_truthy
       end
     end
     context "ongoing and more than 20 minutes old" do
@@ -72,7 +72,7 @@ RSpec.describe BulkImport, type: :model do
       it "is truthy" do
         # Fallback because we failed to parse it
         expect(bulk_import.blocking_error?).to be_truthy
-        expect(bulk_import.failed_timeout?).to be_truthy
+        expect(bulk_import.timeout_failure?).to be_truthy
       end
     end
   end

--- a/spec/vcr_cassettes/bulk_import-open_file.yml
+++ b/spec/vcr_cassettes/bulk_import-open_file.yml
@@ -1,0 +1,76 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://raw.githubusercontent.com/bikeindex/bike_index/main/public/import_all_optional_fields.csv
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Down/5.4.2
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '475'
+      Cache-Control:
+      - max-age=300
+      Content-Security-Policy:
+      - default-src 'none'; style-src 'unsafe-inline'; sandbox
+      Content-Type:
+      - text/plain; charset=utf-8
+      Etag:
+      - W/"04f0b606c73a5fce0a1b65b2323c5ef25de0081fa84c9f991bcd5e89129518b1"
+      Strict-Transport-Security:
+      - max-age=31536000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Github-Request-Id:
+      - 9D80:BD8B9:CC06E:1108ED:689B6429
+      Accept-Ranges:
+      - bytes
+      Date:
+      - Tue, 12 Aug 2025 15:56:33 GMT
+      Via:
+      - 1.1 varnish
+      X-Served-By:
+      - cache-sjc1000124-SJC
+      X-Cache:
+      - MISS
+      X-Cache-Hits:
+      - '0'
+      X-Timer:
+      - S1755014193.421027,VS0,VE131
+      Vary:
+      - Authorization,Accept-Encoding
+      Access-Control-Allow-Origin:
+      - "*"
+      Cross-Origin-Resource-Policy:
+      - cross-origin
+      X-Fastly-Request-Id:
+      - 5c607ee11e0486a40bfcc51d7bb01ba762439b7a
+      Expires:
+      - Tue, 12 Aug 2025 16:01:33 GMT
+      Source-Age:
+      - '0'
+    body:
+      encoding: ASCII-8BIT
+      string: |
+        manufacturer,model,color,email,serial,year,description,address,phone,secondary_serial,owner_name,frame_size,bike_sticker,photo
+        "Trek","Roscoe 8","Green","test@bikeindex.org","xyz_test","2019","I love this, it's my favorite","New York, NY, USA","(888) 777-6666"," ",,29,"XXX123",
+        "Surly","Midnight Special","White","test2@bikeindex.org","example",,,,,"extra serial number","Sally",M,,"https://upload.wikimedia.org/wikipedia/commons/6/68/Bike_Index_registration_spokecard.jpg"
+  recorded_at: Tue, 12 Aug 2025 15:56:33 GMT
+recorded_with: VCR 6.3.1


### PR DESCRIPTION
For remote bulk import files, download and make a tempfile, instead of streaming the URL.

CSU imported a lot of bikes to their organization account. Because of a dumb thing in `UserRegistrationOrganization`, the import caused our job queues to backup. 

This update fixes it so that `Callbacks::AfterBikeSaveJob` doesn't halt and catch fire when a user has > 10k bikes.

Also makes some bulk import display improvements (following #2880)