### PR TITLE
Show hidden serials to orgs, even if org can't edit the bike

### DIFF
--- a/app/assets/stylesheets/revised/sections/bike_boxes.scss
+++ b/app/assets/stylesheets/revised/sections/bike_boxes.scss
@@ -1,10 +1,3 @@
-.bike-serial {
-  color: $body-font-color;
-  background: none;
-  padding: 0;
-  border-radius: none;
-}
-
 .bike-boxes {
   margin-top: $vertical-height;
 

--- a/app/assets/tailwind/application.css
+++ b/app/assets/tailwind/application.css
@@ -231,3 +231,7 @@ body.dark {
     max-width: 1140px;
   }
 }
+
+.serial-span {
+  @apply tw:text-sm tw:font-mono tw:font-light tw:text-gray-900 tw:dark:text-gray-100;
+}

--- a/app/components/org/registration_search/component.html.erb
+++ b/app/components/org/registration_search/component.html.erb
@@ -78,7 +78,7 @@
       <% end %>
 
       <% table.column(label: translation(".serial"), classes: "hideableColumn serial_number_cell") do |bike| %>
-        <%= bike.serial_number %>
+        render_serial_display(<%= bike.serial_number %>)
       <% end %>
 
       <% table.column(sortable: "propulsion_type", label: translation(".propulsion_type"), classes: "hideableColumn propulsion_type_cell") do |bike| %>

--- a/app/components/org/registration_search/component.html.erb
+++ b/app/components/org/registration_search/component.html.erb
@@ -49,7 +49,7 @@
   <% bike_sticker = @bike_sticker %>
 
   <%= tag.div(data: table_wrapper_data_attributes) do %>
-    <%= render(UI::Table::Component.new(records: @bikes, cache_key: "org-#{@organization.id}-bikes_1", render_sortable: true)) do |table| %>
+    <%= render(UI::Table::Component.new(records: @bikes, cache_key: "org-#{@organization.id}-bikes_2", render_sortable: true)) do |table| %>
       <% table.column(label: translation(".url"), classes: "hideableColumn url_cell") do |bike| %>
         <code class="tw:p-0 tw:text-xs!" style="word-break: normal">
           <%= bike.html_url %>

--- a/app/components/org/registration_search/component.rb
+++ b/app/components/org/registration_search/component.rb
@@ -3,6 +3,7 @@
 module Org::RegistrationSearch
   class Component < ApplicationComponent
     include SortableHelper
+    include BikeHelper
 
     delegate :additional_registration_fields, :column_renames,
       :initially_checked_columns, :cycle_type, :active_search_filter_descriptions,

--- a/app/helpers/bike_helper.rb
+++ b/app/helpers/bike_helper.rb
@@ -9,7 +9,7 @@ module BikeHelper
         I18n.t(serial_text.tr(" ", "_"), scope: %i[helpers bike_helper]),
         class: "less-strong")
     else
-      content_tag(:code, bike.serial_display(user), class: "serial-span")
+      content_tag(:span, bike.serial_display(user), class: "serial-span")
     end
     return serial_html unless bike.serial_hidden? && !skip_explanation
 

--- a/app/helpers/bike_helper.rb
+++ b/app/helpers/bike_helper.rb
@@ -9,7 +9,7 @@ module BikeHelper
         I18n.t(serial_text.tr(" ", "_"), scope: %i[helpers bike_helper]),
         class: "less-strong")
     else
-      content_tag(:code, bike.serial_display(user), class: "bike-serial")
+      content_tag(:code, bike.serial_display(user), class: "serial-span")
     end
     return serial_html unless bike.serial_hidden? && !skip_explanation
 

--- a/app/models/bike.rb
+++ b/app/models/bike.rb
@@ -936,9 +936,12 @@ class Bike < ApplicationRecord
   end
 
   def can_see_hidden_serial?(u = nil)
-    authorized?(u) ||
-      u&.id.present? && u.id == user&.id ||
+    return false if u.blank?
+    return true if authorized?(u) || u.id.present? && u.id == user&.id ||
       current_impound_record.present? && current_impound_record.authorized?(u)
+
+    # Seeing serial doesn't require edit access to bike
+    (u.organization_roles.pluck(:organization_id) & bike_organizations.pluck(:organization_id)).any
   end
 
   def calculated_current_ownership

--- a/app/models/bike.rb
+++ b/app/models/bike.rb
@@ -941,7 +941,7 @@ class Bike < ApplicationRecord
       current_impound_record.present? && current_impound_record.authorized?(u)
 
     # Seeing serial doesn't require edit access to bike
-    (u.organization_roles.pluck(:organization_id) & bike_organizations.pluck(:organization_id)).any
+    (u.organization_roles.pluck(:organization_id) & bike_organizations.pluck(:organization_id)).any?
   end
 
   def calculated_current_ownership

--- a/spec/components/org/registration_search/component_spec.rb
+++ b/spec/components/org/registration_search/component_spec.rb
@@ -106,6 +106,15 @@ RSpec.describe Org::RegistrationSearch::Component, type: :component do
     end
   end
 
+  context "when bike is user_hidden" do
+    let(:bike) { FactoryBot.create(:bike_organized, creation_organization: organization, user_hidden: true) }
+
+    it "renders the serial number" do
+      expect(component).to have_css("tbody tr", count: 1)
+      expect(component).to have_text(bike.serial_number)
+    end
+  end
+
   context "with csv_exports enabled" do
     let(:enabled_feature_slugs) { %w[bike_search csv_exports] }
 

--- a/spec/components/org/registration_search/component_spec.rb
+++ b/spec/components/org/registration_search/component_spec.rb
@@ -106,8 +106,14 @@ RSpec.describe Org::RegistrationSearch::Component, type: :component do
     end
   end
 
-  context "when bike is user_hidden" do
-    let(:bike) { FactoryBot.create(:bike_organized, creation_organization: organization, user_hidden: true) }
+  context "when bike is user_hidden and org cannot edit" do
+    let(:bike) do
+      FactoryBot.create(:bike_organized,
+        creation_organization: organization,
+        user_hidden: true,
+        claimed: true,
+        can_edit_claimed: false)
+    end
 
     it "renders the serial number" do
       expect(component).to have_css("tbody tr", count: 1)

--- a/spec/helpers/bike_helper_spec.rb
+++ b/spec/helpers/bike_helper_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe BikeHelper, type: :helper do
     let(:bike) { Bike.new(serial_number: serial_number, cycle_type: "tandem") }
     let(:serial_number) { "fff333" }
     it "is in a code element" do
-      expect(render_serial_display(bike)).to eq("<code class=\"bike-serial\">FFF333</code>")
+      expect(render_serial_display(bike)).to eq("<code class=\"serial-span\">FFF333</code>")
     end
     context "unknown" do
       let(:serial_number) { "unknown" }
@@ -15,7 +15,7 @@ RSpec.describe BikeHelper, type: :helper do
     end
     context "hidden" do
       let(:target) { "<span class=\"less-strong\">hidden</span> <em class=\"small less-less-strong\">because tandem is impounded</em>" }
-      let(:target_authorized) { "<code class=\"bike-serial\">FFF333</code> <em class=\"small less-less-strong\">hidden for unauthorized users</em>" }
+      let(:target_authorized) { "<code class=\"serial-span\">FFF333</code> <em class=\"small less-less-strong\">hidden for unauthorized users</em>" }
       it "returns target" do
         bike.status = "status_impounded"
         expect(render_serial_display(bike)).to eq target
@@ -23,14 +23,14 @@ RSpec.describe BikeHelper, type: :helper do
         expect(render_serial_display(bike, User.new)).to eq target
         superuser = FactoryBot.create(:superuser)
         expect(render_serial_display(bike, superuser)).to eq target_authorized
-        expect(render_serial_display(bike, superuser, skip_explanation: true)).to eq "<code class=\"bike-serial\">FFF333</code>"
+        expect(render_serial_display(bike, superuser, skip_explanation: true)).to eq "<code class=\"serial-span\">FFF333</code>"
       end
     end
     context "with bike_version" do
       let(:bike) { FactoryBot.create(:bike, serial_number: serial_number) }
       let(:bike_version) { FactoryBot.create(:bike_version, bike:) }
       it "renders without error" do
-        expect(render_serial_display(bike_version)).to eq("<code class=\"bike-serial\">FFF333</code>")
+        expect(render_serial_display(bike_version)).to eq("<code class=\"serial-span\">FFF333</code>")
       end
     end
   end

--- a/spec/helpers/bike_helper_spec.rb
+++ b/spec/helpers/bike_helper_spec.rb
@@ -4,8 +4,8 @@ RSpec.describe BikeHelper, type: :helper do
   describe "render_serial_display" do
     let(:bike) { Bike.new(serial_number: serial_number, cycle_type: "tandem") }
     let(:serial_number) { "fff333" }
-    it "is in a code element" do
-      expect(render_serial_display(bike)).to eq("<code class=\"serial-span\">FFF333</code>")
+    it "is in a span element" do
+      expect(render_serial_display(bike)).to eq("<span class=\"serial-span\">FFF333</span>")
     end
     context "unknown" do
       let(:serial_number) { "unknown" }
@@ -15,7 +15,7 @@ RSpec.describe BikeHelper, type: :helper do
     end
     context "hidden" do
       let(:target) { "<span class=\"less-strong\">hidden</span> <em class=\"small less-less-strong\">because tandem is impounded</em>" }
-      let(:target_authorized) { "<code class=\"serial-span\">FFF333</code> <em class=\"small less-less-strong\">hidden for unauthorized users</em>" }
+      let(:target_authorized) { "<span class=\"serial-span\">FFF333</span> <em class=\"small less-less-strong\">hidden for unauthorized users</em>" }
       it "returns target" do
         bike.status = "status_impounded"
         expect(render_serial_display(bike)).to eq target
@@ -23,14 +23,14 @@ RSpec.describe BikeHelper, type: :helper do
         expect(render_serial_display(bike, User.new)).to eq target
         superuser = FactoryBot.create(:superuser)
         expect(render_serial_display(bike, superuser)).to eq target_authorized
-        expect(render_serial_display(bike, superuser, skip_explanation: true)).to eq "<code class=\"serial-span\">FFF333</code>"
+        expect(render_serial_display(bike, superuser, skip_explanation: true)).to eq "<span class=\"serial-span\">FFF333</span>"
       end
     end
     context "with bike_version" do
       let(:bike) { FactoryBot.create(:bike, serial_number: serial_number) }
       let(:bike_version) { FactoryBot.create(:bike_version, bike:) }
       it "renders without error" do
-        expect(render_serial_display(bike_version)).to eq("<code class=\"serial-span\">FFF333</code>")
+        expect(render_serial_display(bike_version)).to eq("<span class=\"serial-span\">FFF333</span>")
       end
     end
   end

--- a/spec/models/bike_spec.rb
+++ b/spec/models/bike_spec.rb
@@ -1283,6 +1283,19 @@ RSpec.describe Bike, type: :model do
           expect(bike.serial_display(impound_user)).to eq "HELLO PARTY"
         end
       end
+      context "when user shares an organization with the bike" do
+        let(:organization) { FactoryBot.create(:organization) }
+        let(:org_user) { FactoryBot.create(:organization_user, organization:) }
+        let(:bike) { FactoryBot.create(:bike_organized, :with_ownership_claimed, serial_number: "Hello Party", creation_organization: organization) }
+        let!(:impound_record) { FactoryBot.create(:impound_record, bike:) }
+
+        it "shows serial to org member without edit access" do
+          expect(bike.reload.status).to eq "status_impounded"
+          expect(bike.authorized?(org_user)).to be_falsey
+          expect(bike.send(:can_see_hidden_serial?, org_user)).to be_truthy
+          expect(bike.serial_display(org_user)).to eq "HELLO PARTY"
+        end
+      end
     end
   end
 


### PR DESCRIPTION
Allow organization members to see hidden serials for bikes associated with their organization, even without edit access to the bike.