### PR TITLE
Consolidate Tooltip preview and admin bike multi-delete toggle

### DIFF
--- a/app/components/ui/tooltip/component_preview.rb
+++ b/app/components/ui/tooltip/component_preview.rb
@@ -3,27 +3,6 @@
 module UI::Tooltip
   class ComponentPreview < ApplicationComponentPreview
     # @!group Variants
-    def default
-      render(UI::Tooltip::Component.new(text: "5–9 mi")) do
-        content_tag(:i, "", class: "tw:block tw:h-5 tw:w-5 tw:rounded tw:bg-purple-400 tw:dark:bg-purple-700 tw:cursor-help")
-      end
-    end
-
-    def with_text_trigger
-      render(UI::Tooltip::Component.new(text: "More information about this thing")) do
-        "hover or focus me"
-      end
-    end
-
-    def with_body_slot
-      render(UI::Tooltip::Component.new) do |tooltip|
-        tooltip.with_body { '<span class="tooltip-body-imperial">5 mi</span>'.html_safe }
-        "body slot trigger"
-      end
-    end
-    # @!endgroup
-
-    # @!group Combined
     def multiple
       render_with_template(template: "ui/tooltip/preview/multiple")
     end

--- a/app/controllers/admin/bikes_controller.rb
+++ b/app/controllers/admin/bikes_controller.rb
@@ -62,7 +62,7 @@ class Admin::BikesController < Admin::BaseController
 
   def get_destroy
     if params[:id] == "multi_delete"
-      bike_ids = defined?(params[:bikes_selected].keys) ? params[:bikes_selected].keys : params[:bikes_selected]
+      bike_ids = params[:bikes_selected].respond_to?(:keys) ? params[:bikes_selected].keys : Array(params[:bikes_selected])
       if bike_ids.any?
         bike_ids.each { |id| BikeDeleterJob.perform_async(id.to_i, false, current_user.id) }
         flash[:success] = "#{bike_ids.count} #{"bike".pluralize(bike_ids.count)} deleted!"

--- a/app/javascript/controllers/table_multi_delete_controller.js
+++ b/app/javascript/controllers/table_multi_delete_controller.js
@@ -1,0 +1,12 @@
+import { Controller } from '@hotwired/stimulus'
+
+// Connects to data-controller="table-multi-delete"
+export default class extends Controller {
+  static targets = ['checkbox']
+
+  toggleAll (event) {
+    event.preventDefault()
+    const anyUnchecked = this.checkboxTargets.some(cb => !cb.checked)
+    this.checkboxTargets.forEach(cb => { cb.checked = anyUnchecked })
+  }
+}

--- a/app/javascript/controllers/ui/table_controller.js
+++ b/app/javascript/controllers/ui/table_controller.js
@@ -13,12 +13,12 @@ export default class extends Controller {
   connect () {
     this.applyEdgeStyles()
     this.boundRefresh = () => this.applyEdgeStyles()
+    this.boundResize = () => this.onResize()
     window.addEventListener('ui-table:refresh', this.boundRefresh)
+    window.addEventListener('resize', this.boundResize)
 
     if (this.stickyValue) {
-      this.boundResize = () => this.setupSticky()
       this.boundScroll = () => this.onScroll()
-      window.addEventListener('resize', this.boundResize)
       this.setupSticky()
     }
   }
@@ -33,6 +33,16 @@ export default class extends Controller {
     if (this.boundScroll) {
       window.removeEventListener('scroll', this.boundScroll)
     }
+    if (this.resizeFrame) cancelAnimationFrame(this.resizeFrame)
+  }
+
+  onResize () {
+    if (this.resizeFrame) return
+    this.resizeFrame = requestAnimationFrame(() => {
+      this.resizeFrame = null
+      this.applyEdgeStyles()
+      if (this.stickyValue) this.setupSticky()
+    })
   }
 
   refresh () {

--- a/app/javascript/controllers/ui/table_controller.js
+++ b/app/javascript/controllers/ui/table_controller.js
@@ -1,6 +1,6 @@
 import { Controller } from '@hotwired/stimulus'
 
-/* global CSS, getComputedStyle, requestAnimationFrame */
+/* global CSS, getComputedStyle, requestAnimationFrame, cancelAnimationFrame */
 
 // Connects to data-controller='ui--table'
 // Applies first/last visible column styles (rounding, borders) that CSS

--- a/app/views/admin/bikes/_table.html.erb
+++ b/app/views/admin/bikes/_table.html.erb
@@ -29,7 +29,7 @@
   <style>.ui-table thead {display: none !important;}</style>
 <% end %>
 
-<%= form_tag get_destroy_admin_bike_path(id: "multi_delete"), method: :get do %>
+<%= form_tag get_destroy_admin_bike_path(id: "multi_delete"), method: :get, data: {controller: "table-multi-delete"} do %>
   <div class="display-multi-check mb-3 text-center">
     <%= submit_tag 'Delete selected', class: 'btn btn-outline-danger' %>
   </div>
@@ -38,9 +38,9 @@
     data-controller="update-cached-sortable-links"
     data-update-cached-sortable-links-base-url-value="<%= url_for(sortable_search_params) %>"
   >
-    <%= render(UI::Table::Component.new(records: bikes, cache_key: "admin-bikes", render_sortable:, classes: show_serial ? "show-admin-bike-table-serial-cell" : nil)) do |table| %>
-      <% table.column(label: link_to(check_mark, "#", id: "multi-checkbox-selector"), classes: "display-multi-check tw:w-8", header_classes: "display-multi-check tw:w-8") do |bike| %>
-        <%= check_box_tag "bikes_selected[#{bike.id}]", bike.id %>
+    <%= render(UI::Table::Component.new(records: bikes, cache_key: "admin-bikes-v2", render_sortable:, classes: show_serial ? "show-admin-bike-table-serial-cell" : nil)) do |table| %>
+      <% table.column(label: button_tag(check_mark, type: "button", class: "twlink tw:bg-transparent tw:border-0 tw:p-0 tw:cursor-pointer", data: {action: "click->table-multi-delete#toggleAll"}), classes: "display-multi-check tw:w-8", header_classes: "display-multi-check tw:w-8") do |bike| %>
+        <%= check_box_tag "bikes_selected[#{bike.id}]", bike.id, false, data: {"table-multi-delete-target" => "checkbox"} %>
       <% end %>
 
       <% table.column(sortable: "id", label: "Added", lower_right: ->(bike) { content_tag(:span, bike.id, class: "only-dev-visible") }) do |bike| %>

--- a/app/views/admin/bikes/missing_manufacturer.html.haml
+++ b/app/views/admin/bikes/missing_manufacturer.html.haml
@@ -43,7 +43,7 @@
 
 = render_admin_pagination_with_count(collection: @bikes)
 
-= form_tag update_manufacturers_admin_bikes_path do
+= form_tag update_manufacturers_admin_bikes_path, data: {controller: "table-multi-delete"} do
   .row
     .col-md-4
       .fancy-select.unfancy
@@ -55,7 +55,7 @@
     %table.table.table-striped.table-bordered.table-sm
       %thead.thead-light
         %th.table-checkbox-select
-          %a#multi-checkbox-selector{ href: "#" }
+          %button{ type: "button", class: "twlink tw:bg-transparent tw:border-0 tw:p-0 tw:cursor-pointer", data: { action: "click->table-multi-delete#toggleAll" } }
             = check_mark
         %th
           Date indexed
@@ -70,7 +70,7 @@
         - @bikes.each do |bike|
           %tr
             %td.table-checkbox-select
-              = check_box_tag "bikes_selected[#{bike.id}]", bike.id
+              = check_box_tag "bikes_selected[#{bike.id}]", bike.id, false, data: { "table-multi-delete-target" => "checkbox" }
             %td
               .less-strong-hold
                 %a.localizeTime{ href: edit_admin_bike_url(bike) }


### PR DESCRIPTION
- Drop the three duplicative individual Tooltip preview variants in favor of the combined `multiple` preview (the system spec already targets that URL).
- Replace the admin bikes index / missing_manufacturer toggle-all anchor with a real button wired to a new `table-multi-delete` Stimulus controller
- Unify `UI::Table` resize handling behind a single rAF-throttled handler so edge-style + sticky both react to resize.