### PR TITLE
Component preview cleanup and Form::Group radio button support

### DIFF
--- a/app/components/admin/address_record_cell/component_preview.rb
+++ b/app/components/admin/address_record_cell/component_preview.rb
@@ -2,7 +2,7 @@
 
 module Admin::AddressRecordCell
   class ComponentPreview < ApplicationComponentPreview
-    # @group Address Variants
+    # @!group Address Variants
 
     def with_us_state
       address_record = AddressRecord.new(

--- a/app/components/admin/badges/bike_hidden_explanation/component_preview.rb
+++ b/app/components/admin/badges/bike_hidden_explanation/component_preview.rb
@@ -2,7 +2,7 @@
 
 module Admin::Badges::BikeHiddenExplanation
   class ComponentPreview < ApplicationComponentPreview
-    # @group Hidden Variants
+    # @!group Hidden Variants
     def user_hidden
       render(Admin::Badges::BikeHiddenExplanation::Component.new(bike: Bike.with_user_hidden.where(user_hidden: true).last))
     end

--- a/app/components/admin/badges/user/component_preview.rb
+++ b/app/components/admin/badges/user/component_preview.rb
@@ -2,7 +2,7 @@
 
 module Admin::Badges::User
   class ComponentPreview < ApplicationComponentPreview
-    # @group User Badge Variants
+    # @!group User Badge Variants
     def default
       render(Admin::Badges::User::Component.new(user: lookbook_user))
     end

--- a/app/components/admin/bike_cell/component_preview.rb
+++ b/app/components/admin/bike_cell/component_preview.rb
@@ -2,7 +2,7 @@
 
 module Admin::BikeCell
   class ComponentPreview < ApplicationComponentPreview
-    # @group Bike Variants
+    # @!group Bike Variants
     def with_bike
       render(Admin::BikeCell::Component.new(bike:))
     end

--- a/app/components/admin/current_header/component_preview.rb
+++ b/app/components/admin/current_header/component_preview.rb
@@ -2,7 +2,7 @@
 
 module Admin::CurrentHeader
   class ComponentPreview < ApplicationComponentPreview
-    # @group Header Variants
+    # @!group Header Variants
 
     def default
       render(Admin::CurrentHeader::Component.new(params: passed_params))

--- a/app/components/admin/organization_cell/component_preview.rb
+++ b/app/components/admin/organization_cell/component_preview.rb
@@ -2,7 +2,7 @@
 
 module Admin::OrganizationCell
   class ComponentPreview < ApplicationComponentPreview
-    # @group Organization Variants
+    # @!group Organization Variants
 
     def with_organization
       render(Admin::OrganizationCell::Component.new(organization:))

--- a/app/components/admin/pagination_with_count/component_preview.rb
+++ b/app/components/admin/pagination_with_count/component_preview.rb
@@ -2,7 +2,7 @@
 
 module Admin::PaginationWithCount
   class ComponentPreview < ApplicationComponentPreview
-    # @group PaginationWithCount Variants
+    # @!group PaginationWithCount Variants
     def default
       pagy = Pagy::Offset.new(count: 100, page: 1, limit: 25)
       render(Admin::PaginationWithCount::Component.new(

--- a/app/components/admin/strava_rate_limit/component_preview.rb
+++ b/app/components/admin/strava_rate_limit/component_preview.rb
@@ -2,7 +2,7 @@
 
 module Admin::StravaRateLimit
   class ComponentPreview < ApplicationComponentPreview
-    # @group amount Variants
+    # @!group amount Variants
     def high_rate_limit
       render(Admin::StravaRateLimit::Component.new(rate_limit_json: high_rate_limit_json))
     end

--- a/app/components/admin/user_cell/component_preview.rb
+++ b/app/components/admin/user_cell/component_preview.rb
@@ -2,7 +2,7 @@
 
 module Admin::UserCell
   class ComponentPreview < ApplicationComponentPreview
-    # @group User Cell Variants
+    # @!group User Cell Variants
     def default
       render(Admin::UserCell::Component.new(user: lookbook_user))
     end

--- a/app/components/form/group/component.html.erb
+++ b/app/components/form/group/component.html.erb
@@ -1,5 +1,6 @@
 <div class="tw:mb-4">
   <%= @form_builder.label @attribute, @label_text, class: "twlabel" %>
+
   <% if radio_button_group? %>
     <%= render(Form::RadioButtonGroup::Component.new(name: @attribute, entries: @entries, selected: @selected)) %>
   <% else %>

--- a/app/components/form/group/component.html.erb
+++ b/app/components/form/group/component.html.erb
@@ -1,4 +1,8 @@
 <div class="tw:mb-4">
   <%= @form_builder.label @attribute, @label_text, class: "twlabel" %>
-  <%= render(Form::Input::Component.new(form_builder: @form_builder, attribute: @attribute, kind: @kind, html_options: @html_options)) %>
+  <% if radio_button_group? %>
+    <%= render(Form::RadioButtonGroup::Component.new(name: @attribute, entries: @entries, selected: @selected)) %>
+  <% else %>
+    <%= render(Form::Input::Component.new(form_builder: @form_builder, attribute: @attribute, kind: @kind, html_options: @html_options)) %>
+  <% end %>
 </div>

--- a/app/components/form/group/component.rb
+++ b/app/components/form/group/component.rb
@@ -3,12 +3,18 @@
 module Form
   module Group
     class Component < ApplicationComponent
-      def initialize(form_builder:, attribute:, kind: :text_field, label_text: nil, html_options: {})
+      def initialize(form_builder:, attribute:, kind: :text_field, label_text: nil, html_options: {}, entries: [], selected: nil)
         @form_builder = form_builder
         @attribute = attribute
         @kind = kind
         @label_text = label_text || attribute.to_s.humanize
         @html_options = html_options
+        @entries = entries
+        @selected = selected
+      end
+
+      def radio_button_group?
+        @kind.to_sym == :radio_button_group
       end
     end
   end

--- a/app/components/form/group/component_preview.rb
+++ b/app/components/form/group/component_preview.rb
@@ -19,6 +19,10 @@ module Form
       def custom_label
         {template: "form/group/component_preview/custom_label"}
       end
+
+      def radio_button_group
+        {template: "form/group/component_preview/radio_button_group"}
+      end
       # @!endgroup
     end
   end

--- a/app/components/form/group/component_preview/radio_button_group.html.erb
+++ b/app/components/form/group/component_preview/radio_button_group.html.erb
@@ -1,0 +1,13 @@
+<%= form_with(url: "#", builder: BikeIndexFormBuilder) do |f| %>
+  <%= render(Form::Group::Component.new(
+    form_builder: f,
+    attribute: :status,
+    kind: :radio_button_group,
+    entries: [
+      {value: "", label: "All"},
+      {value: "active", label: "Active"},
+      {value: "inactive", label: "Inactive"}
+    ],
+    selected: "active"
+  )) %>
+<% end %>

--- a/app/components/member_badge/component_preview.rb
+++ b/app/components/member_badge/component_preview.rb
@@ -2,7 +2,7 @@
 
 module MemberBadge
   class ComponentPreview < ApplicationComponentPreview
-    # @group Level Variants
+    # @!group Level Variants
     # @param level "The membership level"
     def none(level: nil)
       render(MemberBadge::Component.new(level:, classes: "tw:max-w-xs"))

--- a/app/components/page_block/strava_integration/component.html.erb
+++ b/app/components/page_block/strava_integration/component.html.erb
@@ -46,13 +46,13 @@
       <p><%= translation(".sync_error_description") %></p>
     <% end %>
     <%= link_to translation(".disconnect_strava"),
-        helpers.strava_integration_path,
+        strava_integration_path,
         method: :delete,
         class: "btn btn-sm btn-outline-danger tw:mt-4",
         data: { confirm: translation(".disconnect_confirm") } %>
   <% else %>
     <p><%= translation(".integrate_your_bikes_with_strava") %></p>
-    <%= link_to helpers.new_strava_integration_path do %>
+    <%= link_to new_strava_integration_path do %>
       <%= helpers.image_tag("logos/btn_strava_connect.svg", alt: translation(".connect_with_strava"), style: "height: 32px; width: auto;") %>
     <% end %>
   <% end %>

--- a/app/components/page_block/strava_integration/component_preview.rb
+++ b/app/components/page_block/strava_integration/component_preview.rb
@@ -2,7 +2,7 @@
 
 module PageBlock::StravaIntegration
   class ComponentPreview < ApplicationComponentPreview
-    # @group Status Variants
+    # @!group Status Variants
     # @display legacy_stylesheet true
     def not_connected
       render(Component.new(user: built_user))

--- a/app/components/search/kind_select_fields/component_preview.rb
+++ b/app/components/search/kind_select_fields/component_preview.rb
@@ -2,7 +2,7 @@
 
 module Search::KindSelectFields
   class ComponentPreview < ApplicationComponentPreview
-    # @group Kind scopes
+    # @!group Kind scopes
     def default
       render(Search::KindSelectFields::Component.new(kind_scope: "stolen"))
     end

--- a/app/components/ui/address_display/component_preview.rb
+++ b/app/components/ui/address_display/component_preview.rb
@@ -2,7 +2,7 @@
 
 module UI::AddressDisplay
   class ComponentPreview < ApplicationComponentPreview
-    # @group Address Variants
+    # @!group Address Variants
 
     def with_address_record
       render(UI::AddressDisplay::Component.new(address_record:, visible_attribute: :street))

--- a/app/components/ui/card/component_preview.rb
+++ b/app/components/ui/card/component_preview.rb
@@ -2,7 +2,7 @@
 
 module UI::Card
   class ComponentPreview < ApplicationComponentPreview
-    # @group Kind Variants
+    # @!group Kind Variants
     def default
       render(UI::Card::Component.new) do
         "Man braid sustainable solarpunk vexillologist grailed marxism schlitz big mood shabby chic cornhole yuccie PBR&B vegan."

--- a/app/components/ui/pagination/component_preview.rb
+++ b/app/components/ui/pagination/component_preview.rb
@@ -3,7 +3,7 @@
 module UI
   module Pagination
     class ComponentPreview < ApplicationComponentPreview
-      # @group Pagination Variants
+      # @!group Pagination Variants
       # @param page "The page of pagination"
       def first_page(page: 1)
         pagy_a = pagy_arg(default_opts.merge(page:))

--- a/spec/components/form/group/component_spec.rb
+++ b/spec/components/form/group/component_spec.rb
@@ -43,4 +43,17 @@ RSpec.describe Form::Group::Component, type: :component do
       expect(component).to have_css("textarea")
     end
   end
+
+  context "when radio_button_group" do
+    let(:attribute) { :status }
+    let(:kind) { :radio_button_group }
+    let(:entries) { [{value: "", label: "All"}, {value: "active", label: "Active"}] }
+    let(:component) { render_inline(described_class.new(form_builder:, attribute:, kind:, label_text:, entries:, selected: "active")) }
+
+    it "renders label and radio button group" do
+      expect(component).to have_css("label", text: "Status")
+      expect(component).to have_css("input[type='radio'][value='']")
+      expect(component).to have_css("input[type='radio'][value='active'][checked]")
+    end
+  end
 end


### PR DESCRIPTION
- Fix preview annotations to use `@!group` (correct Lookbook syntax) instead of `@group` across all 15 preview files
- Add `radio_button_group` kind to `Form::Group` component, with preview and spec
- Remove unnecessary `helpers.` prefix from path helpers in strava integration component
