### PR TITLE
Update translations

### DIFF
--- a/config/locales/.translation_io
+++ b/config/locales/.translation_io
@@ -1,2 +1,2 @@
 ---
-timestamp: 1757190850
+timestamp: 1758146464

--- a/config/locales/translation.es.yml
+++ b/config/locales/translation.es.yml
@@ -1183,6 +1183,11 @@ es:
         length_is:
         length_min:
         length_max:
+        conflicting_types:
+        invalid_parameters:
+        too_deep_parameters:
+        unknown_auth_strategy:
+        unknown_params_builder:
   flash:
     actions:
       create:
@@ -1260,6 +1265,7 @@ es:
           one:
           other:
         pass_forest:
+        invalid_backend:
     common:
       continue_q:
       key:
@@ -1305,6 +1311,11 @@ es:
     yandex_translate:
       errors:
         no_api_key:
+        no_results:
+    watsonx_translate:
+      errors:
+        no_api_key:
+        no_project_id:
         no_results:
   countries:
     AC:

--- a/config/locales/translation.it.yml
+++ b/config/locales/translation.it.yml
@@ -1193,6 +1193,11 @@ it:
         length_is:
         length_min:
         length_max:
+        conflicting_types:
+        invalid_parameters:
+        too_deep_parameters:
+        unknown_auth_strategy:
+        unknown_params_builder:
   flash:
     actions:
       create:
@@ -1270,6 +1275,7 @@ it:
           one:
           other:
         pass_forest:
+        invalid_backend:
     common:
       continue_q:
       key:
@@ -1315,6 +1321,11 @@ it:
     yandex_translate:
       errors:
         no_api_key:
+        no_results:
+    watsonx_translate:
+      errors:
+        no_api_key:
+        no_project_id:
         no_results:
   countries:
     AC:

--- a/config/locales/translation.nb.yml
+++ b/config/locales/translation.nb.yml
@@ -1204,6 +1204,12 @@ nb:
         length_is: forventes å ha lengde nøyaktig lik %{is}
         length_min: forventes å ha lengde større enn eller lik %{min}
         length_max: forventes å ha lengde mindre enn eller lik %{max}
+        conflicting_types: spørreparametere inneholder motstridende typer
+        invalid_parameters: Spørreparameterne inneholder ugyldig format eller bytesekvens
+        too_deep_parameters: Spørreparametere nestes rekursivt over den angitte grensen
+          (%{limit})
+        unknown_auth_strategy: 'ukjent autentiseringsstrategi: %{strategy}'
+        unknown_params_builder: 'ukjent params_builder: %{params_builder_type}'
   flash:
     actions:
       create:
@@ -1289,6 +1295,7 @@ nb:
           one: 'ugyldig type: %{invalid}. gyldig: %{valid}.'
           other: 'ukjente typer: %{invalid}. gyldig: %{valid}.'
         pass_forest: passere lokalskog
+        invalid_backend: 'Ugyldig backend: %{invalid}. Må være en av %{valid}.'
     common:
       continue_q: Fortsette?
       key: Nøkkel
@@ -1346,6 +1353,14 @@ nb:
         no_api_key: Angi Yandex API-nøkkel via YANDEX_API_KEY miljøvariabel eller
           translation.yandex_api_key i config/i18n-tasks.yml. Få nøkkelen på https://tech.yandex.com/translate.
         no_results: Yandex ga ingen resultater.
+    watsonx_translate:
+      errors:
+        no_api_key: Angi watsonx API-nøkkel via miljøvariabelen WATSONX_API_KEY eller
+          translation.watsonx_api_key i config/i18n-tasks.yml. Hent nøkkelen på https://www.ibm.com/products/watsonx-ai.
+        no_project_id: Angi watsonx-prosjekt-ID via miljøvariabelen WATSONX_PROJECT_ID
+          eller translation.watsonx_api_key i config/i18n-tasks.yml. Hent nøkkelen
+          på https://www.ibm.com/products/watsonx-ai.
+        no_results: watsonx returnerte ingen resultater.
   countries:
     AC: Ascension Island
     AD: Andorra

--- a/config/locales/translation.nl.yml
+++ b/config/locales/translation.nl.yml
@@ -1227,6 +1227,7 @@ nl:
           one: 'ongeldig type: %{invalid}. geldig: %{valid}.'
           other: 'onbekende typen: %{invalid}. geldig: %{valid}.'
         pass_forest: passeren locale bos
+        invalid_backend: 'Ongeldige backend: %{invalid}. Moet een van %{valid} zijn.'
     common:
       continue_q: Doorgaan?
       key: Sleutel
@@ -1287,6 +1288,15 @@ nl:
           of translation.openai_api_key in config/i18n-tasks.yml. Haal de sleutel
           op https://openai.com/.
         no_results: OpenAI heeft geen resultaten opgeleverd.
+    watsonx_translate:
+      errors:
+        no_api_key: Stel de Watsonx API-sleutel in via de omgevingsvariabele WATSONX_API_KEY
+          of translation.watsonx_api_key in config/i18n-tasks.yml. Download de sleutel
+          via https://www.ibm.com/products/watsonx-ai.
+        no_project_id: Stel de Watsonx Project-ID in via de WATSONX_PROJECT_ID omgevingsvariabele
+          of translation.watsonx_api_key in config/i18n-tasks.yml. De sleutel is te
+          vinden op https://www.ibm.com/products/watsonx-ai.
+        no_results: watsonx leverde geen resultaten op.
   grape:
     errors:
       format: "%{attributes} %{message}"
@@ -1349,6 +1359,12 @@ nl:
           is aan %{min}
         length_max: wordt verwacht een lengte te hebben die kleiner is dan of gelijk
           is aan %{max}
+        conflicting_types: query-parameters bevatten conflicterende typen
+        invalid_parameters: query-parameters bevatten ongeldige opmaak of bytevolgorde
+        too_deep_parameters: queryparameters worden recursief genest over de opgegeven
+          limiet (%{limit})
+        unknown_auth_strategy: 'onbekende autorisatiestrategie: %{strategy}'
+        unknown_params_builder: 'onbekende params_builder: %{params_builder_type}'
   flash:
     actions:
       create:


### PR DESCRIPTION
#2910 updated the `i18n-tasks` gem, which caused the `check_translations` step to fail