### PR TITLE
Remove uncached column support from UI::Table

### DIFF
--- a/app/components/ui/table/component.html.erb
+++ b/app/components/ui/table/component.html.erb
@@ -12,15 +12,15 @@
 
     <tbody>
       <% @records.each do |record| %>
-        <tr>
-          <% cache_if(@cache_key, [@cache_key, record]) do %>
+        <% cache_if(@cache_key, [@cache_key, record]) do %>
+          <tr>
             <% @columns.each do |col| %>
               <td class="<%= col.td_classes(bordered: @bordered) %>">
                 <%= col.render_cell(record) { |r| capture { instance_exec(r, &col.cell_block) } } %>
               </td>
             <% end %>
-          <% end %>
-        </tr>
+          </tr>
+        <% end %>
       <% end %>
     </tbody>
   </table>

--- a/app/components/ui/table/component.html.erb
+++ b/app/components/ui/table/component.html.erb
@@ -15,18 +15,10 @@
         <tr>
           <% cache_if(@cache_key, [@cache_key, record]) do %>
             <% @columns.each do |col| %>
-              <% next if col.uncached %>
-
               <td class="<%= col.td_classes(bordered: @bordered) %>">
                 <%= col.render_cell(record) { |r| capture { instance_exec(r, &col.cell_block) } } %>
               </td>
             <% end %>
-          <% end %>
-
-          <% uncached_columns.each do |col| %>
-            <td class="<%= col.td_classes(bordered: @bordered) %>">
-              <%= col.render_cell(record) { |r| capture { instance_exec(r, &col.cell_block) } } %>
-            </td>
           <% end %>
         </tr>
       <% end %>

--- a/app/components/ui/table/component.html.erb
+++ b/app/components/ui/table/component.html.erb
@@ -11,7 +11,7 @@
     </thead>
 
     <tbody>
-      <% @records.each_with_index do |record, row_index| %>
+      <% @records.each do |record| %>
         <tr>
           <% cache_if(@cache_key, [@cache_key, record]) do %>
             <% @columns.each do |col| %>

--- a/app/components/ui/table/component.rb
+++ b/app/components/ui/table/component.rb
@@ -17,14 +17,13 @@ module UI
         @columns = []
       end
 
-      def column(label: nil, sortable: nil, sort_indicator: nil, classes: nil, header_classes: nil, lower_right: nil, uncached: false, &block)
-        @columns << UI::TableColumn::Component.new(label:, sortable:, sort_indicator:, classes:, header_classes:, lower_right:, uncached:, &block)
+      def column(label: nil, sortable: nil, sort_indicator: nil, classes: nil, header_classes: nil, lower_right: nil, &block)
+        @columns << UI::TableColumn::Component.new(label:, sortable:, sort_indicator:, classes:, header_classes:, lower_right:, &block)
         nil
       end
 
       def before_render
         content
-        validate_uncached_columns_are_last!
       end
 
       private
@@ -49,18 +48,6 @@ module UI
 
       def sortable_columns
         @columns.filter_map(&:sortable)
-      end
-
-      def uncached_columns
-        @uncached_columns ||= @columns.select(&:uncached)
-      end
-
-      def validate_uncached_columns_are_last!
-        return if uncached_columns.empty?
-        first_uncached = @columns.index(&:uncached)
-        return if @columns[first_uncached..].all?(&:uncached)
-        raise ArgumentError, "UI::Table uncached columns must be defined after all cached columns. " \
-          "Move uncached columns to the end of the column list so header and body cells align."
       end
 
       def table_classes

--- a/app/components/ui/table/component_preview.rb
+++ b/app/components/ui/table/component_preview.rb
@@ -18,8 +18,7 @@ module UI
         end
       end
 
-      # Cached columns freeze after first render; the uncached "Rendered at" column updates on each reload.
-      def sortable_with_cached_and_uncached_columns
+      def sortable_with_cache
         colors = enthusiasm_colors
         render(UI::Table::Component.new(records: sample_records, cache_key: "preview-cryptids", sort: "name", sort_direction: "desc", render_sortable: true)) do |table|
           table.column(sortable: "name") { |r| r.name }
@@ -27,8 +26,7 @@ module UI
           table.column(label: "Credibility", header_classes: "tw:font-normal") { |r| render(UI::Badge::Component.new(text: r.credibility, color: (r.credibility == "Confirmed") ? :success : :gray, size: :sm)) }
           table.column(label: "Enthusiasm", header_classes: "tw:font-normal") { |r| render(UI::Badge::Component.new(text: r.enthusiasm, color: colors[r.enthusiasm], size: :sm)) }
           table.column(sortable: "sightings") { |r| number_with_delimiter(r.sightings) }
-          table.column(label: "Cached at", header_classes: "tw:font-normal") { |_r| tag.small(l(::Time.current, format: :convert_time), class: "localizeTime preciseTimeSeconds") }
-          table.column(label: "Rendered at", uncached: true) { |_r| tag.small(l(::Time.current, format: :convert_time), class: "localizeTime preciseTimeSeconds") }
+          table.column(label: "Rendered at", header_classes: "tw:font-normal") { |_r| tag.small(l(::Time.current, format: :convert_time), class: "localizeTime preciseTimeSeconds") }
         end
       end
 

--- a/app/components/ui/table_column/component.rb
+++ b/app/components/ui/table_column/component.rb
@@ -9,16 +9,15 @@ module UI
       ARROW_DOWN = "\u2193"
       NBSP = "\u00A0"
 
-      attr_reader :sortable, :cell_block, :uncached
+      attr_reader :sortable, :cell_block
 
-      def initialize(label: nil, sortable: nil, sort_indicator: nil, classes: nil, header_classes: nil, lower_right: nil, uncached: false, &block)
+      def initialize(label: nil, sortable: nil, sort_indicator: nil, classes: nil, header_classes: nil, lower_right: nil, &block)
         @label = label
         @sortable = sortable
         @sort_indicator = sort_indicator
         @classes = classes
         @header_classes = header_classes
         @lower_right = lower_right
-        @uncached = uncached
         @cell_block = block
       end
 

--- a/app/components/ui/table_column/component.rb
+++ b/app/components/ui/table_column/component.rb
@@ -2,8 +2,6 @@
 
 module UI
   module TableColumn
-    # ViewComponent representing a single table column. The table renders this
-    # component once per cell via `render(col.for_record(record))`.
     class Component < ApplicationComponent
       ARROW_UP = "\u2191"
       ARROW_DOWN = "\u2193"

--- a/spec/components/ui/table/component_spec.rb
+++ b/spec/components/ui/table/component_spec.rb
@@ -187,51 +187,6 @@ RSpec.describe UI::Table::Component, type: :component do
       end
     end
 
-    it "renders uncached columns outside the cache block" do
-      user = FactoryBot.create(:user)
-      original_name = user.name
-      call_count = 0
-
-      with_controller_class(ApplicationController) do
-        # First render: populates cache
-        render_inline(described_class.new(records: [user], cache_key: "uncached-test")) do |table|
-          table.column(label: "Name") { |u| u.name }
-          table.column(label: "Dynamic", uncached: true) { |_u|
-            call_count += 1
-            "render-#{call_count}"
-          }
-        end
-
-        # Update name without changing updated_at so the cache key stays the same
-        user.update_column(:name, "Updated Name")
-        user.reload
-
-        result = render_inline(described_class.new(records: [user], cache_key: "uncached-test")) do |table|
-          table.column(label: "Name") { |u| u.name }
-          table.column(label: "Dynamic", uncached: true) { |_u|
-            call_count += 1
-            "render-#{call_count}"
-          }
-        end
-
-        # Cached column still shows original name (stale)
-        expect(result).to have_css("td", text: original_name)
-        expect(result).not_to have_css("td", text: "Updated Name")
-        # Uncached column was re-evaluated
-        expect(result).to have_css("td", text: "render-2")
-      end
-    end
-
-    it "raises when uncached columns are not last" do
-      expect {
-        render_inline(described_class.new(records: records)) do |table|
-          table.column(label: "Name") { |r| r.name }
-          table.column(label: "Action", uncached: true) { |_r| "action" }
-          table.column(label: "Email") { |r| r.email }
-        end
-      }.to raise_error(ArgumentError, /uncached columns must be defined after all cached columns/)
-    end
-
     it "namespaces cache keys with a string" do
       users = FactoryBot.create_list(:user, 1)
 

--- a/spec/components/ui/table/component_system_spec.rb
+++ b/spec/components/ui/table/component_system_spec.rb
@@ -3,8 +3,8 @@
 require "rails_helper"
 
 RSpec.describe UI::Table::Component, :js, type: :system do
-  it "sortable_with_cached_and_uncached_columns is axe clean" do
-    visit("/rails/view_components/ui/table/component/sortable_with_cached_and_uncached_columns")
+  it "sortable_with_cache is axe clean" do
+    visit("/rails/view_components/ui/table/component/sortable_with_cache")
 
     expect(page).to have_css("table")
     expect(page).to be_axe_clean.skipping(*SKIPPABLE_AXE_RULES)


### PR DESCRIPTION
Remove the `uncached` option from `UI::Table` and `UI::TableColumn` components. All columns now render inside the cache block. This removes the `uncached_columns` helper, the `validate_uncached_columns_are_last!` validation, and the corresponding specs and preview.
