### PR TITLE
Add additional tests to org bike access panel

### DIFF
--- a/app/components/org/bike_access_panel/component.html.haml
+++ b/app/components/org/bike_access_panel/component.html.haml
@@ -183,7 +183,7 @@
                           - unless @bike.valid_mailing_address?
                             = translation(".missing_address")
 
-                - if @organization.enabled?("model_audits") && @bike.motorized?
+                - if @organization.enabled?("model_audits")
                   %tr
                     %td= translation(".model_audit")
                     %td

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -4,6 +4,11 @@ Rails.application.configure do
   # While tests run files are not watched, reloading is not necessary.
   config.enable_reloading = false
 
+  # Don't log things in test
+  config.active_record.verbose_query_logs = false
+  config.active_record.query_log_tags_enabled = false
+  config.log_level = :fatal
+
   # Eager loading loads your entire application. When running a single test locally,
   # this is usually not necessary, and can slow down your test suite. However, it's
   # recommended that you enable it in continuous integration systems to ensure eager

--- a/spec/components/org/bike_access_panel/component_spec.rb
+++ b/spec/components/org/bike_access_panel/component_spec.rb
@@ -7,8 +7,8 @@ RSpec.describe Org::BikeAccessPanel::Component, type: :component do
   let(:component) { render_inline(instance) }
   let(:options) { {bike:, organization:, current_user:} }
   let(:bike) { FactoryBot.create(:bike) }
-  let(:organization) { current_user.organizations.first }
-  let(:current_user) { FactoryBot.create(:organization_user) }
+  let(:organization) { FactoryBot.create(:organization) }
+  let(:current_user) { FactoryBot.create(:organization_user, organization:) }
 
   it "renders" do
     expect(instance.render?).to be_truthy
@@ -23,36 +23,48 @@ RSpec.describe Org::BikeAccessPanel::Component, type: :component do
       FactoryBot.create(:bike_organized, :with_ownership_claimed, creation_organization: organization,
         can_edit_claimed:, marked_user_hidden:)
     end
-    let(:can_edit_claimed) { false }
+    let(:can_edit_claimed) { true }
     let(:marked_user_hidden) { false }
 
     it "renders" do
       expect(instance.render?).to be_truthy
       expect(component).to have_css "div"
       expect(instance.send(:organization_registered?)).to be_truthy
-      expect(instance.send(:organization_authorized?)).to be_falsey
-      expect(instance.send(:user_can_edit?)).to be_falsey
+      expect(instance.send(:organization_authorized?)).to be_truthy
+      expect(instance.send(:user_can_edit?)).to be_truthy
+    end
+
+    context "can_edit_claimed: false" do
+      let(:can_edit_claimed) { false }
+      it "renders" do
+        expect(instance.render?).to be_truthy
+        expect(component).to have_css "div"
+        expect(instance.send(:organization_registered?)).to be_truthy
+        expect(instance.send(:organization_authorized?)).to be_falsey
+        expect(instance.send(:user_can_edit?)).to be_falsey
+      end
     end
 
     context "marked_user_hidden: true" do
       let(:marked_user_hidden) { true }
 
-      it "doesn't render" do
-        expect(bike.reload.authorized?(current_user)).to be_falsey
-        expect(bike.user_hidden).to be_truthy
-        expect(bike.visible_by?(current_user)).to be_falsey
-        expect(instance.render?).to be_falsey
-        expect(component).to_not have_css "div"
+      it "renders" do
+        expect(instance.render?).to be_truthy
+        expect(component).to have_css "div"
+        expect(instance.send(:organization_registered?)).to be_truthy
+        expect(instance.send(:organization_authorized?)).to be_truthy
+        expect(instance.send(:user_can_edit?)).to be_truthy
       end
 
-      context "can_edit_claimed: true" do
-        let(:can_edit_claimed) { true }
-        it "renders" do
-          expect(instance.render?).to be_truthy
-          expect(component).to have_css "div"
-          expect(instance.send(:organization_registered?)).to be_truthy
-          expect(instance.send(:organization_authorized?)).to be_truthy
-          expect(instance.send(:user_can_edit?)).to be_truthy
+      context "can_edit_claimed: false" do
+        let(:can_edit_claimed) { false }
+        it "doesn't render" do
+          # Currently, the page also 404s - but just to keep things safe
+          expect(bike.reload.authorized?(current_user)).to be_falsey
+          expect(bike.user_hidden).to be_truthy
+          expect(bike.visible_by?(current_user)).to be_falsey
+          expect(instance.render?).to be_falsey
+          expect(component).to_not have_css "div"
         end
       end
     end
@@ -64,6 +76,29 @@ RSpec.describe Org::BikeAccessPanel::Component, type: :component do
         expect(component).to_not have_css "div"
       end
     end
+
+    context "with model audit and duplicate bike" do
+      let(:organization) { FactoryBot.create(:organization_with_organization_features, enabled_feature_slugs: ["model_audits"]) }
+      let(:model_audit) { FactoryBot.create(:model_audit, frame_model: "Some crazy model", manufacturer: bike.manufacturer ) }
+      let!(:organization_model_audit) { FactoryBot.create(:organization_model_audit, organization:, model_audit:) }
+      let!(:model_attestation) { FactoryBot.create(:model_attestation, organization:, model_audit:) }
+      before { bike.update(model_audit_id: model_audit.id) }
+
+      it "renders the model_audit" do
+        expect(instance.render?).to be_truthy
+        expect(component).to have_css "div"
+        expect(instance.send(:organization_registered?)).to be_truthy
+        expect(instance.send(:organization_authorized?)).to be_truthy
+        expect(instance.send(:user_can_edit?)).to be_truthy
+        expect(whitespace_normalized_body_text(component.to_html)).to match(/#{bike.mnfg_name} Some crazy model/)
+      end
+    end
+
+    context "with duplicate bike" do
+    end
+
+    context "phoneable by" do
+    end
   end
 
   context "not organization bike" do
@@ -74,10 +109,11 @@ RSpec.describe Org::BikeAccessPanel::Component, type: :component do
     end
   end
 
-  context "without organization" do
-    let(:organization) { nil }
+  context "without organization membership" do
+    let(:current_user) { FactoryBot.create(:user) }
 
     it "doesn't render" do
+      expect(current_user.reload.authorized?(organization)).to be_falsey
       expect(instance.render?).to be_falsey
       expect(component).to_not have_css "div"
     end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -78,6 +78,7 @@ RSpec.configure do |config|
   config.include ViewComponent::TestHelpers, type: :component
   config.include ViewComponent::SystemTestHelpers, type: :component
   config.include Capybara::RSpecMatchers, type: :component
+  config.include HtmlContentHelpers, type: :component
   config.before(:each, :browser, type: :system) { driven_by(:selenium) }
   config.before(:each, :js, type: :system) { driven_by(:selenium_chrome_headless) }
 end

--- a/spec/support/html_content_helpers.rb
+++ b/spec/support/html_content_helpers.rb
@@ -4,6 +4,7 @@ module HtmlContentHelpers
     doc = Nokogiri::HTML::DocumentFragment.parse(content.split("</head>").last)
     # Remove all script and style elements completely
     doc.css("script, style").remove
-    doc.text.strip.gsub(/\s+/, " ")
+    # Spaces and also non-breaking spaces
+    doc.text.strip.gsub(/\s+/, " ").gsub("\u00A0", " ")
   end
 end


### PR DESCRIPTION
- Test rendering of Model Audits
- Test rendering of Duplicate bikes
- Test rendering of Phoneable when bike isn't stolen
- Improve sorting of organization bikes, also on the model audits page