### PR TITLE
Add Cloudflare Turnstile to unauthenticated auth forms

### DIFF
--- a/app/controllers/concerns/sessionable.rb
+++ b/app/controllers/concerns/sessionable.rb
@@ -51,6 +51,14 @@ module Sessionable
     store_return_and_authenticate_user(translation_key: :create_account, flash_type: :info)
   end
 
+  def verify_turnstile!
+    return true if Integrations::CloudflareTurnstile.verify(params[:"cf-turnstile-response"], ip: forwarded_ip_address)
+
+    flash[:error] = translation(:turnstile_failed, scope: [:controllers, :concerns, :sessionable, __method__])
+    redirect_back(fallback_location: new_session_url)
+    false
+  end
+
   private
 
   def cookie_options(user)

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -2,6 +2,7 @@ class SessionsController < ApplicationController
   include Sessionable
 
   before_action :skip_if_signed_in, only: [:new, :magic_link]
+  before_action :verify_turnstile!, only: [:create, :create_magic_link]
 
   def new
     render_partner_or_default_signin_layout

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -3,6 +3,8 @@ class UsersController < ApplicationController
 
   before_action :skip_if_signed_in, only: %i[new]
   before_action :find_user_from_token_for_password_reset!, only: %i[update_password_form_with_reset_token update_password_with_reset_token]
+  before_action :verify_turnstile!, only: %i[send_password_reset_email]
+  before_action :verify_turnstile!, only: %i[resend_confirmation_email], unless: -> { unconfirmed_current_user.present? }
 
   def new
     @user ||= User.new(email: params[:email])

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -5,6 +5,15 @@ module ApplicationHelper
     super([key, locale: I18n.locale], options, &block)
   end
 
+  def turnstile_widget
+    return nil unless Integrations::CloudflareTurnstile.configured?
+
+    safe_join([
+      javascript_include_tag("https://challenges.cloudflare.com/turnstile/v0/api.js", async: true, defer: true),
+      content_tag(:div, "", class: "cf-turnstile tw:my-4", data: {sitekey: Integrations::CloudflareTurnstile::SITE_KEY})
+    ])
+  end
+
   def notification_delivery_display(status)
     text = if status == "delivery_success"
       check_mark

--- a/app/services/integrations/cloudflare_turnstile.rb
+++ b/app/services/integrations/cloudflare_turnstile.rb
@@ -1,0 +1,22 @@
+class Integrations::CloudflareTurnstile
+  SITE_KEY = ENV["CLOUDFLARE_TURNSTILE_SITE_KEY"]
+  SECRET_KEY = ENV["CLOUDFLARE_TURNSTILE_SECRET_KEY"]
+  VERIFY_URL = "https://challenges.cloudflare.com/turnstile/v0/siteverify"
+
+  def self.configured?
+    SITE_KEY.present? && SECRET_KEY.present?
+  end
+
+  def self.verify(token, ip: nil)
+    return true unless configured?
+    return false if token.blank?
+
+    response = Faraday.post(VERIFY_URL) do |req|
+      req.headers["Content-Type"] = "application/x-www-form-urlencoded"
+      req.body = URI.encode_www_form({secret: SECRET_KEY, response: token, remoteip: ip}.compact)
+    end
+    JSON.parse(response.body)["success"] == true
+  rescue Faraday::Error, JSON::ParserError
+    false
+  end
+end

--- a/app/views/sessions/magic_link.html.haml
+++ b/app/views/sessions/magic_link.html.haml
@@ -21,4 +21,5 @@
     = form_tag create_magic_link_session_path, method: 'post' do
       .form-group
         %input{ name: 'email', id: 'email', type: 'text', placeholder: t(".your_email_address"), class: 'form-control' }
+      = turnstile_widget
       %input{ type: 'submit', value: t(".get_sign_in_link"), class: 'btn btn-primary btn-lg' }

--- a/app/views/sessions/new.html.haml
+++ b/app/views/sessions/new.html.haml
@@ -66,6 +66,7 @@
                 = f.check_box :remember_me, value: '1', checked: true
                 = t(".keep_me_logged_in")
 
+            = turnstile_widget
             = f.submit t(".log_in"), class: 'btn btn-primary btn-lg'
 
           %p.forgot-password-link= link_to t(".forgot_your_password"), request_password_reset_form_users_path

--- a/app/views/users/please_confirm_email.html.haml
+++ b/app/views/users/please_confirm_email.html.haml
@@ -22,6 +22,7 @@
             = email_field_tag :email, nil, required: true, class: 'form-control'
         .col-md-6
           .actions{ style: "margin-top: 2.5rem;" }
+            = turnstile_widget
             = submit_tag t(".resend_confirmation_email"), class: 'btn btn-primary'
 
 

--- a/app/views/users/request_password_reset_form.html.haml
+++ b/app/views/users/request_password_reset_form.html.haml
@@ -5,4 +5,5 @@
   = form_tag "/users/send_password_reset_email", method: :post do
     .form-group
       %input{ name: 'email', id: 'email', type: 'text', placeholder: t(".your_email_address"), class: 'form-control' }
+    = turnstile_widget
     %input{ type: 'submit', value: t(".reset_your_password"), class: 'btn btn-primary btn-lg' }

--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -34,7 +34,8 @@ Rails.application.configure do
       "https://platform.twitter.com",
       "https://api.mapbox.com",
       "https://cdn.jsdelivr.net",
-      "https://js.stripe.com"
+      "https://js.stripe.com",
+      "https://challenges.cloudflare.com"
     policy.style_src :self, :unsafe_inline,
       "https://fonts.googleapis.com",
       "https://www.gstatic.com", # Google Translate styles
@@ -77,7 +78,8 @@ Rails.application.configure do
       "https://web.facebook.com",
       "https://m.facebook.com",
       "https://platform.twitter.com",
-      "https://js.stripe.com"
+      "https://js.stripe.com",
+      "https://challenges.cloudflare.com"
     policy.report_uri -> do
       "https://api.honeybadger.io/v1/browser/csp?api_key=#{ENV["HONEYBADGER_CSP_API_KEY"]}&report_only=false&env=#{Rails.env}&context[user_id]=#{current_user&.id if respond_to?(:current_user)}"
     end

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -31,14 +31,9 @@ class Rack::Attack
     request.ip unless request.path.start_with?(*SKIP_THROTTLE_PREFIXES)
   end
 
-  # Sign-in: exponential backoff per IP
-  # Level 1: 10 requests in 60 seconds
-  # Level 2: 20 requests in 3600 seconds (1 hour)
-  # Level 3: 30 requests in 216000 seconds (2.5 days)
-  (1..3).each do |level|
-    throttle("sign_in/ip/#{level}", limit: 10 * level, period: (60**level).seconds) do |request|
-      request.ip if request.post? && request.path == SIGN_IN_PATH
-    end
+  # Sign-in: 10 per minute per IP
+  throttle("sign_in/ip", limit: 10, period: 1.minute) do |request|
+    request.ip if request.post? && request.path == SIGN_IN_PATH
   end
 
   # Sign-in: 5 per 20 seconds per email (protects individual accounts)
@@ -50,18 +45,13 @@ class Rack::Attack
     end
   end
 
-  # Sensitive auth endpoints: exponential backoff per IP
-  # Level 1: 5 requests in 60 seconds
-  # Level 2: 10 requests in 3600 seconds (1 hour)
-  # Level 3: 15 requests in 216000 seconds (2.5 days)
-  (1..3).each do |level|
-    throttle("sensitive_auth/ip/#{level}", limit: 5 * level, period: (60**level).seconds) do |request|
-      if request.post?
-        if SENSITIVE_AUTH_PATHS.include?(request.path)
-          request.ip
-        elsif request.path.start_with?("/user_emails/") && request.path.end_with?("/resend_confirmation")
-          request.ip
-        end
+  # Sensitive auth endpoints: 5 per minute per IP
+  throttle("sensitive_auth/ip", limit: 5, period: 1.minute) do |request|
+    if request.post?
+      if SENSITIVE_AUTH_PATHS.include?(request.path)
+        request.ip
+      elsif request.path.start_with?("/user_emails/") && request.path.end_with?("/resend_confirmation")
+        request.ip
       end
     end
   end

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -31,9 +31,14 @@ class Rack::Attack
     request.ip unless request.path.start_with?(*SKIP_THROTTLE_PREFIXES)
   end
 
-  # Sign-in: 10 per minute per IP
-  throttle("sign_in/ip", limit: 10, period: 1.minute) do |request|
-    request.ip if request.post? && request.path == SIGN_IN_PATH
+  # Sign-in: exponential backoff per IP
+  # Level 1: 10 requests in 60 seconds
+  # Level 2: 20 requests in 3600 seconds (1 hour)
+  # Level 3: 30 requests in 216000 seconds (2.5 days)
+  (1..3).each do |level|
+    throttle("sign_in/ip/#{level}", limit: 10 * level, period: (60**level).seconds) do |request|
+      request.ip if request.post? && request.path == SIGN_IN_PATH
+    end
   end
 
   # Sign-in: 5 per 20 seconds per email (protects individual accounts)
@@ -45,13 +50,18 @@ class Rack::Attack
     end
   end
 
-  # Sensitive auth endpoints: 5 per minute per IP
-  throttle("sensitive_auth/ip", limit: 5, period: 1.minute) do |request|
-    if request.post?
-      if SENSITIVE_AUTH_PATHS.include?(request.path)
-        request.ip
-      elsif request.path.start_with?("/user_emails/") && request.path.end_with?("/resend_confirmation")
-        request.ip
+  # Sensitive auth endpoints: exponential backoff per IP
+  # Level 1: 5 requests in 60 seconds
+  # Level 2: 10 requests in 3600 seconds (1 hour)
+  # Level 3: 15 requests in 216000 seconds (2.5 days)
+  (1..3).each do |level|
+    throttle("sensitive_auth/ip/#{level}", limit: 5 * level, period: (60**level).seconds) do |request|
+      if request.post?
+        if SENSITIVE_AUTH_PATHS.include?(request.path)
+          request.ip
+        elsif request.path.start_with?("/user_emails/") && request.path.end_with?("/resend_confirmation")
+          request.ip
+        end
       end
     end
   end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1755,6 +1755,8 @@ en:
             are unsure as to the reasons for this, please contact us.
         skip_if_signed_in:
           already_signed_in: You're already signed in!
+        verify_turnstile:
+          turnstile_failed: Bot check failed. Please try again.
     feedbacks:
       block_the_spam:
         please_sign_in: Please sign in to send that message

--- a/spec/services/integrations/cloudflare_turnstile_spec.rb
+++ b/spec/services/integrations/cloudflare_turnstile_spec.rb
@@ -1,0 +1,63 @@
+require "rails_helper"
+
+RSpec.describe Integrations::CloudflareTurnstile do
+  describe "configured?" do
+    it "is false when keys missing" do
+      stub_const("#{described_class}::SITE_KEY", nil)
+      stub_const("#{described_class}::SECRET_KEY", nil)
+      expect(described_class.configured?).to be false
+    end
+
+    context "with both keys" do
+      before do
+        stub_const("#{described_class}::SITE_KEY", "site")
+        stub_const("#{described_class}::SECRET_KEY", "secret")
+      end
+
+      it "is true" do
+        expect(described_class.configured?).to be true
+      end
+    end
+  end
+
+  describe "verify" do
+    context "when not configured" do
+      before do
+        stub_const("#{described_class}::SITE_KEY", nil)
+        stub_const("#{described_class}::SECRET_KEY", nil)
+      end
+
+      it "passes through" do
+        expect(described_class.verify(nil)).to be true
+        expect(described_class.verify("anything")).to be true
+      end
+    end
+
+    context "when configured" do
+      # Cloudflare-published test keys: always-passing site, always-passing secret
+      # https://developers.cloudflare.com/turnstile/troubleshooting/testing/
+      before do
+        stub_const("#{described_class}::SITE_KEY", "1x00000000000000000000AA")
+        stub_const("#{described_class}::SECRET_KEY", "1x0000000000000000000000000000000AA")
+      end
+
+      it "returns false on blank token" do
+        expect(described_class.verify(nil)).to be false
+        expect(described_class.verify("")).to be false
+      end
+
+      it "verifies a token against the API", vcr: {cassette_name: "cloudflare_turnstile-verify_success"} do
+        # XXXX.DUMMY.TOKEN.XXXX is the dummy widget output for the always-passing site key
+        expect(described_class.verify("XXXX.DUMMY.TOKEN.XXXX")).to be true
+      end
+
+      context "with always-failing secret" do
+        before { stub_const("#{described_class}::SECRET_KEY", "2x0000000000000000000000000000000AA") }
+
+        it "returns false", vcr: {cassette_name: "cloudflare_turnstile-verify_failure"} do
+          expect(described_class.verify("XXXX.DUMMY.TOKEN.XXXX")).to be false
+        end
+      end
+    end
+  end
+end

--- a/spec/vcr_cassettes/cloudflare_turnstile-verify_failure.yml
+++ b/spec/vcr_cassettes/cloudflare_turnstile-verify_failure.yml
@@ -1,0 +1,41 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://challenges.cloudflare.com/turnstile/v0/siteverify
+    body:
+      encoding: US-ASCII
+      string: secret=2x0000000000000000000000000000000AA&response=XXXX.DUMMY.TOKEN.XXXX
+    headers:
+      User-Agent:
+      - Faraday v1.10.4
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 17 Apr 2026 07:18:57 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 9ed9a8a028d278eb-SJC
+      Alt-Svc:
+      - h3=":443"; ma=86400
+    body:
+      encoding: ASCII-8BIT
+      string: '{"error-codes":["invalid-input-response"],"success":false,"messages":[],"metadata":{"result_with_testing_key":true}}'
+  recorded_at: Fri, 17 Apr 2026 07:18:57 GMT
+recorded_with: VCR 6.4.0

--- a/spec/vcr_cassettes/cloudflare_turnstile-verify_success.yml
+++ b/spec/vcr_cassettes/cloudflare_turnstile-verify_success.yml
@@ -1,0 +1,41 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://challenges.cloudflare.com/turnstile/v0/siteverify
+    body:
+      encoding: US-ASCII
+      string: secret=1x0000000000000000000000000000000AA&response=XXXX.DUMMY.TOKEN.XXXX
+    headers:
+      User-Agent:
+      - Faraday v1.10.4
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 17 Apr 2026 07:18:57 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 9ed9a89ffecf80fd-SJC
+      Alt-Svc:
+      - h3=":443"; ma=86400
+    body:
+      encoding: ASCII-8BIT
+      string: '{"challenge_ts":"2026-04-17T07:18:57.274Z","error-codes":[],"hostname":"example.com","metadata":{"result_with_testing_key":true},"success":true}'
+  recorded_at: Fri, 17 Apr 2026 07:18:57 GMT
+recorded_with: VCR 6.4.0


### PR DESCRIPTION
Wraps the four unauthenticated POST endpoints attackers actually target — sign in, magic-link request, password-reset request, and resend confirmation — with a Cloudflare Turnstile challenge. Real users solve the invisible widget transparently; bots fail the verify call and get redirected back with a flash error. Token-based endpoints (\`sign_in_with_magic_link\`, \`update_password_with_reset_token\`) and signed-in actions (\`my_account#update\`, \`user_emails#resend_confirmation\`) keep rack_attack as their only defense — Turnstile adds nothing there. The widget and verification are no-ops unless both \`CLOUDFLARE_TURNSTILE_SITE_KEY\` and \`CLOUDFLARE_TURNSTILE_SECRET_KEY\` are set, so dev/test work unchanged.

## Test plan
- [ ] Set both env vars in production after creating the Turnstile site key in the Cloudflare dashboard
- [ ] Verify the widget renders and is solvable on each of the four forms
- [ ] Confirm a POST without a valid token is rejected with the bot-check flash error
- [ ] Confirm the in-flow resend-confirmation link still works for unconfirmed users (skipped via \`unless: unconfirmed_current_user.present?\`)