### PR TITLE
Replace uncached bike sticker column with Stimulus controller

### DIFF
--- a/app/assets/tailwind/application.css
+++ b/app/assets/tailwind/application.css
@@ -77,17 +77,18 @@
   .ui-table tbody tr:nth-child(even) {
     @apply tw:bg-gray-100 tw:dark:bg-gray-800;
   }
-  .ui-table tbody tr:last-child td:first-child {
-    @apply tw:rounded-bl-sm;
-  }
-  .ui-table tbody tr:last-child td:last-child {
-    @apply tw:rounded-br-sm;
-  }
   .ui-table thead tr th:first-child {
     @apply tw:rounded-tl-sm;
   }
   .ui-table thead tr th:last-child {
     @apply tw:rounded-tr-sm;
+  }
+  /* NOTE: There are no equivalent styles for the bottom left/right ui-table-bordered - they aren't rounded */
+  .ui-table tbody tr:last-child td:first-child {
+    @apply tw:rounded-bl-sm;
+  }
+  .ui-table tbody tr:last-child td:last-child {
+    @apply tw:rounded-br-sm;
   }
 
   .ui-table-bordered tbody tr td:first-child {
@@ -104,7 +105,7 @@
   }
 }
 
-/* Create utility classes for the sides of the table so that it can be applied in JS when columns are hidden  */
+/* Create utility classes for the sides of the table so that it can be applied in JS when columns are hidden */
 @utility ui-table-bordered-td-first {
   @apply tw:border-l tw:border-gray-200 tw:dark:border-gray-700;
 }
@@ -112,10 +113,10 @@
   @apply tw:border-r tw:border-gray-200 tw:dark:border-gray-700;
 }
 @utility ui-table-bordered-th-first {
-  @apply tw:border-l tw:border-gray-200 tw:dark:border-gray-600;
+  @apply tw:border-l tw:border-gray-200 tw:dark:border-gray-600 tw:rounded-tl-sm;
 }
 @utility ui-table-bordered-th-last {
-  @apply tw:border-r tw:border-gray-200 tw:dark:border-gray-600;
+  @apply tw:border-r tw:border-gray-200 tw:dark:border-gray-600 tw:rounded-tr-sm;
 }
 
 @utility base-font {

--- a/app/components/org/bike_search/component.en.yml
+++ b/app/components/org/bike_search/component.en.yml
@@ -4,7 +4,7 @@ en:
     org:
       bike_search:
         affiliation: Affiliation
-        assign_bike_sticker: Link
+        assign_bike_sticker: Assign sticker
         avery: Avery?
         avery_exportable: Avery Exportable
         bike: registration

--- a/app/components/org/bike_search/component.en.yml
+++ b/app/components/org/bike_search/component.en.yml
@@ -15,6 +15,7 @@ en:
         impound_id: Impound ID
         impounded: Impounded
         link: Link
+        link_sticker: link sticker
         manufacturer: Manufacturer
         matching_bikes_html: "%{count} %{cycle_type} matching"
         mfg_model_color_html: manufacturer, model, <span class="less-strong">color</span>

--- a/app/components/org/bike_search/component.html.erb
+++ b/app/components/org/bike_search/component.html.erb
@@ -49,8 +49,11 @@
   <% bike_sticker = @bike_sticker %>
 
   <div
-    data-controller="update-cached-sortable-links"
+    data-controller="update-cached-sortable-links assign-bike-sticker"
     data-update-cached-sortable-links-base-url-value="<%= url_for(@sortable_search_params.merge(organization_id: organization.to_param)) %>"
+    <% if bike_sticker.present? %>
+      data-assign-bike-sticker-sticker-path-value="<%= bike_sticker_path(id: bike_sticker.code, organization_id: bike_sticker.organization_id) %>"
+    <% end %>
   >
     <%= render(UI::Table::Component.new(records: @bikes, cache_key: "org-#{@organization.id}-bikes", render_sortable: true)) do |table| %>
       <% table.column(label: t("components.org.bike_search.url"), classes: "hideableColumn url_cell") do |bike| %>
@@ -189,14 +192,11 @@
             <% end %>
           <% end %>
         <% end %>
-      <% end %>
-
-      <% if bike_sticker.present? %>
-        <% table.column(label: t("components.org.bike_search.assign_bike_sticker"), classes: "assign_bike_sticker_cell", uncached: true) do |bike| %>
+        <% table.column(label: t("components.org.bike_search.assign_bike_sticker"), classes: "assign_bike_sticker_cell tw:hidden") do |bike| %>
           <small>
-            <%= link_to t("components.org.bike_search.assign_bike_sticker"),
-              bike_sticker_path(id: bike_sticker.code, organization_id: bike_sticker.organization_id, bike_id: bike.id),
-              method: "PUT", data: {turbo_frame: "_top"} %>
+            <a data-bike-id="<%= bike.id %>">
+              <%= t("components.org.bike_search.assign_bike_sticker") %>
+            </a>
           </small>
         <% end %>
       <% end %>

--- a/app/components/org/bike_search/component.html.erb
+++ b/app/components/org/bike_search/component.html.erb
@@ -216,7 +216,7 @@
         <% table.column(label: translation(".assign_bike_sticker"), classes: "assign_bike_sticker_cell tw:hidden") do |bike| %>
           <small>
             <a data-bike-id="<%= bike.id %>">
-              <%= translation(".assign_bike_sticker") %>
+              <%= t("components.org.bike_search.link_sticker") %>
             </a>
           </small>
         <% end %>

--- a/app/components/org/bike_search/component.html.erb
+++ b/app/components/org/bike_search/component.html.erb
@@ -197,7 +197,9 @@
             <% if bs.organization.present? && bs.organization_id == organization.id %>
               <%= link_to bs.pretty_code, edit_organization_sticker_path(id: bs.code, organization_id: bs.organization&.to_param), class: "tw:text-xs tw:block tw:mt-1", data: {turbo_frame: "_top"} %>
             <% else %>
-              <small class="tw:text-xs tw:block tw:mt-1"><%= bs.pretty_code %></small>
+              <small class="tw:mt-1 tw:block tw:text-xs">
+                <%= bs.pretty_code %>
+              </small>
             <% end %>
           <% end %>
         <% end %>

--- a/app/components/org/bike_search/component.html.erb
+++ b/app/components/org/bike_search/component.html.erb
@@ -56,13 +56,13 @@
     <% end %>
   >
     <%= render(UI::Table::Component.new(records: @bikes, cache_key: "org-#{@organization.id}-bikes", render_sortable: true)) do |table| %>
-      <% table.column(label: t("components.org.bike_search.url"), classes: "hideableColumn url_cell") do |bike| %>
+      <% table.column(label: translation(".url"), classes: "hideableColumn url_cell") do |bike| %>
         <code class="tw:p-0 tw:text-xs!" style="word-break: normal">
           <%= bike.html_url %>
         </code>
       <% end %>
 
-      <% table.column(sortable: "id", label: t("components.org.bike_search.registered"), classes: "hideableColumn created_at_cell") do |bike| %>
+      <% table.column(sortable: "id", label: translation(".registered"), classes: "hideableColumn created_at_cell") do |bike| %>
         <a
           class="twlink localizeTime"
           href="<%= bike_path(bike, organization_id: organization.to_param) %>"
@@ -73,47 +73,47 @@
         </a>
       <% end %>
 
-      <% table.column(sortable: "updated_by_user_at", label: t("components.org.bike_search.updated"), classes: "hideableColumn updated_at_cell") do |bike| %>
+      <% table.column(sortable: "updated_by_user_at", label: translation(".updated"), classes: "hideableColumn updated_at_cell") do |bike| %>
         <small class="localizeTime">
           <%= l bike.updated_by_user_fallback, format: :convert_time %>
         </small>
       <% end %>
 
-      <% table.column(label: t("components.org.bike_search.stolen"), classes: "hideableColumn stolen_cell") do |bike| %>
+      <% table.column(label: translation(".stolen"), classes: "hideableColumn stolen_cell") do |bike| %>
         <%= check_mark if bike.status_stolen? %>
       <% end %>
 
-      <% table.column(label: t("components.org.bike_search.serial"), classes: "hideableColumn serial_number_cell") do |bike| %>
+      <% table.column(label: translation(".serial"), classes: "hideableColumn serial_number_cell") do |bike| %>
         <%= bike.serial_number %>
       <% end %>
 
-      <% table.column(sortable: "propulsion_type", label: t("components.org.bike_search.propulsion_type"), classes: "hideableColumn propulsion_type_cell") do |bike| %>
+      <% table.column(sortable: "propulsion_type", label: translation(".propulsion_type"), classes: "hideableColumn propulsion_type_cell") do |bike| %>
         <span class="<%= 'tw:text-gray-400' if bike.propulsion_type == 'foot-pedal' %>">
           <%= bike.propulsion_titleize %>
         </span>
       <% end %>
 
-      <% table.column(sortable: "cycle_type", label: t("components.org.bike_search.vehicle_type"), classes: "hideableColumn cycle_type_cell") do |bike| %>
+      <% table.column(sortable: "cycle_type", label: translation(".vehicle_type"), classes: "hideableColumn cycle_type_cell") do |bike| %>
         <span class="<%= 'tw:text-gray-400' if bike.cycle_type == 'bike' %>">
           <%= bike.type_titleize %>
         </span>
       <% end %>
 
-      <% table.column(sortable: "mnfg_name", label: t("components.org.bike_search.manufacturer"), classes: "hideableColumn manufacturer_cell") do |bike| %>
+      <% table.column(sortable: "mnfg_name", label: translation(".manufacturer"), classes: "hideableColumn manufacturer_cell") do |bike| %>
         <%= bike.mnfg_name %>
       <% end %>
 
-      <% table.column(sortable: "frame_model", label: t("components.org.bike_search.model"), classes: "hideableColumn model_cell") do |bike| %>
+      <% table.column(sortable: "frame_model", label: translation(".model"), classes: "hideableColumn model_cell") do |bike| %>
         <%= bike.frame_model %>
       <% end %>
 
-      <% table.column(label: t("components.org.bike_search.color"), classes: "hideableColumn color_cell") do |bike| %>
+      <% table.column(label: translation(".color"), classes: "hideableColumn color_cell") do |bike| %>
         <span class="tw:text-gray-400">
           <%= bike.frame_colors.join(", ") %>
         </span>
       <% end %>
 
-      <% table.column(sortable: "owner_email", label: t("components.org.bike_search.sent_to"), classes: "hideableColumn owner_email_cell") do |bike| %>
+      <% table.column(sortable: "owner_email", label: translation(".sent_to"), classes: "hideableColumn owner_email_cell") do |bike| %>
         <% if bike.email_visible_for?(organization) %>
           <%= bike.owner_email %>
           <small>
@@ -121,12 +121,12 @@
           </small>
         <% else %>
           <em class="tw:text-gray-400">
-            <%= t("components.org.bike_search.email_hidden") %>
+            <%= translation(".email_hidden") %>
           </em>
         <% end %>
       <% end %>
 
-      <% table.column(label: t("components.org.bike_search.source"), classes: "hideableColumn creation_description_cell") do |bike| %>
+      <% table.column(label: translation(".source"), classes: "hideableColumn creation_description_cell") do |bike| %>
         <% if bike.creation_description %>
           <small class="tw:text-gray-400">
             <%= helpers.origin_display(bike.creation_description) %>
@@ -134,18 +134,18 @@
         <% end %>
       <% end %>
 
-      <% table.column(label: t("components.org.bike_search.owner_name"), classes: "hideableColumn owner_name_cell") do |bike| %>
+      <% table.column(label: translation(".owner_name"), classes: "hideableColumn owner_name_cell") do |bike| %>
         <% if bike.owner_name.present? %>
           <em><%= bike.owner_name %></em>
         <% end %>
       <% end %>
 
-      <% table.column(label: t("components.org.bike_search.status_cell"), classes: "hideableColumn status_cell tw:text-xs") do |bike| %>
+      <% table.column(label: translation(".status_cell"), classes: "hideableColumn status_cell tw:text-xs") do |bike| %>
         <%= helpers.status_display(bike.status_humanized_no_with_owner) %>
       <% end %>
 
       <% if organization.enabled?("registration_notes") %>
-        <% table.column(label: t("components.org.bike_search.notes"), classes: "hideableColumn notes_cell tw:leading-none") do |bike| %>
+        <% table.column(label: translation(".notes"), classes: "hideableColumn notes_cell tw:leading-none") do |bike| %>
           <small>
             <%= BikeOrganizationNote.find_by(bike_id: bike.id, organization_id: organization.id)&.body %>
           </small>
@@ -174,12 +174,33 @@
         <% end %>
       <% end %>
 
-      <% table.column(label: t("components.org.bike_search.secondary_number"), classes: "hideableColumn extra_registration_number_cell") do |bike| %>
+      <% table.column(label: translation(".secondary_number"), classes: "hideableColumn extra_registration_number_cell") do |bike| %>
         <%= bike.extra_registration_number %>
       <% end %>
 
+      <% if organization.enabled?("impound_bikes") %>
+        <% table.column(label: translation(".impound_id"), classes: "hideableColumn impound_id_cell") do |bike| %>
+          <% if bike.status_impounded? && bike.current_impound_record.present? %>
+            <%= number_display(bike.current_impound_record.id) %>
+          <% end %>
+        <% end %>
+        <% table.column(label: translation(".impounded"), classes: "hideableColumn impounded_cell") do |bike| %>
+          <% if bike.status_impounded? && bike.current_impound_record&.created_at&.present? %>
+            <small class="localizeTime">
+              <%= l bike.current_impound_record.created_at, format: :convert_time %>
+            </small>
+          <% end %>
+        <% end %>
+      <% end %>
+
+      <% if @organization.enabled?("avery_export") %>
+        <% table.column(label: translation(".avery"), classes: "hideableColumn avery_cell") do |bike| %>
+          <%= check_mark if bike.avery_exportable? %>
+        <% end %>
+      <% end %>
+
       <% if organization.enabled?("bike_stickers") %>
-        <% table.column(label: t("components.org.bike_search.sticker"), classes: "hideableColumn sticker_cell") do |bike| %>
+        <% table.column(label: translation(".sticker"), classes: "hideableColumn sticker_cell") do |bike| %>
           <% bike.bike_stickers.each_with_index do |bs, index| %>
             <% if bs.organization.present? && bs.organization_id == organization.id %>
               <%= link_to bs.pretty_code, edit_organization_sticker_path(id: bs.code, organization_id: bs.organization&.to_param), class: "small", data: {turbo_frame: "_top"} %>
@@ -192,35 +213,11 @@
             <% end %>
           <% end %>
         <% end %>
-      <% end %>
-
-      <% if organization.enabled?("impound_bikes") %>
-        <% table.column(label: t("components.org.bike_search.impound_id"), classes: "hideableColumn impound_id_cell") do |bike| %>
-          <% if bike.status_impounded? && bike.current_impound_record.present? %>
-            <%= number_display(bike.current_impound_record.id) %>
-          <% end %>
-        <% end %>
-        <% table.column(label: t("components.org.bike_search.impounded"), classes: "hideableColumn impounded_cell") do |bike| %>
-          <% if bike.status_impounded? && bike.current_impound_record&.created_at&.present? %>
-            <small class="localizeTime">
-              <%= l bike.current_impound_record.created_at, format: :convert_time %>
-            </small>
-          <% end %>
-        <% end %>
-      <% end %>
-
-      <% if @organization.enabled?("avery_export") %>
-        <% table.column(label: t("components.org.bike_search.avery"), classes: "hideableColumn avery_cell") do |bike| %>
-          <%= check_mark if bike.avery_exportable? %>
-        <% end %>
-      <% end %>
-
-      <% if bike_sticker.present? %>
-        <% table.column(label: t("components.org.bike_search.assign_bike_sticker"), classes: "assign_bike_sticker_cell", uncached: true) do |bike| %>
+        <% table.column(label: translation(".assign_bike_sticker"), classes: "assign_bike_sticker_cell tw:hidden") do |bike| %>
           <small>
-            <%= link_to t("components.org.bike_search.assign_bike_sticker"),
-              bike_sticker_path(id: bike_sticker.code, organization_id: bike_sticker.organization_id, bike_id: bike.id),
-              method: "PUT", data: {turbo_frame: "_top"} %>
+            <a data-bike-id="<%= bike.id %>">
+              <%= translation(".assign_bike_sticker") %>
+            </a>
           </small>
         <% end %>
       <% end %>

--- a/app/components/org/bike_search/component.html.erb
+++ b/app/components/org/bike_search/component.html.erb
@@ -49,10 +49,10 @@
   <% bike_sticker = @bike_sticker %>
 
   <div
-    data-controller="update-cached-sortable-links assign-bike-sticker"
+    data-controller="update-cached-sortable-links org--assign-bike-sticker"
     data-update-cached-sortable-links-base-url-value="<%= url_for(@sortable_search_params.merge(organization_id: organization.to_param)) %>"
     <% if bike_sticker.present? %>
-      data-assign-bike-sticker-sticker-path-value="<%= bike_sticker_path(id: bike_sticker.code, organization_id: bike_sticker.organization_id) %>"
+      data-org--assign-bike-sticker-sticker-path-value="<%= bike_sticker_path(id: bike_sticker.code, organization_id: bike_sticker.organization_id) %>"
     <% end %>
   >
     <%= render(UI::Table::Component.new(records: @bikes, cache_key: "org-#{@organization.id}-bikes", render_sortable: true)) do |table| %>

--- a/app/components/org/bike_search/component.html.erb
+++ b/app/components/org/bike_search/component.html.erb
@@ -1,4 +1,4 @@
-<%= tag.div(class: "org-bikes-search-component", data: wrapper_data_attributes) do %>
+<%= tag.div(class: "org-bikes-search-component", data: component_wrapper_data_attributes) do %>
   <% if @skip_search_and_filters %>
     <%= render(settings_component) unless @skip_settings %>
   <% else %>
@@ -48,14 +48,8 @@
   <% organization = @organization %>
   <% bike_sticker = @bike_sticker %>
 
-  <div
-    data-controller="update-cached-sortable-links org--assign-bike-sticker"
-    data-update-cached-sortable-links-base-url-value="<%= url_for(@sortable_search_params.merge(organization_id: organization.to_param)) %>"
-    <% if bike_sticker.present? %>
-      data-org--assign-bike-sticker-sticker-path-value="<%= bike_sticker_path(id: bike_sticker.code, organization_id: bike_sticker.organization_id) %>"
-    <% end %>
-  >
-    <%= render(UI::Table::Component.new(records: @bikes, cache_key: "org-#{@organization.id}-bikes", render_sortable: true)) do |table| %>
+  <%= tag.div(data: table_wrapper_data_attributes) do %>
+    <%= render(UI::Table::Component.new(records: @bikes, cache_key: "org-#{@organization.id}-bikes_1", render_sortable: true)) do |table| %>
       <% table.column(label: translation(".url"), classes: "hideableColumn url_cell") do |bike| %>
         <code class="tw:p-0 tw:text-xs!" style="word-break: normal">
           <%= bike.html_url %>
@@ -222,7 +216,7 @@
         <% end %>
       <% end %>
     <% end %>
-  </div>
+  <% end %>
 
   <% if show_pagination? %>
     <div class="paginate-container paginate-container-bottom row">

--- a/app/components/org/bike_search/component.html.erb
+++ b/app/components/org/bike_search/component.html.erb
@@ -114,9 +114,7 @@
             <%= link_to "\u{1F50E}", organization_registrations_path(organization_id: organization.to_param, search_email: bike.owner_email), class: "display-sortable-link", data: {turbo_frame: "_top"} %>
           </small>
         <% else %>
-          <em class="tw:text-gray-400">
-            <%= translation(".email_hidden") %>
-          </em>
+          <em class="tw:text-gray-400"><%= translation(".email_hidden") %></em>
         <% end %>
       <% end %>
 

--- a/app/components/org/bike_search/component.html.erb
+++ b/app/components/org/bike_search/component.html.erb
@@ -192,16 +192,12 @@
       <% end %>
 
       <% if organization.enabled?("bike_stickers") %>
-        <% table.column(label: translation(".sticker"), classes: "hideableColumn sticker_cell") do |bike| %>
+        <% table.column(label: translation(".sticker"), classes: "hideableColumn sticker_cell tw:pt-0", header_classes: "tw:pt-1") do |bike| %>
           <% bike.bike_stickers.each_with_index do |bs, index| %>
             <% if bs.organization.present? && bs.organization_id == organization.id %>
-              <%= link_to bs.pretty_code, edit_organization_sticker_path(id: bs.code, organization_id: bs.organization&.to_param), class: "small", data: {turbo_frame: "_top"} %>
+              <%= link_to bs.pretty_code, edit_organization_sticker_path(id: bs.code, organization_id: bs.organization&.to_param), class: "tw:text-xs tw:block tw:mt-1", data: {turbo_frame: "_top"} %>
             <% else %>
-              <small><%= bs.pretty_code %></small>
-            <% end %>
-
-            <% if index > 0 %>
-              <br>
+              <small class="tw:text-xs tw:block tw:mt-1"><%= bs.pretty_code %></small>
             <% end %>
           <% end %>
         <% end %>

--- a/app/components/org/bike_search/component.rb
+++ b/app/components/org/bike_search/component.rb
@@ -68,8 +68,7 @@ module Org::BikeSearch
     def component_wrapper_data_attributes
       return {} if @skip_settings
       {controller: "org--registration-search org--registration-search-column-toggle",
-       "org--registration-search-column-toggle-default-columns-value": initially_checked_columns.to_json,
-       "org--registration-search-column-toggle-assign-bike-sticker-value": @bike_sticker.present?}
+       "org--registration-search-column-toggle-default-columns-value": initially_checked_columns.to_json}
     end
 
     def table_wrapper_data_attributes

--- a/app/components/org/bike_search/component.rb
+++ b/app/components/org/bike_search/component.rb
@@ -65,10 +65,21 @@ module Org::BikeSearch
       @search_query_present || @params[:search_stickers].present? || @params[:search_address].present? || @model_audit.present?
     end
 
-    def wrapper_data_attributes
+    def component_wrapper_data_attributes
       return {} if @skip_settings
       {controller: "org--registration-search org--registration-search-column-toggle",
        "org--registration-search-column-toggle-default-columns-value": initially_checked_columns.to_json}
+    end
+
+    def table_wrapper_data_attributes
+      attrs = {
+        controller: "update-cached-sortable-links org--assign-bike-sticker",
+        "update-cached-sortable-links-base-url-value": helpers.url_for(@sortable_search_params.merge(organization_id: @organization.to_param))
+      }
+      if @bike_sticker.present?
+        attrs[:"org--assign-bike-sticker-sticker-path-value"] = helpers.bike_sticker_path(id: @bike_sticker.code, organization_id: @bike_sticker.organization_id)
+      end
+      attrs
     end
 
     def show_pagination?

--- a/app/components/org/bike_search/component.rb
+++ b/app/components/org/bike_search/component.rb
@@ -68,7 +68,8 @@ module Org::BikeSearch
     def component_wrapper_data_attributes
       return {} if @skip_settings
       {controller: "org--registration-search org--registration-search-column-toggle",
-       "org--registration-search-column-toggle-default-columns-value": initially_checked_columns.to_json}
+       "org--registration-search-column-toggle-default-columns-value": initially_checked_columns.to_json,
+       "org--registration-search-column-toggle-assign-bike-sticker-value": @bike_sticker.present?}
     end
 
     def table_wrapper_data_attributes

--- a/app/components/org/bike_search/component.rb
+++ b/app/components/org/bike_search/component.rb
@@ -74,10 +74,10 @@ module Org::BikeSearch
     def table_wrapper_data_attributes
       attrs = {
         controller: "update-cached-sortable-links org--assign-bike-sticker",
-        "update-cached-sortable-links-base-url-value": helpers.url_for(@sortable_search_params.merge(organization_id: @organization.to_param))
+        "update-cached-sortable-links-base-url-value": url_for(@sortable_search_params.merge(organization_id: @organization.to_param))
       }
       if @bike_sticker.present?
-        attrs[:"org--assign-bike-sticker-sticker-path-value"] = helpers.bike_sticker_path(id: @bike_sticker.code, organization_id: @bike_sticker.organization_id)
+        attrs[:"org--assign-bike-sticker-sticker-path-value"] = bike_sticker_path(id: @bike_sticker.code, organization_id: @bike_sticker.organization_id)
       end
       attrs
     end

--- a/app/javascript/controllers/assign_bike_sticker_controller.js
+++ b/app/javascript/controllers/assign_bike_sticker_controller.js
@@ -1,0 +1,30 @@
+import { Controller } from '@hotwired/stimulus'
+
+// Connects to data-controller='assign-bike-sticker'
+// When a bike_sticker param is present, shows the assign column and wires up link hrefs
+export default class extends Controller {
+  static values = { stickerPath: String }
+
+  connect () {
+    if (!this.hasStickerPathValue || !this.stickerPathValue) return
+    this.showColumn()
+    this.updateLinks()
+  }
+
+  showColumn () {
+    this.element.querySelectorAll('.assign_bike_sticker_cell').forEach(el => {
+      el.classList.remove('tw:hidden')
+    })
+  }
+
+  updateLinks () {
+    const basePath = this.stickerPathValue
+    const separator = basePath.includes('?') ? '&' : '?'
+    this.element.querySelectorAll('.assign_bike_sticker_cell a[data-bike-id]').forEach(link => {
+      const bikeId = link.dataset.bikeId
+      link.href = `${basePath}${separator}bike_id=${bikeId}`
+      link.dataset.turboMethod = 'put'
+      link.dataset.turboFrame = '_top'
+    })
+  }
+}

--- a/app/javascript/controllers/org/assign_bike_sticker_controller.js
+++ b/app/javascript/controllers/org/assign_bike_sticker_controller.js
@@ -1,12 +1,12 @@
 import { Controller } from '@hotwired/stimulus'
 
 // Connects to data-controller='org--assign-bike-sticker'
-// When a bike_sticker param is present, shows the assign column and wires up link hrefs
+// When a bike_sticker param is present, wires up assign link hrefs
 export default class extends Controller {
   static values = { stickerPath: String }
 
   connect () {
-    if (!this.hasStickerPathValue || !this.stickerPathValue) return
+    if (!this.stickerPathValue) return
     this.updateLinks()
   }
 

--- a/app/javascript/controllers/org/assign_bike_sticker_controller.js
+++ b/app/javascript/controllers/org/assign_bike_sticker_controller.js
@@ -7,14 +7,7 @@ export default class extends Controller {
 
   connect () {
     if (!this.hasStickerPathValue || !this.stickerPathValue) return
-    this.showColumn()
     this.updateLinks()
-  }
-
-  showColumn () {
-    this.element.querySelectorAll('.assign_bike_sticker_cell').forEach(el => {
-      el.classList.remove('tw:hidden')
-    })
   }
 
   updateLinks () {

--- a/app/javascript/controllers/org/assign_bike_sticker_controller.js
+++ b/app/javascript/controllers/org/assign_bike_sticker_controller.js
@@ -1,6 +1,6 @@
 import { Controller } from '@hotwired/stimulus'
 
-// Connects to data-controller='assign-bike-sticker'
+// Connects to data-controller='org--assign-bike-sticker'
 // When a bike_sticker param is present, shows the assign column and wires up link hrefs
 export default class extends Controller {
   static values = { stickerPath: String }

--- a/app/javascript/controllers/org/registration_search_column_toggle_controller.js
+++ b/app/javascript/controllers/org/registration_search_column_toggle_controller.js
@@ -24,13 +24,15 @@ export default class extends Controller {
   }
 
   refreshEnabledColumns () {
-    this.enabledColumnsValue = [...this.element.querySelectorAll('th.hideableColumn')].map(th =>
+    const columns = [...this.element.querySelectorAll('th.hideableColumn')].map(th =>
       [...th.classList].find(c => c.endsWith('_cell'))
     ).filter(Boolean)
 
     if (this.assignBikeStickerValue) {
-      this.enabledColumnsValue.push('assign_bike_sticker_cell')
+      columns.push('assign_bike_sticker_cell')
     }
+
+    this.enabledColumnsValue = columns
   }
 
   columnToggled () {

--- a/app/javascript/controllers/org/registration_search_column_toggle_controller.js
+++ b/app/javascript/controllers/org/registration_search_column_toggle_controller.js
@@ -70,7 +70,6 @@ export default class extends Controller {
     // When initially rendering, or if none selected, return early
     if (!firstVisible) return
     const lastVisible = [...this.enabledColumnsValue].reverse().find(col => checked.includes(col))
-    console.log(firstVisible)
 
     const borderClasses = {
       th: { first: 'tw:ui-table-bordered-th-first', last: 'tw:ui-table-bordered-th-last' },
@@ -80,7 +79,10 @@ export default class extends Controller {
     this.enabledColumnsValue.forEach(col => {
       const isVisible = checked.includes(col)
       this.element.querySelectorAll(`.${col}`).forEach(el => {
-        el.classList.toggle('tw:hidden', !isVisible)
+        // assign_bike_sticker_cell visibility is managed by the assign-bike-sticker controller
+        if (col !== 'assign_bike_sticker_cell') {
+          el.classList.toggle('tw:hidden', !isVisible)
+        }
         const tag = el.tagName === 'TH' ? 'th' : 'td'
         el.classList.toggle(borderClasses[tag].first, col === firstVisible)
         el.classList.toggle(borderClasses[tag].last, col === lastVisible)

--- a/app/javascript/controllers/org/registration_search_column_toggle_controller.js
+++ b/app/javascript/controllers/org/registration_search_column_toggle_controller.js
@@ -7,6 +7,15 @@ export default class extends Controller {
   static targets = ['checkboxes']
   static values = { enabledColumns: Array, defaultColumns: Array }
 
+  // Columns whose visibility is managed by other controllers (not checkboxes)
+  get externalColumns () {
+    const columns = []
+    if (this.element.querySelector('[data-org--assign-bike-sticker-sticker-path-value]')) {
+      columns.push('assign_bike_sticker_cell')
+    }
+    return columns
+  }
+
   connect () {
     this.refreshEnabledColumns()
     this.selectStoredVisibleColumns()
@@ -28,12 +37,7 @@ export default class extends Controller {
       [...th.classList].find(c => c.endsWith('_cell'))
     ).filter(Boolean)
 
-    const stickerEl = this.element.querySelector('[data-org--assign-bike-sticker-sticker-path-value]')
-    if (stickerEl) {
-      columns.push('assign_bike_sticker_cell')
-    }
-
-    this.enabledColumnsValue = columns
+    this.enabledColumnsValue = columns.concat(this.externalColumns)
   }
 
   columnToggled () {
@@ -60,11 +64,12 @@ export default class extends Controller {
     })
     localStorage.setItem('orgRegistrationColumns', JSON.stringify(checked))
 
-    // assign_bike_sticker_cell visibility is managed by the assign-bike-sticker controller
-    const stickerTh = this.element.querySelector('th.assign_bike_sticker_cell')
-    if (stickerTh && !stickerTh.classList.contains('tw:hidden')) {
-      checked.push('assign_bike_sticker_cell')
-    }
+    // External columns are visible when their th is visible (managed elsewhere)
+    const external = this.externalColumns
+    external.forEach(col => {
+      const th = this.element.querySelector(`th.${col}`)
+      if (th && !th.classList.contains('tw:hidden')) checked.push(col)
+    })
 
     const firstVisible = this.enabledColumnsValue.find(col => checked.includes(col))
     // When initially rendering, or if none selected, return early
@@ -79,8 +84,7 @@ export default class extends Controller {
     this.enabledColumnsValue.forEach(col => {
       const isVisible = checked.includes(col)
       this.element.querySelectorAll(`.${col}`).forEach(el => {
-        // assign_bike_sticker_cell visibility is managed by the assign-bike-sticker controller
-        if (col !== 'assign_bike_sticker_cell') {
+        if (!external.includes(col)) {
           el.classList.toggle('tw:hidden', !isVisible)
         }
         const tag = el.tagName === 'TH' ? 'th' : 'td'

--- a/app/javascript/controllers/org/registration_search_column_toggle_controller.js
+++ b/app/javascript/controllers/org/registration_search_column_toggle_controller.js
@@ -5,16 +5,7 @@ import { Controller } from '@hotwired/stimulus'
 // Connects to data-controller='org--registration-search-column-toggle'
 export default class extends Controller {
   static targets = ['checkboxes']
-  static values = { enabledColumns: Array, defaultColumns: Array }
-
-  // Columns whose visibility is managed by other controllers (not checkboxes)
-  get externalColumns () {
-    const columns = []
-    if (this.element.querySelector('[data-org--assign-bike-sticker-sticker-path-value]')) {
-      columns.push('assign_bike_sticker_cell')
-    }
-    return columns
-  }
+  static values = { enabledColumns: Array, defaultColumns: Array, assignBikeSticker: Boolean }
 
   connect () {
     this.refreshEnabledColumns()
@@ -33,11 +24,13 @@ export default class extends Controller {
   }
 
   refreshEnabledColumns () {
-    const columns = [...this.element.querySelectorAll('th.hideableColumn')].map(th =>
+    this.enabledColumnsValue = [...this.element.querySelectorAll('th.hideableColumn')].map(th =>
       [...th.classList].find(c => c.endsWith('_cell'))
     ).filter(Boolean)
 
-    this.enabledColumnsValue = columns.concat(this.externalColumns)
+    if (this.assignBikeStickerValue) {
+      this.enabledColumnsValue.push('assign_bike_sticker_cell')
+    }
   }
 
   columnToggled () {
@@ -64,12 +57,9 @@ export default class extends Controller {
     })
     localStorage.setItem('orgRegistrationColumns', JSON.stringify(checked))
 
-    // External columns are visible when their th is visible (managed elsewhere)
-    const external = this.externalColumns
-    external.forEach(col => {
-      const th = this.element.querySelector(`th.${col}`)
-      if (th && !th.classList.contains('tw:hidden')) checked.push(col)
-    })
+    if (this.assignBikeStickerValue) {
+      checked.push('assign_bike_sticker_cell')
+    }
 
     const firstVisible = this.enabledColumnsValue.find(col => checked.includes(col))
     // When initially rendering, or if none selected, return early
@@ -84,9 +74,7 @@ export default class extends Controller {
     this.enabledColumnsValue.forEach(col => {
       const isVisible = checked.includes(col)
       this.element.querySelectorAll(`.${col}`).forEach(el => {
-        if (!external.includes(col)) {
-          el.classList.toggle('tw:hidden', !isVisible)
-        }
+        el.classList.toggle('tw:hidden', !isVisible)
         const tag = el.tagName === 'TH' ? 'th' : 'td'
         el.classList.toggle(borderClasses[tag].first, col === firstVisible)
         el.classList.toggle(borderClasses[tag].last, col === lastVisible)

--- a/app/javascript/controllers/org/registration_search_column_toggle_controller.js
+++ b/app/javascript/controllers/org/registration_search_column_toggle_controller.js
@@ -24,9 +24,16 @@ export default class extends Controller {
   }
 
   refreshEnabledColumns () {
-    this.enabledColumnsValue = [...this.element.querySelectorAll('th.hideableColumn')].map(th =>
+    const columns = [...this.element.querySelectorAll('th.hideableColumn')].map(th =>
       [...th.classList].find(c => c.endsWith('_cell'))
     ).filter(Boolean)
+
+    const stickerEl = this.element.querySelector('[data-org--assign-bike-sticker-sticker-path-value]')
+    if (stickerEl) {
+      columns.push('assign_bike_sticker_cell')
+    }
+
+    this.enabledColumnsValue = columns
   }
 
   columnToggled () {
@@ -54,7 +61,10 @@ export default class extends Controller {
     localStorage.setItem('orgRegistrationColumns', JSON.stringify(checked))
 
     const firstVisible = this.enabledColumnsValue.find(col => checked.includes(col))
+    // When initially rendering, or if none selected, return early
+    if (!firstVisible) return;
     const lastVisible = [...this.enabledColumnsValue].reverse().find(col => checked.includes(col))
+    console.log(firstVisible)
 
     const borderClasses = {
       th: { first: 'tw:ui-table-bordered-th-first', last: 'tw:ui-table-bordered-th-last' },

--- a/app/javascript/controllers/org/registration_search_column_toggle_controller.js
+++ b/app/javascript/controllers/org/registration_search_column_toggle_controller.js
@@ -60,9 +60,15 @@ export default class extends Controller {
     })
     localStorage.setItem('orgRegistrationColumns', JSON.stringify(checked))
 
+    // assign_bike_sticker_cell visibility is managed by the assign-bike-sticker controller
+    const stickerTh = this.element.querySelector('th.assign_bike_sticker_cell')
+    if (stickerTh && !stickerTh.classList.contains('tw:hidden')) {
+      checked.push('assign_bike_sticker_cell')
+    }
+
     const firstVisible = this.enabledColumnsValue.find(col => checked.includes(col))
     // When initially rendering, or if none selected, return early
-    if (!firstVisible) return;
+    if (!firstVisible) return
     const lastVisible = [...this.enabledColumnsValue].reverse().find(col => checked.includes(col))
     console.log(firstVisible)
 

--- a/app/javascript/controllers/org/registration_search_column_toggle_controller.js
+++ b/app/javascript/controllers/org/registration_search_column_toggle_controller.js
@@ -24,6 +24,9 @@ export default class extends Controller {
   }
 
   refreshEnabledColumns () {
+    // Stimulus Array values return a fresh copy on each read, so mutating
+    // via push won't persist (and assign_bike_sticker_cell is ignored)
+    // build the full array, then assign it once.
     const columns = [...this.element.querySelectorAll('th.hideableColumn')].map(th =>
       [...th.classList].find(c => c.endsWith('_cell'))
     ).filter(Boolean)

--- a/app/views/organized/registrations/search.html.erb
+++ b/app/views/organized/registrations/search.html.erb
@@ -25,6 +25,7 @@
   class="org-bikes-search-component"
   data-controller="org--registration-search org--registration-search-column-toggle"
   data-org--registration-search-column-toggle-default-columns-value="<%= bike_search_settings.initially_checked_columns.to_json %>"
+  data-org--registration-search-column-toggle-assign-bike-sticker-value="<%= @bike_sticker.present? %>"
 >
   <div class="mb-4">
     <%= render(Search::FormOrganized::Component.new(

--- a/config/locales/.translation_io
+++ b/config/locales/.translation_io
@@ -1,2 +1,2 @@
 ---
-timestamp: 1775620841
+timestamp: 1775937890

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -4524,7 +4524,7 @@ en:
         is_currently_linked: is currently linked.
         isnt_linked_to_a_bike: isn't linked to a bike.
         search_org_bikes_html: >-
-          Or, search %{org_name}'s bikes, view the bike and click <em>link it</em>
+          Or, search %{org_name}'s bikes, view the bike and click <em>link sticker</em>
           to connect it to this %{bike_sticker_kind}
         update: Update
     bulk_imports:

--- a/config/locales/translation.es.yml
+++ b/config/locales/translation.es.yml
@@ -4751,6 +4751,7 @@ es:
         impound_id:
         assign_bike_sticker:
         email_hidden:
+        link_sticker:
       bike_search_settings:
         address:
         all:

--- a/config/locales/translation.it.yml
+++ b/config/locales/translation.it.yml
@@ -4833,6 +4833,7 @@ it:
         impound_id:
         assign_bike_sticker: Collegamento
         email_hidden:
+        link_sticker:
       bike_search_settings:
         address:
         all: Tutti

--- a/config/locales/translation.nb.yml
+++ b/config/locales/translation.nb.yml
@@ -6004,6 +6004,7 @@ nb:
         impound_id: Beslags-ID
         assign_bike_sticker: Link
         email_hidden: e-post skjult
+        link_sticker: lenkeklistremerke
       bike_search_settings:
         address: 'Adresse:'
         all: Alle

--- a/config/locales/translation.nl.yml
+++ b/config/locales/translation.nl.yml
@@ -6163,6 +6163,7 @@ nl:
         impound_id: Inbeslagname-ID
         assign_bike_sticker: Link
         email_hidden: email verborgen
+        link_sticker: link sticker
       bike_search_settings:
         address: 'Adres:'
         all: Alle

--- a/spec/integration/organized/registrations_search_spec.rb
+++ b/spec/integration/organized/registrations_search_spec.rb
@@ -284,7 +284,7 @@ RSpec.describe "Organized registrations search", :js, type: :system do
       visit "#{bikes_path}?bike_sticker=#{unlinked_sticker.code}"
       expect(page).to have_css("table", wait: 10)
       expect(page).to have_css("th.assign_bike_sticker_cell")
-      expect(page).to have_css("td.assign_bike_sticker_cell a", text: "Link", minimum: 1)
+      expect(page).to have_css("td.assign_bike_sticker_cell a", text: "link sticker", minimum: 1)
 
       # Click the first "Link" to assign the sticker to a bike
       first("td.assign_bike_sticker_cell a").click


### PR DESCRIPTION
The `assign_bike_sticker` column in organized registration search was marked `uncached: true` because its link URL depends on the `bike_sticker` URL param, which broke table fragment caching. This replaces it with a cached column (hidden by default via `tw:hidden`) and a new `assign-bike-sticker` Stimulus controller.