### PR TITLE
Sanitize HTML in everything combobox to prevent XSS

### DIFF
--- a/app/javascript/controllers/search/everything_combobox_controller.js
+++ b/app/javascript/controllers/search/everything_combobox_controller.js
@@ -28,6 +28,12 @@ export default class extends Controller {
     this.initializeHeaderSearch($(this.inputTarget), this.apiUrlValue)
   }
 
+  escapeHtml (text) {
+    const div = document.createElement('div')
+    div.textContent = text
+    return div.innerHTML
+  }
+
   initializeHeaderSearch ($queryField, url) {
     const perPage = 15
     // TODO: Find this dynamically? Set it at a higher level?
@@ -53,6 +59,7 @@ export default class extends Controller {
       placeholder: $queryField.attr('placeholder'), // Pull placeholder from HTML
       // dropdownParent: $(searchFormSelector), // Append to search for for easier css access
       templateResult: formatSearchText, // let custom formatter work
+      templateSelection: (item) => this.escapeHtml(item.text), // Escape selected item text
       // selectOnClose: true // Turned off in PR#2325
       escapeMarkup: function (markup) { return markup }, // Allow our fancy display of options
       ajax: {
@@ -126,15 +133,16 @@ export default class extends Controller {
   }
 
   formatSearchText (item, translations) {
-    if (item.loading) return item.text
-    if (item.category === 'propulsion') return '<span>' + translations.searchFor + ' <strong>' + item.text + '</strong> only</span>'
-    if (item.category === 'cycle_type') return '<span>' + translations.searchOnlyFor + ' <strong>' + item.text + '</strong></span>'
+    if (item.loading) return this.escapeHtml(item.text)
+    const text = this.escapeHtml(item.text)
+    if (item.category === 'propulsion') return '<span>' + translations.searchFor + ' <strong>' + text + '</strong> only</span>'
+    if (item.category === 'cycle_type') return '<span>' + translations.searchOnlyFor + ' <strong>' + text + '</strong></span>'
 
     const getPrefix = () => {
       if (item.category === 'colors') {
         const p = "<span class='sch_'>" + translations.searchObjName + ' ' + translations.thatAre + ' </span>'
         if (item.display) {
-          return p + "<span class='sclr' style='background: " + item.display + ";'></span>"
+          return p + "<span class='sclr' style='background: " + this.escapeHtml(item.display) + ";'></span>"
         } else {
           return p + "<span class='sclr'>stckrs</span>"
         }
@@ -147,7 +155,7 @@ export default class extends Controller {
       }
     }
 
-    return getPrefix() + " <span class='label'>" + item.text + '</span>'
+    return getPrefix() + " <span class='label'>" + text + '</span>'
   }
 
   // Don't include manufacturers if a manufacturer is selected

--- a/spec/components/search/form/component_system_spec.rb
+++ b/spec/components/search/form/component_system_spec.rb
@@ -115,6 +115,38 @@ RSpec.describe Search::Form::Component, :js, type: :system do
       # TODO: test for entering location: you, location: anywhere
     end
 
+    it "sanitizes XSS in autocomplete results" do
+      # Mock autocomplete API to return a payload that sets a DOM attribute if executed
+      page.execute_script(<<~JS)
+        var origAjax = $.ajax;
+        $.ajax = function(settings) {
+          if (settings.url && settings.url.includes('autocomplete')) {
+            var d = $.Deferred();
+            setTimeout(function() {
+              d.resolve({
+                matches: [{
+                  search_id: 'xss_test',
+                  text: '<img src=x onerror="document.body.dataset.xss=1">',
+                  category: 'colors',
+                  display: null
+                }]
+              });
+            }, 50);
+            return d.promise();
+          }
+          return origAjax.apply(this, arguments);
+        };
+      JS
+
+      find(".select2-container").click
+      expect(page).to have_css(".select2-results__option", wait: 5)
+
+      # Select the malicious option to also test selection rendering
+      find(".select2-results__option").click
+
+      expect(page.evaluate_script("document.body.dataset.xss")).to be_nil
+    end
+
     it "scrolls through paginated options" do
       visit(preview_path)
 


### PR DESCRIPTION
The everything combobox sets Select2's `escapeMarkup` to a pass-through so `formatSearchText` can render styled result markup (color swatches, category prefixes, etc.), but user-supplied `item.text` and `item.display` from the autocomplete API were being concatenated into that HTML unescaped — same for selected items via the default `templateSelection`. This change adds an `escapeHtml` helper and applies it in `formatSearchText`, in the style attribute for color swatches, and in a new `templateSelection` callback. Adds a system spec that mocks the autocomplete AJAX to return an `<img onerror>` payload and asserts the handler never fires.