### PR TITLE
Add UI::Tooltip component, use it in UI::Badge

### DIFF
--- a/app/components/admin/badges/user/component.html.erb
+++ b/app/components/admin/badges/user/component.html.erb
@@ -1,7 +1,7 @@
 <span class="<%= wrapper_class %>">
   <% if @tags.include?(:donor) %>
     <span>
-      <%= render ::UI::Badge::Component.new(text: "D", title: "Donor", color: badge_color(:donor)) %>
+      <%= render ::UI::Badge::Component.new(text: "D", title: (@full_text ? nil : "Donor"), color: badge_color(:donor)) %>
 
       <% if @full_text %>
         <span class="less-strong">Donor</span>
@@ -11,7 +11,7 @@
 
   <% if @tags.include?(:member) %>
     <span>
-      <%= render ::UI::Badge::Component.new(text: "M", title: "Member", color: badge_color(:member)) %>
+      <%= render ::UI::Badge::Component.new(text: "M", title: (@full_text ? nil : "Member"), color: badge_color(:member)) %>
 
       <% if @full_text %>
         <span class="less-strong">Member</span>
@@ -21,7 +21,7 @@
 
   <% if @tags.include?(:organization_role) %>
     <span>
-      <%= render ::UI::Badge::Component.new(text: org_icon_text, title: org_full_text, color: badge_color(:organization_role)) %>
+      <%= render ::UI::Badge::Component.new(text: org_icon_text, title: (@full_text ? nil : org_full_text), color: badge_color(:organization_role)) %>
 
       <% if @full_text %>
         <span class="less-strong"><%= org_full_text %></span>
@@ -31,7 +31,7 @@
 
   <% if @tags.include?(:recovery) %>
     <span>
-      <%= render ::UI::Badge::Component.new(text: "R", title: "Recovered bike", color: badge_color(:recovery)) %>
+      <%= render ::UI::Badge::Component.new(text: "R", title: (@full_text ? nil : "Recovered bike"), color: badge_color(:recovery)) %>
 
       <% if @full_text %>
         <span class="less-strong">Recovered bike</span>
@@ -41,7 +41,7 @@
 
   <% if @tags.include?(:superuser) %>
     <span>
-      <%= render ::UI::Badge::Component.new(text: "S", title: "Superuser", color: badge_color(:superuser)) %>
+      <%= render ::UI::Badge::Component.new(text: "S", title: (@full_text ? nil : "Superuser"), color: badge_color(:superuser)) %>
 
       <% if @full_text %>
         <span class="less-strong">Superuser</span>
@@ -51,7 +51,7 @@
 
   <% if @tags.include?(:theft_alert) %>
     <span>
-      <%= render ::UI::Badge::Component.new(text: "P", title: "Promoted alert purchaser", color: badge_color(:theft_alert)) %>
+      <%= render ::UI::Badge::Component.new(text: "P", title: (@full_text ? nil : "Promoted alert purchaser"), color: badge_color(:theft_alert)) %>
 
       <% if @full_text %>
         <span class="less-strong">Promoted alert</span>
@@ -61,7 +61,7 @@
 
   <% if banned? %>
     <span>
-      <%= render ::UI::Badge::Component.new(text: "B", title: banned_text, color: badge_color(:banned)) %>
+      <%= render ::UI::Badge::Component.new(text: "B", title: (@full_text ? nil : banned_text), color: badge_color(:banned)) %>
 
       <% if @full_text %>
         <span class="less-strong"><%= banned_text %></span>
@@ -71,7 +71,7 @@
 
   <% if email_banned? %>
     <span>
-      <%= render ::UI::Badge::Component.new(text: "EB", title: "Email Banned: #{email_banned_text}", color: badge_color(:email_banned)) %>
+      <%= render ::UI::Badge::Component.new(text: "EB", title: (@full_text ? nil : "Email Banned: #{email_banned_text}"), color: badge_color(:email_banned)) %>
 
       <% if @full_text %>
         <span class="less-strong">Email Banned: <%= email_banned_text %></span>

--- a/app/components/ui/badge/component.rb
+++ b/app/components/ui/badge/component.rb
@@ -2,7 +2,7 @@
 
 module UI::Badge
   class Component < ApplicationComponent
-    BASE_CLASSES = "tw:inline-flex tw:border tw:items-center tw:leading-4 tw:rounded-full tw:cursor-default"
+    BASE_CLASSES = "tw:inline-flex tw:border tw:items-center tw:leading-4 tw:rounded-full"
 
     SIZES = {
       sm: "tw:text-xs tw:font-medium tw:px-1 tw:py-px",
@@ -24,20 +24,31 @@ module UI::Badge
       empty: "tw:bg-white tw:text-gray-700 tw:border-gray-300 tw:dark:bg-gray-900 tw:dark:text-gray-200 tw:dark:border-gray-600"
     }.freeze
 
-    def self.badge_classes(color:, size:)
-      [BASE_CLASSES, COLORS[color], SIZES[size]].join(" ")
+    def self.badge_classes(color:, size:, cursor: "tw:cursor-default")
+      [BASE_CLASSES, cursor, COLORS[color], SIZES[size]].join(" ")
     end
 
     def initialize(text:, title: nil, color: :gray, size: :md)
       @text = text
-      @title = title || text
+      @title = title
       @color = COLORS.key?(color) ? color : :gray
       @size = SIZES.include?(size) ? size : :md
     end
 
     def call
-      content_tag(:span, content.presence || @text,
-        class: self.class.badge_classes(color: @color, size: @size), title: @title)
+      badge = content_tag(:span, content.presence || @text, class: badge_class)
+      return badge unless custom_title?
+      render(UI::Tooltip::Component.new(text: @title)) { badge }
+    end
+
+    private
+
+    def custom_title?
+      @title.present? && @title != @text
+    end
+
+    def badge_class
+      self.class.badge_classes(color: @color, size: @size, cursor: custom_title? ? "tw:cursor-help" : "tw:cursor-default")
     end
   end
 end

--- a/app/components/ui/badge/component_preview.rb
+++ b/app/components/ui/badge/component_preview.rb
@@ -12,6 +12,10 @@ module UI
         render(UI::Badge::Component.new(text: "Organization", color: :notice, size: :sm))
       end
 
+      def notice_sm_with_title
+        render(UI::Badge::Component.new(text: "N", title: "Notice", color: :notice, size: :sm))
+      end
+
       def purple_md
         render(UI::Badge::Component.new(text: "Superuser", color: :purple, size: :md))
       end

--- a/app/components/ui/tooltip/component.html.erb
+++ b/app/components/ui/tooltip/component.html.erb
@@ -1,0 +1,33 @@
+<span class="ui-tooltip tw:inline-block" data-controller="ui--tooltip">
+  <span
+    data-ui--tooltip-target="trigger"
+    data-action="
+      mouseenter->ui--tooltip#showOnHover
+      mouseleave->ui--tooltip#hideOnHover
+      focusin->ui--tooltip#showOnFocus
+      focusout->ui--tooltip#hideOnFocusout
+    "
+    tabindex="0"
+    aria-describedby="<%= tooltip_id %>"
+    class="
+      tw:inline-block tw:rounded tw:focus:outline-none
+      tw:focus-visible:ring-2 tw:focus-visible:ring-purple-400
+    "
+  >
+    <%= content %>
+  </span>
+
+  <span
+    data-ui--tooltip-target="tooltip"
+    role="tooltip"
+    id="<%= tooltip_id %>"
+    class="
+      tw:pointer-events-none tw:z-50 tw:hidden tw:rounded tw:border
+      tw:border-purple-400 tw:bg-purple-900 tw:px-2 tw:py-1 tw:text-xs
+      tw:whitespace-nowrap tw:text-white tw:dark:border-purple-300
+      tw:dark:bg-purple-100 tw:dark:text-purple-900
+    "
+  >
+    <%= tooltip_body %>
+  </span>
+</span>

--- a/app/components/ui/tooltip/component.rb
+++ b/app/components/ui/tooltip/component.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module UI::Tooltip
+  class Component < ApplicationComponent
+    renders_one :body
+
+    def initialize(text: nil)
+      @text = text
+    end
+
+    private
+
+    def tooltip_body
+      body? ? body : @text
+    end
+
+    def tooltip_id
+      @tooltip_id ||= "tooltip-#{SecureRandom.hex(4)}"
+    end
+  end
+end

--- a/app/components/ui/tooltip/component_preview.rb
+++ b/app/components/ui/tooltip/component_preview.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+module UI::Tooltip
+  class ComponentPreview < ApplicationComponentPreview
+    # @!group Variants
+    def default
+      render(UI::Tooltip::Component.new(text: "5–9 mi")) do
+        content_tag(:i, "", class: "tw:block tw:h-5 tw:w-5 tw:rounded tw:bg-purple-400 tw:dark:bg-purple-700 tw:cursor-help")
+      end
+    end
+
+    def with_text_trigger
+      render(UI::Tooltip::Component.new(text: "More information about this thing")) do
+        "hover or focus me"
+      end
+    end
+
+    def with_body_slot
+      render(UI::Tooltip::Component.new) do |tooltip|
+        tooltip.with_body { '<span class="tooltip-body-imperial">5 mi</span>'.html_safe }
+        "body slot trigger"
+      end
+    end
+    # @!endgroup
+
+    # @!group Combined
+    def multiple
+      render_with_template(template: "ui/tooltip/preview/multiple")
+    end
+    # @!endgroup
+  end
+end

--- a/app/components/ui/tooltip/preview/multiple.html.erb
+++ b/app/components/ui/tooltip/preview/multiple.html.erb
@@ -1,0 +1,19 @@
+<div class="tw:flex tw:flex-col tw:gap-6 tw:p-8">
+  <%= render(UI::Tooltip::Component.new(text: "5–9 mi")) do %>
+    <i
+      class="
+        tw:block tw:h-5 tw:w-5 tw:cursor-help tw:rounded tw:bg-purple-400
+        tw:dark:bg-purple-700
+      "
+    ></i>
+  <% end %>
+
+  <%= render(UI::Tooltip::Component.new(text: "More information about this thing")) do %>
+    hover or focus me
+  <% end %>
+
+  <%= render(UI::Tooltip::Component.new) do |tooltip| %>
+    <% tooltip.with_body { '<span class="tooltip-body-imperial">5 mi</span>'.html_safe } %>
+    body slot trigger
+  <% end %>
+</div>

--- a/app/javascript/controllers/ui/tooltip_controller.js
+++ b/app/javascript/controllers/ui/tooltip_controller.js
@@ -1,0 +1,94 @@
+import { Controller } from '@hotwired/stimulus'
+import { computePosition, flip, shift, offset, autoUpdate } from '@floating-ui/dom'
+
+let topZIndex = 50
+
+// Connects to data-controller="ui--tooltip"
+//
+// State model: two independent flags, OR'd together.
+//   hoverActive       toggled by mouseenter/mouseleave
+//   persistentActive  toggled by focus / cleared by focusout or click-outside
+// The tooltip is visible whenever either flag is true.
+export default class extends Controller {
+  static targets = ['trigger', 'tooltip']
+  static values = {
+    placement: { type: String, default: 'top' }
+  }
+
+  initialize () {
+    this.hoverActive = false
+    this.persistentActive = false
+  }
+
+  connect () {
+    this.clickOutside = this.clickOutside.bind(this)
+  }
+
+  disconnect () {
+    this.close()
+  }
+
+  showOnHover () {
+    this.hoverActive = true
+    this.sync()
+  }
+
+  hideOnHover () {
+    this.hoverActive = false
+    this.sync()
+  }
+
+  showOnFocus () {
+    this.persistentActive = true
+    document.addEventListener('click', this.clickOutside)
+    this.sync()
+  }
+
+  hideOnFocusout () {
+    this.persistentActive = false
+    this.sync()
+  }
+
+  clickOutside (event) {
+    if (this.element.contains(event.target)) return
+    this.persistentActive = false
+    this.sync()
+  }
+
+  sync () {
+    if (this.hoverActive || this.persistentActive) this.open()
+    else this.close()
+  }
+
+  open () {
+    if (this.isOpen) return
+    this.isOpen = true
+    topZIndex += 1
+    this.tooltipTarget.style.zIndex = topZIndex
+    this.tooltipTarget.classList.remove('tw:hidden')
+    this.cleanup = autoUpdate(this.triggerTarget, this.tooltipTarget, () => this.updatePosition())
+  }
+
+  close () {
+    if (!this.isOpen) return
+    this.isOpen = false
+    this.tooltipTarget.classList.add('tw:hidden')
+    document.removeEventListener('click', this.clickOutside)
+    if (this.cleanup) {
+      this.cleanup()
+      this.cleanup = null
+    }
+  }
+
+  async updatePosition () {
+    const { x, y } = await computePosition(this.triggerTarget, this.tooltipTarget, {
+      placement: this.placementValue,
+      middleware: [offset(6), flip(), shift({ padding: 4 })]
+    })
+    Object.assign(this.tooltipTarget.style, {
+      left: `${x}px`,
+      top: `${y}px`,
+      position: 'absolute'
+    })
+  }
+}

--- a/spec/components/admin/badges/user/component_spec.rb
+++ b/spec/components/admin/badges/user/component_spec.rb
@@ -27,10 +27,9 @@ RSpec.describe Admin::Badges::User::Component, type: :component do
       expect(user.donor?).to be_truthy
       result = render_component(user:)
       expect(result).to have_text("D")
-      expect(result).to have_css("[title='Donor']", text: "D")
+      expect(result).to have_css("[role='tooltip']", text: "Donor", visible: :all)
 
       result_full = render_component(user:, full_text: true)
-      expect(result_full).to have_css("[title='Donor']", text: "D")
       expect(result_full).to have_text(/D\s*onor/)
     end
 
@@ -41,13 +40,13 @@ RSpec.describe Admin::Badges::User::Component, type: :component do
         expect(user.donor?).to be_truthy
         expect(user.theft_alert_purchaser?).to be_truthy
         result = render_component(user:)
-        expect(result).to have_css("[title='Donor']", text: "D")
-        expect(result).to have_css("[title='Promoted alert purchaser']", text: "P")
+        expect(result).to have_css("[role='tooltip']", text: "Donor", visible: :all)
+        expect(result).to have_css("[role='tooltip']", text: "Promoted alert purchaser", visible: :all)
 
         # If superuser, don't show other stuff
         FactoryBot.create(:superuser_ability, user:)
         result_superuser = render_component(user:)
-        expect(result_superuser).to have_css("[title='Superuser']", text: "S")
+        expect(result_superuser).to have_css("[role='tooltip']", text: "Superuser", visible: :all)
       end
     end
   end
@@ -61,10 +60,10 @@ RSpec.describe Admin::Badges::User::Component, type: :component do
       expect(membership.reload.status).to eq "active"
       expect(user.donor?).to be_falsey
       result = render_component(user:)
-      expect(result).to have_css("[title='Member']")
+      expect(result).to have_css("[role='tooltip']", text: "Member", visible: :all)
 
       component_text = whitespace_normalized_body_text(result.to_html)
-      expect(component_text).to eq("M")
+      expect(component_text).to eq("M Member")
     end
 
     it "renders full text" do
@@ -93,7 +92,7 @@ RSpec.describe Admin::Badges::User::Component, type: :component do
       expect(user.reload).to be_present
       result = render_component(user:)
       component_text = whitespace_normalized_body_text(result.to_html)
-      expect(component_text).to eq("R")
+      expect(component_text).to eq("R Recovered bike")
     end
   end
 
@@ -104,7 +103,7 @@ RSpec.describe Admin::Badges::User::Component, type: :component do
     it "renders org icon for unpaid org" do
       expect(user.paid_org?).to be_falsey
       result = render_component(user:)
-      expect(result).to have_css("[title='organization member - Bike Shop']")
+      expect(result).to have_css("[role='tooltip']", text: "organization member - Bike Shop", visible: :all)
       expect(result).to have_text("O-BS")
     end
 
@@ -115,10 +114,10 @@ RSpec.describe Admin::Badges::User::Component, type: :component do
         expect(user.paid_org?).to be_truthy
         allow_any_instance_of(Organization).to receive(:paid_money?).and_return(true)
         result = render_component(user:)
-        expect(result).to have_css("[title='Paid organization member - Law Enforcement']")
+        expect(result).to have_css("[role='tooltip']", text: "Paid organization member - Law Enforcement", visible: :all)
 
         component_text = whitespace_normalized_body_text(result.to_html)
-        expect(component_text).to eq("$O-P")
+        expect(component_text).to eq("$O-P Paid organization member - Law Enforcement")
 
         result_full = render_component(user:, full_text: true)
         component_text = whitespace_normalized_body_text(result_full.to_html)
@@ -132,7 +131,7 @@ RSpec.describe Admin::Badges::User::Component, type: :component do
     it "shows banned" do
       result = render_component(user:)
       expect(result).to have_text("B")
-      expect(result).to have_css("[title='Banned']")
+      expect(result).to have_css("[role='tooltip']", text: "Banned", visible: :all)
 
       result_full = render_component(user:, full_text: true)
       component_text = whitespace_normalized_body_text(result_full.to_html)
@@ -146,7 +145,7 @@ RSpec.describe Admin::Badges::User::Component, type: :component do
         user.reload
         result = render_component(user:)
         expect(result).to have_text("B")
-        expect(result).to have_css("[title='Banned: Known criminal']")
+        expect(result).to have_css("[role='tooltip']", text: "Banned: Known criminal", visible: :all)
 
         result_full = render_component(user:, full_text: true)
         component_text = whitespace_normalized_body_text(result_full.to_html)
@@ -161,7 +160,7 @@ RSpec.describe Admin::Badges::User::Component, type: :component do
     it "shows email banned" do
       result = render_component(user:)
       expect(result).to have_text("EB")
-      expect(result).to have_css("[title='Email Banned: domain']")
+      expect(result).to have_css("[role='tooltip']", text: "Email Banned: domain", visible: :all)
 
       result_full = render_component(user:, full_text: true)
       component_text = whitespace_normalized_body_text(result_full.to_html)

--- a/spec/components/ui/badge/component_spec.rb
+++ b/spec/components/ui/badge/component_spec.rb
@@ -10,21 +10,31 @@ RSpec.describe UI::Badge::Component, type: :component do
   let(:color) { nil }
   let(:title) { nil }
 
-  it "renders with default gray color" do
+  it "renders with default gray color and no tooltip" do
     expect(component).to have_css("span")
     expect(component).to have_text("Test Badge")
-    expect(component).to have_css("span[title='Test Badge']")
+    expect(component).not_to have_css("[role='tooltip']")
 
     html = component.to_html
     expect(html).to include("tw:bg-gray-300")
     expect(html).to include("tw:inline-flex")
     expect(html).to include("tw:rounded-full")
+    expect(html).to include("tw:cursor-default")
   end
 
-  context "with custom title" do
+  context "with title equal to text" do
+    let(:title) { "Test Badge" }
+    it "does not render a tooltip" do
+      expect(component).not_to have_css("[role='tooltip']")
+      expect(component.to_html).to include("tw:cursor-default")
+    end
+  end
+
+  context "with custom title differing from text" do
     let(:title) { "Custom Title" }
-    it "uses custom title" do
-      expect(component).to have_css("span[title='Custom Title']")
+    it "wraps in a UI::Tooltip with cursor-help" do
+      expect(component.css("[role='tooltip']").text.strip).to eq "Custom Title"
+      expect(component.to_html).to include("tw:cursor-help")
       expect(component).to have_text("Test Badge")
     end
   end

--- a/spec/components/ui/badge/component_system_spec.rb
+++ b/spec/components/ui/badge/component_system_spec.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe UI::Badge::Component, :js, type: :system do
+  it "wraps the badge in a UI::Tooltip when title differs from text" do
+    visit "/rails/view_components/ui/badge/component/notice_sm_with_title"
+
+    tooltip = find("[role='tooltip']", visible: :all)
+    expect(tooltip.text(:all)).to eq "Notice"
+    expect(tooltip).not_to be_visible
+    expect(page).to be_axe_clean.skipping(*SKIPPABLE_AXE_RULES)
+
+    trigger = find("[aria-describedby='#{tooltip[:id]}']")
+    expect(trigger).to have_text "N"
+    expect(trigger.find("span.tw\\:cursor-help")).to be_present
+
+    trigger.hover
+
+    expect(tooltip).to be_visible
+  end
+
+  it "renders badges without a tooltip when no custom title is provided" do
+    visit "/rails/view_components/ui/badge/component/success"
+
+    expect(page).to have_css("span.tw\\:cursor-default")
+    expect(page).to have_text "Donor"
+    expect(page).not_to have_css("[role='tooltip']")
+  end
+end

--- a/spec/components/ui/tooltip/component_system_spec.rb
+++ b/spec/components/ui/tooltip/component_system_spec.rb
@@ -1,0 +1,103 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe UI::Tooltip::Component, :js, type: :system do
+  let(:preview_url) { "/rails/view_components/ui/tooltip/component/multiple" }
+
+  def tooltip_position(id)
+    page.evaluate_script(<<~JS)
+      (() => {
+        const style = document.getElementById(#{id.to_json}).style
+        return { top: style.top, left: style.left }
+      })()
+    JS
+  end
+
+  def tooltip_z_index(id)
+    page.evaluate_script("document.getElementById(#{id.to_json}).style.zIndex")
+  end
+
+  it "renders accessibly and supports the full hover/focus/click state machine" do
+    visit preview_url
+
+    tooltips = all("[role='tooltip']", visible: :all)
+    expect(tooltips.size).to be >= 2
+    expect(tooltips.map { |t| t[:id] }.uniq.size).to eq tooltips.size
+    expect(page).to be_axe_clean.skipping(*SKIPPABLE_AXE_RULES)
+
+    tooltip = tooltips.first
+    trigger = find("[aria-describedby='#{tooltip[:id]}']")
+    expect(trigger[:tabindex]).to eq "0"
+    expect(tooltip.text(:all)).to eq "5–9 mi"
+    expect(tooltip).not_to be_visible
+
+    body_tooltip = find(".tooltip-body-imperial", visible: :all).find(:xpath, "ancestor::*[@role='tooltip']", visible: :all)
+    expect(body_tooltip).to have_css(".tooltip-body-imperial", text: "5 mi", visible: :all)
+
+    # Hover shows, mouseleave hides
+    trigger.hover
+    expect(tooltip).to be_visible
+    expect(tooltip_position(tooltip[:id])).to include("top" => be_present, "left" => be_present)
+    find("body").hover
+    expect(tooltip).not_to be_visible
+
+    # Focus shows, body click hides
+    page.execute_script("arguments[0].focus()", trigger)
+    expect(tooltip).to be_visible
+    find("body").click
+    expect(tooltip).not_to be_visible
+
+    # Hover-only is NOT dismissed by a body click, only by mouseleave
+    trigger.hover
+    page.execute_script("document.body.click()")
+    expect(tooltip).to be_visible
+    find("body").hover
+    expect(tooltip).not_to be_visible
+
+    # Hover-then-focus stays visible until BOTH clear
+    trigger.hover
+    page.execute_script("arguments[0].focus()", trigger)
+    find("body").hover
+    expect(tooltip).to be_visible
+    page.execute_script("arguments[0].blur()", trigger)
+    expect(tooltip).not_to be_visible
+
+    # Focus-then-hover is symmetric: stays through mouseleave until blur
+    page.execute_script("arguments[0].focus()", trigger)
+    trigger.hover
+    find("body").hover
+    expect(tooltip).to be_visible
+    page.execute_script("arguments[0].blur()", trigger)
+    expect(tooltip).not_to be_visible
+
+    # Focus moving to another trigger hides the first
+    triggers = tooltips.map { |t| find("[aria-describedby='#{t[:id]}']") }
+    page.execute_script("arguments[0].focus()", triggers.first)
+    expect(tooltips.first).to be_visible
+    page.execute_script("arguments[0].focus()", triggers.last)
+    expect(tooltips.first).not_to be_visible
+    page.execute_script("arguments[0].blur()", triggers.last)
+
+    # Clicking the trigger persists the tooltip through mouseleave until a body click
+    trigger.hover
+    trigger.click
+    find("body").hover
+    expect(tooltip).to be_visible
+    find("body").click
+    expect(tooltip).not_to be_visible
+
+    # Click layering pushes each clicked tooltip's z-index higher
+    tooltips.each { |t| find("[aria-describedby='#{t[:id]}']").click }
+    z_indexes = tooltips.map { |t| tooltip_z_index(t[:id]).to_i }
+    expect(z_indexes).to eq z_indexes.sort
+    expect(z_indexes.last).to be > z_indexes.first
+  end
+
+  it "is accessible in dark mode" do
+    visit "#{preview_url}?lookbook[display][theme]=dark"
+
+    expect(page).to have_css("[role='tooltip']", visible: :all)
+    expect(page).to be_axe_clean.skipping(*SKIPPABLE_AXE_RULES)
+  end
+end


### PR DESCRIPTION
New `UI::Tooltip` ViewComponent backed by a Stimulus controller and `@floating-ui/dom` (already pinned), with a hover/focus/click-outside state machine, `role="tooltip"`, and `aria-describedby` wiring. `UI::Badge` now wraps itself in `UI::Tooltip` when `title:` differs from `text:` (with `cursor-help`), otherwise renders a plain span with `cursor-default` — replacing the previous unconditional HTML `title` attribute