### PR TITLE
Prevent registration search preview from rendering bikes on prod

### DIFF
--- a/app/components/org/registration_search/component_preview.rb
+++ b/app/components/org/registration_search/component_preview.rb
@@ -4,10 +4,9 @@ module Org::RegistrationSearch
   class ComponentPreview < ApplicationComponentPreview
     # @display legacy_stylesheet true
     def default
-      organization = lookbook_organization
       pagy = Pagy::Offset.new(count: bikes.count, page: 1, limit: 10)
       render Org::RegistrationSearch::Component.new(
-        organization:,
+        organization: lookbook_organization,
         pagy:,
         bikes:,
         per_page: 10,
@@ -19,9 +18,9 @@ module Org::RegistrationSearch
     private
 
     def bikes
-      return Bike.none if Rails.env.production? || organization&.bikes.blank?
+      return Bike.none if Rails.env.production? || lookbook_organization&.bikes.blank?
 
-      organization.bikes.limit(5)
+      lookbook_organization.bikes.limit(5)
     end
   end
 end

--- a/app/components/org/registration_search/component_preview.rb
+++ b/app/components/org/registration_search/component_preview.rb
@@ -5,7 +5,6 @@ module Org::RegistrationSearch
     # @display legacy_stylesheet true
     def default
       organization = lookbook_organization
-      bikes = organization&.bikes&.limit(5) || Bike.none
       pagy = Pagy::Offset.new(count: bikes.count, page: 1, limit: 10)
       render Org::RegistrationSearch::Component.new(
         organization:,
@@ -15,6 +14,14 @@ module Org::RegistrationSearch
         params: {},
         time_range: 1.year.ago..Time.current
       )
+    end
+
+    private
+
+    def bikes
+      return Bike.none if Rails.env.production? || organization&.bikes.blank?
+
+      organization.bikes.limit(5)
     end
   end
 end


### PR DESCRIPTION
- Adds a production guard to the org registration search component preview so it returns `Bike.none` in production, preventing real bike data (which may contain PII) from being rendered in Lookbook previews
