### PR TITLE
Skip Honeybadger report for expired Strava OAuth sessions

### DIFF
--- a/app/controllers/strava_integrations_controller.rb
+++ b/app/controllers/strava_integrations_controller.rb
@@ -118,7 +118,6 @@ class StravaIntegrationsController < ApplicationController
   end
 
   def session_state_matches?(params_state, session_state)
-    params_state.present? && session_state.present? &&
-      ActiveSupport::SecurityUtils.secure_compare(params_state.to_s, session_state.to_s)
+    ActiveSupport::SecurityUtils.secure_compare(params_state.to_s, session_state.to_s)
   end
 end

--- a/app/controllers/strava_integrations_controller.rb
+++ b/app/controllers/strava_integrations_controller.rb
@@ -118,6 +118,7 @@ class StravaIntegrationsController < ApplicationController
   end
 
   def session_state_matches?(session_state)
+    return false if session_state.blank?
     return true if ActiveSupport::SecurityUtils.secure_compare(params[:state].to_s, session_state.to_s)
     Rails.error.report(StandardError.new("Invalid Strava OAuth state"),
       context: {user_id: current_user.id, param_state: params[:state], session_state:})

--- a/app/controllers/strava_integrations_controller.rb
+++ b/app/controllers/strava_integrations_controller.rb
@@ -28,7 +28,7 @@ class StravaIntegrationsController < ApplicationController
       return
     end
 
-    unless params[:state].present? && session_state_matches?(session.delete(:strava_oauth_state))
+    unless session_state_matches?(params[:state], session.delete(:strava_oauth_state))
       flash[:error] = "Invalid OAuth state. Please try again."
       redirect_to return_to
       return
@@ -117,7 +117,7 @@ class StravaIntegrationsController < ApplicationController
     Integrations::Strava::Client::DEFAULT_SCOPE.split(",").all? { |s| granted.include?(s) }
   end
 
-  def session_state_matches?(session_state)
-    session_state.present? && ActiveSupport::SecurityUtils.secure_compare(params[:state].to_s, session_state.to_s)
+  def session_state_matches?(params_state, session_state)
+    ActiveSupport::SecurityUtils.secure_compare(params_state&.to_s, session_state&.to_s)
   end
 end

--- a/app/controllers/strava_integrations_controller.rb
+++ b/app/controllers/strava_integrations_controller.rb
@@ -118,6 +118,7 @@ class StravaIntegrationsController < ApplicationController
   end
 
   def session_state_matches?(params_state, session_state)
-    ActiveSupport::SecurityUtils.secure_compare(params_state&.to_s, session_state&.to_s)
+    params_state.present? && session_state.present? &&
+      ActiveSupport::SecurityUtils.secure_compare(params_state.to_s, session_state.to_s)
   end
 end

--- a/app/controllers/strava_integrations_controller.rb
+++ b/app/controllers/strava_integrations_controller.rb
@@ -118,10 +118,6 @@ class StravaIntegrationsController < ApplicationController
   end
 
   def session_state_matches?(session_state)
-    return false if session_state.blank?
-    return true if ActiveSupport::SecurityUtils.secure_compare(params[:state].to_s, session_state.to_s)
-    Rails.error.report(StandardError.new("Invalid Strava OAuth state"),
-      context: {user_id: current_user.id, param_state: params[:state], session_state:})
-    false
+    session_state.present? && ActiveSupport::SecurityUtils.secure_compare(params[:state].to_s, session_state.to_s)
   end
 end

--- a/spec/requests/strava_integrations_request_spec.rb
+++ b/spec/requests/strava_integrations_request_spec.rb
@@ -79,6 +79,14 @@ RSpec.describe StravaIntegrationsController, type: :request do
         end
       end
 
+      context "with expired session (no session state)" do
+        it "redirects with error flash without reporting to error tracker" do
+          get "/strava_integration/callback", params: {code: "test_auth_code", state: "stale_state_from_url"}
+          expect(response).to redirect_to(my_account_path)
+          expect(flash[:error]).to match(/invalid oauth state/i)
+        end
+      end
+
       context "with insufficient permissions" do
         it "redirects with error and does not create integration or strava_requests" do
           oauth_state = initiate_oauth_flow

--- a/spec/requests/strava_integrations_request_spec.rb
+++ b/spec/requests/strava_integrations_request_spec.rb
@@ -80,8 +80,10 @@ RSpec.describe StravaIntegrationsController, type: :request do
       end
 
       context "with expired session (no session state)" do
-        it "redirects with error flash without reporting to error tracker" do
-          get "/strava_integration/callback", params: {code: "test_auth_code", state: "stale_state_from_url"}
+        it "redirects with error flash and does not create integration" do
+          expect {
+            get "/strava_integration/callback", params: {code: "test_auth_code", state: "stale_state_from_url"}
+          }.to change(StravaIntegration, :count).by(0)
           expect(response).to redirect_to(my_account_path)
           expect(flash[:error]).to match(/invalid oauth state/i)
         end


### PR DESCRIPTION
When a user's session expires between initiating Strava OAuth and completing the callback, `session[:strava_oauth_state]` is nil. This is a normal edge case (expired session, different browser, cookie blocking) — not a security issue. Skip error reporting.