### PR TITLE
Add google.co.id to CSP frame-src, bikeindex.org to connect-src

### DIFF
--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -66,6 +66,7 @@ Rails.application.configure do
       "https://www.google.fr",
       "https://www.google.it",
       "https://www.google.nl",
+      "https://www.google.co.id",
       "https://www.google.co.in",
       "https://www.google.co.jp",
       "https://www.google.com.mx",

--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -41,6 +41,7 @@ Rails.application.configure do
       "https://cdn.jsdelivr.net",
       "https://api.mapbox.com"
     policy.connect_src :self,
+      "https://bikeindex.org",
       "https://bikebook.herokuapp.com",
       "https://www.google-analytics.com",
       "https://*.google-analytics.com",


### PR DESCRIPTION
Fix two CSP violations:

- **frame-src**: Add `https://www.google.co.id` (Google Indonesia) for Google Ads conversion tracking iframes. This was causing ~260 reports on [Honeybadger fault 128222429](https://app.honeybadger.io/projects/138070/faults/128222429), all from the `/users/please_confirm_email` page.
- **connect-src**: Add `https://bikeindex.org` explicitly so vendored widget JS API calls (which hardcode the full domain) work even when `'self'` doesn't resolve as expected in the proxy/CDN context.

🤖 Generated with [Claude Code](https://claude.com/claude-code)