### PR TITLE
Extract column toggle controller, rename org--bike-search

### DIFF
--- a/app/assets/stylesheets/revised/pages/organized/_bikes.scss
+++ b/app/assets/stylesheets/revised/pages/organized/_bikes.scss
@@ -1,25 +1,3 @@
-.org-bikes-search-component {
-  .organized-bikes-settings-toggle {
-    color: $gray-light;
-  }
-  &.javascriptFunctioning .hiddenColumn {
-    display: none;
-  }
-  .settings-list {
-    padding: 2 * $vertical-height $vertical-height $vertical-height;
-    background: $gray-lighter;
-    border: solid 1px rgba($gray-light, 0.7);
-    margin: 24px 0;
-    label {
-      cursor: pointer;
-      margin-bottom: 0;
-    }
-    .form-group {
-      margin-bottom: 0;
-    }
-  }
-}
-
 #organized_bikes_new {
   @include media-breakpoint-down(sm) {
     .organized-wrap > .container {

--- a/app/assets/tailwind/application.css
+++ b/app/assets/tailwind/application.css
@@ -70,17 +70,36 @@
     @apply tw:border-0 tw:h-px tw:bg-gray-200 tw:dark:bg-gray-700 tw:my-8;
   }
 
-  .twtable-striped tr:nth-child(odd) {
+  .ui-table tr:nth-child(odd) {
     @apply tw:bg-white tw:dark:bg-gray-900;
   }
-  .twtable-striped tr:nth-child(even) {
+  .ui-table tr:nth-child(even) {
     @apply tw:bg-gray-100 tw:dark:bg-gray-800;
   }
-  .twtable-striped tr:last-child td:first-child {
+  .ui-table tr:last-child td:first-child {
     @apply tw:rounded-bl-sm;
   }
-  .twtable-striped tr:last-child td:last-child {
+  .ui-table tr:last-child td:last-child {
     @apply tw:rounded-br-sm;
+  }
+  thead tr th:first-child {
+    @apply tw:rounded-tl-sm;
+  }
+  thead tr th:last-child {
+    @apply tw:rounded-tr-sm;
+  }
+
+  .ui-table-bordered tr td:first-child {
+    @apply tw:border-l tw:border-gray-200 tw:dark:border-gray-700;
+  }
+  .ui-table-bordered tr td:last-child {
+    @apply tw:border-r tw:border-gray-200 tw:dark:border-gray-700;
+  }
+  thead:has(+ .ui-table-bordered) tr th:first-child {
+    @apply tw:border-l tw:border-gray-200 tw:dark:border-gray-600;
+  }
+  thead:has(+ .ui-table-bordered) tr th:last-child {
+    @apply tw:border-r tw:border-gray-200 tw:dark:border-gray-600;
   }
 }
 

--- a/app/components/org/bike_search/component.html.erb
+++ b/app/components/org/bike_search/component.html.erb
@@ -55,43 +55,45 @@
     >
       <thead class="small-header sortable">
         <tr>
-          <th class="hiddenColumn url_cell"><%= translation(".url") %></th>
+          <th class="hideableColumn url_cell"><%= translation(".url") %></th>
 
-          <th class="hiddenColumn created_at_cell">
+          <th class="hideableColumn created_at_cell">
             <%= sortable("id", translation(".registered")) %>
           </th>
 
-          <th class="hiddenColumn updated_at_cell">
+          <th class="hideableColumn updated_at_cell">
             <%= sortable("updated_by_user_at", translation(".updated")) %>
           </th>
 
-          <th class="hiddenColumn stolen_cell">
+          <th class="hideableColumn stolen_cell">
             <small><%= translation(".stolen") %></small>
           </th>
 
-          <th class="hiddenColumn serial_number_cell">
+          <th class="hideableColumn serial_number_cell">
             <%= translation(".serial") %>
           </th>
 
-          <th class="hiddenColumn propulsion_type_cell">
+          <th class="hideableColumn propulsion_type_cell">
             <%= sortable("propulsion_type", translation(".propulsion_type")) %>
           </th>
 
-          <th class="hiddenColumn cycle_type_cell">
+          <th class="hideableColumn cycle_type_cell">
             <%= sortable("cycle_type", translation(".vehicle_type")) %>
           </th>
 
-          <th class="hiddenColumn manufacturer_cell">
+          <th class="hideableColumn manufacturer_cell">
             <%= sortable("mnfg_name", translation(".manufacturer")) %>
           </th>
 
-          <th class="hiddenColumn model_cell">
+          <th class="hideableColumn model_cell">
             <%= sortable("frame_model", translation(".model")) %>
           </th>
 
-          <th class="hiddenColumn color_cell"><%= translation(".color") %></th>
+          <th class="hideableColumn color_cell">
+            <%= translation(".color") %>
+          </th>
 
-          <th class="hiddenColumn owner_email_cell">
+          <th class="hideableColumn owner_email_cell">
             <small class="hidden-sm-up">
               <%= translation(".mfg_model_color_html") %>
               <br>
@@ -100,20 +102,20 @@
             <%= sortable("owner_email", translation(".sent_to")) %>
           </th>
 
-          <th class="hiddenColumn creation_description_cell">
+          <th class="hideableColumn creation_description_cell">
             <%= translation(".source") %>
           </th>
 
-          <th class="hiddenColumn owner_name_cell">
+          <th class="hideableColumn owner_name_cell">
             <small><%= translation(".owner_name") %></small>
           </th>
 
-          <th class="hiddenColumn status_cell">
+          <th class="hideableColumn status_cell">
             <small><%= translation(".status_cell") %></small>
           </th>
 
           <% if @organization.enabled?("registration_notes") %>
-            <th class="hiddenColumn notes_cell">
+            <th class="hideableColumn notes_cell">
               <%= translation(".notes") %>
             </th>
           <% end %>
@@ -121,18 +123,18 @@
           <% additional_registration_fields.each do |reg_field| %>
             <% next if reg_field == "extra_registration_number" %>
 
-            <th class="hiddenColumn <%= "#{reg_field}_cell" %>">
+            <th class="hideableColumn <%= "#{reg_field}_cell" %>">
               <%= column_renames[:"#{reg_field}_cell"] %>
             </th>
           <% end %>
 
           <%# All organizations can see additional serial# %>
-          <th class="hiddenColumn extra_registration_number_cell">
+          <th class="hideableColumn extra_registration_number_cell">
             <%= translation(".secondary_number") %>
           </th>
 
           <% if @organization.enabled?("bike_stickers") %>
-            <th class="hiddenColumn sticker_cell">
+            <th class="hideableColumn sticker_cell">
               <%= translation(".sticker") %>
             </th>
           <% end %>
@@ -144,16 +146,16 @@
           <% end %>
 
           <% if @organization.enabled?("impound_bikes") %>
-            <th class="hiddenColumn impound_id_cell">
+            <th class="hideableColumn impound_id_cell">
               <%= translation(".impound_id") %>
             </th>
-            <th class="hiddenColumn impounded_cell">
+            <th class="hideableColumn impounded_cell">
               <%= translation(".impounded") %>
             </th>
           <% end %>
 
           <% if show_avery_export? %>
-            <th class="hiddenColumn avery_cell">
+            <th class="hideableColumn avery_cell">
               <%= translation(".avery") %>
             </th>
           <% end %>
@@ -185,7 +187,7 @@
           style: "width: 100%; max-width: 15rem; margin-top:15px;",
           data: {
             org__bike_search_target: "perPage",
-            action: "change->org--bike-search#perPageChanged"
+            action: "change->org--registration-search#perPageChanged"
           } %>
       </div>
     </div>

--- a/app/components/org/bike_search/component.rb
+++ b/app/components/org/bike_search/component.rb
@@ -68,8 +68,8 @@ module Org::BikeSearch
 
     def wrapper_data_attributes
       return {} if @skip_settings
-      {controller: "org--bike-search",
-       "org--bike-search-default-columns-value": initially_checked_columns.to_json}
+      {controller: "org--registration-search org--registration-search-column-toggle",
+       "org--registration-search-column-toggle-default-columns-value": initially_checked_columns.to_json}
     end
 
     def show_pagination?

--- a/app/components/org/bike_search_row/component.html.erb
+++ b/app/components/org/bike_search_row/component.html.erb
@@ -1,8 +1,8 @@
-<td class="hiddenColumn url_cell">
+<td class="hideableColumn url_cell">
   <code class="small p0" style="word-break: normal"><%= @bike.html_url %></code>
 </td>
 
-<td class="hiddenColumn created_at_cell">
+<td class="hideableColumn created_at_cell">
   <a
     class="localizeTime"
     href="<%= bike_path(@bike, organization_id: @organization.to_param) %>"
@@ -13,39 +13,39 @@
   </a>
 </td>
 
-<td class="hiddenColumn updated_at_cell">
+<td class="hideableColumn updated_at_cell">
   <small class="localizeTime">
     <%= l @bike.updated_by_user_fallback, format: :convert_time %>
   </small>
 </td>
 
-<td class="hiddenColumn table-cell-check stolen_cell">
+<td class="hideableColumn table-cell-check stolen_cell">
   <%= check_mark if @bike.status_stolen? %>
 </td>
 
-<td class="hiddenColumn serial_number_cell"><%= @bike.serial_number %></td>
+<td class="hideableColumn serial_number_cell"><%= @bike.serial_number %></td>
 
-<td class="hiddenColumn propulsion_type_cell">
+<td class="hideableColumn propulsion_type_cell">
   <span class="<%= 'less-strong' if @bike.propulsion_type == 'foot-pedal' %>">
     <%= @bike.propulsion_titleize %>
   </span>
 </td>
 
-<td class="hiddenColumn cycle_type_cell">
+<td class="hideableColumn cycle_type_cell">
   <span class="<%= 'less-strong' if @bike.cycle_type == 'bike' %>">
     <%= @bike.type_titleize %>
   </span>
 </td>
 
-<td class="hiddenColumn manufacturer_cell"><%= @bike.mnfg_name %></td>
+<td class="hideableColumn manufacturer_cell"><%= @bike.mnfg_name %></td>
 
-<td class="hiddenColumn model_cell"><%= @bike.frame_model %></td>
+<td class="hideableColumn model_cell"><%= @bike.frame_model %></td>
 
-<td class="hiddenColumn color_cell">
+<td class="hideableColumn color_cell">
   <span class="less-strong"><%= @bike.frame_colors.join(", ") %></span>
 </td>
 
-<td class="hiddenColumn owner_email_cell">
+<td class="hideableColumn owner_email_cell">
   <small class="hidden-sm-up">
     <%= helpers.organized_bike_text(@bike) %>
     <br>
@@ -61,7 +61,7 @@
   <% end %>
 </td>
 
-<td class="hiddenColumn creation_description_cell">
+<td class="hideableColumn creation_description_cell">
   <% if @bike.creation_description %>
     <small class="less-strong">
       <%= helpers.origin_display(@bike.creation_description) %>
@@ -69,18 +69,18 @@
   <% end %>
 </td>
 
-<td class="hiddenColumn owner_name_cell">
+<td class="hideableColumn owner_name_cell">
   <% if @bike.owner_name.present? %>
     <em><%= @bike.owner_name %></em>
   <% end %>
 </td>
 
-<td class="hiddenColumn status_cell small">
+<td class="hideableColumn status_cell small">
   <%= helpers.status_display(@bike.status_humanized_no_with_owner) %>
 </td>
 
 <% if @organization.enabled?("registration_notes") %>
-  <td class="hiddenColumn notes_cell tw:leading-none">
+  <td class="hideableColumn notes_cell tw:leading-none">
     <small><%= bike_organization_note&.body %></small>
   </td>
 <% end %>
@@ -88,7 +88,7 @@
 <% @additional_registration_fields.each do |reg_field| %>
   <% next if reg_field == "extra_registration_number" %>
 
-  <td class="hiddenColumn <%= "#{reg_field}_cell" %>">
+  <td class="hideableColumn <%= "#{reg_field}_cell" %>">
     <% bike_attr = OrganizationFeature.reg_field_to_bike_attrs(reg_field) %>
 
     <% if bike_attr == "address" %>
@@ -108,12 +108,12 @@
 <% end %>
 
 <%# All organizations can see additional serial# %>
-<td class="hiddenColumn extra_registration_number_cell">
+<td class="hideableColumn extra_registration_number_cell">
   <%= @bike.extra_registration_number %>
 </td>
 
 <% if @organization.enabled?("bike_stickers") %>
-  <td class="hiddenColumn sticker_cell">
+  <td class="hideableColumn sticker_cell">
     <% @bike.bike_stickers.each_with_index do |bike_sticker, index| %>
       <% if bike_sticker.organization.present? && bike_sticker.organization_id == @organization.id %>
         <%= link_to bike_sticker.pretty_code,
@@ -131,12 +131,12 @@
 <% end %>
 
 <% if @organization.enabled?("impound_bikes") %>
-  <td class="hiddenColumn impound_id_cell">
+  <td class="hideableColumn impound_id_cell">
     <% if @bike.status_impounded? && @bike.current_impound_record.present? %>
       <%= number_display(@bike.current_impound_record.id) %>
     <% end %>
   </td>
-  <td class="hiddenColumn impounded_cell">
+  <td class="hideableColumn impounded_cell">
     <% if @bike.status_impounded? && @bike.current_impound_record&.created_at&.present? %>
       <small class="localizeTime">
         <%= l @bike.current_impound_record.created_at, format: :convert_time %>

--- a/app/components/org/bike_search_settings/component.html.erb
+++ b/app/components/org/bike_search_settings/component.html.erb
@@ -1,6 +1,6 @@
 <div
-  class="settings-list <%= 'tw:hidden!' unless settings_default_open? %>"
-  data-org--bike-search-target="settings"
+  class="[&_.form-group]:tw:mb-0 tw:my-4 tw:border tw:border-gray-300/70 tw:bg-gray-100 tw:px-3 tw:pt-4 tw:pb-3 <%= 'tw:hidden!' unless settings_default_open? %>"
+  data-org--registration-search-target="settings"
 >
   <h3 class="header-font-alt"><%= translation(".visible_columns") %></h3>
 
@@ -12,15 +12,21 @@
       tw:md:grid-flow-col tw:md:grid-cols-3
     "
     style="grid-template-rows: repeat(<%= column_rows %>, auto)"
+    data-org--registration-search-column-toggle-target="checkboxes"
   >
     <% enabled_columns.each do |cell_name| %>
-      <label class="tw:flex tw:items-center tw:gap-1 tw:leading-[1.25]!">
+      <label
+        class="
+          tw:mb-0! tw:flex tw:cursor-pointer tw:items-center tw:gap-1
+          tw:leading-[1.25]!
+        "
+      >
         <% if cell_name == "avery_cell" %>
           <%= check_box_tag cell_name, cell_name, show_avery_export?,
-              data: { action: "change->org--bike-search#averyToggled" } %>
+              data: { action: "change->org--registration-search-column-toggle#averyToggled" } %>
         <% else %>
           <%= check_box_tag cell_name, cell_name, false,
-              data: { action: "change->org--bike-search#columnToggled" } %>
+              data: { action: "change->org--registration-search-column-toggle#columnToggled" } %>
         <% end %>
 
         <%= column_renames[cell_name.to_sym] %>
@@ -76,8 +82,8 @@
         <button
           type="button"
           class="btn btn-sm btn-outline-secondary uncap"
-          data-action="click->org--bike-search#toggleNotesSearch"
-          data-org--bike-search-target="notesButton"
+          data-action="click->org--registration-search#toggleNotesSearch"
+          data-org--registration-search-target="notesButton"
         >
           <%= translation(".show_notes_search") %>
         </button>
@@ -87,7 +93,7 @@
         <div class="tw:ml-auto tw:text-right">
           <%= link_to translation(".create_export_of_vehicles", cycle_type: cycle_type.pluralize(2)),
               organization_registrations_path(search_params.merge(create_export: true)),
-              class: "gray-link", data: {turbo_frame: "_top", "org--bike-search-target": "exportLink"} %>
+              class: "gray-link", data: {turbo_frame: "_top", "org--registration-search-target": "exportLink"} %>
         </div>
       <% end %>
     </div>
@@ -98,8 +104,8 @@
   <button
     type="button"
     class="btn btn-sm btn-outline-primary uncap <%= 'active' if settings_default_open? %>"
-    data-action="click->org--bike-search#toggleSettings"
-    data-org--bike-search-target="settingsButton"
+    data-action="click->org--registration-search#toggleSettings"
+    data-org--registration-search-target="settingsButton"
   >
     <%= translation(".settings") %>
     <%= helpers.inline_svg_tag "icons/settings_slider.svg", class: "tw:inline", alt: "settings icon" %>

--- a/app/components/org/bike_search_settings/component.rb
+++ b/app/components/org/bike_search_settings/component.rb
@@ -123,7 +123,7 @@ module Org::BikeSearchSettings
       border_l = first ? "" : "tw:-ml-px"
 
       tag.label(class: [
-        "tw:cursor-pointer tw:select-none tw:inline-flex tw:items-center",
+        "tw:cursor-pointer tw:select-none tw:inline-flex tw:items-center tw:mb-0!",
         "tw:border tw:border-gray-300 tw:px-3 tw:py-1 tw:text-sm tw:leading-snug",
         "tw:transition-colors tw:has-[:checked]:bg-gray-700 tw:has-[:checked]:text-white tw:has-[:checked]:border-gray-700",
         "tw:hover:bg-gray-100 tw:has-[:checked]:hover:bg-gray-700",
@@ -132,7 +132,7 @@ module Org::BikeSearchSettings
         radio_button_tag(name, value, checked,
           class: "tw:sr-only",
           form: "Search_Form",
-          data: {action: "change->org--bike-search#filterChanged"}) +
+          data: {action: "change->org--registration-search#filterChanged"}) +
           label_text.html_safe
       end
     end

--- a/app/components/search/form_organized/component.html.erb
+++ b/app/components/search/form_organized/component.html.erb
@@ -40,7 +40,7 @@
           <% if render_notes_field? %>
             <div
               class="tw:hidden tw:flex-1"
-              data-org--bike-search-target="notesField"
+              data-org--registration-search-target="notesField"
             >
               <%= label_tag :search_notes,
                 translation(".search_notes"),

--- a/app/components/ui/table/component.html.erb
+++ b/app/components/ui/table/component.html.erb
@@ -2,31 +2,29 @@
   <table class="<%= table_classes %>">
     <thead class="tw:bg-gray-50 tw:text-sm tw:dark:bg-gray-700">
       <tr>
-        <% @columns.each_with_index do |col, i| %>
-          <th class="<%= col.th_classes(i, total: @columns.length, bordered: @bordered) %>">
+        <% @columns.each do |col| %>
+          <th class="<%= col.th_classes(bordered: @bordered) %>">
             <%= col.render_header(render_sortable: @render_sortable, current_sort:, current_direction:, sortable_url: method(:sortable_url)) %>
           </th>
         <% end %>
       </tr>
     </thead>
 
-    <tbody class="twtable-striped">
+    <tbody class="ui-table<%= ' ui-table-bordered' if @bordered %>">
       <% @records.each_with_index do |record, row_index| %>
         <tr>
           <% cache_if(@cache_key, [@cache_key, record]) do %>
-            <% @columns.each_with_index do |col, i| %>
+            <% @columns.each do |col| %>
               <% next if col.uncached %>
 
-              <td class="<%= col.td_classes(i, bordered: @bordered) %>">
+              <td class="<%= col.td_classes(bordered: @bordered) %>">
                 <%= col.render_cell(record) { |r| capture { instance_exec(r, &col.cell_block) } } %>
               </td>
             <% end %>
           <% end %>
 
-          <% uncached_columns.each_with_index do |col, i| %>
-            <% cached_columns_count ||= @columns.count - uncached_columns.count %>
-
-            <td class="<%= col.td_classes(cached_columns_count + i, bordered: @bordered) %>">
+          <% uncached_columns.each do |col| %>
+            <td class="<%= col.td_classes(bordered: @bordered) %>">
               <%= col.render_cell(record) { |r| capture { instance_exec(r, &col.cell_block) } } %>
             </td>
           <% end %>

--- a/app/components/ui/table/component.html.erb
+++ b/app/components/ui/table/component.html.erb
@@ -10,7 +10,7 @@
       </tr>
     </thead>
 
-    <tbody class="ui-table<%= ' ui-table-bordered' if @bordered %>">
+    <tbody class="ui-table <%= ' ui-table-bordered' if @bordered %>">
       <% @records.each_with_index do |record, row_index| %>
         <tr>
           <% cache_if(@cache_key, [@cache_key, record]) do %>

--- a/app/components/ui/table_column/component.rb
+++ b/app/components/ui/table_column/component.rb
@@ -48,24 +48,20 @@ module UI
         end
       end
 
-      def th_classes(index, total:, bordered:)
+      def th_classes(bordered:)
         classes = ["tw:px-1 tw:py-2"]
         if bordered
-          classes << "tw:border-b tw:border-r tw:border-t tw:border-gray-200 tw:dark:border-gray-600"
-          classes << "tw:border-l" if index == 0
+          classes << "tw:border-b tw:border-l tw:border-t tw:border-gray-200 tw:dark:border-gray-600"
         end
-        classes << "tw:rounded-tl-sm" if index == 0
-        classes << "tw:rounded-tr-sm" if index == total - 1
         classes << @classes if @classes
         classes << @header_classes if @header_classes
         classes.join(" ")
       end
 
-      def td_classes(index, bordered:)
+      def td_classes(bordered:)
         classes = ["tw:px-1 tw:py-1"]
         if bordered
-          classes << "tw:border-b tw:border-r tw:border-gray-200 tw:dark:border-gray-700"
-          classes << "tw:border-l" if index == 0
+          classes << "tw:border-b tw:border-l tw:border-gray-200 tw:dark:border-gray-700"
         else
           classes << "tw:border-b tw:border-gray-100 tw:dark:border-gray-700"
         end

--- a/app/components/ui/table_column/component.rb
+++ b/app/components/ui/table_column/component.rb
@@ -60,10 +60,10 @@ module UI
 
       def td_classes(bordered:)
         classes = ["tw:px-1 tw:py-1"]
-        if bordered
-          classes << "tw:border-b tw:border-l tw:border-gray-200 tw:dark:border-gray-700"
+        classes << if bordered
+          "tw:border-b tw:border-l tw:border-gray-200 tw:dark:border-gray-700"
         else
-          classes << "tw:border-b tw:border-gray-100 tw:dark:border-gray-700"
+          "tw:border-b tw:border-gray-100 tw:dark:border-gray-700"
         end
         classes << @classes if @classes
         classes.join(" ")

--- a/app/javascript/controllers/org/bike_search_controller.js
+++ b/app/javascript/controllers/org/bike_search_controller.js
@@ -106,10 +106,10 @@ export default class extends Controller {
   }
 
   selectStoredVisibleColumns () {
-    const stored = localStorage.getItem('orgBikeColumns')
+    const stored = localStorage.getItem('orgRegistrationColumns')
     let columns = this.defaultColumnsValue
     if (stored) {
-      try { columns = JSON.parse(stored) } catch { localStorage.removeItem('orgBikeColumns') }
+      try { columns = JSON.parse(stored) } catch { localStorage.removeItem('orgRegistrationColumns') }
     }
 
     this.settingsTarget.querySelectorAll('input[type=checkbox]').forEach(cb => {
@@ -135,11 +135,11 @@ export default class extends Controller {
       }
     })
     // Store enabled columns so they persist across page loads
-    localStorage.setItem('orgBikeColumns', JSON.stringify(checked))
+    localStorage.setItem('orgRegistrationColumns', JSON.stringify(checked))
 
     this.element.querySelectorAll('.hiddenColumn').forEach(el => {
       const isVisible = visible.some(col => el.classList.contains(col))
-      el.style.display = isVisible ? '' : 'none'
+      el.classList.toggle('tw:hidden', !isVisible)
     })
   }
 }

--- a/app/javascript/controllers/org/registration_search_column_toggle_controller.js
+++ b/app/javascript/controllers/org/registration_search_column_toggle_controller.js
@@ -8,9 +8,7 @@ export default class extends Controller {
   static values = { enabledColumns: Array, defaultColumns: Array }
 
   connect () {
-    this.enabledColumnsValue = [...this.element.querySelectorAll('th.hideableColumn')].map(th =>
-      [...th.classList].find(c => c.endsWith('_cell'))
-    ).filter(Boolean)
+    this.refreshEnabledColumns()
     this.selectStoredVisibleColumns()
     document.addEventListener('turbo:frame-render', this.handleFrameRender)
   }
@@ -20,7 +18,14 @@ export default class extends Controller {
   }
 
   handleFrameRender = () => {
+    this.refreshEnabledColumns()
     this.updateVisibleColumns()
+  }
+
+  refreshEnabledColumns () {
+    this.enabledColumnsValue = [...this.element.querySelectorAll('th.hideableColumn')].map(th =>
+      [...th.classList].find(c => c.endsWith('_cell'))
+    ).filter(Boolean)
   }
 
   columnToggled () {
@@ -72,9 +77,11 @@ export default class extends Controller {
     // Store enabled columns so they persist across page loads
     localStorage.setItem('orgRegistrationColumns', JSON.stringify(checked))
 
-    this.element.querySelectorAll('.hideableColumn').forEach(el => {
-      const isVisible = visible.some(col => el.classList.contains(col))
-      el.classList.toggle('tw:hidden', !isVisible)
+    this.enabledColumnsValue.forEach(col => {
+      const isVisible = visible.includes(col)
+      this.element.querySelectorAll(`.${col}`).forEach(el => {
+        el.classList.toggle('tw:hidden', !isVisible)
+      })
     })
   }
 }

--- a/app/javascript/controllers/org/registration_search_column_toggle_controller.js
+++ b/app/javascript/controllers/org/registration_search_column_toggle_controller.js
@@ -17,7 +17,8 @@ export default class extends Controller {
     document.removeEventListener('turbo:frame-render', this.handleFrameRender)
   }
 
-  handleFrameRender = () => {
+  handleFrameRender = (event) => {
+    if (!this.element.contains(event.target)) return
     this.refreshEnabledColumns()
     this.updateVisibleColumns()
   }
@@ -45,6 +46,10 @@ export default class extends Controller {
     window.location = url.toString()
   }
 
+  isAveryCheckbox (cb) {
+    return cb.dataset.action?.includes('averyToggled')
+  }
+
   selectStoredVisibleColumns () {
     const stored = localStorage.getItem('orgRegistrationColumns')
     let columns = this.defaultColumnsValue
@@ -53,7 +58,7 @@ export default class extends Controller {
     }
 
     this.checkboxesTarget.querySelectorAll('input[type=checkbox]').forEach(cb => {
-      if (cb.dataset.action && cb.dataset.action.includes('averyToggled')) return
+      if (this.isAveryCheckbox(cb)) return
       cb.checked = columns.includes(cb.name)
     })
     this.updateVisibleColumns()
@@ -63,7 +68,7 @@ export default class extends Controller {
     const checked = []
     const visible = []
     this.checkboxesTarget.querySelectorAll('input[type=checkbox]').forEach(cb => {
-      if (cb.dataset.action && cb.dataset.action.includes('averyToggled')) {
+      if (this.isAveryCheckbox(cb)) {
         // Avery state is URL-driven, not stored in localStorage, but still
         // needs to be in the visible list so the column cells are shown
         if (cb.checked) visible.push(cb.name)
@@ -74,7 +79,6 @@ export default class extends Controller {
         visible.push(cb.name)
       }
     })
-    // Store enabled columns so they persist across page loads
     localStorage.setItem('orgRegistrationColumns', JSON.stringify(checked))
 
     this.enabledColumnsValue.forEach(col => {

--- a/app/javascript/controllers/org/registration_search_column_toggle_controller.js
+++ b/app/javascript/controllers/org/registration_search_column_toggle_controller.js
@@ -1,0 +1,80 @@
+import { Controller } from '@hotwired/stimulus'
+
+/* global localStorage */
+
+// Connects to data-controller='org--registration-search-column-toggle'
+export default class extends Controller {
+  static targets = ['checkboxes']
+  static values = { enabledColumns: Array, defaultColumns: Array }
+
+  connect () {
+    this.enabledColumnsValue = [...this.element.querySelectorAll('th.hideableColumn')].map(th =>
+      [...th.classList].find(c => c.endsWith('_cell'))
+    ).filter(Boolean)
+    this.selectStoredVisibleColumns()
+    document.addEventListener('turbo:frame-render', this.handleFrameRender)
+  }
+
+  disconnect () {
+    document.removeEventListener('turbo:frame-render', this.handleFrameRender)
+  }
+
+  handleFrameRender = () => {
+    this.updateVisibleColumns()
+  }
+
+  columnToggled () {
+    this.updateVisibleColumns()
+  }
+
+  // Avery export requires a page reload because the server conditionally
+  // renders avery column cells based on the search_avery_export param
+  averyToggled (event) {
+    const url = new URL(window.location)
+    if (event.target.checked) {
+      url.searchParams.set('search_avery_export', 'true')
+    } else {
+      url.searchParams.delete('search_avery_export')
+    }
+    url.searchParams.set('search_no_js', 'true')
+    window.location = url.toString()
+  }
+
+  selectStoredVisibleColumns () {
+    const stored = localStorage.getItem('orgRegistrationColumns')
+    let columns = this.defaultColumnsValue
+    if (stored) {
+      try { columns = JSON.parse(stored) } catch { localStorage.removeItem('orgRegistrationColumns') }
+    }
+
+    this.checkboxesTarget.querySelectorAll('input[type=checkbox]').forEach(cb => {
+      if (cb.dataset.action && cb.dataset.action.includes('averyToggled')) return
+      cb.checked = columns.includes(cb.name)
+    })
+    this.updateVisibleColumns()
+  }
+
+  updateVisibleColumns () {
+    const checked = []
+    const visible = []
+    this.checkboxesTarget.querySelectorAll('input[type=checkbox]').forEach(cb => {
+      if (cb.dataset.action && cb.dataset.action.includes('averyToggled')) {
+        // Avery state is URL-driven, not stored in localStorage, but still
+        // needs to be in the visible list so the column cells are shown
+        if (cb.checked) visible.push(cb.name)
+        return
+      }
+      if (cb.checked) {
+        checked.push(cb.name)
+        visible.push(cb.name)
+      }
+    })
+    // Store enabled columns so they persist across page loads
+    localStorage.setItem('orgRegistrationColumns', JSON.stringify(checked))
+
+    this.element.querySelectorAll('.hideableColumn').forEach(el => {
+      const isVisible = visible.some(col => el.classList.contains(col))
+      el.classList.toggle('tw:hidden', !isVisible)
+    })
+  }
+}

--- a/app/javascript/controllers/org/registration_search_controller.js
+++ b/app/javascript/controllers/org/registration_search_controller.js
@@ -8,7 +8,7 @@ export default class extends Controller {
   static targets = ['settings', 'settingsButton', 'perPage', 'exportLink', 'notesField', 'notesButton']
 
   connect () {
-    if (localStorage.getItem('orgBikeSettingsOpen') === 'true') {
+    if (localStorage.getItem('orgRegistrationSettingsOpen') === 'true') {
       collapse('show', this.settingsTarget, 0)
       if (this.hasSettingsButtonTarget) this.settingsButtonTarget.classList.add('active')
     }
@@ -28,7 +28,7 @@ export default class extends Controller {
     const wasHidden = this.settingsTarget.classList.contains('tw:hidden!') ||
       this.settingsTarget.classList.contains('tw:hidden')
     collapse('toggle', this.settingsTarget)
-    localStorage.setItem('orgBikeSettingsOpen', wasHidden ? 'true' : 'false')
+    localStorage.setItem('orgRegistrationSettingsOpen', wasHidden ? 'true' : 'false')
     if (this.hasSettingsButtonTarget) this.settingsButtonTarget.classList.toggle('active', wasHidden)
   }
 
@@ -36,7 +36,7 @@ export default class extends Controller {
     if (!this.hasNotesFieldTarget) return
     const input = this.notesFieldTarget.querySelector('input')
     const hasValue = input && input.value.length > 0
-    if (hasValue || localStorage.getItem('orgBikeNotesSearchOpen') === 'true') {
+    if (hasValue || localStorage.getItem('orgRegistrationNotesSearchOpen') === 'true') {
       this.showNotesSearch()
     }
   }
@@ -53,13 +53,13 @@ export default class extends Controller {
 
   showNotesSearch () {
     this.notesFieldTarget.classList.remove('tw:hidden')
-    localStorage.setItem('orgBikeNotesSearchOpen', 'true')
+    localStorage.setItem('orgRegistrationNotesSearchOpen', 'true')
     if (this.hasNotesButtonTarget) this.notesButtonTarget.classList.add('active')
   }
 
   hideNotesSearch () {
     this.notesFieldTarget.classList.add('tw:hidden')
-    localStorage.setItem('orgBikeNotesSearchOpen', 'false')
+    localStorage.setItem('orgRegistrationNotesSearchOpen', 'false')
     if (this.hasNotesButtonTarget) this.notesButtonTarget.classList.remove('active')
   }
 

--- a/app/javascript/controllers/org/registration_search_controller.js
+++ b/app/javascript/controllers/org/registration_search_controller.js
@@ -3,19 +3,16 @@ import { collapse } from 'utils/collapse_utils'
 
 /* global localStorage */
 
-// Connects to data-controller='org--bike-search'
+// Connects to data-controller='org--registration-search'
 export default class extends Controller {
   static targets = ['settings', 'settingsButton', 'perPage', 'exportLink', 'notesField', 'notesButton']
-  static values = { defaultColumns: Array }
 
   connect () {
-    this.selectStoredVisibleColumns()
     if (localStorage.getItem('orgBikeSettingsOpen') === 'true') {
       collapse('show', this.settingsTarget, 0)
       if (this.hasSettingsButtonTarget) this.settingsButtonTarget.classList.add('active')
     }
     this.initNotesSearch()
-    // Re-apply column visibility when turbo frame updates with new table content
     document.addEventListener('turbo:frame-render', this.handleFrameRender)
   }
 
@@ -24,7 +21,6 @@ export default class extends Controller {
   }
 
   handleFrameRender = () => {
-    this.updateVisibleColumns()
     this.updateExportLink()
   }
 
@@ -34,23 +30,6 @@ export default class extends Controller {
     collapse('toggle', this.settingsTarget)
     localStorage.setItem('orgBikeSettingsOpen', wasHidden ? 'true' : 'false')
     if (this.hasSettingsButtonTarget) this.settingsButtonTarget.classList.toggle('active', wasHidden)
-  }
-
-  columnToggled () {
-    this.updateVisibleColumns()
-  }
-
-  // Avery export requires a page reload because the server conditionally
-  // renders avery column cells based on the search_avery_export param
-  averyToggled (event) {
-    const url = new URL(window.location)
-    if (event.target.checked) {
-      url.searchParams.set('search_avery_export', 'true')
-    } else {
-      url.searchParams.delete('search_avery_export')
-    }
-    url.searchParams.set('search_no_js', 'true')
-    window.location = url.toString()
   }
 
   initNotesSearch () {
@@ -103,43 +82,5 @@ export default class extends Controller {
     const url = new URL(window.location)
     url.searchParams.set('create_export', 'true')
     this.exportLinkTarget.href = url.toString()
-  }
-
-  selectStoredVisibleColumns () {
-    const stored = localStorage.getItem('orgRegistrationColumns')
-    let columns = this.defaultColumnsValue
-    if (stored) {
-      try { columns = JSON.parse(stored) } catch { localStorage.removeItem('orgRegistrationColumns') }
-    }
-
-    this.settingsTarget.querySelectorAll('input[type=checkbox]').forEach(cb => {
-      if (cb.dataset.action && cb.dataset.action.includes('averyToggled')) return
-      cb.checked = columns.includes(cb.name)
-    })
-    this.updateVisibleColumns()
-  }
-
-  updateVisibleColumns () {
-    const checked = []
-    const visible = []
-    this.settingsTarget.querySelectorAll('input[type=checkbox]').forEach(cb => {
-      if (cb.dataset.action && cb.dataset.action.includes('averyToggled')) {
-        // Avery state is URL-driven, not stored in localStorage, but still
-        // needs to be in the visible list so the column cells are shown
-        if (cb.checked) visible.push(cb.name)
-        return
-      }
-      if (cb.checked) {
-        checked.push(cb.name)
-        visible.push(cb.name)
-      }
-    })
-    // Store enabled columns so they persist across page loads
-    localStorage.setItem('orgRegistrationColumns', JSON.stringify(checked))
-
-    this.element.querySelectorAll('.hiddenColumn').forEach(el => {
-      const isVisible = visible.some(col => el.classList.contains(col))
-      el.classList.toggle('tw:hidden', !isVisible)
-    })
   }
 }

--- a/app/views/organized/registrations/_cached_bike_table_row.html.erb
+++ b/app/views/organized/registrations/_cached_bike_table_row.html.erb
@@ -20,7 +20,7 @@
   <% end %>
 
   <% if bike_search.show_avery_export? %>
-    <td class="hiddenColumn hidden-xs-down avery_cell">
+    <td class="hideableColumn hidden-xs-down avery_cell">
       <%= check_mark if bike.avery_exportable? %>
     </td>
   <% end %>

--- a/app/views/organized/registrations/search.html.erb
+++ b/app/views/organized/registrations/search.html.erb
@@ -24,8 +24,8 @@
 
 <div
   class="org-bikes-search-component"
-  data-controller="org--bike-search"
-  data-org--bike-search-default-columns-value="<%= bike_search_settings.initially_checked_columns.to_json %>"
+  data-controller="org--registration-search org--registration-search-column-toggle"
+  data-org--registration-search-column-toggle-default-columns-value="<%= bike_search_settings.initially_checked_columns.to_json %>"
 >
   <div class="mb-4">
     <%= render(Search::FormOrganized::Component.new(

--- a/spec/components/org/bike_search/component_spec.rb
+++ b/spec/components/org/bike_search/component_spec.rb
@@ -36,11 +36,11 @@ RSpec.describe Org::BikeSearch::Component, type: :component do
   it "renders table with form, checkboxes, and content block" do
     expect(component).to have_css("table.table")
     expect(component).to have_css("tbody tr", count: 1)
-    expect(component).to have_css(".settings-list", visible: :all)
+    expect(component).to have_css("[data-org--registration-search-target='settings']", visible: :all)
     # Search form
     expect(component).to have_css("#Search_Form")
     # checkboxes
-    expect(component).to have_css(".settings-list.tw\\:hidden\\!", visible: :all)
+    expect(component).to have_css("[data-org--registration-search-target='settings'].tw\\:hidden\\!", visible: :all)
     expect(component).to have_css("input[type='checkbox']", visible: :all)
     # pagination
     expect(component).to have_css(".paginate-container")

--- a/spec/components/org/bike_search/component_system_spec.rb
+++ b/spec/components/org/bike_search/component_system_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Org::BikeSearch::Component, :js, type: :system do
 
   before do
     visit(preview_path)
-    page.execute_script("localStorage.removeItem('orgRegistrationColumns'); localStorage.setItem('orgBikeSettingsOpen', 'false')")
+    page.execute_script("localStorage.removeItem('orgRegistrationColumns'); localStorage.setItem('orgRegistrationSettingsOpen', 'false')")
     visit(preview_path)
     expect(page).to have_css("[data-controller~='org--registration-search']", wait: 5)
   end

--- a/spec/components/org/bike_search/component_system_spec.rb
+++ b/spec/components/org/bike_search/component_system_spec.rb
@@ -9,14 +9,14 @@ RSpec.describe Org::BikeSearch::Component, :js, type: :system do
 
   before do
     visit(preview_path)
-    page.execute_script("localStorage.removeItem('orgBikeColumns'); localStorage.setItem('orgBikeSettingsOpen', 'false')")
+    page.execute_script("localStorage.removeItem('orgRegistrationColumns'); localStorage.setItem('orgBikeSettingsOpen', 'false')")
     visit(preview_path)
-    expect(page).to have_css("[data-controller='org--bike-search']", wait: 5)
+    expect(page).to have_css("[data-controller~='org--registration-search']", wait: 5)
   end
 
   it "toggles settings panel visibility" do
     expect(page).to be_axe_clean.skipping(*SKIPPABLE_AXE_RULES)
-    settings_selector = "[data-org--bike-search-target='settings']"
+    settings_selector = "[data-org--registration-search-target='settings']"
     expect(page).not_to have_css(settings_selector, visible: true, wait: 2)
 
     click_button "settings"
@@ -60,7 +60,7 @@ RSpec.describe Org::BikeSearch::Component, :js, type: :system do
     # Wait for the JS change handler to update the column visibility before reading localStorage
     expect(page).to have_css("th.url_cell", visible: true, wait: 5)
 
-    stored = page.evaluate_script("localStorage.getItem('orgBikeColumns')")
+    stored = page.evaluate_script("localStorage.getItem('orgRegistrationColumns')")
     columns = JSON.parse(stored)
     expect(columns).to include("url_cell")
 

--- a/spec/components/org/bike_search_settings/component_spec.rb
+++ b/spec/components/org/bike_search_settings/component_spec.rb
@@ -152,7 +152,7 @@ RSpec.describe Org::BikeSearchSettings::Component, type: :component do
 
   describe "rendering" do
     it "renders settings panel with columns and settings button" do
-      expect(component).to have_css(".settings-list", visible: :all)
+      expect(component).to have_css("[data-org--registration-search-target='settings']", visible: :all)
       expect(component).to have_css("input[type='checkbox']", visible: :all)
       expect(component).to have_button("settings", visible: :all)
     end
@@ -188,7 +188,7 @@ RSpec.describe Org::BikeSearchSettings::Component, type: :component do
       let(:search_stickers) { "with" }
 
       it "opens settings by default" do
-        expect(component).to have_css(".settings-list:not(.tw\\:hidden\\!)", visible: :all)
+        expect(component).to have_css("[data-org--registration-search-target='settings']:not(.tw\\:hidden\\!)", visible: :all)
       end
     end
   end

--- a/spec/components/ui/table/component_spec.rb
+++ b/spec/components/ui/table/component_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe UI::Table::Component, type: :component do
     expect(component).to have_css("th", text: "Email")
     expect(component).to have_css("td", text: "Alice")
     expect(component).to have_css("td", text: "bob@example.com")
-    expect(component).to have_css("tbody.twtable-striped")
+    expect(component).to have_css("tbody.ui-table")
   end
 
   context "with custom classes" do

--- a/spec/components/ui/table_column/component_spec.rb
+++ b/spec/components/ui/table_column/component_spec.rb
@@ -9,30 +9,24 @@ RSpec.describe UI::TableColumn::Component do
     let(:col) { described_class.new(label: "Name") }
 
     it "includes base classes" do
-      result = col.th_classes(1, total: 3, bordered: false)
-      expect(result).to include("tw:px-1 tw:py-2")
+      expect(col.th_classes(bordered: false)).to include("tw:px-1 tw:py-2")
     end
 
     it "includes border classes when bordered" do
-      result = col.th_classes(0, total: 3, bordered: true)
+      result = col.th_classes(bordered: true)
       expect(result).to include("border-b")
       expect(result).to include("border-l")
     end
 
-    it "includes corner rounding for first and last" do
-      expect(col.th_classes(0, total: 3, bordered: false)).to include("rounded-tl-sm")
-      expect(col.th_classes(2, total: 3, bordered: false)).to include("rounded-tr-sm")
-    end
-
     it "includes custom classes" do
       col = described_class.new(label: "Name", classes: "text-xs")
-      expect(col.th_classes(0, total: 1, bordered: false)).to include("text-xs")
+      expect(col.th_classes(bordered: false)).to include("text-xs")
     end
 
     it "includes header_classes on th but not td" do
       col = described_class.new(label: "Name", header_classes: "w-32")
-      expect(col.th_classes(0, total: 1, bordered: false)).to include("w-32")
-      expect(col.td_classes(0, bordered: false)).not_to include("w-32")
+      expect(col.th_classes(bordered: false)).to include("w-32")
+      expect(col.td_classes(bordered: false)).not_to include("w-32")
     end
   end
 
@@ -40,14 +34,13 @@ RSpec.describe UI::TableColumn::Component do
     let(:col) { described_class.new(label: "Name") }
 
     it "includes bordered classes when bordered" do
-      result = col.td_classes(0, bordered: true)
-      expect(result).to include("tw:border-b tw:border-r")
+      result = col.td_classes(bordered: true)
+      expect(result).to include("tw:border-b")
       expect(result).to include("tw:border-l")
     end
 
     it "includes unbordered classes when not bordered" do
-      result = col.td_classes(1, bordered: false)
-      expect(result).to include("tw:border-b tw:border-gray-100")
+      expect(col.td_classes(bordered: false)).to include("tw:border-b tw:border-gray-100")
     end
   end
 

--- a/spec/integration/organized/registrations_search_spec.rb
+++ b/spec/integration/organized/registrations_search_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe "Organized bikes search", :js, type: :system do
+RSpec.describe "Organized registrations search", :js, type: :system do
   let(:organization) { FactoryBot.create(:organization_with_organization_features, enabled_feature_slugs:) }
   let(:enabled_feature_slugs) { %w[bike_search csv_exports impound_bikes registration_notes] }
   let(:user) { FactoryBot.create(:organization_admin, organization:) }
@@ -21,13 +21,16 @@ RSpec.describe "Organized bikes search", :js, type: :system do
     click_button "Log in"
   end
 
+  def settings_selector
+    "[data-org--registration-search-target='settings']"
+  end
+
   def expect_settings_open
-    expect(find(".settings-list", visible: :all)["class"]).not_to include("tw:hidden!")
+    expect(find(settings_selector, visible: :all)["class"]).not_to include("tw:hidden!")
   end
 
   def open_settings_if_not
-    # if settings
-    if find(".settings-list", visible: :all)["class"].include?("tw:hidden!")
+    if find(settings_selector, visible: :all)["class"].include?("tw:hidden!")
       click_button "settings"
     end
   end
@@ -157,14 +160,38 @@ RSpec.describe "Organized bikes search", :js, type: :system do
       expect(page).to have_css("table.table", wait: 10)
       expect(page).to have_css("tbody tr", minimum: 4, wait: 10)
 
-      # Open settings and choose "only stolen"
+      # Default columns are visible
+      expect(page).to have_css("th.manufacturer_cell", visible: :visible)
+      expect(page).to have_css("th.owner_email_cell", visible: :visible)
+      expect(page).to have_css("th.stolen_cell", visible: :visible)
+      # Non-default columns are hidden
+      expect(page).to have_css("th.serial_number_cell", visible: :hidden)
+      expect(page).to have_css("th.url_cell", visible: :hidden)
+      expect(page).to have_css("th.impounded_cell", visible: :hidden)
+      # Uncheck a default column — it hides
       open_settings_if_not
+      uncheck "manufacturer_cell"
+      expect(page).to have_css("th.manufacturer_cell", visible: :hidden)
+      expect(page).to have_css("td.manufacturer_cell", visible: :hidden, minimum: 1)
+      # Check a non-default column — it shows
+      check "serial_number_cell"
+      expect(page).to have_css("th.serial_number_cell", visible: :visible)
+      expect(page).to have_css("td.serial_number_cell", visible: :visible, minimum: 1)
+      # Show impounded column
+      check "impounded_cell"
+      expect(page).to have_css("th.impounded_cell", visible: :visible)
+
+      # Choose "only stolen"
       choose("search_status_stolen", allow_label_click: true, visible: :all)
       expect(page).to have_current_path(/search_status=stolen/, wait: 10)
       expect(page).to have_css("table.table", wait: 10)
       expect(page).to have_css("tbody tr", count: 1)
       expect(page).to have_text("1 registration matching")
       expect(page).to have_text("only stolen")
+      # Column choices persist after the search
+      expect(page).to have_css("th.manufacturer_cell", visible: :hidden)
+      expect(page).to have_css("th.serial_number_cell", visible: :visible)
+      expect(page).to have_css("th.impounded_cell", visible: :visible)
 
       # Settings persisted open via localStorage; choose "only impounded"
       expect_settings_open
@@ -189,6 +216,10 @@ RSpec.describe "Organized bikes search", :js, type: :system do
       expect(page).to have_current_path(/search_status=all/, wait: 10)
       expect(page).to have_css("table.table", wait: 10)
       expect(page).to have_css("tbody tr", minimum: 4, wait: 10)
+      # Column choices still persist
+      expect(page).to have_css("th.manufacturer_cell", visible: :hidden)
+      expect(page).to have_css("th.serial_number_cell", visible: :visible)
+      expect(page).to have_css("th.impounded_cell", visible: :visible)
     end
   end
 


### PR DESCRIPTION
- Extract column visibility toggling from `org--bike-search` into a new `org--registration-search-column-toggle` Stimulus controller
- Rename `org--bike-search` controller to `org--registration-search`
- Replace `.settings-list` SCSS with Tailwind classes
- Rename `hiddenColumn` CSS class to `hideableColumn`
- Rename localStorage keys from `orgBike*` to `orgRegistration*`
- Add column visibility integration specs
- Rename `bikes_search_spec.rb` to `registrations_search_spec.rb`
