### PR TITLE
Block editing stickers that don't belong to the organization

### DIFF
--- a/app/controllers/organized/stickers_controller.rb
+++ b/app/controllers/organized/stickers_controller.rb
@@ -4,6 +4,7 @@ module Organized
 
     before_action :ensure_access_to_bike_stickers! # Because this checks ensure_admin
     before_action :find_bike_sticker, only: %i[edit update]
+    before_action :ensure_sticker_for_current_organization, only: :edit
 
     def index
       @per_page = permitted_per_page
@@ -72,6 +73,14 @@ module Organized
       return true if current_organization.enabled?("bike_stickers") || current_user.superuser?
 
       raise_do_not_have_access!
+    end
+
+    def ensure_sticker_for_current_organization
+      return true if [@bike_sticker.organization_id, @bike_sticker.secondary_organization_id]
+        .include?(current_organization.id)
+
+      flash[:error] = translation(:not_your_organizations_sticker, bike_sticker: @bike_sticker.code)
+      redirect_back(fallback_location: organization_stickers_path(organization_id: current_organization.to_param)) && return
     end
   end
 end

--- a/app/controllers/organized/stickers_controller.rb
+++ b/app/controllers/organized/stickers_controller.rb
@@ -4,7 +4,7 @@ module Organized
 
     before_action :ensure_access_to_bike_stickers! # Because this checks ensure_admin
     before_action :find_bike_sticker, only: %i[edit update]
-    before_action :ensure_sticker_for_current_organization, only: :edit
+    before_action :ensure_sticker_for_current_organization, only: %i[edit update]
 
     def index
       @per_page = permitted_per_page
@@ -76,6 +76,7 @@ module Organized
     end
 
     def ensure_sticker_for_current_organization
+      return true unless @bike_sticker.claimed?
       return true if [@bike_sticker.organization_id, @bike_sticker.secondary_organization_id]
         .include?(current_organization.id)
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1898,10 +1898,11 @@ en:
           successfully_created: Parking Notification for %{bike_type} created
           unable_to_create: Unable to create - %{errors}
       stickers:
+        ensure_sticker_for_current_organization:
+          not_your_organizations_sticker: Sticker %{bike_sticker} isn't your organization's
+            sticker.
         find_bike_sticker:
           unable_to_find_sticker: 'Unable to find sticker with code: %{bike_sticker}.'
-        ensure_sticker_for_current_organization:
-          not_your_organizations_sticker: "Sticker %{bike_sticker} isn't your organization's sticker."
         update:
           cannot_update: >-
             You can't update that %{bike_sticker_kind}. Please contact support@bikeindex.org

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1900,6 +1900,8 @@ en:
       stickers:
         find_bike_sticker:
           unable_to_find_sticker: 'Unable to find sticker with code: %{bike_sticker}.'
+        ensure_sticker_for_current_organization:
+          not_your_organizations_sticker: "Sticker %{bike_sticker} isn't your organization's sticker."
         update:
           cannot_update: >-
             You can't update that %{bike_sticker_kind}. Please contact support@bikeindex.org

--- a/spec/requests/organized/stickers_request_spec.rb
+++ b/spec/requests/organized/stickers_request_spec.rb
@@ -92,16 +92,28 @@ RSpec.describe Organized::StickersController, type: :request do
           expect(response).to render_template(:edit)
           expect(assigns(:current_organization)&.id).to eq current_organization.id
         end
-        context "non-organization bike_sticker" do
+        context "unclaimed non-organization bike_sticker" do
           let(:og_organization) { FactoryBot.create(:organization) }
           let!(:bike_sticker) { FactoryBot.create(:bike_sticker, organization: og_organization, code: "zzz999") }
+          it "renders" do
+            get "#{base_url}/#{bike_sticker.code}/edit"
+            expect(response).to render_template(:edit)
+            expect(assigns(:bike_sticker)&.id).to eq bike_sticker.id
+          end
+        end
+        context "claimed non-organization bike_sticker" do
+          let(:og_organization) { FactoryBot.create(:organization) }
+          let!(:bike_sticker) { FactoryBot.create(:bike_sticker_claimed, organization: og_organization, code: "zzz999") }
           it "redirects back with a flash error" do
             get "#{base_url}/#{bike_sticker.code}/edit", headers: {"HTTP_REFERER" => stickers_root_path}
             expect(response).to redirect_to(stickers_root_path)
             expect(flash[:error]).to match(/organization/i)
           end
           context "when current_organization is the secondary_organization" do
-            let!(:bike_sticker) { FactoryBot.create(:bike_sticker, organization: og_organization, secondary_organization: current_organization, code: "zzz999") }
+            let!(:bike_sticker) do
+              FactoryBot.create(:bike_sticker_claimed, organization: og_organization, code: "zzz999")
+                .tap { |s| s.update!(secondary_organization: current_organization) }
+            end
             it "renders" do
               get "#{base_url}/#{bike_sticker.code}/edit"
               expect(response).to render_template(:edit)
@@ -177,10 +189,10 @@ RSpec.describe Organized::StickersController, type: :request do
             end
           end
         end
-        context "non-organization bike_sticker" do
+        context "unclaimed non-organization bike_sticker" do
           let(:og_organization) { FactoryBot.create(:organization) }
           let!(:bike_sticker) { FactoryBot.create(:bike_sticker, organization: og_organization) }
-          it "updates" do
+          it "updates and assigns secondary_organization" do
             expect(bike_sticker.reload.organization_id).to be_present
             expect(bike_sticker.claimed?).to be_falsey
             expect {
@@ -194,6 +206,20 @@ RSpec.describe Organized::StickersController, type: :request do
             expect(bike_sticker.organization_id).to eq og_organization.id
             expect(bike_sticker.secondary_organization_id).to eq current_organization.id
             expect(bike_sticker.bike_id).to eq bike2.id
+          end
+        end
+        context "claimed non-organization bike_sticker" do
+          let(:og_organization) { FactoryBot.create(:organization) }
+          let!(:bike_sticker) { FactoryBot.create(:bike_sticker_claimed, organization: og_organization) }
+          it "redirects back with a flash error and does not update" do
+            expect {
+              put "#{base_url}/#{bike_sticker.code}", params: {bike_id: bike2.id},
+                headers: {"HTTP_REFERER" => stickers_root_path}
+            }.to_not change(BikeStickerUpdate, :count)
+            expect(response).to redirect_to(stickers_root_path)
+            expect(flash[:error]).to match(/organization/i)
+            expect(bike_sticker.reload.bike_id).to_not eq bike2.id
+            expect(bike_sticker.secondary_organization_id).to be_nil
           end
         end
         context "nil bike_id" do

--- a/spec/requests/organized/stickers_request_spec.rb
+++ b/spec/requests/organized/stickers_request_spec.rb
@@ -92,6 +92,23 @@ RSpec.describe Organized::StickersController, type: :request do
           expect(response).to render_template(:edit)
           expect(assigns(:current_organization)&.id).to eq current_organization.id
         end
+        context "non-organization bike_sticker" do
+          let(:og_organization) { FactoryBot.create(:organization) }
+          let!(:bike_sticker) { FactoryBot.create(:bike_sticker, organization: og_organization, code: "zzz999") }
+          it "redirects back with a flash error" do
+            get "#{base_url}/#{bike_sticker.code}/edit", headers: {"HTTP_REFERER" => stickers_root_path}
+            expect(response).to redirect_to(stickers_root_path)
+            expect(flash[:error]).to match(/organization/i)
+          end
+          context "when current_organization is the secondary_organization" do
+            let!(:bike_sticker) { FactoryBot.create(:bike_sticker, organization: og_organization, secondary_organization: current_organization, code: "zzz999") }
+            it "renders" do
+              get "#{base_url}/#{bike_sticker.code}/edit"
+              expect(response).to render_template(:edit)
+              expect(assigns(:bike_sticker)&.id).to eq bike_sticker.id
+            end
+          end
+        end
       end
 
       describe "update" do


### PR DESCRIPTION
Editing a sticker via `Organized::StickersController` previously always allowed editing and updating stickers from other organizations.

This was to support secondary organization ownership of stickers - *however* - because organizations could edit claimed stickers, they could see the owner information (ie email) for stickers that weren't part of their organization.

This update makes it so organizations can edit and update unclaimed stickers - which makes them the secondary organization for the sticker - but prevents them from seeing information about claimed stickers that they aren't authorized for.