### PR TITLE
Make avery a cached column in org bike search

### DIFF
--- a/app/components/org/bike_search/component.html.erb
+++ b/app/components/org/bike_search/component.html.erb
@@ -191,16 +191,6 @@
         <% end %>
       <% end %>
 
-      <% if bike_sticker.present? %>
-        <% table.column(label: t("components.org.bike_search.assign_bike_sticker"), classes: "assign_bike_sticker_cell", uncached: true) do |bike| %>
-          <small>
-            <%= link_to t("components.org.bike_search.assign_bike_sticker"),
-              bike_sticker_path(id: bike_sticker.code, organization_id: bike_sticker.organization_id, bike_id: bike.id),
-              method: "PUT", data: {turbo_frame: "_top"} %>
-          </small>
-        <% end %>
-      <% end %>
-
       <% if organization.enabled?("impound_bikes") %>
         <% table.column(label: t("components.org.bike_search.impound_id"), classes: "hideableColumn impound_id_cell") do |bike| %>
           <% if bike.status_impounded? && bike.current_impound_record.present? %>
@@ -219,6 +209,16 @@
       <% if @organization.enabled?("avery_export") %>
         <% table.column(label: t("components.org.bike_search.avery"), classes: "hideableColumn avery_cell") do |bike| %>
           <%= check_mark if bike.avery_exportable? %>
+        <% end %>
+      <% end %>
+
+      <% if bike_sticker.present? %>
+        <% table.column(label: t("components.org.bike_search.assign_bike_sticker"), classes: "assign_bike_sticker_cell", uncached: true) do |bike| %>
+          <small>
+            <%= link_to t("components.org.bike_search.assign_bike_sticker"),
+              bike_sticker_path(id: bike_sticker.code, organization_id: bike_sticker.organization_id, bike_id: bike.id),
+              method: "PUT", data: {turbo_frame: "_top"} %>
+          </small>
         <% end %>
       <% end %>
     <% end %>

--- a/app/components/org/bike_search/component.html.erb
+++ b/app/components/org/bike_search/component.html.erb
@@ -217,7 +217,7 @@
       <% end %>
 
       <% if @include_avery && organization.enabled?("avery_export") %>
-        <% table.column(label: t("components.org.bike_search.avery"), classes: "hideableColumn avery_cell", uncached: true) do |bike| %>
+        <% table.column(label: t("components.org.bike_search.avery"), classes: "hideableColumn avery_cell") do |bike| %>
           <%= check_mark if bike.avery_exportable? %>
         <% end %>
       <% end %>

--- a/app/components/org/bike_search/component.html.erb
+++ b/app/components/org/bike_search/component.html.erb
@@ -216,7 +216,7 @@
         <% end %>
       <% end %>
 
-      <% if @include_avery && organization.enabled?("avery_export") %>
+      <% if @organization.enabled?("avery_export") %>
         <% table.column(label: t("components.org.bike_search.avery"), classes: "hideableColumn avery_cell") do |bike| %>
           <%= check_mark if bike.avery_exportable? %>
         <% end %>

--- a/app/components/org/bike_search/component.rb
+++ b/app/components/org/bike_search/component.rb
@@ -24,7 +24,6 @@ module Org::BikeSearch
       bike_sticker: nil,
       model_audit: nil,
       skip_search_and_filters: false,
-      include_avery: false,
       skip_settings: false
     )
       @organization = organization
@@ -43,7 +42,6 @@ module Org::BikeSearch
       @bike_sticker = bike_sticker
       @model_audit = model_audit
       @skip_search_and_filters = skip_search_and_filters
-      @include_avery = include_avery
       @skip_settings = skip_settings
     end
 
@@ -58,7 +56,6 @@ module Org::BikeSearch
         search_stickers: @search_stickers,
         search_address: @search_address,
         search_status: @search_status,
-        include_avery: @include_avery,
         bike_sticker: @bike_sticker,
         skip_search_and_filters: @skip_search_and_filters
       )

--- a/app/components/org/bike_search/component.rb
+++ b/app/components/org/bike_search/component.rb
@@ -4,7 +4,7 @@ module Org::BikeSearch
   class Component < ApplicationComponent
     include SortableHelper
 
-    delegate :additional_registration_fields, :show_avery_export?, :column_renames,
+    delegate :additional_registration_fields, :column_renames,
       :initially_checked_columns, :cycle_type, :active_search_filter_descriptions,
       to: :settings_component
     def initialize(

--- a/app/components/org/bike_search_settings/component.html.erb
+++ b/app/components/org/bike_search_settings/component.html.erb
@@ -21,13 +21,8 @@
           tw:leading-[1.25]!
         "
       >
-        <% if cell_name == "avery_cell" %>
-          <%= check_box_tag cell_name, cell_name, show_avery_export?,
-              data: { action: "change->org--registration-search-column-toggle#averyToggled" } %>
-        <% else %>
-          <%= check_box_tag cell_name, cell_name, false,
-              data: { action: "change->org--registration-search-column-toggle#columnToggled" } %>
-        <% end %>
+        <%= check_box_tag cell_name, cell_name, false,
+            data: { action: "change->org--registration-search-column-toggle#columnToggled" } %>
 
         <%= column_renames[cell_name.to_sym] %>
       </label>

--- a/app/components/org/bike_search_settings/component.rb
+++ b/app/components/org/bike_search_settings/component.rb
@@ -48,7 +48,6 @@ module Org::BikeSearchSettings
       search_stickers: nil,
       search_address: nil,
       search_status: "all",
-      include_avery: false,
       bike_sticker: nil,
       skip_search_and_filters: false
     )
@@ -59,7 +58,6 @@ module Org::BikeSearchSettings
       @search_stickers = search_stickers
       @search_address = search_address
       @search_status = search_status
-      @include_avery = include_avery
       @bike_sticker = bike_sticker
       @skip_search_and_filters = skip_search_and_filters
     end
@@ -80,7 +78,7 @@ module Org::BikeSearchSettings
         cols = %w[created_at_cell stolen_cell manufacturer_cell model_cell
           color_cell owner_email_cell owner_name_cell creation_description_cell]
         cols += ["sticker_cell"] if @organization.enabled?("bike_stickers")
-        cols += ["avery_cell"] if @include_avery && @organization.enabled?("avery_export")
+        cols += ["avery_cell"] if @organization.enabled?("avery_export")
         cols += ["impounded_cell"] if @params[:search_impoundedness] == "impounded"
         cols
       end
@@ -139,7 +137,7 @@ module Org::BikeSearchSettings
         cols += additional_registration_fields.map { |f| "#{f}_cell" }
         cols += ["notes_cell"] if @organization.enabled?("registration_notes")
         cols += %w[impound_id_cell impounded_cell] if @organization.enabled?("impound_bikes")
-        cols += ["avery_cell"] if @include_avery && @organization.enabled?("avery_export")
+        cols += ["avery_cell"] if @organization.enabled?("avery_export")
         cols.uniq.sort { |a, b| column_renames[a.to_sym] <=> column_renames[b.to_sym] }
       end
     end

--- a/app/components/org/bike_search_settings/component.rb
+++ b/app/components/org/bike_search_settings/component.rb
@@ -80,17 +80,10 @@ module Org::BikeSearchSettings
         cols = %w[created_at_cell stolen_cell manufacturer_cell model_cell
           color_cell owner_email_cell owner_name_cell creation_description_cell]
         cols += ["sticker_cell"] if @organization.enabled?("bike_stickers")
-        cols += ["avery_cell"] if show_avery_export?
+        cols += ["avery_cell"] if @include_avery && @organization.enabled?("avery_export")
         cols += ["impounded_cell"] if @params[:search_impoundedness] == "impounded"
         cols
       end
-    end
-
-    def show_avery_export?
-      return @show_avery_export if defined?(@show_avery_export)
-
-      @show_avery_export = @include_avery && @organization.enabled?("avery_export") &&
-        Binxtils::InputNormalizer.boolean(@params[:search_avery_export])
     end
 
     def column_renames

--- a/app/components/org/bike_search_settings/component.rb
+++ b/app/components/org/bike_search_settings/component.rb
@@ -78,7 +78,6 @@ module Org::BikeSearchSettings
         cols = %w[created_at_cell stolen_cell manufacturer_cell model_cell
           color_cell owner_email_cell owner_name_cell creation_description_cell]
         cols += ["sticker_cell"] if @organization.enabled?("bike_stickers")
-        cols += ["avery_cell"] if @organization.enabled?("avery_export")
         cols += ["impounded_cell"] if @params[:search_impoundedness] == "impounded"
         cols
       end

--- a/app/javascript/controllers/org/registration_search_column_toggle_controller.js
+++ b/app/javascript/controllers/org/registration_search_column_toggle_controller.js
@@ -33,23 +33,6 @@ export default class extends Controller {
     this.updateVisibleColumns()
   }
 
-  // Avery export requires a page reload because the server conditionally
-  // renders avery column cells based on the search_avery_export param
-  averyToggled (event) {
-    const url = new URL(window.location)
-    if (event.target.checked) {
-      url.searchParams.set('search_avery_export', 'true')
-    } else {
-      url.searchParams.delete('search_avery_export')
-    }
-    url.searchParams.set('search_no_js', 'true')
-    window.location = url.toString()
-  }
-
-  isAveryCheckbox (cb) {
-    return cb.dataset.action?.includes('averyToggled')
-  }
-
   selectStoredVisibleColumns () {
     const stored = localStorage.getItem('orgRegistrationColumns')
     let columns = this.defaultColumnsValue
@@ -58,7 +41,6 @@ export default class extends Controller {
     }
 
     this.checkboxesTarget.querySelectorAll('input[type=checkbox]').forEach(cb => {
-      if (this.isAveryCheckbox(cb)) return
       cb.checked = columns.includes(cb.name)
     })
     this.updateVisibleColumns()
@@ -66,23 +48,13 @@ export default class extends Controller {
 
   updateVisibleColumns () {
     const checked = []
-    const visible = []
     this.checkboxesTarget.querySelectorAll('input[type=checkbox]').forEach(cb => {
-      if (this.isAveryCheckbox(cb)) {
-        // Avery state is URL-driven, not stored in localStorage, but still
-        // needs to be in the visible list so the column cells are shown
-        if (cb.checked) visible.push(cb.name)
-        return
-      }
-      if (cb.checked) {
-        checked.push(cb.name)
-        visible.push(cb.name)
-      }
+      if (cb.checked) checked.push(cb.name)
     })
     localStorage.setItem('orgRegistrationColumns', JSON.stringify(checked))
 
-    const firstVisible = this.enabledColumnsValue.find(col => visible.includes(col))
-    const lastVisible = [...this.enabledColumnsValue].reverse().find(col => visible.includes(col))
+    const firstVisible = this.enabledColumnsValue.find(col => checked.includes(col))
+    const lastVisible = [...this.enabledColumnsValue].reverse().find(col => checked.includes(col))
 
     const borderClasses = {
       th: { first: 'tw:ui-table-bordered-th-first', last: 'tw:ui-table-bordered-th-last' },
@@ -90,7 +62,7 @@ export default class extends Controller {
     }
 
     this.enabledColumnsValue.forEach(col => {
-      const isVisible = visible.includes(col)
+      const isVisible = checked.includes(col)
       this.element.querySelectorAll(`.${col}`).forEach(el => {
         el.classList.toggle('tw:hidden', !isVisible)
         const tag = el.tagName === 'TH' ? 'th' : 'td'

--- a/app/views/organized/registrations/_results.html.erb
+++ b/app/views/organized/registrations/_results.html.erb
@@ -15,6 +15,5 @@
   bike_sticker: @bike_sticker,
   model_audit: @model_audit,
   skip_search_and_filters: true,
-  include_avery: true,
   skip_settings: true
 )) %>

--- a/app/views/organized/registrations/search.html.erb
+++ b/app/views/organized/registrations/search.html.erb
@@ -12,7 +12,6 @@
   search_stickers: @search_stickers,
   search_address: @search_address,
   search_status: @search_status,
-  include_avery: true,
   bike_sticker: @bike_sticker
 ) %>
 

--- a/spec/integration/organized/registrations_search_spec.rb
+++ b/spec/integration/organized/registrations_search_spec.rb
@@ -236,20 +236,19 @@ RSpec.describe "Organized registrations search", :js, type: :system do
     it "toggles avery export column via checkbox" do
       visit bikes_path
       expect(page).to have_css("table", wait: 10)
-      # Avery column is visible by default when avery_export is enabled
-      expect(page).to have_css("th.avery_cell", visible: :visible)
-      expect(page).to have_css("td.avery_cell", text: "✓")
+      expect(page).not_to have_css("th.avery_cell", visible: :visible)
       expect(page).not_to have_css("th.assign_bike_sticker_cell")
 
-      # Open settings and uncheck avery — hides column client-side
+      # Open settings and check avery — toggles column visibility client-side
       open_settings_if_not
-      uncheck "avery_cell"
-      expect(page).not_to have_css("th.avery_cell", visible: :visible)
-
-      # Re-check avery — shows column again
       check "avery_cell"
+      # Avery column should be visible with check mark for exportable bike
       expect(page).to have_css("th.avery_cell", visible: :visible)
       expect(page).to have_css("td.avery_cell", text: "✓")
+
+      # Uncheck avery — hides column client-side
+      uncheck "avery_cell"
+      expect(page).not_to have_css("th.avery_cell", visible: :visible)
 
       # Open settings and choose "only with address"
       choose("search_address_with_street", allow_label_click: true, visible: :all)

--- a/spec/integration/organized/registrations_search_spec.rb
+++ b/spec/integration/organized/registrations_search_spec.rb
@@ -236,24 +236,19 @@ RSpec.describe "Organized registrations search", :js, type: :system do
     it "toggles avery export column via checkbox" do
       visit bikes_path
       expect(page).to have_css("table", wait: 10)
-      expect(page).not_to have_css("th.avery_cell")
+      expect(page).not_to have_css("th.avery_cell:not(.tw\\:hidden)")
       expect(page).not_to have_css("th.assign_bike_sticker_cell")
 
-      # Open settings and check avery — triggers page reload with param
+      # Open settings and check avery — toggles column visibility client-side
       open_settings_if_not
       check "avery_cell"
-      expect(page).to have_current_path(/search_avery_export=true/, wait: 10)
       # Avery column should be visible with check mark for exportable bike
-      expect(page).to have_css("th.avery_cell")
+      expect(page).to have_css("th.avery_cell:not(.tw\\:hidden)")
       expect(page).to have_css("td.avery_cell", text: "✓")
 
-      expect_settings_open
-      # Settings panel is already open (persisted via localStorage)
-      # Uncheck avery — triggers page reload without param
-      expect(page).to have_field("avery_cell", checked: true, wait: 5)
+      # Uncheck avery — hides column client-side
       uncheck "avery_cell"
-      expect(page).not_to have_current_path(/search_avery_export/, wait: 10)
-      expect(page).not_to have_css("th.avery_cell")
+      expect(page).not_to have_css("th.avery_cell:not(.tw\\:hidden)")
 
       # Open settings and choose "only with address"
       choose("search_address_with_street", allow_label_click: true, visible: :all)

--- a/spec/integration/organized/registrations_search_spec.rb
+++ b/spec/integration/organized/registrations_search_spec.rb
@@ -236,19 +236,20 @@ RSpec.describe "Organized registrations search", :js, type: :system do
     it "toggles avery export column via checkbox" do
       visit bikes_path
       expect(page).to have_css("table", wait: 10)
-      expect(page).not_to have_css("th.avery_cell", visible: :visible)
-      expect(page).not_to have_css("th.assign_bike_sticker_cell")
-
-      # Open settings and check avery — toggles column visibility client-side
-      open_settings_if_not
-      check "avery_cell"
-      # Avery column should be visible with check mark for exportable bike
+      # Avery column is visible by default when avery_export is enabled
       expect(page).to have_css("th.avery_cell", visible: :visible)
       expect(page).to have_css("td.avery_cell", text: "✓")
+      expect(page).not_to have_css("th.assign_bike_sticker_cell")
 
-      # Uncheck avery — hides column client-side
+      # Open settings and uncheck avery — hides column client-side
+      open_settings_if_not
       uncheck "avery_cell"
       expect(page).not_to have_css("th.avery_cell", visible: :visible)
+
+      # Re-check avery — shows column again
+      check "avery_cell"
+      expect(page).to have_css("th.avery_cell", visible: :visible)
+      expect(page).to have_css("td.avery_cell", text: "✓")
 
       # Open settings and choose "only with address"
       choose("search_address_with_street", allow_label_click: true, visible: :all)

--- a/spec/integration/organized/registrations_search_spec.rb
+++ b/spec/integration/organized/registrations_search_spec.rb
@@ -236,19 +236,19 @@ RSpec.describe "Organized registrations search", :js, type: :system do
     it "toggles avery export column via checkbox" do
       visit bikes_path
       expect(page).to have_css("table", wait: 10)
-      expect(page).not_to have_css("th.avery_cell:not(.tw\\:hidden)")
+      expect(page).not_to have_css("th.avery_cell", visible: :visible)
       expect(page).not_to have_css("th.assign_bike_sticker_cell")
 
       # Open settings and check avery — toggles column visibility client-side
       open_settings_if_not
       check "avery_cell"
       # Avery column should be visible with check mark for exportable bike
-      expect(page).to have_css("th.avery_cell:not(.tw\\:hidden)")
+      expect(page).to have_css("th.avery_cell", visible: :visible)
       expect(page).to have_css("td.avery_cell", text: "✓")
 
       # Uncheck avery — hides column client-side
       uncheck "avery_cell"
-      expect(page).not_to have_css("th.avery_cell:not(.tw\\:hidden)")
+      expect(page).not_to have_css("th.avery_cell", visible: :visible)
 
       # Open settings and choose "only with address"
       choose("search_address_with_street", allow_label_click: true, visible: :all)


### PR DESCRIPTION
Make the avery column in organized bike search behave like all other columns. Previously it was marked `uncached: true` and had special-cased JS that triggered a full page reload to toggle visibility via a URL param (`search_avery_export`). Now it's a normal cached column — toggled client-side via localStorage, just like stickers, stolen, etc.