### PR TITLE
Update user address record backfill

### DIFF
--- a/app/jobs/backfills/address_records_for_users_job.rb
+++ b/app/jobs/backfills/address_records_for_users_job.rb
@@ -7,7 +7,7 @@ class Backfills::AddressRecordsForUsersJob < ApplicationJob
 
   class << self
     def iterable_scope
-      User.where.not(latitude: nil).where(address_record_id: nil)
+      User.where(address_record_id: nil).where.not(city: nil, street: nil)
     end
 
     def build_or_create_for(user, country_id: nil)
@@ -17,9 +17,6 @@ class Backfills::AddressRecordsForUsersJob < ApplicationJob
       return user.update(address_record: existing_address_record) if existing_address_record.present?
 
       user.address_record = AddressRecord.new(user_id: user.id, kind: :user, country_id:)
-
-      return user.address_record if user.latitude.blank? || user.longitude.blank?
-
       user.address_record.attributes = AddressRecord.attrs_from_legacy(user)
       user.skip_update = true
       user.save


### PR DESCRIPTION
Address Record was added in #2780 - the backfill only was done for User's that had latitude and longitude.

Turns out there are a bunch of users with address information that don't have coordinates, so update the backfill so it can be run before removing the user address attributes (#2787)