### PR TITLE
Fix TypeError in admin organizations cache helper

### DIFF
--- a/app/views/admin/organizations/_table.html.haml
+++ b/app/views/admin/organizations/_table.html.haml
@@ -26,7 +26,7 @@
         Locations
     %tbody
       - @organizations.each do |organization|
-        - cache(organization, "v1") do
+        - cache([organization, "v1"]) do
           %tr
             %td
               = link_to organization.name, admin_organization_url(organization)


### PR DESCRIPTION
Fix `TypeError: no implicit conversion of Symbol into Integer` on the admin dashboard, from invalid cache key added in #3392