### PR TITLE
Fix stale preview class references on lookbook reload in dev

### DIFF
--- a/config/initializers/lookbook.rb
+++ b/config/initializers/lookbook.rb
@@ -16,14 +16,14 @@ end
 #
 # This forces preview_class to re-resolve on every access in development,
 # so it always returns the current class from the autoloader.
-Rails.application.config.after_initialize do
-  next unless Rails.env.development?
-
-  Lookbook::PreviewEntity.class_eval do
-    def preview_class
-      @code_object.path.constantize
-    rescue NameError
-      @preview_class
+if Rails.env.development?
+  Rails.application.config.after_initialize do
+    Lookbook::PreviewEntity.class_eval do
+      def preview_class
+        @code_object.path.constantize
+      rescue NameError
+        @preview_class
+      end
     end
   end
 end

--- a/config/initializers/lookbook.rb
+++ b/config/initializers/lookbook.rb
@@ -5,3 +5,25 @@ Lookbook.configure do |config|
   config.ui_theme_overrides = {header_bg: "#3498db"}
   config.preview_paths = ["#{Rails.root}/app/components/"]
 end
+
+# Fix stale class references during development code reloading.
+#
+# Lookbook caches preview class objects in PreviewEntity, but only refreshes
+# previews for files that changed. After Zeitwerk unloads ALL constants, the
+# unchanged previews hold stale class references whose module namespaces no
+# longer have autoloads configured - causing constant resolution failures
+# (e.g. `Component` resolving to the AR model instead of the view component).
+#
+# This forces preview_class to re-resolve on every access in development,
+# so it always returns the current class from the autoloader.
+Rails.application.config.after_initialize do
+  next unless Rails.env.development?
+
+  Lookbook::PreviewEntity.class_eval do
+    def preview_class
+      @code_object.path.constantize
+    rescue NameError
+      @preview_class
+    end
+  end
+end


### PR DESCRIPTION
Lookbook caches preview class objects in `PreviewEntity` but only refreshes previews for files that changed, so unchanged previews keep references to classes whose module namespaces have been unloaded by Zeitwerk — causing constant resolution failures on reload (e.g. `Component` falling through to the AR `Component` model instead of the view component).

This monkey-patches `PreviewEntity#preview_class` in development to re-resolve the class via `constantize` on every access.

Maybe it won't work - we'll find out!