### PR TITLE
Handle missing ImpoundRecord in ProcessImpoundUpdatesJob

### DIFF
--- a/app/jobs/process_impound_updates_job.rb
+++ b/app/jobs/process_impound_updates_job.rb
@@ -2,7 +2,8 @@ class ProcessImpoundUpdatesJob < ApplicationJob
   sidekiq_options queue: "high_priority"
 
   def perform(impound_record_id)
-    impound_record = ImpoundRecord.find(impound_record_id)
+    impound_record = ImpoundRecord.find_by(id: impound_record_id)
+    return if impound_record.blank?
 
     update_display_ids(impound_record) if impound_record.organized?
     claim_retrieved = nil

--- a/spec/jobs/process_impound_updates_job_spec.rb
+++ b/spec/jobs/process_impound_updates_job_spec.rb
@@ -8,6 +8,12 @@ RSpec.describe ProcessImpoundUpdatesJob, type: :job do
   let(:impound_record_update) { FactoryBot.build(:impound_record_update, impound_record: impound_record, processed: false, kind: kind) }
   let(:kind) { "note" }
 
+  context "when impound_record not found" do
+    it "returns without error" do
+      expect { instance.perform(999999) }.not_to raise_error
+    end
+  end
+
   it "resolves the impound_record_update" do
     impound_record.reload
     # The factory force updates bike, so force un-update


### PR DESCRIPTION
ProcessImpoundUpdatesJob raises `ActiveRecord::RecordNotFound` and retries indefinitely when an ImpoundRecord has been deleted. This switches from `find` to `find_by` with an early return so the job completes silently when the record no longer exists.