### PR TITLE
Add contact name field to demo request modals

### DIFF
--- a/app/components/page_block/landing_for_law_enforcement/component.html.erb
+++ b/app/components/page_block/landing_for_law_enforcement/component.html.erb
@@ -298,6 +298,7 @@
   <%= render(UI::Modal::Component.new(title: "Contact us for a free trial", id: "law-enforcement-demo-modal")) do |modal| %>
     <% modal.with_body do %>
       <%= form_for @feedback do |f| %>
+        <%= render(Form::Group::Component.new(form_builder: f, attribute: :contact_name, label_text: "Name")) %>
         <%= render(Form::Group::Component.new(form_builder: f, attribute: :name, label_text: "City", html_options: {required: true})) %>
         <%= render(Form::Group::Component.new(form_builder: f, attribute: :phone_number)) %>
         <%= render(Form::Group::Component.new(form_builder: f, attribute: :email, kind: :email_field, html_options: {required: true, value: @current_user&.email})) %>

--- a/app/components/page_block/landing_for_law_enforcement/component.html.erb
+++ b/app/components/page_block/landing_for_law_enforcement/component.html.erb
@@ -298,10 +298,10 @@
   <%= render(UI::Modal::Component.new(title: "Contact us for a free trial", id: "law-enforcement-demo-modal")) do |modal| %>
     <% modal.with_body do %>
       <%= form_for @feedback do |f| %>
-        <%= render(Form::Group::Component.new(form_builder: f, attribute: :contact_name, label_text: "Name")) %>
         <%= render(Form::Group::Component.new(form_builder: f, attribute: :name, label_text: "City", html_options: {required: true})) %>
-        <%= render(Form::Group::Component.new(form_builder: f, attribute: :phone_number)) %>
+        <%= render(Form::Group::Component.new(form_builder: f, attribute: :contact_name, label_text: "Name")) %>
         <%= render(Form::Group::Component.new(form_builder: f, attribute: :email, kind: :email_field, html_options: {required: true, value: @current_user&.email})) %>
+        <%= render(Form::Group::Component.new(form_builder: f, attribute: :phone_number)) %>
 
         <div class="tw:hidden">
           <%= render(Form::Group::Component.new(form_builder: f, attribute: :additional, kind: :text_area, label_text: "Additional information")) %>

--- a/app/components/page_block/landing_for_schools/component.html.erb
+++ b/app/components/page_block/landing_for_schools/component.html.erb
@@ -290,6 +290,7 @@
   <%= render(UI::Modal::Component.new(title: "Contact us for a free trial", id: "schools-demo-modal")) do |modal| %>
     <% modal.with_body do %>
       <%= form_for @feedback do |f| %>
+        <%= render(Form::Group::Component.new(form_builder: f, attribute: :contact_name, label_text: "Name")) %>
         <%= render(Form::Group::Component.new(form_builder: f, attribute: :name, label_text: "School", html_options: {required: true})) %>
         <%= render(Form::Group::Component.new(form_builder: f, attribute: :phone_number)) %>
 

--- a/app/components/page_block/landing_for_schools/component.html.erb
+++ b/app/components/page_block/landing_for_schools/component.html.erb
@@ -298,6 +298,7 @@
         <div class="tw:hidden">
           <%= render(Form::Group::Component.new(form_builder: f, attribute: :additional, kind: :text_area, label_text: "Additional information")) %>
         </div>
+
         <%= f.hidden_field :feedback_type, value: "lead_for_school" %>
         <%= f.hidden_field :body, value: "lead" %>
 

--- a/app/components/page_block/landing_for_schools/component.html.erb
+++ b/app/components/page_block/landing_for_schools/component.html.erb
@@ -290,15 +290,14 @@
   <%= render(UI::Modal::Component.new(title: "Contact us for a free trial", id: "schools-demo-modal")) do |modal| %>
     <% modal.with_body do %>
       <%= form_for @feedback do |f| %>
-        <%= render(Form::Group::Component.new(form_builder: f, attribute: :contact_name, label_text: "Name")) %>
         <%= render(Form::Group::Component.new(form_builder: f, attribute: :name, label_text: "School", html_options: {required: true})) %>
+        <%= render(Form::Group::Component.new(form_builder: f, attribute: :contact_name, label_text: "Name")) %>
+        <%= render(Form::Group::Component.new(form_builder: f, attribute: :email, kind: :email_field, html_options: {required: true, value: @current_user&.email})) %>
         <%= render(Form::Group::Component.new(form_builder: f, attribute: :phone_number)) %>
 
         <div class="tw:hidden">
           <%= render(Form::Group::Component.new(form_builder: f, attribute: :additional, kind: :text_area, label_text: "Additional information")) %>
         </div>
-
-        <%= render(Form::Group::Component.new(form_builder: f, attribute: :email, kind: :email_field, html_options: {required: true, value: @current_user&.email})) %>
         <%= f.hidden_field :feedback_type, value: "lead_for_school" %>
         <%= f.hidden_field :body, value: "lead" %>
 

--- a/app/controllers/feedbacks_controller.rb
+++ b/app/controllers/feedbacks_controller.rb
@@ -48,7 +48,7 @@ class FeedbacksController < ApplicationController
 
   def permitted_parameters
     params.require(:feedback).permit(:body, :email, :name, :title, :feedback_type, :feedback_hash,
-      :package_size, :phone_number, :additional)
+      :package_size, :phone_number, :contact_name, :additional)
   end
 
   def set_permitted_format

--- a/app/models/feedback.rb
+++ b/app/models/feedback.rb
@@ -106,6 +106,10 @@ class Feedback < ApplicationRecord
     self.feedback_hash = (feedback_hash || {}).merge(phone_number: val)
   end
 
+  def contact_name=(val)
+    self.feedback_hash = (feedback_hash || {}).merge(contact_name: val)
+  end
+
   def notify_admins
     BikeDeleterJob.new.perform(bike.id, false, user_id) if delete_request? && bike.present?
     return true if self.class.no_notification_kinds.include?(kind)
@@ -143,6 +147,10 @@ class Feedback < ApplicationRecord
 
   def phone_number
     (feedback_hash || {})["phone_number"]
+  end
+
+  def contact_name
+    (feedback_hash || {})["contact_name"]
   end
 
   def kind_humanized

--- a/spec/integration/landing_pages_lead_submission_spec.rb
+++ b/spec/integration/landing_pages_lead_submission_spec.rb
@@ -11,8 +11,9 @@ RSpec.describe "Landing page demo modals", :js, type: :system do
     expect(page).to have_current_path("/my_account", wait: 5)
   end
 
-  def fill_in_and_submit_demo_form(name_label:, name_value:, email: nil)
+  def fill_in_and_submit_demo_form(name_label:, name_value:, contact_name: "Jane Doe", email: nil)
     expect(page).to have_content("Contact us for a free trial", wait: 5)
+    fill_in "Name", with: contact_name
     fill_in name_label, with: name_value
     fill_in "Phone number", with: "5551234567"
     fill_in "Email", with: email if email
@@ -22,7 +23,7 @@ RSpec.describe "Landing page demo modals", :js, type: :system do
   context "for_schools" do
     let(:target_attributes) do
       {kind: "lead_for_school", name: "Test University", email: "admin@testuni.edu",
-       phone_number: "5551234567", title: "New School lead: Test University"}
+       contact_name: "Jane Doe", phone_number: "5551234567", title: "New School lead: Test University"}
     end
 
     it "submits a school lead via hero button" do
@@ -46,7 +47,7 @@ RSpec.describe "Landing page demo modals", :js, type: :system do
     let(:user) { FactoryBot.create(:user_confirmed) }
     let(:target_attributes) do
       {kind: "lead_for_city", name: "Portland", email: user.email,
-       phone_number: "5551234567", title: "New City lead: Portland"}
+       contact_name: "Jane Doe", phone_number: "5551234567", title: "New City lead: Portland"}
     end
 
     it "submits a city lead via CTA button" do


### PR DESCRIPTION
Follow up to #3413

- Add a "Name" field (`contact_name`) to the demo request modals on `/for_schools` and `/for_law_enforcement` pages
- Stored in `feedback_hash` following the same pattern as `phone_number`
- Updated permitted params and integration tests