### PR TITLE
Move stimulus controllers to app/javascript/controllers

### DIFF
--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -16,8 +16,7 @@ const application = Application.start()
 // Configure Stimulus development experience
 application.debug = false
 window.Stimulus = application
-
-lazyLoadControllersFrom('components', application)
+lazyLoadControllersFrom('controllers', application)
 
 function localizeTime () {
   if (!window.timeLocalizer) window.timeLocalizer = new TimeLocalizer()


### PR DESCRIPTION
sidecar view component controllers seem great in theory, but it ultimately wasn't the right level of abstraction. 