### PR TITLE
Fix three Honeybadger faults: admin strava table, donation job sort, Strava 404s

### DIFF
--- a/app/jobs/email/donation_job.rb
+++ b/app/jobs/email/donation_job.rb
@@ -61,10 +61,7 @@ class Email::DonationJob < ApplicationJob
 
     payment.user.bikes.select do |b|
       b.stolen_recovery? && b.recovered_records.where(recovered_at: relevant_period(payment)).any?
-    end.sort do |a, b|
-      # most recent recovery
-      a.recovered_records.last.recovered_at <=> b.recovered_records.recovered_at
-    end
+    end.sort_by { |bike| bike.recovered_records.first.recovered_at }
   end
 
   def matching_stolen_bikes(payment)

--- a/app/models/strava_request.rb
+++ b/app/models/strava_request.rb
@@ -182,7 +182,7 @@ class StravaRequest < AnalyticsRecord
 
       StravaRequest.create!(user_id:, strava_integration_id:, request_type:, proxy_request:,
         parameters: parameters.except("error_response_status"))
-    elsif error? && raise_on_error
+    elsif error? && raise_on_error && response.status != 404
       raise "Strava API error #{response.status}: #{response.body}"
     end
   end

--- a/app/views/admin/strava_activities/_table.html.erb
+++ b/app/views/admin/strava_activities/_table.html.erb
@@ -49,7 +49,7 @@
   <% end %>
 
   <% table.column(sortable: "distance_meters", label: "Distance (miles)", classes: "tw:text-xs") do |strava_activity| %>
-    <%= number_display(strava_activity.distance_miles.round) %>
+    <%= number_display(strava_activity.distance_miles&.round) %>
   <% end %>
 
   <% table.column(label: "Gear", header_classes: "tw:font-normal") do |strava_activity| %>

--- a/spec/jobs/email/donation_job_spec.rb
+++ b/spec/jobs/email/donation_job_spec.rb
@@ -147,6 +147,15 @@ RSpec.describe Email::DonationJob, type: :job do
         expect(payment.notifications.first.bike_id).to be_present
         expect(payment.notifications.first.bike_id).to eq recovery2.bike&.id
       end
+
+      context "with multiple recovered bikes" do
+        let!(:recovery1) { FactoryBot.create(:stolen_record_recovered, bike: bike1, recovered_at: Time.current - 2.weeks) }
+        it "picks the most recent recovery" do
+          user.reload
+          expect(instance.calculated_notification_kind(payment)).to eq "donation_recovered"
+          expect(instance.bike_for_notification(payment, "donation_recovered")&.id).to eq bike2.id
+        end
+      end
     end
   end
 end

--- a/spec/models/strava_request_spec.rb
+++ b/spec/models/strava_request_spec.rb
@@ -191,6 +191,22 @@ RSpec.describe StravaRequest, type: :model do
       end
     end
 
+    context "404 record not found" do
+      let(:response) do
+        instance_double(Faraday::Response, success?: false, status: 404, headers:,
+          body: {"message" => "Record Not Found", "errors" => [{"resource" => "Activity", "field" => "id", "code" => "invalid"}]})
+      end
+
+      it "marks as error but does not raise even with raise_on_error" do
+        expect {
+          strava_request.update_from_response(response, raise_on_error: true)
+        }.not_to raise_error
+
+        expect(strava_request.reload.error?).to be true
+        expect(strava_request.parameters).to eq({page: 1, error_response_status: 404}.as_json)
+      end
+    end
+
     context "rate limited response with re_enqueue" do
       let(:response) { instance_double(Faraday::Response, success?: false, status: 429, headers:, body: "Rate limited") }
 

--- a/spec/requests/admin/strava_activities_request_spec.rb
+++ b/spec/requests/admin/strava_activities_request_spec.rb
@@ -15,5 +15,15 @@ RSpec.describe Admin::StravaActivitiesController, type: :request do
       expect(response).to render_template(:index)
       expect(assigns(:collection).pluck(:id)).to eq([strava_activity.id])
     end
+
+    context "with nil distance_meters" do
+      let!(:strava_activity) { FactoryBot.create(:strava_activity, distance_meters: nil) }
+
+      it "responds with ok" do
+        get base_url
+        expect(response.status).to eq(200)
+        expect(assigns(:collection).pluck(:id)).to eq([strava_activity.id])
+      end
+    end
   end
 end


### PR DESCRIPTION
Fixes three production exceptions surfaced by Honeybadger.

- **`admin/strava_activities#index`** ([fault 129778105](https://app.honeybadger.io/projects/35931/faults/129778105)): the table called `.round` on `strava_activity.distance_miles`, which returns `nil` when `distance_meters` is blank. Changed to `&.round`.
- **`Email::DonationJob`** ([fault 123543295](https://app.honeybadger.io/projects/35931/faults/123543295)): the sort comparator in `matching_recovered_bikes` was missing `.last` on the right side, calling `recovered_at` on an `ActiveRecord::CollectionProxy`. Replaced with `sort_by`. Also fixed the ordering — `recovered_records` is scoped `recovered_at desc`, so the previous `.last` returned the *oldest* recovery; switched to `.first` to match the "most recent recovery" intent.
- **`StravaJobs::RequestRunner`** ([fault 129192835](https://app.honeybadger.io/projects/35931/faults/129192835)): `update_from_response` raised on every error when `raise_on_error: true`, including 404 "Record Not Found" responses that occur routinely when a user deletes an activity on Strava. Skip the raise for 404s; the request is still recorded with `error?` status for analytics.
