### PR TITLE
Allow any HTTPS image source in CSP for news pages

### DIFF
--- a/app/controllers/news_controller.rb
+++ b/app/controllers/news_controller.rb
@@ -1,4 +1,8 @@
 class NewsController < ApplicationController
+  content_security_policy do |policy|
+    policy.img_src :self, :data, :blob, :https
+  end
+
   def index
     @blogs = matching_blogs
     @blogs_count ||= @blogs.count


### PR DESCRIPTION
Blog posts on `/news/` embed images from arbitrary external domains (e.g. Wikimedia, East Bay Times), causing CSP `img-src` violations reported to Honeybadger. This relaxes the `img-src` directive to allow any `https:` source specifically for `NewsController`, since blog content will always reference varied external image hosts.

Fixes Honeybadger faults [#129339525](https://app.honeybadger.io/projects/138070/faults/129339525) and [#129339515](https://app.honeybadger.io/projects/138070/faults/129339515).