### PR TITLE
Skip Facebook pixel on org_public and OrganizationsController views

### DIFF
--- a/app/views/shared/_footer_revised.html.erb
+++ b/app/views/shared/_footer_revised.html.erb
@@ -176,7 +176,7 @@
   </nav>
 </footer>
 
-<% skip_facebook ||= controller_namespace.in?(%w[organized oauth]) %>
+<% skip_facebook ||= controller_namespace.in?(%w[organized org_public oauth]) || controller_name == "organizations" %>
 
 <% unless skip_facebook %>
   <%# Facebook pixel %>


### PR DESCRIPTION
Extends the existing `skip_facebook` gate so the Facebook pixel is also omitted from the `org_public` namespace (public impound lookups) and from top-level `OrganizationsController` views (new org signup, embed forms). 