### PR TITLE
Fix check_translations failure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 # Ignore local config files
 /.bundle
+# Ignore vendored gems
+/vendor/bundle
 
 # Ignore all logfiles and tempfiles.
 /log/*.log*

--- a/Gemfile
+++ b/Gemfile
@@ -137,7 +137,7 @@ group :development do
   gem "rerun" # restart sidekiq processes in development on app change
   gem "hotwire-livereload", "~> 1.4.1" # See #2759 for reasoning on version
   gem "terminal-notifier"
-  gem "annotate_rb", github: "sethherr/annotate_rb", branch: "rename-annotate_rb"
+  gem "annotaterb"
 end
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -35,13 +35,6 @@ GIT
     sidekiq-failures (1.0.4)
       sidekiq (>= 4.0.0)
 
-GIT
-  remote: https://github.com/sethherr/annotate_rb.git
-  revision: a947916dff1eab2c1b570a8b57020fb24337c797
-  branch: rename-annotate_rb
-  specs:
-    annotate_rb (5.0.0)
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -120,6 +113,9 @@ GEM
       uri (>= 0.13.1)
     addressable (2.8.7)
       public_suffix (>= 2.0.2, < 7.0)
+    annotaterb (4.18.0)
+      activerecord (>= 6.0.0)
+      activesupport (>= 6.0.0)
     api-pagination (6.0.0)
     ast (2.4.3)
     aws-eventstream (1.3.1)
@@ -863,7 +859,7 @@ PLATFORMS
 DEPENDENCIES
   MailchimpMarketing!
   active_model_serializers (~> 0.8.3)
-  annotate_rb!
+  annotaterb
   api-pagination
   aws-sdk-core (= 3.211)
   aws-sdk-s3 (= 1.170)

--- a/config/locales/.translation_io
+++ b/config/locales/.translation_io
@@ -1,2 +1,2 @@
 ---
-timestamp: 1755098760
+timestamp: 1755812942


### PR DESCRIPTION
`check_translations` [failed on main](https://github.com/bikeindex/bike_index/actions/runs/17139316413/job/48623017937)

The failure was that vendored gems made the git tree dirty.

So update to ignore vendored gems.