### PR TITLE
Fix flat modules and add Style/ClassAndModuleChildren rubocop

### DIFF
--- a/.rubocop_custom.yml
+++ b/.rubocop_custom.yml
@@ -7,6 +7,13 @@ AllCops:
     - "spec/vcr_cassettes/*"
     - "vendor/bundle/**/*"
 
+Style/ClassAndModuleChildren:
+  Enabled: true
+  EnforcedStyle: nested
+  AutoCorrect: always
+  Exclude:
+    - "config/initializers/rack_attack.rb"
+
 Layout/ClassStructure:
   Enabled: true
   ExpectedOrder:

--- a/app/components/admin/address_record_cell/component.rb
+++ b/app/components/admin/address_record_cell/component.rb
@@ -1,13 +1,15 @@
 # frozen_string_literal: true
 
-module Admin::AddressRecordCell
-  class Component < ApplicationComponent
-    def initialize(address_record:)
-      @address_record = address_record
-    end
+module Admin
+  module AddressRecordCell
+    class Component < ApplicationComponent
+      def initialize(address_record:)
+        @address_record = address_record
+      end
 
-    def render?
-      @address_record.present?
+      def render?
+        @address_record.present?
+      end
     end
   end
 end

--- a/app/components/admin/address_record_cell/component_preview.rb
+++ b/app/components/admin/address_record_cell/component_preview.rb
@@ -1,30 +1,32 @@
 # frozen_string_literal: true
 
-module Admin::AddressRecordCell
-  class ComponentPreview < ApplicationComponentPreview
-    # @!group Address Variants
+module Admin
+  module AddressRecordCell
+    class ComponentPreview < ApplicationComponentPreview
+      # @!group Address Variants
 
-    def with_us_state
-      address_record = AddressRecord.new(
-        city: "Davis",
-        region_record: State.friendly_find("CA"),
-        country: Country.united_states
-      )
-      render(Admin::AddressRecordCell::Component.new(address_record:))
-    end
+      def with_us_state
+        address_record = AddressRecord.new(
+          city: "Davis",
+          region_record: State.friendly_find("CA"),
+          country: Country.united_states
+        )
+        render(Admin::AddressRecordCell::Component.new(address_record:))
+      end
 
-    def with_non_us_country
-      address_record = AddressRecord.new(
-        city: "Toronto",
-        region_string: "ON",
-        country: Country.friendly_find("CA")
-      )
-      render(Admin::AddressRecordCell::Component.new(address_record:))
-    end
+      def with_non_us_country
+        address_record = AddressRecord.new(
+          city: "Toronto",
+          region_string: "ON",
+          country: Country.friendly_find("CA")
+        )
+        render(Admin::AddressRecordCell::Component.new(address_record:))
+      end
 
-    def with_city_only
-      address_record = AddressRecord.new(city: "Portland")
-      render(Admin::AddressRecordCell::Component.new(address_record:))
+      def with_city_only
+        address_record = AddressRecord.new(city: "Portland")
+        render(Admin::AddressRecordCell::Component.new(address_record:))
+      end
     end
   end
 end

--- a/app/components/admin/badges/bike_hidden_explanation/component.rb
+++ b/app/components/admin/badges/bike_hidden_explanation/component.rb
@@ -1,55 +1,59 @@
 # frozen_string_literal: true
 
-module Admin::Badges::BikeHiddenExplanation
-  class Component < ApplicationComponent
-    def initialize(bike:)
-      @bike = bike
-    end
+module Admin
+  module Badges
+    module BikeHiddenExplanation
+      class Component < ApplicationComponent
+        def initialize(bike:)
+          @bike = bike
+        end
 
-    def render?
-      @bike.present? && !@bike.current?
-    end
+        def render?
+          @bike.present? && !@bike.current?
+        end
 
-    def call
-      safe_join(
-        [deleted_content, user_hidden_content, likely_spam_content, example_content].compact,
-        " & "
-      )
-    end
+        def call
+          safe_join(
+            [deleted_content, user_hidden_content, likely_spam_content, example_content].compact,
+            " & "
+          )
+        end
 
-    private
+        private
 
-    def user_hidden_content
-      return unless @bike.user_hidden?
+        def user_hidden_content
+          return unless @bike.user_hidden?
 
-      content_tag(:small, "user hidden", class: UI::Alert::Component::TEXT_CLASSES[:notice])
-    end
+          content_tag(:small, "user hidden", class: UI::Alert::Component::TEXT_CLASSES[:notice])
+        end
 
-    # BikeVersion can't be example
-    def example_content
-      return unless @bike.is_a?(Bike) && @bike.example?
+        # BikeVersion can't be example
+        def example_content
+          return unless @bike.is_a?(Bike) && @bike.example?
 
-      content_tag(:small, "test", title: "example (aka test)", class: error_class)
-    end
+          content_tag(:small, "test", title: "example (aka test)", class: error_class)
+        end
 
-    # BikeVersion can't be likey spam
-    def likely_spam_content
-      return unless @bike.is_a?(Bike) && @bike.likely_spam?
+        # BikeVersion can't be likey spam
+        def likely_spam_content
+          return unless @bike.is_a?(Bike) && @bike.likely_spam?
 
-      content_tag(:small, "spam", title: "LIKELY spam", class: error_class)
-    end
+          content_tag(:small, "spam", title: "LIKELY spam", class: error_class)
+        end
 
-    def deleted_content
-      return unless @bike.deleted?
+        def deleted_content
+          return unless @bike.deleted?
 
-      content_tag(:small,
-        content_tag(:span, "deleted: ") +
-          content_tag(:span, l(@bike.deleted_at, format: :convert_time), class: "localizeTime"),
-        class: UI::Alert::Component::TEXT_CLASSES[:warning])
-    end
+          content_tag(:small,
+            content_tag(:span, "deleted: ") +
+              content_tag(:span, l(@bike.deleted_at, format: :convert_time), class: "localizeTime"),
+            class: UI::Alert::Component::TEXT_CLASSES[:warning])
+        end
 
-    def error_class
-      UI::Alert::Component::TEXT_CLASSES[:error]
+        def error_class
+          UI::Alert::Component::TEXT_CLASSES[:error]
+        end
+      end
     end
   end
 end

--- a/app/components/admin/badges/bike_hidden_explanation/component_preview.rb
+++ b/app/components/admin/badges/bike_hidden_explanation/component_preview.rb
@@ -1,28 +1,32 @@
 # frozen_string_literal: true
 
-module Admin::Badges::BikeHiddenExplanation
-  class ComponentPreview < ApplicationComponentPreview
-    # @!group Hidden Variants
-    def user_hidden
-      render(Admin::Badges::BikeHiddenExplanation::Component.new(bike: Bike.with_user_hidden.where(user_hidden: true).last))
-    end
+module Admin
+  module Badges
+    module BikeHiddenExplanation
+      class ComponentPreview < ApplicationComponentPreview
+        # @!group Hidden Variants
+        def user_hidden
+          render(Admin::Badges::BikeHiddenExplanation::Component.new(bike: Bike.with_user_hidden.where(user_hidden: true).last))
+        end
 
-    def example
-      render(Admin::Badges::BikeHiddenExplanation::Component.new(bike: Bike.example.last))
-    end
+        def example
+          render(Admin::Badges::BikeHiddenExplanation::Component.new(bike: Bike.example.last))
+        end
 
-    def spam
-      render(Admin::Badges::BikeHiddenExplanation::Component.new(bike: Bike.spam.last))
-    end
+        def spam
+          render(Admin::Badges::BikeHiddenExplanation::Component.new(bike: Bike.spam.last))
+        end
 
-    def deleted
-      render(Admin::Badges::BikeHiddenExplanation::Component.new(bike: Bike.only_deleted.last))
-    end
+        def deleted
+          render(Admin::Badges::BikeHiddenExplanation::Component.new(bike: Bike.only_deleted.last))
+        end
 
-    def all_of_em
-      bike = Bike.new(example: true, likely_spam: true, user_hidden: true, deleted_at: Time.current - 1.hour)
+        def all_of_em
+          bike = Bike.new(example: true, likely_spam: true, user_hidden: true, deleted_at: Time.current - 1.hour)
 
-      render(Admin::Badges::BikeHiddenExplanation::Component.new(bike:))
+          render(Admin::Badges::BikeHiddenExplanation::Component.new(bike:))
+        end
+      end
     end
   end
 end

--- a/app/components/admin/badges/marketplace_listing/component.rb
+++ b/app/components/admin/badges/marketplace_listing/component.rb
@@ -1,37 +1,41 @@
 # frozen_string_literal: true
 
 # NOTE: Currently not a badge, just colored text.
-module Admin::Badges::MarketplaceListing
-  class Component < ApplicationComponent
-    KINDS = %i[marketplace_listing].freeze
+module Admin
+  module Badges
+    module MarketplaceListing
+      class Component < ApplicationComponent
+        KINDS = %i[marketplace_listing].freeze
 
-    def initialize(status:, kind:, status_humanized: nil)
-      @status = status
-      @status_humanized = status_humanized || humanize(@status)
-      @kind = KINDS.include?(kind) ? kind : KINDS.first
-    end
+        def initialize(status:, kind:, status_humanized: nil)
+          @status = status
+          @status_humanized = status_humanized || humanize(@status)
+          @kind = KINDS.include?(kind) ? kind : KINDS.first
+        end
 
-    def call
-      content_tag(:span, @status_humanized, class: status_class)
-    end
+        def call
+          content_tag(:span, @status_humanized, class: status_class)
+        end
 
-    def render?
-      @status.present?
-    end
+        def render?
+          @status.present?
+        end
 
-    private
+        private
 
-    def humanize(str)
-      str&.to_s&.tr("_", " ")
-    end
+        def humanize(str)
+          str&.to_s&.tr("_", " ")
+        end
 
-    def status_class
-      case @status
-      when "for_sale" then UI::Alert::Component::TEXT_CLASSES[:notice]
-      when "sold" then UI::Alert::Component::TEXT_CLASSES[:success]
-      when "removed" then UI::Alert::Component::TEXT_CLASSES[:warning]
-      else
-        ""
+        def status_class
+          case @status
+          when "for_sale" then UI::Alert::Component::TEXT_CLASSES[:notice]
+          when "sold" then UI::Alert::Component::TEXT_CLASSES[:success]
+          when "removed" then UI::Alert::Component::TEXT_CLASSES[:warning]
+          else
+            ""
+          end
+        end
       end
     end
   end

--- a/app/components/admin/badges/marketplace_listing/component_preview.rb
+++ b/app/components/admin/badges/marketplace_listing/component_preview.rb
@@ -1,11 +1,15 @@
 # frozen_string_literal: true
 
-module Admin::Badges::MarketplaceListing
-  class ComponentPreview < ApplicationComponentPreview
-    # @param status text "Status string to render the status badge for"
-    # @param kind text "Kind of status"
-    def default(kind: "marketplace_listing", status: "for_sale")
-      render(Admin::Badges::MarketplaceListing::Component.new(kind: kind&.to_sym, status:))
+module Admin
+  module Badges
+    module MarketplaceListing
+      class ComponentPreview < ApplicationComponentPreview
+        # @param status text "Status string to render the status badge for"
+        # @param kind text "Kind of status"
+        def default(kind: "marketplace_listing", status: "for_sale")
+          render(Admin::Badges::MarketplaceListing::Component.new(kind: kind&.to_sym, status:))
+        end
+      end
     end
   end
 end

--- a/app/components/admin/badges/user/component.rb
+++ b/app/components/admin/badges/user/component.rb
@@ -1,99 +1,103 @@
 # frozen_string_literal: true
 
-module Admin::Badges::User
-  class Component < ApplicationComponent
-    KIND_LETTERS = {
-      bike_shop: "BS",
-      bike_advocacy: "V",
-      law_enforcement: "P",
-      school: "S",
-      bike_manufacturer: "M",
-      ambassador: "A"
-    }.freeze
+module Admin
+  module Badges
+    module User
+      class Component < ApplicationComponent
+        KIND_LETTERS = {
+          bike_shop: "BS",
+          bike_advocacy: "V",
+          law_enforcement: "P",
+          school: "S",
+          bike_manufacturer: "M",
+          ambassador: "A"
+        }.freeze
 
-    def initialize(user:, full_text: false)
-      @user = user
-      @full_text = full_text
-      @tags = compute_tags
-    end
+        def initialize(user:, full_text: false)
+          @user = user
+          @full_text = full_text
+          @tags = compute_tags
+        end
 
-    def render?
-      @tags.any? || banned? || email_banned?
-    end
+        def render?
+          @tags.any? || banned? || email_banned?
+        end
 
-    private
+        private
 
-    def banned?
-      @user&.banned?
-    end
+        def banned?
+          @user&.banned?
+        end
 
-    def banned_text
-      return @banned_text if defined?(@banned_text)
+        def banned_text
+          return @banned_text if defined?(@banned_text)
 
-      @banned_text = [
-        "Banned",
-        @user.user_ban.present? ? @user.user_ban.reason&.humanize : nil
-      ].compact.join(": ")
-    end
+          @banned_text = [
+            "Banned",
+            @user.user_ban.present? ? @user.user_ban.reason&.humanize : nil
+          ].compact.join(": ")
+        end
 
-    def email_banned?
-      @email_bans ||= @user&.email_bans_active || []
+        def email_banned?
+          @email_bans ||= @user&.email_bans_active || []
 
-      @email_bans.any?
-    end
+          @email_bans.any?
+        end
 
-    def email_banned_text
-      @email_bans.map { EmailBan.reason_humanized(it.reason) }.join(", ")
-    end
+        def email_banned_text
+          @email_bans.map { EmailBan.reason_humanized(it.reason) }.join(", ")
+        end
 
-    def compute_tags
-      return [] if @user&.id.blank?
-      return [:superuser] if @user.superuser?
+        def compute_tags
+          return [] if @user&.id.blank?
+          return [:superuser] if @user.superuser?
 
-      result = []
-      result << :donor if @user.donor?
-      result << :member if @user.membership_active.present?
-      result << :recovery if @user.recovered_records.limit(1).any?
-      result << :theft_alert if @user.theft_alert_purchaser?
-      result << :organization_role if organization.present?
-      result
-    end
+          result = []
+          result << :donor if @user.donor?
+          result << :member if @user.membership_active.present?
+          result << :recovery if @user.recovered_records.limit(1).any?
+          result << :theft_alert if @user.theft_alert_purchaser?
+          result << :organization_role if organization.present?
+          result
+        end
 
-    def organization
-      @organization ||= @user&.organization_prioritized
-    end
+        def organization
+          @organization ||= @user&.organization_prioritized
+        end
 
-    def org_icon_text
-      [
-        organization.paid_money? ? "$" : nil,
-        "O-",
-        KIND_LETTERS[organization.kind.to_sym] || "O"
-      ].compact.join("")
-    end
+        def org_icon_text
+          [
+            organization.paid_money? ? "$" : nil,
+            "O-",
+            KIND_LETTERS[organization.kind.to_sym] || "O"
+          ].compact.join("")
+        end
 
-    def org_full_text
-      [
-        organization.paid_money? ? "Paid" : nil,
-        "organization member -",
-        Organization.kind_humanized(organization.kind)
-      ].compact.join(" ")
-    end
+        def org_full_text
+          [
+            organization.paid_money? ? "Paid" : nil,
+            "organization member -",
+            Organization.kind_humanized(organization.kind)
+          ].compact.join(" ")
+        end
 
-    def wrapper_class
-      "tw:inline-flex tw:gap-1 #{"tw:gap-x-3" if @full_text}"
-    end
+        def wrapper_class
+          "tw:inline-flex tw:gap-1 #{"tw:gap-x-3" if @full_text}"
+        end
 
-    def badge_color(variant)
-      {
-        donor: :success,
-        member: :success,
-        organization_role: :notice,
-        superuser: :purple,
-        recovery: :warning,
-        theft_alert: :cyan,
-        banned: :error,
-        email_banned: :error
-      }[variant]
+        def badge_color(variant)
+          {
+            donor: :success,
+            member: :success,
+            organization_role: :notice,
+            superuser: :purple,
+            recovery: :warning,
+            theft_alert: :cyan,
+            banned: :error,
+            email_banned: :error
+          }[variant]
+        end
+      end
     end
   end
 end

--- a/app/components/admin/badges/user/component_preview.rb
+++ b/app/components/admin/badges/user/component_preview.rb
@@ -1,36 +1,40 @@
 # frozen_string_literal: true
 
-module Admin::Badges::User
-  class ComponentPreview < ApplicationComponentPreview
-    # @!group User Badge Variants
-    def default
-      render(Admin::Badges::User::Component.new(user: lookbook_user))
-    end
+module Admin
+  module Badges
+    module User
+      class ComponentPreview < ApplicationComponentPreview
+        # @!group User Badge Variants
+        def default
+          render(Admin::Badges::User::Component.new(user: lookbook_user))
+        end
 
-    def full_text
-      render(Admin::Badges::User::Component.new(user: lookbook_user, full_text: true))
-    end
+        def full_text
+          render(Admin::Badges::User::Component.new(user: lookbook_user, full_text: true))
+        end
 
-    def multiple_badges
-      render(Admin::Badges::User::Component.new(user: multi_badge_user, full_text: true))
-    end
+        def multiple_badges
+          render(Admin::Badges::User::Component.new(user: multi_badge_user, full_text: true))
+        end
 
-    def banned
-      render(Admin::Badges::User::Component.new(user: ::User.new(banned: true), full_text: true))
-    end
+        def banned
+          render(Admin::Badges::User::Component.new(user: ::User.new(banned: true), full_text: true))
+        end
 
-    def no_user
-      render(Admin::Badges::User::Component.new(user: nil))
-    end
-    # @endgroup
+        def no_user
+          render(Admin::Badges::User::Component.new(user: nil))
+        end
+        # @endgroup
 
-    private
+        private
 
-    def multi_badge_user
-      if ENV["LOOKBOOK_SECONDARY_USER_ID"].present?
-        ::User.find(ENV["LOOKBOOK_SECONDARY_USER_ID"])
-      else
-        ::User.new
+        def multi_badge_user
+          if ENV["LOOKBOOK_SECONDARY_USER_ID"].present?
+            ::User.find(ENV["LOOKBOOK_SECONDARY_USER_ID"])
+          else
+            ::User.new
+          end
+        end
       end
     end
   end

--- a/app/components/admin/bike_cell/component.rb
+++ b/app/components/admin/bike_cell/component.rb
@@ -1,70 +1,72 @@
 # frozen_string_literal: true
 
-module Admin::BikeCell
-  class Component < ApplicationComponent
-    include Binxtils::SortableHelper
+module Admin
+  module BikeCell
+    class Component < ApplicationComponent
+      include Binxtils::SortableHelper
 
-    def initialize(
-      bike: nil,
-      bike_id: nil,
-      bike_link_path: nil,
-      search_url: nil,
-      render_search: nil,
-      skip_status: false
-    )
-      @bike = bike
-      @bike_id = bike_id || bike&.id
-      @bike = Bike.unscoped.find_by(id: @bike_id) if @bike.blank? && @bike_id.present?
+      def initialize(
+        bike: nil,
+        bike_id: nil,
+        bike_link_path: nil,
+        search_url: nil,
+        render_search: nil,
+        skip_status: false
+      )
+        @bike = bike
+        @bike_id = bike_id || bike&.id
+        @bike = Bike.unscoped.find_by(id: @bike_id) if @bike.blank? && @bike_id.present?
 
-      # Store the raw bike_link_path value (can be false, nil, or a path)
-      @bike_link_path_arg = bike_link_path
-      @passed_search_url = search_url
-      @render_search = (bike_id.present? && render_search.nil?) ? @search_url.present? : render_search
-      @skip_status = skip_status
-    end
-
-    def render?
-      @bike.present? || @bike_id.present?
-    end
-
-    private
-
-    def bike_link_path
-      # bike_link_path can be false to not link
-      return nil if @bike_link_path_arg == false
-      return @bike_link_path_arg if @bike_link_path_arg.present?
-      if @bike_id.present?
-        return @bike&.version? ? admin_bike_version_path(@bike_id) : admin_bike_path(@bike_id)
+        # Store the raw bike_link_path value (can be false, nil, or a path)
+        @bike_link_path_arg = bike_link_path
+        @passed_search_url = search_url
+        @render_search = (bike_id.present? && render_search.nil?) ? @search_url.present? : render_search
+        @skip_status = skip_status
       end
 
-      nil
-    end
+      def render?
+        @bike.present? || @bike_id.present?
+      end
 
-    def search_url
-      @passed_search_url || url_for(sortable_search_params.merge(search_bike_id: @bike_id))
-    end
+      private
 
-    def bike_content
-      content_tag(:span) do
-        concat(content_tag(:small, "📷 ")) if @bike.thumb_path.present?
-        concat(@bike.frame_colors.to_sentence)
-        concat(" ")
-        concat(content_tag(:strong, @bike.mnfg_name))
-        if @bike.frame_model.present?
-          concat(" ")
-          concat(content_tag(:em, @bike.frame_model_truncated))
+      def bike_link_path
+        # bike_link_path can be false to not link
+        return nil if @bike_link_path_arg == false
+        return @bike_link_path_arg if @bike_link_path_arg.present?
+        if @bike_id.present?
+          return @bike&.version? ? admin_bike_version_path(@bike_id) : admin_bike_path(@bike_id)
         end
-        concat(content_tag(:small, " #{@bike.type}")) unless @bike.cycle_type == "bike"
-        if @bike.version?
+
+        nil
+      end
+
+      def search_url
+        @passed_search_url || url_for(sortable_search_params.merge(search_bike_id: @bike_id))
+      end
+
+      def bike_content
+        content_tag(:span) do
+          concat(content_tag(:small, "📷 ")) if @bike.thumb_path.present?
+          concat(@bike.frame_colors.to_sentence)
           concat(" ")
-          concat(render(UI::Badge::Component.new(text: "V", title: "Bike Version", color: :purple, size: :sm)))
-        elsif @bike.unregistered_parking_notification?
-          concat(content_tag(:em, " unregistered", class: "small text-warning"))
-        elsif @bike.creation_description.present?
-          concat(", ")
-          concat(content_tag(:small, class: "less-strong") do
-            content_tag(:span, @bike.creation_description, title: BikeServices::Displayer.origin_title(@bike.creation_description))
-          end)
+          concat(content_tag(:strong, @bike.mnfg_name))
+          if @bike.frame_model.present?
+            concat(" ")
+            concat(content_tag(:em, @bike.frame_model_truncated))
+          end
+          concat(content_tag(:small, " #{@bike.type}")) unless @bike.cycle_type == "bike"
+          if @bike.version?
+            concat(" ")
+            concat(render(UI::Badge::Component.new(text: "V", title: "Bike Version", color: :purple, size: :sm)))
+          elsif @bike.unregistered_parking_notification?
+            concat(content_tag(:em, " unregistered", class: "small text-warning"))
+          elsif @bike.creation_description.present?
+            concat(", ")
+            concat(content_tag(:small, class: "less-strong") do
+              content_tag(:span, @bike.creation_description, title: BikeServices::Displayer.origin_title(@bike.creation_description))
+            end)
+          end
         end
       end
     end

--- a/app/components/admin/bike_cell/component_preview.rb
+++ b/app/components/admin/bike_cell/component_preview.rb
@@ -1,45 +1,47 @@
 # frozen_string_literal: true
 
-module Admin::BikeCell
-  class ComponentPreview < ApplicationComponentPreview
-    # @!group Bike Variants
-    def with_bike
-      render(Admin::BikeCell::Component.new(bike:))
-    end
+module Admin
+  module BikeCell
+    class ComponentPreview < ApplicationComponentPreview
+      # @!group Bike Variants
+      def with_bike
+        render(Admin::BikeCell::Component.new(bike:))
+      end
 
-    def with_bike_and_link
-      render(Admin::BikeCell::Component.new(bike:, bike_link_path: admin_bike_path(bike.id)))
-    end
+      def with_bike_and_link
+        render(Admin::BikeCell::Component.new(bike:, bike_link_path: admin_bike_path(bike.id)))
+      end
 
-    def with_bike_id_only
-      render(Admin::BikeCell::Component.new(bike_id: bike.id))
-    end
+      def with_bike_id_only
+        render(Admin::BikeCell::Component.new(bike_id: bike.id))
+      end
 
-    def missing_bike
-      render(Admin::BikeCell::Component.new(bike_id: 99999999))
-    end
+      def missing_bike
+        render(Admin::BikeCell::Component.new(bike_id: 99999999))
+      end
 
-    def deleted_bike
-      render(Admin::BikeCell::Component.new(bike_id: 195))
-    end
+      def deleted_bike
+        render(Admin::BikeCell::Component.new(bike_id: 195))
+      end
 
-    def with_search_link
-      render(Admin::BikeCell::Component.new(
-        bike:,
-        render_search: true,
-        search_url: admin_bikes_path(search_bike_id: bike.id)
-      ))
-    end
+      def with_search_link
+        render(Admin::BikeCell::Component.new(
+          bike:,
+          render_search: true,
+          search_url: admin_bikes_path(search_bike_id: bike.id)
+        ))
+      end
 
-    def bike_version
-      render(Admin::BikeCell::Component.new(bike: BikeVersion.find(1)))
-    end
-    # @endgroup
+      def bike_version
+        render(Admin::BikeCell::Component.new(bike: BikeVersion.find(1)))
+      end
+      # @endgroup
 
-    private
+      private
 
-    def bike
-      Bike.find(35)
+      def bike
+        Bike.find(35)
+      end
     end
   end
 end

--- a/app/components/admin/chart_organization_statuses/component.rb
+++ b/app/components/admin/chart_organization_statuses/component.rb
@@ -1,63 +1,65 @@
 # frozen_string_literal: true
 
-module Admin::ChartOrganizationStatuses
-  class Component < ApplicationComponent
-    include GraphingHelper
+module Admin
+  module ChartOrganizationStatuses
+    class Component < ApplicationComponent
+      include GraphingHelper
 
-    COLORS = %w[#FBCA04 #0E8A16 #006B75 #1D76DB #0052CC #B60205 #D93F0B #5319E7 #D4C5F9 #2C3E50 #F9D0C4 #C2E0C6 #C5DEF5 #7DCABB].freeze
+      COLORS = %w[#FBCA04 #0E8A16 #006B75 #1D76DB #0052CC #B60205 #D93F0B #5319E7 #D4C5F9 #2C3E50 #F9D0C4 #C2E0C6 #C5DEF5 #7DCABB].freeze
 
-    def initialize(matching_organization_statuses:, matching_organization_statuses_untimed:, time_range:, pos_kind:, ended:, current:)
-      @matching_organization_statuses = matching_organization_statuses
-      @matching_organization_statuses_untimed = matching_organization_statuses_untimed
-      @time_range = time_range
-      @pos_kind = pos_kind
-      @ended = ended
-      @current = current
-    end
-
-    private
-
-    def show_with_pos_counts?
-      %w[not_no_pos with_pos].include?(@pos_kind)
-    end
-
-    def pos_kinds_start_counts
-      @pos_kinds_start_counts ||= build_pos_kind_data(:start_at).first
-    end
-
-    def start_colors
-      @start_colors ||= build_pos_kind_data(:start_at).last
-    end
-
-    def pos_kinds_end_counts
-      @pos_kinds_end_counts ||= build_pos_kind_data(:end_at).first
-    end
-
-    def end_colors
-      @end_colors ||= build_pos_kind_data(:end_at).last
-    end
-
-    def build_pos_kind_data(column)
-      counts = []
-      colors = []
-      Organization.pos_kinds.each_with_index do |k, i|
-        scoped = @matching_organization_statuses.where(pos_kind: k)
-        next unless scoped.where(column => @time_range).limit(1).present?
-
-        counts << {name: k.humanize, data: time_range_counts(collection: scoped, column:)}
-        colors << COLORS[i]
+      def initialize(matching_organization_statuses:, matching_organization_statuses_untimed:, time_range:, pos_kind:, ended:, current:)
+        @matching_organization_statuses = matching_organization_statuses
+        @matching_organization_statuses_untimed = matching_organization_statuses_untimed
+        @time_range = time_range
+        @pos_kind = pos_kind
+        @ended = ended
+        @current = current
       end
-      [counts, colors]
-    end
 
-    def start_count
-      scope = show_with_pos_counts? ? @matching_organization_statuses_untimed.with_pos : @matching_organization_statuses_untimed
-      scope.at_time(@time_range.first).count
-    end
+      private
 
-    def end_count
-      scope = show_with_pos_counts? ? @matching_organization_statuses_untimed.with_pos : @matching_organization_statuses_untimed
-      scope.at_time(@time_range.last).count
+      def show_with_pos_counts?
+        %w[not_no_pos with_pos].include?(@pos_kind)
+      end
+
+      def pos_kinds_start_counts
+        @pos_kinds_start_counts ||= build_pos_kind_data(:start_at).first
+      end
+
+      def start_colors
+        @start_colors ||= build_pos_kind_data(:start_at).last
+      end
+
+      def pos_kinds_end_counts
+        @pos_kinds_end_counts ||= build_pos_kind_data(:end_at).first
+      end
+
+      def end_colors
+        @end_colors ||= build_pos_kind_data(:end_at).last
+      end
+
+      def build_pos_kind_data(column)
+        counts = []
+        colors = []
+        Organization.pos_kinds.each_with_index do |k, i|
+          scoped = @matching_organization_statuses.where(pos_kind: k)
+          next unless scoped.where(column => @time_range).limit(1).present?
+
+          counts << {name: k.humanize, data: time_range_counts(collection: scoped, column:)}
+          colors << COLORS[i]
+        end
+        [counts, colors]
+      end
+
+      def start_count
+        scope = show_with_pos_counts? ? @matching_organization_statuses_untimed.with_pos : @matching_organization_statuses_untimed
+        scope.at_time(@time_range.first).count
+      end
+
+      def end_count
+        scope = show_with_pos_counts? ? @matching_organization_statuses_untimed.with_pos : @matching_organization_statuses_untimed
+        scope.at_time(@time_range.last).count
+      end
     end
   end
 end

--- a/app/components/admin/current_header/component.rb
+++ b/app/components/admin/current_header/component.rb
@@ -1,110 +1,112 @@
 # frozen_string_literal: true
 
-module Admin::CurrentHeader
-  class Component < ApplicationComponent
-    include Binxtils::SortableHelper
+module Admin
+  module CurrentHeader
+    class Component < ApplicationComponent
+      include Binxtils::SortableHelper
 
-    HEADER_KEYS = %i[
-      organization_id
-      primary_activity
-      search_bike_id
-      search_kind
-      search_marketplace_listing_id
-      search_membership_id
-      user_id
-      search_strava_integration_id
-    ].freeze
+      HEADER_KEYS = %i[
+        organization_id
+        primary_activity
+        search_bike_id
+        search_kind
+        search_marketplace_listing_id
+        search_membership_id
+        user_id
+        search_strava_integration_id
+      ].freeze
 
-    def initialize(params:, viewing: nil, kind_humanized: nil, user_subject: nil, bike: nil, marketplace_listing: nil, primary_activity: nil, current_organization: nil)
-      @params = params
-      @viewing = viewing
-      @kind_humanized = kind_humanized
-      @user_subject = user_subject
-      @bike = bike
-      @marketplace_listing = marketplace_listing
-      @primary_activity = primary_activity
-      @current_organization = current_organization
-    end
+      def initialize(params:, viewing: nil, kind_humanized: nil, user_subject: nil, bike: nil, marketplace_listing: nil, primary_activity: nil, current_organization: nil)
+        @params = params
+        @viewing = viewing
+        @kind_humanized = kind_humanized
+        @user_subject = user_subject
+        @bike = bike
+        @marketplace_listing = marketplace_listing
+        @primary_activity = primary_activity
+        @current_organization = current_organization
+      end
 
-    def render?
-      (@params.keys.map(&:to_sym) & HEADER_KEYS).any? || show_user? || show_marketplace_listing? ||
-        show_organization?
-    end
+      def render?
+        (@params.keys.map(&:to_sym) & HEADER_KEYS).any? || show_user? || show_marketplace_listing? ||
+          show_organization?
+      end
 
-    private
+      private
 
-    def viewing
-      @viewing || controller_name.humanize
-    end
+      def viewing
+        @viewing || controller_name.humanize
+      end
 
-    def show_user?
-      @user_subject.present? || @params[:user_id].present?
-    end
+      def show_user?
+        @user_subject.present? || @params[:user_id].present?
+      end
 
-    def show_bike?
-      bike_subject.present? || @params[:search_bike_id].present?
-    end
+      def show_bike?
+        bike_subject.present? || @params[:search_bike_id].present?
+      end
 
-    def bike_subject
-      @bike_subject ||= @bike || Bike.unscoped.find_by_id(@params[:search_bike_id])
-    end
+      def bike_subject
+        @bike_subject ||= @bike || Bike.unscoped.find_by_id(@params[:search_bike_id])
+      end
 
-    def show_marketplace_listing?
-      @params[:search_marketplace_listing_id].present? || @marketplace_listing.present?
-    end
+      def show_marketplace_listing?
+        @params[:search_marketplace_listing_id].present? || @marketplace_listing.present?
+      end
 
-    def marketplace_listing_subject
-      @marketplace_listing || MarketplaceListing.find_by_id(@params[:search_marketplace_listing_id])
-    end
+      def marketplace_listing_subject
+        @marketplace_listing || MarketplaceListing.find_by_id(@params[:search_marketplace_listing_id])
+      end
 
-    def show_organization?
-      @params[:organization_id].present? || organization_subject.present?
-    end
+      def show_organization?
+        @params[:organization_id].present? || organization_subject.present?
+      end
 
-    def organization_subject
-      @current_organization
-    end
+      def organization_subject
+        @current_organization
+      end
 
-    def show_membership?
-      membership_id.present?
-    end
+      def show_membership?
+        membership_id.present?
+      end
 
-    def membership_id
-      @params[:search_membership_id]
-    end
+      def membership_id
+        @params[:search_membership_id]
+      end
 
-    def show_kind?
-      @params[:search_kind].present?
-    end
+      def show_kind?
+        @params[:search_kind].present?
+      end
 
-    def show_strava_integration?
-      strava_integration_id.present?
-    end
+      def show_strava_integration?
+        strava_integration_id.present?
+      end
 
-    def strava_integration_id
-      @params[:search_strava_integration_id]
-    end
+      def strava_integration_id
+        @params[:search_strava_integration_id]
+      end
 
-    def strava_integration
-      return @strava_integration if defined?(@strava_integration)
+      def strava_integration
+        return @strava_integration if defined?(@strava_integration)
 
-      @strava_integration = StravaIntegration.find_by_id(strava_integration_id)
-    end
+        @strava_integration = StravaIntegration.find_by_id(strava_integration_id)
+      end
 
-    def kind_humanized
-      @kind_humanized || @params[:search_kind]&.humanize
-    end
+      def kind_humanized
+        @kind_humanized || @params[:search_kind]&.humanize
+      end
 
-    def show_primary_activity?
-      @params[:primary_activity].present? || primary_activity_subject.present?
-    end
+      def show_primary_activity?
+        @params[:primary_activity].present? || primary_activity_subject.present?
+      end
 
-    def primary_activity_subject
-      @primary_activity_subject ||= @primary_activity || PrimaryActivity.find_by_id(@params[:primary_activity])
-    end
+      def primary_activity_subject
+        @primary_activity_subject ||= @primary_activity || PrimaryActivity.find_by_id(@params[:primary_activity])
+      end
 
-    def error_text_class
-      UI::Alert::Component::TEXT_CLASSES[:error]
+      def error_text_class
+        UI::Alert::Component::TEXT_CLASSES[:error]
+      end
     end
   end
 end

--- a/app/components/admin/current_header/component_preview.rb
+++ b/app/components/admin/current_header/component_preview.rb
@@ -1,28 +1,30 @@
 # frozen_string_literal: true
 
-module Admin::CurrentHeader
-  class ComponentPreview < ApplicationComponentPreview
-    # @!group Header Variants
+module Admin
+  module CurrentHeader
+    class ComponentPreview < ApplicationComponentPreview
+      # @!group Header Variants
 
-    def default
-      render(Admin::CurrentHeader::Component.new(params: passed_params))
-    end
+      def default
+        render(Admin::CurrentHeader::Component.new(params: passed_params))
+      end
 
-    def with_current_organization
-      current_organization = Organization.friendly_find "hogwarts"
-      primary_activity = PrimaryActivity.friendly_find "Gravel"
-      render(Admin::CurrentHeader::Component.new(current_organization:, params: passed_params, primary_activity:, viewing: "Notifications"))
-    end
+      def with_current_organization
+        current_organization = Organization.friendly_find "hogwarts"
+        primary_activity = PrimaryActivity.friendly_find "Gravel"
+        render(Admin::CurrentHeader::Component.new(current_organization:, params: passed_params, primary_activity:, viewing: "Notifications"))
+      end
 
-    def with_bike
-      bike = Bike.first
-      render(Admin::CurrentHeader::Component.new(params: passed_params(search_bike_id: bike.id), bike:, viewing: "Activities"))
-    end
+      def with_bike
+        bike = Bike.first
+        render(Admin::CurrentHeader::Component.new(params: passed_params(search_bike_id: bike.id), bike:, viewing: "Activities"))
+      end
 
-    private
+      private
 
-    def passed_params(hash = {})
-      ActionController::Parameters.new(hash)
+      def passed_params(hash = {})
+        ActionController::Parameters.new(hash)
+      end
     end
   end
 end

--- a/app/components/admin/index_skeleton/component.rb
+++ b/app/components/admin/index_skeleton/component.rb
@@ -1,109 +1,111 @@
 # frozen_string_literal: true
 
-module Admin::IndexSkeleton
-  class Component < ApplicationComponent
-    include Binxtils::SortableHelper
+module Admin
+  module IndexSkeleton
+    class Component < ApplicationComponent
+      include Binxtils::SortableHelper
 
-    def initialize(
-      collection: nil,
-      viewing: nil,
-      index_title: nil,
-      nav_header_list_items: nil,
-      skip_charting: false,
-      rendered_chart: nil,
-      render_sortable: true,
-      time_range_column: nil,
-      admin_search_form: nil,
-      table_view: nil,
-      chart_collection: nil
-    )
-      @collection = collection
-      @viewing = viewing
-      @index_title = index_title
-      @nav_header_list_items = nav_header_list_items
-      @skip_charting = skip_charting
-      @rendered_chart = rendered_chart
-      @render_sortable = render_sortable
-      @time_range_column_override = time_range_column
-      @admin_search_form = admin_search_form
-      @table_view = table_view
-      @chart_collection = chart_collection
-    end
-
-    def before_render
-      @collection ||= controller.instance_variable_get(:@collection)
-      @render_chart = controller.instance_variable_get(:@render_chart)
-      @pagy = controller.instance_variable_get(:@pagy)
-      @per_page = controller.instance_variable_get(:@per_page)
-      @render_deleted = controller.instance_variable_get(:@render_deleted)
-      @time_range = controller.instance_variable_get(:@time_range)
-      @period = controller.instance_variable_get(:@period)
-      @time_range_column = @time_range_column_override || controller.instance_variable_get(:@time_range_column) || "created_at"
-      @user_subject = controller.instance_variable_get(:@user_subject)
-      @bike = controller.instance_variable_get(:@bike)
-      @marketplace_listing = controller.instance_variable_get(:@marketplace_listing)
-      @primary_activity = controller.instance_variable_get(:@primary_activity)
-      @current_organization = helpers.respond_to?(:current_organization) ? helpers.current_organization : nil
-      @params = helpers.params
-    end
-
-    private
-
-    def viewing
-      @viewing || helpers.controller_name.humanize
-    end
-
-    def show_chart?
-      !@skip_charting && @render_chart
-    end
-
-    def default_chart
-      data = UI::Chart::Component.time_range_counts(collection: @chart_collection, time_range: @time_range, column: @time_range_column)
-      render(UI::Chart::Component.new(series: [{name: viewing, data:}], time_range: @time_range))
-    end
-
-    def current_header_component
-      Admin::CurrentHeader::Component.new(
-        params: @params, viewing: @viewing,
-        user_subject: @user_subject, bike: @bike,
-        marketplace_listing: @marketplace_listing,
-        primary_activity: @primary_activity,
-        current_organization: @current_organization
+      def initialize(
+        collection: nil,
+        viewing: nil,
+        index_title: nil,
+        nav_header_list_items: nil,
+        skip_charting: false,
+        rendered_chart: nil,
+        render_sortable: true,
+        time_range_column: nil,
+        admin_search_form: nil,
+        table_view: nil,
+        chart_collection: nil
       )
-    end
-
-    def pagination_component(skip_total: false)
-      Admin::PaginationWithCount::Component.new(
-        collection: @collection, viewing:, skip_total:,
-        pagy: @pagy, per_page: @per_page, time_range: @time_range,
-        period: @period, time_range_column: @time_range_column, params: @params
-      )
-    end
-
-    def show_deleted_link?
-      !@render_deleted.nil?
-    end
-
-    def deleted_active?
-      @render_deleted.present? && @render_deleted != false
-    end
-
-    def deleted_label
-      case @render_deleted
-      when "including" then "Including deleted"
-      when "only" then "Only deleted"
-      else "deleted"
+        @collection = collection
+        @viewing = viewing
+        @index_title = index_title
+        @nav_header_list_items = nav_header_list_items
+        @skip_charting = skip_charting
+        @rendered_chart = rendered_chart
+        @render_sortable = render_sortable
+        @time_range_column_override = time_range_column
+        @admin_search_form = admin_search_form
+        @table_view = table_view
+        @chart_collection = chart_collection
       end
-    end
 
-    def deleted_item_class(value)
-      if value.nil? ? !deleted_active? : @render_deleted == value
-        "active"
+      def before_render
+        @collection ||= controller.instance_variable_get(:@collection)
+        @render_chart = controller.instance_variable_get(:@render_chart)
+        @pagy = controller.instance_variable_get(:@pagy)
+        @per_page = controller.instance_variable_get(:@per_page)
+        @render_deleted = controller.instance_variable_get(:@render_deleted)
+        @time_range = controller.instance_variable_get(:@time_range)
+        @period = controller.instance_variable_get(:@period)
+        @time_range_column = @time_range_column_override || controller.instance_variable_get(:@time_range_column) || "created_at"
+        @user_subject = controller.instance_variable_get(:@user_subject)
+        @bike = controller.instance_variable_get(:@bike)
+        @marketplace_listing = controller.instance_variable_get(:@marketplace_listing)
+        @primary_activity = controller.instance_variable_get(:@primary_activity)
+        @current_organization = helpers.respond_to?(:current_organization) ? helpers.current_organization : nil
+        @params = helpers.params
       end
-    end
 
-    def default_table_view
-      helpers.render(partial: "table", locals: {collection: @collection, render_sortable: @render_sortable})
+      private
+
+      def viewing
+        @viewing || helpers.controller_name.humanize
+      end
+
+      def show_chart?
+        !@skip_charting && @render_chart
+      end
+
+      def default_chart
+        data = UI::Chart::Component.time_range_counts(collection: @chart_collection, time_range: @time_range, column: @time_range_column)
+        render(UI::Chart::Component.new(series: [{name: viewing, data:}], time_range: @time_range))
+      end
+
+      def current_header_component
+        Admin::CurrentHeader::Component.new(
+          params: @params, viewing: @viewing,
+          user_subject: @user_subject, bike: @bike,
+          marketplace_listing: @marketplace_listing,
+          primary_activity: @primary_activity,
+          current_organization: @current_organization
+        )
+      end
+
+      def pagination_component(skip_total: false)
+        Admin::PaginationWithCount::Component.new(
+          collection: @collection, viewing:, skip_total:,
+          pagy: @pagy, per_page: @per_page, time_range: @time_range,
+          period: @period, time_range_column: @time_range_column, params: @params
+        )
+      end
+
+      def show_deleted_link?
+        !@render_deleted.nil?
+      end
+
+      def deleted_active?
+        @render_deleted.present? && @render_deleted != false
+      end
+
+      def deleted_label
+        case @render_deleted
+        when "including" then "Including deleted"
+        when "only" then "Only deleted"
+        else "deleted"
+        end
+      end
+
+      def deleted_item_class(value)
+        if value.nil? ? !deleted_active? : @render_deleted == value
+          "active"
+        end
+      end
+
+      def default_table_view
+        helpers.render(partial: "table", locals: {collection: @collection, render_sortable: @render_sortable})
+      end
     end
   end
 end

--- a/app/components/admin/organization_cell/component.rb
+++ b/app/components/admin/organization_cell/component.rb
@@ -1,28 +1,30 @@
 # frozen_string_literal: true
 
-module Admin::OrganizationCell
-  class Component < ApplicationComponent
-    include Binxtils::SortableHelper
+module Admin
+  module OrganizationCell
+    class Component < ApplicationComponent
+      include Binxtils::SortableHelper
 
-    def initialize(organization: nil, organization_id: nil, render_search: false)
-      @organization = organization
-      @organization_id = organization_id || organization&.id
-      @render_search = render_search
-    end
+      def initialize(organization: nil, organization_id: nil, render_search: false)
+        @organization = organization
+        @organization_id = organization_id || organization&.id
+        @render_search = render_search
+      end
 
-    private
+      private
 
-    def organization_present?
-      @organization_id.present?
-    end
+      def organization_present?
+        @organization_id.present?
+      end
 
-    def organization_subject
-      return @organization if @organization.present?
-      Organization.unscoped.find_by(id: @organization_id) if @organization_id.present?
-    end
+      def organization_subject
+        return @organization if @organization.present?
+        Organization.unscoped.find_by(id: @organization_id) if @organization_id.present?
+      end
 
-    def error_text_class
-      UI::Alert::Component::TEXT_CLASSES[:error]
+      def error_text_class
+        UI::Alert::Component::TEXT_CLASSES[:error]
+      end
     end
   end
 end

--- a/app/components/admin/organization_cell/component_preview.rb
+++ b/app/components/admin/organization_cell/component_preview.rb
@@ -1,29 +1,31 @@
 # frozen_string_literal: true
 
-module Admin::OrganizationCell
-  class ComponentPreview < ApplicationComponentPreview
-    # @!group Organization Variants
+module Admin
+  module OrganizationCell
+    class ComponentPreview < ApplicationComponentPreview
+      # @!group Organization Variants
 
-    def with_organization
-      render(Admin::OrganizationCell::Component.new(organization:))
-    end
+      def with_organization
+        render(Admin::OrganizationCell::Component.new(organization:))
+      end
 
-    def with_organization_id
-      render(Admin::OrganizationCell::Component.new(organization_id: Organization.deleted.first.id))
-    end
+      def with_organization_id
+        render(Admin::OrganizationCell::Component.new(organization_id: Organization.deleted.first.id))
+      end
 
-    def with_search_link
-      render(Admin::OrganizationCell::Component.new(organization:, render_search: true))
-    end
+      def with_search_link
+        render(Admin::OrganizationCell::Component.new(organization:, render_search: true))
+      end
 
-    def missing_organization
-      render(Admin::OrganizationCell::Component.new(organization_id: 99999999))
-    end
+      def missing_organization
+        render(Admin::OrganizationCell::Component.new(organization_id: 99999999))
+      end
 
-    private
+      private
 
-    def organization
-      Organization.friendly_find "hogwarts"
+      def organization
+        Organization.friendly_find "hogwarts"
+      end
     end
   end
 end

--- a/app/components/admin/pagination_with_count/component.rb
+++ b/app/components/admin/pagination_with_count/component.rb
@@ -1,70 +1,72 @@
 # frozen_string_literal: true
 
-module Admin::PaginationWithCount
-  class Component < ApplicationComponent
-    include GraphingHelper # for humanized_time_range_column
+module Admin
+  module PaginationWithCount
+    class Component < ApplicationComponent
+      include GraphingHelper # for humanized_time_range_column
 
-    def initialize(collection:, count: nil, skip_total: false, skip_today: false, skip_pagination: false, humanized_time_range_column_override: nil, viewing: nil, pagy: nil, per_page: nil, time_range: nil, period: nil, time_range_column: nil, params: {})
-      @collection = collection
-      @count = count
-      @skip_total = skip_total
-      @skip_today = skip_today
-      @skip_pagination = skip_pagination
-      @humanized_time_range_column_override = humanized_time_range_column_override
-      @viewing = viewing
-      @pagy = pagy
-      @per_page = per_page
-      @time_range = time_range
-      @period = period
-      @time_range_column = time_range_column
-      @params = params
-    end
-
-    private
-
-    def count
-      return @count if @count.present?
-      return @pagy.count if @pagy.respond_to?(:count)
-      @collection.count
-    end
-
-    def viewing
-      return @viewing if @viewing.present?
-      if @collection.respond_to?(:table_name)
-        @collection.table_name.humanize
-      elsif @collection.first
-        @collection.first.class.table_name.humanize
-      else
-        "records"
+      def initialize(collection:, count: nil, skip_total: false, skip_today: false, skip_pagination: false, humanized_time_range_column_override: nil, viewing: nil, pagy: nil, per_page: nil, time_range: nil, period: nil, time_range_column: nil, params: {})
+        @collection = collection
+        @count = count
+        @skip_total = skip_total
+        @skip_today = skip_today
+        @skip_pagination = skip_pagination
+        @humanized_time_range_column_override = humanized_time_range_column_override
+        @viewing = viewing
+        @pagy = pagy
+        @per_page = per_page
+        @time_range = time_range
+        @period = period
+        @time_range_column = time_range_column
+        @params = params
       end
-    end
 
-    def humanized_time_range_column_display
-      if @humanized_time_range_column_override.present?
-        @humanized_time_range_column_override
-      else
-        humanized_time_range_column(@time_range_column)
+      private
+
+      def count
+        return @count if @count.present?
+        return @pagy.count if @pagy.respond_to?(:count)
+        @collection.count
       end
-    end
 
-    def show_time_range?
-      @time_range.present? && @period != "all"
-    end
+      def viewing
+        return @viewing if @viewing.present?
+        if @collection.respond_to?(:table_name)
+          @collection.table_name.humanize
+        elsif @collection.first
+          @collection.first.class.table_name.humanize
+        else
+          "records"
+        end
+      end
 
-    def show_today_count?
-      !@skip_total && @collection.respond_to?(:total_count)
-    end
+      def humanized_time_range_column_display
+        if @humanized_time_range_column_override.present?
+          @humanized_time_range_column_override
+        else
+          humanized_time_range_column(@time_range_column)
+        end
+      end
 
-    def today_count
-      @collection.where("#{@collection.table_name}.#{@time_range_column || "created_at"} >= ?", Time.current.beginning_of_day).total_count
-    end
+      def show_time_range?
+        @time_range.present? && @period != "all"
+      end
 
-    def per_pages
-      [10, 25, 50, 100, @per_page.to_i].uniq.sort
-    end
+      def show_today_count?
+        !@skip_total && @collection.respond_to?(:total_count)
+      end
 
-    def per_page_select_id
-      "per_page_select#{"-skiptotal" if @skip_total}"
+      def today_count
+        @collection.where("#{@collection.table_name}.#{@time_range_column || "created_at"} >= ?", Time.current.beginning_of_day).total_count
+      end
+
+      def per_pages
+        [10, 25, 50, 100, @per_page.to_i].uniq.sort
+      end
+
+      def per_page_select_id
+        "per_page_select#{"-skiptotal" if @skip_total}"
+      end
     end
   end
 end

--- a/app/components/admin/pagination_with_count/component_preview.rb
+++ b/app/components/admin/pagination_with_count/component_preview.rb
@@ -1,58 +1,60 @@
 # frozen_string_literal: true
 
-module Admin::PaginationWithCount
-  class ComponentPreview < ApplicationComponentPreview
-    # @!group PaginationWithCount Variants
-    def default
-      pagy = Pagy::Offset.new(count: 100, page: 1, limit: 25)
-      render(Admin::PaginationWithCount::Component.new(
-        collection: collection,
-        pagy:,
-        per_page: 25,
-        params: {}
-      ))
-    end
+module Admin
+  module PaginationWithCount
+    class ComponentPreview < ApplicationComponentPreview
+      # @!group PaginationWithCount Variants
+      def default
+        pagy = Pagy::Offset.new(count: 100, page: 1, limit: 25)
+        render(Admin::PaginationWithCount::Component.new(
+          collection: collection,
+          pagy:,
+          per_page: 25,
+          params: {}
+        ))
+      end
 
-    def with_viewing_override
-      pagy = Pagy::Offset.new(count: 50, page: 1, limit: 25)
-      render(Admin::PaginationWithCount::Component.new(
-        collection: collection,
-        viewing: "Custom Items",
-        pagy:,
-        per_page: 25,
-        params: {}
-      ))
-    end
+      def with_viewing_override
+        pagy = Pagy::Offset.new(count: 50, page: 1, limit: 25)
+        render(Admin::PaginationWithCount::Component.new(
+          collection: collection,
+          viewing: "Custom Items",
+          pagy:,
+          per_page: 25,
+          params: {}
+        ))
+      end
 
-    def skip_total
-      pagy = Pagy::Offset.new(count: 100, page: 2, limit: 50)
-      render(Admin::PaginationWithCount::Component.new(
-        collection: collection,
-        skip_total: true,
-        pagy:,
-        per_page: 50,
-        params: {}
-      ))
-    end
+      def skip_total
+        pagy = Pagy::Offset.new(count: 100, page: 2, limit: 50)
+        render(Admin::PaginationWithCount::Component.new(
+          collection: collection,
+          skip_total: true,
+          pagy:,
+          per_page: 50,
+          params: {}
+        ))
+      end
 
-    def with_time_range
-      pagy = Pagy::Offset.new(count: 75, page: 1, limit: 25)
-      time_range = (1.week.ago..Time.current)
-      render(Admin::PaginationWithCount::Component.new(
-        collection: collection,
-        pagy:,
-        per_page: 25,
-        time_range:,
-        period: "week",
-        time_range_column: "created_at",
-        params: {}
-      ))
-    end
+      def with_time_range
+        pagy = Pagy::Offset.new(count: 75, page: 1, limit: 25)
+        time_range = (1.week.ago..Time.current)
+        render(Admin::PaginationWithCount::Component.new(
+          collection: collection,
+          pagy:,
+          per_page: 25,
+          time_range:,
+          period: "week",
+          time_range_column: "created_at",
+          params: {}
+        ))
+      end
 
-    private
+      private
 
-    def collection
-      Bike.all
+      def collection
+        Bike.all
+      end
     end
   end
 end

--- a/app/components/admin/strava_rate_limit/component.rb
+++ b/app/components/admin/strava_rate_limit/component.rb
@@ -1,44 +1,46 @@
 # frozen_string_literal: true
 
-module Admin::StravaRateLimit
-  class Component < ApplicationComponent
-    def initialize(rate_limit_json:)
-      @rate_limit_json = rate_limit_json
-    end
+module Admin
+  module StravaRateLimit
+    class Component < ApplicationComponent
+      def initialize(rate_limit_json:)
+        @rate_limit_json = rate_limit_json
+      end
 
-    def render?
-      @rate_limit_json.present?
-    end
+      def render?
+        @rate_limit_json.present?
+      end
 
-    private
+      private
 
-    def short_available
-      effective_limit("short")
-    end
+      def short_available
+        effective_limit("short")
+      end
 
-    def short_limit
-      effective_total("short")
-    end
+      def short_limit
+        effective_total("short")
+      end
 
-    def daily_available
-      effective_limit("long")
-    end
+      def daily_available
+        effective_limit("long")
+      end
 
-    def daily_limit
-      effective_total("long")
-    end
+      def daily_limit
+        effective_total("long")
+      end
 
-    # Use read limits unless the main limit is more restrictive (less available)
-    def effective_limit(period)
-      main = (@rate_limit_json["#{period}_limit"] || 0) - (@rate_limit_json["#{period}_usage"] || 0)
-      read = (@rate_limit_json["read_#{period}_limit"] || 0) - (@rate_limit_json["read_#{period}_usage"] || 0)
-      [main, read].min
-    end
+      # Use read limits unless the main limit is more restrictive (less available)
+      def effective_limit(period)
+        main = (@rate_limit_json["#{period}_limit"] || 0) - (@rate_limit_json["#{period}_usage"] || 0)
+        read = (@rate_limit_json["read_#{period}_limit"] || 0) - (@rate_limit_json["read_#{period}_usage"] || 0)
+        [main, read].min
+      end
 
-    def effective_total(period)
-      main = @rate_limit_json["#{period}_limit"] || 0
-      read = @rate_limit_json["read_#{period}_limit"] || 0
-      [main, read].min
+      def effective_total(period)
+        main = @rate_limit_json["#{period}_limit"] || 0
+        read = @rate_limit_json["read_#{period}_limit"] || 0
+        [main, read].min
+      end
     end
   end
 end

--- a/app/components/admin/strava_rate_limit/component_preview.rb
+++ b/app/components/admin/strava_rate_limit/component_preview.rb
@@ -1,60 +1,62 @@
 # frozen_string_literal: true
 
-module Admin::StravaRateLimit
-  class ComponentPreview < ApplicationComponentPreview
-    # @!group amount Variants
-    def high_rate_limit
-      render(Admin::StravaRateLimit::Component.new(rate_limit_json: high_rate_limit_json))
-    end
+module Admin
+  module StravaRateLimit
+    class ComponentPreview < ApplicationComponentPreview
+      # @!group amount Variants
+      def high_rate_limit
+        render(Admin::StravaRateLimit::Component.new(rate_limit_json: high_rate_limit_json))
+      end
 
-    def medium_rate_limit
-      render(Admin::StravaRateLimit::Component.new(rate_limit_json: medium_rate_limit_json))
-    end
+      def medium_rate_limit
+        render(Admin::StravaRateLimit::Component.new(rate_limit_json: medium_rate_limit_json))
+      end
 
-    def low_rate_limit
-      render(Admin::StravaRateLimit::Component.new(rate_limit_json: low_rate_limit_json))
-    end
-    # @endgroup
+      def low_rate_limit
+        render(Admin::StravaRateLimit::Component.new(rate_limit_json: low_rate_limit_json))
+      end
+      # @endgroup
 
-    private
+      private
 
-    def high_rate_limit_json
-      {
-        long_limit: 6000,
-        long_usage: 3,
-        short_limit: 600,
-        short_usage: 1,
-        read_long_limit: 3000,
-        read_long_usage: 3,
-        read_short_limit: 300,
-        read_short_usage: 1
-      }.as_json
-    end
+      def high_rate_limit_json
+        {
+          long_limit: 6000,
+          long_usage: 3,
+          short_limit: 600,
+          short_usage: 1,
+          read_long_limit: 3000,
+          read_long_usage: 3,
+          read_short_limit: 300,
+          read_short_usage: 1
+        }.as_json
+      end
 
-    def medium_rate_limit_json
-      {
-        long_limit: 6000,
-        long_usage: 3,
-        short_limit: 600,
-        short_usage: 1,
-        read_long_limit: 3000,
-        read_long_usage: 3,
-        read_short_limit: 300,
-        read_short_usage: 1
-      }.as_json
-    end
+      def medium_rate_limit_json
+        {
+          long_limit: 6000,
+          long_usage: 3,
+          short_limit: 600,
+          short_usage: 1,
+          read_long_limit: 3000,
+          read_long_usage: 3,
+          read_short_limit: 300,
+          read_short_usage: 1
+        }.as_json
+      end
 
-    def low_rate_limit_json
-      {
-        long_limit: 6000,
-        long_usage: 3,
-        short_limit: 600,
-        short_usage: 1,
-        read_long_limit: 3000,
-        read_long_usage: 3,
-        read_short_limit: 300,
-        read_short_usage: 1
-      }.as_json
+      def low_rate_limit_json
+        {
+          long_limit: 6000,
+          long_usage: 3,
+          short_limit: 600,
+          short_usage: 1,
+          read_long_limit: 3000,
+          read_long_usage: 3,
+          read_short_limit: 300,
+          read_short_usage: 1
+        }.as_json
+      end
     end
   end
 end

--- a/app/components/admin/strava_requests_chart/component.rb
+++ b/app/components/admin/strava_requests_chart/component.rb
@@ -1,106 +1,108 @@
 # frozen_string_literal: true
 
-module Admin::StravaRequestsChart
-  class Component < ApplicationComponent
-    RESPONSE_STATUS_BADGE_COLORS = {
-      pending: :cyan,
-      success: :success,
-      rate_limited: :warning,
-      error: :error,
-      skipped: :purple,
-      integration_deleted: :gray,
-      token_refresh_failed: :rose,
-      insufficient_token_privileges: :orange
-    }.freeze
+module Admin
+  module StravaRequestsChart
+    class Component < ApplicationComponent
+      RESPONSE_STATUS_BADGE_COLORS = {
+        pending: :cyan,
+        success: :success,
+        rate_limited: :warning,
+        error: :error,
+        skipped: :purple,
+        integration_deleted: :gray,
+        token_refresh_failed: :rose,
+        insufficient_token_privileges: :orange
+      }.freeze
 
-    RESPONSE_STATUS_HEX_COLORS = {
-      pending: "#22d3ee",
-      success: "#10b981",
-      error: "#DC2626",
-      rate_limited: "#f59e0b",
-      token_refresh_failed: "#fb7185",
-      integration_deleted: "#9ca3af",
-      skipped: "#a855f7",
-      insufficient_token_privileges: "#fb923c"
-    }.freeze
+      RESPONSE_STATUS_HEX_COLORS = {
+        pending: "#22d3ee",
+        success: "#10b981",
+        error: "#DC2626",
+        rate_limited: "#f59e0b",
+        token_refresh_failed: "#fb7185",
+        integration_deleted: "#9ca3af",
+        skipped: "#a855f7",
+        insufficient_token_privileges: "#fb923c"
+      }.freeze
 
-    def initialize(collection:, time_range:, time_range_column: "created_at", show_integration_chart: true)
-      @collection = collection
-      @time_range = time_range
-      @time_range_column = time_range_column
-      @show_integration_chart = show_integration_chart
-    end
-
-    private
-
-    def status_series
-      @status_series ||= build_series(StravaRequest::RESPONSE_STATUS_ENUM, :response_status)
-    end
-
-    def type_series
-      @type_series ||= build_series(StravaRequest::REQUEST_TYPE_ENUM, :request_type)
-    end
-
-    def pie_columns
-      @pie_columns ||= begin
-        columns = [
-          ["Response status", status_pie_counts, status_pie_colors],
-          ["Request type", type_pie_counts, type_pie_colors]
-        ]
-        columns << ["By integration", integration_counts, nil] if @show_integration_chart
-        columns
+      def initialize(collection:, time_range:, time_range_column: "created_at", show_integration_chart: true)
+        @collection = collection
+        @time_range = time_range
+        @time_range_column = time_range_column
+        @show_integration_chart = show_integration_chart
       end
-    end
 
-    def pie_chart_opts(colors)
-      opts = {thousands: ",", library: {plugins: {legend: {position: "bottom"}}}}
-      opts[:colors] = colors if colors
-      opts
-    end
+      private
 
-    def status_bar_colors
-      status_series.map { |s| RESPONSE_STATUS_HEX_COLORS[s[:name].parameterize(separator: "_").to_sym] }
-    end
-
-    def status_pie_counts
-      @status_pie_counts ||= build_pie_counts(StravaRequest::RESPONSE_STATUS_ENUM, :response_status)
-    end
-
-    def status_pie_colors
-      status_pie_counts.keys.map { |key| RESPONSE_STATUS_HEX_COLORS[key.parameterize(separator: "_").to_sym] }
-    end
-
-    def type_pie_counts
-      @type_pie_counts ||= build_pie_counts(StravaRequest::REQUEST_TYPE_ENUM, :request_type)
-    end
-
-    def type_pie_colors
-      type_pie_counts.keys.each_with_index.map { |_, i| UI::Chart::Component::COLORS[i % UI::Chart::Component::COLORS.size] }
-    end
-
-    def build_pie_counts(enum, column)
-      enum.each_with_object({}) do |(key, _), hash|
-        count = @collection.where(column => key).count
-        hash[key.to_s.humanize] = count if count > 0
+      def status_series
+        @status_series ||= build_series(StravaRequest::RESPONSE_STATUS_ENUM, :response_status)
       end
-    end
 
-    def build_series(enum, column)
-      enum.filter_map do |key, _|
-        scoped = @collection.where(column => key)
-        next if scoped.limit(1).blank?
-        {name: key.to_s.humanize, data: UI::Chart::Component.time_range_counts(collection: scoped, time_range: @time_range, column: @time_range_column)}
+      def type_series
+        @type_series ||= build_series(StravaRequest::REQUEST_TYPE_ENUM, :request_type)
       end
-    end
 
-    def integration_counts
-      counts = @collection.group(:strava_integration_id).count.sort_by { |_, count| -count }
-      integration_ids = counts.map(&:first)
-      emails = StravaIntegration.where(id: integration_ids).joins(:user).pluck(:id, "users.email").to_h
-      counts.to_h do |integration_id, count|
-        email = emails[integration_id]
-        label = email ? "#{email} (id: #{integration_id})" : "user deleted (id: #{integration_id})"
-        [label, count]
+      def pie_columns
+        @pie_columns ||= begin
+          columns = [
+            ["Response status", status_pie_counts, status_pie_colors],
+            ["Request type", type_pie_counts, type_pie_colors]
+          ]
+          columns << ["By integration", integration_counts, nil] if @show_integration_chart
+          columns
+        end
+      end
+
+      def pie_chart_opts(colors)
+        opts = {thousands: ",", library: {plugins: {legend: {position: "bottom"}}}}
+        opts[:colors] = colors if colors
+        opts
+      end
+
+      def status_bar_colors
+        status_series.map { |s| RESPONSE_STATUS_HEX_COLORS[s[:name].parameterize(separator: "_").to_sym] }
+      end
+
+      def status_pie_counts
+        @status_pie_counts ||= build_pie_counts(StravaRequest::RESPONSE_STATUS_ENUM, :response_status)
+      end
+
+      def status_pie_colors
+        status_pie_counts.keys.map { |key| RESPONSE_STATUS_HEX_COLORS[key.parameterize(separator: "_").to_sym] }
+      end
+
+      def type_pie_counts
+        @type_pie_counts ||= build_pie_counts(StravaRequest::REQUEST_TYPE_ENUM, :request_type)
+      end
+
+      def type_pie_colors
+        type_pie_counts.keys.each_with_index.map { |_, i| UI::Chart::Component::COLORS[i % UI::Chart::Component::COLORS.size] }
+      end
+
+      def build_pie_counts(enum, column)
+        enum.each_with_object({}) do |(key, _), hash|
+          count = @collection.where(column => key).count
+          hash[key.to_s.humanize] = count if count > 0
+        end
+      end
+
+      def build_series(enum, column)
+        enum.filter_map do |key, _|
+          scoped = @collection.where(column => key)
+          next if scoped.limit(1).blank?
+          {name: key.to_s.humanize, data: UI::Chart::Component.time_range_counts(collection: scoped, time_range: @time_range, column: @time_range_column)}
+        end
+      end
+
+      def integration_counts
+        counts = @collection.group(:strava_integration_id).count.sort_by { |_, count| -count }
+        integration_ids = counts.map(&:first)
+        emails = StravaIntegration.where(id: integration_ids).joins(:user).pluck(:id, "users.email").to_h
+        counts.to_h do |integration_id, count|
+          email = emails[integration_id]
+          label = email ? "#{email} (id: #{integration_id})" : "user deleted (id: #{integration_id})"
+          [label, count]
+        end
       end
     end
   end

--- a/app/components/admin/strava_requests_rate_limit_details/component.rb
+++ b/app/components/admin/strava_requests_rate_limit_details/component.rb
@@ -1,34 +1,36 @@
 # frozen_string_literal: true
 
-module Admin::StravaRequestsRateLimitDetails
-  class Component < ApplicationComponent
-    def initialize(now: Time.current.utc)
-      @now = now
-      @rate_limit_json = StravaRequest.estimated_current_rate_limit.as_json
-      @batch_size = StravaJobs::ScheduledRequestEnqueuer::BATCH_SIZE
-      @headroom = Integrations::Strava::Client::RATE_LIMIT_HEADROOM
-      @fetch_activity_short_headroom = Integrations::Strava::Client::FETCH_ACTIVITY_SHORT_HEADROOM
-      @fetch_activity_long_headroom = Integrations::Strava::Client::FETCH_ACTIVITY_LONG_HEADROOM
-      @enqueuer_fetch_activity_short_headroom = StravaJobs::ScheduledRequestEnqueuer::ENQUEUER_FETCH_ACTIVITY_SHORT_HEADROOM
-      @enqueuer_fetch_activity_long_headroom = StravaJobs::ScheduledRequestEnqueuer::ENQUEUER_FETCH_ACTIVITY_LONG_HEADROOM
-    end
-
-    private
-
-    def short_resets_in
-      (15 - @now.min % 15).minutes - @now.sec.seconds
-    end
-
-    def short_resets_display
-      if short_resets_in < 60
-        helpers.pluralize(short_resets_in.to_i, "second")
-      else
-        helpers.pluralize((short_resets_in / 60).to_i, "min")
+module Admin
+  module StravaRequestsRateLimitDetails
+    class Component < ApplicationComponent
+      def initialize(now: Time.current.utc)
+        @now = now
+        @rate_limit_json = StravaRequest.estimated_current_rate_limit.as_json
+        @batch_size = StravaJobs::ScheduledRequestEnqueuer::BATCH_SIZE
+        @headroom = Integrations::Strava::Client::RATE_LIMIT_HEADROOM
+        @fetch_activity_short_headroom = Integrations::Strava::Client::FETCH_ACTIVITY_SHORT_HEADROOM
+        @fetch_activity_long_headroom = Integrations::Strava::Client::FETCH_ACTIVITY_LONG_HEADROOM
+        @enqueuer_fetch_activity_short_headroom = StravaJobs::ScheduledRequestEnqueuer::ENQUEUER_FETCH_ACTIVITY_SHORT_HEADROOM
+        @enqueuer_fetch_activity_long_headroom = StravaJobs::ScheduledRequestEnqueuer::ENQUEUER_FETCH_ACTIVITY_LONG_HEADROOM
       end
-    end
 
-    def long_resets_at
-      @now.tomorrow.beginning_of_day
+      private
+
+      def short_resets_in
+        (15 - @now.min % 15).minutes - @now.sec.seconds
+      end
+
+      def short_resets_display
+        if short_resets_in < 60
+          helpers.pluralize(short_resets_in.to_i, "second")
+        else
+          helpers.pluralize((short_resets_in / 60).to_i, "min")
+        end
+      end
+
+      def long_resets_at
+        @now.tomorrow.beginning_of_day
+      end
     end
   end
 end

--- a/app/components/admin/user_cell/component.rb
+++ b/app/components/admin/user_cell/component.rb
@@ -1,71 +1,73 @@
 # frozen_string_literal: true
 
-module Admin::UserCell
-  class Component < ApplicationComponent
-    include Binxtils::SortableHelper
+module Admin
+  module UserCell
+    class Component < ApplicationComponent
+      include Binxtils::SortableHelper
 
-    def initialize(
-      user: nil,
-      user_id: nil,
-      email: nil,
-      user_link_path: nil,
-      search_url: nil,
-      render_search: nil
-    )
-      @user = user
-      @user_id = user_id || user&.id
-      @email = email || user&.email
-      @search_url = search_url
-      @user_link_path_arg = user_link_path
-      @render_search = render_search.nil? ? @search_url.present? : render_search
-    end
+      def initialize(
+        user: nil,
+        user_id: nil,
+        email: nil,
+        user_link_path: nil,
+        search_url: nil,
+        render_search: nil
+      )
+        @user = user
+        @user_id = user_id || user&.id
+        @email = email || user&.email
+        @search_url = search_url
+        @user_link_path_arg = user_link_path
+        @render_search = render_search.nil? ? @search_url.present? : render_search
+      end
 
-    def render?
-      @user.present? || @user_id.present? || @email.present?
-    end
+      def render?
+        @user.present? || @user_id.present? || @email.present?
+      end
 
-    private
+      private
 
-    def user_link_path
-      # bike_link_path can be false to not link
-      return if @user_link_path_arg == false
-      return @user_link_path_arg if @user_link_path_arg.present?
-      return admin_user_path(@user_id) if @user_id.present?
+      def user_link_path
+        # bike_link_path can be false to not link
+        return if @user_link_path_arg == false
+        return @user_link_path_arg if @user_link_path_arg.present?
+        return admin_user_path(@user_id) if @user_id.present?
 
-      nil
-    end
+        nil
+      end
 
-    def email_display
-      @email&.truncate(30)
-    end
+      def email_display
+        @email&.truncate(30)
+      end
 
-    def show_missing_user?
-      @user.blank? && @user_id.present?
-    end
+      def show_missing_user?
+        @user.blank? && @user_id.present?
+      end
 
-    def show_email_for_missing_user?
-      !@email.present?
-    end
+      def show_email_for_missing_user?
+        !@email.present?
+      end
 
-    def show_user_link?
-      user_link_path.present?
-    end
+      def show_user_link?
+        user_link_path.present?
+      end
 
-    def show_email_only?
-      @email.present? && @user.blank?
-    end
+      def show_email_only?
+        @email.present? && @user.blank?
+      end
 
-    def show_search?
-      @render_search && (@email.present? || @user_id.present?)
-    end
+      def show_search?
+        @render_search && (@email.present? || @user_id.present?)
+      end
 
-    def computed_search_url
-      return @search_url if @search_url.present?
+      def computed_search_url
+        return @search_url if @search_url.present?
 
-      if @user_id.present?
-        url_for(sortable_search_params.merge(user_id: @user_id))
-      elsif @email.present?
-        url_for(sortable_search_params.merge(search_email: @email))
+        if @user_id.present?
+          url_for(sortable_search_params.merge(user_id: @user_id))
+        elsif @email.present?
+          url_for(sortable_search_params.merge(search_email: @email))
+        end
       end
     end
   end

--- a/app/components/admin/user_cell/component_preview.rb
+++ b/app/components/admin/user_cell/component_preview.rb
@@ -1,26 +1,28 @@
 # frozen_string_literal: true
 
-module Admin::UserCell
-  class ComponentPreview < ApplicationComponentPreview
-    # @!group User Cell Variants
-    def default
-      render(Admin::UserCell::Component.new(user: lookbook_user))
-    end
+module Admin
+  module UserCell
+    class ComponentPreview < ApplicationComponentPreview
+      # @!group User Cell Variants
+      def default
+        render(Admin::UserCell::Component.new(user: lookbook_user))
+      end
 
-    def missing_user
-      render(Admin::UserCell::Component.new(user_id: 999999, email: "missing@example.com"))
-    end
+      def missing_user
+        render(Admin::UserCell::Component.new(user_id: 999999, email: "missing@example.com"))
+      end
 
-    def email_only
-      render(Admin::UserCell::Component.new(email: "orphaned@example.com"))
-    end
+      def email_only
+        render(Admin::UserCell::Component.new(email: "orphaned@example.com"))
+      end
 
-    def with_search
-      render(Admin::UserCell::Component.new(user: lookbook_user, render_search: true))
-    end
+      def with_search
+        render(Admin::UserCell::Component.new(user: lookbook_user, render_search: true))
+      end
 
-    def without_search
-      render(Admin::UserCell::Component.new(user: lookbook_user, render_search: false))
+      def without_search
+        render(Admin::UserCell::Component.new(user: lookbook_user, render_search: false))
+      end
     end
   end
 end

--- a/app/components/admin/user_show/component.rb
+++ b/app/components/admin/user_show/component.rb
@@ -1,37 +1,39 @@
 # frozen_string_literal: true
 
-module Admin::UserShow
-  class Component < ApplicationComponent
-    def initialize(user:, bikes:, bikes_count:)
-      @user = user
-      @bikes = bikes
-      @bikes_count = bikes_count
-    end
+module Admin
+  module UserShow
+    class Component < ApplicationComponent
+      def initialize(user:, bikes:, bikes_count:)
+        @user = user
+        @bikes = bikes
+        @bikes_count = bikes_count
+      end
 
-    private
+      private
 
-    def object_limit
-      10
-    end
+      def object_limit
+        10
+      end
 
-    def marketplace_messages
-      MarketplaceMessage.where(sender_id: @user.id).order(id: :desc)
-    end
+      def marketplace_messages
+        MarketplaceMessage.where(sender_id: @user.id).order(id: :desc)
+      end
 
-    def memberships
-      Membership.where(user_id: @user.id).order(id: :desc)
-    end
+      def memberships
+        Membership.where(user_id: @user.id).order(id: :desc)
+      end
 
-    def user_alerts
-      @user.user_alerts.order(created_at: :desc)
-    end
+      def user_alerts
+        @user.user_alerts.order(created_at: :desc)
+      end
 
-    def payments
-      @user.payments.reorder(created_at: :desc).paid
-    end
+      def payments
+        @user.payments.reorder(created_at: :desc).paid
+      end
 
-    def mailchimp_datum
-      @user.mailchimp_datum
+      def mailchimp_datum
+        @user.mailchimp_datum
+      end
     end
   end
 end

--- a/app/components/admin/user_show/component_preview.rb
+++ b/app/components/admin/user_show/component_preview.rb
@@ -1,9 +1,11 @@
 # frozen_string_literal: true
 
-module Admin::UserShow
-  class ComponentPreview < ApplicationComponentPreview
-    def default
-      render(Admin::UserShow::Component.new(user:, bikes:, bikes_count:))
+module Admin
+  module UserShow
+    class ComponentPreview < ApplicationComponentPreview
+      def default
+        render(Admin::UserShow::Component.new(user:, bikes:, bikes_count:))
+      end
     end
   end
 end

--- a/app/components/emails/finished_registration/component.rb
+++ b/app/components/emails/finished_registration/component.rb
@@ -1,97 +1,99 @@
 # frozen_string_literal: true
 
-module Emails::FinishedRegistration
-  class Component < ApplicationComponent
-    def self.tempo_snippet_for_ownership?(ownership)
-      ownership.status_with_owner? &&
-        ownership.new_registration? &&
-        ownership.organization_id.blank?
-    end
-
-    def initialize(ownership:, bike: nil, email_preview: false)
-      @ownership = ownership
-      @bike = bike
-      @email_preview = email_preview
-    end
-
-    private
-
-    def bike
-      @bike ||= Bike.unscoped.find(@ownership.bike_id)
-    end
-
-    def user
-      @ownership.owner
-    end
-
-    def organization
-      @ownership.organization
-    end
-
-    def creation_org
-      bike.creation_organization
-    end
-
-    def email
-      @ownership.owner_email
-    end
-
-    def new_bike?
-      @ownership.new_registration?
-    end
-
-    def new_user?
-      User.fuzzy_email_find(@ownership.owner_email).present?
-    end
-
-    def donation_message?
-      bike.status_stolen? && !(organization && !organization.paid?)
-    end
-
-    def registered_by_owner?
-      @ownership.user.present? && bike.creator_id == @ownership.user_id
-    end
-
-    def render_tempo_snippet?
-      self.class.tempo_snippet_for_ownership?(@ownership) && tempo_snippet&.is_enabled
-    end
-
-    def tempo_snippet
-      @tempo_snippet ||= MailSnippet.tempo.order(:id).last
-    end
-
-    def org_name
-      creation_org&.name || @ownership&.creator&.display_name
-    end
-
-    def bike_type_for_message
-      if bike.status_impounded?
-        translation("recovered_bike_type", bike_type: bike.type)
-      elsif bike.status_stolen?
-        translation("stolen_bike_type", bike_type: bike.type)
-      else
-        bike.type
+module Emails
+  module FinishedRegistration
+    class Component < ApplicationComponent
+      def self.tempo_snippet_for_ownership?(ownership)
+        ownership.status_with_owner? &&
+          ownership.new_registration? &&
+          ownership.organization_id.blank?
       end
-    end
 
-    def bike_url_with_token
-      if @email_preview
-        "/404"
-      else
-        bike_url(bike, t: @ownership.token, email:)
+      def initialize(ownership:, bike: nil, email_preview: false)
+        @ownership = ownership
+        @bike = bike
+        @email_preview = email_preview
       end
-    end
 
-    def recovery_url
-      if @email_preview
-        "/404"
-      else
-        edit_bike_recovery_url(bike_id: bike.id, token: bike.fetch_current_stolen_record.find_or_create_recovery_link_token)
+      private
+
+      def bike
+        @bike ||= Bike.unscoped.find(@ownership.bike_id)
       end
-    end
 
-    def show_organization_stolen_message?
-      OrganizationStolenMessage.shown_to?(bike.current_stolen_record)
+      def user
+        @ownership.owner
+      end
+
+      def organization
+        @ownership.organization
+      end
+
+      def creation_org
+        bike.creation_organization
+      end
+
+      def email
+        @ownership.owner_email
+      end
+
+      def new_bike?
+        @ownership.new_registration?
+      end
+
+      def new_user?
+        User.fuzzy_email_find(@ownership.owner_email).present?
+      end
+
+      def donation_message?
+        bike.status_stolen? && !(organization && !organization.paid?)
+      end
+
+      def registered_by_owner?
+        @ownership.user.present? && bike.creator_id == @ownership.user_id
+      end
+
+      def render_tempo_snippet?
+        self.class.tempo_snippet_for_ownership?(@ownership) && tempo_snippet&.is_enabled
+      end
+
+      def tempo_snippet
+        @tempo_snippet ||= MailSnippet.tempo.order(:id).last
+      end
+
+      def org_name
+        creation_org&.name || @ownership&.creator&.display_name
+      end
+
+      def bike_type_for_message
+        if bike.status_impounded?
+          translation("recovered_bike_type", bike_type: bike.type)
+        elsif bike.status_stolen?
+          translation("stolen_bike_type", bike_type: bike.type)
+        else
+          bike.type
+        end
+      end
+
+      def bike_url_with_token
+        if @email_preview
+          "/404"
+        else
+          bike_url(bike, t: @ownership.token, email:)
+        end
+      end
+
+      def recovery_url
+        if @email_preview
+          "/404"
+        else
+          edit_bike_recovery_url(bike_id: bike.id, token: bike.fetch_current_stolen_record.find_or_create_recovery_link_token)
+        end
+      end
+
+      def show_organization_stolen_message?
+        OrganizationStolenMessage.shown_to?(bike.current_stolen_record)
+      end
     end
   end
 end

--- a/app/components/emails/partials/bike_box/component.rb
+++ b/app/components/emails/partials/bike_box/component.rb
@@ -1,41 +1,45 @@
 # frozen_string_literal: true
 
-module Emails::Partials::BikeBox
-  class Component < ApplicationComponent
-    def initialize(bike:, ownership:, bike_url_path:)
-      @bike = bike
-      @ownership = ownership
-      @bike_url_path = bike_url_path
-    end
+module Emails
+  module Partials
+    module BikeBox
+      class Component < ApplicationComponent
+        def initialize(bike:, ownership:, bike_url_path:)
+          @bike = bike
+          @ownership = ownership
+          @bike_url_path = bike_url_path
+        end
 
-    private
+        private
 
-    def skip_link_tracking?
-      @bike_url_path.match?(/\?/)
-    end
+        def skip_link_tracking?
+          @bike_url_path.match?(/\?/)
+        end
 
-    def thumb_url
-      @bike.thumb_path || @bike.stock_photo_url || "https://files.bikeindex.org/email_assets/bike_photo_placeholder.png"
-    end
+        def thumb_url
+          @bike.thumb_path || @bike.stock_photo_url || "https://files.bikeindex.org/email_assets/bike_photo_placeholder.png"
+        end
 
-    def placeholder?
-      @bike.thumb_path.blank? && @bike.stock_photo_url.blank?
-    end
+        def placeholder?
+          @bike.thumb_path.blank? && @bike.stock_photo_url.blank?
+        end
 
-    def color_label
-      translation("color").pluralize(@bike.frame_colors.count)
-    end
+        def color_label
+          translation("color").pluralize(@bike.frame_colors.count)
+        end
 
-    def show_paint_description?
-      BikeServices::Displayer.paint_description?(@bike)
-    end
+        def show_paint_description?
+          BikeServices::Displayer.paint_description?(@bike)
+        end
 
-    def stolen_record
-      @bike.current_stolen_record
-    end
+        def stolen_record
+          @bike.current_stolen_record
+        end
 
-    def show_color_warning?
-      @ownership&.new_registration? && @bike.pos?
+        def show_color_warning?
+          @ownership&.new_registration? && @bike.pos?
+        end
+      end
     end
   end
 end

--- a/app/components/emails/partials/bike_box/component_preview.rb
+++ b/app/components/emails/partials/bike_box/component_preview.rb
@@ -1,9 +1,13 @@
 # frozen_string_literal: true
 
-module Emails::Partials::BikeBox
-  class ComponentPreview < ApplicationComponentPreview
-    def default
-      render(Emails::Partials::BikeBox::Component.new(bike:, ownership:, bike_url_path:))
+module Emails
+  module Partials
+    module BikeBox
+      class ComponentPreview < ApplicationComponentPreview
+        def default
+          render(Emails::Partials::BikeBox::Component.new(bike:, ownership:, bike_url_path:))
+        end
+      end
     end
   end
 end

--- a/app/components/form/legacy_form_well/address_record/component.rb
+++ b/app/components/form/legacy_form_well/address_record/component.rb
@@ -1,102 +1,106 @@
 # frozen_string_literal: true
 
-module Form::LegacyFormWell::AddressRecord
-  class Component < ApplicationComponent
-    STATIC_FIELDS_OPTIONS = %i[shown hidden]
+module Form
+  module LegacyFormWell
+    module AddressRecord
+      class Component < ApplicationComponent
+        STATIC_FIELDS_OPTIONS = %i[shown hidden]
 
-    # NOTE: Keep in mind this renders for the embed and embed_extended views (which don't have tailwind styles)
-    def initialize(form_builder:,
-      organization: nil,
-      not_related_fields: false,
-      static_fields: false,
-      current_country_id: nil,
-      embed_layout: false,
-      bike_status: nil, # stolen, impounded, etc
-      no_street: nil,
-      street_2: false)
-      @builder = form_builder
-      @organization = organization
+        # NOTE: Keep in mind this renders for the embed and embed_extended views (which don't have tailwind styles)
+        def initialize(form_builder:,
+          organization: nil,
+          not_related_fields: false,
+          static_fields: false,
+          current_country_id: nil,
+          embed_layout: false,
+          bike_status: nil, # stolen, impounded, etc
+          no_street: nil,
+          street_2: false)
+          @builder = form_builder
+          @organization = organization
 
-      @no_street = no_street?(no_street, @builder.object, @organization)
-      @street_2 = !no_street && street_2
+          @no_street = no_street?(no_street, @builder.object, @organization)
+          @street_2 = !no_street && street_2
 
-      @builder.object.country_id ||= current_country_id
-      @initial_country_id = @builder.object.country_id
-      @static_fields = STATIC_FIELDS_OPTIONS.include?(static_fields) ? static_fields : false
-      @embed_layout = Binxtils::InputNormalizer.boolean(embed_layout)
-      @bike_status = translated_status(bike_status)
+          @builder.object.country_id ||= current_country_id
+          @initial_country_id = @builder.object.country_id
+          @static_fields = STATIC_FIELDS_OPTIONS.include?(static_fields) ? static_fields : false
+          @embed_layout = Binxtils::InputNormalizer.boolean(embed_layout)
+          @bike_status = translated_status(bike_status)
 
-      @wrapper_class = if @embed_layout
-        "input-group"
-      else
-        not_related_fields ? "" : "related-fields"
+          @wrapper_class = if @embed_layout
+            "input-group"
+          else
+            not_related_fields ? "" : "related-fields"
+          end
+        end
+
+        private
+
+        def no_street?(no_street, object, organization)
+          # If it's not nil, assume it was passed deliberately
+          return no_street if [true, false].include?(no_street)
+
+          object.user.present? && object.user.no_address ||
+            organization.present? && organization&.enabled?("no_address")
+        end
+
+        def country_required?
+          @builder.object.address_present?
+        end
+
+        def non_static_field_class
+          return "" unless @static_fields
+
+          (@static_fields == :shown) ? "tw:hidden!" : ""
+        end
+
+        def static_field_class
+          return "" unless @static_fields
+
+          (@static_fields == :hidden) ? "tw:hidden!" : ""
+        end
+
+        def initial_state_class
+          (@initial_country_id == Country.united_states_id) ? "" : "tw:hidden!" # Should check if address_object.country_id == Country.united_states_id
+        end
+
+        def initial_region_class
+          initial_state_class.blank? ? "tw:hidden!" : ""
+        end
+
+        def address_label
+          return translation(:where_was_it_status, bike_status: @bike_status) if @bike_status.present?
+
+          txt = @organization&.registration_field_labels&.dig("reg_address")
+          return txt.html_safe if txt.present?
+
+          @no_street ? translation(:address_no_street) : translation(:address)
+        end
+
+        def street_placeholder
+          if @bike_status.present?
+            translation(:address_or_intersection)
+          else
+            translation(@organization&.school? ? :address_school : :address)
+          end
+        end
+
+        def address_required?
+          return true if @bike_status.present?
+
+          @organization&.enabled?("require_reg_address")
+        end
+
+        def translated_status(bike_status)
+          return nil if bike_status.blank?
+
+          humanized_status = Bike.status_humanized(bike_status)
+          # it makes more sense to show "where was it found" than impounded
+          humanized_status = "found" if humanized_status == "impounded"
+          Bike.status_humanized_translated(humanized_status)
+        end
       end
-    end
-
-    private
-
-    def no_street?(no_street, object, organization)
-      # If it's not nil, assume it was passed deliberately
-      return no_street if [true, false].include?(no_street)
-
-      object.user.present? && object.user.no_address ||
-        organization.present? && organization&.enabled?("no_address")
-    end
-
-    def country_required?
-      @builder.object.address_present?
-    end
-
-    def non_static_field_class
-      return "" unless @static_fields
-
-      (@static_fields == :shown) ? "tw:hidden!" : ""
-    end
-
-    def static_field_class
-      return "" unless @static_fields
-
-      (@static_fields == :hidden) ? "tw:hidden!" : ""
-    end
-
-    def initial_state_class
-      (@initial_country_id == Country.united_states_id) ? "" : "tw:hidden!" # Should check if address_object.country_id == Country.united_states_id
-    end
-
-    def initial_region_class
-      initial_state_class.blank? ? "tw:hidden!" : ""
-    end
-
-    def address_label
-      return translation(:where_was_it_status, bike_status: @bike_status) if @bike_status.present?
-
-      txt = @organization&.registration_field_labels&.dig("reg_address")
-      return txt.html_safe if txt.present?
-
-      @no_street ? translation(:address_no_street) : translation(:address)
-    end
-
-    def street_placeholder
-      if @bike_status.present?
-        translation(:address_or_intersection)
-      else
-        translation(@organization&.school? ? :address_school : :address)
-      end
-    end
-
-    def address_required?
-      return true if @bike_status.present?
-
-      @organization&.enabled?("require_reg_address")
-    end
-
-    def translated_status(bike_status)
-      return nil if bike_status.blank?
-
-      humanized_status = Bike.status_humanized(bike_status)
-      # it makes more sense to show "where was it found" than impounded
-      humanized_status = "found" if humanized_status == "impounded"
-      Bike.status_humanized_translated(humanized_status)
     end
   end
 end

--- a/app/components/form/legacy_form_well/address_record/component_preview.rb
+++ b/app/components/form/legacy_form_well/address_record/component_preview.rb
@@ -1,27 +1,31 @@
 # frozen_string_literal: true
 
-module Form::LegacyFormWell::AddressRecord
-  class ComponentPreview < ApplicationComponentPreview
-    layout "component_preview_form_wrap"
+module Form
+  module LegacyFormWell
+    module AddressRecord
+      class ComponentPreview < ApplicationComponentPreview
+        layout "component_preview_form_wrap"
 
-    # @param organization_id text "Organization ID to render the fields for"
-    def default(organization_id: nil)
-      organization = Organization.friendly_find(organization_id)
+        # @param organization_id text "Organization ID to render the fields for"
+        def default(organization_id: nil)
+          organization = Organization.friendly_find(organization_id)
 
-      {template: "form/legacy_form_well/address_record/component_preview/default",
-       locals: {organization:}}
+          {template: "form/legacy_form_well/address_record/component_preview/default",
+           locals: {organization:}}
+        end
+
+        def impounded_bike
+          {template: "form/legacy_form_well/address_record/component_preview/default",
+           locals: {bike_status: "status_impounded"}}
+        end
+
+        # TODO: WTF, why isn't the @param working :/
+        # def with_organization
+        # end
+
+        # def with_organization_with_all_helpers
+        # end
+      end
     end
-
-    def impounded_bike
-      {template: "form/legacy_form_well/address_record/component_preview/default",
-       locals: {bike_status: "status_impounded"}}
-    end
-
-    # TODO: WTF, why isn't the @param working :/
-    # def with_organization
-    # end
-
-    # def with_organization_with_all_helpers
-    # end
   end
 end

--- a/app/components/form/legacy_form_well/address_record_with_default/component.rb
+++ b/app/components/form/legacy_form_well/address_record_with_default/component.rb
@@ -1,25 +1,29 @@
 # frozen_string_literal: true
 
-module Form::LegacyFormWell::AddressRecordWithDefault
-  class Component < ApplicationComponent
-    def initialize(form_builder:, user:, no_street: false)
-      @builder = form_builder
-      @user = user
-      @no_street = no_street
+module Form
+  module LegacyFormWell
+    module AddressRecordWithDefault
+      class Component < ApplicationComponent
+        def initialize(form_builder:, user:, no_street: false)
+          @builder = form_builder
+          @user = user
+          @no_street = no_street
 
-      @address_static_fields = if render_user_account_address?
-        @builder.object.user_account_address ? :shown : :hidden
-      else
-        false
+          @address_static_fields = if render_user_account_address?
+            @builder.object.user_account_address ? :shown : :hidden
+          else
+            false
+          end
+        end
+
+        private
+
+        def render_user_account_address?
+          return false if @user.blank? || @user.address_record.blank?
+
+          true
+        end
       end
-    end
-
-    private
-
-    def render_user_account_address?
-      return false if @user.blank? || @user.address_record.blank?
-
-      true
     end
   end
 end

--- a/app/components/form/legacy_form_well/address_record_with_default/component_preview.rb
+++ b/app/components/form/legacy_form_well/address_record_with_default/component_preview.rb
@@ -1,11 +1,15 @@
 # frozen_string_literal: true
 
-module Form::LegacyFormWell::AddressRecordWithDefault
-  class ComponentPreview < ApplicationComponentPreview
-    layout "component_preview_form_wrap"
+module Form
+  module LegacyFormWell
+    module AddressRecordWithDefault
+      class ComponentPreview < ApplicationComponentPreview
+        layout "component_preview_form_wrap"
 
-    def default
-      {template: "form/legacy_form_well/address_record_with_default/component_preview/default"}
+        def default
+          {template: "form/legacy_form_well/address_record_with_default/component_preview/default"}
+        end
+      end
     end
   end
 end

--- a/app/components/form/legacy_form_well/form_group_row/component.rb
+++ b/app/components/form/legacy_form_well/form_group_row/component.rb
@@ -1,12 +1,16 @@
 # frozen_string_literal: true
 
-module Form::LegacyFormWell::FormGroupRow
-  class Component < ApplicationComponent
-    def initialize(form_builder:, label:, label_translation: nil, row_classes: "form-group row")
-      @form_builder = form_builder
-      @label = label
-      @label_translation = label_translation
-      @row_classes = (row_classes || "") + " form-group row"
+module Form
+  module LegacyFormWell
+    module FormGroupRow
+      class Component < ApplicationComponent
+        def initialize(form_builder:, label:, label_translation: nil, row_classes: "form-group row")
+          @form_builder = form_builder
+          @label = label
+          @label_translation = label_translation
+          @row_classes = (row_classes || "") + " form-group row"
+        end
+      end
     end
   end
 end

--- a/app/components/messages/for_sale_item/component.rb
+++ b/app/components/messages/for_sale_item/component.rb
@@ -1,29 +1,31 @@
 # frozen_string_literal: true
 
-module Messages::ForSaleItem
-  class Component < ApplicationComponent
-    def initialize(result_view: nil, current_user: nil, vehicle: nil, vehicle_id: nil, marketplace_listing: nil)
-      @component_class = SearchResults::Container::Component.component_class_for_result_view(result_view || :bike_box)
-      @search_kind = :marketplace
+module Messages
+  module ForSaleItem
+    class Component < ApplicationComponent
+      def initialize(result_view: nil, current_user: nil, vehicle: nil, vehicle_id: nil, marketplace_listing: nil)
+        @component_class = SearchResults::Container::Component.component_class_for_result_view(result_view || :bike_box)
+        @search_kind = :marketplace
 
-      @current_user = current_user
-      @vehicle = vehicle
-      @vehicle ||= Bike.unscoped.find_by_id(vehicle_id) if vehicle_id.present?
-      @marketplace_listing = marketplace_listing
-    end
+        @current_user = current_user
+        @vehicle = vehicle
+        @vehicle ||= Bike.unscoped.find_by_id(vehicle_id) if vehicle_id.present?
+        @marketplace_listing = marketplace_listing
+      end
 
-    private
+      private
 
-    def search_kind
-      :marketplace
-    end
+      def search_kind
+        :marketplace
+      end
 
-    def skip_cache
-      true
-    end
+      def skip_cache
+        true
+      end
 
-    def container_class
-      SearchResults::Container::Component.container_class(@component_class)
+      def container_class
+        SearchResults::Container::Component.container_class(@component_class)
+      end
     end
   end
 end

--- a/app/components/messages/for_sale_item/component_preview.rb
+++ b/app/components/messages/for_sale_item/component_preview.rb
@@ -1,36 +1,38 @@
 # frozen_string_literal: true
 
-module Messages::ForSaleItem
-  class ComponentPreview < ApplicationComponentPreview
-    # @display legacy_stylesheet true
-    def default
-      render(Messages::ForSaleItem::Component.new(current_user: lookbook_user,
-        vehicle: test_vehicle))
-    end
+module Messages
+  module ForSaleItem
+    class ComponentPreview < ApplicationComponentPreview
+      # @display legacy_stylesheet true
+      def default
+        render(Messages::ForSaleItem::Component.new(current_user: lookbook_user,
+          vehicle: test_vehicle))
+      end
 
-    # @display legacy_stylesheet true
-    def deleted_vehicle
-      marketplace_listing = MarketplaceListing.find_by_id(1)
+      # @display legacy_stylesheet true
+      def deleted_vehicle
+        marketplace_listing = MarketplaceListing.find_by_id(1)
 
-      render(Messages::ForSaleItem::Component.new(current_user: lookbook_user,
-        vehicle: nil, vehicle_id: 2796501, marketplace_listing:))
-    end
+        render(Messages::ForSaleItem::Component.new(current_user: lookbook_user,
+          vehicle: nil, vehicle_id: 2796501, marketplace_listing:))
+      end
 
-    private
+      private
 
-    def test_vehicle
-      Bike.new(
-        id: 35,
-        serial_number: "XXX999",
-        mnfg_name: "Humble Frameworks",
-        year: "2015",
-        primary_frame_color_id: Color.where(name: "Purple").first_or_create,
-        frame_model: "self titled",
-        frame_material: :steel,
-        cycle_type: :bike,
-        is_for_sale: true,
-        thumb_path: "https://files.bikeindex.org/uploads/Pu/395980/small_D3C6B1AF-F1FC-4BAA-BD39-9C107871FCAE.jpeg"
-      )
+      def test_vehicle
+        Bike.new(
+          id: 35,
+          serial_number: "XXX999",
+          mnfg_name: "Humble Frameworks",
+          year: "2015",
+          primary_frame_color_id: Color.where(name: "Purple").first_or_create,
+          frame_model: "self titled",
+          frame_material: :steel,
+          cycle_type: :bike,
+          is_for_sale: true,
+          thumb_path: "https://files.bikeindex.org/uploads/Pu/395980/small_D3C6B1AF-F1FC-4BAA-BD39-9C107871FCAE.jpeg"
+        )
+      end
     end
   end
 end

--- a/app/components/messages/thread_show/component.rb
+++ b/app/components/messages/thread_show/component.rb
@@ -1,91 +1,93 @@
 # frozen_string_literal: true
 
-module Messages::ThreadShow
-  class Component < ApplicationComponent
-    def initialize(
-      current_user:,
-      marketplace_messages:,
-      initial_message: nil,
-      marketplace_listing: nil,
-      can_send_message: false,
-      new_marketplace_message: nil
-    )
-      @marketplace_messages = marketplace_messages || []
+module Messages
+  module ThreadShow
+    class Component < ApplicationComponent
+      def initialize(
+        current_user:,
+        marketplace_messages:,
+        initial_message: nil,
+        marketplace_listing: nil,
+        can_send_message: false,
+        new_marketplace_message: nil
+      )
+        @marketplace_messages = marketplace_messages || []
 
-      @initial_message = initial_message || @marketplace_messages&.first
-      @marketplace_listing = marketplace_listing || @initial_message&.marketplace_listing
-      @sale = @marketplace_listing.sale
-      @current_user = current_user
+        @initial_message = initial_message || @marketplace_messages&.first
+        @marketplace_listing = marketplace_listing || @initial_message&.marketplace_listing
+        @sale = @marketplace_listing.sale
+        @current_user = current_user
 
-      @other_user_name, @other_user_id = @initial_message&.other_user_display_and_id(@current_user)
+        @other_user_name, @other_user_id = @initial_message&.other_user_display_and_id(@current_user)
 
-      @can_send_message = can_send_message
-      if @can_send_message
-        @new_marketplace_message = new_marketplace_message ||
-          MarketplaceMessage.new(marketplace_listing_id: @marketplace_listing.id, initial_record_id: @initial_message&.id)
-      end
-    end
-
-    def render?
-      @initial_message.present? || @marketplace_listing.present?
-    end
-
-    private
-
-    def new_thread?
-      @initial_message.blank?
-    end
-
-    def current_user_seller?
-      return false if @initial_message.blank?
-
-      @initial_message.receiver_id == @current_user.id
-    end
-
-    def user_banned?
-      return false if @initial_message.blank?
-
-      @initial_message.sender&.banned? || @initial_message.receiver&.banned?
-    end
-
-    def user_deleted?
-      return false if @initial_message.blank?
-
-      @initial_message.sender.blank? || @initial_message.receiver&.blank?
-    end
-
-    def show_mark_sold?
-      return false if new_thread?
-
-      current_user_seller? && @marketplace_listing.current?
-    end
-
-    def sold_alert_rendered?
-      @sold_alert_rendered
-    end
-
-    def render_sold_alert
-      @sold_alert_rendered = true
-      render(UI::Alert::Component.new(kind: :notice, margin_classes: "tw:my-8")) { sold_alert_content }
-    end
-
-    def item_type_display
-      @marketplace_listing.item_type_display.downcase
-    end
-
-    def sold_alert_content
-      content_tag(:span) do
-        if current_user_seller?
-          buyer = if @sale.buyer&.id == @other_user_id
-            "#{@other_user_name} (this message)"
-          else
-            "another user (#{@sale.buyer_name})"
-          end
-          concat(content_tag(:span, "You marked this #{item_type_display} sold to #{buyer} "))
-        else
-          concat(content_tag(:span, "This #{item_type_display} was sold "))
+        @can_send_message = can_send_message
+        if @can_send_message
+          @new_marketplace_message = new_marketplace_message ||
+            MarketplaceMessage.new(marketplace_listing_id: @marketplace_listing.id, initial_record_id: @initial_message&.id)
         end
-        concat(content_tag(:span, l(@sale.created_at, format: :convert_time), class: "localizeTime withPreposition"))
+      end
+
+      def render?
+        @initial_message.present? || @marketplace_listing.present?
+      end
+
+      private
+
+      def new_thread?
+        @initial_message.blank?
+      end
+
+      def current_user_seller?
+        return false if @initial_message.blank?
+
+        @initial_message.receiver_id == @current_user.id
+      end
+
+      def user_banned?
+        return false if @initial_message.blank?
+
+        @initial_message.sender&.banned? || @initial_message.receiver&.banned?
+      end
+
+      def user_deleted?
+        return false if @initial_message.blank?
+
+        @initial_message.sender.blank? || @initial_message.receiver&.blank?
+      end
+
+      def show_mark_sold?
+        return false if new_thread?
+
+        current_user_seller? && @marketplace_listing.current?
+      end
+
+      def sold_alert_rendered?
+        @sold_alert_rendered
+      end
+
+      def render_sold_alert
+        @sold_alert_rendered = true
+        render(UI::Alert::Component.new(kind: :notice, margin_classes: "tw:my-8")) { sold_alert_content }
+      end
+
+      def item_type_display
+        @marketplace_listing.item_type_display.downcase
+      end
+
+      def sold_alert_content
+        content_tag(:span) do
+          if current_user_seller?
+            buyer = if @sale.buyer&.id == @other_user_id
+              "#{@other_user_name} (this message)"
+            else
+              "another user (#{@sale.buyer_name})"
+            end
+            concat(content_tag(:span, "You marked this #{item_type_display} sold to #{buyer} "))
+          else
+            concat(content_tag(:span, "This #{item_type_display} was sold "))
+          end
+          concat(content_tag(:span, l(@sale.created_at, format: :convert_time), class: "localizeTime withPreposition"))
+        end
       end
     end
   end

--- a/app/components/messages/thread_show/component_preview.rb
+++ b/app/components/messages/thread_show/component_preview.rb
@@ -1,114 +1,116 @@
 # frozen_string_literal: true
 
-module Messages::ThreadShow
-  class ComponentPreview < ApplicationComponentPreview
-    # @display legacy_stylesheet true
-    # @param message_id text "Message ID to view (only works in dev)"
-    def buyer(message_id: nil)
-      marketplace_messages = if Rails.env.development? && message_id.present?
-        current_user, marketplace_messages = user_and_marketplace_messages_for(:buyer, message_id)
-        marketplace_messages
-      else
-        current_user = lookbook_user
-        mocked_marketplace_messages(item_owner: :other_user)
+module Messages
+  module ThreadShow
+    class ComponentPreview < ApplicationComponentPreview
+      # @display legacy_stylesheet true
+      # @param message_id text "Message ID to view (only works in dev)"
+      def buyer(message_id: nil)
+        marketplace_messages = if Rails.env.development? && message_id.present?
+          current_user, marketplace_messages = user_and_marketplace_messages_for(:buyer, message_id)
+          marketplace_messages
+        else
+          current_user = lookbook_user
+          mocked_marketplace_messages(item_owner: :other_user)
+        end
+
+        render(Messages::ThreadShow::Component.new(current_user:, marketplace_messages:, can_send_message: true))
       end
 
-      render(Messages::ThreadShow::Component.new(current_user:, marketplace_messages:, can_send_message: true))
-    end
+      # @display legacy_stylesheet true
+      # @param message_id text "Message ID to view (only works in dev)"
+      def seller(message_id: nil)
+        marketplace_messages = if Rails.env.development? && message_id.present?
+          current_user, marketplace_messages = user_and_marketplace_messages_for(:seller, message_id)
+          marketplace_messages
+        else
+          current_user = lookbook_user
+          mocked_marketplace_messages(item_owner: :lookbook_user, is_initial_message: true)
+        end
 
-    # @display legacy_stylesheet true
-    # @param message_id text "Message ID to view (only works in dev)"
-    def seller(message_id: nil)
-      marketplace_messages = if Rails.env.development? && message_id.present?
-        current_user, marketplace_messages = user_and_marketplace_messages_for(:seller, message_id)
-        marketplace_messages
-      else
-        current_user = lookbook_user
-        mocked_marketplace_messages(item_owner: :lookbook_user, is_initial_message: true)
+        render(Messages::ThreadShow::Component.new(current_user:, marketplace_messages:, can_send_message: true))
       end
 
-      render(Messages::ThreadShow::Component.new(current_user:, marketplace_messages:, can_send_message: true))
-    end
+      private
 
-    private
+      def other_user
+        return @other_user if defined?(@other_user)
 
-    def other_user
-      return @other_user if defined?(@other_user)
-
-      @other_user = User.find_by_email("contact@bikeindex.org") ||
-        User.new(name: "John Smith", username: "some-username", id: 42)
-    end
-
-    def mocked_marketplace_messages(item_owner: :other_user, is_initial_message: false, sender: nil)
-      marketplace_listing = marketplace_listing((item_owner == :other_user) ? other_user : lookbook_user)
-      initial_sender = (item_owner == :other_user) ? lookbook_user : other_user
-
-      initial_record = build_marketplace_message(id: 42, marketplace_listing:, sender: initial_sender,
-        body: "When are you available? Can I come by to pick it up sometime this week?",
-        created_at: Time.current - 1.hour)
-
-      return [initial_record] if is_initial_message
-      sender ||= (item_owner == :other_user) ? other_user : lookbook_user
-      [
-        initial_record,
-        build_marketplace_message(id: 43, marketplace_listing:, initial_record:, messages_prior_count: 1, sender:)
-      ]
-    end
-
-    def build_marketplace_message(id:, marketplace_listing:, sender:, initial_record: nil, body: nil, messages_prior_count: 0, created_at: nil)
-      body ||= "I'm available tuesday evening"
-      created_at ||= Time.current - 1.minute
-      receiver = (sender.id == lookbook_user.id) ? other_user : lookbook_user
-
-      message = MarketplaceMessage.new(
-        id:,
-        messages_prior_count:,
-        subject: "I'm interested in buying this bike",
-        body:,
-        initial_record:,
-        marketplace_listing:,
-        receiver:,
-        sender:,
-        created_at:
-      )
-      message.send(:set_calculated_attributes)
-      message
-    end
-
-    def marketplace_listing(seller)
-      MarketplaceListing.new(id: 42, seller:, item:,
-        condition: :excellent, amount_cents: 10_000, status: :for_sale,
-        published_at: Time.current - 1.day)
-    end
-
-    def user_and_marketplace_messages_for(user_target, message_id)
-      marketplace_message = MarketplaceMessage.find(message_id)
-      messages = if marketplace_message.initial_message?
-        [marketplace_message]
-      else
-        MarketplaceMessage.where(initial_record_id: marketplace_message.initial_record_id)
-          .where("id <= ?", marketplace_message.id).order(:id)
+        @other_user = User.find_by_email("contact@bikeindex.org") ||
+          User.new(name: "John Smith", username: "some-username", id: 42)
       end
 
-      [
-        (user_target == :seller) ? messages.first.receiver : messages.first.sender,
-        messages
-      ]
-    end
+      def mocked_marketplace_messages(item_owner: :other_user, is_initial_message: false, sender: nil)
+        marketplace_listing = marketplace_listing((item_owner == :other_user) ? other_user : lookbook_user)
+        initial_sender = (item_owner == :other_user) ? lookbook_user : other_user
 
-    def item
-      Bike.new(
-        id: 35,
-        serial_number: "XXX999",
-        mnfg_name: "Humble Frameworks",
-        year: "2015",
-        primary_frame_color_id: Color.where(name: "Purple").first_or_create,
-        frame_model: "self titled",
-        frame_material: :steel,
-        cycle_type: :bike,
-        is_for_sale: true,
-        thumb_path: "https://files.bikeindex.org/uploads/Pu/395980/small_D3C6B1AF-F1FC-4BAA-BD39-9C107871FCAE.jpeg"
-      )
+        initial_record = build_marketplace_message(id: 42, marketplace_listing:, sender: initial_sender,
+          body: "When are you available? Can I come by to pick it up sometime this week?",
+          created_at: Time.current - 1.hour)
+
+        return [initial_record] if is_initial_message
+        sender ||= (item_owner == :other_user) ? other_user : lookbook_user
+        [
+          initial_record,
+          build_marketplace_message(id: 43, marketplace_listing:, initial_record:, messages_prior_count: 1, sender:)
+        ]
+      end
+
+      def build_marketplace_message(id:, marketplace_listing:, sender:, initial_record: nil, body: nil, messages_prior_count: 0, created_at: nil)
+        body ||= "I'm available tuesday evening"
+        created_at ||= Time.current - 1.minute
+        receiver = (sender.id == lookbook_user.id) ? other_user : lookbook_user
+
+        message = MarketplaceMessage.new(
+          id:,
+          messages_prior_count:,
+          subject: "I'm interested in buying this bike",
+          body:,
+          initial_record:,
+          marketplace_listing:,
+          receiver:,
+          sender:,
+          created_at:
+        )
+        message.send(:set_calculated_attributes)
+        message
+      end
+
+      def marketplace_listing(seller)
+        MarketplaceListing.new(id: 42, seller:, item:,
+          condition: :excellent, amount_cents: 10_000, status: :for_sale,
+          published_at: Time.current - 1.day)
+      end
+
+      def user_and_marketplace_messages_for(user_target, message_id)
+        marketplace_message = MarketplaceMessage.find(message_id)
+        messages = if marketplace_message.initial_message?
+          [marketplace_message]
+        else
+          MarketplaceMessage.where(initial_record_id: marketplace_message.initial_record_id)
+            .where("id <= ?", marketplace_message.id).order(:id)
+        end
+
+        [
+          (user_target == :seller) ? messages.first.receiver : messages.first.sender,
+          messages
+        ]
+      end
+
+      def item
+        Bike.new(
+          id: 35,
+          serial_number: "XXX999",
+          mnfg_name: "Humble Frameworks",
+          year: "2015",
+          primary_frame_color_id: Color.where(name: "Purple").first_or_create,
+          frame_model: "self titled",
+          frame_material: :steel,
+          cycle_type: :bike,
+          is_for_sale: true,
+          thumb_path: "https://files.bikeindex.org/uploads/Pu/395980/small_D3C6B1AF-F1FC-4BAA-BD39-9C107871FCAE.jpeg"
+        )
+      end
     end
   end
 end

--- a/app/components/messages/thread_show_message/component.rb
+++ b/app/components/messages/thread_show_message/component.rb
@@ -1,54 +1,56 @@
 # frozen_string_literal: true
 
-module Messages::ThreadShowMessage
-  class Component < ApplicationComponent
-    def initialize(marketplace_message:, initial_message:, current_user:, other_user_name: nil, other_user_id: nil)
-      @marketplace_message = marketplace_message
-      @initial_message = initial_message
-      @current_user = current_user
+module Messages
+  module ThreadShowMessage
+    class Component < ApplicationComponent
+      def initialize(marketplace_message:, initial_message:, current_user:, other_user_name: nil, other_user_id: nil)
+        @marketplace_message = marketplace_message
+        @initial_message = initial_message
+        @current_user = current_user
 
-      # other_user_id and other_user_name should be passed in!
-      @other_user_name, @other_user_id = if other_user_id.present?
-        [other_user_name, other_user_id]
-      else
-        @initial_message&.other_user_display_and_id(@current_user)
+        # other_user_id and other_user_name should be passed in!
+        @other_user_name, @other_user_id = if other_user_id.present?
+          [other_user_name, other_user_id]
+        else
+          @initial_message&.other_user_display_and_id(@current_user)
+        end
       end
-    end
 
-    private
+      private
 
-    def currently_buyer?
-      @initial_message.sender_id == @current_user.id
-    end
-
-    def initial_message?
-      @marketplace_message.id == @initial_message.id
-    end
-
-    def user_display(user_id, parens: false)
-      str = if user_id == @current_user.id
-        @current_user.marketplace_message_name
-      else
-        @other_user_name
+      def currently_buyer?
+        @initial_message.sender_id == @current_user.id
       end
-      parens ? "(#{str})" : str
-    end
 
-    # Make sent messages align right, received left
-    # duplicated in Messages::ThreadShow for the reply form
-    def margin_class
-      if @current_user.id == @marketplace_message.sender_id
-        "tw:ml-4 tw:lg:ml-8"
-      else
-        "tw:mr-4 tw:lg:mr-8"
+      def initial_message?
+        @marketplace_message.id == @initial_message.id
       end
-    end
 
-    def receiver_display
-      if @marketplace_message.receiver_id == @current_user.id
-        translation(".me")
-      else
-        @other_user_name
+      def user_display(user_id, parens: false)
+        str = if user_id == @current_user.id
+          @current_user.marketplace_message_name
+        else
+          @other_user_name
+        end
+        parens ? "(#{str})" : str
+      end
+
+      # Make sent messages align right, received left
+      # duplicated in Messages::ThreadShow for the reply form
+      def margin_class
+        if @current_user.id == @marketplace_message.sender_id
+          "tw:ml-4 tw:lg:ml-8"
+        else
+          "tw:mr-4 tw:lg:mr-8"
+        end
+      end
+
+      def receiver_display
+        if @marketplace_message.receiver_id == @current_user.id
+          translation(".me")
+        else
+          @other_user_name
+        end
       end
     end
   end

--- a/app/components/messages/threads_index/component.rb
+++ b/app/components/messages/threads_index/component.rb
@@ -1,95 +1,97 @@
 # frozen_string_literal: true
 
 # NOTE: This component makes a number of DB calls - so rendering of this should be cached!
-module Messages::ThreadsIndex
-  class Component < ApplicationComponent
-    TRUNCATED_MESSAGE_LENGTH = 120
+module Messages
+  module ThreadsIndex
+    class Component < ApplicationComponent
+      TRUNCATED_MESSAGE_LENGTH = 120
 
-    def initialize(marketplace_message:, current_user:)
-      @marketplace_message = marketplace_message
-      @messages_prior_arr = @marketplace_message.messages_prior.pluck(:kind, :sender_id)
-      @initial_record = @marketplace_message.initial_record
-      @current_user = current_user
+      def initialize(marketplace_message:, current_user:)
+        @marketplace_message = marketplace_message
+        @messages_prior_arr = @marketplace_message.messages_prior.pluck(:kind, :sender_id)
+        @initial_record = @marketplace_message.initial_record
+        @current_user = current_user
 
-      @other_user_name, @other_user_id = @marketplace_message.other_user_display_and_id(@current_user)
-    end
-
-    private
-
-    def message_path
-      # NOTE: This path, with anchor, is also used in the marketplace_message_notification mailer
-      my_account_message_path(id: @initial_record.id, anchor: "message-#{@marketplace_message.id}")
-    end
-
-    def item_title
-      @marketplace_message.item&.title_string ||
-        "#{@marketplace_message.item_type}: #{@marketplace_message.item_id}"
-    end
-
-    def message_display
-      if @marketplace_message.initial_message?
-        "#{@initial_record.subject} - #{@marketplace_message.body}".truncate(TRUNCATED_MESSAGE_LENGTH)
-      else
-        @marketplace_message.body.truncate(TRUNCATED_MESSAGE_LENGTH)
+        @other_user_name, @other_user_id = @marketplace_message.other_user_display_and_id(@current_user)
       end
-    end
 
-    def sender_display_html
-      if @marketplace_message.initial_message?
-        if @marketplace_message.sender_id == @current_user.id
-          content_tag(:span, to_sender_text)
+      private
+
+      def message_path
+        # NOTE: This path, with anchor, is also used in the marketplace_message_notification mailer
+        my_account_message_path(id: @initial_record.id, anchor: "message-#{@marketplace_message.id}")
+      end
+
+      def item_title
+        @marketplace_message.item&.title_string ||
+          "#{@marketplace_message.item_type}: #{@marketplace_message.item_id}"
+      end
+
+      def message_display
+        if @marketplace_message.initial_message?
+          "#{@initial_record.subject} - #{@marketplace_message.body}".truncate(TRUNCATED_MESSAGE_LENGTH)
         else
-          content_tag(:strong, @other_user_name, class: "tw:font-bold")
+          @marketplace_message.body.truncate(TRUNCATED_MESSAGE_LENGTH)
         end
-      elsif unrequited_sender?(@marketplace_message)
-        content_tag(:span, (to_sender_text + count_html).html_safe)
-      else
-        content_tag(:span, (
-          messages_prior_sender_text +
-          content_tag(:strong, user_display(@marketplace_message.sender_id), class: "tw:font-bold") +
-          count_html
-        ).html_safe)
       end
-    end
 
-    def unrequited_sender?(marketplace_message)
-      marketplace_message.sender_buyer? && @messages_prior_arr.all? { |kind, _| kind == "sender_buyer" }
-    end
-
-    def sender_full_text
-      (@messages_prior_arr.map { |_, id| user_display(id) } +
-        [user_display(@marketplace_message.sender_id)])
-        .join(", ")
-    end
-
-    def messages_prior_sender_text
-      initial_sender_id = @messages_prior_arr.first.last
-      text = user_display(initial_sender_id)
-
-      # If the initial sender is the same as the final sender, always include the other user display
-      # - to indicate that user has replied
-      if @messages_prior_arr.count > 1 && initial_sender_id == @marketplace_message.sender_id
-        "#{text}, #{user_display(@marketplace_message.receiver_id)}" +
-          ((@messages_prior_arr.count > 2) ? "... " : ", ")
-      else
-        text + ((@messages_prior_arr.count > 1) ? "... " : ", ")
+      def sender_display_html
+        if @marketplace_message.initial_message?
+          if @marketplace_message.sender_id == @current_user.id
+            content_tag(:span, to_sender_text)
+          else
+            content_tag(:strong, @other_user_name, class: "tw:font-bold")
+          end
+        elsif unrequited_sender?(@marketplace_message)
+          content_tag(:span, (to_sender_text + count_html).html_safe)
+        else
+          content_tag(:span, (
+            messages_prior_sender_text +
+            content_tag(:strong, user_display(@marketplace_message.sender_id), class: "tw:font-bold") +
+            count_html
+          ).html_safe)
+        end
       end
-    end
 
-    def to_sender_text
-      "#{translation(".to")}: #{@other_user_name}"
-    end
-
-    def user_display(user_id)
-      if user_id == @current_user.id
-        translation(".me")
-      else
-        @other_user_name
+      def unrequited_sender?(marketplace_message)
+        marketplace_message.sender_buyer? && @messages_prior_arr.all? { |kind, _| kind == "sender_buyer" }
       end
-    end
 
-    def count_html
-      content_tag(:span, " #{@marketplace_message.messages_prior_count + 1}", class: "tw:opacity-65")
+      def sender_full_text
+        (@messages_prior_arr.map { |_, id| user_display(id) } +
+          [user_display(@marketplace_message.sender_id)])
+          .join(", ")
+      end
+
+      def messages_prior_sender_text
+        initial_sender_id = @messages_prior_arr.first.last
+        text = user_display(initial_sender_id)
+
+        # If the initial sender is the same as the final sender, always include the other user display
+        # - to indicate that user has replied
+        if @messages_prior_arr.count > 1 && initial_sender_id == @marketplace_message.sender_id
+          "#{text}, #{user_display(@marketplace_message.receiver_id)}" +
+            ((@messages_prior_arr.count > 2) ? "... " : ", ")
+        else
+          text + ((@messages_prior_arr.count > 1) ? "... " : ", ")
+        end
+      end
+
+      def to_sender_text
+        "#{translation(".to")}: #{@other_user_name}"
+      end
+
+      def user_display(user_id)
+        if user_id == @current_user.id
+          translation(".me")
+        else
+          @other_user_name
+        end
+      end
+
+      def count_html
+        content_tag(:span, " #{@marketplace_message.messages_prior_count + 1}", class: "tw:opacity-65")
+      end
     end
   end
 end

--- a/app/components/messages/threads_index/component_preview.rb
+++ b/app/components/messages/threads_index/component_preview.rb
@@ -1,56 +1,58 @@
 # frozen_string_literal: true
 
-module Messages::ThreadsIndex
-  class ComponentPreview < ApplicationComponentPreview
-    def default
-      {
-        template: "messages/threads_index/component_preview/default",
-        locals: {current_user: lookbook_user, marketplace_messages:}
-      }
-    end
+module Messages
+  module ThreadsIndex
+    class ComponentPreview < ApplicationComponentPreview
+      def default
+        {
+          template: "messages/threads_index/component_preview/default",
+          locals: {current_user: lookbook_user, marketplace_messages:}
+        }
+      end
 
-    private
+      private
 
-    def marketplace_messages
-      [
-        built_marketplace_message(default_marketplace_message_attrs),
-        built_marketplace_message(default_marketplace_message_attrs.merge(body: "yes")),
-        built_marketplace_message(default_marketplace_message_attrs.merge(body: long_body, created_at: Time.current - 6.months))
-      ]
-    end
+      def marketplace_messages
+        [
+          built_marketplace_message(default_marketplace_message_attrs),
+          built_marketplace_message(default_marketplace_message_attrs.merge(body: "yes")),
+          built_marketplace_message(default_marketplace_message_attrs.merge(body: long_body, created_at: Time.current - 6.months))
+        ]
+      end
 
-    def other_user
-      User.new(name: "John Smith", username: "some-username", id: 42)
-    end
+      def other_user
+        User.new(name: "John Smith", username: "some-username", id: 42)
+      end
 
-    def default_marketplace_message_attrs
-      {
-        id: 42,
-        messages_prior_count: 0,
-        subject: "I'm interested in buying this bike",
-        body: "When are you available? Can I come by to pick it up sometime this week?",
-        initial_record_id: 42,
-        marketplace_listing: marketplace_listing,
-        receiver: lookbook_user,
-        sender: other_user,
-        created_at: Time.current - 2.hours
-      }
-    end
+      def default_marketplace_message_attrs
+        {
+          id: 42,
+          messages_prior_count: 0,
+          subject: "I'm interested in buying this bike",
+          body: "When are you available? Can I come by to pick it up sometime this week?",
+          initial_record_id: 42,
+          marketplace_listing: marketplace_listing,
+          receiver: lookbook_user,
+          sender: other_user,
+          created_at: Time.current - 2.hours
+        }
+      end
 
-    def marketplace_listing
-      item = Bike.new(id: 42, year: Date.current.year - 4, mnfg_name: "Salsa", cycle_type: "bike")
-      MarketplaceListing.new(id: 42, seller: lookbook_user, item:)
-    end
+      def marketplace_listing
+        item = Bike.new(id: 42, year: Date.current.year - 4, mnfg_name: "Salsa", cycle_type: "bike")
+        MarketplaceListing.new(id: 42, seller: lookbook_user, item:)
+      end
 
-    def built_marketplace_message(attrs)
-      message = MarketplaceMessage.new(attrs)
-      message.send(:set_calculated_attributes)
-      message
-    end
+      def built_marketplace_message(attrs)
+        message = MarketplaceMessage.new(attrs)
+        message.send(:set_calculated_attributes)
+        message
+      end
 
-    def long_body
-      "Cred poutine 8-bit, put a bird on it iceland tofu knausgaard craft beer fingerstache distillery pitchfork authentic master cleanse jawn banjo.\n\n" \
-      "Mixtape distillery raw denim four loko dreamcatcher. Celiac schlitz mlkshk whatever, gochujang chia disrupt actually lomo distillery."
+      def long_body
+        "Cred poutine 8-bit, put a bird on it iceland tofu knausgaard craft beer fingerstache distillery pitchfork authentic master cleanse jawn banjo.\n\n" \
+        "Mixtape distillery raw denim four loko dreamcatcher. Celiac schlitz mlkshk whatever, gochujang chia disrupt actually lomo distillery."
+      end
     end
   end
 end

--- a/app/components/org/bike_access_panel/component.rb
+++ b/app/components/org/bike_access_panel/component.rb
@@ -1,103 +1,105 @@
 # frozen_string_literal: true
 
-module Org::BikeAccessPanel
-  class Component < ApplicationComponent
-    include OrganizedHelper
-    include VehicleHelper
+module Org
+  module BikeAccessPanel
+    class Component < ApplicationComponent
+      include OrganizedHelper
+      include VehicleHelper
 
-    def initialize(bike: nil, organization: nil, current_user: nil)
-      @bike = bike
-      @organization = organization
-      @user = current_user
-    end
+      def initialize(bike: nil, organization: nil, current_user: nil)
+        @bike = bike
+        @organization = organization
+        @user = current_user
+      end
 
-    def render?
-      @bike.present? && @organization.present? && @user.present? &&
-        @user.authorized?(@organization) && @bike.visible_by?(@user)
-    end
+      def render?
+        @bike.present? && @organization.present? && @user.present? &&
+          @user.authorized?(@organization) && @bike.visible_by?(@user)
+      end
 
-    private
+      private
 
-    def organization_registered?
-      return @organization_registered if defined?(@organization_registered)
+      def organization_registered?
+        return @organization_registered if defined?(@organization_registered)
 
-      @organization_registered = @bike.organized?(@organization)
-    end
+        @organization_registered = @bike.organized?(@organization)
+      end
 
-    def organization_authorized?
-      @bike.authorized_by_organization?(org: @organization)
-    end
+      def organization_authorized?
+        @bike.authorized_by_organization?(org: @organization)
+      end
 
-    def user_can_edit?
-      @bike.authorized?(@user)
-    end
+      def user_can_edit?
+        @bike.authorized?(@user)
+      end
 
-    # Only show the unstolen notification form if bike is with_owner (ie, not if bike is found)
-    def display_unstolen_notification_form?
-      @bike.status_with_owner? && @organization.enabled?("unstolen_notifications")
-    end
+      # Only show the unstolen notification form if bike is with_owner (ie, not if bike is found)
+      def display_unstolen_notification_form?
+        @bike.status_with_owner? && @organization.enabled?("unstolen_notifications")
+      end
 
-    def show_sticker_modal?
-      # display stickers if org has paid for them
-      @organization.enabled?("bike_stickers")
-    end
+      def show_sticker_modal?
+        # display stickers if org has paid for them
+        @organization.enabled?("bike_stickers")
+      end
 
-    def display_original_ownership?
-      original_ownership.id != @bike.current_ownership_id &&
-        original_ownership.organization_id == @organization.id
-    end
+      def display_original_ownership?
+        original_ownership.id != @bike.current_ownership_id &&
+          original_ownership.organization_id == @organization.id
+      end
 
-    def current_ownership
-      @current_ownership ||= @bike.current_ownership
-    end
+      def current_ownership
+        @current_ownership ||= @bike.current_ownership
+      end
 
-    def original_ownership
-      @original_ownership ||= @bike.ownerships.initial.first
-    end
+      def original_ownership
+        @original_ownership ||= @bike.ownerships.initial.first
+      end
 
-    def other_user_bikes
-      # If user isn't present, use email to search
-      @other_user_bikes ||= if @bike.user.present?
-        @bike.user.bikes
-      else
-        Bike.where(owner_email: @bike.owner_email)
-      end.reorder(id: :desc)
-    end
+      def other_user_bikes
+        # If user isn't present, use email to search
+        @other_user_bikes ||= if @bike.user.present?
+          @bike.user.bikes
+        else
+          Bike.where(owner_email: @bike.owner_email)
+        end.reorder(id: :desc)
+      end
 
-    def other_user_bikes_count
-      @other_user_bikes_count ||= other_user_bikes.count
-    end
+      def other_user_bikes_count
+        @other_user_bikes_count ||= other_user_bikes.count
+      end
 
-    def duplicate_bikes
-      @duplicate_bikes ||= @bike.duplicate_bikes.reorder(id: :desc).limit(25)
-    end
+      def duplicate_bikes
+        @duplicate_bikes ||= @bike.duplicate_bikes.reorder(id: :desc).limit(25)
+      end
 
-    def show_notes?
-      organization_registered? && @organization.enabled?("registration_notes")
-    end
+      def show_notes?
+        organization_registered? && @organization.enabled?("registration_notes")
+      end
 
-    def bike_organization_note
-      @bike_organization_note ||= BikeOrganizationNote.find_by(bike_id: @bike.id, organization_id: @organization.id)
-    end
+      def bike_organization_note
+        @bike_organization_note ||= BikeOrganizationNote.find_by(bike_id: @bike.id, organization_id: @organization.id)
+      end
 
-    # CSS grid template areas for the card body layout
-    # Mobile: message (if applicable), table, notes (if applicable) — stacked
-    # Desktop: table on left (7fr), message+notes on right (5fr)
-    # NOTE: classes are written as full literals so Tailwind JIT can detect them
-    def card_body_grid_classes
-      base = "tw:grid tw:gap-4 tw:grid-cols-1"
-      if display_unstolen_notification_form? && show_notes?
-        # tw:[grid-template-areas:'message'_'table'_'notes'] tw:md:[grid-template-areas:'table_message'_'table_notes']
-        "#{base} tw:md:grid-cols-[7fr_5fr] tw:[grid-template-areas:'message'_'table'_'notes'] tw:md:[grid-template-areas:'table_message'_'table_notes']"
-      elsif display_unstolen_notification_form?
-        # tw:[grid-template-areas:'message'_'table'] tw:md:[grid-template-areas:'table_message']
-        "#{base} tw:md:grid-cols-[7fr_5fr] tw:[grid-template-areas:'message'_'table'] tw:md:[grid-template-areas:'table_message']"
-      elsif show_notes?
-        # tw:[grid-template-areas:'table'_'notes'] tw:md:[grid-template-areas:'table_notes']
-        "#{base} tw:md:grid-cols-[7fr_5fr] tw:[grid-template-areas:'table'_'notes'] tw:md:[grid-template-areas:'table_notes']"
-      else
-        # tw:md:[grid-template-areas:'table_.']
-        "#{base} tw:md:grid-cols-[7fr_5fr] tw:md:[grid-template-areas:'table_.']"
+      # CSS grid template areas for the card body layout
+      # Mobile: message (if applicable), table, notes (if applicable) — stacked
+      # Desktop: table on left (7fr), message+notes on right (5fr)
+      # NOTE: classes are written as full literals so Tailwind JIT can detect them
+      def card_body_grid_classes
+        base = "tw:grid tw:gap-4 tw:grid-cols-1"
+        if display_unstolen_notification_form? && show_notes?
+          # tw:[grid-template-areas:'message'_'table'_'notes'] tw:md:[grid-template-areas:'table_message'_'table_notes']
+          "#{base} tw:md:grid-cols-[7fr_5fr] tw:[grid-template-areas:'message'_'table'_'notes'] tw:md:[grid-template-areas:'table_message'_'table_notes']"
+        elsif display_unstolen_notification_form?
+          # tw:[grid-template-areas:'message'_'table'] tw:md:[grid-template-areas:'table_message']
+          "#{base} tw:md:grid-cols-[7fr_5fr] tw:[grid-template-areas:'message'_'table'] tw:md:[grid-template-areas:'table_message']"
+        elsif show_notes?
+          # tw:[grid-template-areas:'table'_'notes'] tw:md:[grid-template-areas:'table_notes']
+          "#{base} tw:md:grid-cols-[7fr_5fr] tw:[grid-template-areas:'table'_'notes'] tw:md:[grid-template-areas:'table_notes']"
+        else
+          # tw:md:[grid-template-areas:'table_.']
+          "#{base} tw:md:grid-cols-[7fr_5fr] tw:md:[grid-template-areas:'table_.']"
+        end
       end
     end
   end

--- a/app/components/org/bike_access_panel/component_preview.rb
+++ b/app/components/org/bike_access_panel/component_preview.rb
@@ -1,14 +1,16 @@
 # frozen_string_literal: true
 
-module Org::BikeAccessPanel
-  class ComponentPreview < ApplicationComponentPreview
-    # @display legacy_stylesheet true
-    def default
-      # TODO: render something - without personal info
-      organization = Organization.friendly_find("hogwarts")
-      bike = nil
-      current_user = nil
-      render(Org::BikeAccessPanel::Component.new(bike:, organization:, current_user:))
+module Org
+  module BikeAccessPanel
+    class ComponentPreview < ApplicationComponentPreview
+      # @display legacy_stylesheet true
+      def default
+        # TODO: render something - without personal info
+        organization = Organization.friendly_find("hogwarts")
+        bike = nil
+        current_user = nil
+        render(Org::BikeAccessPanel::Component.new(bike:, organization:, current_user:))
+      end
     end
   end
 end

--- a/app/components/org/bulk_import_error/component.rb
+++ b/app/components/org/bulk_import_error/component.rb
@@ -1,40 +1,42 @@
 # frozen_string_literal: true
 
-module Org::BulkImportError
-  class Component < ApplicationComponent
-    def initialize(bulk_import:, short_display: false, in_admin: false)
-      @bulk_import = bulk_import
-      @short_display = short_display
-      @in_admin = in_admin
-    end
+module Org
+  module BulkImportError
+    class Component < ApplicationComponent
+      def initialize(bulk_import:, short_display: false, in_admin: false)
+        @bulk_import = bulk_import
+        @short_display = short_display
+        @in_admin = in_admin
+      end
 
-    def render?
-      @bulk_import.import_errors?
-    end
+      def render?
+        @bulk_import.import_errors?
+      end
 
-    private
+      private
 
-    def short_text
-      errors = []
-      errors << short_file_text if @bulk_import.file_errors.present?
-      errors << translation(".unknown_ascend_name") if @bulk_import.ascend_errors.present?
-      errors << short_line_text if @bulk_import.line_errors.present?
-      errors.join(", ")
-    end
+      def short_text
+        errors = []
+        errors << short_file_text if @bulk_import.file_errors.present?
+        errors << translation(".unknown_ascend_name") if @bulk_import.ascend_errors.present?
+        errors << short_line_text if @bulk_import.line_errors.present?
+        errors.join(", ")
+      end
 
-    def short_file_text
-      file_errors = @bulk_import.file_errors
-      return file_errors.first if file_errors.length == 1 && file_errors.first.match?(/Invalid file extension/i)
-      translation(".file")
-    end
+      def short_file_text
+        file_errors = @bulk_import.file_errors
+        return file_errors.first if file_errors.length == 1 && file_errors.first.match?(/Invalid file extension/i)
+        translation(".file")
+      end
 
-    def short_line_text
-      count = @bulk_import.line_errors.length
-      helpers.pluralize(helpers.number_with_delimiter(count), translation(".line_error"))
-    end
+      def short_line_text
+        count = @bulk_import.line_errors.length
+        helpers.pluralize(helpers.number_with_delimiter(count), translation(".line_error"))
+      end
 
-    def other_errors
-      @bulk_import.import_errors.except("file", "file_lines", "line", "ascend", "bikes")
+      def other_errors
+        @bulk_import.import_errors.except("file", "file_lines", "line", "ascend", "bikes")
+      end
     end
   end
 end

--- a/app/components/org/bulk_import_error/component_preview.rb
+++ b/app/components/org/bulk_import_error/component_preview.rb
@@ -1,9 +1,11 @@
 # frozen_string_literal: true
 
-module Org::BulkImportError
-  class ComponentPreview < ApplicationComponentPreview
-    def default
-      render(Org::BulkImportError::Component.new(bulk_import:, short_display:))
+module Org
+  module BulkImportError
+    class ComponentPreview < ApplicationComponentPreview
+      def default
+        render(Org::BulkImportError::Component.new(bulk_import:, short_display:))
+      end
     end
   end
 end

--- a/app/components/org/impound_records_index/component.rb
+++ b/app/components/org/impound_records_index/component.rb
@@ -1,65 +1,67 @@
 # frozen_string_literal: true
 
-module Org::ImpoundRecordsIndex
-  class Component < ApplicationComponent
-    include Binxtils::SortableHelper
+module Org
+  module ImpoundRecordsIndex
+    class Component < ApplicationComponent
+      include Binxtils::SortableHelper
 
-    def initialize(pagy:, impound_records:, search_status:, search_unregisteredness:, time_range:, available_statuses:, current_organization:, search_proximity:, search_location:, interpreted_params:)
-      @pagy = pagy
-      @impound_records = impound_records
-      @search_status = search_status
-      @search_unregisteredness = search_unregisteredness
-      @time_range = time_range
-      @available_statuses = available_statuses
-      @current_organization = current_organization
-      @search_proximity = search_proximity
-      @search_location = search_location
-      @interpreted_params = interpreted_params
-    end
-
-    private
-
-    def kinds_for_select
-      # This gets us the correct kinds for the current impound_record
-      # e.g. no retrieved_by_owner for unregistered_parking_notification
-      # Never include claim_approved or denied, even if they're valid update kinds - they have to be done through impound_claims
-      # Also - never display "current" because it can't be updated that way
-      ImpoundRecordUpdate.kinds_humanized.except(:claim_approved, :claim_denied, :current, :expired)
-    end
-
-    def skip_resolved
-      ImpoundRecord.active_statuses.include?(@search_status)
-    end
-
-    def render_status
-      %w[all resolved].include?(@search_status)
-    end
-
-    def status_dropdown_text
-      if @search_status != "current" && ImpoundRecord.statuses.include?(@search_status)
-        ImpoundRecord.statuses_humanized[@search_status.to_sym]
-      elsif @search_status == "all"
-        translation(".all_statuses")
-      else
-        translation(".status_records", status: @search_status.titleize)
+      def initialize(pagy:, impound_records:, search_status:, search_unregisteredness:, time_range:, available_statuses:, current_organization:, search_proximity:, search_location:, interpreted_params:)
+        @pagy = pagy
+        @impound_records = impound_records
+        @search_status = search_status
+        @search_unregisteredness = search_unregisteredness
+        @time_range = time_range
+        @available_statuses = available_statuses
+        @current_organization = current_organization
+        @search_proximity = search_proximity
+        @search_location = search_location
+        @interpreted_params = interpreted_params
       end
-    end
 
-    def display_status_for(status)
-      if status != "current" && ImpoundRecord.statuses.include?(status)
-        ImpoundRecord.statuses_humanized[status.to_sym]
-      elsif status == "all"
-        translation(".all_statuses")
-      else
-        translation(".status_records", status: status.titleize)
+      private
+
+      def kinds_for_select
+        # This gets us the correct kinds for the current impound_record
+        # e.g. no retrieved_by_owner for unregistered_parking_notification
+        # Never include claim_approved or denied, even if they're valid update kinds - they have to be done through impound_claims
+        # Also - never display "current" because it can't be updated that way
+        ImpoundRecordUpdate.kinds_humanized.except(:claim_approved, :claim_denied, :current, :expired)
       end
-    end
 
-    def unregisteredness_dropdown_text
-      case @search_unregisteredness
-      when "only_registered" then translation(".only_user_registered")
-      when "only_unregistered" then translation(".only_unregistered")
-      else translation(".all_bikes")
+      def skip_resolved
+        ImpoundRecord.active_statuses.include?(@search_status)
+      end
+
+      def render_status
+        %w[all resolved].include?(@search_status)
+      end
+
+      def status_dropdown_text
+        if @search_status != "current" && ImpoundRecord.statuses.include?(@search_status)
+          ImpoundRecord.statuses_humanized[@search_status.to_sym]
+        elsif @search_status == "all"
+          translation(".all_statuses")
+        else
+          translation(".status_records", status: @search_status.titleize)
+        end
+      end
+
+      def display_status_for(status)
+        if status != "current" && ImpoundRecord.statuses.include?(status)
+          ImpoundRecord.statuses_humanized[status.to_sym]
+        elsif status == "all"
+          translation(".all_statuses")
+        else
+          translation(".status_records", status: status.titleize)
+        end
+      end
+
+      def unregisteredness_dropdown_text
+        case @search_unregisteredness
+        when "only_registered" then translation(".only_user_registered")
+        when "only_unregistered" then translation(".only_unregistered")
+        else translation(".all_bikes")
+        end
       end
     end
   end

--- a/app/components/org/location_address_fields/component.rb
+++ b/app/components/org/location_address_fields/component.rb
@@ -1,21 +1,23 @@
 # frozen_string_literal: true
 
-module Org::LocationAddressFields
-  class Component < ApplicationComponent
-    def initialize(form_builder:)
-      @builder = form_builder
+module Org
+  module LocationAddressFields
+    class Component < ApplicationComponent
+      def initialize(form_builder:)
+        @builder = form_builder
 
-      @initial_country_id = @builder.object.country_id || Country.united_states_id
-    end
+        @initial_country_id = @builder.object.country_id || Country.united_states_id
+      end
 
-    private
+      private
 
-    def initial_state_class
-      (@initial_country_id == Country.united_states_id) ? "" : "tw:hidden!"
-    end
+      def initial_state_class
+        (@initial_country_id == Country.united_states_id) ? "" : "tw:hidden!"
+      end
 
-    def initial_region_class
-      initial_state_class.blank? ? "tw:hidden!" : ""
+      def initial_region_class
+        initial_state_class.blank? ? "tw:hidden!" : ""
+      end
     end
   end
 end

--- a/app/components/org/multi_search_results/component.rb
+++ b/app/components/org/multi_search_results/component.rb
@@ -1,32 +1,34 @@
 # frozen_string_literal: true
 
-module Org::MultiSearchResults
-  class Component < ApplicationComponent
-    include Binxtils::SortableHelper
+module Org
+  module MultiSearchResults
+    class Component < ApplicationComponent
+      include Binxtils::SortableHelper
 
-    def initialize(organization:, serial:, serial_chip_id:, pagy:, bikes:, interpreted_params:, per_page:, close_serials: nil)
-      @organization = organization
-      @serial = serial
-      @serial_chip_id = serial_chip_id
-      @pagy = pagy
-      @bikes = bikes
-      @interpreted_params = interpreted_params
-      @per_page = per_page
-      @close_serials = close_serials
-    end
+      def initialize(organization:, serial:, serial_chip_id:, pagy:, bikes:, interpreted_params:, per_page:, close_serials: nil)
+        @organization = organization
+        @serial = serial
+        @serial_chip_id = serial_chip_id
+        @pagy = pagy
+        @bikes = bikes
+        @interpreted_params = interpreted_params
+        @per_page = per_page
+        @close_serials = close_serials
+      end
 
-    private
+      private
 
-    def result_index
-      @serial_chip_id&.delete_prefix("chip_")
-    end
+      def result_index
+        @serial_chip_id&.delete_prefix("chip_")
+      end
 
-    def show_view_all?
-      @pagy.count > @pagy.limit
-    end
+      def show_view_all?
+        @pagy.count > @pagy.limit
+      end
 
-    def view_all_path
-      helpers.organization_registrations_path(organization_id: @organization.to_param, search_serial: @serial)
+      def view_all_path
+        helpers.organization_registrations_path(organization_id: @organization.to_param, search_serial: @serial)
+      end
     end
   end
 end

--- a/app/components/org/multi_search_results/component_preview.rb
+++ b/app/components/org/multi_search_results/component_preview.rb
@@ -1,27 +1,29 @@
 # frozen_string_literal: true
 
-module Org::MultiSearchResults
-  class ComponentPreview < ApplicationComponentPreview
-    # @display legacy_stylesheet true
-    def default
-      pagy = Pagy::Offset.new(count: bikes.count, page: 1, limit: 10)
-      render Component.new(
-        organization: lookbook_organization,
-        serial: "SERIAL111",
-        serial_chip_id: "chip_0",
-        pagy:,
-        bikes:,
-        interpreted_params: {},
-        per_page: 10
-      )
-    end
+module Org
+  module MultiSearchResults
+    class ComponentPreview < ApplicationComponentPreview
+      # @display legacy_stylesheet true
+      def default
+        pagy = Pagy::Offset.new(count: bikes.count, page: 1, limit: 10)
+        render Component.new(
+          organization: lookbook_organization,
+          serial: "SERIAL111",
+          serial_chip_id: "chip_0",
+          pagy:,
+          bikes:,
+          interpreted_params: {},
+          per_page: 10
+        )
+      end
 
-    private
+      private
 
-    def bikes
-      return Bike.none if Rails.env.production? || lookbook_organization&.bikes.blank?
+      def bikes
+        return Bike.none if Rails.env.production? || lookbook_organization&.bikes.blank?
 
-      lookbook_organization.bikes.limit(5)
+        lookbook_organization.bikes.limit(5)
+      end
     end
   end
 end

--- a/app/components/org/registration_search/component.rb
+++ b/app/components/org/registration_search/component.rb
@@ -1,93 +1,95 @@
 # frozen_string_literal: true
 
-module Org::RegistrationSearch
-  class Component < ApplicationComponent
-    include Binxtils::SortableHelper
+module Org
+  module RegistrationSearch
+    class Component < ApplicationComponent
+      include Binxtils::SortableHelper
 
-    delegate :additional_registration_fields, :column_renames,
-      :initially_checked_columns, :cycle_type, :active_search_filter_descriptions,
-      to: :settings_component
-    def initialize(
-      organization:,
-      pagy:,
-      per_page:,
-      params:,
-      bikes: [],
-      current_user: nil,
-      interpreted_params: {},
-      sortable_search_params: {},
-      search_stickers: nil,
-      search_address: nil,
-      search_status: "all",
-      search_query_present: false,
-      time_range: nil,
-      stolenness: "all",
-      bike_sticker: nil,
-      model_audit: nil,
-      skip_search_and_filters: false,
-      skip_settings: false,
-      skip_count: false
-    )
-      @organization = organization
-      @pagy = pagy
-      @bikes = bikes
-      @current_user = current_user
-      @interpreted_params = interpreted_params
-      @sortable_search_params = sortable_search_params
-      @per_page = per_page
-      @params = params
-      @search_stickers = search_stickers
-      @search_address = search_address
-      @search_status = search_status
-      @search_query_present = search_query_present
-      @time_range = time_range
-      @stolenness = stolenness
-      @bike_sticker = bike_sticker
-      @model_audit = model_audit
-      @skip_search_and_filters = skip_search_and_filters
-      @skip_settings = skip_settings
-      @skip_count = skip_count
-    end
-
-    private
-
-    def settings_component
-      @settings_component ||= Org::RegistrationSearchSettings::Component.new(
-        organization: @organization,
-        interpreted_params: @interpreted_params,
-        sortable_search_params: @sortable_search_params,
-        params: @params,
-        search_stickers: @search_stickers,
-        search_address: @search_address,
-        search_status: @search_status,
-        bike_sticker: @bike_sticker,
-        skip_search_and_filters: @skip_search_and_filters
+      delegate :additional_registration_fields, :column_renames,
+        :initially_checked_columns, :cycle_type, :active_search_filter_descriptions,
+        to: :settings_component
+      def initialize(
+        organization:,
+        pagy:,
+        per_page:,
+        params:,
+        bikes: [],
+        current_user: nil,
+        interpreted_params: {},
+        sortable_search_params: {},
+        search_stickers: nil,
+        search_address: nil,
+        search_status: "all",
+        search_query_present: false,
+        time_range: nil,
+        stolenness: "all",
+        bike_sticker: nil,
+        model_audit: nil,
+        skip_search_and_filters: false,
+        skip_settings: false,
+        skip_count: false
       )
-    end
-
-    def show_search_query_summary?
-      @search_query_present || @params[:search_stickers].present? || @params[:search_address].present? || @model_audit.present?
-    end
-
-    def component_wrapper_data_attributes
-      return {} if @skip_settings
-      {controller: "org--registration-search org--registration-search-column-toggle",
-       "org--registration-search-column-toggle-default-columns-value": initially_checked_columns.to_json}
-    end
-
-    def table_wrapper_data_attributes
-      attrs = {
-        controller: "update-cached-sortable-links org--assign-bike-sticker",
-        "update-cached-sortable-links-base-url-value": url_for(@sortable_search_params.merge(organization_id: @organization.to_param))
-      }
-      if @bike_sticker.present?
-        attrs[:"org--assign-bike-sticker-sticker-path-value"] = bike_sticker_path(id: @bike_sticker.code, organization_id: @bike_sticker.organization_id)
+        @organization = organization
+        @pagy = pagy
+        @bikes = bikes
+        @current_user = current_user
+        @interpreted_params = interpreted_params
+        @sortable_search_params = sortable_search_params
+        @per_page = per_page
+        @params = params
+        @search_stickers = search_stickers
+        @search_address = search_address
+        @search_status = search_status
+        @search_query_present = search_query_present
+        @time_range = time_range
+        @stolenness = stolenness
+        @bike_sticker = bike_sticker
+        @model_audit = model_audit
+        @skip_search_and_filters = skip_search_and_filters
+        @skip_settings = skip_settings
+        @skip_count = skip_count
       end
-      attrs
-    end
 
-    def show_pagination?
-      @pagy.pages > 1
+      private
+
+      def settings_component
+        @settings_component ||= Org::RegistrationSearchSettings::Component.new(
+          organization: @organization,
+          interpreted_params: @interpreted_params,
+          sortable_search_params: @sortable_search_params,
+          params: @params,
+          search_stickers: @search_stickers,
+          search_address: @search_address,
+          search_status: @search_status,
+          bike_sticker: @bike_sticker,
+          skip_search_and_filters: @skip_search_and_filters
+        )
+      end
+
+      def show_search_query_summary?
+        @search_query_present || @params[:search_stickers].present? || @params[:search_address].present? || @model_audit.present?
+      end
+
+      def component_wrapper_data_attributes
+        return {} if @skip_settings
+        {controller: "org--registration-search org--registration-search-column-toggle",
+         "org--registration-search-column-toggle-default-columns-value": initially_checked_columns.to_json}
+      end
+
+      def table_wrapper_data_attributes
+        attrs = {
+          controller: "update-cached-sortable-links org--assign-bike-sticker",
+          "update-cached-sortable-links-base-url-value": url_for(@sortable_search_params.merge(organization_id: @organization.to_param))
+        }
+        if @bike_sticker.present?
+          attrs[:"org--assign-bike-sticker-sticker-path-value"] = bike_sticker_path(id: @bike_sticker.code, organization_id: @bike_sticker.organization_id)
+        end
+        attrs
+      end
+
+      def show_pagination?
+        @pagy.pages > 1
+      end
     end
   end
 end

--- a/app/components/org/registration_search/component_preview.rb
+++ b/app/components/org/registration_search/component_preview.rb
@@ -1,26 +1,28 @@
 # frozen_string_literal: true
 
-module Org::RegistrationSearch
-  class ComponentPreview < ApplicationComponentPreview
-    # @display legacy_stylesheet true
-    def default
-      pagy = Pagy::Offset.new(count: bikes.count, page: 1, limit: 10)
-      render Org::RegistrationSearch::Component.new(
-        organization: lookbook_organization,
-        pagy:,
-        bikes:,
-        per_page: 10,
-        params: {},
-        time_range: 1.year.ago..Time.current
-      )
-    end
+module Org
+  module RegistrationSearch
+    class ComponentPreview < ApplicationComponentPreview
+      # @display legacy_stylesheet true
+      def default
+        pagy = Pagy::Offset.new(count: bikes.count, page: 1, limit: 10)
+        render Org::RegistrationSearch::Component.new(
+          organization: lookbook_organization,
+          pagy:,
+          bikes:,
+          per_page: 10,
+          params: {},
+          time_range: 1.year.ago..Time.current
+        )
+      end
 
-    private
+      private
 
-    def bikes
-      return Bike.none if Rails.env.production? || lookbook_organization&.bikes.blank?
+      def bikes
+        return Bike.none if Rails.env.production? || lookbook_organization&.bikes.blank?
 
-      lookbook_organization.bikes.limit(5)
+        lookbook_organization.bikes.limit(5)
+      end
     end
   end
 end

--- a/app/components/org/registration_search_settings/component.rb
+++ b/app/components/org/registration_search_settings/component.rb
@@ -1,128 +1,130 @@
 # frozen_string_literal: true
 
-module Org::RegistrationSearchSettings
-  class Component < ApplicationComponent
-    COLUMN_RENAME_KEYS = %i[
-      created_at_cell
-      updated_at_cell
-      stolen_cell
-      serial_number_cell
-      manufacturer_cell
-      model_cell
-      color_cell
-      owner_email_cell
-      creation_description_cell
-      owner_name_cell
-      reg_organization_affiliation_cell
-      reg_extra_registration_number_cell
-      reg_phone_cell
-      reg_address_cell
-      reg_student_id_cell
-      notes_cell
-      sticker_cell
-      impound_id_cell
-      impounded_cell
-      avery_cell
-      cycle_type_cell
-      propulsion_type_cell
-      status_cell
-      url_cell
-    ].freeze
+module Org
+  module RegistrationSearchSettings
+    class Component < ApplicationComponent
+      COLUMN_RENAME_KEYS = %i[
+        created_at_cell
+        updated_at_cell
+        stolen_cell
+        serial_number_cell
+        manufacturer_cell
+        model_cell
+        color_cell
+        owner_email_cell
+        creation_description_cell
+        owner_name_cell
+        reg_organization_affiliation_cell
+        reg_extra_registration_number_cell
+        reg_phone_cell
+        reg_address_cell
+        reg_student_id_cell
+        notes_cell
+        sticker_cell
+        impound_id_cell
+        impounded_cell
+        avery_cell
+        cycle_type_cell
+        propulsion_type_cell
+        status_cell
+        url_cell
+      ].freeze
 
-    ORG_PREFIXED_COLUMNS = %i[reg_organization_affiliation_cell reg_student_id_cell notes_cell].freeze
+      ORG_PREFIXED_COLUMNS = %i[reg_organization_affiliation_cell reg_student_id_cell notes_cell].freeze
 
-    FILTER_DESCRIPTION_KEYS = {
-      search_stickers: {with: ".filter_with_stickers_html", none: ".filter_no_sticker_html"},
-      search_address: {with_street: ".filter_with_address_html", without_street: ".filter_no_address_html"},
-      search_status: {not_impounded: ".filter_not_impounded_html", impounded: ".filter_impounded_html",
-                      with_owner: ".filter_not_stolen_or_impounded_html", stolen: ".filter_stolen_html"}
-    }.freeze
+      FILTER_DESCRIPTION_KEYS = {
+        search_stickers: {with: ".filter_with_stickers_html", none: ".filter_no_sticker_html"},
+        search_address: {with_street: ".filter_with_address_html", without_street: ".filter_no_address_html"},
+        search_status: {not_impounded: ".filter_not_impounded_html", impounded: ".filter_impounded_html",
+                        with_owner: ".filter_not_stolen_or_impounded_html", stolen: ".filter_stolen_html"}
+      }.freeze
 
-    attr_reader :organization
+      attr_reader :organization
 
-    def initialize(
-      organization:,
-      interpreted_params: {},
-      sortable_search_params: {},
-      params: {},
-      search_stickers: nil,
-      search_address: nil,
-      search_status: "all",
-      bike_sticker: nil,
-      skip_search_and_filters: false
-    )
-      @organization = organization
-      @interpreted_params = interpreted_params
-      @sortable_search_params = sortable_search_params
-      @params = params
-      @search_stickers = search_stickers
-      @search_address = search_address
-      @search_status = search_status
-      @bike_sticker = bike_sticker
-      @skip_search_and_filters = skip_search_and_filters
-    end
-
-    # Called via delegation from Org::RegistrationSearch
-    def active_search_filter_descriptions
-      values = {search_stickers: @search_stickers, search_address: @search_address, search_status: @search_status}
-
-      FILTER_DESCRIPTION_KEYS.filter_map do |param, mapping|
-        value = values[param]
-        key = mapping[value.to_sym] if value.is_a?(String)
-        translation(key) if key
+      def initialize(
+        organization:,
+        interpreted_params: {},
+        sortable_search_params: {},
+        params: {},
+        search_stickers: nil,
+        search_address: nil,
+        search_status: "all",
+        bike_sticker: nil,
+        skip_search_and_filters: false
+      )
+        @organization = organization
+        @interpreted_params = interpreted_params
+        @sortable_search_params = sortable_search_params
+        @params = params
+        @search_stickers = search_stickers
+        @search_address = search_address
+        @search_status = search_status
+        @bike_sticker = bike_sticker
+        @skip_search_and_filters = skip_search_and_filters
       end
-    end
 
-    def initially_checked_columns
-      @initially_checked_columns ||= begin
-        cols = %w[created_at_cell stolen_cell manufacturer_cell model_cell
-          color_cell owner_email_cell owner_name_cell creation_description_cell]
-        cols += ["sticker_cell"] if @organization.enabled?("bike_stickers")
-        cols += ["impounded_cell"] if @params[:search_impoundedness] == "impounded"
-        cols
+      # Called via delegation from Org::RegistrationSearch
+      def active_search_filter_descriptions
+        values = {search_stickers: @search_stickers, search_address: @search_address, search_status: @search_status}
+
+        FILTER_DESCRIPTION_KEYS.filter_map do |param, mapping|
+          value = values[param]
+          key = mapping[value.to_sym] if value.is_a?(String)
+          translation(key) if key
+        end
       end
-    end
 
-    def column_renames
-      @column_renames ||= COLUMN_RENAME_KEYS.map { |key|
-        name = translation(".#{key}")
-        name = "#{@organization.short_name} #{name}" if ORG_PREFIXED_COLUMNS.include?(key)
-        [key, name]
-      }.to_h
-    end
-
-    def additional_registration_fields
-      @additional_registration_fields ||= @organization.additional_registration_fields - ["reg_bike_sticker"]
-    end
-
-    def cycle_type
-      @cycle_type ||= begin
-        merged = @params.merge(@interpreted_params)
-        BikeServices::Displayer.vehicle_search?(merged) ? translation(".vehicle") : translation(".bike")
+      def initially_checked_columns
+        @initially_checked_columns ||= begin
+          cols = %w[created_at_cell stolen_cell manufacturer_cell model_cell
+            color_cell owner_email_cell owner_name_cell creation_description_cell]
+          cols += ["sticker_cell"] if @organization.enabled?("bike_stickers")
+          cols += ["impounded_cell"] if @params[:search_impoundedness] == "impounded"
+          cols
+        end
       end
-    end
 
-    private
-
-    def enabled_columns
-      @enabled_columns ||= begin
-        cols = initially_checked_columns.dup
-        cols += %w[url_cell updated_at_cell serial_number_cell cycle_type_cell propulsion_type_cell status_cell]
-        cols += additional_registration_fields.map { |f| "#{f}_cell" }
-        cols += ["notes_cell"] if @organization.enabled?("registration_notes")
-        cols += %w[impound_id_cell impounded_cell] if @organization.enabled?("impound_bikes")
-        cols += ["avery_cell"] if @organization.enabled?("avery_export")
-        cols.uniq.sort { |a, b| column_renames[a.to_sym] <=> column_renames[b.to_sym] }
+      def column_renames
+        @column_renames ||= COLUMN_RENAME_KEYS.map { |key|
+          name = translation(".#{key}")
+          name = "#{@organization.short_name} #{name}" if ORG_PREFIXED_COLUMNS.include?(key)
+          [key, name]
+        }.to_h
       end
-    end
 
-    def settings_default_open?
-      @search_stickers.present? || @search_address.present? ||
-        @params[:search_impoundedness].present? || Binxtils::InputNormalizer.boolean(@params[:search_open])
-    end
+      def additional_registration_fields
+        @additional_registration_fields ||= @organization.additional_registration_fields - ["reg_bike_sticker"]
+      end
 
-    def search_params
-      @search_params ||= (@sortable_search_params || {}).merge((@interpreted_params || {}).merge(organization_id: @organization.to_param))
+      def cycle_type
+        @cycle_type ||= begin
+          merged = @params.merge(@interpreted_params)
+          BikeServices::Displayer.vehicle_search?(merged) ? translation(".vehicle") : translation(".bike")
+        end
+      end
+
+      private
+
+      def enabled_columns
+        @enabled_columns ||= begin
+          cols = initially_checked_columns.dup
+          cols += %w[url_cell updated_at_cell serial_number_cell cycle_type_cell propulsion_type_cell status_cell]
+          cols += additional_registration_fields.map { |f| "#{f}_cell" }
+          cols += ["notes_cell"] if @organization.enabled?("registration_notes")
+          cols += %w[impound_id_cell impounded_cell] if @organization.enabled?("impound_bikes")
+          cols += ["avery_cell"] if @organization.enabled?("avery_export")
+          cols.uniq.sort { |a, b| column_renames[a.to_sym] <=> column_renames[b.to_sym] }
+        end
+      end
+
+      def settings_default_open?
+        @search_stickers.present? || @search_address.present? ||
+          @params[:search_impoundedness].present? || Binxtils::InputNormalizer.boolean(@params[:search_open])
+      end
+
+      def search_params
+        @search_params ||= (@sortable_search_params || {}).merge((@interpreted_params || {}).merge(organization_id: @organization.to_param))
+      end
     end
   end
 end

--- a/app/components/page_block/choose_membership/component.rb
+++ b/app/components/page_block/choose_membership/component.rb
@@ -1,43 +1,45 @@
 # frozen_string_literal: true
 
-module PageBlock::ChooseMembership
-  class Component < ApplicationComponent
-    def initialize(currency:, interval: nil, level: nil, membership: nil, referral_source: nil)
-      @currency = currency
-      @membership = membership || Membership.new
-      @membership.set_interval = @membership.interval || interval || StripePrice.interval_default
-      @membership.level ||= passed_membership_level(level)
-      @referral_source = referral_source
-    end
-
-    private
-
-    def price_display(amount_cents, interval)
-      interval_display = (interval == "monthly") ? "month" : "year"
-      interval_classes = "intervalDisplay #{interval} #{"tw:hidden!" unless @membership.set_interval == interval}"
-
-      tag.h3(class: "tw:inline-flex tw:items-stretch #{interval_classes}") do
-        safe_join([
-          tag.span(MoneyFormatter.money_format(amount_cents, @currency), class: "tw:text-2xl tw:font-semibold"),
-          tag.span(class: "tw:ml-1 tw:text-xs tw:flex tw:flex-col tw:justify-center tw:leading-none tw:text-left") do
-            safe_join([
-              tag.span("per"),
-              tag.span(interval_display)
-            ])
-          end
-        ])
+module PageBlock
+  module ChooseMembership
+    class Component < ApplicationComponent
+      def initialize(currency:, interval: nil, level: nil, membership: nil, referral_source: nil)
+        @currency = currency
+        @membership = membership || Membership.new
+        @membership.set_interval = @membership.interval || interval || StripePrice.interval_default
+        @membership.level ||= passed_membership_level(level)
+        @referral_source = referral_source
       end
-    end
 
-    def passed_membership_level(level = nil)
-      return :basic unless Membership::LEVEL_ENUM.key?(level&.to_sym)
+      private
 
-      level.to_sym
-    end
+      def price_display(amount_cents, interval)
+        interval_display = (interval == "monthly") ? "month" : "year"
+        interval_classes = "intervalDisplay #{interval} #{"tw:hidden!" unless @membership.set_interval == interval}"
 
-    # TODO: Actually use membership levels
-    def membership_levels
-      Membership.levels_ordered
+        tag.h3(class: "tw:inline-flex tw:items-stretch #{interval_classes}") do
+          safe_join([
+            tag.span(MoneyFormatter.money_format(amount_cents, @currency), class: "tw:text-2xl tw:font-semibold"),
+            tag.span(class: "tw:ml-1 tw:text-xs tw:flex tw:flex-col tw:justify-center tw:leading-none tw:text-left") do
+              safe_join([
+                tag.span("per"),
+                tag.span(interval_display)
+              ])
+            end
+          ])
+        end
+      end
+
+      def passed_membership_level(level = nil)
+        return :basic unless Membership::LEVEL_ENUM.key?(level&.to_sym)
+
+        level.to_sym
+      end
+
+      # TODO: Actually use membership levels
+      def membership_levels
+        Membership.levels_ordered
+      end
     end
   end
 end

--- a/app/components/page_block/choose_membership/component_preview.rb
+++ b/app/components/page_block/choose_membership/component_preview.rb
@@ -1,9 +1,11 @@
 # frozen_string_literal: true
 
-module PageBlock::ChooseMembership
-  class ComponentPreview < ApplicationComponentPreview
-    def default
-      render(PageBlock::ChooseMembership::Component.new(currency: Currency.default))
+module PageBlock
+  module ChooseMembership
+    class ComponentPreview < ApplicationComponentPreview
+      def default
+        render(PageBlock::ChooseMembership::Component.new(currency: Currency.default))
+      end
     end
   end
 end

--- a/app/components/page_block/header_tags/component.rb
+++ b/app/components/page_block/header_tags/component.rb
@@ -1,234 +1,236 @@
 # frozen_string_literal: true
 
-module PageBlock::HeaderTags
-  class Component < ApplicationComponent
-    DEFAULT_IMAGE = "/opengraph.png"
-    DEFAULT_TWITTER = "@bikeindex"
+module PageBlock
+  module HeaderTags
+    class Component < ApplicationComponent
+      DEFAULT_IMAGE = "/opengraph.png"
+      DEFAULT_TWITTER = "@bikeindex"
 
-    def initialize(controller_name:, action_name:, request_url:, page_title: nil, page_obj: nil, updated_at: nil, organization_name: nil, controller_namespace: nil)
-      # TODO: Do any pages need a query string?
-      @page_url = request_url.split("?").first
+      def initialize(controller_name:, action_name:, request_url:, page_title: nil, page_obj: nil, updated_at: nil, organization_name: nil, controller_namespace: nil)
+        # TODO: Do any pages need a query string?
+        @page_url = request_url.split("?").first
 
-      # TODO: Don't actually need to store @page_key, it's just for page_json_ld
-      @page_key = translation_key_for(controller_namespace:, controller_name:, action_name:, page_obj:)
-      @display_auto_discovery = controller_name == "news"
+        # TODO: Don't actually need to store @page_key, it's just for page_json_ld
+        @page_key = translation_key_for(controller_namespace:, controller_name:, action_name:, page_obj:)
+        @display_auto_discovery = controller_name == "news"
 
-      @page_title = page_title
+        @page_title = page_title
 
-      if page_obj.is_a?(Bike) || page_obj.is_a?(BikeVersion)
-        assign_bike_attrs(page_obj, action_name)
-      elsif page_obj.is_a?(Blog)
-        assign_blog_attrs(page_obj)
-      elsif @page_key == "users_show"
-        assign_user_attrs(page_obj)
+        if page_obj.is_a?(Bike) || page_obj.is_a?(BikeVersion)
+          assign_bike_attrs(page_obj, action_name)
+        elsif page_obj.is_a?(Blog)
+          assign_blog_attrs(page_obj)
+        elsif @page_key == "users_show"
+          assign_user_attrs(page_obj)
+        end
+
+        @page_description ||= translation_if_exists("meta_descriptions.#{@page_key}", organization_name) ||
+          default_description
+        @page_title ||= translation_if_exists("meta_titles.#{@page_key}", organization_name) ||
+          auto_title_for(controller_name:, controller_namespace:, action_name:, organization_name:)
+
+        # Always prefix admin with emoji, regardless of how title was assigned
+        @page_title = "🧰 #{@page_title}" if controller_namespace == "admin"
       end
 
-      @page_description ||= translation_if_exists("meta_descriptions.#{@page_key}", organization_name) ||
-        default_description
-      @page_title ||= translation_if_exists("meta_titles.#{@page_key}", organization_name) ||
-        auto_title_for(controller_name:, controller_namespace:, action_name:, organization_name:)
+      private
 
-      # Always prefix admin with emoji, regardless of how title was assigned
-      @page_title = "🧰 #{@page_title}" if controller_namespace == "admin"
-    end
-
-    private
-
-    def default_description
-      I18n.t("meta_descriptions.welcome_index")
-    end
-
-    def page_image
-      @page_image || DEFAULT_IMAGE
-    end
-
-    def twitter_image
-      @twitter_image || page_image
-    end
-
-    def facebook_image
-      @facebook_image || page_image
-    end
-
-    def twitter_creator
-      @twitter_creator || DEFAULT_TWITTER
-    end
-
-    def known_image_dimensions?
-      facebook_image == DEFAULT_IMAGE || @image_dimensions.present?
-    end
-
-    def image_width
-      @image_dimensions&.first || 1200 # default image is 1200
-    end
-
-    def image_height
-      @image_dimensions&.last || 630 # default image is 630
-    end
-
-    def og_updated_property
-      (@meta_type == "article") ? "article:modified_time" : "og:updated_time"
-    end
-
-    def url_canonical
-      @url_canonical || @page_url
-    end
-
-    def page_json_ld
-      # ... eventually might want to use Vehicle, but currently would use no properties
-      json_ld_type = if @meta_type == "article"
-        (@page_key == "news_show") ? "BlogPosting" : "Article"
-      else
-        "WebPage"
-      end
-      {
-        "@context" => "http://schema.org",
-        "@type" => json_ld_type,
-        "image" => page_image,
-        "url" => @page_url,
-        "headline" => @page_title,
-        "alternativeHeadline" => (@secondary_title.present? ? @secondary_title : @page_description)
-      }.merge(@published_at.present? ? {"datePublished" => @published_at} : {})
-        .merge(@updated_at.present? ? {"dateModified" => @updated_at} : {})
-    end
-
-    def date(datetime = nil)
-      datetime&.strftime("%Y-%m-%d") # Verify 8601
-    end
-
-    def time(datetime = nil)
-      datetime&.utc&.iso8601(0)
-    end
-
-    #
-    #
-    # Translation and auto assign methods
-    #
-
-    def translation_key_for(controller_namespace:, controller_name:, action_name:, page_obj:)
-      return "bikes_new" if controller_name == "welcome" && action_name == "choose_registration"
-
-      if %w[bikes bike_versions].include?(controller_name)
-        return "bikes_new_stolen" if (action_name == "new" || action_name == "create") && page_obj&.status_stolen?
-      elsif %w[embed embed_extended embed_create_success].include?(action_name)
-        # All the registration embed forms have the same title and description
-        controller_name = "registrations"
-        action_name = "embed"
+      def default_description
+        I18n.t("meta_descriptions.welcome_index")
       end
 
-      [controller_namespace, controller_name, action_name].compact.join("_")
-    end
-
-    # Check I18n.exists first - otherwise translation throws an error
-    def translation_if_exists(key, organization_name)
-      I18n.exists?(key) ? I18n.t(key, organization: organization_name) : nil
-    end
-
-    def auto_title_for(controller_name:, controller_namespace:, action_name:, organization_name:)
-      namespace_title = if controller_namespace == "organized"
-        organization_name
+      def page_image
+        @page_image || DEFAULT_IMAGE
       end
 
-      [
-        namespace_title,
-        auto_controller_and_action_title(controller_name, action_name)
-      ].compact.join(" ")
-    end
-
-    def auto_controller_and_action_title(controller_name, action_name)
-      case action_name
-      when "index"
-        controller_name.humanize
-      when "new", "edit", "show", "create"
-        "#{auto_action_name_title(action_name)} #{controller_name.humanize.singularize.downcase}"
-      else
-        action_name.humanize
-      end
-    end
-
-    def auto_action_name_title(action_name)
-      {
-        new: "New",
-        edit: "Edit",
-        show: "View",
-        create: "Created"
-      }.as_json.freeze[action_name]
-    end
-
-    #
-    #
-    # Below here is page type specific assignment
-    #
-
-    def assign_blog_attrs(blog)
-      @updated_at = time(blog.updated_at)
-      @published_at = time(blog.updated_at)
-      @meta_type = "article"
-      @page_title ||= blog.title
-      @page_description ||= blog.description
-      @secondary_title = blog.secondary_title if blog.secondary_title.present?
-      @page_image = if blog.index_image.present?
-        blog.index_image_lg
-      elsif blog.public_images.any?
-        blog.public_images.last.image_url
-      end
-      @url_canonical = blog.canonical_url if blog.canonical_url?
-      return unless blog.user.present?
-
-      @twitter_creator = "@#{blog.user.twitter}" if blog.user.twitter
-      @author = "/users/#{blog.user&.to_param}"
-    end
-
-    def assign_bike_attrs(bike, action_name)
-      @updated_at = time(bike&.updated_at)
-      return unless action_name == "show"
-
-      status_prefix = bike.status_with_owner? ? nil : bike.status_humanized.titleize
-      @page_title ||= [status_prefix, bike.title_string].compact.join(" ")
-
-      @page_description = bike_page_description(bike, status_prefix)
-
-      if (header_image_urls = BikeServices::Displayer.header_image_urls(bike))
-        @image_dimensions = [1200, 630]
-        @page_image = header_image_urls[:facebook]
-        @facebook_image = header_image_urls[:facebook]
-        @twitter_image = header_image_urls[:twitter]
+      def twitter_image
+        @twitter_image || page_image
       end
 
-      if bike.owner&.show_twitter && bike.owner.twitter.present?
-        @twitter_creator = "@#{bike.owner.twitter}"
+      def facebook_image
+        @facebook_image || page_image
       end
-    end
 
-    def bike_page_description(bike, status_prefix)
-      special_status_string = if bike.is_a?(BikeVersion)
+      def twitter_creator
+        @twitter_creator || DEFAULT_TWITTER
+      end
+
+      def known_image_dimensions?
+        facebook_image == DEFAULT_IMAGE || @image_dimensions.present?
+      end
+
+      def image_width
+        @image_dimensions&.first || 1200 # default image is 1200
+      end
+
+      def image_height
+        @image_dimensions&.last || 630 # default image is 630
+      end
+
+      def og_updated_property
+        (@meta_type == "article") ? "article:modified_time" : "og:updated_time"
+      end
+
+      def url_canonical
+        @url_canonical || @page_url
+      end
+
+      def page_json_ld
+        # ... eventually might want to use Vehicle, but currently would use no properties
+        json_ld_type = if @meta_type == "article"
+          (@page_key == "news_show") ? "BlogPosting" : "Article"
+        else
+          "WebPage"
+        end
+        {
+          "@context" => "http://schema.org",
+          "@type" => json_ld_type,
+          "image" => page_image,
+          "url" => @page_url,
+          "headline" => @page_title,
+          "alternativeHeadline" => (@secondary_title.present? ? @secondary_title : @page_description)
+        }.merge(@published_at.present? ? {"datePublished" => @published_at} : {})
+          .merge(@updated_at.present? ? {"dateModified" => @updated_at} : {})
+      end
+
+      def date(datetime = nil)
+        datetime&.strftime("%Y-%m-%d") # Verify 8601
+      end
+
+      def time(datetime = nil)
+        datetime&.utc&.iso8601(0)
+      end
+
+      #
+      #
+      # Translation and auto assign methods
+      #
+
+      def translation_key_for(controller_namespace:, controller_name:, action_name:, page_obj:)
+        return "bikes_new" if controller_name == "welcome" && action_name == "choose_registration"
+
+        if %w[bikes bike_versions].include?(controller_name)
+          return "bikes_new_stolen" if (action_name == "new" || action_name == "create") && page_obj&.status_stolen?
+        elsif %w[embed embed_extended embed_create_success].include?(action_name)
+          # All the registration embed forms have the same title and description
+          controller_name = "registrations"
+          action_name = "embed"
+        end
+
+        [controller_namespace, controller_name, action_name].compact.join("_")
+      end
+
+      # Check I18n.exists first - otherwise translation throws an error
+      def translation_if_exists(key, organization_name)
+        I18n.exists?(key) ? I18n.t(key, organization: organization_name) : nil
+      end
+
+      def auto_title_for(controller_name:, controller_namespace:, action_name:, organization_name:)
+        namespace_title = if controller_namespace == "organized"
+          organization_name
+        end
+
         [
-          "Version",
-          bike.start_at.present? ? "from: #{date(bike.start_at)}" : nil,
-          bike.end_at.present? ? "to: #{date(bike.end_at)}" : nil
+          namespace_title,
+          auto_controller_and_action_title(controller_name, action_name)
         ].compact.join(" ")
-      elsif bike.status_stolen? && bike.current_stolen_record.present?
-        "#{status_prefix}: #{date(bike.current_stolen_record.date_stolen)}, from: #{bike.current_stolen_record.address(country: [:iso])}"
-      elsif bike.current_impound_record.present?
-        "#{status_prefix}: #{date(bike.current_impound_record.impounded_at)}, in: #{bike.current_impound_record.formatted_address_string}"
       end
 
-      # Don't show serial on bike versions
-      serial_display = bike.is_a?(Bike) ? ", serial: #{bike.serial_display}" : ""
+      def auto_controller_and_action_title(controller_name, action_name)
+        case action_name
+        when "index"
+          controller_name.humanize
+        when "new", "edit", "show", "create"
+          "#{auto_action_name_title(action_name)} #{controller_name.humanize.singularize.downcase}"
+        else
+          action_name.humanize
+        end
+      end
 
-      [
-        "#{bike.frame_colors.to_sentence} #{bike.title_string}#{serial_display}.",
-        (bike.description.present? ? "#{bike.description}." : nil),
-        special_status_string
-      ].compact.join(" ")
-    end
+      def auto_action_name_title(action_name)
+        {
+          new: "New",
+          edit: "Edit",
+          show: "View",
+          create: "Created"
+        }.as_json.freeze[action_name]
+      end
 
-    def assign_user_attrs(user)
-      @page_title = Binxtils::InputNormalizer.sanitize(user.name) if user.name.present?
-      @page_description = "Bike Index user account: #{user.title}" if user.title.present?
+      #
+      #
+      # Below here is page type specific assignment
+      #
 
-      if user.avatar && user.avatar.url != "https://files.bikeindex.org/blank.png"
-        @page_image = user.avatar.url
+      def assign_blog_attrs(blog)
+        @updated_at = time(blog.updated_at)
+        @published_at = time(blog.updated_at)
+        @meta_type = "article"
+        @page_title ||= blog.title
+        @page_description ||= blog.description
+        @secondary_title = blog.secondary_title if blog.secondary_title.present?
+        @page_image = if blog.index_image.present?
+          blog.index_image_lg
+        elsif blog.public_images.any?
+          blog.public_images.last.image_url
+        end
+        @url_canonical = blog.canonical_url if blog.canonical_url?
+        return unless blog.user.present?
+
+        @twitter_creator = "@#{blog.user.twitter}" if blog.user.twitter
+        @author = "/users/#{blog.user&.to_param}"
+      end
+
+      def assign_bike_attrs(bike, action_name)
+        @updated_at = time(bike&.updated_at)
+        return unless action_name == "show"
+
+        status_prefix = bike.status_with_owner? ? nil : bike.status_humanized.titleize
+        @page_title ||= [status_prefix, bike.title_string].compact.join(" ")
+
+        @page_description = bike_page_description(bike, status_prefix)
+
+        if (header_image_urls = BikeServices::Displayer.header_image_urls(bike))
+          @image_dimensions = [1200, 630]
+          @page_image = header_image_urls[:facebook]
+          @facebook_image = header_image_urls[:facebook]
+          @twitter_image = header_image_urls[:twitter]
+        end
+
+        if bike.owner&.show_twitter && bike.owner.twitter.present?
+          @twitter_creator = "@#{bike.owner.twitter}"
+        end
+      end
+
+      def bike_page_description(bike, status_prefix)
+        special_status_string = if bike.is_a?(BikeVersion)
+          [
+            "Version",
+            bike.start_at.present? ? "from: #{date(bike.start_at)}" : nil,
+            bike.end_at.present? ? "to: #{date(bike.end_at)}" : nil
+          ].compact.join(" ")
+        elsif bike.status_stolen? && bike.current_stolen_record.present?
+          "#{status_prefix}: #{date(bike.current_stolen_record.date_stolen)}, from: #{bike.current_stolen_record.address(country: [:iso])}"
+        elsif bike.current_impound_record.present?
+          "#{status_prefix}: #{date(bike.current_impound_record.impounded_at)}, in: #{bike.current_impound_record.formatted_address_string}"
+        end
+
+        # Don't show serial on bike versions
+        serial_display = bike.is_a?(Bike) ? ", serial: #{bike.serial_display}" : ""
+
+        [
+          "#{bike.frame_colors.to_sentence} #{bike.title_string}#{serial_display}.",
+          (bike.description.present? ? "#{bike.description}." : nil),
+          special_status_string
+        ].compact.join(" ")
+      end
+
+      def assign_user_attrs(user)
+        @page_title = Binxtils::InputNormalizer.sanitize(user.name) if user.name.present?
+        @page_description = "Bike Index user account: #{user.title}" if user.title.present?
+
+        if user.avatar && user.avatar.url != "https://files.bikeindex.org/blank.png"
+          @page_image = user.avatar.url
+        end
       end
     end
   end

--- a/app/components/page_block/homepage_for_buttons/component.rb
+++ b/app/components/page_block/homepage_for_buttons/component.rb
@@ -1,9 +1,11 @@
 # frozen_string_literal: true
 
-module PageBlock::HomepageForButtons
-  class Component < ApplicationComponent
-    def initialize(skip_theft: false)
-      @skip_theft = skip_theft
+module PageBlock
+  module HomepageForButtons
+    class Component < ApplicationComponent
+      def initialize(skip_theft: false)
+        @skip_theft = skip_theft
+      end
     end
   end
 end

--- a/app/components/page_block/homepage_for_buttons/component_preview.rb
+++ b/app/components/page_block/homepage_for_buttons/component_preview.rb
@@ -1,10 +1,12 @@
 # frozen_string_literal: true
 
-module PageBlock::HomepageForButtons
-  class ComponentPreview < ApplicationComponentPreview
-    # @display kelsey_stylesheet true
-    def default
-      render(PageBlock::HomepageForButtons::Component.new)
+module PageBlock
+  module HomepageForButtons
+    class ComponentPreview < ApplicationComponentPreview
+      # @display kelsey_stylesheet true
+      def default
+        render(PageBlock::HomepageForButtons::Component.new)
+      end
     end
   end
 end

--- a/app/components/page_block/homepage_top/component.rb
+++ b/app/components/page_block/homepage_top/component.rb
@@ -1,65 +1,67 @@
 # frozen_string_literal: true
 
-module PageBlock::HomepageTop
-  class Component < ApplicationComponent
-    include MoneyHelper
+module PageBlock
+  module HomepageTop
+    class Component < ApplicationComponent
+      include MoneyHelper
 
-    def initialize(recoveries_value:, organization_count:, recovery_displays:)
-      @recoveries_value = recoveries_value
-      @organization_count = organization_count
-      @recovery_displays = recovery_displays.select { it.photo_url.present? }
-    end
+      def initialize(recoveries_value:, organization_count:, recovery_displays:)
+        @recoveries_value = recoveries_value
+        @organization_count = organization_count
+        @recovery_displays = recovery_displays.select { it.photo_url.present? }
+      end
 
-    private
+      private
 
-    def bike_tile_images
-      (0..16).map { it.to_s.rjust(2, "0") }
-        .map { image_url("kelsey/bike_tiles/bike-entry_00#{it}.png") }
-    end
+      def bike_tile_images
+        (0..16).map { it.to_s.rjust(2, "0") }
+          .map { image_url("kelsey/bike_tiles/bike-entry_00#{it}.png") }
+      end
 
-    def recoveries_value
-      recoveries_as_currency.gsub(/\D/, "")
-    end
+      def recoveries_value
+        recoveries_as_currency.gsub(/\D/, "")
+      end
 
-    def recoveries_value_symbol
-      recoveries_as_currency.gsub(/\d/, "")
-    end
+      def recoveries_value_symbol
+        recoveries_as_currency.gsub(/\d/, "")
+      end
 
-    def recoveries_as_currency
-      as_currency(@recoveries_value / 1_000_000)
-    end
+      def recoveries_as_currency
+        as_currency(@recoveries_value / 1_000_000)
+      end
 
-    def recovery_steps
-      [
-        {
-          stepNumber: "STEP 1",
-          title: "REGISTER YOUR BIKE",
-          text: "It's simple. Submit your name, bike manufacturer, serial number, and component information to enter your bike into the most widely used bike registry on the planet.",
-          background: image_url("kelsey/step1.gif"),
-          rotation: 0
-        },
-        {
-          stepNumber: "STEP 2",
-          title: "ALERT THE COMMUNITY",
-          text: "If your bike goes missing, mark it as lost or stolen to notify the entire Bike Index community and its partners.",
-          background: image_url("kelsey/step2.gif"),
-          rotation: 90
-        },
-        {
-          stepNumber: "STEP 3",
-          title: "THE COMMUNITY RESPONDS",
-          text: "A user or partner encounters your bike, uses Bike Index to identify it, and contacts you.",
-          background: image_url("kelsey/step3.gif"),
-          rotation: 180
-        },
-        {
-          stepNumber: "STEP 4",
-          title: "YOU GET YOUR BIKE BACK",
-          text: "With the help of the Bike Index community and its partners, you have the information necessary to recover your lost or stolen bike at no cost to you. It's what we do.",
-          background: image_url("kelsey/step4.gif"),
-          rotation: 270
-        }
-      ]
+      def recovery_steps
+        [
+          {
+            stepNumber: "STEP 1",
+            title: "REGISTER YOUR BIKE",
+            text: "It's simple. Submit your name, bike manufacturer, serial number, and component information to enter your bike into the most widely used bike registry on the planet.",
+            background: image_url("kelsey/step1.gif"),
+            rotation: 0
+          },
+          {
+            stepNumber: "STEP 2",
+            title: "ALERT THE COMMUNITY",
+            text: "If your bike goes missing, mark it as lost or stolen to notify the entire Bike Index community and its partners.",
+            background: image_url("kelsey/step2.gif"),
+            rotation: 90
+          },
+          {
+            stepNumber: "STEP 3",
+            title: "THE COMMUNITY RESPONDS",
+            text: "A user or partner encounters your bike, uses Bike Index to identify it, and contacts you.",
+            background: image_url("kelsey/step3.gif"),
+            rotation: 180
+          },
+          {
+            stepNumber: "STEP 4",
+            title: "YOU GET YOUR BIKE BACK",
+            text: "With the help of the Bike Index community and its partners, you have the information necessary to recover your lost or stolen bike at no cost to you. It's what we do.",
+            background: image_url("kelsey/step4.gif"),
+            rotation: 270
+          }
+        ]
+      end
     end
   end
 end

--- a/app/components/page_block/homepage_top/component_preview.rb
+++ b/app/components/page_block/homepage_top/component_preview.rb
@@ -1,11 +1,13 @@
 # frozen_string_literal: true
 
-module PageBlock::HomepageTop
-  class ComponentPreview < ApplicationComponentPreview
-    # @display kelsey_stylesheet true
-    def default
-      render(PageBlock::HomepageTop::Component.new(recoveries_value: Counts.recoveries_value,
-        organization_count: Organization.count, recovery_displays: RecoveryDisplay.limit(5)))
+module PageBlock
+  module HomepageTop
+    class ComponentPreview < ApplicationComponentPreview
+      # @display kelsey_stylesheet true
+      def default
+        render(PageBlock::HomepageTop::Component.new(recoveries_value: Counts.recoveries_value,
+          organization_count: Organization.count, recovery_displays: RecoveryDisplay.limit(5)))
+      end
     end
   end
 end

--- a/app/components/page_block/landing_demo_modal/component.rb
+++ b/app/components/page_block/landing_demo_modal/component.rb
@@ -1,13 +1,15 @@
 # frozen_string_literal: true
 
-module PageBlock::LandingDemoModal
-  class Component < ApplicationComponent
-    def initialize(feedback:, feedback_type:, modal_id:, name_label:, current_user: nil)
-      @feedback = feedback
-      @current_user = current_user
-      @name_label = name_label
-      @feedback_type = feedback_type
-      @modal_id = modal_id
+module PageBlock
+  module LandingDemoModal
+    class Component < ApplicationComponent
+      def initialize(feedback:, feedback_type:, modal_id:, name_label:, current_user: nil)
+        @feedback = feedback
+        @current_user = current_user
+        @name_label = name_label
+        @feedback_type = feedback_type
+        @modal_id = modal_id
+      end
     end
   end
 end

--- a/app/components/page_block/landing_demo_modal/component_preview.rb
+++ b/app/components/page_block/landing_demo_modal/component_preview.rb
@@ -1,14 +1,16 @@
 # frozen_string_literal: true
 
-module PageBlock::LandingDemoModal
-  class ComponentPreview < ApplicationComponentPreview
-    def default
-      render(PageBlock::LandingDemoModal::Component.new(
-        feedback: Feedback.new,
-        name_label: "School",
-        feedback_type: "lead_for_school",
-        modal_id: "schools-demo-modal"
-      ))
+module PageBlock
+  module LandingDemoModal
+    class ComponentPreview < ApplicationComponentPreview
+      def default
+        render(PageBlock::LandingDemoModal::Component.new(
+          feedback: Feedback.new,
+          name_label: "School",
+          feedback_type: "lead_for_school",
+          modal_id: "schools-demo-modal"
+        ))
+      end
     end
   end
 end

--- a/app/components/page_block/landing_for_law_enforcement/component.rb
+++ b/app/components/page_block/landing_for_law_enforcement/component.rb
@@ -1,83 +1,85 @@
 # frozen_string_literal: true
 
-module PageBlock::LandingForLawEnforcement
-  class Component < ApplicationComponent
-    include MoneyHelper
+module PageBlock
+  module LandingForLawEnforcement
+    class Component < ApplicationComponent
+      include MoneyHelper
 
-    PARTNER_CITIES = %w[Calgary Edmonton Lethbridge Bend Portland Sunnyvale Davis].freeze
+      PARTNER_CITIES = %w[Calgary Edmonton Lethbridge Bend Portland Sunnyvale Davis].freeze
 
-    TOOLS = [
-      {key: "leadsonline", image: "features_0001_leadsonline.png", title: "LeadsOnline Integration",
-       description: "Theft victims add their police report number, entering bikes into LEADS so pawn shops can flag stolen property."},
-      {key: "hot-sheet", image: "features_0005_daily-hot-sheet.png", title: "Daily Hot Sheet",
-       description: "Local stolen bike reports delivered to your inbox every morning with complete details and photos."},
-      {key: "dashboard", image: "features_0008_dashboard-analytics.png", title: "Dashboard Analytics",
-       description: "Filter bikes by time and status to track trends and identify where recovery efforts are most effective."},
-      {key: "direct-contact", image: "features_0009_direct-communication.png", title: "Direct Contact with Owners",
-       description: "Message bike owners directly via phone or email for abandoned bikes and recovered property with logged communications."},
-      {key: "export", image: "features_0007_data-export.png", title: "Data Export",
-       description: "Export and share registration and recovery data with leadership to demonstrate program impact and success."},
-      {key: "impound", image: "features_0002_impound-lot.png", title: "Impound Lot Management",
-       description: "Upload and search impound lot bikes, automatically notify owners, and manage ownership claims through the platform."},
-      {key: "credibility", image: "features_0004_credibility-badges.png", title: "Credibility Badges",
-       description: "Owner credibility scores based on account age, registration source, and history help identify legitimate claims."},
-      {key: "pos", image: "features_0000_POS.png", title: "POS Integration",
-       description: "Local bike shops automatically register every bike they sell directly into your law enforcement dashboard system."},
-      {key: "social-alerts", image: "features_0003_social-media-alerts.png", title: "Social Media Alerts",
-       description: "Automatic social media posts on Twitter, Facebook, and Instagram reach bike-sympathetic community members who can help."},
-      {key: "qr-stickers", image: "features_0006_qr-stickers.png", title: "QR Stickers",
-       description: "Tamper-proof stickers break apart when removed and provide instant owner lookup for recovered bikes in the field."}
-    ].freeze
+      TOOLS = [
+        {key: "leadsonline", image: "features_0001_leadsonline.png", title: "LeadsOnline Integration",
+         description: "Theft victims add their police report number, entering bikes into LEADS so pawn shops can flag stolen property."},
+        {key: "hot-sheet", image: "features_0005_daily-hot-sheet.png", title: "Daily Hot Sheet",
+         description: "Local stolen bike reports delivered to your inbox every morning with complete details and photos."},
+        {key: "dashboard", image: "features_0008_dashboard-analytics.png", title: "Dashboard Analytics",
+         description: "Filter bikes by time and status to track trends and identify where recovery efforts are most effective."},
+        {key: "direct-contact", image: "features_0009_direct-communication.png", title: "Direct Contact with Owners",
+         description: "Message bike owners directly via phone or email for abandoned bikes and recovered property with logged communications."},
+        {key: "export", image: "features_0007_data-export.png", title: "Data Export",
+         description: "Export and share registration and recovery data with leadership to demonstrate program impact and success."},
+        {key: "impound", image: "features_0002_impound-lot.png", title: "Impound Lot Management",
+         description: "Upload and search impound lot bikes, automatically notify owners, and manage ownership claims through the platform."},
+        {key: "credibility", image: "features_0004_credibility-badges.png", title: "Credibility Badges",
+         description: "Owner credibility scores based on account age, registration source, and history help identify legitimate claims."},
+        {key: "pos", image: "features_0000_POS.png", title: "POS Integration",
+         description: "Local bike shops automatically register every bike they sell directly into your law enforcement dashboard system."},
+        {key: "social-alerts", image: "features_0003_social-media-alerts.png", title: "Social Media Alerts",
+         description: "Automatic social media posts on Twitter, Facebook, and Instagram reach bike-sympathetic community members who can help."},
+        {key: "qr-stickers", image: "features_0006_qr-stickers.png", title: "QR Stickers",
+         description: "Tamper-proof stickers break apart when removed and provide instant owner lookup for recovered bikes in the field."}
+      ].freeze
 
-    FEATURES = [
-      {image: "assets-law_1.png", title: "Law Enforcement Dashboard",
-       description: "See registration efforts in real-time. Track regional metrics, filter by time period, and export data to share results up the chain of command."},
-      {image: "assets-law_2.png", title: "Investigative Resources",
-       description: "QR stickers, LeadsOnline integration, daily stolen bike hot sheets, and credibility badges help you identify bad actors and verify ownership."},
-      {image: "assets-law_3.png", title: "Community Recovery",
-       description: "Our network of ambassadors and social media tools turn your community into allies. Automatic theft alerts on Twitter, Facebook, and Instagram."}
-    ].freeze
+      FEATURES = [
+        {image: "assets-law_1.png", title: "Law Enforcement Dashboard",
+         description: "See registration efforts in real-time. Track regional metrics, filter by time period, and export data to share results up the chain of command."},
+        {image: "assets-law_2.png", title: "Investigative Resources",
+         description: "QR stickers, LeadsOnline integration, daily stolen bike hot sheets, and credibility badges help you identify bad actors and verify ownership."},
+        {image: "assets-law_3.png", title: "Community Recovery",
+         description: "Our network of ambassadors and social media tools turn your community into allies. Automatic theft alerts on Twitter, Facebook, and Instagram."}
+      ].freeze
 
-    TESTIMONIALS = [
-      {quote: "We're going to find a lot more stolen bikes quicker and hope to alleviate the bike thefts that are happening.",
-       author: "Cst. Shawn Davis", org: "LPS"},
-      {quote: "With Calgarians already registering almost 9,000 bikes and further building Bike Index's database, Calgary's recovery number is already climbing.",
-       author: "Cst. Dan Seibel", org: "CPS"},
-      {quote: "We are very excited to partner with Bike Index, as this partnership symbolizes a joint effort in returning countless numbers of bicycles to their rightful owners.",
-       author: "Officer Brittany Elenes", org: "LAPD"}
-    ].freeze
+      TESTIMONIALS = [
+        {quote: "We're going to find a lot more stolen bikes quicker and hope to alleviate the bike thefts that are happening.",
+         author: "Cst. Shawn Davis", org: "LPS"},
+        {quote: "With Calgarians already registering almost 9,000 bikes and further building Bike Index's database, Calgary's recovery number is already climbing.",
+         author: "Cst. Dan Seibel", org: "CPS"},
+        {quote: "We are very excited to partner with Bike Index, as this partnership symbolizes a joint effort in returning countless numbers of bicycles to their rightful owners.",
+         author: "Officer Brittany Elenes", org: "LAPD"}
+      ].freeze
 
-    def initialize(feedback: Feedback.new, current_user: nil)
-      @feedback = feedback
-      @current_user = current_user
-    end
+      def initialize(feedback: Feedback.new, current_user: nil)
+        @feedback = feedback
+        @current_user = current_user
+      end
 
-    private
+      private
 
-    def recoveries_value_display
-      as_currency(Counts.recoveries_value / 1_000_000) + "M+"
-    end
+      def recoveries_value_display
+        as_currency(Counts.recoveries_value / 1_000_000) + "M+"
+      end
 
-    def recoveries_display
-      number_with_delimiter(Counts.recoveries)
-    end
+      def recoveries_display
+        number_with_delimiter(Counts.recoveries)
+      end
 
-    def organizations_display
-      number_with_delimiter(Counts.organizations)
-    end
+      def organizations_display
+        number_with_delimiter(Counts.organizations)
+      end
 
-    def bike_tile_images
-      (0..16).map { it.to_s.rjust(2, "0") }
-        .map { image_url("kelsey/bike_tiles/bike-entry_00#{it}.png") }
-    end
+      def bike_tile_images
+        (0..16).map { it.to_s.rjust(2, "0") }
+          .map { image_url("kelsey/bike_tiles/bike-entry_00#{it}.png") }
+      end
 
-    def partner_logos
-      PARTNER_CITIES.map do |city|
-        {name: city, image: image_url("kelsey/lawpartners/#{city}.png")}
-      end + [
-        {name: "Boise City", image: image_url("kelsey/lawpartners/Boise City.png")},
-        {name: "Los Angeles", image: image_url("kelsey/lawpartners/LA.png")}
-      ]
+      def partner_logos
+        PARTNER_CITIES.map do |city|
+          {name: city, image: image_url("kelsey/lawpartners/#{city}.png")}
+        end + [
+          {name: "Boise City", image: image_url("kelsey/lawpartners/Boise City.png")},
+          {name: "Los Angeles", image: image_url("kelsey/lawpartners/LA.png")}
+        ]
+      end
     end
   end
 end

--- a/app/components/page_block/landing_for_law_enforcement/component_preview.rb
+++ b/app/components/page_block/landing_for_law_enforcement/component_preview.rb
@@ -1,10 +1,12 @@
 # frozen_string_literal: true
 
-module PageBlock::LandingForLawEnforcement
-  class ComponentPreview < ApplicationComponentPreview
-    # @display kelsey_stylesheet true
-    def default
-      render(PageBlock::LandingForLawEnforcement::Component.new)
+module PageBlock
+  module LandingForLawEnforcement
+    class ComponentPreview < ApplicationComponentPreview
+      # @display kelsey_stylesheet true
+      def default
+        render(PageBlock::LandingForLawEnforcement::Component.new)
+      end
     end
   end
 end

--- a/app/components/page_block/landing_for_schools/component.rb
+++ b/app/components/page_block/landing_for_schools/component.rb
@@ -1,102 +1,104 @@
 # frozen_string_literal: true
 
-module PageBlock::LandingForSchools
-  class Component < ApplicationComponent
-    include MoneyHelper
+module PageBlock
+  module LandingForSchools
+    class Component < ApplicationComponent
+      include MoneyHelper
 
-    def initialize(feedback: Feedback.new, current_user: nil)
-      @feedback = feedback
-      @current_user = current_user
-    end
+      def initialize(feedback: Feedback.new, current_user: nil)
+        @feedback = feedback
+        @current_user = current_user
+      end
 
-    private
+      private
 
-    def recoveries_value_display
-      as_currency(Counts.recoveries_value / 1_000_000) + "M+"
-    end
+      def recoveries_value_display
+        as_currency(Counts.recoveries_value / 1_000_000) + "M+"
+      end
 
-    def recoveries_display
-      number_with_delimiter(Counts.recoveries)
-    end
+      def recoveries_display
+        number_with_delimiter(Counts.recoveries)
+      end
 
-    def organizations_display
-      number_with_delimiter(Counts.organizations)
-    end
+      def organizations_display
+        number_with_delimiter(Counts.organizations)
+      end
 
-    def bike_tile_images
-      (0..16).map { it.to_s.rjust(2, "0") }
-        .map { image_url("kelsey/bike_tiles/bike-entry_00#{it}.png") }
-    end
+      def bike_tile_images
+        (0..16).map { it.to_s.rjust(2, "0") }
+          .map { image_url("kelsey/bike_tiles/bike-entry_00#{it}.png") }
+      end
 
-    def university_partners
-      [
-        {file: "CU-Boulder.png", name: "CU Boulder"},
-        {file: "Penn-State.png", name: "Penn State"},
-        {file: "Princeton.png", name: "Princeton"},
-        {file: "Stevens-Institute-of-Technology.png", name: "Stevens Institute"},
-        {file: "UC-Davis.png", name: "UC Davis"},
-        {file: "UC-San-Diego.png", name: "UC San Diego"},
-        {file: "UCLA.png", name: "UCLA"},
-        {file: "University-of-Maryland.png", name: "University of Maryland"},
-        {file: "University-of-Pittsburgh.png", name: "University of Pittsburgh"},
-        {file: "University-of-Washington.png", name: "University of Washington"}
-      ]
-    end
+      def university_partners
+        [
+          {file: "CU-Boulder.png", name: "CU Boulder"},
+          {file: "Penn-State.png", name: "Penn State"},
+          {file: "Princeton.png", name: "Princeton"},
+          {file: "Stevens-Institute-of-Technology.png", name: "Stevens Institute"},
+          {file: "UC-Davis.png", name: "UC Davis"},
+          {file: "UC-San-Diego.png", name: "UC San Diego"},
+          {file: "UCLA.png", name: "UCLA"},
+          {file: "University-of-Maryland.png", name: "University of Maryland"},
+          {file: "University-of-Pittsburgh.png", name: "University of Pittsburgh"},
+          {file: "University-of-Washington.png", name: "University of Washington"}
+        ]
+      end
 
-    def features
-      [
-        {
-          image: "kelsey/universities/assets-uni_1.png",
-          title: "All-in-One Database",
-          text: "Streamlined registration, tracking, and impound management with clear workflows for lost and stolen bike cases across all campus departments."
-        },
-        {
-          image: "kelsey/universities/assets-uni_2.png",
-          title: "Extensive Tools & Workflows",
-          text: "QR stickers, searchable catalogs, direct messaging, and legacy transfer tools help you modernize operations and reduce administrative burden."
-        },
-        {
-          image: "kelsey/universities/assets-uni_3.png",
-          title: "e-Vehicle & Micromobility Management",
-          text: "Manage campus vehicles, including e-personal mobility devices (EPAMDs), by verifying UL certification and centralizing safety documentation."
-        }
-      ]
-    end
+      def features
+        [
+          {
+            image: "kelsey/universities/assets-uni_1.png",
+            title: "All-in-One Database",
+            text: "Streamlined registration, tracking, and impound management with clear workflows for lost and stolen bike cases across all campus departments."
+          },
+          {
+            image: "kelsey/universities/assets-uni_2.png",
+            title: "Extensive Tools & Workflows",
+            text: "QR stickers, searchable catalogs, direct messaging, and legacy transfer tools help you modernize operations and reduce administrative burden."
+          },
+          {
+            image: "kelsey/universities/assets-uni_3.png",
+            title: "e-Vehicle & Micromobility Management",
+            text: "Manage campus vehicles, including e-personal mobility devices (EPAMDs), by verifying UL certification and centralizing safety documentation."
+          }
+        ]
+      end
 
-    def tools
-      [
-        {image: "kelsey/universities/features_database.png.png", title: "All-in-One Database", text: "Staff can access the same information on bikes, locations, and updates, fostering seamless collaboration."},
-        {image: "kelsey/universities/features_catalog.png", title: "Searchable Catalog", text: "Quickly find bike details and contact information for cyclists."},
-        {image: "kelsey/universities/features_direct-communication.png", title: "Direct Messaging", text: "Communicate with students and faculty regarding their bikes and track message history."},
-        {image: "kelsey/universities/features_updates.png", title: "Alerts & Recovery Network", text: "Issue alerts about maintenance, theft recovery, and more utilizing our national network."},
-        {image: "kelsey/universities/features_impound.png", title: "Impound Bikes With Ease", text: "Impound bikes in the field or from your dashboard and create a public searchable database."},
-        {image: "kelsey/universities/features_legacy-transfer.png", title: "Legacy Transfer", text: "Import existing bike registrations into Bike Index for continuity and ease of use."},
-        {image: "kelsey/universities/features_graduate.png", title: "Graduate Bikes", text: "Automatically remove bikes that are no longer on campus from your system."},
-        {image: "kelsey/universities/features_qr-stickers.png", title: "QR Code Stickers", text: "Permit, track and message bike owners quickly and easily with scannable stickers."}
-      ]
-    end
+      def tools
+        [
+          {image: "kelsey/universities/features_database.png.png", title: "All-in-One Database", text: "Staff can access the same information on bikes, locations, and updates, fostering seamless collaboration."},
+          {image: "kelsey/universities/features_catalog.png", title: "Searchable Catalog", text: "Quickly find bike details and contact information for cyclists."},
+          {image: "kelsey/universities/features_direct-communication.png", title: "Direct Messaging", text: "Communicate with students and faculty regarding their bikes and track message history."},
+          {image: "kelsey/universities/features_updates.png", title: "Alerts & Recovery Network", text: "Issue alerts about maintenance, theft recovery, and more utilizing our national network."},
+          {image: "kelsey/universities/features_impound.png", title: "Impound Bikes With Ease", text: "Impound bikes in the field or from your dashboard and create a public searchable database."},
+          {image: "kelsey/universities/features_legacy-transfer.png", title: "Legacy Transfer", text: "Import existing bike registrations into Bike Index for continuity and ease of use."},
+          {image: "kelsey/universities/features_graduate.png", title: "Graduate Bikes", text: "Automatically remove bikes that are no longer on campus from your system."},
+          {image: "kelsey/universities/features_qr-stickers.png", title: "QR Code Stickers", text: "Permit, track and message bike owners quickly and easily with scannable stickers."}
+        ]
+      end
 
-    def testimonials
-      [
-        {
-          quote: "Among other options, Bike Index really stands out for their commitment to creating tailored, accessible solutions, and their nonprofit, advocacy ethos.",
-          author: "Ted Sweeney",
-          role: "former UW Active Transportation Specialist",
-          image: "kelsey/illustrations/comic-assets_bike-love-1.png"
-        },
-        {
-          quote: "We're excited to partner with Bike Index to provide Centre Region cyclists with a more intuitive and effective bike registration and recovery service.",
-          author: "Cecily Zhu",
-          role: "Penn State Alternative Transportation Program Coordinator",
-          image: "kelsey/illustrations/comic-assets_bike-love-2.png"
-        },
-        {
-          quote: "It comes down to efficiency. The Bike Index features allow a university bike program to operate more efficiently and in a more timely manner. That's important when it comes to students' bikes at a large university.",
-          author: "Thomas Worth",
-          role: "University of Maryland Department of Transportation Services",
-          image: "kelsey/illustrations/comic-assets_bike-love-3.png"
-        }
-      ]
+      def testimonials
+        [
+          {
+            quote: "Among other options, Bike Index really stands out for their commitment to creating tailored, accessible solutions, and their nonprofit, advocacy ethos.",
+            author: "Ted Sweeney",
+            role: "former UW Active Transportation Specialist",
+            image: "kelsey/illustrations/comic-assets_bike-love-1.png"
+          },
+          {
+            quote: "We're excited to partner with Bike Index to provide Centre Region cyclists with a more intuitive and effective bike registration and recovery service.",
+            author: "Cecily Zhu",
+            role: "Penn State Alternative Transportation Program Coordinator",
+            image: "kelsey/illustrations/comic-assets_bike-love-2.png"
+          },
+          {
+            quote: "It comes down to efficiency. The Bike Index features allow a university bike program to operate more efficiently and in a more timely manner. That's important when it comes to students' bikes at a large university.",
+            author: "Thomas Worth",
+            role: "University of Maryland Department of Transportation Services",
+            image: "kelsey/illustrations/comic-assets_bike-love-3.png"
+          }
+        ]
+      end
     end
   end
 end

--- a/app/components/page_block/landing_for_schools/component_preview.rb
+++ b/app/components/page_block/landing_for_schools/component_preview.rb
@@ -1,10 +1,12 @@
 # frozen_string_literal: true
 
-module PageBlock::LandingForSchools
-  class ComponentPreview < ApplicationComponentPreview
-    # @display kelsey_stylesheet true
-    def default
-      render(PageBlock::LandingForSchools::Component.new)
+module PageBlock
+  module LandingForSchools
+    class ComponentPreview < ApplicationComponentPreview
+      # @display kelsey_stylesheet true
+      def default
+        render(PageBlock::LandingForSchools::Component.new)
+      end
     end
   end
 end

--- a/app/components/page_block/marketplace_listing_panel/component.rb
+++ b/app/components/page_block/marketplace_listing_panel/component.rb
@@ -1,23 +1,25 @@
 # frozen_string_literal: true
 
-module PageBlock::MarketplaceListingPanel
-  class Component < ApplicationComponent
-    def initialize(marketplace_listing: nil)
-      @marketplace_listing = marketplace_listing
-    end
+module PageBlock
+  module MarketplaceListingPanel
+    class Component < ApplicationComponent
+      def initialize(marketplace_listing: nil)
+        @marketplace_listing = marketplace_listing
+      end
 
-    def render?
-      @marketplace_listing.present?
-    end
+      def render?
+        @marketplace_listing.present?
+      end
 
-    private
+      private
 
-    def still_for_sale_if_show
-      still_for_sale_at = @marketplace_listing.still_for_sale_at
-      return if still_for_sale_at.blank? || @marketplace_listing.published_at.blank? ||
-        still_for_sale_at < (@marketplace_listing.published_at + 1.day)
+      def still_for_sale_if_show
+        still_for_sale_at = @marketplace_listing.still_for_sale_at
+        return if still_for_sale_at.blank? || @marketplace_listing.published_at.blank? ||
+          still_for_sale_at < (@marketplace_listing.published_at + 1.day)
 
-      still_for_sale_at
+        still_for_sale_at
+      end
     end
   end
 end

--- a/app/components/page_block/marketplace_listing_panel/component_preview.rb
+++ b/app/components/page_block/marketplace_listing_panel/component_preview.rb
@@ -1,15 +1,17 @@
 # frozen_string_literal: true
 
-module PageBlock::MarketplaceListingPanel
-  class ComponentPreview < ApplicationComponentPreview
-    def default
-      render(PageBlock::MarketplaceListingPanel::Component.new(marketplace_listing:))
-    end
+module PageBlock
+  module MarketplaceListingPanel
+    class ComponentPreview < ApplicationComponentPreview
+      def default
+        render(PageBlock::MarketplaceListingPanel::Component.new(marketplace_listing:))
+      end
 
-    private
+      private
 
-    def marketplace_listing
-      MarketplaceListing.last
+      def marketplace_listing
+        MarketplaceListing.last
+      end
     end
   end
 end

--- a/app/components/page_block/new_sale_form/component.rb
+++ b/app/components/page_block/new_sale_form/component.rb
@@ -1,25 +1,27 @@
 # frozen_string_literal: true
 
-module PageBlock::NewSaleForm
-  class Component < ApplicationComponent
-    def initialize(currency:, sale:, item: nil, marketplace_message: nil)
-      @currency = currency
-      @sale = sale
-      @marketplace_message = marketplace_message || @sale.marketplace_message
-      @item = item || @marketplace_message&.item
+module PageBlock
+  module NewSaleForm
+    class Component < ApplicationComponent
+      def initialize(currency:, sale:, item: nil, marketplace_message: nil)
+        @currency = currency
+        @sale = sale
+        @marketplace_message = marketplace_message || @sale.marketplace_message
+        @item = item || @marketplace_message&.item
 
-      # Assign a default amount
-      @sale.amount_cents ||= @sale.marketplace_listing&.amount_cents
-    end
+        # Assign a default amount
+        @sale.amount_cents ||= @sale.marketplace_listing&.amount_cents
+      end
 
-    private
+      private
 
-    def item_type
-      @item.type
-    end
+      def item_type
+        @item.type
+      end
 
-    def buyer_name
-      @marketplace_message.buyer_name
+      def buyer_name
+        @marketplace_message.buyer_name
+      end
     end
   end
 end

--- a/app/components/page_block/new_sale_form/component_preview.rb
+++ b/app/components/page_block/new_sale_form/component_preview.rb
@@ -1,22 +1,24 @@
 # frozen_string_literal: true
 
-module PageBlock::NewSaleForm
-  class ComponentPreview < ApplicationComponentPreview
-    # @display legacy_stylesheet true
-    def default
-      render(PageBlock::NewSaleForm::Component.new(currency: Currency.default, sale:,
-        marketplace_message:))
-    end
+module PageBlock
+  module NewSaleForm
+    class ComponentPreview < ApplicationComponentPreview
+      # @display legacy_stylesheet true
+      def default
+        render(PageBlock::NewSaleForm::Component.new(currency: Currency.default, sale:,
+          marketplace_message:))
+      end
 
-    private
+      private
 
-    def sale
-      sale, _ = Sale.build_and_authorize(user: lookbook_user, marketplace_message:)
-      sale
-    end
+      def sale
+        sale, _ = Sale.build_and_authorize(user: lookbook_user, marketplace_message:)
+        sale
+      end
 
-    def marketplace_message
-      MarketplaceMessage.find(2)
+      def marketplace_message
+        MarketplaceMessage.find(2)
+      end
     end
   end
 end

--- a/app/components/page_block/strava_integration/component.rb
+++ b/app/components/page_block/strava_integration/component.rb
@@ -1,48 +1,50 @@
 # frozen_string_literal: true
 
-module PageBlock::StravaIntegration
-  class Component < ApplicationComponent
-    def initialize(user:)
-      @user = user
-      @strava_integration = user.strava_integration
-    end
+module PageBlock
+  module StravaIntegration
+    class Component < ApplicationComponent
+      def initialize(user:)
+        @user = user
+        @strava_integration = user.strava_integration
+      end
 
-    private
+      private
 
-    def connected?
-      @strava_integration.present?
-    end
+      def connected?
+        @strava_integration.present?
+      end
 
-    def syncing?
-      connected? && @strava_integration.syncing?
-    end
+      def syncing?
+        connected? && @strava_integration.syncing?
+      end
 
-    def synced?
-      connected? && @strava_integration.synced?
-    end
+      def synced?
+        connected? && @strava_integration.synced?
+      end
 
-    def error?
-      connected? && @strava_integration.error?
-    end
+      def error?
+        connected? && @strava_integration.error?
+      end
 
-    def pending?
-      connected? && @strava_integration.pending?
-    end
+      def pending?
+        connected? && @strava_integration.pending?
+      end
 
-    def progress_percent
-      @strava_integration.sync_progress_percent
-    end
+      def progress_percent
+        @strava_integration.sync_progress_percent
+      end
 
-    def downloaded_count
-      @strava_integration.activities_downloaded_count
-    end
+      def downloaded_count
+        @strava_integration.activities_downloaded_count
+      end
 
-    def total_count
-      @strava_integration.athlete_activity_count || "?"
-    end
+      def total_count
+        @strava_integration.athlete_activity_count || "?"
+      end
 
-    def strava_icon
-      helpers.inline_svg_tag("logos/strava.svg", title: "Strava", style: "vertical-align: baseline; display: inline-block; height: 12px; width: auto;")
+      def strava_icon
+        helpers.inline_svg_tag("logos/strava.svg", title: "Strava", style: "vertical-align: baseline; display: inline-block; height: 12px; width: auto;")
+      end
     end
   end
 end

--- a/app/components/page_block/strava_integration/component_preview.rb
+++ b/app/components/page_block/strava_integration/component_preview.rb
@@ -1,47 +1,49 @@
 # frozen_string_literal: true
 
-module PageBlock::StravaIntegration
-  class ComponentPreview < ApplicationComponentPreview
-    # @!group Status Variants
-    # @display legacy_stylesheet true
-    def not_connected
-      render(Component.new(user: built_user))
-    end
+module PageBlock
+  module StravaIntegration
+    class ComponentPreview < ApplicationComponentPreview
+      # @!group Status Variants
+      # @display legacy_stylesheet true
+      def not_connected
+        render(Component.new(user: built_user))
+      end
 
-    # @display legacy_stylesheet true
-    def syncing
-      render(Component.new(user: user_with_strava(:syncing)))
-    end
+      # @display legacy_stylesheet true
+      def syncing
+        render(Component.new(user: user_with_strava(:syncing)))
+      end
 
-    # @display legacy_stylesheet true
-    def synced
-      render(Component.new(user: user_with_strava(:synced)))
-    end
+      # @display legacy_stylesheet true
+      def synced
+        render(Component.new(user: user_with_strava(:synced)))
+      end
 
-    # @display legacy_stylesheet true
-    def error
-      render(Component.new(user: user_with_strava(:error)))
-    end
-    # @endgroup
+      # @display legacy_stylesheet true
+      def error
+        render(Component.new(user: user_with_strava(:error)))
+      end
+      # @endgroup
 
-    private
+      private
 
-    def built_user
-      User.new(name: "Preview User", email: "preview@example.com")
-    end
+      def built_user
+        User.new(name: "Preview User", email: "preview@example.com")
+      end
 
-    def user_with_strava(status)
-      user = built_user
-      strava_integration = user.build_strava_integration(
-        access_token: "preview_token",
-        refresh_token: "preview_refresh",
-        status:,
-        athlete_activity_count: 150,
-        activities_downloaded_count: (status == :syncing) ? 50 : 150
-      )
-      strava_integration.strava_gears.build(strava_id: "b1", name: "My Road Bike", gear_type: "bike")
-      strava_integration.strava_gears.build(strava_id: "b2", name: "My Mountain Bike", gear_type: "bike")
-      user
+      def user_with_strava(status)
+        user = built_user
+        strava_integration = user.build_strava_integration(
+          access_token: "preview_token",
+          refresh_token: "preview_refresh",
+          status:,
+          athlete_activity_count: 150,
+          activities_downloaded_count: (status == :syncing) ? 50 : 150
+        )
+        strava_integration.strava_gears.build(strava_id: "b1", name: "My Road Bike", gear_type: "bike")
+        strava_integration.strava_gears.build(strava_id: "b2", name: "My Mountain Bike", gear_type: "bike")
+        user
+      end
     end
   end
 end

--- a/app/components/search/everything_combobox/component.rb
+++ b/app/components/search/everything_combobox/component.rb
@@ -1,23 +1,25 @@
 # frozen_string_literal: true
 
-module Search::EverythingCombobox
-  class Component < ApplicationComponent
-    API_URL = "/api/autocomplete"
+module Search
+  module EverythingCombobox
+    class Component < ApplicationComponent
+      API_URL = "/api/autocomplete"
 
-    def initialize(selected_query_items_options:, query:, search_obj_name: nil)
-      @opt_vals = opt_vals_for(selected_query_items_options)
-      @query = query
-      @search_obj_name = search_obj_name
-    end
+      def initialize(selected_query_items_options:, query:, search_obj_name: nil)
+        @opt_vals = opt_vals_for(selected_query_items_options)
+        @query = query
+        @search_obj_name = search_obj_name
+      end
 
-    private
+      private
 
-    def opt_vals_for(selected_query_items_options)
-      selected_query_items_options.map do |item|
-        if item.is_a?(String)
-          [item, item]
-        else
-          [item["text"], item["search_id"]]
+      def opt_vals_for(selected_query_items_options)
+        selected_query_items_options.map do |item|
+          if item.is_a?(String)
+            [item, item]
+          else
+            [item["text"], item["search_id"]]
+          end
         end
       end
     end

--- a/app/components/search/everything_combobox/component_preview.rb
+++ b/app/components/search/everything_combobox/component_preview.rb
@@ -1,19 +1,21 @@
 # frozen_string_literal: true
 
-module Search::EverythingCombobox
-  class ComponentPreview < ApplicationComponentPreview
-    def default
-      render(Search::EverythingCombobox::Component.new(**default_options))
-    end
+module Search
+  module EverythingCombobox
+    class ComponentPreview < ApplicationComponentPreview
+      def default
+        render(Search::EverythingCombobox::Component.new(**default_options))
+      end
 
-    private
+      private
 
-    def default_options(interpreted_params = nil)
-      interpreted_params ||= BikeSearchable.searchable_interpreted_params({})
-      {
-        query: interpreted_params[:query],
-        selected_query_items_options: BikeSearchable.selected_query_items_options(interpreted_params)
-      }
+      def default_options(interpreted_params = nil)
+        interpreted_params ||= BikeSearchable.searchable_interpreted_params({})
+        {
+          query: interpreted_params[:query],
+          selected_query_items_options: BikeSearchable.selected_query_items_options(interpreted_params)
+        }
+      end
     end
   end
 end

--- a/app/components/search/form/component.rb
+++ b/app/components/search/form/component.rb
@@ -1,86 +1,88 @@
 # frozen_string_literal: true
 
-module Search::Form
-  class Component < ApplicationComponent
-    def initialize(
-      target_search_path:,
-      target_frame:,
-      interpreted_params:,
-      marketplace_scope: nil,
-      currency: nil,
-      price_min_amount: nil,
-      price_max_amount: nil,
-      result_view: nil,
-      search_obj_name: "Registrations"
-    )
-      @marketplace_scope = marketplace_scope
-      @target_search_path = target_search_path
-      @target_frame = target_frame
-      @interpreted_params = interpreted_params
-      @selected_query_items_options = BikeSearchable.selected_query_items_options(@interpreted_params)
-      @currency_sym = (currency || Currency.default).symbol.to_s
-      @price_min_amount = price_min_amount
-      @price_max_amount = price_max_amount
-      @result_view = SearchResults::Container::Component.permitted_result_view(result_view)
-      @search_obj_name = search_obj_name
-    end
-
-    private
-
-    def is_marketplace?
-      @marketplace_scope.present?
-    end
-
-    def render_result_view?
-      is_marketplace? # only marketplace for now
-    end
-
-    def kind_select_options
-      kind_scope = @marketplace_scope || @interpreted_params[:stolenness]
-
-      @interpreted_params.slice(:location, :distance).merge(kind_scope:)
-    end
-
-    def query
-      @interpreted_params[:query] # might be more complicated someday
-    end
-
-    def serial_value
-      @interpreted_params[:raw_serial]
-    end
-
-    def render_serial_field?
-      # Always render serial unless viewing marketplace - TODO: bike versions too
-      return true unless is_marketplace?
-
-      # Render the serial field, if it was passed
-      @interpreted_params[:serial].present?
-    end
-
-    def serial_looks_like_not_a_serial?
-      @interpreted_params[:raw_serial].present? && @interpreted_params[:serial].blank?
-    end
-
-    def render_activity_and_price_wrapper?
-      render_price_field? || render_primary_activity_field?
-    end
-
-    def render_price_field?
-      is_marketplace? # only on marketplace
-    end
-
-    def render_primary_activity_field?
-      return true if is_marketplace? # Also show on bike versions
-
-      # Render the primary_activity field, if it was passed
-      @interpreted_params[:primary_activity].present?
-    end
-
-    def primary_activity_select_opts
-      options_for_select(
-        PrimaryActivity.by_priority.map { |pa| [pa.display_name_search, pa.id] },
-        selected: @interpreted_params[:primary_activity]
+module Search
+  module Form
+    class Component < ApplicationComponent
+      def initialize(
+        target_search_path:,
+        target_frame:,
+        interpreted_params:,
+        marketplace_scope: nil,
+        currency: nil,
+        price_min_amount: nil,
+        price_max_amount: nil,
+        result_view: nil,
+        search_obj_name: "Registrations"
       )
+        @marketplace_scope = marketplace_scope
+        @target_search_path = target_search_path
+        @target_frame = target_frame
+        @interpreted_params = interpreted_params
+        @selected_query_items_options = BikeSearchable.selected_query_items_options(@interpreted_params)
+        @currency_sym = (currency || Currency.default).symbol.to_s
+        @price_min_amount = price_min_amount
+        @price_max_amount = price_max_amount
+        @result_view = SearchResults::Container::Component.permitted_result_view(result_view)
+        @search_obj_name = search_obj_name
+      end
+
+      private
+
+      def is_marketplace?
+        @marketplace_scope.present?
+      end
+
+      def render_result_view?
+        is_marketplace? # only marketplace for now
+      end
+
+      def kind_select_options
+        kind_scope = @marketplace_scope || @interpreted_params[:stolenness]
+
+        @interpreted_params.slice(:location, :distance).merge(kind_scope:)
+      end
+
+      def query
+        @interpreted_params[:query] # might be more complicated someday
+      end
+
+      def serial_value
+        @interpreted_params[:raw_serial]
+      end
+
+      def render_serial_field?
+        # Always render serial unless viewing marketplace - TODO: bike versions too
+        return true unless is_marketplace?
+
+        # Render the serial field, if it was passed
+        @interpreted_params[:serial].present?
+      end
+
+      def serial_looks_like_not_a_serial?
+        @interpreted_params[:raw_serial].present? && @interpreted_params[:serial].blank?
+      end
+
+      def render_activity_and_price_wrapper?
+        render_price_field? || render_primary_activity_field?
+      end
+
+      def render_price_field?
+        is_marketplace? # only on marketplace
+      end
+
+      def render_primary_activity_field?
+        return true if is_marketplace? # Also show on bike versions
+
+        # Render the primary_activity field, if it was passed
+        @interpreted_params[:primary_activity].present?
+      end
+
+      def primary_activity_select_opts
+        options_for_select(
+          PrimaryActivity.by_priority.map { |pa| [pa.display_name_search, pa.id] },
+          selected: @interpreted_params[:primary_activity]
+        )
+      end
     end
   end
 end

--- a/app/components/search/form/component_preview.rb
+++ b/app/components/search/form/component_preview.rb
@@ -1,51 +1,53 @@
 # frozen_string_literal: true
 
-module Search::Form
-  class ComponentPreview < ApplicationComponentPreview
-    # TODO: It would be nice to group these, but the IDs collide and select2 breaks
-    def default
-      render(Search::Form::Component.new(**default_options(preview_name: "default")))
-    end
+module Search
+  module Form
+    class ComponentPreview < ApplicationComponentPreview
+      # TODO: It would be nice to group these, but the IDs collide and select2 breaks
+      def default
+        render(Search::Form::Component.new(**default_options(preview_name: "default")))
+      end
 
-    def chicago_tall_bike
-      interpreted_params = BikeSearchable.searchable_interpreted_params({
-        stolenness: "proximity", location: "Chicago, IL", query_items: ["v_9"]
-      })
+      def chicago_tall_bike
+        interpreted_params = BikeSearchable.searchable_interpreted_params({
+          stolenness: "proximity", location: "Chicago, IL", query_items: ["v_9"]
+        })
 
-      render(Search::Form::Component.new(**default_options(interpreted_params, preview_name: "chicago_tall_bike")))
-    end
+        render(Search::Form::Component.new(**default_options(interpreted_params, preview_name: "chicago_tall_bike")))
+      end
 
-    def for_sale
-      sale_options = default_options({stolenness: :all}, preview_name: "for_sale").merge(
-        target_frame: :search_marketplace_results_frame,
-        marketplace_scope: "for_sale"
-      )
-      render(Search::Form::Component.new(**sale_options))
-    end
+      def for_sale
+        sale_options = default_options({stolenness: :all}, preview_name: "for_sale").merge(
+          target_frame: :search_marketplace_results_frame,
+          marketplace_scope: "for_sale"
+        )
+        render(Search::Form::Component.new(**sale_options))
+      end
 
-    def for_sale_san_francisco_atb
-      sale_options = default_options(BikeSearchable.searchable_interpreted_params({
-        stolenness: :all, location: "San Francisco, CA", distance: 101, primary_activity: "ATB"
-      }), preview_name: "for_sale_san_francisco_atb")
-        .merge(target_frame: :search_marketplace_results_frame, marketplace_scope: "for_sale_proximity")
+      def for_sale_san_francisco_atb
+        sale_options = default_options(BikeSearchable.searchable_interpreted_params({
+          stolenness: :all, location: "San Francisco, CA", distance: 101, primary_activity: "ATB"
+        }), preview_name: "for_sale_san_francisco_atb")
+          .merge(target_frame: :search_marketplace_results_frame, marketplace_scope: "for_sale_proximity")
 
-      render(Search::Form::Component.new(**sale_options))
-    end
+        render(Search::Form::Component.new(**sale_options))
+      end
 
-    private
+      private
 
-    # this is the path of the raw preview - so when search is submitted, it just re-renders
-    def target_search_path(preview_name)
-      "/rails/view_components/search/form/component/#{preview_name}"
-    end
+      # this is the path of the raw preview - so when search is submitted, it just re-renders
+      def target_search_path(preview_name)
+        "/rails/view_components/search/form/component/#{preview_name}"
+      end
 
-    def default_options(interpreted_params = nil, preview_name:)
-      interpreted_params ||= BikeSearchable.searchable_interpreted_params({})
-      {
-        target_search_path: target_search_path(preview_name),
-        target_frame: :search_registrations_results_frame,
-        interpreted_params:
-      }
+      def default_options(interpreted_params = nil, preview_name:)
+        interpreted_params ||= BikeSearchable.searchable_interpreted_params({})
+        {
+          target_search_path: target_search_path(preview_name),
+          target_frame: :search_registrations_results_frame,
+          interpreted_params:
+        }
+      end
     end
   end
 end

--- a/app/components/search/form_organized/component.rb
+++ b/app/components/search/form_organized/component.rb
@@ -1,41 +1,43 @@
 # frozen_string_literal: true
 
-module Search::FormOrganized
-  class Component < ApplicationComponent
-    def initialize(target_search_path:, interpreted_params:, target_frame: nil, skip_serial_field: false, settings_component: nil)
-      @target_search_path = target_search_path
-      @interpreted_params = interpreted_params
-      @target_frame = target_frame
-      @skip_serial_field = skip_serial_field
-      @settings_component = settings_component
-      @selected_query_items_options = BikeSearchable.selected_query_items_options(@interpreted_params)
-    end
-
-    private
-
-    def turbo?
-      @target_frame.present?
-    end
-
-    def form_data
-      if turbo?
-        {:turbo_frame => @target_frame, :turbo_action => "advance",
-         :turbo => true, "search--form-target" => "form"}
-      else
-        {turbo: false}
+module Search
+  module FormOrganized
+    class Component < ApplicationComponent
+      def initialize(target_search_path:, interpreted_params:, target_frame: nil, skip_serial_field: false, settings_component: nil)
+        @target_search_path = target_search_path
+        @interpreted_params = interpreted_params
+        @target_frame = target_frame
+        @skip_serial_field = skip_serial_field
+        @settings_component = settings_component
+        @selected_query_items_options = BikeSearchable.selected_query_items_options(@interpreted_params)
       end
-    end
 
-    def render_serial_field?
-      !@skip_serial_field
-    end
+      private
 
-    def serial_looks_like_not_a_serial?
-      @interpreted_params[:raw_serial].present? && @interpreted_params[:serial].blank?
-    end
+      def turbo?
+        @target_frame.present?
+      end
 
-    def render_notes_field?
-      @settings_component&.organization&.enabled?("registration_notes")
+      def form_data
+        if turbo?
+          {:turbo_frame => @target_frame, :turbo_action => "advance",
+           :turbo => true, "search--form-target" => "form"}
+        else
+          {turbo: false}
+        end
+      end
+
+      def render_serial_field?
+        !@skip_serial_field
+      end
+
+      def serial_looks_like_not_a_serial?
+        @interpreted_params[:raw_serial].present? && @interpreted_params[:serial].blank?
+      end
+
+      def render_notes_field?
+        @settings_component&.organization&.enabled?("registration_notes")
+      end
     end
   end
 end

--- a/app/components/search/form_organized/component_preview.rb
+++ b/app/components/search/form_organized/component_preview.rb
@@ -1,31 +1,33 @@
 # frozen_string_literal: true
 
-module Search::FormOrganized
-  class ComponentPreview < ApplicationComponentPreview
-    def default
-      render(Search::FormOrganized::Component.new(**default_options))
-    end
+module Search
+  module FormOrganized
+    class ComponentPreview < ApplicationComponentPreview
+      def default
+        render(Search::FormOrganized::Component.new(**default_options))
+      end
 
-    def with_serial_value
-      interpreted_params = {raw_serial: "ABC123", serial: "ABC123", query: nil}
-      render(Search::FormOrganized::Component.new(**default_options(interpreted_params)))
-    end
+      def with_serial_value
+        interpreted_params = {raw_serial: "ABC123", serial: "ABC123", query: nil}
+        render(Search::FormOrganized::Component.new(**default_options(interpreted_params)))
+      end
 
-    def without_serial_field
-      render(Search::FormOrganized::Component.new(**default_options.merge(skip_serial_field: true)))
-    end
+      def without_serial_field
+        render(Search::FormOrganized::Component.new(**default_options.merge(skip_serial_field: true)))
+      end
 
-    private
+      private
 
-    def target_search_path
-      "/rails/view_components/search/form_organized/component/default"
-    end
+      def target_search_path
+        "/rails/view_components/search/form_organized/component/default"
+      end
 
-    def default_options(interpreted_params = {})
-      {
-        target_search_path:,
-        interpreted_params:
-      }
+      def default_options(interpreted_params = {})
+        {
+          target_search_path:,
+          interpreted_params:
+        }
+      end
     end
   end
 end

--- a/app/components/search/kind_option/component.rb
+++ b/app/components/search/kind_option/component.rb
@@ -1,23 +1,25 @@
 # frozen_string_literal: true
 
-module Search::KindOption
-  class Component < ApplicationComponent
-    def initialize(option_kind:, option:, option_text:, is_selected:, button_url: nil)
-      @option_kind = option_kind
-      @option = option
-      @option_text = option_text
-      @is_selected = is_selected
-      @button_url = button_url
-    end
+module Search
+  module KindOption
+    class Component < ApplicationComponent
+      def initialize(option_kind:, option:, option_text:, is_selected:, button_url: nil)
+        @option_kind = option_kind
+        @option = option
+        @option_text = option_text
+        @is_selected = is_selected
+        @button_url = button_url
+      end
 
-    private
+      private
 
-    def test_id
-      "Search::KindOption-#{@option}"
-    end
+      def test_id
+        "Search::KindOption-#{@option}"
+      end
 
-    def is_button?
-      @button_url.present?
+      def is_button?
+        @button_url.present?
+      end
     end
   end
 end

--- a/app/components/search/kind_select_fields/component.rb
+++ b/app/components/search/kind_select_fields/component.rb
@@ -1,83 +1,85 @@
 # frozen_string_literal: true
 
-module Search::KindSelectFields
-  class Component < ApplicationComponent
-    DEFAULT_DISTANCE = 100
-    MAX_DISTANCE = 2_000 # IDK, seems reasonable
-    MARKETPLACE_SCOPES = %w[for_sale_proximity for_sale].freeze
-    # TODO: add Found, Found in search area
-    STOLENNESS_SCOPES = %w[proximity stolen non all for_sale].freeze
+module Search
+  module KindSelectFields
+    class Component < ApplicationComponent
+      DEFAULT_DISTANCE = 100
+      MAX_DISTANCE = 2_000 # IDK, seems reasonable
+      MARKETPLACE_SCOPES = %w[for_sale_proximity for_sale].freeze
+      # TODO: add Found, Found in search area
+      STOLENNESS_SCOPES = %w[proximity stolen non all for_sale].freeze
 
-    def initialize(kind_scope:, location: nil, distance: nil)
-      @kind_scope = kind_scope
-      @is_marketplace = MARKETPLACE_SCOPES.include?(@kind_scope)
+      def initialize(kind_scope:, location: nil, distance: nil)
+        @kind_scope = kind_scope
+        @is_marketplace = MARKETPLACE_SCOPES.include?(@kind_scope)
 
-      @distance = GeocodeHelper.permitted_distance(distance, default_distance:)
-      @location = location
-    end
-
-    private
-
-    def default_distance
-      @is_marketplace ? Search::MarketplaceController::DEFAULT_DISTANCE : GeocodeHelper::DEFAULT_DISTANCE
-    end
-
-    def api_count_url
-      @is_marketplace ? "/search/marketplace/counts" : "/api/v3/search/count"
-    end
-
-    def location_initially_shown?
-      %w[proximity for_sale_proximity].include?(@kind_scope)
-    end
-
-    def kind_options
-      @is_marketplace ? MARKETPLACE_SCOPES : STOLENNESS_SCOPES
-    end
-
-    def option_kind
-      @is_marketplace ? :marketplace_scope : :stolenness
-    end
-
-    def opt_selected?(opt)
-      opt == @kind_scope
-    end
-
-    # Button only shows up on registration search
-    def opt_is_button?(opt)
-      opt == "for_sale" && !@is_marketplace
-    end
-
-    def opt_button_url(opt)
-      if opt_is_button?(opt)
-        search_marketplace_path
-      end
-    end
-
-    def final_radio_option(opt)
-      if @is_marketplace
-        kind_options.last == opt
-      else
-        # the button is the final option, so return 2nd to last
-        kind_options[-2] == opt # 2nd to last
-      end
-    end
-
-    def li_classes(opt)
-      return "tw:w-full tw:md:pl-1 tw:pt-1 tw:md:pt-0" if opt_is_button?(opt)
-
-      classes = "tw:w-full tw:has-checked:bg-gray-100 tw:has-checked:dark:bg-gray-800 tw:border tw:border-gray-200 tw:dark:border-gray-600"
-
-      if final_radio_option(opt)
-        return classes += " tw:md:rounded-r-sm tw:rounded-b-sm tw:md:rounded-bl-none"
-      else
-        classes += " tw:border-b-0 tw:md:border-b tw:border-r tw:md:border-r-0"
+        @distance = GeocodeHelper.permitted_distance(distance, default_distance:)
+        @location = location
       end
 
-      if kind_options.first == opt
-        classes += " tw:md:rounded-l-sm tw:rounded-t-sm tw:md:rounded-tr-none"
+      private
+
+      def default_distance
+        @is_marketplace ? Search::MarketplaceController::DEFAULT_DISTANCE : GeocodeHelper::DEFAULT_DISTANCE
       end
 
-      classes + " tw:border-b-0 tw:md:border-b tw:md:border-r"
+      def api_count_url
+        @is_marketplace ? "/search/marketplace/counts" : "/api/v3/search/count"
+      end
+
+      def location_initially_shown?
+        %w[proximity for_sale_proximity].include?(@kind_scope)
+      end
+
+      def kind_options
+        @is_marketplace ? MARKETPLACE_SCOPES : STOLENNESS_SCOPES
+      end
+
+      def option_kind
+        @is_marketplace ? :marketplace_scope : :stolenness
+      end
+
+      def opt_selected?(opt)
+        opt == @kind_scope
+      end
+
+      # Button only shows up on registration search
+      def opt_is_button?(opt)
+        opt == "for_sale" && !@is_marketplace
+      end
+
+      def opt_button_url(opt)
+        if opt_is_button?(opt)
+          search_marketplace_path
+        end
+      end
+
+      def final_radio_option(opt)
+        if @is_marketplace
+          kind_options.last == opt
+        else
+          # the button is the final option, so return 2nd to last
+          kind_options[-2] == opt # 2nd to last
+        end
+      end
+
+      def li_classes(opt)
+        return "tw:w-full tw:md:pl-1 tw:pt-1 tw:md:pt-0" if opt_is_button?(opt)
+
+        classes = "tw:w-full tw:has-checked:bg-gray-100 tw:has-checked:dark:bg-gray-800 tw:border tw:border-gray-200 tw:dark:border-gray-600"
+
+        if final_radio_option(opt)
+          return classes += " tw:md:rounded-r-sm tw:rounded-b-sm tw:md:rounded-bl-none"
+        else
+          classes += " tw:border-b-0 tw:md:border-b tw:border-r tw:md:border-r-0"
+        end
+
+        if kind_options.first == opt
+          classes += " tw:md:rounded-l-sm tw:rounded-t-sm tw:md:rounded-tr-none"
+        end
+
+        classes + " tw:border-b-0 tw:md:border-b tw:md:border-r"
+      end
     end
   end
 end

--- a/app/components/search/kind_select_fields/component_preview.rb
+++ b/app/components/search/kind_select_fields/component_preview.rb
@@ -1,21 +1,23 @@
 # frozen_string_literal: true
 
-module Search::KindSelectFields
-  class ComponentPreview < ApplicationComponentPreview
-    # @!group Kind scopes
-    def default
-      render(Search::KindSelectFields::Component.new(kind_scope: "stolen"))
-    end
+module Search
+  module KindSelectFields
+    class ComponentPreview < ApplicationComponentPreview
+      # @!group Kind scopes
+      def default
+        render(Search::KindSelectFields::Component.new(kind_scope: "stolen"))
+      end
 
-    def chicago_tall_bike
-      render(Search::KindSelectFields::Component.new(kind_scope: "proximity",
-        location: "Chicago, IL"))
-    end
+      def chicago_tall_bike
+        render(Search::KindSelectFields::Component.new(kind_scope: "proximity",
+          location: "Chicago, IL"))
+      end
 
-    def for_sale
-      render(Search::KindSelectFields::Component.new(kind_scope: "for_sale",
-        location: "Chicago, IL"))
+      def for_sale
+        render(Search::KindSelectFields::Component.new(kind_scope: "for_sale",
+          location: "Chicago, IL"))
+      end
+      # @endgroup
     end
-    # @endgroup
   end
 end

--- a/app/components/search/result_view_select/component.rb
+++ b/app/components/search/result_view_select/component.rb
@@ -1,20 +1,22 @@
 # frozen_string_literal: true
 
-module Search::ResultViewSelect
-  class Component < ApplicationComponent
-    def initialize(result_view: nil)
-      @selected_result_view = SearchResults::Container::Component.permitted_result_view(result_view)
-    end
+module Search
+  module ResultViewSelect
+    class Component < ApplicationComponent
+      def initialize(result_view: nil)
+        @selected_result_view = SearchResults::Container::Component.permitted_result_view(result_view)
+      end
 
-    private
+      private
 
-    def selected?(option)
-      @selected_result_view == option
-    end
+      def selected?(option)
+        @selected_result_view == option
+      end
 
-    def label_classes
-      "tw:cursor-pointer tw:p-2 tw:rounded tw:block tw:has-checked:bg-gray-100 " \
-      "tw:has-checked:dark:bg-gray-800 tw:border tw:border-gray-200 tw:dark:border-gray-600"
+      def label_classes
+        "tw:cursor-pointer tw:p-2 tw:rounded tw:block tw:has-checked:bg-gray-100 " \
+        "tw:has-checked:dark:bg-gray-800 tw:border tw:border-gray-200 tw:dark:border-gray-600"
+      end
     end
   end
 end

--- a/app/components/search/result_view_select/component_preview.rb
+++ b/app/components/search/result_view_select/component_preview.rb
@@ -1,9 +1,11 @@
 # frozen_string_literal: true
 
-module Search::ResultViewSelect
-  class ComponentPreview < ApplicationComponentPreview
-    def default
-      render(Search::ResultViewSelect::Component.new)
+module Search
+  module ResultViewSelect
+    class ComponentPreview < ApplicationComponentPreview
+      def default
+        render(Search::ResultViewSelect::Component.new)
+      end
     end
   end
 end

--- a/app/components/search_results/bike_box/component.rb
+++ b/app/components/search_results/bike_box/component.rb
@@ -1,67 +1,69 @@
 # frozen_string_literal: true
 
-module SearchResults::BikeBox
-  class Component < ApplicationComponent
-    include BikeHelper
+module SearchResults
+  module BikeBox
+    class Component < ApplicationComponent
+      include BikeHelper
 
-    # NOTE: be cautious about passing in current_user and caching,
-    # since current_user shows their hidden serials
-    def initialize(bike:, current_user: nil, event_record: nil, search_kind: nil, skip_cache: false, render_deleted: false)
-      @render_deleted = render_deleted
-      return if bike.blank? || !@render_deleted && bike.deleted?
+      # NOTE: be cautious about passing in current_user and caching,
+      # since current_user shows their hidden serials
+      def initialize(bike:, current_user: nil, event_record: nil, search_kind: nil, skip_cache: false, render_deleted: false)
+        @render_deleted = render_deleted
+        return if bike.blank? || !@render_deleted && bike.deleted?
 
-      @bike = bike
-      @search_kind = SearchResults::Container::Component.permitted_search_kind(search_kind)
+        @bike = bike
+        @search_kind = SearchResults::Container::Component.permitted_search_kind(search_kind)
 
-      # NOTE: passed event_record renders - even if it isn't the current_event_record
-      @event_record = event_record || @bike.current_event_record
+        # NOTE: passed event_record renders - even if it isn't the current_event_record
+        @event_record = event_record || @bike.current_event_record
 
-      # If this is cached (it is by default), don't show the serial for the user
-      @is_cached = !skip_cache
-      @current_user = current_user unless @is_cached
-    end
-
-    def render?
-      @bike.present?
-    end
-
-    private
-
-    def render_second_column?
-      @event_record.present?
-    end
-
-    def render_for_sale_info?
-      @event_record.is_a?(MarketplaceListing)
-    end
-
-    # If for sale, return "For Sale" - otherwise returns price
-    def price_span
-      return bike_status_span(@bike) if @event_record.for_sale?
-
-      content_tag(:strong, translation(".price"), class: "attr-title")
-    end
-
-    def occurred_at_with_fallback
-      @bike.occurred_at || @event_record&.updated_at || @bike.updated_at
-    end
-
-    def address_string
-      if @event_record.is_a?(ImpoundRecord)
-        @event_record.formatted_address_string # It's address_record
-      else
-        @event_record.address(country: [:iso])
+        # If this is cached (it is by default), don't show the serial for the user
+        @is_cached = !skip_cache
+        @current_user = current_user unless @is_cached
       end
-    end
 
-    # copies from application_helper
-    # TODO: replace with DefinitionList::Container::Component
-    def attr_list_item(desc, title)
-      return nil unless desc.present?
+      def render?
+        @bike.present?
+      end
 
-      content_tag(:li) do
-        content_tag(:strong, "#{title}: ", class: "attr-title") +
-          content_tag(:span, desc)
+      private
+
+      def render_second_column?
+        @event_record.present?
+      end
+
+      def render_for_sale_info?
+        @event_record.is_a?(MarketplaceListing)
+      end
+
+      # If for sale, return "For Sale" - otherwise returns price
+      def price_span
+        return bike_status_span(@bike) if @event_record.for_sale?
+
+        content_tag(:strong, translation(".price"), class: "attr-title")
+      end
+
+      def occurred_at_with_fallback
+        @bike.occurred_at || @event_record&.updated_at || @bike.updated_at
+      end
+
+      def address_string
+        if @event_record.is_a?(ImpoundRecord)
+          @event_record.formatted_address_string # It's address_record
+        else
+          @event_record.address(country: [:iso])
+        end
+      end
+
+      # copies from application_helper
+      # TODO: replace with DefinitionList::Container::Component
+      def attr_list_item(desc, title)
+        return nil unless desc.present?
+
+        content_tag(:li) do
+          content_tag(:strong, "#{title}: ", class: "attr-title") +
+            content_tag(:span, desc)
+        end
       end
     end
   end

--- a/app/components/search_results/bike_box/component_preview.rb
+++ b/app/components/search_results/bike_box/component_preview.rb
@@ -1,36 +1,38 @@
 # frozen_string_literal: true
 
-module SearchResults::BikeBox
-  class ComponentPreview < ApplicationComponentPreview
-    def self.vehicles
-      built_bike = Bike.new(
-        id: 35,
-        serial_number: "XXX999 999xxxx",
-        mnfg_name: "Humble Frameworks",
-        year: "2015",
-        primary_frame_color_id: Color.where(name: "Purple").first_or_create,
-        frame_model: "self titled",
-        frame_material: :steel,
-        cycle_type: :bike,
-        thumb_path:
-          "https://files.bikeindex.org/uploads/Pu/395980/small_D3C6B1AF-F1FC-4BAA-BD39-9C107871FCAE.jpeg"
-      )
-      [
-        built_bike,
-        Bike.status_stolen.first,
-        Bike.status_impounded.first,
-        MarketplaceListing.for_sale.last&.item
-      ].compact
-    end
+module SearchResults
+  module BikeBox
+    class ComponentPreview < ApplicationComponentPreview
+      def self.vehicles
+        built_bike = Bike.new(
+          id: 35,
+          serial_number: "XXX999 999xxxx",
+          mnfg_name: "Humble Frameworks",
+          year: "2015",
+          primary_frame_color_id: Color.where(name: "Purple").first_or_create,
+          frame_model: "self titled",
+          frame_material: :steel,
+          cycle_type: :bike,
+          thumb_path:
+            "https://files.bikeindex.org/uploads/Pu/395980/small_D3C6B1AF-F1FC-4BAA-BD39-9C107871FCAE.jpeg"
+        )
+        [
+          built_bike,
+          Bike.status_stolen.first,
+          Bike.status_impounded.first,
+          MarketplaceListing.for_sale.last&.item
+        ].compact
+      end
 
-    # TODO: pass bikes from here, rather than in the template :/
-    # Other previews to include:
-    # - every status (stolen, abandoned, impounded, parking)
-    # - no photo, minimal information
-    # - serial user_hidden
+      # TODO: pass bikes from here, rather than in the template :/
+      # Other previews to include:
+      # - every status (stolen, abandoned, impounded, parking)
+      # - no photo, minimal information
+      # - serial user_hidden
 
-    def default
-      {template: "search_results/bike_box/component_preview/default"}
+      def default
+        {template: "search_results/bike_box/component_preview/default"}
+      end
     end
   end
 end

--- a/app/components/search_results/container/component.rb
+++ b/app/components/search_results/container/component.rb
@@ -1,59 +1,61 @@
 # frozen_string_literal: true
 
-module SearchResults::Container
-  class Component < ApplicationComponent
-    RESULT_VIEW_COMPONENT = {
-      bike_box: SearchResults::BikeBox::Component,
-      thumbnail: SearchResults::VehicleThumbnail::Component
-    }.freeze
-    SEARCH_KINDS = %i[registration marketplace].freeze
+module SearchResults
+  module Container
+    class Component < ApplicationComponent
+      RESULT_VIEW_COMPONENT = {
+        bike_box: SearchResults::BikeBox::Component,
+        thumbnail: SearchResults::VehicleThumbnail::Component
+      }.freeze
+      SEARCH_KINDS = %i[registration marketplace].freeze
 
-    class << self
-      def permitted_search_kind(search_kind = nil)
-        kind_sym = search_kind&.to_sym
-        SEARCH_KINDS.include?(kind_sym) ? kind_sym : SEARCH_KINDS.first
-      end
+      class << self
+        def permitted_search_kind(search_kind = nil)
+          kind_sym = search_kind&.to_sym
+          SEARCH_KINDS.include?(kind_sym) ? kind_sym : SEARCH_KINDS.first
+        end
 
-      def permitted_result_view(result_view, default: nil)
-        kind_sym = result_view&.to_sym
-        default ||= RESULT_VIEW_COMPONENT.keys.first
-        raise "Unknown default '#{default}'" unless RESULT_VIEW_COMPONENT.key?(default)
+        def permitted_result_view(result_view, default: nil)
+          kind_sym = result_view&.to_sym
+          default ||= RESULT_VIEW_COMPONENT.keys.first
+          raise "Unknown default '#{default}'" unless RESULT_VIEW_COMPONENT.key?(default)
 
-        RESULT_VIEW_COMPONENT.key?(kind_sym) ? kind_sym : default
-      end
+          RESULT_VIEW_COMPONENT.key?(kind_sym) ? kind_sym : default
+        end
 
-      def component_class_for_result_view(result_view)
-        RESULT_VIEW_COMPONENT[permitted_result_view(result_view)]
-      end
+        def component_class_for_result_view(result_view)
+          RESULT_VIEW_COMPONENT[permitted_result_view(result_view)]
+        end
 
-      def container_class(component_class)
-        if component_class == SearchResults::VehicleThumbnail::Component
-          "tw:grid tw:gap-x-3 tw:gap-y-6 tw:lg:gap-y-8 tw:justify-items-center tw:xs:grid-cols-2 " \
-          "tw:sm:grid-cols-[repeat(auto-fit,minmax(16rem,1fr))]"
-        else
-          "bike-boxes"
+        def container_class(component_class)
+          if component_class == SearchResults::VehicleThumbnail::Component
+            "tw:grid tw:gap-x-3 tw:gap-y-6 tw:lg:gap-y-8 tw:justify-items-center tw:xs:grid-cols-2 " \
+            "tw:sm:grid-cols-[repeat(auto-fit,minmax(16rem,1fr))]"
+          else
+            "bike-boxes"
+          end
         end
       end
-    end
 
-    def initialize(result_view: nil, search_kind: nil, current_user: nil, vehicles: nil, skip_cache: false, no_results: nil)
-      @component_class = self.class.component_class_for_result_view(result_view)
-      @search_kind = self.class.permitted_search_kind(search_kind)
+      def initialize(result_view: nil, search_kind: nil, current_user: nil, vehicles: nil, skip_cache: false, no_results: nil)
+        @component_class = self.class.component_class_for_result_view(result_view)
+        @search_kind = self.class.permitted_search_kind(search_kind)
 
-      @current_user = current_user
-      @vehicles = vehicles
-      @skip_cache = skip_cache
-      @no_results = no_results || translation(".no_results")
-    end
+        @current_user = current_user
+        @vehicles = vehicles
+        @skip_cache = skip_cache
+        @no_results = no_results || translation(".no_results")
+      end
 
-    private
+      private
 
-    def render_no_results?
-      @vehicles.blank? && content.blank?
-    end
+      def render_no_results?
+        @vehicles.blank? && content.blank?
+      end
 
-    def container_class
-      self.class.container_class(@component_class)
+      def container_class
+        self.class.container_class(@component_class)
+      end
     end
   end
 end

--- a/app/components/search_results/multi_result_chip/component.rb
+++ b/app/components/search_results/multi_result_chip/component.rb
@@ -1,41 +1,43 @@
 # frozen_string_literal: true
 
-module SearchResults::MultiResultChip
-  class Component < ApplicationComponent
-    def initialize(serial:, serial_chip_id:, result_count:)
-      @serial = serial
-      @serial_chip_id = serial_chip_id
-      @result_count = result_count
-    end
+module SearchResults
+  module MultiResultChip
+    class Component < ApplicationComponent
+      def initialize(serial:, serial_chip_id:, result_count:)
+        @serial = serial
+        @serial_chip_id = serial_chip_id
+        @result_count = result_count
+      end
 
-    def call
-      content_tag(:span, id: @serial_chip_id, class: badge_classes) do
-        if has_results?
-          content_tag(:a, href: "#result_#{@serial_chip_id.delete_prefix("chip_")}", class: serial_span_classes) do
-            @serial
+      def call
+        content_tag(:span, id: @serial_chip_id, class: badge_classes) do
+          if has_results?
+            content_tag(:a, href: "#result_#{@serial_chip_id.delete_prefix("chip_")}", class: serial_span_classes) do
+              @serial
+            end
+          else
+            inner = content_tag(:span, @serial, class: "serial-span")
+            inner += content_tag(:small, translation(".no_results"), class: "tw:block tw:text-2xs tw:leading-none tw:ml-3")
+            inner
           end
-        else
-          inner = content_tag(:span, @serial, class: "serial-span")
-          inner += content_tag(:small, translation(".no_results"), class: "tw:block tw:text-2xs tw:leading-none tw:ml-3")
-          inner
         end
       end
-    end
 
-    private
+      private
 
-    def has_results?
-      @result_count > 0
-    end
+      def has_results?
+        @result_count > 0
+      end
 
-    def serial_span_classes
-      "serial-span tw:underline! tw:hover:font-bold! tw:text-emerald-900! tw:py-1 tw:px-2"
-    end
+      def serial_span_classes
+        "serial-span tw:underline! tw:hover:font-bold! tw:text-emerald-900! tw:py-1 tw:px-2"
+      end
 
-    def badge_classes
-      b_classes = UI::Badge::Component.badge_classes(color: has_results? ? :success : :gray, size: :md)
-      b_classes += " tw:p-0! tw:cursor-pointer" if has_results?
-      b_classes
+      def badge_classes
+        b_classes = UI::Badge::Component.badge_classes(color: has_results? ? :success : :gray, size: :md)
+        b_classes += " tw:p-0! tw:cursor-pointer" if has_results?
+        b_classes
+      end
     end
   end
 end

--- a/app/components/search_results/multi_result_chip/component_preview.rb
+++ b/app/components/search_results/multi_result_chip/component_preview.rb
@@ -1,19 +1,21 @@
 # frozen_string_literal: true
 
-module SearchResults::MultiResultChip
-  class ComponentPreview < ApplicationComponentPreview
-    # @!group Results
-    def one_result
-      render(Component.new(serial: "SERIAL111", serial_chip_id: "chip_0", result_count: 1))
-    end
+module SearchResults
+  module MultiResultChip
+    class ComponentPreview < ApplicationComponentPreview
+      # @!group Results
+      def one_result
+        render(Component.new(serial: "SERIAL111", serial_chip_id: "chip_0", result_count: 1))
+      end
 
-    def many_results
-      render(Component.new(serial: "SERIAL222", serial_chip_id: "chip_1", result_count: 3009))
-    end
+      def many_results
+        render(Component.new(serial: "SERIAL222", serial_chip_id: "chip_1", result_count: 3009))
+      end
 
-    def no_results
-      render(Component.new(serial: "NONEXISTENT", serial_chip_id: "chip_2", result_count: 0))
+      def no_results
+        render(Component.new(serial: "NONEXISTENT", serial_chip_id: "chip_2", result_count: 0))
+      end
+      # @!endgroup
     end
-    # @!endgroup
   end
 end

--- a/app/components/search_results/vehicle_thumbnail/component.rb
+++ b/app/components/search_results/vehicle_thumbnail/component.rb
@@ -1,65 +1,67 @@
 # frozen_string_literal: true
 
-module SearchResults::VehicleThumbnail
-  class Component < ApplicationComponent
-    include BikeHelper
+module SearchResults
+  module VehicleThumbnail
+    class Component < ApplicationComponent
+      include BikeHelper
 
-    # current_user is ignored, but included to match other SearchResults components
-    def initialize(bike:, current_user: nil, event_record: nil, skip_cache: false, search_kind: nil)
-      @bike = bike
-      return if @bike.blank?
+      # current_user is ignored, but included to match other SearchResults components
+      def initialize(bike:, current_user: nil, event_record: nil, skip_cache: false, search_kind: nil)
+        @bike = bike
+        return if @bike.blank?
 
-      @search_kind = SearchResults::Container::Component.permitted_search_kind(search_kind)
-      @event_record = event_record || @bike.current_event_record
+        @search_kind = SearchResults::Container::Component.permitted_search_kind(search_kind)
+        @event_record = event_record || @bike.current_event_record
 
-      @is_cached = !skip_cache
-    end
-
-    def render?
-      @bike.present?
-    end
-
-    private
-
-    def render_status?
-      @search_kind != :marketplace && !@bike.status_with_owner?
-    end
-
-    def permitted_search_kind(search_kind)
-      SearchResults::Container
-    end
-
-    def render_for_sale_info?
-      @event_record.is_a?(MarketplaceListing)
-    end
-
-    def render_event_date?
-      @event_record.present? && !@event_record.is_a?(MarketplaceListing)
-    end
-
-    def occurred_at_with_fallback
-      @bike.occurred_at || @event_record&.updated_at || @bike.updated_at
-    end
-
-    def vehicle_image_tag
-      thumb_image_url = BikeServices::Displayer.thumb_image_url(@bike)
-      if thumb_image_url.present?
-        image_tag(thumb_image_url, alt: @bike.title_string, skip_pipeline: true, class: "tw:rounded tw:w-full tw:h-full tw:object-cover")
-      else
-        image_tag(bike_placeholder_image_path, alt: @bike.title_string, title: "No image",
-          class: "tw-block tw:w-full tw:rounded tw:p-8")
+        @is_cached = !skip_cache
       end
-    end
 
-    def render_footer?
-      address_formatted.present?
-    end
+      def render?
+        @bike.present?
+      end
 
-    def address_formatted
-      @address_formatted ||= if @event_record.is_a?(MarketplaceListing)
-        @event_record.formatted_address_string
-      else
-        @event_record&.address(country: [:iso])
+      private
+
+      def render_status?
+        @search_kind != :marketplace && !@bike.status_with_owner?
+      end
+
+      def permitted_search_kind(search_kind)
+        SearchResults::Container
+      end
+
+      def render_for_sale_info?
+        @event_record.is_a?(MarketplaceListing)
+      end
+
+      def render_event_date?
+        @event_record.present? && !@event_record.is_a?(MarketplaceListing)
+      end
+
+      def occurred_at_with_fallback
+        @bike.occurred_at || @event_record&.updated_at || @bike.updated_at
+      end
+
+      def vehicle_image_tag
+        thumb_image_url = BikeServices::Displayer.thumb_image_url(@bike)
+        if thumb_image_url.present?
+          image_tag(thumb_image_url, alt: @bike.title_string, skip_pipeline: true, class: "tw:rounded tw:w-full tw:h-full tw:object-cover")
+        else
+          image_tag(bike_placeholder_image_path, alt: @bike.title_string, title: "No image",
+            class: "tw-block tw:w-full tw:rounded tw:p-8")
+        end
+      end
+
+      def render_footer?
+        address_formatted.present?
+      end
+
+      def address_formatted
+        @address_formatted ||= if @event_record.is_a?(MarketplaceListing)
+          @event_record.formatted_address_string
+        else
+          @event_record&.address(country: [:iso])
+        end
       end
     end
   end

--- a/app/components/search_results/vehicle_thumbnail/component_preview.rb
+++ b/app/components/search_results/vehicle_thumbnail/component_preview.rb
@@ -1,35 +1,37 @@
 # frozen_string_literal: true
 
-module SearchResults::VehicleThumbnail
-  class ComponentPreview < ApplicationComponentPreview
-    def default
-      render(SearchResults::Container::Component.new(
-        result_view: :thumbnail,
-        search_kind: :registration,
-        vehicles: SearchResults::BikeBox::ComponentPreview.vehicles + SearchResults::BikeBox::ComponentPreview.vehicles
-      ))
-    end
+module SearchResults
+  module VehicleThumbnail
+    class ComponentPreview < ApplicationComponentPreview
+      def default
+        render(SearchResults::Container::Component.new(
+          result_view: :thumbnail,
+          search_kind: :registration,
+          vehicles: SearchResults::BikeBox::ComponentPreview.vehicles + SearchResults::BikeBox::ComponentPreview.vehicles
+        ))
+      end
 
-    def marketplace
-      render(SearchResults::Container::Component.new(
-        result_view: :thumbnail,
-        search_kind: :marketplace,
-        vehicles: marketplace_vehicles
-      ))
-    end
+      def marketplace
+        render(SearchResults::Container::Component.new(
+          result_view: :thumbnail,
+          search_kind: :marketplace,
+          vehicles: marketplace_vehicles
+        ))
+      end
 
-    def no_results
-      render(SearchResults::Container::Component.new(
-        result_view: :thumbnail,
-        search_kind: :marketplace,
-        vehicles: nil
-      ))
-    end
+      def no_results
+        render(SearchResults::Container::Component.new(
+          result_view: :thumbnail,
+          search_kind: :marketplace,
+          vehicles: nil
+        ))
+      end
 
-    private
+      private
 
-    def marketplace_vehicles
-      Bike.for_sale.limit(15)
+      def marketplace_vehicles
+        Bike.for_sale.limit(15)
+      end
     end
   end
 end

--- a/app/components/ui/address_display/component.rb
+++ b/app/components/ui/address_display/component.rb
@@ -1,74 +1,76 @@
 # frozen_string_literal: true
 
-module UI::AddressDisplay
-  class Component < ApplicationComponent
-    KINDS = %i[multiline single_line]
-    def initialize(address_record: nil, address_hash: nil, visible_attribute: nil, render_country: false, kind: nil)
-      @kind = KINDS.include?(kind) ? kind : KINDS.first
-      @address_record = address_record.is_a?(AddressRecord) ? address_record : nil
-      @address_hash = address_hash&.with_indifferent_access
-      @visible_attribute = AddressRecord.permitted_visible_attribute(visible_attribute)
-      @render_country = render_country
-    end
-
-    def render?
-      @address_record.present? || @address_hash.present?
-    end
-
-    def call
-      content_tag(:span, address_content_tags, class: "tw:leading-[1.5]")
-    end
-
-    private
-
-    def address_content_tags
-      content_tags = [final_line]
-
-      if @visible_attribute == :street
-        content_tags = street_tags + content_tags
+module UI
+  module AddressDisplay
+    class Component < ApplicationComponent
+      KINDS = %i[multiline single_line]
+      def initialize(address_record: nil, address_hash: nil, visible_attribute: nil, render_country: false, kind: nil)
+        @kind = KINDS.include?(kind) ? kind : KINDS.first
+        @address_record = address_record.is_a?(AddressRecord) ? address_record : nil
+        @address_hash = address_hash&.with_indifferent_access
+        @visible_attribute = AddressRecord.permitted_visible_attribute(visible_attribute)
+        @render_country = render_country
       end
 
-      content_tags.reduce(:+)
-    end
-
-    def street_tags
-      street_lines = if @address_record.present?
-        [@address_record.street, @address_record.street_2]
-      else
-        @address_hash[:street]&.split(",")&.map(&:strip)
-      end.compact
-
-      street_lines.map { content_tag(:span, it + line_separator, class: line_classes) }
-    end
-
-    def final_line
-      if @address_record.present?
-        line_parts = [@address_record.region]
-        line_parts += [@address_record.postal_code] unless @visible_attribute == :city
-
-        line_parts = [@address_record.city, line_parts.join(" ")]
-        line_parts += [@address_record.country_name] if @render_country
-      else
-        line_parts = [@address_hash[:state]]
-        line_parts += [@address_hash[:zipcode]] unless @visible_attribute == :city
-
-        line_parts = [@address_hash[:city], line_parts.join(" ")]
-        line_parts += [@address_hash[:country]] if @render_country
+      def render?
+        @address_record.present? || @address_hash.present?
       end
 
-      content_tag(:span, line_parts.compact.join(", "), class: line_classes)
-    end
+      def call
+        content_tag(:span, address_content_tags, class: "tw:leading-[1.5]")
+      end
 
-    def single_line?
-      @kind == :single_line
-    end
+      private
 
-    def line_separator
-      single_line? ? ", " : "\n"
-    end
+      def address_content_tags
+        content_tags = [final_line]
 
-    def line_classes
-      single_line? ? "tw:inline-block" : "tw:block"
+        if @visible_attribute == :street
+          content_tags = street_tags + content_tags
+        end
+
+        content_tags.reduce(:+)
+      end
+
+      def street_tags
+        street_lines = if @address_record.present?
+          [@address_record.street, @address_record.street_2]
+        else
+          @address_hash[:street]&.split(",")&.map(&:strip)
+        end.compact
+
+        street_lines.map { content_tag(:span, it + line_separator, class: line_classes) }
+      end
+
+      def final_line
+        if @address_record.present?
+          line_parts = [@address_record.region]
+          line_parts += [@address_record.postal_code] unless @visible_attribute == :city
+
+          line_parts = [@address_record.city, line_parts.join(" ")]
+          line_parts += [@address_record.country_name] if @render_country
+        else
+          line_parts = [@address_hash[:state]]
+          line_parts += [@address_hash[:zipcode]] unless @visible_attribute == :city
+
+          line_parts = [@address_hash[:city], line_parts.join(" ")]
+          line_parts += [@address_hash[:country]] if @render_country
+        end
+
+        content_tag(:span, line_parts.compact.join(", "), class: line_classes)
+      end
+
+      def single_line?
+        @kind == :single_line
+      end
+
+      def line_separator
+        single_line? ? ", " : "\n"
+      end
+
+      def line_classes
+        single_line? ? "tw:inline-block" : "tw:block"
+      end
     end
   end
 end

--- a/app/components/ui/address_display/component_preview.rb
+++ b/app/components/ui/address_display/component_preview.rb
@@ -1,45 +1,47 @@
 # frozen_string_literal: true
 
-module UI::AddressDisplay
-  class ComponentPreview < ApplicationComponentPreview
-    # @!group Address Variants
+module UI
+  module AddressDisplay
+    class ComponentPreview < ApplicationComponentPreview
+      # @!group Address Variants
 
-    def with_address_record
-      render(UI::AddressDisplay::Component.new(address_record:, visible_attribute: :street))
-    end
+      def with_address_record
+        render(UI::AddressDisplay::Component.new(address_record:, visible_attribute: :street))
+      end
 
-    def with_address_hash
-      render(UI::AddressDisplay::Component.new(address_hash:, visible_attribute: :street))
-    end
+      def with_address_hash
+        render(UI::AddressDisplay::Component.new(address_hash:, visible_attribute: :street))
+      end
 
-    # @param visible_attribute text "Visible attribute"
-    def with_address_record_and_visible_attribute(visible_attribute: "city")
-      render(UI::AddressDisplay::Component.new(address_record:, visible_attribute:))
-    end
+      # @param visible_attribute text "Visible attribute"
+      def with_address_record_and_visible_attribute(visible_attribute: "city")
+        render(UI::AddressDisplay::Component.new(address_record:, visible_attribute:))
+      end
 
-    def single_line
-      render(UI::AddressDisplay::Component.new(address_record:, visible_attribute: :street, kind: :single_line))
-    end
+      def single_line
+        render(UI::AddressDisplay::Component.new(address_record:, visible_attribute: :street, kind: :single_line))
+      end
 
-    private
+      private
 
-    def address_record
-      AddressRecord.new(
-        city: "Davis",
-        region_record: State.friendly_find("CA"),
-        country: Country.united_states,
-        street: "1 Shields Ave",
-        street_2: "C/O BicyclingPlus",
-        postal_code: "95616",
-        latitude: 38.5449065,
-        longitude: -121.7405167
-      )
-    end
+      def address_record
+        AddressRecord.new(
+          city: "Davis",
+          region_record: State.friendly_find("CA"),
+          country: Country.united_states,
+          street: "1 Shields Ave",
+          street_2: "C/O BicyclingPlus",
+          postal_code: "95616",
+          latitude: 38.5449065,
+          longitude: -121.7405167
+        )
+      end
 
-    # Legacy address hash
-    def address_hash
-      {street: "Some Ave", city: "Brooklyn", zipcode: "11222",
-       latitude: 40, longitude: -73, state: "NY", country: "US"}
+      # Legacy address hash
+      def address_hash
+        {street: "Some Ave", city: "Brooklyn", zipcode: "11222",
+         latitude: 40, longitude: -73, state: "NY", country: "US"}
+      end
     end
   end
 end

--- a/app/components/ui/badge/component.rb
+++ b/app/components/ui/badge/component.rb
@@ -1,54 +1,56 @@
 # frozen_string_literal: true
 
-module UI::Badge
-  class Component < ApplicationComponent
-    BASE_CLASSES = "tw:inline-flex tw:border tw:items-center tw:leading-4 tw:rounded-full"
+module UI
+  module Badge
+    class Component < ApplicationComponent
+      BASE_CLASSES = "tw:inline-flex tw:border tw:items-center tw:leading-4 tw:rounded-full"
 
-    SIZES = {
-      sm: "tw:text-xs tw:font-medium tw:px-1 tw:py-px",
-      md: "tw:text-xs tw:font-bold tw:px-2 tw:py-1",
-      lg: "tw:text-md tw:font-extrabold tw:px-3 tw:py-1"
-    }
+      SIZES = {
+        sm: "tw:text-xs tw:font-medium tw:px-1 tw:py-px",
+        md: "tw:text-xs tw:font-bold tw:px-2 tw:py-1",
+        lg: "tw:text-md tw:font-extrabold tw:px-3 tw:py-1"
+      }
 
-    COLORS = {
-      notice: "tw:bg-blue-300 tw:text-blue-900 tw:dark:bg-blue-800 tw:dark:text-blue-200",
-      error: "tw:bg-red-300 tw:text-red-950 tw:dark:bg-red-800 tw:dark:text-red-300",
-      warning: "tw:bg-amber-300 tw:text-amber-900 tw:dark:bg-amber-800 tw:dark:text-amber-200",
-      success: "tw:bg-emerald-500 tw:text-emerald-900 tw:dark:bg-emerald-800 tw:dark:text-emerald-200",
-      # Special badge classes:
-      cyan: "tw:bg-cyan-400 tw:text-cyan-900 tw:dark:bg-cyan-800 tw:dark:text-cyan-200",
-      gray: "tw:bg-gray-300 tw:text-gray-900 tw:dark:bg-gray-700 tw:dark:text-gray-200",
-      purple: "tw:bg-purple-300 tw:text-purple-900 tw:dark:bg-purple-800 tw:dark:text-purple-200",
-      rose: "tw:bg-rose-400 tw:text-rose-950 tw:dark:bg-rose-800 tw:dark:text-rose-300",
-      orange: "tw:bg-orange-400 tw:text-orange-950 tw:dark:bg-orange-800 tw:dark:text-orange-300",
-      empty: "tw:bg-white tw:text-gray-700 tw:border-gray-300 tw:dark:bg-gray-900 tw:dark:text-gray-200 tw:dark:border-gray-600"
-    }.freeze
+      COLORS = {
+        notice: "tw:bg-blue-300 tw:text-blue-900 tw:dark:bg-blue-800 tw:dark:text-blue-200",
+        error: "tw:bg-red-300 tw:text-red-950 tw:dark:bg-red-800 tw:dark:text-red-300",
+        warning: "tw:bg-amber-300 tw:text-amber-900 tw:dark:bg-amber-800 tw:dark:text-amber-200",
+        success: "tw:bg-emerald-500 tw:text-emerald-900 tw:dark:bg-emerald-800 tw:dark:text-emerald-200",
+        # Special badge classes:
+        cyan: "tw:bg-cyan-400 tw:text-cyan-900 tw:dark:bg-cyan-800 tw:dark:text-cyan-200",
+        gray: "tw:bg-gray-300 tw:text-gray-900 tw:dark:bg-gray-700 tw:dark:text-gray-200",
+        purple: "tw:bg-purple-300 tw:text-purple-900 tw:dark:bg-purple-800 tw:dark:text-purple-200",
+        rose: "tw:bg-rose-400 tw:text-rose-950 tw:dark:bg-rose-800 tw:dark:text-rose-300",
+        orange: "tw:bg-orange-400 tw:text-orange-950 tw:dark:bg-orange-800 tw:dark:text-orange-300",
+        empty: "tw:bg-white tw:text-gray-700 tw:border-gray-300 tw:dark:bg-gray-900 tw:dark:text-gray-200 tw:dark:border-gray-600"
+      }.freeze
 
-    def self.badge_classes(color:, size:, cursor: "tw:cursor-default")
-      [BASE_CLASSES, cursor, COLORS[color], SIZES[size]].join(" ")
-    end
+      def self.badge_classes(color:, size:, cursor: "tw:cursor-default")
+        [BASE_CLASSES, cursor, COLORS[color], SIZES[size]].join(" ")
+      end
 
-    def initialize(text:, title: nil, color: :gray, size: :md)
-      @text = text
-      @title = title
-      @color = COLORS.key?(color) ? color : :gray
-      @size = SIZES.include?(size) ? size : :md
-    end
+      def initialize(text:, title: nil, color: :gray, size: :md)
+        @text = text
+        @title = title
+        @color = COLORS.key?(color) ? color : :gray
+        @size = SIZES.include?(size) ? size : :md
+      end
 
-    def call
-      badge = content_tag(:span, content.presence || @text, class: badge_class)
-      return badge unless custom_title?
-      render(UI::Tooltip::Component.new(text: @title)) { badge }
-    end
+      def call
+        badge = content_tag(:span, content.presence || @text, class: badge_class)
+        return badge unless custom_title?
+        render(UI::Tooltip::Component.new(text: @title)) { badge }
+      end
 
-    private
+      private
 
-    def custom_title?
-      @title.present? && @title != @text
-    end
+      def custom_title?
+        @title.present? && @title != @text
+      end
 
-    def badge_class
-      self.class.badge_classes(color: @color, size: @size, cursor: custom_title? ? "tw:cursor-help" : "tw:cursor-default")
+      def badge_class
+        self.class.badge_classes(color: @color, size: @size, cursor: custom_title? ? "tw:cursor-help" : "tw:cursor-default")
+      end
     end
   end
 end

--- a/app/components/ui/card/component.rb
+++ b/app/components/ui/card/component.rb
@@ -1,17 +1,19 @@
 # frozen_string_literal: true
 
-module UI::Card
-  class Component < ApplicationComponent
-    def initialize(additional_classes: nil, shadow: false)
-      @additional_classes = additional_classes || ""
-      @additional_classes += " tw:shadow-sm" if shadow
-    end
+module UI
+  module Card
+    class Component < ApplicationComponent
+      def initialize(additional_classes: nil, shadow: false)
+        @additional_classes = additional_classes || ""
+        @additional_classes += " tw:shadow-sm" if shadow
+      end
 
-    private
+      private
 
-    def card_classes
-      "tw:p-4 tw:bg-white tw:border tw:border-gray-200 tw:rounded-sm " \
-      "tw:dark:bg-gray-800 tw:dark:border-gray-700 " + @additional_classes
+      def card_classes
+        "tw:p-4 tw:bg-white tw:border tw:border-gray-200 tw:rounded-sm " \
+        "tw:dark:bg-gray-800 tw:dark:border-gray-700 " + @additional_classes
+      end
     end
   end
 end

--- a/app/components/ui/card/component_preview.rb
+++ b/app/components/ui/card/component_preview.rb
@@ -1,17 +1,19 @@
 # frozen_string_literal: true
 
-module UI::Card
-  class ComponentPreview < ApplicationComponentPreview
-    # @!group Kind Variants
-    def default
-      render(UI::Card::Component.new) do
-        "Man braid sustainable solarpunk vexillologist grailed marxism schlitz big mood shabby chic cornhole yuccie PBR&B vegan."
+module UI
+  module Card
+    class ComponentPreview < ApplicationComponentPreview
+      # @!group Kind Variants
+      def default
+        render(UI::Card::Component.new) do
+          "Man braid sustainable solarpunk vexillologist grailed marxism schlitz big mood shabby chic cornhole yuccie PBR&B vegan."
+        end
       end
-    end
 
-    def with_shadow
-      render(UI::Card::Component.new(shadow: true)) do
-        "Man braid sustainable solarpunk vexillologist grailed marxism schlitz big mood shabby chic cornhole yuccie PBR&B vegan."
+      def with_shadow
+        render(UI::Card::Component.new(shadow: true)) do
+          "Man braid sustainable solarpunk vexillologist grailed marxism schlitz big mood shabby chic cornhole yuccie PBR&B vegan."
+        end
       end
     end
   end

--- a/app/components/ui/chart/component.rb
+++ b/app/components/ui/chart/component.rb
@@ -1,74 +1,76 @@
 # frozen_string_literal: true
 
-module UI::Chart
-  class Component < ApplicationComponent
-    COLORS = %w[#3498db #DC2626 #D97706 #7C3AED #059669 #DB2777 #475569].freeze
+module UI
+  module Chart
+    class Component < ApplicationComponent
+      COLORS = %w[#3498db #DC2626 #D97706 #7C3AED #059669 #DB2777 #475569].freeze
 
-    class << self
-      def time_range_counts(collection:, time_range:, column: "created_at")
-        collection_grouped(collection:, column:, time_range:).count
-      end
+      class << self
+        def time_range_counts(collection:, time_range:, column: "created_at")
+          collection_grouped(collection:, column:, time_range:).count
+        end
 
-      def time_range_amounts(collection:, time_range:, column: "created_at", amount_column: "amount_cents", convert_to_dollars: false)
-        result = collection_grouped(collection:, column:, time_range:).sum(amount_column)
-        return result unless convert_to_dollars
+        def time_range_amounts(collection:, time_range:, column: "created_at", amount_column: "amount_cents", convert_to_dollars: false)
+          result = collection_grouped(collection:, column:, time_range:).sum(amount_column)
+          return result unless convert_to_dollars
 
-        result.transform_values { |v| (v.to_f / 100.00).round(2) }
-      end
+          result.transform_values { |v| (v.to_f / 100.00).round(2) }
+        end
 
-      private
+        private
 
-      def collection_grouped(collection:, time_range:, column: "created_at")
-        collection.send(
-          group_by_method(time_range),
-          column,
-          range: time_range,
-          format: group_by_format(time_range)
-        )
-      end
+        def collection_grouped(collection:, time_range:, column: "created_at")
+          collection.send(
+            group_by_method(time_range),
+            column,
+            range: time_range,
+            format: group_by_format(time_range)
+          )
+        end
 
-      def group_by_method(time_range)
-        period_s = time_range.last - time_range.first
-        if period_s < 3601 # 1.hour + 1 second
-          :group_by_minute
-        elsif period_s < 5.days
-          :group_by_hour
-        elsif period_s < 5_000_000 # around 60 days
-          :group_by_day
-        elsif period_s < 31449600 # 364 days (52 weeks)
-          :group_by_week
-        else
-          :group_by_month
+        def group_by_method(time_range)
+          period_s = time_range.last - time_range.first
+          if period_s < 3601 # 1.hour + 1 second
+            :group_by_minute
+          elsif period_s < 5.days
+            :group_by_hour
+          elsif period_s < 5_000_000 # around 60 days
+            :group_by_day
+          elsif period_s < 31449600 # 364 days (52 weeks)
+            :group_by_week
+          else
+            :group_by_month
+          end
+        end
+
+        def group_by_format(time_range, group_period = nil)
+          period_s = time_range.last - time_range.first
+          group_period ||= group_by_method(time_range)
+          if group_period == :group_by_minute
+            "%l:%M %p"
+          elsif group_period == :group_by_hour
+            "%a%l %p"
+          elsif group_period == :group_by_month
+            "%Y-%-m"
+          elsif group_period == :group_by_day && (period_s < 10.days)
+            "%a %-m-%-d"
+          else
+            "%Y-%-m-%-d"
+          end
         end
       end
 
-      def group_by_format(time_range, group_period = nil)
-        period_s = time_range.last - time_range.first
-        group_period ||= group_by_method(time_range)
-        if group_period == :group_by_minute
-          "%l:%M %p"
-        elsif group_period == :group_by_hour
-          "%a%l %p"
-        elsif group_period == :group_by_month
-          "%Y-%-m"
-        elsif group_period == :group_by_day && (period_s < 10.days)
-          "%a %-m-%-d"
-        else
-          "%Y-%-m-%-d"
-        end
+      def initialize(series:, time_range:, stacked: false, thousands: ",", colors: nil)
+        @series = series
+        @time_range = time_range
+        @stacked = stacked
+        @thousands = thousands
+        @colors = colors || COLORS
       end
-    end
 
-    def initialize(series:, time_range:, stacked: false, thousands: ",", colors: nil)
-      @series = series
-      @time_range = time_range
-      @stacked = stacked
-      @thousands = thousands
-      @colors = colors || COLORS
-    end
-
-    def call
-      helpers.column_chart @series, stacked: @stacked, thousands: @thousands, colors: @colors
+      def call
+        helpers.column_chart @series, stacked: @stacked, thousands: @thousands, colors: @colors
+      end
     end
   end
 end

--- a/app/components/ui/chart/component_preview.rb
+++ b/app/components/ui/chart/component_preview.rb
@@ -1,16 +1,18 @@
 # frozen_string_literal: true
 
-module UI::Chart
-  class ComponentPreview < ApplicationComponentPreview
-    def bikes_by_status
-      time_range = 1.week.ago..Time.current
-      series = Bike::STATUS_ENUM.keys.filter_map do |status|
-        scoped = Bike.where(status:, created_at: time_range)
-        next if scoped.limit(1).blank?
-        {name: Bike.status_humanized(status), data: UI::Chart::Component.time_range_counts(collection: scoped, time_range:)}
+module UI
+  module Chart
+    class ComponentPreview < ApplicationComponentPreview
+      def bikes_by_status
+        time_range = 1.week.ago..::Time.current
+        series = Bike::STATUS_ENUM.keys.filter_map do |status|
+          scoped = Bike.where(status:, created_at: time_range)
+          next if scoped.limit(1).blank?
+          {name: Bike.status_humanized(status), data: UI::Chart::Component.time_range_counts(collection: scoped, time_range:)}
+        end
+        series = [{name: "No bikes", data: {}}] if series.empty?
+        render(UI::Chart::Component.new(series:, time_range:, stacked: true))
       end
-      series = [{name: "No bikes", data: {}}] if series.empty?
-      render(UI::Chart::Component.new(series:, time_range:, stacked: true))
     end
   end
 end

--- a/app/components/ui/definition_list/container/component.rb
+++ b/app/components/ui/definition_list/container/component.rb
@@ -1,9 +1,13 @@
 # frozen_string_literal: true
 
-module UI::DefinitionList::Container
-  class Component < ApplicationComponent
-    def initialize(multi_columns: false)
-      @multi_columns = multi_columns
+module UI
+  module DefinitionList
+    module Container
+      class Component < ApplicationComponent
+        def initialize(multi_columns: false)
+          @multi_columns = multi_columns
+        end
+      end
     end
   end
 end

--- a/app/components/ui/definition_list/container/component_preview.rb
+++ b/app/components/ui/definition_list/container/component_preview.rb
@@ -1,15 +1,19 @@
 # frozen_string_literal: true
 
-module UI::DefinitionList::Container
-  class ComponentPreview < ApplicationComponentPreview
-    # @!group Multi Column
-    def default
-      {template: "ui/definition_list/container/component_preview/default", locals: {multi_columns: false}}
-    end
+module UI
+  module DefinitionList
+    module Container
+      class ComponentPreview < ApplicationComponentPreview
+        # @!group Multi Column
+        def default
+          {template: "ui/definition_list/container/component_preview/default", locals: {multi_columns: false}}
+        end
 
-    def multi_columns_true
-      {template: "ui/definition_list/container/component_preview/default", locals: {multi_columns: true}}
+        def multi_columns_true
+          {template: "ui/definition_list/container/component_preview/default", locals: {multi_columns: true}}
+        end
+        # @!endgroup
+      end
     end
-    # @!endgroup
   end
 end

--- a/app/components/ui/definition_list/container/component_preview/default.html.erb
+++ b/app/components/ui/definition_list/container/component_preview/default.html.erb
@@ -38,7 +38,7 @@
   <%= render(
     UI::DefinitionList::Row::Component.new(
       label: "Some time",
-      value: Time.current - 1.hour,
+      value: ::Time.current - 1.hour,
     ),
   ) %>
 

--- a/app/components/ui/definition_list/row/component.rb
+++ b/app/components/ui/definition_list/row/component.rb
@@ -1,56 +1,60 @@
 # frozen_string_literal: true
 
-module UI::DefinitionList::Row
-  class Component < ApplicationComponent
-    def initialize(label:, value: nil, render_with_no_value: false, full_width: false, time_localizer_settings: nil)
-      @label = label
-      @value = value
-      @render_with_no_value = render_with_no_value
-      @full_width = full_width
+module UI
+  module DefinitionList
+    module Row
+      class Component < ApplicationComponent
+        def initialize(label:, value: nil, render_with_no_value: false, full_width: false, time_localizer_settings: nil)
+          @label = label
+          @value = value
+          @render_with_no_value = render_with_no_value
+          @full_width = full_width
 
-      # TODO: actually support originalTimeZone. When this is set currently, we show the timezone,
-      # but it's still the user's timezone
-      @include_time_zone = time_localizer_settings&.include?(:originalTimeZone) || false
+          # TODO: actually support originalTimeZone. When this is set currently, we show the timezone,
+          # but it's still the user's timezone
+          @include_time_zone = time_localizer_settings&.include?(:originalTimeZone) || false
 
-      @time_localizer_classes = time_localizer_classes(time_localizer_settings)
-    end
+          @time_localizer_classes = time_localizer_classes(time_localizer_settings)
+        end
 
-    def render?
-      return true if @render_with_no_value
+        def render?
+          return true if @render_with_no_value
 
-      @value.present? || content.present?
-    end
+          @value.present? || content.present?
+        end
 
-    private
+        private
 
-    def render_convertime?
-      @value.present? && (@value.is_a?(Time) || @value.is_a?(Date))
-    end
+        def render_convertime?
+          @value.present? && (@value.is_a?(::Time) || @value.is_a?(Date))
+        end
 
-    def no_value_content
-      translation(".no_value")
-    end
+        def no_value_content
+          translation(".no_value")
+        end
 
-    def wrapper_classes
-      if @full_width
-        "tw:col-span-full"
-      else
-        "tw:items-center tw:@sm:flex tw:@sm:gap-x-2 tw:@sm:pt-2"
-      end + " tw:pt-3 tw:leading-tight"
-    end
+        def wrapper_classes
+          if @full_width
+            "tw:col-span-full"
+          else
+            "tw:items-center tw:@sm:flex tw:@sm:gap-x-2 tw:@sm:pt-2"
+          end + " tw:pt-3 tw:leading-tight"
+        end
 
-    def dt_classes
-      if @full_width
-        "tw:pb-1"
-      else
-        "tw:@sm:text-right tw:@sm:w-1/4 tw:min-w-[100px]"
-      end + " tw:text-sm tw:leading-none tw:opacity-65 tw:font-bold!"
-    end
+        def dt_classes
+          if @full_width
+            "tw:pb-1"
+          else
+            "tw:@sm:text-right tw:@sm:w-1/4 tw:min-w-[100px]"
+          end + " tw:text-sm tw:leading-none tw:opacity-65 tw:font-bold!"
+        end
 
-    def time_localizer_classes(time_localizer_settings)
-      time_localizer_settings ||= []
-      time_localizer_settings << "localizeTime"
-      time_localizer_settings.join(" ")
+        def time_localizer_classes(time_localizer_settings)
+          time_localizer_settings ||= []
+          time_localizer_settings << "localizeTime"
+          time_localizer_settings.join(" ")
+        end
+      end
     end
   end
 end

--- a/app/components/ui/loading_spinner/component.rb
+++ b/app/components/ui/loading_spinner/component.rb
@@ -1,46 +1,48 @@
 # frozen_string_literal: true
 
-module UI::LoadingSpinner
-  class Component < ApplicationComponent
-    SIZES = {
-      sm: "tw:h-3 tw:w-3",
-      md: "tw:h-15 tw:w-15"
-    }.freeze
+module UI
+  module LoadingSpinner
+    class Component < ApplicationComponent
+      SIZES = {
+        sm: "tw:h-3 tw:w-3",
+        md: "tw:h-15 tw:w-15"
+      }.freeze
 
-    def initialize(text: nil, size: :md)
-      @text = text
-      @size = SIZES.key?(size) ? size : :md
-    end
+      def initialize(text: nil, size: :md)
+        @text = text
+        @size = SIZES.key?(size) ? size : :md
+      end
 
-    def call
-      if inline?
-        spinner_svg
-      else
-        content_tag(:div, class: "tw:animate-pulse tw:justify-center tw:p-6 tw:text-center") do
-          safe_join([content_tag(:p, @text, class: "tw:text-lg"), spinner_svg])
+      def call
+        if inline?
+          spinner_svg
+        else
+          content_tag(:div, class: "tw:animate-pulse tw:justify-center tw:p-6 tw:text-center") do
+            safe_join([content_tag(:p, @text, class: "tw:text-lg"), spinner_svg])
+          end
         end
       end
-    end
 
-    def inline?
-      @text.blank?
-    end
+      def inline?
+        @text.blank?
+      end
 
-    private
+      private
 
-    def spinner_svg
-      classes = "tw:animate-spin tw:text-slate-400 tw:dark:text-blue-800 #{SIZES[@size]}"
-      classes = "tw:inline #{classes}" if inline?
-      classes = "tw:mx-auto tw:mt-4 #{classes}" unless inline?
+      def spinner_svg
+        classes = "tw:animate-spin tw:text-slate-400 tw:dark:text-blue-800 #{SIZES[@size]}"
+        classes = "tw:inline #{classes}" if inline?
+        classes = "tw:mx-auto tw:mt-4 #{classes}" unless inline?
 
-      content_tag(:svg, class: classes, xmlns: "http://www.w3.org/2000/svg",
-        fill: "none", viewBox: "0 0 24 24") do
-        safe_join([
-          tag.circle(class: "tw:opacity-25", cx: "12", cy: "12", r: "10",
-            stroke: "currentColor", "stroke-width": "4"),
-          tag.path(class: "tw:opacity-75", fill: "currentColor",
-            d: "M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z")
-        ])
+        content_tag(:svg, class: classes, xmlns: "http://www.w3.org/2000/svg",
+          fill: "none", viewBox: "0 0 24 24") do
+          safe_join([
+            tag.circle(class: "tw:opacity-25", cx: "12", cy: "12", r: "10",
+              stroke: "currentColor", "stroke-width": "4"),
+            tag.path(class: "tw:opacity-75", fill: "currentColor",
+              d: "M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z")
+          ])
+        end
       end
     end
   end

--- a/app/components/ui/loading_spinner/component_preview.rb
+++ b/app/components/ui/loading_spinner/component_preview.rb
@@ -1,20 +1,22 @@
 # frozen_string_literal: true
 
-module UI::LoadingSpinner
-  class ComponentPreview < ApplicationComponentPreview
-    # @!group Sizes
-    def sm
-      render(UI::LoadingSpinner::Component.new(size: :sm))
-    end
+module UI
+  module LoadingSpinner
+    class ComponentPreview < ApplicationComponentPreview
+      # @!group Sizes
+      def sm
+        render(UI::LoadingSpinner::Component.new(size: :sm))
+      end
 
-    def md
-      render(UI::LoadingSpinner::Component.new(size: :md))
-    end
+      def md
+        render(UI::LoadingSpinner::Component.new(size: :md))
+      end
 
-    def md_with_text
-      render(UI::LoadingSpinner::Component.new(text: "Loading results...", size: :md))
-    end
+      def md_with_text
+        render(UI::LoadingSpinner::Component.new(text: "Loading results...", size: :md))
+      end
 
-    # @!endgroup
+      # @!endgroup
+    end
   end
 end

--- a/app/components/ui/time/component_preview/default.html.erb
+++ b/app/components/ui/time/component_preview/default.html.erb
@@ -17,27 +17,27 @@
 
 <p id="current-time">
   <span class="tw:text-sm tw:opacity-65">Current time:</span>
-  <%= render(UI::Time::Component.new(time: Time.current)) %>
+  <%= render(UI::Time::Component.new(time: ::Time.current)) %>
 </p>
 
 <p>
   <span class="tw:text-sm tw:opacity-65">Yesterday:</span>
-  <%= render(UI::Time::Component.new(time: Time.current - 1.day)) %>
+  <%= render(UI::Time::Component.new(time: ::Time.current - 1.day)) %>
 </p>
 
 <p>
   <span class="tw:text-sm tw:opacity-65">Tomorrow:</span>
-  <%= render(UI::Time::Component.new(time: Time.current + 1.day)) %>
+  <%= render(UI::Time::Component.new(time: ::Time.current + 1.day)) %>
 </p>
 
 <p>
   <span class="tw:text-sm tw:opacity-65">One week ago:</span>
-  <%= render(UI::Time::Component.new(time: Time.current - 7.days)) %>
+  <%= render(UI::Time::Component.new(time: ::Time.current - 7.days)) %>
 </p>
 
 <p>
   <span class="tw:text-sm tw:opacity-65">One year ago:</span>
-  <%= render(UI::Time::Component.new(time: Time.current - 1.year)) %>
+  <%= render(UI::Time::Component.new(time: ::Time.current - 1.year)) %>
 </p>
 
 <h6 class="tw:mt-5 tw:mb-1 tw:text-sm tw:opacity-65">
@@ -46,10 +46,10 @@
 
 <p>
   <span class="tw:text-sm tw:opacity-65">Yesterday (precise time):</span>
-  <%= render(UI::Time::Component.new(time: Time.current - 1.day, format: :localize_time_precise)) %>
+  <%= render(UI::Time::Component.new(time: ::Time.current - 1.day, format: :localize_time_precise)) %>
 </p>
 
 <p>
   <span class="tw:text-sm tw:opacity-65">One year ago (precise time):</span>
-  <%= render(UI::Time::Component.new(time: Time.current - 1.year, format: :localize_time_precise)) %>
+  <%= render(UI::Time::Component.new(time: ::Time.current - 1.year, format: :localize_time_precise)) %>
 </p>

--- a/app/components/ui/time_localizer/component_preview.rb
+++ b/app/components/ui/time_localizer/component_preview.rb
@@ -2,10 +2,12 @@
 
 # NOTE: this component is here for testing. It uses the same time_localizer.js setup as everything else
 
-module UI::TimeLocalizer
-  class ComponentPreview < ApplicationComponentPreview
-    def default(time_zone: nil)
-      {template: "ui/time_localizer/component_preview/default", locals: {time_zone:}}
+module UI
+  module TimeLocalizer
+    class ComponentPreview < ApplicationComponentPreview
+      def default(time_zone: nil)
+        {template: "ui/time_localizer/component_preview/default", locals: {time_zone:}}
+      end
     end
   end
 end

--- a/app/components/ui/time_localizer/component_preview/default.html.erb
+++ b/app/components/ui/time_localizer/component_preview/default.html.erb
@@ -18,7 +18,7 @@
     <span class="tw:text-sm tw:opacity-65">Current time:</span>
 
     <span class="localizeTime">
-      <%= l Time.current, format: :convert_time %>
+      <%= l ::Time.current, format: :convert_time %>
     </span>
   </p>
 </div>
@@ -28,7 +28,7 @@
     <span class="tw:text-sm tw:opacity-65">Yesterday:</span>
 
     <span class="localizeTime">
-      <%= l (Time.current - 1.day), format: :convert_time %>
+      <%= l (::Time.current - 1.day), format: :convert_time %>
     </span>
   </p>
 </div>
@@ -38,7 +38,7 @@
     <span class="tw:text-sm tw:opacity-65">Tomorrow:</span>
 
     <span class="localizeTime">
-      <%= l (Time.current + 1.day), format: :convert_time %>
+      <%= l (::Time.current + 1.day), format: :convert_time %>
     </span>
   </p>
 </div>
@@ -48,7 +48,7 @@
     <span class="tw:text-sm tw:opacity-65">One week ago:</span>
 
     <span class="localizeTime">
-      <%= l (Time.current - 7.days), format: :convert_time %>
+      <%= l (::Time.current - 7.days), format: :convert_time %>
     </span>
   </p>
 </div>
@@ -58,7 +58,7 @@
     <span class="tw:text-sm tw:opacity-65">One year ago:</span>
 
     <span class="localizeTime">
-      <%= l (Time.current - 1.year), format: :convert_time %>
+      <%= l (::Time.current - 1.year), format: :convert_time %>
     </span>
   </p>
 </div>
@@ -68,7 +68,7 @@
     <span class="tw:text-sm tw:opacity-65">Yesterday (precise time):</span>
 
     <span class="localizeTime preciseTime">
-      <%= l (Time.current - 1.day), format: :convert_time %>
+      <%= l (::Time.current - 1.day), format: :convert_time %>
     </span>
   </p>
 </div>
@@ -80,7 +80,7 @@
     </span>
 
     <span class="localizeTime preciseTimeSeconds">
-      <%= l (Time.current - 1.year), format: :convert_time %>
+      <%= l (::Time.current - 1.year), format: :convert_time %>
     </span>
   </p>
 </div>

--- a/app/components/ui/tooltip/component.rb
+++ b/app/components/ui/tooltip/component.rb
@@ -1,21 +1,23 @@
 # frozen_string_literal: true
 
-module UI::Tooltip
-  class Component < ApplicationComponent
-    renders_one :body
+module UI
+  module Tooltip
+    class Component < ApplicationComponent
+      renders_one :body
 
-    def initialize(text: nil)
-      @text = text
-    end
+      def initialize(text: nil)
+        @text = text
+      end
 
-    private
+      private
 
-    def tooltip_body
-      body? ? body : @text
-    end
+      def tooltip_body
+        body? ? body : @text
+      end
 
-    def tooltip_id
-      @tooltip_id ||= "tooltip-#{SecureRandom.hex(4)}"
+      def tooltip_id
+        @tooltip_id ||= "tooltip-#{SecureRandom.hex(4)}"
+      end
     end
   end
 end

--- a/app/components/ui/tooltip/component_preview.rb
+++ b/app/components/ui/tooltip/component_preview.rb
@@ -1,32 +1,34 @@
 # frozen_string_literal: true
 
-module UI::Tooltip
-  class ComponentPreview < ApplicationComponentPreview
-    # @!group Variants
-    def default
-      render(UI::Tooltip::Component.new(text: "5–9 mi")) do
-        content_tag(:i, "", class: "tw:block tw:h-5 tw:w-5 tw:rounded tw:bg-purple-400 tw:dark:bg-purple-700 tw:cursor-help")
+module UI
+  module Tooltip
+    class ComponentPreview < ApplicationComponentPreview
+      # @!group Variants
+      def default
+        render(UI::Tooltip::Component.new(text: "5–9 mi")) do
+          content_tag(:i, "", class: "tw:block tw:h-5 tw:w-5 tw:rounded tw:bg-purple-400 tw:dark:bg-purple-700 tw:cursor-help")
+        end
       end
-    end
 
-    def with_text_trigger
-      render(UI::Tooltip::Component.new(text: "More information about this thing")) do
-        "hover or focus me"
+      def with_text_trigger
+        render(UI::Tooltip::Component.new(text: "More information about this thing")) do
+          "hover or focus me"
+        end
       end
-    end
 
-    def with_body_slot
-      render(UI::Tooltip::Component.new) do |tooltip|
-        tooltip.with_body { '<span class="tooltip-body-imperial">5 mi</span>'.html_safe }
-        "body slot trigger"
+      def with_body_slot
+        render(UI::Tooltip::Component.new) do |tooltip|
+          tooltip.with_body { '<span class="tooltip-body-imperial">5 mi</span>'.html_safe }
+          "body slot trigger"
+        end
       end
-    end
-    # @!endgroup
+      # @!endgroup
 
-    # @!group Combined
-    def multiple
-      render_with_template(template: "ui/tooltip/preview/multiple")
+      # @!group Combined
+      def multiple
+        render_with_template(template: "ui/tooltip/preview/multiple")
+      end
+      # @!endgroup
     end
-    # @!endgroup
   end
 end

--- a/app/components/ui/user_text_block_display/component.rb
+++ b/app/components/ui/user_text_block_display/component.rb
@@ -1,16 +1,18 @@
 # frozen_string_literal: true
 
-module UI::UserTextBlockDisplay
-  class Component < ApplicationComponent
-    def initialize(text: nil, additional_classes: nil, max_height_class: "tw:max-h-80")
-      @text = text&.strip
-      @additional_classes = additional_classes || ""
-      @additional_classes += " #{max_height_class}"
-      @overflow_class = max_height_class.present? ? "tw:overflow-y-auto" : ""
-    end
+module UI
+  module UserTextBlockDisplay
+    class Component < ApplicationComponent
+      def initialize(text: nil, additional_classes: nil, max_height_class: "tw:max-h-80")
+        @text = text&.strip
+        @additional_classes = additional_classes || ""
+        @additional_classes += " #{max_height_class}"
+        @overflow_class = max_height_class.present? ? "tw:overflow-y-auto" : ""
+      end
 
-    def render?
-      @text.present?
+      def render?
+        @text.present?
+      end
     end
   end
 end

--- a/app/components/ui/user_text_block_display/component_preview.rb
+++ b/app/components/ui/user_text_block_display/component_preview.rb
@@ -1,21 +1,23 @@
 # frozen_string_literal: true
 
-module UI::UserTextBlockDisplay
-  class ComponentPreview < ApplicationComponentPreview
-    def default
-      render(UI::UserTextBlockDisplay::Component.new(text:))
-    end
+module UI
+  module UserTextBlockDisplay
+    class ComponentPreview < ApplicationComponentPreview
+      def default
+        render(UI::UserTextBlockDisplay::Component.new(text:))
+      end
 
-    private
+      private
 
-    def text
-      "Same jianbing pabst gorpcore pok pok tracklocross bike lyfe and love" \
-      "\n\nhoodie seitan food truck palo santo, Tbh neutral milk hotel scenester " \
-      "portland bikes and tallbikes and unicycles and banh mi." \
-      "\nAll morn the loss of All City\nall hail the black market" \
-      "\n\nTruffaut polaroid hammock you probably haven't heard of them. Plaid chartreuse austin cold-pressed bruh. Slow-carb tousled iPhone skateboard helvetica 3 wolf moon, hot chicken lyft pork belly solarpunk neutral milk hotel humblebrag taxidermy pinterest. Keytar synth photo booth keffiyeh, twee organic tumblr raw denim butcher DSA leggings YOLO skateboard praxis. PBR&B man braid shabby chic pitchfork. Fam gentrify sartorial gochujang, pop-up copper mug letterpress. You probably haven't heard of them raw denim venmo authentic poutine pok pok gluten-free solarpunk gochujang tattooed kitsch man braid mukbang marxism meditation." \
-      "\n\nChurch-key gluten-free bitters forage asymmetrical, kogi wolf organic mustache. Kickstarter tilde swag flexitarian. Chartreuse lomo godard vibecession +1. Shoreditch blog master cleanse, iceland chillwave farm-to-table small batch." \
-      "\n\nTry-hard coloring book farm-to-table, biodiesel gluten-free hot chicken blackbird spyplane tacos craft beer. Venmo try-hard green juice XOXO. Solarpunk hexagon swag viral, lumbersexual neutra kinfolk irony iPhone post-ironic celiac banjo before they sold out try-hard. Iceland sus taxidermy blackbird spyplane humblebrag bicycle rights pork belly iPhone brunch helvetica sustainable. 8-bit succulents biodiesel, cliche live-edge tonx viral blackbird spyplane leggings yes plz swag. Iceland single-origin coffee banjo taiyaki snackwave tbh biodiesel salvia. Narwhal cupping grailed, schlitz tumblr taxidermy yuccie."
+      def text
+        "Same jianbing pabst gorpcore pok pok tracklocross bike lyfe and love" \
+        "\n\nhoodie seitan food truck palo santo, Tbh neutral milk hotel scenester " \
+        "portland bikes and tallbikes and unicycles and banh mi." \
+        "\nAll morn the loss of All City\nall hail the black market" \
+        "\n\nTruffaut polaroid hammock you probably haven't heard of them. Plaid chartreuse austin cold-pressed bruh. Slow-carb tousled iPhone skateboard helvetica 3 wolf moon, hot chicken lyft pork belly solarpunk neutral milk hotel humblebrag taxidermy pinterest. Keytar synth photo booth keffiyeh, twee organic tumblr raw denim butcher DSA leggings YOLO skateboard praxis. PBR&B man braid shabby chic pitchfork. Fam gentrify sartorial gochujang, pop-up copper mug letterpress. You probably haven't heard of them raw denim venmo authentic poutine pok pok gluten-free solarpunk gochujang tattooed kitsch man braid mukbang marxism meditation." \
+        "\n\nChurch-key gluten-free bitters forage asymmetrical, kogi wolf organic mustache. Kickstarter tilde swag flexitarian. Chartreuse lomo godard vibecession +1. Shoreditch blog master cleanse, iceland chillwave farm-to-table small batch." \
+        "\n\nTry-hard coloring book farm-to-table, biodiesel gluten-free hot chicken blackbird spyplane tacos craft beer. Venmo try-hard green juice XOXO. Solarpunk hexagon swag viral, lumbersexual neutra kinfolk irony iPhone post-ironic celiac banjo before they sold out try-hard. Iceland sus taxidermy blackbird spyplane humblebrag bicycle rights pork belly iPhone brunch helvetica sustainable. 8-bit succulents biodiesel, cliche live-edge tonx viral blackbird spyplane leggings yes plz swag. Iceland single-origin coffee banjo taiyaki snackwave tbh biodiesel salvia. Narwhal cupping grailed, schlitz tumblr taxidermy yuccie."
+      end
     end
   end
 end

--- a/app/controllers/admin/ads_controller.rb
+++ b/app/controllers/admin/ads_controller.rb
@@ -1,52 +1,54 @@
-class Admin::AdsController < Admin::BaseController
-  before_action :find_ad, except: [:index, :new, :create]
-  before_action :find_organizations, only: [:new, :edit]
+module Admin
+  class AdsController < Admin::BaseController
+    before_action :find_ad, except: [:index, :new, :create]
+    before_action :find_organizations, only: [:new, :edit]
 
-  def index
-    @ads = Ad.all
-  end
-
-  def show
-    redirect_to edit_admin_ad_url(@ad)
-  end
-
-  def edit
-  end
-
-  def update
-    if @ad.update(permitted_parameters)
-      flash[:success] = "Ad Saved!"
-      redirect_to admin_ad_url(@ad)
-    else
-      render action: :edit
+    def index
+      @ads = Ad.all
     end
-  end
 
-  def new
-    @ad = Ad.new
-  end
-
-  def create
-    @ad = Ad.create(permitted_parameters)
-    if @ad.save
-      flash[:success] = "Ad Created!"
+    def show
       redirect_to edit_admin_ad_url(@ad)
-    else
-      render action: :new
     end
-  end
 
-  protected
+    def edit
+    end
 
-  def permitted_parameters
-    params.require(:ad).permit(:title, :body, :target_url, :organization_id, :image)
-  end
+    def update
+      if @ad.update(permitted_parameters)
+        flash[:success] = "Ad Saved!"
+        redirect_to admin_ad_url(@ad)
+      else
+        render action: :edit
+      end
+    end
 
-  def find_ad
-    @ad = Ad.find(params[:id])
-  end
+    def new
+      @ad = Ad.new
+    end
 
-  def find_organizations
-    @organizations = Organization.all
+    def create
+      @ad = Ad.create(permitted_parameters)
+      if @ad.save
+        flash[:success] = "Ad Created!"
+        redirect_to edit_admin_ad_url(@ad)
+      else
+        render action: :new
+      end
+    end
+
+    protected
+
+    def permitted_parameters
+      params.require(:ad).permit(:title, :body, :target_url, :organization_id, :image)
+    end
+
+    def find_ad
+      @ad = Ad.find(params[:id])
+    end
+
+    def find_organizations
+      @organizations = Organization.all
+    end
   end
 end

--- a/app/controllers/admin/ambassador_task_assignments_controller.rb
+++ b/app/controllers/admin/ambassador_task_assignments_controller.rb
@@ -1,38 +1,40 @@
-class Admin::AmbassadorTaskAssignmentsController < Admin::BaseController
-  include Binxtils::SortableTable
+module Admin
+  class AmbassadorTaskAssignmentsController < Admin::BaseController
+    include Binxtils::SortableTable
 
-  def index
-    matching_assignments =
-      AmbassadorTaskAssignment
-        .includes(:ambassador_task, ambassador: {organization_roles: :organization})
-        .completed_assignments(filters: filter_params, sort: {sort_column => sort_direction})
+    def index
+      matching_assignments =
+        AmbassadorTaskAssignment
+          .includes(:ambassador_task, ambassador: {organization_roles: :organization})
+          .completed_assignments(filters: filter_params, sort: {sort_column => sort_direction})
 
-    @ambassador_task_assignments =
-      matching_assignments
-    # There aren't many task assignments, so just ignore pagination
-    # Kaminari
-    #   .paginate_array(matching_assignments)
-    #   .page(params.fetch(:page, 1))
-    #   .per(params.fetch(:per_page, 25))
+      @ambassador_task_assignments =
+        matching_assignments
+      # There aren't many task assignments, so just ignore pagination
+      # Kaminari
+      #   .paginate_array(matching_assignments)
+      #   .page(params.fetch(:page, 1))
+      #   .per(params.fetch(:per_page, 25))
+    end
+
+    private
+
+    def sortable_columns
+      %w[completed_at organization_name ambassador_task_title ambassador_name]
+    end
+
+    def filter_params
+      params
+        .permit(:search_organization_id, :search_ambassador_task_id, :search_ambassador_id)
+        .to_h
+        .map { |k, v| [k[/(?<=search_).+/].to_sym, v] }
+        .to_h
+    end
+
+    def organization_filter
+      params[:search_organization_id]
+    end
+
+    helper_method :organization_filter
   end
-
-  private
-
-  def sortable_columns
-    %w[completed_at organization_name ambassador_task_title ambassador_name]
-  end
-
-  def filter_params
-    params
-      .permit(:search_organization_id, :search_ambassador_task_id, :search_ambassador_id)
-      .to_h
-      .map { |k, v| [k[/(?<=search_).+/].to_sym, v] }
-      .to_h
-  end
-
-  def organization_filter
-    params[:search_organization_id]
-  end
-
-  helper_method :organization_filter
 end

--- a/app/controllers/admin/ambassador_tasks_controller.rb
+++ b/app/controllers/admin/ambassador_tasks_controller.rb
@@ -1,54 +1,56 @@
-class Admin::AmbassadorTasksController < Admin::BaseController
-  before_action :find_ambassador_task, only: %w[edit update]
+module Admin
+  class AmbassadorTasksController < Admin::BaseController
+    before_action :find_ambassador_task, only: %w[edit update]
 
-  def index
-    @ambassador_tasks = AmbassadorTask.all.order(created_at: :asc)
-  end
+    def index
+      @ambassador_tasks = AmbassadorTask.all.order(created_at: :asc)
+    end
 
-  def new
-    @ambassador_task = AmbassadorTask.new
-  end
+    def new
+      @ambassador_task = AmbassadorTask.new
+    end
 
-  def create
-    @ambassador_task = AmbassadorTask.new(ambassador_task_params)
+    def create
+      @ambassador_task = AmbassadorTask.new(ambassador_task_params)
 
-    if @ambassador_task.save
+      if @ambassador_task.save
+        redirect_to admin_ambassador_tasks_url
+      else
+        flash.now[:error] = @ambassador_task.errors.full_messages.join("\n")
+        render :new
+      end
+    end
+
+    def edit
+    end
+
+    def update
+      if @ambassador_task.update(ambassador_task_params)
+        redirect_to admin_ambassador_tasks_url
+      else
+        flash.now[:error] = @ambassador_task.errors.full_messages.join("\n")
+        render :edit
+      end
+    end
+
+    def destroy
+      ambassador_task = AmbassadorTask.find_by(id: params[:id])
+
+      unless ambassador_task&.destroy
+        flash[:error] = "Could not delete ambassador task."
+      end
+
       redirect_to admin_ambassador_tasks_url
-    else
-      flash.now[:error] = @ambassador_task.errors.full_messages.join("\n")
-      render :new
-    end
-  end
-
-  def edit
-  end
-
-  def update
-    if @ambassador_task.update(ambassador_task_params)
-      redirect_to admin_ambassador_tasks_url
-    else
-      flash.now[:error] = @ambassador_task.errors.full_messages.join("\n")
-      render :edit
-    end
-  end
-
-  def destroy
-    ambassador_task = AmbassadorTask.find_by(id: params[:id])
-
-    unless ambassador_task&.destroy
-      flash[:error] = "Could not delete ambassador task."
     end
 
-    redirect_to admin_ambassador_tasks_url
-  end
+    private
 
-  private
+    def ambassador_task_params
+      params.require(:ambassador_task).permit(:title, :description)
+    end
 
-  def ambassador_task_params
-    params.require(:ambassador_task).permit(:title, :description)
-  end
-
-  def find_ambassador_task
-    @ambassador_task = AmbassadorTask.find(params[:id])
+    def find_ambassador_task
+      @ambassador_task = AmbassadorTask.find(params[:id])
+    end
   end
 end

--- a/app/controllers/admin/b_params_controller.rb
+++ b/app/controllers/admin/b_params_controller.rb
@@ -1,38 +1,40 @@
-class Admin::BParamsController < Admin::BaseController
-  include Binxtils::SortableTable
+module Admin
+  class BParamsController < Admin::BaseController
+    include Binxtils::SortableTable
 
-  def index
-    @per_page = permitted_per_page
-    @pagy, @b_params = pagy(:countish, matching_b_params
-      .includes(:creator, :organization)
-      .reorder("b_params.#{sort_column} #{sort_direction}"), limit: @per_page, page: permitted_page)
-  end
-
-  def show
-    @b_param = BParam.find(params[:id])
-  end
-
-  helper_method :matching_b_params
-
-  private
-
-  def sortable_columns
-    %w[created_at updated_at creator_id origin created_bike_id email]
-  end
-
-  def matching_b_params
-    matching_b_params = BParam
-    if params[:search_completeness] == "only_incomplete"
-      @search_completeness = "only_incomplete"
-      matching_b_params = matching_b_params.without_bike
-    elsif params[:search_completeness] == "only_complete"
-      @search_completeness = "only_succeeded"
-      matching_b_params = matching_b_params.with_bike
-    else
-      @search_completeness = "all"
+    def index
+      @per_page = permitted_per_page
+      @pagy, @b_params = pagy(:countish, matching_b_params
+        .includes(:creator, :organization)
+        .reorder("b_params.#{sort_column} #{sort_direction}"), limit: @per_page, page: permitted_page)
     end
-    matching_b_params = matching_b_params.where(organization_id: current_organization.id) if params[:organization_id].present?
-    matching_b_params = matching_b_params.email_search(params[:query]) if params[:query].present?
-    matching_b_params.where(created_at: @time_range)
+
+    def show
+      @b_param = BParam.find(params[:id])
+    end
+
+    helper_method :matching_b_params
+
+    private
+
+    def sortable_columns
+      %w[created_at updated_at creator_id origin created_bike_id email]
+    end
+
+    def matching_b_params
+      matching_b_params = BParam
+      if params[:search_completeness] == "only_incomplete"
+        @search_completeness = "only_incomplete"
+        matching_b_params = matching_b_params.without_bike
+      elsif params[:search_completeness] == "only_complete"
+        @search_completeness = "only_succeeded"
+        matching_b_params = matching_b_params.with_bike
+      else
+        @search_completeness = "all"
+      end
+      matching_b_params = matching_b_params.where(organization_id: current_organization.id) if params[:organization_id].present?
+      matching_b_params = matching_b_params.email_search(params[:query]) if params[:query].present?
+      matching_b_params.where(created_at: @time_range)
+    end
   end
 end

--- a/app/controllers/admin/base_controller.rb
+++ b/app/controllers/admin/base_controller.rb
@@ -1,71 +1,73 @@
-class Admin::BaseController < ApplicationController
-  before_action :require_index_admin!
-  layout "admin"
-  DEFAULT_SEARCH_STATUSES = %w[
-    stolen with_owner abandoned impounded unregistered_parking_notification
-  ].freeze
+module Admin
+  class BaseController < ApplicationController
+    before_action :require_index_admin!
+    layout "admin"
+    DEFAULT_SEARCH_STATUSES = %w[
+      stolen with_owner abandoned impounded unregistered_parking_notification
+    ].freeze
 
-  # Permit viewing deleted organizations
-  def current_organization
-    return @current_organization if defined?(@current_organization)
-    return @current_organization = nil if params[:organization_id] == "none" # manual nil organization setting
+    # Permit viewing deleted organizations
+    def current_organization
+      return @current_organization if defined?(@current_organization)
+      return @current_organization = nil if params[:organization_id] == "none" # manual nil organization setting
 
-    @current_organization = Organization.unscoped.friendly_find(params[:organization_id])
-    set_passive_organization(@current_organization)
-  end
-
-  private
-
-  def search_deleted_scope(scope)
-    @render_deleted = %w[including only].include?(params[:search_deleted]) ? params[:search_deleted] : false
-    case @render_deleted
-    when "only" then scope.only_deleted
-    when "including" then scope.with_deleted
-    else scope
-    end
-  end
-
-  def admin_search_bike_statuses(bikes, default_statuses: nil)
-    # Search ignored overrides status searches
-    @ignored_only = Binxtils::InputNormalizer.boolean(params[:search_ignored])
-    return bikes.ignored if @ignored_only
-
-    @searched_statuses = params.keys.select do |k|
-      k.start_with?("search_status_") && Binxtils::InputNormalizer.boolean(params[k])
-    end.map { |k| k.gsub(/\Asearch_status_/, "") }
-    @default_statuses = default_statuses || DEFAULT_SEARCH_STATUSES
-    @searched_statuses = @default_statuses if @searched_statuses.blank?
-    @not_default_statuses = @searched_statuses != @default_statuses
-
-    if @searched_statuses.include?("example_only")
-      bikes = bikes.where(example: true)
-    elsif !@searched_statuses.include?("example")
-      bikes = bikes.where(example: false)
+      @current_organization = Organization.unscoped.friendly_find(params[:organization_id])
+      set_passive_organization(@current_organization)
     end
 
-    if @searched_statuses.include?("spam_only")
-      bikes = bikes.where(likely_spam: true)
-    elsif !@searched_statuses.include?("spam")
-      bikes = bikes.where(likely_spam: false)
+    private
+
+    def search_deleted_scope(scope)
+      @render_deleted = %w[including only].include?(params[:search_deleted]) ? params[:search_deleted] : false
+      case @render_deleted
+      when "only" then scope.only_deleted
+      when "including" then scope.with_deleted
+      else scope
+      end
     end
 
-    if @searched_statuses.include?("deleted_only")
-      bikes = bikes.where.not(deleted_at: nil)
-    elsif !@searched_statuses.include?("deleted")
-      bikes = bikes.where(deleted_at: nil)
+    def admin_search_bike_statuses(bikes, default_statuses: nil)
+      # Search ignored overrides status searches
+      @ignored_only = Binxtils::InputNormalizer.boolean(params[:search_ignored])
+      return bikes.ignored if @ignored_only
+
+      @searched_statuses = params.keys.select do |k|
+        k.start_with?("search_status_") && Binxtils::InputNormalizer.boolean(params[k])
+      end.map { |k| k.gsub(/\Asearch_status_/, "") }
+      @default_statuses = default_statuses || DEFAULT_SEARCH_STATUSES
+      @searched_statuses = @default_statuses if @searched_statuses.blank?
+      @not_default_statuses = @searched_statuses != @default_statuses
+
+      if @searched_statuses.include?("example_only")
+        bikes = bikes.where(example: true)
+      elsif !@searched_statuses.include?("example")
+        bikes = bikes.where(example: false)
+      end
+
+      if @searched_statuses.include?("spam_only")
+        bikes = bikes.where(likely_spam: true)
+      elsif !@searched_statuses.include?("spam")
+        bikes = bikes.where(likely_spam: false)
+      end
+
+      if @searched_statuses.include?("deleted_only")
+        bikes = bikes.where.not(deleted_at: nil)
+      elsif !@searched_statuses.include?("deleted")
+        bikes = bikes.where(deleted_at: nil)
+      end
+
+      bike_statuses = bike_search_statuses(@searched_statuses)
+      bikes.where(status: bike_statuses)
     end
 
-    bike_statuses = bike_search_statuses(@searched_statuses)
-    bikes.where(status: bike_statuses)
-  end
-
-  # Match the statuses with bike statuses
-  def bike_search_statuses(searched_statuses)
-    bike_statuses = searched_statuses.map do |k|
-      (k == "unregistered_parking_notification") ? k : "status_#{k}"
+    # Match the statuses with bike statuses
+    def bike_search_statuses(searched_statuses)
+      bike_statuses = searched_statuses.map do |k|
+        (k == "unregistered_parking_notification") ? k : "status_#{k}"
+      end
+      statuses = bike_statuses & Bike.statuses
+      # Return all bike statuses if there are no matches (e.g. searching for "deleted_only")
+      statuses.any? ? statuses : Bike.statuses
     end
-    statuses = bike_statuses & Bike.statuses
-    # Return all bike statuses if there are no matches (e.g. searching for "deleted_only")
-    statuses.any? ? statuses : Bike.statuses
   end
 end

--- a/app/controllers/admin/bike_organization_notes_controller.rb
+++ b/app/controllers/admin/bike_organization_notes_controller.rb
@@ -1,53 +1,55 @@
 # frozen_string_literal: true
 
-class Admin::BikeOrganizationNotesController < Admin::BaseController
-  include Binxtils::SortableTable
+module Admin
+  class BikeOrganizationNotesController < Admin::BaseController
+    include Binxtils::SortableTable
 
-  def index
-    @per_page = permitted_per_page(default: 50)
-    @pagy, @collection = pagy(:countish,
-      matching_bike_organization_notes.includes(:user, :bike, :organization).reorder(sortable_opts),
-      limit: @per_page,
-      page: permitted_page)
-  end
-
-  def show
-    @bike_organization_note = BikeOrganizationNote.find(params[:id])
-  end
-
-  helper_method :matching_bike_organization_notes
-
-  private
-
-  def sortable_columns
-    %w[created_at updated_at user_id bike_id organization_id].freeze
-  end
-
-  def sortable_opts
-    "bike_organization_notes.#{sort_column} #{sort_direction}"
-  end
-
-  def earliest_period_date
-    BikeOrganizationNote.minimum(:created_at) || Time.current
-  end
-
-  def matching_bike_organization_notes
-    bike_organization_notes = BikeOrganizationNote.all
-
-    if params[:user_id].present?
-      bike_organization_notes = bike_organization_notes.where(user_id: user_subject&.id || params[:user_id])
+    def index
+      @per_page = permitted_per_page(default: 50)
+      @pagy, @collection = pagy(:countish,
+        matching_bike_organization_notes.includes(:user, :bike, :organization).reorder(sortable_opts),
+        limit: @per_page,
+        page: permitted_page)
     end
 
-    if params[:search_organization_id].present?
-      bike_organization_notes = bike_organization_notes.where(organization_id: params[:search_organization_id])
+    def show
+      @bike_organization_note = BikeOrganizationNote.find(params[:id])
     end
 
-    if params[:search_bike_id].present?
-      bike_organization_notes = bike_organization_notes.where(bike_id: params[:search_bike_id])
+    helper_method :matching_bike_organization_notes
+
+    private
+
+    def sortable_columns
+      %w[created_at updated_at user_id bike_id organization_id].freeze
     end
 
-    @time_range_column = sort_column if %w[updated_at].include?(sort_column)
-    @time_range_column ||= "created_at"
-    bike_organization_notes.where(@time_range_column => @time_range)
+    def sortable_opts
+      "bike_organization_notes.#{sort_column} #{sort_direction}"
+    end
+
+    def earliest_period_date
+      BikeOrganizationNote.minimum(:created_at) || Time.current
+    end
+
+    def matching_bike_organization_notes
+      bike_organization_notes = BikeOrganizationNote.all
+
+      if params[:user_id].present?
+        bike_organization_notes = bike_organization_notes.where(user_id: user_subject&.id || params[:user_id])
+      end
+
+      if params[:search_organization_id].present?
+        bike_organization_notes = bike_organization_notes.where(organization_id: params[:search_organization_id])
+      end
+
+      if params[:search_bike_id].present?
+        bike_organization_notes = bike_organization_notes.where(bike_id: params[:search_bike_id])
+      end
+
+      @time_range_column = sort_column if %w[updated_at].include?(sort_column)
+      @time_range_column ||= "created_at"
+      bike_organization_notes.where(@time_range_column => @time_range)
+    end
   end
 end

--- a/app/controllers/admin/bike_sticker_updates_controller.rb
+++ b/app/controllers/admin/bike_sticker_updates_controller.rb
@@ -1,64 +1,66 @@
-class Admin::BikeStickerUpdatesController < Admin::BaseController
-  include Binxtils::SortableTable
+module Admin
+  class BikeStickerUpdatesController < Admin::BaseController
+    include Binxtils::SortableTable
 
-  def index
-    @per_page = permitted_per_page
-    @pagy, @bike_sticker_updates =
-      pagy(:countish, matching_bike_sticker_updates
-        .reorder("bike_sticker_updates.#{sort_column} #{sort_direction}")
-        .includes(:organization, :user, :bike), limit: @per_page, page: permitted_page)
-  end
-
-  helper_method :matching_bike_sticker_updates
-
-  private
-
-  def sortable_columns
-    %w[created_at kind creator_kind update_number organization_kind bike_id bike_sticker_id organization_id user_id]
-  end
-
-  def earliest_period_date
-    BikeStickerUpdate.minimum(:created_at)
-  end
-
-  def matching_bike_sticker_updates
-    bike_sticker_updates = BikeStickerUpdate.all
-    bike_stickers = BikeSticker.all
-    if params[:organization_id] == "none"
-      bike_sticker_updates = bike_sticker_updates.where(organization_id: nil)
-    elsif current_organization.present?
-      bike_sticker_updates = bike_sticker_updates.where(organization_id: current_organization.id)
-      bike_stickers = bike_stickers.where(organization_id: current_organization.id)
-    end
-    if params[:search_kind].present? && BikeStickerUpdate.kinds.include?(params[:search_kind])
-      @search_kind = params[:search_kind]
-      bike_sticker_updates = bike_sticker_updates.where(kind: @search_kind)
-    else
-      @search_kind = "all"
-    end
-    if params[:search_organization_kind].present? && BikeStickerUpdate.organization_kinds.include?(params[:search_kind])
-      @search_organization_kind = params[:search_organization_kind]
-      bike_sticker_updates = bike_sticker_updates.where(kind: @search_organization_kind)
-    else
-      @search_organization_kind = "all"
-    end
-    if params[:search_creator_kind].present? && BikeStickerUpdate.creator_kinds.include?(params[:search_creator_kind])
-      @search_creator_kind = params[:search_creator_kind]
-      bike_sticker_updates = bike_sticker_updates.where(creator_kind: @search_creator_kind)
-    else
-      @search_creator_kind = "all"
-    end
-    if params[:user_id].present?
-      bike_sticker_updates = bike_sticker_updates.where(user_id: user_subject&.id || params[:user_id])
+    def index
+      @per_page = permitted_per_page
+      @pagy, @bike_sticker_updates =
+        pagy(:countish, matching_bike_sticker_updates
+          .reorder("bike_sticker_updates.#{sort_column} #{sort_direction}")
+          .includes(:organization, :user, :bike), limit: @per_page, page: permitted_page)
     end
 
-    if params[:search_bike_sticker_id].present?
-      @searched_bike_stickers = BikeSticker.where(id: params[:search_bike_sticker_id])
-      bike_sticker_updates = bike_sticker_updates.where(bike_sticker_id: @searched_bike_stickers.pluck(:id))
-    elsif params[:search_query].present?
-      @searched_bike_stickers = bike_stickers.sticker_code_search(params[:search_query])
-      bike_sticker_updates = bike_sticker_updates.where(bike_sticker_id: @searched_bike_stickers.pluck(:id))
+    helper_method :matching_bike_sticker_updates
+
+    private
+
+    def sortable_columns
+      %w[created_at kind creator_kind update_number organization_kind bike_id bike_sticker_id organization_id user_id]
     end
-    bike_sticker_updates.where(created_at: @time_range)
+
+    def earliest_period_date
+      BikeStickerUpdate.minimum(:created_at)
+    end
+
+    def matching_bike_sticker_updates
+      bike_sticker_updates = BikeStickerUpdate.all
+      bike_stickers = BikeSticker.all
+      if params[:organization_id] == "none"
+        bike_sticker_updates = bike_sticker_updates.where(organization_id: nil)
+      elsif current_organization.present?
+        bike_sticker_updates = bike_sticker_updates.where(organization_id: current_organization.id)
+        bike_stickers = bike_stickers.where(organization_id: current_organization.id)
+      end
+      if params[:search_kind].present? && BikeStickerUpdate.kinds.include?(params[:search_kind])
+        @search_kind = params[:search_kind]
+        bike_sticker_updates = bike_sticker_updates.where(kind: @search_kind)
+      else
+        @search_kind = "all"
+      end
+      if params[:search_organization_kind].present? && BikeStickerUpdate.organization_kinds.include?(params[:search_kind])
+        @search_organization_kind = params[:search_organization_kind]
+        bike_sticker_updates = bike_sticker_updates.where(kind: @search_organization_kind)
+      else
+        @search_organization_kind = "all"
+      end
+      if params[:search_creator_kind].present? && BikeStickerUpdate.creator_kinds.include?(params[:search_creator_kind])
+        @search_creator_kind = params[:search_creator_kind]
+        bike_sticker_updates = bike_sticker_updates.where(creator_kind: @search_creator_kind)
+      else
+        @search_creator_kind = "all"
+      end
+      if params[:user_id].present?
+        bike_sticker_updates = bike_sticker_updates.where(user_id: user_subject&.id || params[:user_id])
+      end
+
+      if params[:search_bike_sticker_id].present?
+        @searched_bike_stickers = BikeSticker.where(id: params[:search_bike_sticker_id])
+        bike_sticker_updates = bike_sticker_updates.where(bike_sticker_id: @searched_bike_stickers.pluck(:id))
+      elsif params[:search_query].present?
+        @searched_bike_stickers = bike_stickers.sticker_code_search(params[:search_query])
+        bike_sticker_updates = bike_sticker_updates.where(bike_sticker_id: @searched_bike_stickers.pluck(:id))
+      end
+      bike_sticker_updates.where(created_at: @time_range)
+    end
   end
 end

--- a/app/controllers/admin/bike_stickers_controller.rb
+++ b/app/controllers/admin/bike_stickers_controller.rb
@@ -1,174 +1,176 @@
-class Admin::BikeStickersController < Admin::BaseController
-  include Binxtils::SortableTable
+module Admin
+  class BikeStickersController < Admin::BaseController
+    include Binxtils::SortableTable
 
-  def index
-    @pagy, @bike_stickers = scoped_bike_stickers(matching_bike_stickers)
+    def index
+      @pagy, @bike_stickers = scoped_bike_stickers(matching_bike_stickers)
 
-    @bike_sticker_batches = if @bike_sticker_batch.present?
-      [@bike_sticker_batch]
-    elsif @matching_batches
-      BikeStickerBatch.where(id: matching_bike_stickers.reorder(:bike_sticker_batch_id).distinct.pluck(:bike_sticker_batch_id))
-        .reorder(id: :desc)
-        .includes(:organization)
-    else
-      @all_batches = Binxtils::InputNormalizer.boolean(params[:search_all_batches])
-      batches = BikeStickerBatch.reorder(id: :desc).includes(:organization)
-      @all_batches ? batches : batches.limit(5)
+      @bike_sticker_batches = if @bike_sticker_batch.present?
+        [@bike_sticker_batch]
+      elsif @matching_batches
+        BikeStickerBatch.where(id: matching_bike_stickers.reorder(:bike_sticker_batch_id).distinct.pluck(:bike_sticker_batch_id))
+          .reorder(id: :desc)
+          .includes(:organization)
+      else
+        @all_batches = Binxtils::InputNormalizer.boolean(params[:search_all_batches])
+        batches = BikeStickerBatch.reorder(id: :desc).includes(:organization)
+        @all_batches ? batches : batches.limit(5)
+      end
     end
-  end
 
-  def new
-    @bike_sticker_batch ||= BikeStickerBatch.new
-    @bike_sticker_batch.organization ||= current_organization
-    @bike_sticker_batch.initial_code_integer ||= 1
-    @organizations = Organization.all
-  end
-
-  def create
-    create_batch_if_valid!
-    if @bike_sticker_batch.id.present?
-      flash[:success] = "Batch ##{@bike_sticker_batch.id} created. Please wait a few minutes for the stickers to finish creating"
-      CreateBikeStickerCodesJob.perform_async(@bike_sticker_batch.id,
-        @bike_sticker_batch.stickers_to_create_count, @bike_sticker_batch.initial_code_integer)
-      redirect_to admin_bike_stickers_path(search_bike_sticker_batch_id: @bike_sticker_batch.id)
-    else
+    def new
+      @bike_sticker_batch ||= BikeStickerBatch.new
+      @bike_sticker_batch.organization ||= current_organization
+      @bike_sticker_batch.initial_code_integer ||= 1
       @organizations = Organization.all
-      render :new
     end
-  end
 
-  def reassign
-    @pagy, @bike_stickers = scoped_bike_stickers(selected_bike_stickers)
-    # Check that the selection matches our criteria
-    @valid_selection = @bike_sticker1.present? &&
-      selected_bike_stickers.count > 0 &&
-      selected_bike_stickers.count <= max_reassign_size &&
-      params[:organization_id].present? &&
-      params[:search_bike_sticker_batch_id].present?
-    # update if possible
-    if @valid_selection && Binxtils::InputNormalizer.boolean(params[:reassign_now])
-      AdminReassignBikeStickerCodesJob.perform_async(current_user.id,
-        current_organization.id,
-        @bike_sticker_batch.id,
-        @bike_sticker1&.id,
-        @bike_sticker2&.id)
-      flash[:success] = "Reassigning organization! Please wait a few minutes for the stickers to finish updating"
-      redirect_to admin_bike_stickers_path
-      return
-    end
-    @bike_sticker_batches = if @bike_sticker_batch.present?
-      [@bike_sticker_batch]
-    else
-      BikeStickerBatch.where(organization_id: 1).reorder(id: :desc)
-    end
-  end
-
-  helper_method :matching_bike_stickers, :max_reassign_size, :selected_bike_stickers
-
-  private
-
-  def max_reassign_size
-    1000
-  end
-
-  def sortable_columns
-    %w[created_at updated_at claimed_at code_integer organization_id bike_sticker_batch_id]
-  end
-
-  def default_column
-    (action_name == "reassign") ? "code_integer" : sortable_columns.first
-  end
-
-  def default_direction
-    (action_name == "reassign") ? "asc" : "desc"
-  end
-
-  def matching_bike_stickers
-    return @matching_bike_stickers if defined?(@matching_bike_stickers)
-
-    bike_stickers = BikeSticker.all
-    if current_organization.present?
-      @matching_batches = true
-      bike_stickers = bike_stickers.where(organization_id: current_organization.id)
-    end
-    if params[:search_bike_sticker_batch_id].present?
-      @bike_sticker_batch = BikeStickerBatch.find(params[:search_bike_sticker_batch_id].to_i)
-      bike_stickers = bike_stickers.where(bike_sticker_batch_id: @bike_sticker_batch.id)
-    end
-    if params[:search_claimed].present? || sort_column == "claimed_at"
-      @search_claimed = true
-      @matching_batches = true
-      bike_stickers = bike_stickers.claimed
-    end
-    if params[:search_query].present?
-      @matching_batches = true
-      bike_stickers = bike_stickers.sticker_code_search(params[:search_query])
-    end
-    @time_range_column = sort_column if %w[created_at updated_at claimed_at].include?(sort_column)
-    @time_range_column ||= "created_at"
-    @matching_bike_stickers = bike_stickers.where(@time_range_column => @time_range)
-  end
-
-  def selected_bike_stickers
-    return @selected_bike_stickers if defined?(@selected_bike_stickers)
-
-    bike_stickers = BikeSticker.all
-    if params[:search_sticker1].present?
-      @bike_sticker1 = bike_stickers.lookup(params[:search_sticker1])
-      if @bike_sticker1.present?
-        bike_stickers = bike_stickers.where("code_integer >= ?", @bike_sticker1.code_integer)
+    def create
+      create_batch_if_valid!
+      if @bike_sticker_batch.id.present?
+        flash[:success] = "Batch ##{@bike_sticker_batch.id} created. Please wait a few minutes for the stickers to finish creating"
+        CreateBikeStickerCodesJob.perform_async(@bike_sticker_batch.id,
+          @bike_sticker_batch.stickers_to_create_count, @bike_sticker_batch.initial_code_integer)
+        redirect_to admin_bike_stickers_path(search_bike_sticker_batch_id: @bike_sticker_batch.id)
+      else
+        @organizations = Organization.all
+        render :new
       end
     end
-    if params[:search_sticker2].present?
-      @bike_sticker2 = bike_stickers.lookup(params[:search_sticker2])
-      if @bike_sticker2.present?
-        bike_stickers = bike_stickers.where("code_integer <= ?", @bike_sticker2.code_integer)
+
+    def reassign
+      @pagy, @bike_stickers = scoped_bike_stickers(selected_bike_stickers)
+      # Check that the selection matches our criteria
+      @valid_selection = @bike_sticker1.present? &&
+        selected_bike_stickers.count > 0 &&
+        selected_bike_stickers.count <= max_reassign_size &&
+        params[:organization_id].present? &&
+        params[:search_bike_sticker_batch_id].present?
+      # update if possible
+      if @valid_selection && Binxtils::InputNormalizer.boolean(params[:reassign_now])
+        AdminReassignBikeStickerCodesJob.perform_async(current_user.id,
+          current_organization.id,
+          @bike_sticker_batch.id,
+          @bike_sticker1&.id,
+          @bike_sticker2&.id)
+        flash[:success] = "Reassigning organization! Please wait a few minutes for the stickers to finish updating"
+        redirect_to admin_bike_stickers_path
+        return
+      end
+      @bike_sticker_batches = if @bike_sticker_batch.present?
+        [@bike_sticker_batch]
+      else
+        BikeStickerBatch.where(organization_id: 1).reorder(id: :desc)
       end
     end
-    # Assign batch based on passed sticker id or  the first sticker found
-    if params[:search_bike_sticker_batch_id].present?
-      @bike_sticker_batch = BikeStickerBatch.find(params[:search_bike_sticker_batch_id])
-    elsif @bike_sticker_batch.blank? && (@bike_sticker1.present? || @bike_sticker2.present?)
-      @bike_sticker_batch = @bike_sticker1&.bike_sticker_batch || @bike_sticker2&.bike_sticker_batch
+
+    helper_method :matching_bike_stickers, :max_reassign_size, :selected_bike_stickers
+
+    private
+
+    def max_reassign_size
+      1000
     end
 
-    bike_stickers = bike_stickers.where(bike_sticker_batch_id: @bike_sticker_batch.id) if @bike_sticker_batch.present?
-    @selected_bike_stickers = bike_stickers
-  end
-
-  def scoped_bike_stickers(stickers)
-    @per_page = permitted_per_page
-    pagy(:countish, stickers.reorder("bike_stickers.#{sort_column} #{sort_direction}")
-      .includes(:organization, :bike_sticker_batch, :bike_sticker_updates, :bike), limit: @per_page, page: permitted_page)
-  end
-
-  def permitted_parameters
-    params.require(:bike_sticker_batch)
-      .permit(:notes, :prefix, :initial_code_integer, :stickers_to_create_count,
-        :organization_id, :code_number_length)
-      .merge(user_id: current_user.id)
-  end
-
-  def create_batch_if_valid!
-    @bike_sticker_batch = BikeStickerBatch.new(permitted_parameters)
-    @bike_sticker_batch.validate
-    unless @bike_sticker_batch.stickers_to_create_count.to_i > 0
-      @bike_sticker_batch.errors.add(:base, "Number of stickers to create is required")
-    end
-    if @bike_sticker_batch.organization_id.blank?
-      @bike_sticker_batch.errors.add(:organization_id, "Organization required")
+    def sortable_columns
+      %w[created_at updated_at claimed_at code_integer organization_id bike_sticker_batch_id]
     end
 
-    if @bike_sticker_batch.prefix.blank?
-      @bike_sticker_batch.errors.add(:prefix, "Prefix is required")
-    else
-      overlapping_batches = BikeStickerBatch.where(prefix: @bike_sticker_batch.prefix).select do |batch|
-        @bike_sticker_batch.initial_code_integer.between?(batch.min_code_integer, batch.max_code_integer)
+    def default_column
+      (action_name == "reassign") ? "code_integer" : sortable_columns.first
+    end
+
+    def default_direction
+      (action_name == "reassign") ? "asc" : "desc"
+    end
+
+    def matching_bike_stickers
+      return @matching_bike_stickers if defined?(@matching_bike_stickers)
+
+      bike_stickers = BikeSticker.all
+      if current_organization.present?
+        @matching_batches = true
+        bike_stickers = bike_stickers.where(organization_id: current_organization.id)
       end
-      overlapping_batches.each { |b| @bike_sticker_batch.errors.add(:base, "Existing sticker batch ##{b.id} has overlapping codes") }
+      if params[:search_bike_sticker_batch_id].present?
+        @bike_sticker_batch = BikeStickerBatch.find(params[:search_bike_sticker_batch_id].to_i)
+        bike_stickers = bike_stickers.where(bike_sticker_batch_id: @bike_sticker_batch.id)
+      end
+      if params[:search_claimed].present? || sort_column == "claimed_at"
+        @search_claimed = true
+        @matching_batches = true
+        bike_stickers = bike_stickers.claimed
+      end
+      if params[:search_query].present?
+        @matching_batches = true
+        bike_stickers = bike_stickers.sticker_code_search(params[:search_query])
+      end
+      @time_range_column = sort_column if %w[created_at updated_at claimed_at].include?(sort_column)
+      @time_range_column ||= "created_at"
+      @matching_bike_stickers = bike_stickers.where(@time_range_column => @time_range)
     end
 
-    @bike_sticker_batch.save unless @bike_sticker_batch.errors.any?
-    @bike_sticker_batch
+    def selected_bike_stickers
+      return @selected_bike_stickers if defined?(@selected_bike_stickers)
+
+      bike_stickers = BikeSticker.all
+      if params[:search_sticker1].present?
+        @bike_sticker1 = bike_stickers.lookup(params[:search_sticker1])
+        if @bike_sticker1.present?
+          bike_stickers = bike_stickers.where("code_integer >= ?", @bike_sticker1.code_integer)
+        end
+      end
+      if params[:search_sticker2].present?
+        @bike_sticker2 = bike_stickers.lookup(params[:search_sticker2])
+        if @bike_sticker2.present?
+          bike_stickers = bike_stickers.where("code_integer <= ?", @bike_sticker2.code_integer)
+        end
+      end
+      # Assign batch based on passed sticker id or  the first sticker found
+      if params[:search_bike_sticker_batch_id].present?
+        @bike_sticker_batch = BikeStickerBatch.find(params[:search_bike_sticker_batch_id])
+      elsif @bike_sticker_batch.blank? && (@bike_sticker1.present? || @bike_sticker2.present?)
+        @bike_sticker_batch = @bike_sticker1&.bike_sticker_batch || @bike_sticker2&.bike_sticker_batch
+      end
+
+      bike_stickers = bike_stickers.where(bike_sticker_batch_id: @bike_sticker_batch.id) if @bike_sticker_batch.present?
+      @selected_bike_stickers = bike_stickers
+    end
+
+    def scoped_bike_stickers(stickers)
+      @per_page = permitted_per_page
+      pagy(:countish, stickers.reorder("bike_stickers.#{sort_column} #{sort_direction}")
+        .includes(:organization, :bike_sticker_batch, :bike_sticker_updates, :bike), limit: @per_page, page: permitted_page)
+    end
+
+    def permitted_parameters
+      params.require(:bike_sticker_batch)
+        .permit(:notes, :prefix, :initial_code_integer, :stickers_to_create_count,
+          :organization_id, :code_number_length)
+        .merge(user_id: current_user.id)
+    end
+
+    def create_batch_if_valid!
+      @bike_sticker_batch = BikeStickerBatch.new(permitted_parameters)
+      @bike_sticker_batch.validate
+      unless @bike_sticker_batch.stickers_to_create_count.to_i > 0
+        @bike_sticker_batch.errors.add(:base, "Number of stickers to create is required")
+      end
+      if @bike_sticker_batch.organization_id.blank?
+        @bike_sticker_batch.errors.add(:organization_id, "Organization required")
+      end
+
+      if @bike_sticker_batch.prefix.blank?
+        @bike_sticker_batch.errors.add(:prefix, "Prefix is required")
+      else
+        overlapping_batches = BikeStickerBatch.where(prefix: @bike_sticker_batch.prefix).select do |batch|
+          @bike_sticker_batch.initial_code_integer.between?(batch.min_code_integer, batch.max_code_integer)
+        end
+        overlapping_batches.each { |b| @bike_sticker_batch.errors.add(:base, "Existing sticker batch ##{b.id} has overlapping codes") }
+      end
+
+      @bike_sticker_batch.save unless @bike_sticker_batch.errors.any?
+      @bike_sticker_batch
+    end
   end
 end

--- a/app/controllers/admin/bike_versions_controller.rb
+++ b/app/controllers/admin/bike_versions_controller.rb
@@ -1,51 +1,53 @@
-class Admin::BikeVersionsController < Admin::BaseController
-  include Binxtils::SortableTable
+module Admin
+  class BikeVersionsController < Admin::BaseController
+    include Binxtils::SortableTable
 
-  def index
-    @per_page = permitted_per_page(default: 50)
-    @pagy, @collection = pagy(:countish,
-      matching_bike_versions.includes(:bike, :owner).reorder(sortable_opts),
-      limit: @per_page,
-      page: permitted_page)
-  end
-
-  def show
-    @bike_version = BikeVersion.unscoped.find(params[:id])
-    @bike = @bike_version.bike
-  end
-
-  helper_method :matching_bike_versions
-
-  protected
-
-  def sortable_columns
-    %w[created_at bike_id owner_id visibility]
-  end
-
-  def sortable_opts
-    "bike_versions.#{sort_column} #{sort_direction}"
-  end
-
-  def earliest_period_date
-    Time.at(1641016800) # 2022-01-01 00:00 - first bike version
-  end
-
-  def matching_bike_versions
-    bike_versions = BikeVersion.unscoped
-
-    if params[:search_bike_id].present?
-      @bike = Bike.unscoped.find_by(id: params[:search_bike_id])
-      bike_versions = bike_versions.where(bike_id: params[:search_bike_id])
+    def index
+      @per_page = permitted_per_page(default: 50)
+      @pagy, @collection = pagy(:countish,
+        matching_bike_versions.includes(:bike, :owner).reorder(sortable_opts),
+        limit: @per_page,
+        page: permitted_page)
     end
 
-    if params[:user_id].present?
-      bike_versions = bike_versions.where(owner_id: user_subject&.id || params[:user_id])
+    def show
+      @bike_version = BikeVersion.unscoped.find(params[:id])
+      @bike = @bike_version.bike
     end
 
-    if params[:search_visibility].present?
-      bike_versions = bike_versions.where(visibility: params[:search_visibility])
+    helper_method :matching_bike_versions
+
+    protected
+
+    def sortable_columns
+      %w[created_at bike_id owner_id visibility]
     end
 
-    bike_versions.where(created_at: @time_range)
+    def sortable_opts
+      "bike_versions.#{sort_column} #{sort_direction}"
+    end
+
+    def earliest_period_date
+      Time.at(1641016800) # 2022-01-01 00:00 - first bike version
+    end
+
+    def matching_bike_versions
+      bike_versions = BikeVersion.unscoped
+
+      if params[:search_bike_id].present?
+        @bike = Bike.unscoped.find_by(id: params[:search_bike_id])
+        bike_versions = bike_versions.where(bike_id: params[:search_bike_id])
+      end
+
+      if params[:user_id].present?
+        bike_versions = bike_versions.where(owner_id: user_subject&.id || params[:user_id])
+      end
+
+      if params[:search_visibility].present?
+        bike_versions = bike_versions.where(visibility: params[:search_visibility])
+      end
+
+      bike_versions.where(created_at: @time_range)
+    end
   end
 end

--- a/app/controllers/admin/bikes_controller.rb
+++ b/app/controllers/admin/bikes_controller.rb
@@ -1,258 +1,260 @@
-class Admin::BikesController < Admin::BaseController
-  include Binxtils::SortableTable
+module Admin
+  class BikesController < Admin::BaseController
+    include Binxtils::SortableTable
 
-  before_action :find_bike, only: %i[edit update show]
-  before_action :set_period, only: %i[index missing_manufacturer]
-  around_action :set_reading_role, only: %i[index show]
+    before_action :find_bike, only: %i[edit update show]
+    before_action :set_period, only: %i[index missing_manufacturer]
+    around_action :set_reading_role, only: %i[index show]
 
-  def index
-    @per_page = permitted_per_page(default: 100)
+    def index
+      @per_page = permitted_per_page(default: 100)
 
-    @pagy, @bikes = pagy(:countish, available_bikes.includes(:creation_organization, :current_ownership, :paint)
-      .reorder("bikes.#{sort_column} #{sort_direction}"), limit: @per_page, page: permitted_page)
-  end
-
-  def missing_manufacturer
-    @per_page = permitted_per_page(default: 100)
-    @pagy, @bikes = pagy(:countish,
-      missing_manufacturer_bikes.includes(:creation_organization, :current_ownership, :paint),
-      limit: @per_page,
-      page: permitted_page)
-  end
-
-  def update_manufacturers
-    if params[:manufacturer_id].present? && params[:bikes_selected].present?
-      manufacturer_id = params[:manufacturer_id]
-      bike_ids = params[:bikes_selected].keys
-      bike_ids.each do |bid|
-        Bike.unscoped.find_by_id(bid)&.update(manufacturer_id: manufacturer_id, manufacturer_other: nil)
-      end
-      # Needs to happen after the manufacturer has been assigned
-      Bike.unscoped.where(id: bike_ids).distinct.pluck(:model_audit_id)
-        .each { |i| UpdateModelAuditJob.perform_async(i) }
-      flash[:success] = "Success. #{bike_ids.count} Bikes updated"
-    else
-      flash[:notice] = "Sorry, you need to add bikes and a manufacturer"
+      @pagy, @bikes = pagy(:countish, available_bikes.includes(:creation_organization, :current_ownership, :paint)
+        .reorder("bikes.#{sort_column} #{sort_direction}"), limit: @per_page, page: permitted_page)
     end
-    redirect_back(fallback_location: root_url)
-  end
 
-  def duplicates
-    duplicate_groups = if params[:show_ignored]
-      DuplicateBikeGroup.order("created_at desc")
-    else
-      DuplicateBikeGroup.unignored.order("created_at desc")
+    def missing_manufacturer
+      @per_page = permitted_per_page(default: 100)
+      @pagy, @bikes = pagy(:countish,
+        missing_manufacturer_bikes.includes(:creation_organization, :current_ownership, :paint),
+        limit: @per_page,
+        page: permitted_page)
     end
-    @per_page = permitted_per_page
-    @duplicate_groups_count = duplicate_groups.size
-    @pagy, @duplicate_groups = pagy(:countish, duplicate_groups, limit: @per_page, page: permitted_page)
-  end
 
-  def ignore_duplicate_toggle
-    duplicate_bike_group = DuplicateBikeGroup.find(params[:id])
-    duplicate_bike_group.ignore = !duplicate_bike_group.ignore
-    duplicate_bike_group.save
-    flash[:success] = "Successfully marked #{duplicate_bike_group.segment} #{duplicate_bike_group.ignore ? "ignored" : "Un-ignored"}"
-    redirect_back(fallback_location: root_url)
-  end
-
-  def destroy
-    destroy_bike
-  end
-
-  def get_destroy
-    if params[:id] == "multi_delete"
-      bike_ids = defined?(params[:bikes_selected].keys) ? params[:bikes_selected].keys : params[:bikes_selected]
-      if bike_ids.any?
-        bike_ids.each { |id| BikeDeleterJob.perform_async(id.to_i, false, current_user.id) }
-        flash[:success] = "#{bike_ids.count} #{"bike".pluralize(bike_ids.count)} deleted!"
+    def update_manufacturers
+      if params[:manufacturer_id].present? && params[:bikes_selected].present?
+        manufacturer_id = params[:manufacturer_id]
+        bike_ids = params[:bikes_selected].keys
+        bike_ids.each do |bid|
+          Bike.unscoped.find_by_id(bid)&.update(manufacturer_id: manufacturer_id, manufacturer_other: nil)
+        end
+        # Needs to happen after the manufacturer has been assigned
+        Bike.unscoped.where(id: bike_ids).distinct.pluck(:model_audit_id)
+          .each { |i| UpdateModelAuditJob.perform_async(i) }
+        flash[:success] = "Success. #{bike_ids.count} Bikes updated"
       else
-        flash[:error] = "No bikes selected to delete!"
+        flash[:notice] = "Sorry, you need to add bikes and a manufacturer"
       end
-      redirect_back(fallback_location: admin_bikes_url)
-    else
+      redirect_back(fallback_location: root_url)
+    end
+
+    def duplicates
+      duplicate_groups = if params[:show_ignored]
+        DuplicateBikeGroup.order("created_at desc")
+      else
+        DuplicateBikeGroup.unignored.order("created_at desc")
+      end
+      @per_page = permitted_per_page
+      @duplicate_groups_count = duplicate_groups.size
+      @pagy, @duplicate_groups = pagy(:countish, duplicate_groups, limit: @per_page, page: permitted_page)
+    end
+
+    def ignore_duplicate_toggle
+      duplicate_bike_group = DuplicateBikeGroup.find(params[:id])
+      duplicate_bike_group.ignore = !duplicate_bike_group.ignore
+      duplicate_bike_group.save
+      flash[:success] = "Successfully marked #{duplicate_bike_group.segment} #{duplicate_bike_group.ignore ? "ignored" : "Un-ignored"}"
+      redirect_back(fallback_location: root_url)
+    end
+
+    def destroy
       destroy_bike
     end
-  end
 
-  def show
-    @active_tab = params[:active_tab]
-    if @active_tab.present?
-      @page_title = "#{@active_tab.titleize}: #{@bike.title_string}"
-    else
-      redirect_to edit_admin_bike_path and return
-    end
-  end
-
-  def edit
-    @recoveries = @bike.recovered_records
-    @organizations = Organization.all
-  end
-
-  def update
-    update_params = permitted_parameters.except(:stolen_records_attributes)
-    BikeServices::OwnershipTransferer.find_or_create(@bike, updator: current_user,
-      new_owner_email: update_params.delete("owner_email"),
-      skip_email: update_params.delete("skip_email"))
-
-    BikeServices::StolenRecordUpdator.new(bike: @bike, params:).update_records
-
-    if params[:mark_recovered_reason].present?
-      @bike.current_stolen_record.add_recovery_information(
-        recovered_description: params[:mark_recovered_reason],
-        index_helped_recovery: params[:mark_recovered_we_helped],
-        can_share_recovery: params[:can_share_recovery],
-        recovering_user_id: current_user.id
-      )
-    end
-    if @bike.update(update_params)
-      @bike.create_normalized_serial_segments
-      return if return_to_if_present
-
-      flash[:success] = "Bike was successfully updated."
-      redirect_to(edit_admin_bike_url(@bike)) && return
-    else
-      render action: "edit"
-    end
-  end
-
-  def unrecover
-    stolen_record = StolenRecord.unscoped.where(bike_id: params[:bike_id],
-      id: params[:stolen_record_id]).first
-    if stolen_record.present?
-      flash[:success] = "Marked unrecovered!"
-      stolen_record.update(recovered_at: nil, current: true, recovery_link_token: nil)
-    else
-      flash[:error] = "Stolen record not found! Contact a developer"
-    end
-    redirect_to admin_bike_path(params[:bike_id])
-  end
-
-  helper_method :available_bikes
-
-  protected
-
-  def sortable_columns
-    %w[id owner_email manufacturer_id updated_by_user_at]
-  end
-
-  def permitted_parameters
-    params.require(:bike).permit(BikeServices::Creator.old_attr_accessible + [bike_organization_ids: []])
-  end
-
-  def destroy_bike
-    find_bike
-    BikeDeleterJob.new.perform(@bike.id, false, current_user.id)
-    flash[:success] = "Bike deleted!"
-    redirect_to admin_bikes_url
-  end
-
-  def find_bike
-    @bike = Bike.unscoped.find(params[:id])
-  end
-
-  def matching_bikes
-    bikes = if params[:user_id].present?
-      user_subject&.bikes
-    elsif params[:search_phone].present?
-      Bike.search_phone(params[:search_phone])
-    else
-      # This unscopes, so it doesn't work with anything above
-      Bike.unscoped
-    end
-    if params[:search_manufacturer].present?
-      @manufacturer = Manufacturer.friendly_find(params[:search_manufacturer])
-      bikes = if @manufacturer.present?
-        bikes.where(manufacturer_id: @manufacturer&.id)
+    def get_destroy
+      if params[:id] == "multi_delete"
+        bike_ids = defined?(params[:bikes_selected].keys) ? params[:bikes_selected].keys : params[:bikes_selected]
+        if bike_ids.any?
+          bike_ids.each { |id| BikeDeleterJob.perform_async(id.to_i, false, current_user.id) }
+          flash[:success] = "#{bike_ids.count} #{"bike".pluralize(bike_ids.count)} deleted!"
+        else
+          flash[:error] = "No bikes selected to delete!"
+        end
+        redirect_back(fallback_location: admin_bikes_url)
       else
-        bikes.where(mnfg_name: params[:search_manufacturer])
+        destroy_bike
       end
     end
-    if current_organization.present?
-      bikes = if Binxtils::InputNormalizer.boolean(params[:search_only_creation_organization])
-        bikes.includes(:ownerships).where(ownerships: {organization_id: current_organization.id})
+
+    def show
+      @active_tab = params[:active_tab]
+      if @active_tab.present?
+        @page_title = "#{@active_tab.titleize}: #{@bike.title_string}"
       else
-        bikes.organization(current_organization)
+        redirect_to edit_admin_bike_path and return
       end
-    elsif params[:organization_id] == "false"
-      # Have to include deleted_at or else we get nil
-      bikes = bikes.includes(:ownerships).where(deleted_at: nil, ownerships: {organization_id: nil})
     end
 
-    @motorized = Binxtils::InputNormalizer.boolean(params[:search_motorized])
-    bikes = bikes.motorized if @motorized
-
-    # Get a query error if both are passed
-    if params[:search_email].present? && user_subject.blank?
-      @search_email = params[:search_email]
-      bikes = bikes.admin_text_search(@search_email)
-    elsif params[:search_domain].present?
-      @search_domain = params[:search_domain]
-      bikes = bikes.matching_domain(@search_domain)
+    def edit
+      @recoveries = @bike.recovered_records
+      @organizations = Organization.all
     end
 
-    if params[:serial].present?
-      @serial_normalized = SerialNormalizer.normalized_and_corrected(params[:serial])
-      bikes = bikes.matching_serial(@serial_normalized)
+    def update
+      update_params = permitted_parameters.except(:stolen_records_attributes)
+      BikeServices::OwnershipTransferer.find_or_create(@bike, updator: current_user,
+        new_owner_email: update_params.delete("owner_email"),
+        skip_email: update_params.delete("skip_email"))
+
+      BikeServices::StolenRecordUpdator.new(bike: @bike, params:).update_records
+
+      if params[:mark_recovered_reason].present?
+        @bike.current_stolen_record.add_recovery_information(
+          recovered_description: params[:mark_recovered_reason],
+          index_helped_recovery: params[:mark_recovered_we_helped],
+          can_share_recovery: params[:can_share_recovery],
+          recovering_user_id: current_user.id
+        )
+      end
+      if @bike.update(update_params)
+        @bike.create_normalized_serial_segments
+        return if return_to_if_present
+
+        flash[:success] = "Bike was successfully updated."
+        redirect_to(edit_admin_bike_url(@bike)) && return
+      else
+        render action: "edit"
+      end
     end
 
-    if params[:search_model_audit_id].present?
-      @model_audit = ModelAudit.find_by_id(params[:search_model_audit_id])
-      bikes = bikes.where(model_audit_id: params[:search_model_audit_id])
+    def unrecover
+      stolen_record = StolenRecord.unscoped.where(bike_id: params[:bike_id],
+        id: params[:stolen_record_id]).first
+      if stolen_record.present?
+        flash[:success] = "Marked unrecovered!"
+        stolen_record.update(recovered_at: nil, current: true, recovery_link_token: nil)
+      else
+        flash[:error] = "Stolen record not found! Contact a developer"
+      end
+      redirect_to admin_bike_path(params[:bike_id])
     end
 
-    if params[:search_doorkeeper_app_id].present?
-      @doorkeeper_app = Doorkeeper::Application.find_by_id(params[:search_doorkeeper_app_id])
-      bikes = bikes.includes(:ownerships).where(ownerships: {doorkeeper_app_id: params[:search_doorkeeper_app_id]})
+    helper_method :available_bikes
+
+    protected
+
+    def sortable_columns
+      %w[id owner_email manufacturer_id updated_by_user_at]
     end
 
-    if params[:primary_activity].present?
-      @primary_activity = PrimaryActivity.friendly_find(params[:primary_activity])
-      bikes = bikes.where(primary_activity_id: @primary_activity.id) if @primary_activity.present?
+    def permitted_parameters
+      params.require(:bike).permit(BikeServices::Creator.old_attr_accessible + [bike_organization_ids: []])
     end
 
-    search_statuses = DEFAULT_SEARCH_STATUSES + (current_user.su_option?(:no_hide_spam) ? ["spam"] : [])
-    bikes = admin_search_bike_statuses(bikes, default_statuses: search_statuses)
-
-    @pos_search_type = %w[lightspeed_pos ascend_pos any_pos no_pos].include?(params[:search_pos]) ? params[:search_pos] : nil
-    bikes = bikes.send(@pos_search_type) if @pos_search_type.present?
-    @origin_search_type = Ownership.origins.include?(params[:search_origin]) ? params[:search_origin] : nil
-    bikes = bikes.includes(:ownerships).where(ownerships: {origin: @origin_search_type}) if @origin_search_type.present?
-    @multi_delete = Binxtils::InputNormalizer.boolean(params[:search_multi_delete])
-    bikes
-  end
-
-  def available_bikes
-    @available_bikes ||= matching_bikes.where(created_at: @time_range)
-  end
-
-  def missing_manufacturer_bikes
-    session.delete(:missing_manufacturer_time_order) if params[:reset_view].present?
-    if params[:search_time_ordered].present?
-      session[:missing_manufacturer_time_order] = Binxtils::InputNormalizer.boolean(params[:search_time_ordered])
+    def destroy_bike
+      find_bike
+      BikeDeleterJob.new.perform(@bike.id, false, current_user.id)
+      flash[:success] = "Bike deleted!"
+      redirect_to admin_bikes_url
     end
-    bikes = Bike.unscoped.where(manufacturer_id: Manufacturer.other.id).not_spam
-    @motorized = Binxtils::InputNormalizer.boolean(params[:search_motorized])
-    bikes = bikes.where(likely_spam: false) unless Binxtils::InputNormalizer.boolean(params[:search_spam])
-    bikes = bikes.where(deleted_at: nil) unless Binxtils::InputNormalizer.boolean(params[:search_deleted])
-    bikes = bikes.motorized if @motorized
-    bikes = bikes.where("manufacturer_other ILIKE ?", "%#{params[:search_other_name]}%") if params[:search_other_name].present?
-    bikes = bikes.where(created_at: @time_range) unless @period == "all"
-    @include_blank = Binxtils::InputNormalizer.boolean(params[:search_include_blank])
-    bikes = bikes.where.not(manufacturer_other: nil) unless @include_blank
-    bikes = if session[:missing_manufacturer_time_order]
-      bikes.order("created_at desc")
-    else
-      bikes.order(bikes.arel_table["manufacturer_other"].lower)
+
+    def find_bike
+      @bike = Bike.unscoped.find(params[:id])
     end
-    if current_organization.present?
-      bikes = bikes.where(creation_organization_id: current_organization.id)
-    elsif params[:search_exclude_organization_ids].present?
-      @exclude_organizations = params[:search_exclude_organization_ids].split(",").map do |s|
-        Organization.friendly_find(s)
-      end.compact
-      bikes = bikes.where.not(creation_organization_id: @exclude_organizations.map(&:id))
+
+    def matching_bikes
+      bikes = if params[:user_id].present?
+        user_subject&.bikes
+      elsif params[:search_phone].present?
+        Bike.search_phone(params[:search_phone])
+      else
+        # This unscopes, so it doesn't work with anything above
+        Bike.unscoped
+      end
+      if params[:search_manufacturer].present?
+        @manufacturer = Manufacturer.friendly_find(params[:search_manufacturer])
+        bikes = if @manufacturer.present?
+          bikes.where(manufacturer_id: @manufacturer&.id)
+        else
+          bikes.where(mnfg_name: params[:search_manufacturer])
+        end
+      end
+      if current_organization.present?
+        bikes = if Binxtils::InputNormalizer.boolean(params[:search_only_creation_organization])
+          bikes.includes(:ownerships).where(ownerships: {organization_id: current_organization.id})
+        else
+          bikes.organization(current_organization)
+        end
+      elsif params[:organization_id] == "false"
+        # Have to include deleted_at or else we get nil
+        bikes = bikes.includes(:ownerships).where(deleted_at: nil, ownerships: {organization_id: nil})
+      end
+
+      @motorized = Binxtils::InputNormalizer.boolean(params[:search_motorized])
+      bikes = bikes.motorized if @motorized
+
+      # Get a query error if both are passed
+      if params[:search_email].present? && user_subject.blank?
+        @search_email = params[:search_email]
+        bikes = bikes.admin_text_search(@search_email)
+      elsif params[:search_domain].present?
+        @search_domain = params[:search_domain]
+        bikes = bikes.matching_domain(@search_domain)
+      end
+
+      if params[:serial].present?
+        @serial_normalized = SerialNormalizer.normalized_and_corrected(params[:serial])
+        bikes = bikes.matching_serial(@serial_normalized)
+      end
+
+      if params[:search_model_audit_id].present?
+        @model_audit = ModelAudit.find_by_id(params[:search_model_audit_id])
+        bikes = bikes.where(model_audit_id: params[:search_model_audit_id])
+      end
+
+      if params[:search_doorkeeper_app_id].present?
+        @doorkeeper_app = Doorkeeper::Application.find_by_id(params[:search_doorkeeper_app_id])
+        bikes = bikes.includes(:ownerships).where(ownerships: {doorkeeper_app_id: params[:search_doorkeeper_app_id]})
+      end
+
+      if params[:primary_activity].present?
+        @primary_activity = PrimaryActivity.friendly_find(params[:primary_activity])
+        bikes = bikes.where(primary_activity_id: @primary_activity.id) if @primary_activity.present?
+      end
+
+      search_statuses = DEFAULT_SEARCH_STATUSES + (current_user.su_option?(:no_hide_spam) ? ["spam"] : [])
+      bikes = admin_search_bike_statuses(bikes, default_statuses: search_statuses)
+
+      @pos_search_type = %w[lightspeed_pos ascend_pos any_pos no_pos].include?(params[:search_pos]) ? params[:search_pos] : nil
+      bikes = bikes.send(@pos_search_type) if @pos_search_type.present?
+      @origin_search_type = Ownership.origins.include?(params[:search_origin]) ? params[:search_origin] : nil
+      bikes = bikes.includes(:ownerships).where(ownerships: {origin: @origin_search_type}) if @origin_search_type.present?
+      @multi_delete = Binxtils::InputNormalizer.boolean(params[:search_multi_delete])
+      bikes
     end
-    bikes
+
+    def available_bikes
+      @available_bikes ||= matching_bikes.where(created_at: @time_range)
+    end
+
+    def missing_manufacturer_bikes
+      session.delete(:missing_manufacturer_time_order) if params[:reset_view].present?
+      if params[:search_time_ordered].present?
+        session[:missing_manufacturer_time_order] = Binxtils::InputNormalizer.boolean(params[:search_time_ordered])
+      end
+      bikes = Bike.unscoped.where(manufacturer_id: Manufacturer.other.id).not_spam
+      @motorized = Binxtils::InputNormalizer.boolean(params[:search_motorized])
+      bikes = bikes.where(likely_spam: false) unless Binxtils::InputNormalizer.boolean(params[:search_spam])
+      bikes = bikes.where(deleted_at: nil) unless Binxtils::InputNormalizer.boolean(params[:search_deleted])
+      bikes = bikes.motorized if @motorized
+      bikes = bikes.where("manufacturer_other ILIKE ?", "%#{params[:search_other_name]}%") if params[:search_other_name].present?
+      bikes = bikes.where(created_at: @time_range) unless @period == "all"
+      @include_blank = Binxtils::InputNormalizer.boolean(params[:search_include_blank])
+      bikes = bikes.where.not(manufacturer_other: nil) unless @include_blank
+      bikes = if session[:missing_manufacturer_time_order]
+        bikes.order("created_at desc")
+      else
+        bikes.order(bikes.arel_table["manufacturer_other"].lower)
+      end
+      if current_organization.present?
+        bikes = bikes.where(creation_organization_id: current_organization.id)
+      elsif params[:search_exclude_organization_ids].present?
+        @exclude_organizations = params[:search_exclude_organization_ids].split(",").map do |s|
+          Organization.friendly_find(s)
+        end.compact
+        bikes = bikes.where.not(creation_organization_id: @exclude_organizations.map(&:id))
+      end
+      bikes
+    end
   end
 end

--- a/app/controllers/admin/bulk_imports_controller.rb
+++ b/app/controllers/admin/bulk_imports_controller.rb
@@ -1,109 +1,111 @@
-class Admin::BulkImportsController < Admin::BaseController
-  include Binxtils::SortableTable
+module Admin
+  class BulkImportsController < Admin::BaseController
+    include Binxtils::SortableTable
 
-  before_action :find_bulk_import, only: [:show, :update]
+    before_action :find_bulk_import, only: [:show, :update]
 
-  def index
-    params[:page] || 1
-    @per_page = permitted_per_page(default: 10)
-    @org_count = Binxtils::InputNormalizer.boolean(params[:search_org_count])
-    @pagy, @bulk_imports = pagy(:countish, matching_bulk_imports.includes(:organization, :user, :ownerships)
-      .reorder(sort_column + " " + sort_direction), limit: @per_page, page: permitted_page)
-  end
-
-  def show
-  end
-
-  def new
-    @bulk_import = BulkImport.new(organization_id: current_organization&.id, no_notify: params[:no_notify])
-  end
-
-  def update
-    if params[:reprocess]
-      @bulk_import.enqueue_job
-      flash[:success] = "Bulk Import enqueued for processing"
-    else
-      flash[:error] = "Ooooops, can't do that, how the hell did you manage to?"
-    end
-    redirect_to admin_bulk_import_url(@bulk_import)
-  end
-
-  def create
-    @bulk_import = BulkImport.new(permitted_parameters.merge(user_id: current_user.id))
-    if @bulk_import.save
-      flash[:success] = "Bulk Import created!"
-      redirect_to admin_bulk_imports_url
-    else
-      flash[:error] = "Unable to create bulk import"
-      render action: :new
-    end
-  end
-
-  helper_method :matching_bulk_imports
-
-  protected
-
-  def permitted_parameters
-    params.require(:bulk_import).permit(:organization_id, :file, :no_notify, :no_duplicate)
-  end
-
-  def default_period
-    "month"
-  end
-
-  def find_bulk_import
-    @bulk_import = BulkImport.find(params[:id])
-  end
-
-  def sortable_columns
-    %w[created_at progress user_id]
-  end
-
-  def error_kinds
-    %w[file_error line_error no_error ascend_error]
-  end
-
-  def matching_bulk_imports
-    return @matching_bulk_imports if defined?(@matching_bulk_imports)
-
-    bulk_imports = BulkImport
-    if params[:search_ascend] == "only_ascend"
-      @only_ascend = true
-      bulk_imports = bulk_imports.ascend
-    elsif params[:search_ascend] == "not_ascend"
-      @not_ascend = true
-      bulk_imports = bulk_imports.not_ascend
+    def index
+      params[:page] || 1
+      @per_page = permitted_per_page(default: 10)
+      @org_count = Binxtils::InputNormalizer.boolean(params[:search_org_count])
+      @pagy, @bulk_imports = pagy(:countish, matching_bulk_imports.includes(:organization, :user, :ownerships)
+        .reorder(sort_column + " " + sort_direction), limit: @per_page, page: permitted_page)
     end
 
-    if params[:search_errors].present?
-      @search_errors = error_kinds.include?(params[:search_errors]) ? params[:search_errors] : "any_error"
-      bulk_imports = if params[:search_errors] == "file_error"
-        bulk_imports.file_errors
-      elsif params[:search_errors] == "line_error"
-        bulk_imports.line_errors
-      elsif params[:search_errors] == "no_error"
-        bulk_imports.no_import_errors
-      elsif params[:search_errors] == "ascend_error"
-        bulk_imports.ascend_errors
+    def show
+    end
+
+    def new
+      @bulk_import = BulkImport.new(organization_id: current_organization&.id, no_notify: params[:no_notify])
+    end
+
+    def update
+      if params[:reprocess]
+        @bulk_import.enqueue_job
+        flash[:success] = "Bulk Import enqueued for processing"
       else
-        bulk_imports.import_errors
+        flash[:error] = "Ooooops, can't do that, how the hell did you manage to?"
+      end
+      redirect_to admin_bulk_import_url(@bulk_import)
+    end
+
+    def create
+      @bulk_import = BulkImport.new(permitted_parameters.merge(user_id: current_user.id))
+      if @bulk_import.save
+        flash[:success] = "Bulk Import created!"
+        redirect_to admin_bulk_imports_url
+      else
+        flash[:error] = "Unable to create bulk import"
+        render action: :new
       end
     end
 
-    if BulkImport.progresses.include?(params[:search_progress])
-      @progress = params[:search_progress]
-      bulk_imports = bulk_imports.where(progress: @progress)
-    else
-      @progress = "all"
+    helper_method :matching_bulk_imports
+
+    protected
+
+    def permitted_parameters
+      params.require(:bulk_import).permit(:organization_id, :file, :no_notify, :no_duplicate)
     end
 
-    if params[:organization_id].present?
-      bulk_imports = if current_organization.present?
-        bulk_imports.where(organization_id: current_organization.id)
-      else
-        bulk_imports.where(organization_id: nil)
-      end
+    def default_period
+      "month"
     end
-    @matching_bulk_imports = bulk_imports.where(created_at: @time_range)
+
+    def find_bulk_import
+      @bulk_import = BulkImport.find(params[:id])
+    end
+
+    def sortable_columns
+      %w[created_at progress user_id]
+    end
+
+    def error_kinds
+      %w[file_error line_error no_error ascend_error]
+    end
+
+    def matching_bulk_imports
+      return @matching_bulk_imports if defined?(@matching_bulk_imports)
+
+      bulk_imports = BulkImport
+      if params[:search_ascend] == "only_ascend"
+        @only_ascend = true
+        bulk_imports = bulk_imports.ascend
+      elsif params[:search_ascend] == "not_ascend"
+        @not_ascend = true
+        bulk_imports = bulk_imports.not_ascend
+      end
+
+      if params[:search_errors].present?
+        @search_errors = error_kinds.include?(params[:search_errors]) ? params[:search_errors] : "any_error"
+        bulk_imports = if params[:search_errors] == "file_error"
+          bulk_imports.file_errors
+        elsif params[:search_errors] == "line_error"
+          bulk_imports.line_errors
+        elsif params[:search_errors] == "no_error"
+          bulk_imports.no_import_errors
+        elsif params[:search_errors] == "ascend_error"
+          bulk_imports.ascend_errors
+        else
+          bulk_imports.import_errors
+        end
+      end
+
+      if BulkImport.progresses.include?(params[:search_progress])
+        @progress = params[:search_progress]
+        bulk_imports = bulk_imports.where(progress: @progress)
+      else
+        @progress = "all"
+      end
+
+      if params[:organization_id].present?
+        bulk_imports = if current_organization.present?
+          bulk_imports.where(organization_id: current_organization.id)
+        else
+          bulk_imports.where(organization_id: nil)
+        end
+      end
+      @matching_bulk_imports = bulk_imports.where(created_at: @time_range)
+    end
   end
 end

--- a/app/controllers/admin/content_tags_controller.rb
+++ b/app/controllers/admin/content_tags_controller.rb
@@ -1,65 +1,67 @@
-class Admin::ContentTagsController < Admin::BaseController
-  include Binxtils::SortableTable
+module Admin
+  class ContentTagsController < Admin::BaseController
+    include Binxtils::SortableTable
 
-  before_action :find_content_tag, only: %i[edit update]
+    before_action :find_content_tag, only: %i[edit update]
 
-  def index
-    @per_page = permitted_per_page(default: 100)
-    @pagy, @content_tags = pagy(:countish, matching_content_tags
-      .order(sort_column + " " + sort_direction), limit: @per_page, page: permitted_page)
-  end
-
-  def new
-    @content_tag ||= ContentTag.new
-  end
-
-  def show
-    redirect_to edit_admin_content_tag_path
-  end
-
-  def edit
-    @blogs = @content_tag.blogs.includes(:user, :content_tags)
-  end
-
-  def update
-    @content_tag.update(permitted_parameters)
-    flash[:success] = "Tag updated" unless flash[:error].present?
-    redirect_to admin_content_tags_path
-  end
-
-  def create
-    @content_tag = ContentTag.new(permitted_parameters)
-    if @content_tag.save
-      flash[:success] = "Tag created"
-      redirect_to admin_content_tags_path
-    else
-      flash[:error] = "Unable to create"
-      render :new
+    def index
+      @per_page = permitted_per_page(default: 100)
+      @pagy, @content_tags = pagy(:countish, matching_content_tags
+        .order(sort_column + " " + sort_direction), limit: @per_page, page: permitted_page)
     end
-  end
 
-  helper_method :matching_content_tags
+    def new
+      @content_tag ||= ContentTag.new
+    end
 
-  protected
+    def show
+      redirect_to edit_admin_content_tag_path
+    end
 
-  def sortable_columns
-    %w[name created_at updated_at priority]
-  end
+    def edit
+      @blogs = @content_tag.blogs.includes(:user, :content_tags)
+    end
 
-  def matching_content_tags
-    ContentTag
-  end
+    def update
+      @content_tag.update(permitted_parameters)
+      flash[:success] = "Tag updated" unless flash[:error].present?
+      redirect_to admin_content_tags_path
+    end
 
-  # Because we start with alpha ordering
-  def default_direction
-    "asc"
-  end
+    def create
+      @content_tag = ContentTag.new(permitted_parameters)
+      if @content_tag.save
+        flash[:success] = "Tag created"
+        redirect_to admin_content_tags_path
+      else
+        flash[:error] = "Unable to create"
+        render :new
+      end
+    end
 
-  def permitted_parameters
-    params.require(:content_tag).permit(:name, :priority, :description)
-  end
+    helper_method :matching_content_tags
 
-  def find_content_tag
-    @content_tag = ContentTag.friendly_find(params[:id])
+    protected
+
+    def sortable_columns
+      %w[name created_at updated_at priority]
+    end
+
+    def matching_content_tags
+      ContentTag
+    end
+
+    # Because we start with alpha ordering
+    def default_direction
+      "asc"
+    end
+
+    def permitted_parameters
+      params.require(:content_tag).permit(:name, :priority, :description)
+    end
+
+    def find_content_tag
+      @content_tag = ContentTag.friendly_find(params[:id])
+    end
   end
 end

--- a/app/controllers/admin/ctypes_controller.rb
+++ b/app/controllers/admin/ctypes_controller.rb
@@ -1,49 +1,51 @@
-class Admin::CtypesController < Admin::BaseController
-  before_action :find_ctypes, only: [:edit, :update, :destroy]
+module Admin
+  class CtypesController < Admin::BaseController
+    before_action :find_ctypes, only: [:edit, :update, :destroy]
 
-  def index
-    @ctypes = Ctype.all
-  end
-
-  def new
-    @ctype = Ctype.new
-  end
-
-  def edit
-  end
-
-  def update
-    if @ctype.update(permitted_parameters)
-      flash[:success] = "Component Type Saved!"
-      redirect_to admin_ctypes_url
-    else
-      render action: :edit
+    def index
+      @ctypes = Ctype.all
     end
-  end
 
-  def create
-    @ctype = Ctype.create(permitted_parameters)
-    if @ctype.save
-      flash[:success] = "Component type created!"
-      redirect_to admin_ctypes_url
-    else
-      render action: :new
+    def new
+      @ctype = Ctype.new
     end
-  end
 
-  def destroy
-    @ctype.destroy
-    redirect_to admin_ctypes_url
-  end
+    def edit
+    end
 
-  protected
+    def update
+      if @ctype.update(permitted_parameters)
+        flash[:success] = "Component Type Saved!"
+        redirect_to admin_ctypes_url
+      else
+        render action: :edit
+      end
+    end
 
-  def permitted_parameters
-    params.require(:ctype).permit(:name, :slug, :secondary_name, :image, :image_cache, :cgroup_id, :cgroup, :has_multiple, :cgroup_name)
-  end
+    def create
+      @ctype = Ctype.create(permitted_parameters)
+      if @ctype.save
+        flash[:success] = "Component type created!"
+        redirect_to admin_ctypes_url
+      else
+        render action: :new
+      end
+    end
 
-  def find_ctypes
-    @ctype = Ctype.friendly_find(params[:id])
-    raise ActionController::RoutingError.new("Not Found") unless @ctype.present?
+    def destroy
+      @ctype.destroy
+      redirect_to admin_ctypes_url
+    end
+
+    protected
+
+    def permitted_parameters
+      params.require(:ctype).permit(:name, :slug, :secondary_name, :image, :image_cache, :cgroup_id, :cgroup, :has_multiple, :cgroup_name)
+    end
+
+    def find_ctypes
+      @ctype = Ctype.friendly_find(params[:id])
+      raise ActionController::RoutingError.new("Not Found") unless @ctype.present?
+    end
   end
 end

--- a/app/controllers/admin/customer_contacts_controller.rb
+++ b/app/controllers/admin/customer_contacts_controller.rb
@@ -1,30 +1,32 @@
-class Admin::CustomerContactsController < Admin::BaseController
-  def show
-    @customer_contact = CustomerContact.find(params[:id])
-  end
-
-  def create
-    @customer_contact = CustomerContact.new(permitted_parameters)
-    if @customer_contact.save
-      flash[:success] = "Email sent successfully!"
-      Email::AdminContactStolenJob.perform_async(@customer_contact.id)
-    else
-      flash[:error] = "Email send error!\n#{@customer_contact.errors.full_messages.to_sentence}"
+module Admin
+  class CustomerContactsController < Admin::BaseController
+    def show
+      @customer_contact = CustomerContact.find(params[:id])
     end
-    redirect_to edit_admin_stolen_bike_url(@customer_contact.bike_id)
-  end
 
-  private
+    def create
+      @customer_contact = CustomerContact.new(permitted_parameters)
+      if @customer_contact.save
+        flash[:success] = "Email sent successfully!"
+        Email::AdminContactStolenJob.perform_async(@customer_contact.id)
+      else
+        flash[:error] = "Email send error!\n#{@customer_contact.errors.full_messages.to_sentence}"
+      end
+      redirect_to edit_admin_stolen_bike_url(@customer_contact.bike_id)
+    end
 
-  def permitted_parameters
-    params.require(:customer_contact).permit(
-      :bike_id,
-      :body,
-      :creator_email,
-      :creator_id,
-      :kind,
-      :title,
-      :user_email
-    )
+    private
+
+    def permitted_parameters
+      params.require(:customer_contact).permit(
+        :bike_id,
+        :body,
+        :creator_email,
+        :creator_id,
+        :kind,
+        :title,
+        :user_email
+      )
+    end
   end
 end

--- a/app/controllers/admin/dashboard_controller.rb
+++ b/app/controllers/admin/dashboard_controller.rb
@@ -1,67 +1,69 @@
-class Admin::DashboardController < Admin::BaseController
-  around_action :set_reading_role, only: [:index]
+module Admin
+  class DashboardController < Admin::BaseController
+    around_action :set_reading_role, only: [:index]
 
-  def index
-    @period = "week"
-    set_period # graphing set up
-    @organizations = Organization.unscoped.order("created_at DESC").limit(10)
-    bikes = Bike.unscoped.default_includes
-      .includes(:creation_organization, :paint, :recovered_records)
-    bikes = bikes.not_spam unless current_user.su_option?(:no_hide_spam)
-    @bikes = bikes.order(id: :desc).limit(10)
-    @users = User.valid_only.includes(organization_roles: [:organization]).limit(5).order(id: :desc)
-  end
+    def index
+      @period = "week"
+      set_period # graphing set up
+      @organizations = Organization.unscoped.order("created_at DESC").limit(10)
+      bikes = Bike.unscoped.default_includes
+        .includes(:creation_organization, :paint, :recovered_records)
+      bikes = bikes.not_spam unless current_user.su_option?(:no_hide_spam)
+      @bikes = bikes.order(id: :desc).limit(10)
+      @users = User.valid_only.includes(organization_roles: [:organization]).limit(5).order(id: :desc)
+    end
 
-  def maintenance
-    # @bikes here because this is the only one we're using the standard admin bikes table
-    @bikes = Bike.unscoped.order("created_at desc").where(example: true).limit(10)
-    mnfg_other_id = Manufacturer.other.id
-    @component_mnfgs = Component.where(manufacturer_id: mnfg_other_id).reorder(id: :desc).includes(:bike, :ctype).limit(50)
-    @component_types = Component.where(ctype_id: Ctype.other.id).reorder(id: :desc).includes(:bike, :ctype).limit(50)
-    @bikes_other_handlebar_type = Bike.where(handlebar_type: Bike.handlebar_types[:other]).reorder(id: :desc).limit(50)
-    @paint = Paint.where("color_id IS NULL")
-  end
+    def maintenance
+      # @bikes here because this is the only one we're using the standard admin bikes table
+      @bikes = Bike.unscoped.order("created_at desc").where(example: true).limit(10)
+      mnfg_other_id = Manufacturer.other.id
+      @component_mnfgs = Component.where(manufacturer_id: mnfg_other_id).reorder(id: :desc).includes(:bike, :ctype).limit(50)
+      @component_types = Component.where(ctype_id: Ctype.other.id).reorder(id: :desc).includes(:bike, :ctype).limit(50)
+      @bikes_other_handlebar_type = Bike.where(handlebar_type: Bike.handlebar_types[:other]).reorder(id: :desc).limit(50)
+      @paint = Paint.where("color_id IS NULL")
+    end
 
-  def autocomplete_status
-    @autocomplete_info = Autocomplete::Loader.info
-  end
+    def autocomplete_status
+      @autocomplete_info = Autocomplete::Loader.info
+    end
 
-  def scheduled_jobs
-  end
+    def scheduled_jobs
+    end
 
-  def crediblity_badges
-  end
+    def crediblity_badges
+    end
 
-  def bust_z_cache
-    Rails.cache.clear
-    flash[:success] = "Z cash WAAAAAS busted!"
-    redirect_to admin_root_url
-  end
+    def bust_z_cache
+      Rails.cache.clear
+      flash[:success] = "Z cash WAAAAAS busted!"
+      redirect_to admin_root_url
+    end
 
-  def destroy_example_bikes
-    org = Organization.friendly_find("bikeindex")
-    bikes = Bike.unscoped.where(example: true)
-    # The example bikes for the API docs on production are created by Bike Index Administrators
-    # This way we don't clear them when we clear the rest of the example bikes
-    bikes.each { |b| b.destroy unless b.creation_organization_id == org.id }
-    flash[:success] = "Example bikes cleared!"
-    redirect_to admin_root_url
-  end
+    def destroy_example_bikes
+      org = Organization.friendly_find("bikeindex")
+      bikes = Bike.unscoped.where(example: true)
+      # The example bikes for the API docs on production are created by Bike Index Administrators
+      # This way we don't clear them when we clear the rest of the example bikes
+      bikes.each { |b| b.destroy unless b.creation_organization_id == org.id }
+      flash[:success] = "Example bikes cleared!"
+      redirect_to admin_root_url
+    end
 
-  def tsvs
-    @blocklist = FileCacheMaintainer.blocklist
-    @tsvs = FileCacheMaintainer.files
-  end
+    def tsvs
+      @blocklist = FileCacheMaintainer.blocklist
+      @tsvs = FileCacheMaintainer.files
+    end
 
-  def update_tsv_blocklist
-    new_blocklist = params[:blocklist].split(/\n|\r/).reject { |t| t.blank? }
-    FileCacheMaintainer.reset_blocklist_ids(new_blocklist)
-    redirect_to admin_tsvs_path
-  end
+    def update_tsv_blocklist
+      new_blocklist = params[:blocklist].split(/\n|\r/).reject { |t| t.blank? }
+      FileCacheMaintainer.reset_blocklist_ids(new_blocklist)
+      redirect_to admin_tsvs_path
+    end
 
-  def ip_location
-    @cloudflare_hash = IpAddressParser.location_hash(request)
-    @geocoder_hash = IpAddressParser.location_hash_geocoder(forwarded_ip_address, new_attrs: true)
-    @headers = request.headers.to_h.select { |k, _v| k.start_with?("HTTP_") }.to_h
+    def ip_location
+      @cloudflare_hash = IpAddressParser.location_hash(request)
+      @geocoder_hash = IpAddressParser.location_hash_geocoder(forwarded_ip_address, new_attrs: true)
+      @headers = request.headers.to_h.select { |k, _v| k.start_with?("HTTP_") }.to_h
+    end
   end
 end

--- a/app/controllers/admin/email_bans_controller.rb
+++ b/app/controllers/admin/email_bans_controller.rb
@@ -1,27 +1,29 @@
-class Admin::EmailBansController < Admin::BaseController
-  include Binxtils::SortableTable
+module Admin
+  class EmailBansController < Admin::BaseController
+    include Binxtils::SortableTable
 
-  def index
-    @per_page = permitted_per_page(default: 50)
-    @pagy, @collection = pagy(:countish,
-      matching_email_bans.includes(:user).reorder("email_bans.#{sort_column} #{sort_direction}"),
-      limit: @per_page,
-      page: permitted_page)
-  end
+    def index
+      @per_page = permitted_per_page(default: 50)
+      @pagy, @collection = pagy(:countish,
+        matching_email_bans.includes(:user).reorder("email_bans.#{sort_column} #{sort_direction}"),
+        limit: @per_page,
+        page: permitted_page)
+    end
 
-  helper_method :matching_email_bans
+    helper_method :matching_email_bans
 
-  protected
+    protected
 
-  def sortable_columns
-    %w[created_at reason start_at end_at user_id]
-  end
+    def sortable_columns
+      %w[created_at reason start_at end_at user_id]
+    end
 
-  def matching_email_bans
-    email_bans = EmailBan
+    def matching_email_bans
+      email_bans = EmailBan
 
-    @time_range_column = sort_column if %w[updated_at status_changed_at].include?(sort_column)
-    @time_range_column ||= "created_at"
-    email_bans.where(@time_range_column => @time_range)
+      @time_range_column = sort_column if %w[updated_at status_changed_at].include?(sort_column)
+      @time_range_column ||= "created_at"
+      email_bans.where(@time_range_column => @time_range)
+    end
   end
 end

--- a/app/controllers/admin/email_domains_controller.rb
+++ b/app/controllers/admin/email_domains_controller.rb
@@ -1,132 +1,134 @@
 # frozen_string_literal: true
 
-class Admin::EmailDomainsController < Admin::BaseController
-  include Binxtils::SortableTable
+module Admin
+  class EmailDomainsController < Admin::BaseController
+    include Binxtils::SortableTable
 
-  before_action :find_email_domain, only: %i[show update]
-  helper_method :searchable_statuses, :matching_email_domains
+    before_action :find_email_domain, only: %i[show update]
+    helper_method :searchable_statuses, :matching_email_domains
 
-  def index
-    @per_page = permitted_per_page
+    def index
+      @per_page = permitted_per_page
 
-    @pagy, @email_domains = pagy(:countish, ordered_email_domains, limit: @per_page, page: permitted_page)
-  end
-
-  def new
-    @email_domain = EmailDomain.new
-  end
-
-  def create
-    @email_domain = EmailDomain.new(email_domain_params)
-    @email_domain.creator = current_user
-
-    if @email_domain.save
-      @email_domain.process!
-      flash[:success] = "New email domain created"
-      redirect_to admin_email_domains_url and return
-    else
-      flash.now[:error] = @email_domain.errors.full_messages.to_sentence
+      @pagy, @email_domains = pagy(:countish, ordered_email_domains, limit: @per_page, page: permitted_page)
     end
-    render :new
-  end
 
-  def show
-    @subdomains = @email_domain.calculated_subdomains
-    unless @email_domain.tld_matches_subdomains?
-      @matching_tld = EmailDomain.find_matching_domain(@email_domain.tld)
+    def new
+      @email_domain = EmailDomain.new
     end
-  end
 
-  def edit
-    redirect_to admin_email_domain_path
-  end
+    def create
+      @email_domain = EmailDomain.new(email_domain_params)
+      @email_domain.creator = current_user
 
-  def update
-    # Only check if allowed to make banned if updating to make banned
-    if permitted_update_parameters[:status] == "banned" && !@email_domain.banned? && @email_domain.ban_blockers.any?
-      flash.now[:error] = domain_ban_message(@email_domain)
-    else
-      @email_domain.creator_id ||= current_user.id
-      @email_domain.data["no_auto_assign_status"] = true
-      if @email_domain.update(permitted_update_parameters)
-        flash[:success] = "Domain Saved!"
-        @email_domain.reload.process!
-        redirect_to admin_email_domain_url(@email_domain) and return
+      if @email_domain.save
+        @email_domain.process!
+        flash[:success] = "New email domain created"
+        redirect_to admin_email_domains_url and return
       else
-        flash[:error] = @email_domain.errors.full_messages
+        flash.now[:error] = @email_domain.errors.full_messages.to_sentence
+      end
+      render :new
+    end
+
+    def show
+      @subdomains = @email_domain.calculated_subdomains
+      unless @email_domain.tld_matches_subdomains?
+        @matching_tld = EmailDomain.find_matching_domain(@email_domain.tld)
       end
     end
 
-    render action: :show
-  end
-
-  private
-
-  def sortable_columns
-    %w[created_at updated_at domain creator_id status user_count bike_count status_changed_at
-      spam_score domain_length]
-  end
-
-  def searchable_statuses
-    EmailDomain.statuses.keys.map(&:to_s) + %w[ban_or_provisional]
-  end
-
-  def ordered_email_domains
-    order_sql = if sort_column == "bike_count"
-      Arel.sql("COALESCE((data -> 'bike_count')::integer, 0) #{sort_direction}")
-    elsif sort_column == "spam_score"
-      Arel.sql("COALESCE((data -> 'spam_score')::integer, 0) #{sort_direction}")
-    elsif sort_column == "domain"
-      Arel.sql("REVERSE(domain) #{sort_direction}")
-    elsif sort_column == "domain_length"
-      Arel.sql("LENGTH(domain) ASC")
-    else
-      "email_domains.#{sort_column} #{sort_direction}"
-    end
-    matching_email_domains.includes(:creator).reorder(order_sql)
-  end
-
-  def find_email_domain
-    @email_domain = EmailDomain.find(params[:id])
-  end
-
-  def matching_email_domains
-    email_domains = EmailDomain
-    @status = searchable_statuses.include?(params[:search_status]) ? params[:search_status] : nil
-    email_domains = @status.present? ? email_domains.send(@status) : email_domains.not_ignored
-    if params[:query].present?
-      email_domains = email_domains.where("domain ILIKE ?", "%#{params[:query]}%")
-    end
-    if params[:search_tld].present?
-      @tld = params[:search_tld]
-      email_domains = (@tld == "only_tld") ? email_domains.tld : email_domains.subdomain
+    def edit
+      redirect_to admin_email_domain_path
     end
 
-    @show_matching_users = Binxtils::InputNormalizer.boolean(params[:search_matching_users])
-    @time_range_column = sort_column if %w[updated_at status_changed_at].include?(sort_column)
-    @time_range_column ||= "created_at"
+    def update
+      # Only check if allowed to make banned if updating to make banned
+      if permitted_update_parameters[:status] == "banned" && !@email_domain.banned? && @email_domain.ban_blockers.any?
+        flash.now[:error] = domain_ban_message(@email_domain)
+      else
+        @email_domain.creator_id ||= current_user.id
+        @email_domain.data["no_auto_assign_status"] = true
+        if @email_domain.update(permitted_update_parameters)
+          flash[:success] = "Domain Saved!"
+          @email_domain.reload.process!
+          redirect_to admin_email_domain_url(@email_domain) and return
+        else
+          flash[:error] = @email_domain.errors.full_messages
+        end
+      end
 
-    email_domains.where(@time_range_column => @time_range)
-  end
+      render action: :show
+    end
 
-  def earliest_period_date
-    Time.at(1735711200) # 2025-01-1
-  end
+    private
 
-  def permitted_update_parameters
-    params.require(:email_domain).permit(:status)
-  end
+    def sortable_columns
+      %w[created_at updated_at domain creator_id status user_count bike_count status_changed_at
+        spam_score domain_length]
+    end
 
-  def email_domain_params
-    params.require(:email_domain).permit(:domain)
-  end
+    def searchable_statuses
+      EmailDomain.statuses.keys.map(&:to_s) + %w[ban_or_provisional]
+    end
 
-  def domain_ban_message(email_domain)
-    bikes_count = email_domain.calculated_bikes.count
-    if bikes_count > 0
-      "Doesn't seem like a new spam email domain - there are *#{bikes_count}* bikes"
-    else
-      "Blocked by: #{email_domain.ban_blockers.map(&:humanize).join(", ")}"
+    def ordered_email_domains
+      order_sql = if sort_column == "bike_count"
+        Arel.sql("COALESCE((data -> 'bike_count')::integer, 0) #{sort_direction}")
+      elsif sort_column == "spam_score"
+        Arel.sql("COALESCE((data -> 'spam_score')::integer, 0) #{sort_direction}")
+      elsif sort_column == "domain"
+        Arel.sql("REVERSE(domain) #{sort_direction}")
+      elsif sort_column == "domain_length"
+        Arel.sql("LENGTH(domain) ASC")
+      else
+        "email_domains.#{sort_column} #{sort_direction}"
+      end
+      matching_email_domains.includes(:creator).reorder(order_sql)
+    end
+
+    def find_email_domain
+      @email_domain = EmailDomain.find(params[:id])
+    end
+
+    def matching_email_domains
+      email_domains = EmailDomain
+      @status = searchable_statuses.include?(params[:search_status]) ? params[:search_status] : nil
+      email_domains = @status.present? ? email_domains.send(@status) : email_domains.not_ignored
+      if params[:query].present?
+        email_domains = email_domains.where("domain ILIKE ?", "%#{params[:query]}%")
+      end
+      if params[:search_tld].present?
+        @tld = params[:search_tld]
+        email_domains = (@tld == "only_tld") ? email_domains.tld : email_domains.subdomain
+      end
+
+      @show_matching_users = Binxtils::InputNormalizer.boolean(params[:search_matching_users])
+      @time_range_column = sort_column if %w[updated_at status_changed_at].include?(sort_column)
+      @time_range_column ||= "created_at"
+
+      email_domains.where(@time_range_column => @time_range)
+    end
+
+    def earliest_period_date
+      Time.at(1735711200) # 2025-01-1
+    end
+
+    def permitted_update_parameters
+      params.require(:email_domain).permit(:status)
+    end
+
+    def email_domain_params
+      params.require(:email_domain).permit(:domain)
+    end
+
+    def domain_ban_message(email_domain)
+      bikes_count = email_domain.calculated_bikes.count
+      if bikes_count > 0
+        "Doesn't seem like a new spam email domain - there are *#{bikes_count}* bikes"
+      else
+        "Blocked by: #{email_domain.ban_blockers.map(&:humanize).join(", ")}"
+      end
     end
   end
 end

--- a/app/controllers/admin/exchange_rates_controller.rb
+++ b/app/controllers/admin/exchange_rates_controller.rb
@@ -1,77 +1,79 @@
 # frozen_string_literal: true
 
-class Admin::ExchangeRatesController < Admin::BaseController
-  include Binxtils::SortableTable
+module Admin
+  class ExchangeRatesController < Admin::BaseController
+    include Binxtils::SortableTable
 
-  before_action :find_exchange_rate, only: %w[edit update]
+    before_action :find_exchange_rate, only: %w[edit update]
 
-  def index
-    @exchange_rates =
-      ExchangeRate.where(filter_params).order(sort_column => sort_direction)
-  end
+    def index
+      @exchange_rates =
+        ExchangeRate.where(filter_params).order(sort_column => sort_direction)
+    end
 
-  def new
-    @exchange_rate = ExchangeRate.new
-  end
+    def new
+      @exchange_rate = ExchangeRate.new
+    end
 
-  def create
-    @exchange_rate = ExchangeRate.new(exchange_rate_params)
+    def create
+      @exchange_rate = ExchangeRate.new(exchange_rate_params)
 
-    if @exchange_rate.save
+      if @exchange_rate.save
+        redirect_to admin_exchange_rates_url
+      else
+        flash.now[:error] = @exchange_rate.errors.full_messages.to_sentence
+        render :new
+      end
+    end
+
+    def edit
+    end
+
+    def update
+      if @exchange_rate.update(exchange_rate_params)
+        redirect_to admin_exchange_rates_url
+      else
+        flash.now[:error] = @exchange_rate.errors.full_messages.join("\n")
+        render :edit
+      end
+    end
+
+    def destroy
+      exchange_rate = ExchangeRate.find_by(id: params[:id])
+
+      unless exchange_rate&.destroy
+        flash[:error] = "Could not delete exchange rate."
+      end
+
       redirect_to admin_exchange_rates_url
-    else
-      flash.now[:error] = @exchange_rate.errors.full_messages.to_sentence
-      render :new
-    end
-  end
-
-  def edit
-  end
-
-  def update
-    if @exchange_rate.update(exchange_rate_params)
-      redirect_to admin_exchange_rates_url
-    else
-      flash.now[:error] = @exchange_rate.errors.full_messages.join("\n")
-      render :edit
-    end
-  end
-
-  def destroy
-    exchange_rate = ExchangeRate.find_by(id: params[:id])
-
-    unless exchange_rate&.destroy
-      flash[:error] = "Could not delete exchange rate."
     end
 
-    redirect_to admin_exchange_rates_url
+    private
+
+    def exchange_rate_params
+      params.require(:exchange_rate).permit(:from, :to, :rate)
+    end
+
+    def find_exchange_rate
+      @exchange_rate = ExchangeRate.find(params[:id])
+    end
+
+    def sortable_columns
+      %w[to from rate updated_at]
+    end
+
+    def default_direction
+      "asc"
+    end
+
+    def filter_params
+      params
+        .permit(:search_to)
+        .to_h
+        .map { |k, v| [k[/(?<=search_).+/].to_sym, v] }
+        .to_h
+    end
+
+    helper_method :filter_params
   end
-
-  private
-
-  def exchange_rate_params
-    params.require(:exchange_rate).permit(:from, :to, :rate)
-  end
-
-  def find_exchange_rate
-    @exchange_rate = ExchangeRate.find(params[:id])
-  end
-
-  def sortable_columns
-    %w[to from rate updated_at]
-  end
-
-  def default_direction
-    "asc"
-  end
-
-  def filter_params
-    params
-      .permit(:search_to)
-      .to_h
-      .map { |k, v| [k[/(?<=search_).+/].to_sym, v] }
-      .to_h
-  end
-
-  helper_method :filter_params
 end

--- a/app/controllers/admin/exports_controller.rb
+++ b/app/controllers/admin/exports_controller.rb
@@ -1,46 +1,48 @@
-class Admin::ExportsController < Admin::BaseController
-  before_action :set_period, only: [:index]
+module Admin
+  class ExportsController < Admin::BaseController
+    before_action :set_period, only: [:index]
 
-  def index
-    @per_page = permitted_per_page(default: 10)
-    @pagy, @collection = pagy(:countish,
-      matching_exports.includes(:organization, :user).order(created_at: :desc),
-      limit: @per_page, page: permitted_page)
-  end
-
-  helper_method :matching_exports
-
-  private
-
-  def earliest_period_date
-    Time.at(1535760000) # 2018-09-01
-  end
-
-  def matching_exports
-    exports = if params[:organization_id].present?
-      Export.where(organization_id: current_organization.id)
-    else
-      Export.all
+    def index
+      @per_page = permitted_per_page(default: 10)
+      @pagy, @collection = pagy(:countish,
+        matching_exports.includes(:organization, :user).order(created_at: :desc),
+        limit: @per_page, page: permitted_page)
     end
-    exports = search_deleted_scope(exports)
-    case params[:search_registrations]
-    when "specific" then exports = exports.specific
-    when "incomplete" then exports = exports.incompletes
-    when "incompletes_and_registrations" then exports = exports.incompletes_and_registrations
-    when "registered" then exports = exports.registrations
-    when "impounded" then exports = exports.impounded
+
+    helper_method :matching_exports
+
+    private
+
+    def earliest_period_date
+      Time.at(1535760000) # 2018-09-01
     end
-    @stickers = Binxtils::InputNormalizer.boolean(params[:search_stickers])
-    exports = exports.with_stickers if @stickers
-    @with_dates = Binxtils::InputNormalizer.boolean(params[:search_with_dates])
-    exports = exports.with_dates if @with_dates
-    @impounded = Binxtils::InputNormalizer.boolean(params[:search_impounded])
-    exports = exports.impounded if @impounded
-    if params[:search_kind] == "avery"
-      exports = exports.avery
-    elsif params[:search_kind].present?
-      exports = exports.where(kind: params[:search_kind])
+
+    def matching_exports
+      exports = if params[:organization_id].present?
+        Export.where(organization_id: current_organization.id)
+      else
+        Export.all
+      end
+      exports = search_deleted_scope(exports)
+      case params[:search_registrations]
+      when "specific" then exports = exports.specific
+      when "incomplete" then exports = exports.incompletes
+      when "incompletes_and_registrations" then exports = exports.incompletes_and_registrations
+      when "registered" then exports = exports.registrations
+      when "impounded" then exports = exports.impounded
+      end
+      @stickers = Binxtils::InputNormalizer.boolean(params[:search_stickers])
+      exports = exports.with_stickers if @stickers
+      @with_dates = Binxtils::InputNormalizer.boolean(params[:search_with_dates])
+      exports = exports.with_dates if @with_dates
+      @impounded = Binxtils::InputNormalizer.boolean(params[:search_impounded])
+      exports = exports.impounded if @impounded
+      if params[:search_kind] == "avery"
+        exports = exports.avery
+      elsif params[:search_kind].present?
+        exports = exports.where(kind: params[:search_kind])
+      end
+      exports.where(created_at: @time_range)
     end
-    exports.where(created_at: @time_range)
   end
 end

--- a/app/controllers/admin/external_registry_bikes_controller.rb
+++ b/app/controllers/admin/external_registry_bikes_controller.rb
@@ -1,60 +1,62 @@
-class Admin::ExternalRegistryBikesController < Admin::BaseController
-  include Binxtils::SortableTable
+module Admin
+  class ExternalRegistryBikesController < Admin::BaseController
+    include Binxtils::SortableTable
 
-  before_action :find_bike, only: %i[show]
+    before_action :find_bike, only: %i[show]
 
-  def index
-    @per_page = permitted_per_page(default: 100)
-    @pagy, @bikes =
-      pagy(:countish, matching_bikes
-        .reorder("external_registry_bikes.#{sort_column} #{sort_direction}"), limit: @per_page, page: permitted_page)
-  end
-
-  def show
-  end
-
-  helper_method :registry_types
-
-  private
-
-  def find_bike
-    @bike = ExternalRegistryBike.find(params[:id])
-  end
-
-  def registry_types
-    ["Project529Bike",
-      "StopHelingBike",
-      "VerlorenOfGevondenBike"]
-  end
-
-  def matching_bikes
-    return @matching_bikes if defined?(@matching_bikes)
-
-    @matching_bikes = ExternalRegistryBike.all
-
-    if params[:search_serial_normalized].present?
-      @matching_bikes = @matching_bikes.where(serial_normalized: params[:search_serial_normalized])
+    def index
+      @per_page = permitted_per_page(default: 100)
+      @pagy, @bikes =
+        pagy(:countish, matching_bikes
+          .reorder("external_registry_bikes.#{sort_column} #{sort_direction}"), limit: @per_page, page: permitted_page)
     end
 
-    search_type = params[:search_type]&.split("::")&.last
-    @search_type = if registry_types.include?(search_type)
-      @matching_bikes = @matching_bikes.where(type: "ExternalRegistryBike::#{search_type}")
-      search_type
-    else
-      "all"
+    def show
     end
 
-    @search_status = if Bike.statuses.include?(params[:search_status])
-      @matching_bikes = @matching_bikes.where(status: params[:search_status])
-      params[:search_status]
-    else
-      "all"
+    helper_method :registry_types
+
+    private
+
+    def find_bike
+      @bike = ExternalRegistryBike.find(params[:id])
     end
 
-    @matching_bikes = @matching_bikes.where(created_at: @time_range)
-  end
+    def registry_types
+      ["Project529Bike",
+        "StopHelingBike",
+        "VerlorenOfGevondenBike"]
+    end
 
-  def sortable_columns
-    %w[created_at mnfg_name status]
+    def matching_bikes
+      return @matching_bikes if defined?(@matching_bikes)
+
+      @matching_bikes = ExternalRegistryBike.all
+
+      if params[:search_serial_normalized].present?
+        @matching_bikes = @matching_bikes.where(serial_normalized: params[:search_serial_normalized])
+      end
+
+      search_type = params[:search_type]&.split("::")&.last
+      @search_type = if registry_types.include?(search_type)
+        @matching_bikes = @matching_bikes.where(type: "ExternalRegistryBike::#{search_type}")
+        search_type
+      else
+        "all"
+      end
+
+      @search_status = if Bike.statuses.include?(params[:search_status])
+        @matching_bikes = @matching_bikes.where(status: params[:search_status])
+        params[:search_status]
+      else
+        "all"
+      end
+
+      @matching_bikes = @matching_bikes.where(created_at: @time_range)
+    end
+
+    def sortable_columns
+      %w[created_at mnfg_name status]
+    end
   end
 end

--- a/app/controllers/admin/external_registry_credentials_controller.rb
+++ b/app/controllers/admin/external_registry_credentials_controller.rb
@@ -1,62 +1,64 @@
-class Admin::ExternalRegistryCredentialsController < Admin::BaseController
-  before_action :find_external_registry_credential, only: %i[edit update reset]
+module Admin
+  class ExternalRegistryCredentialsController < Admin::BaseController
+    before_action :find_external_registry_credential, only: %i[edit update reset]
 
-  def index
-    @external_registry_credentials = ExternalRegistryCredential.all
-  end
+    def index
+      @external_registry_credentials = ExternalRegistryCredential.all
+    end
 
-  def new
-    @external_registry_credential = ExternalRegistryCredential.new
-  end
+    def new
+      @external_registry_credential = ExternalRegistryCredential.new
+    end
 
-  def create
-    @external_registry_credential = ExternalRegistryCredential.new(external_registry_credential_params)
+    def create
+      @external_registry_credential = ExternalRegistryCredential.new(external_registry_credential_params)
 
-    if @external_registry_credential.save
-      flash[:info] = "Saved!"
+      if @external_registry_credential.save
+        flash[:info] = "Saved!"
+        redirect_to admin_external_registry_credentials_url
+      else
+        flash[:error] =
+          @external_registry_credential.errors.full_messages.to_sentence
+        render :new
+      end
+    end
+
+    def edit
+    end
+
+    def update
+      if @external_registry_credential.update(external_registry_credential_params)
+        flash[:info] = "Updated!"
+        redirect_to admin_external_registry_credentials_url
+      else
+        flash[:error] = @external_registry_credential.errors.full_messages.to_sentence
+        render :edit
+      end
+    end
+
+    def reset
+      if @external_registry_credential.set_access_token
+        flash[:info] = "Access token set!"
+      else
+        flash[:error] = @external_registry_credential.errors.full_messages.to_sentence
+      end
+
       redirect_to admin_external_registry_credentials_url
-    else
-      flash[:error] =
-        @external_registry_credential.errors.full_messages.to_sentence
-      render :new
-    end
-  end
-
-  def edit
-  end
-
-  def update
-    if @external_registry_credential.update(external_registry_credential_params)
-      flash[:info] = "Updated!"
-      redirect_to admin_external_registry_credentials_url
-    else
-      flash[:error] = @external_registry_credential.errors.full_messages.to_sentence
-      render :edit
-    end
-  end
-
-  def reset
-    if @external_registry_credential.set_access_token
-      flash[:info] = "Access token set!"
-    else
-      flash[:error] = @external_registry_credential.errors.full_messages.to_sentence
     end
 
-    redirect_to admin_external_registry_credentials_url
-  end
+    private
 
-  private
+    def find_external_registry_credential
+      @external_registry_credential = ExternalRegistryCredential.find(params[:id])
+    end
 
-  def find_external_registry_credential
-    @external_registry_credential = ExternalRegistryCredential.find(params[:id])
-  end
+    def external_registry_credential_params
+      model_type = params[:type]&.underscore&.tr("/", "_")
+      params[model_type][:type] = params[:type]
 
-  def external_registry_credential_params
-    model_type = params[:type]&.underscore&.tr("/", "_")
-    params[model_type][:type] = params[:type]
-
-    params
-      .require(model_type)
-      .permit(:app_id, :access_token, :refresh_token, :type)
+      params
+        .require(model_type)
+        .permit(:app_id, :access_token, :refresh_token, :type)
+    end
   end
 end

--- a/app/controllers/admin/feedbacks_controller.rb
+++ b/app/controllers/admin/feedbacks_controller.rb
@@ -1,59 +1,61 @@
-class Admin::FeedbacksController < Admin::BaseController
-  include Binxtils::SortableTable
+module Admin
+  class FeedbacksController < Admin::BaseController
+    include Binxtils::SortableTable
 
-  def index
-    params[:page] || 1
-    @per_page = permitted_per_page(default: 50)
-    @pagy, @feedbacks = pagy(:countish, available_feedbacks.reorder("feedbacks.#{sort_column} #{sort_direction}"),
-      limit: @per_page, page: permitted_page)
-    @render_kind_counts = Binxtils::InputNormalizer.boolean(params[:search_kind_counts])
-  end
-
-  def show
-    @feedback = Feedback.find(params[:id])
-    if @feedback&.feedback_hash&.include?("bike_id")
-      @bike = Bike.unscoped.find_by_id(@feedback.feedback_hash["bike_id"])
+    def index
+      params[:page] || 1
+      @per_page = permitted_per_page(default: 50)
+      @pagy, @feedbacks = pagy(:countish, available_feedbacks.reorder("feedbacks.#{sort_column} #{sort_direction}"),
+        limit: @per_page, page: permitted_page)
+      @render_kind_counts = Binxtils::InputNormalizer.boolean(params[:search_kind_counts])
     end
-  end
 
-  helper_method :available_feedbacks, :permitted_kinds
-
-  private
-
-  def sortable_columns
-    %w[created_at feedback_type]
-  end
-
-  def permitted_kinds
-    %w[all stolen_tip] + Feedback.kinds
-  end
-
-  def matching_feedbacks
-    feedbacks = Feedback
-    if params[:search_kind].present? && permitted_kinds.include?(params[:search_kind])
-      @search_kind = params[:search_kind]
-      feedbacks = feedbacks.public_send(@search_kind) unless @search_kind == "all"
-    else
-      @search_kind = "all"
+    def show
+      @feedback = Feedback.find(params[:id])
+      if @feedback&.feedback_hash&.include?("bike_id")
+        @bike = Bike.unscoped.find_by_id(@feedback.feedback_hash["bike_id"])
+      end
     end
-    if params[:user_id].present?
-      feedbacks = feedbacks.where(user_id: user_subject&.id || params[:user_id])
-    end
-    if params[:search_email].present?
-      feedbacks = feedbacks.where("email ILIKE ?", "%#{EmailNormalizer.normalize(params[:search_email])}%")
-    end
-    if params[:search_bike_id].present?
-      feedbacks = feedbacks.bike(params[:search_bike_id])
-    end
-    feedbacks
-  end
 
-  def available_feedbacks
-    matching_feedbacks.where(created_at: @time_range)
-  end
+    helper_method :available_feedbacks, :permitted_kinds
 
-  # Override earliest period date, to use 1 week before first feedback created
-  def earliest_period_date
-    Time.at(1362190586)
+    private
+
+    def sortable_columns
+      %w[created_at feedback_type]
+    end
+
+    def permitted_kinds
+      %w[all stolen_tip] + Feedback.kinds
+    end
+
+    def matching_feedbacks
+      feedbacks = Feedback
+      if params[:search_kind].present? && permitted_kinds.include?(params[:search_kind])
+        @search_kind = params[:search_kind]
+        feedbacks = feedbacks.public_send(@search_kind) unless @search_kind == "all"
+      else
+        @search_kind = "all"
+      end
+      if params[:user_id].present?
+        feedbacks = feedbacks.where(user_id: user_subject&.id || params[:user_id])
+      end
+      if params[:search_email].present?
+        feedbacks = feedbacks.where("email ILIKE ?", "%#{EmailNormalizer.normalize(params[:search_email])}%")
+      end
+      if params[:search_bike_id].present?
+        feedbacks = feedbacks.bike(params[:search_bike_id])
+      end
+      feedbacks
+    end
+
+    def available_feedbacks
+      matching_feedbacks.where(created_at: @time_range)
+    end
+
+    # Override earliest period date, to use 1 week before first feedback created
+    def earliest_period_date
+      Time.at(1362190586)
+    end
   end
 end

--- a/app/controllers/admin/graduated_notifications_controller.rb
+++ b/app/controllers/admin/graduated_notifications_controller.rb
@@ -1,36 +1,38 @@
-class Admin::GraduatedNotificationsController < Admin::BaseController
-  include Binxtils::SortableTable
+module Admin
+  class GraduatedNotificationsController < Admin::BaseController
+    include Binxtils::SortableTable
 
-  def index
-    @per_page = permitted_per_page(default: 50)
-    @pagy, @graduated_notifications = pagy(:countish, matching_graduated_notifications.includes(:user, :organization, :bike)
-      .order(sort_column + " " + sort_direction), limit: @per_page, page: permitted_page)
-  end
-
-  helper_method :matching_graduated_notifications
-
-  protected
-
-  def sortable_columns
-    %w[created_at organization_id kind updated_at user_id resolved_at]
-  end
-
-  def matching_graduated_notifications
-    return @matching_graduated_notifications if defined?(@matching_graduated_notifications)
-
-    graduated_notifications = GraduatedNotification
-    if GraduatedNotification.statuses.include?(params[:search_status])
-      @search_status = params[:search_status]
-      graduated_notifications = graduated_notifications.where(status: @search_status)
-    else
-      @search_status = "all"
+    def index
+      @per_page = permitted_per_page(default: 50)
+      @pagy, @graduated_notifications = pagy(:countish, matching_graduated_notifications.includes(:user, :organization, :bike)
+        .order(sort_column + " " + sort_direction), limit: @per_page, page: permitted_page)
     end
-    if params[:search_bike_id].present?
-      @bike = Bike.unscoped.friendly_find(params[:search_bike_id])
-      graduated_notifications = graduated_notifications.where(bike_id: params[:search_bike_id])
+
+    helper_method :matching_graduated_notifications
+
+    protected
+
+    def sortable_columns
+      %w[created_at organization_id kind updated_at user_id resolved_at]
     end
-    graduated_notifications = graduated_notifications.marked_remaining if sort_column == "marked_remaining_at"
-    graduated_notifications = graduated_notifications.where(organization_id: current_organization.id) if current_organization.present?
-    @matching_graduated_notifications = graduated_notifications.where(created_at: @time_range)
+
+    def matching_graduated_notifications
+      return @matching_graduated_notifications if defined?(@matching_graduated_notifications)
+
+      graduated_notifications = GraduatedNotification
+      if GraduatedNotification.statuses.include?(params[:search_status])
+        @search_status = params[:search_status]
+        graduated_notifications = graduated_notifications.where(status: @search_status)
+      else
+        @search_status = "all"
+      end
+      if params[:search_bike_id].present?
+        @bike = Bike.unscoped.friendly_find(params[:search_bike_id])
+        graduated_notifications = graduated_notifications.where(bike_id: params[:search_bike_id])
+      end
+      graduated_notifications = graduated_notifications.marked_remaining if sort_column == "marked_remaining_at"
+      graduated_notifications = graduated_notifications.where(organization_id: current_organization.id) if current_organization.present?
+      @matching_graduated_notifications = graduated_notifications.where(created_at: @time_range)
+    end
   end
 end

--- a/app/controllers/admin/graphs_controller.rb
+++ b/app/controllers/admin/graphs_controller.rb
@@ -1,130 +1,132 @@
-class Admin::GraphsController < Admin::BaseController
-  before_action :set_period
-  before_action :set_variable_graph_kind
-  around_action :set_reading_role
+module Admin
+  class GraphsController < Admin::BaseController
+    before_action :set_period
+    before_action :set_variable_graph_kind
+    around_action :set_reading_role
 
-  def index
-    @total_count = if @kind == "users"
-      matching_users.count
-    elsif @kind == "recoveries"
-      matching_recoveries.where(recovered_at: @time_range).count
-    elsif @kind == "bikes"
-      matching_bikes.count
+    def index
+      @total_count = if @kind == "users"
+        matching_users.count
+      elsif @kind == "recoveries"
+        matching_recoveries.where(recovered_at: @time_range).count
+      elsif @kind == "bikes"
+        matching_bikes.count
+      end
+      @page_title = "#{@kind.humanize} graphs"
     end
-    @page_title = "#{@kind.humanize} graphs"
-  end
 
-  def variable
-    chart_data = if @kind == "users"
-      helpers.time_range_counts(collection: User.where(created_at: @time_range))
-    elsif @kind == "bikes"
-      bike_chart_data
-    elsif @kind == "recoveries"
-      helpers.time_range_counts(collection: matching_recoveries)
-    end
-    if chart_data.present?
-      render json: chart_data.chart_json
-    else
-      render json: {error: "unable to parse chart"}
-    end
-  end
-
-  def tables
-    @kind = ""
-  end
-
-  helper_method :shown_bike_graph_kinds, :matching_bikes, :pos_search_kinds, :default_period
-
-  protected
-
-  def set_variable_graph_kind
-    # NOTE: pos_integrations redirects you to the OrganizationStatusesController
-    @graph_kinds = %w[general users bikes recoveries pos_integrations]
-    @kind = @graph_kinds.include?(params[:search_kind]) ? params[:search_kind] : @graph_kinds.first
-  end
-
-  def matching_users
-    User.where(created_at: @time_range)
-  end
-
-  def matching_recoveries
-    StolenRecord.recovered.where(recovered_at: @time_range)
-  end
-
-  def matching_bikes
-    return @matching_bikes if defined?(@matching_bikes)
-
-    bikes = Bike.unscoped.where(created_at: @time_range)
-    if params[:search_manufacturer].present?
-      @manufacturer = Manufacturer.friendly_find(params[:search_manufacturer])
-      bikes = if @manufacturer.present?
-        bikes.where(manufacturer_id: @manufacturer&.id)
+    def variable
+      chart_data = if @kind == "users"
+        helpers.time_range_counts(collection: User.where(created_at: @time_range))
+      elsif @kind == "bikes"
+        bike_chart_data
+      elsif @kind == "recoveries"
+        helpers.time_range_counts(collection: matching_recoveries)
+      end
+      if chart_data.present?
+        render json: chart_data.chart_json
       else
-        bikes.where(mnfg_name: params[:search_manufacturer])
+        render json: {error: "unable to parse chart"}
       end
     end
-    @matching_bikes = admin_search_bike_statuses(bikes)
-  end
 
-  def default_period
-    "year"
-  end
+    def tables
+      @kind = ""
+    end
 
-  def bike_graph_kinds
-    %w[stolen origin pos ignored]
-  end
+    helper_method :shown_bike_graph_kinds, :matching_bikes, :pos_search_kinds, :default_period
 
-  def shown_bike_graph_kinds
-    bike_graph_kinds - ["ignored"]
-  end
+    protected
 
-  def pos_search_kinds
-    %w[lightspeed_pos ascend_pos does_not_need_pos no_pos]
-  end
+    def set_variable_graph_kind
+      # NOTE: pos_integrations redirects you to the OrganizationStatusesController
+      @graph_kinds = %w[general users bikes recoveries pos_integrations]
+      @kind = @graph_kinds.include?(params[:search_kind]) ? params[:search_kind] : @graph_kinds.first
+    end
 
-  def bike_chart_data
-    bikes = matching_bikes
-    bike_graph_kind = bike_graph_kinds.include?(params[:bike_graph_kind]) ? params[:bike_graph_kind] : bike_graph_kinds.first
-    if bike_graph_kind == "stolen"
-      [
-        {
-          name: "Registered bikes",
-          data: helpers.time_range_counts(collection: bikes)
-        },
-        {
-          name: "Stolen records",
-          data: helpers.time_range_counts(collection: StolenRecord.unscoped.joins(:bike).merge(bikes), column: "stolen_records.created_at")
-        }
-      ]
-    elsif bike_graph_kind == "origin"
-      Ownership.origins.map do |origin|
-        {
-          name: origin.humanize,
-          data: helpers.time_range_counts(collection: bikes.includes(:ownerships).where(ownerships: {origin: origin}))
-        }
+    def matching_users
+      User.where(created_at: @time_range)
+    end
+
+    def matching_recoveries
+      StolenRecord.recovered.where(recovered_at: @time_range)
+    end
+
+    def matching_bikes
+      return @matching_bikes if defined?(@matching_bikes)
+
+      bikes = Bike.unscoped.where(created_at: @time_range)
+      if params[:search_manufacturer].present?
+        @manufacturer = Manufacturer.friendly_find(params[:search_manufacturer])
+        bikes = if @manufacturer.present?
+          bikes.where(manufacturer_id: @manufacturer&.id)
+        else
+          bikes.where(mnfg_name: params[:search_manufacturer])
+        end
       end
-    elsif bike_graph_kind == "pos"
-      pos_search_kinds.map do |pos_kind|
-        {
-          name: pos_kind.humanize,
-          data: helpers.time_range_counts(collection: bikes.send(pos_kind))
-        }
+      @matching_bikes = admin_search_bike_statuses(bikes)
+    end
+
+    def default_period
+      "year"
+    end
+
+    def bike_graph_kinds
+      %w[stolen origin pos ignored]
+    end
+
+    def shown_bike_graph_kinds
+      bike_graph_kinds - ["ignored"]
+    end
+
+    def pos_search_kinds
+      %w[lightspeed_pos ascend_pos does_not_need_pos no_pos]
+    end
+
+    def bike_chart_data
+      bikes = matching_bikes
+      bike_graph_kind = bike_graph_kinds.include?(params[:bike_graph_kind]) ? params[:bike_graph_kind] : bike_graph_kinds.first
+      if bike_graph_kind == "stolen"
+        [
+          {
+            name: "Registered bikes",
+            data: helpers.time_range_counts(collection: bikes)
+          },
+          {
+            name: "Stolen records",
+            data: helpers.time_range_counts(collection: StolenRecord.unscoped.joins(:bike).merge(bikes), column: "stolen_records.created_at")
+          }
+        ]
+      elsif bike_graph_kind == "origin"
+        Ownership.origins.map do |origin|
+          {
+            name: origin.humanize,
+            data: helpers.time_range_counts(collection: bikes.includes(:ownerships).where(ownerships: {origin: origin}))
+          }
+        end
+      elsif bike_graph_kind == "pos"
+        pos_search_kinds.map do |pos_kind|
+          {
+            name: pos_kind.humanize,
+            data: helpers.time_range_counts(collection: bikes.send(pos_kind))
+          }
+        end
+      elsif bike_graph_kind == "ignored"
+        [
+          {
+            name: "Spam",
+            data: helpers.time_range_counts(collection: bikes.spam)
+          },
+          {
+            name: "Deleted",
+            data: helpers.time_range_counts(collection: bikes.deleted)
+          },
+          {
+            name: "Test",
+            data: helpers.time_range_counts(collection: bikes.example)
+          }
+        ]
       end
-    elsif bike_graph_kind == "ignored"
-      [
-        {
-          name: "Spam",
-          data: helpers.time_range_counts(collection: bikes.spam)
-        },
-        {
-          name: "Deleted",
-          data: helpers.time_range_counts(collection: bikes.deleted)
-        },
-        {
-          name: "Test",
-          data: helpers.time_range_counts(collection: bikes.example)
-        }
-      ]
     end
   end
 end

--- a/app/controllers/admin/impound_claims_controller.rb
+++ b/app/controllers/admin/impound_claims_controller.rb
@@ -1,61 +1,63 @@
-class Admin::ImpoundClaimsController < Admin::BaseController
-  include Binxtils::SortableTable
+module Admin
+  class ImpoundClaimsController < Admin::BaseController
+    include Binxtils::SortableTable
 
-  before_action :find_impound_claim, except: [:index]
+    before_action :find_impound_claim, except: [:index]
 
-  def index
-    @per_page = permitted_per_page(default: 50)
-    @pagy, @impound_claims = pagy(:countish,
-      matching_impound_claims.includes(:user, :organization, :impound_record, :bike_claimed, :bike_submitting)
-        .order(sort_column + " " + sort_direction),
-      limit: @per_page,
-      page: permitted_page)
-  end
+    def index
+      @per_page = permitted_per_page(default: 50)
+      @pagy, @impound_claims = pagy(:countish,
+        matching_impound_claims.includes(:user, :organization, :impound_record, :bike_claimed, :bike_submitting)
+          .order(sort_column + " " + sort_direction),
+        limit: @per_page,
+        page: permitted_page)
+    end
 
-  def show
-  end
+    def show
+    end
 
-  helper_method :matching_impound_claims, :available_statuses
+    helper_method :matching_impound_claims, :available_statuses
 
-  protected
+    protected
 
-  def available_statuses
-    %w[all current resolved] + (ImpoundClaim.statuses - ["current"]) # current ordered the way we want to display
-  end
+    def available_statuses
+      %w[all current resolved] + (ImpoundClaim.statuses - ["current"]) # current ordered the way we want to display
+    end
 
-  def sortable_columns
-    %w[created_at organization_id updated_at status user_id impound_record resolved_at]
-  end
+    def sortable_columns
+      %w[created_at organization_id updated_at status user_id impound_record resolved_at]
+    end
 
-  def earliest_period_date
-    Time.at(1611367147) # 14 days before first impound claim created
-  end
+    def earliest_period_date
+      Time.at(1611367147) # 14 days before first impound claim created
+    end
 
-  def matching_impound_claims
-    impound_claims = ImpoundClaim
+    def matching_impound_claims
+      impound_claims = ImpoundClaim
 
-    if params[:search_status] == "all"
-      @search_status = "all"
-    else
-      @search_status = available_statuses.include?(params[:search_status]) ? params[:search_status] : available_statuses.first
-      impound_claims = if ImpoundClaim.statuses.include?(@search_status)
-        impound_claims.where(status: @search_status)
+      if params[:search_status] == "all"
+        @search_status = "all"
       else
-        impound_claims.public_send(@search_status)
+        @search_status = available_statuses.include?(params[:search_status]) ? params[:search_status] : available_statuses.first
+        impound_claims = if ImpoundClaim.statuses.include?(@search_status)
+          impound_claims.where(status: @search_status)
+        else
+          impound_claims.public_send(@search_status)
+        end
       end
+
+      if params[:search_bike_id].present?
+        impound_claims = impound_claims.involving_bike_id(params[:search_bike_id])
+      end
+      impound_claims = impound_claims.where(organization_id: current_organization.id) if current_organization.present?
+
+      impound_claims.where(created_at: @time_range)
     end
 
-    if params[:search_bike_id].present?
-      impound_claims = impound_claims.involving_bike_id(params[:search_bike_id])
+    def find_impound_claim
+      @impound_claim = ImpoundClaim.find(params[:id])
+      @impound_record = @impound_claim.impound_record
+      @parking_notification = @impound_record.parking_notification
     end
-    impound_claims = impound_claims.where(organization_id: current_organization.id) if current_organization.present?
-
-    impound_claims.where(created_at: @time_range)
-  end
-
-  def find_impound_claim
-    @impound_claim = ImpoundClaim.find(params[:id])
-    @impound_record = @impound_claim.impound_record
-    @parking_notification = @impound_record.parking_notification
   end
 end

--- a/app/controllers/admin/impound_records_controller.rb
+++ b/app/controllers/admin/impound_records_controller.rb
@@ -1,65 +1,67 @@
-class Admin::ImpoundRecordsController < Admin::BaseController
-  include Binxtils::SortableTable
+module Admin
+  class ImpoundRecordsController < Admin::BaseController
+    include Binxtils::SortableTable
 
-  before_action :find_impound_record, except: [:index]
+    before_action :find_impound_record, except: [:index]
 
-  def index
-    params[:page] || 1
-    @per_page = permitted_per_page(default: 50)
-    @pagy, @impound_records = pagy(:countish, matching_impound_records.includes(:user, :organization, :bike, :impound_claims)
-      .order("impound_records.#{sort_column}" + " " + sort_direction), limit: @per_page, page: permitted_page)
-  end
+    def index
+      params[:page] || 1
+      @per_page = permitted_per_page(default: 50)
+      @pagy, @impound_records = pagy(:countish, matching_impound_records.includes(:user, :organization, :bike, :impound_claims)
+        .order("impound_records.#{sort_column}" + " " + sort_direction), limit: @per_page, page: permitted_page)
+    end
 
-  def show
-  end
+    def show
+    end
 
-  helper_method :matching_impound_records, :available_statuses
+    helper_method :matching_impound_records, :available_statuses
 
-  protected
+    protected
 
-  def available_statuses
-    %w[all current resolved] + (ImpoundRecord.statuses - ["current"]) # current ordered the way we want to display
-  end
+    def available_statuses
+      %w[all current resolved] + (ImpoundRecord.statuses - ["current"]) # current ordered the way we want to display
+    end
 
-  def sortable_columns
-    %w[created_at organization_id location_id updated_at status user_id resolved_at]
-  end
+    def sortable_columns
+      %w[created_at organization_id location_id updated_at status user_id resolved_at]
+    end
 
-  def earliest_period_date
-    Time.at(1580853693) # 14 days before first impound record created
-  end
+    def earliest_period_date
+      Time.at(1580853693) # 14 days before first impound record created
+    end
 
-  def matching_impound_records
-    impound_records = ImpoundRecord
+    def matching_impound_records
+      impound_records = ImpoundRecord
 
-    if params[:search_status] == "all"
-      @search_status = "all"
-    else
-      @search_status = available_statuses.include?(params[:search_status]) ? params[:search_status] : available_statuses.first
-      impound_records = if ImpoundRecord.statuses.include?(@search_status)
-        impound_records.where(status: @search_status)
+      if params[:search_status] == "all"
+        @search_status = "all"
       else
-        impound_records.public_send(@search_status)
+        @search_status = available_statuses.include?(params[:search_status]) ? params[:search_status] : available_statuses.first
+        impound_records = if ImpoundRecord.statuses.include?(@search_status)
+          impound_records.where(status: @search_status)
+        else
+          impound_records.public_send(@search_status)
+        end
       end
+      @with_claims = Binxtils::InputNormalizer.boolean(params[:search_with_claims])
+      impound_records = impound_records.with_claims if @with_claims
+      if params[:search_bike_id].present?
+        impound_records = impound_records.where(bike_id: params[:search_bike_id])
+      end
+      if params[:user_id].present?
+        impound_records = impound_records.where(user_id: user_subject&.id || params[:user_id])
+      end
+      impound_records = impound_records.where(organization_id: current_organization.id) if current_organization.present?
+      impound_records.where(created_at: @time_range)
     end
-    @with_claims = Binxtils::InputNormalizer.boolean(params[:search_with_claims])
-    impound_records = impound_records.with_claims if @with_claims
-    if params[:search_bike_id].present?
-      impound_records = impound_records.where(bike_id: params[:search_bike_id])
-    end
-    if params[:user_id].present?
-      impound_records = impound_records.where(user_id: user_subject&.id || params[:user_id])
-    end
-    impound_records = impound_records.where(organization_id: current_organization.id) if current_organization.present?
-    impound_records.where(created_at: @time_range)
-  end
 
-  def find_impound_record
-    @impound_record = if params[:id].match?(/\A\d+\z/)
-      ImpoundRecord.find(params[:id])
-    else
-      ImpoundRecord.friendly_find!(params[:id])
+    def find_impound_record
+      @impound_record = if params[:id].match?(/\A\d+\z/)
+        ImpoundRecord.find(params[:id])
+      else
+        ImpoundRecord.friendly_find!(params[:id])
+      end
+      @bike = @impound_record.bike
     end
-    @bike = @impound_record.bike
   end
 end

--- a/app/controllers/admin/invoices_controller.rb
+++ b/app/controllers/admin/invoices_controller.rb
@@ -1,67 +1,69 @@
-class Admin::InvoicesController < Admin::BaseController
-  include Binxtils::SortableTable
+module Admin
+  class InvoicesController < Admin::BaseController
+    include Binxtils::SortableTable
 
-  def index
-    @per_page = permitted_per_page(default: 50)
-    @pagy, @invoices =
-      pagy(:countish, matching_invoices
-        .includes(:organization, :payments, :organization_features, :first_invoice)
-        .reorder(sort_column + " " + sort_direction), limit: @per_page, page: permitted_page)
-  end
-
-  helper_method :matching_invoices
-
-  protected
-
-  def sortable_columns
-    %w[id organization_id amount_cents amount_due_cents amount_paid_cents subscription_start_at subscription_end_at]
-  end
-
-  def earliest_period_date
-    Time.at(1528767966) # First invoice
-  end
-
-  def latest_period_date
-    return super unless @period.in?(%w[all custom])
-    Invoice.maximum(:subscription_end_at) || Time.current
-  end
-
-  def matching_invoices
-    @query = params[:query]
-    invoices = if @query == "active"
-      Invoice.active
-    elsif @query == "inactive"
-      Invoice.inactive
-    elsif @query == "first_invoice"
-      Invoice.first_invoice
-    elsif @query == "renewal_invoice"
-      Invoice.renewal_invoice
-    else
-      @query = nil
-      Invoice
+    def index
+      @per_page = permitted_per_page(default: 50)
+      @pagy, @invoices =
+        pagy(:countish, matching_invoices
+          .includes(:organization, :payments, :organization_features, :first_invoice)
+          .reorder(sort_column + " " + sort_direction), limit: @per_page, page: permitted_page)
     end
 
-    if %w[only_paid only_free].include?(params[:search_paid])
-      @search_paid = params[:search_paid]
-      invoices = (@search_paid == "only_paid") ? invoices.paid : invoices.free
+    helper_method :matching_invoices
+
+    protected
+
+    def sortable_columns
+      %w[id organization_id amount_cents amount_due_cents amount_paid_cents subscription_start_at subscription_end_at]
     end
 
-    if %w[subscription_start_at subscription_end_at].include?(params[:time_range_column])
-      @time_range_column = params[:time_range_column]
-      @search_endless = "not_endless" if @time_range_column == "subscription_end_at"
-    else
-      @time_range_column = "created_at"
+    def earliest_period_date
+      Time.at(1528767966) # First invoice
     end
 
-    if %w[endless_only not_endless].include?(params[:search_endless])
-      @search_endless ||= params[:search_endless]
-      invoices = (@search_endless == "endless_only") ? invoices.endless : invoices.not_endless
+    def latest_period_date
+      return super unless @period.in?(%w[all custom])
+      Invoice.maximum(:subscription_end_at) || Time.current
     end
 
-    if current_organization.present?
-      invoices = invoices.where(organization_id: current_organization.id)
-    end
+    def matching_invoices
+      @query = params[:query]
+      invoices = if @query == "active"
+        Invoice.active
+      elsif @query == "inactive"
+        Invoice.inactive
+      elsif @query == "first_invoice"
+        Invoice.first_invoice
+      elsif @query == "renewal_invoice"
+        Invoice.renewal_invoice
+      else
+        @query = nil
+        Invoice
+      end
 
-    invoices.where(@time_range_column => @time_range)
+      if %w[only_paid only_free].include?(params[:search_paid])
+        @search_paid = params[:search_paid]
+        invoices = (@search_paid == "only_paid") ? invoices.paid : invoices.free
+      end
+
+      if %w[subscription_start_at subscription_end_at].include?(params[:time_range_column])
+        @time_range_column = params[:time_range_column]
+        @search_endless = "not_endless" if @time_range_column == "subscription_end_at"
+      else
+        @time_range_column = "created_at"
+      end
+
+      if %w[endless_only not_endless].include?(params[:search_endless])
+        @search_endless ||= params[:search_endless]
+        invoices = (@search_endless == "endless_only") ? invoices.endless : invoices.not_endless
+      end
+
+      if current_organization.present?
+        invoices = invoices.where(organization_id: current_organization.id)
+      end
+
+      invoices.where(@time_range_column => @time_range)
+    end
   end
 end

--- a/app/controllers/admin/logged_searches_controller.rb
+++ b/app/controllers/admin/logged_searches_controller.rb
@@ -1,72 +1,74 @@
-class Admin::LoggedSearchesController < Admin::BaseController
-  include Binxtils::SortableTable
+module Admin
+  class LoggedSearchesController < Admin::BaseController
+    include Binxtils::SortableTable
 
-  def index
-    @per_page = permitted_per_page(default: 10)
-    @pagy, @logged_searches =
-      pagy(:countish, matching_logged_searches
-        .reorder("logged_searches.#{sort_column} #{sort_direction}")
-        .includes(:organization, :user), limit: @per_page, page: permitted_page)
-  end
+    def index
+      @per_page = permitted_per_page(default: 10)
+      @pagy, @logged_searches =
+        pagy(:countish, matching_logged_searches
+          .reorder("logged_searches.#{sort_column} #{sort_direction}")
+          .includes(:organization, :user), limit: @per_page, page: permitted_page)
+    end
 
-  helper_method :matching_logged_searches, :special_endpoints
+    helper_method :matching_logged_searches, :special_endpoints
 
-  private
+    private
 
-  def sortable_columns
-    %w[request_at created_at duration_ms endpoint stolenness ip_address organization_id user_id
-      serial_normalized page].freeze
-  end
+    def sortable_columns
+      %w[request_at created_at duration_ms endpoint stolenness ip_address organization_id user_id
+        serial_normalized page].freeze
+    end
 
-  def earliest_period_date
-    LoggedSearch.minimum(:request_at) || Time.current - 1.day
-  end
+    def earliest_period_date
+      LoggedSearch.minimum(:request_at) || Time.current - 1.day
+    end
 
-  def special_endpoints
-    %w[not_web_bikes organized]
-  end
+    def special_endpoints
+      %w[not_web_bikes organized]
+    end
 
-  def matching_logged_searches
-    logged_searches = LoggedSearch.all
+    def matching_logged_searches
+      logged_searches = LoggedSearch.all
 
-    if special_endpoints.include?(params[:search_endpoint])
-      @endpoint = params[:search_endpoint]
-      logged_searches = case @endpoint
-      when "not_web_bikes" then logged_searches.where.not(endpoint: :web_bikes)
-      when "organized" then logged_searches.organized
+      if special_endpoints.include?(params[:search_endpoint])
+        @endpoint = params[:search_endpoint]
+        logged_searches = case @endpoint
+        when "not_web_bikes" then logged_searches.where.not(endpoint: :web_bikes)
+        when "organized" then logged_searches.organized
+        end
+      elsif LoggedSearch.endpoints.key?(params[:search_endpoint])
+        @endpoint = params[:search_endpoint]
+        logged_searches = logged_searches.where(endpoint: @endpoint)
+      else
+        @endpoint = "all"
       end
-    elsif LoggedSearch.endpoints.key?(params[:search_endpoint])
-      @endpoint = params[:search_endpoint]
-      logged_searches = logged_searches.where(endpoint: @endpoint)
-    else
-      @endpoint = "all"
+
+      @serial = Binxtils::InputNormalizer.boolean(params[:search_serial])
+      logged_searches = logged_searches.serial if @serial
+
+      @includes_query = Binxtils::InputNormalizer.boolean(params[:search_includes_query])
+      logged_searches = logged_searches.includes_query if @includes_query
+
+      @with_location = Binxtils::InputNormalizer.boolean(params[:search_with_location])
+      logged_searches = logged_searches.with_location if @with_location
+
+      if params[:search_ip_address].present?
+        logged_searches = logged_searches.where(ip_address: params[:search_ip_address])
+      end
+      if params[:user_id].present?
+        logged_searches = logged_searches.where(user_id: user_subject&.id || params[:user_id])
+      end
+      if params[:organization_id].present?
+        logged_searches = logged_searches.where(organization_id: params[:organization_id])
+      end
+
+      logged_searches = logged_searches.where.not(user_id: nil) if sort_column == "user_id"
+      logged_searches = logged_searches.where.not(organization_id: nil) if sort_column == "organization_id"
+      logged_searches = logged_searches.where.not(page: nil) if sort_column == "page"
+
+      @time_range_column = sort_column if %w[created_at updated_at].include?(sort_column)
+      @time_range_column ||= "request_at"
+      logged_searches.where(@time_range_column => @time_range)
     end
-
-    @serial = Binxtils::InputNormalizer.boolean(params[:search_serial])
-    logged_searches = logged_searches.serial if @serial
-
-    @includes_query = Binxtils::InputNormalizer.boolean(params[:search_includes_query])
-    logged_searches = logged_searches.includes_query if @includes_query
-
-    @with_location = Binxtils::InputNormalizer.boolean(params[:search_with_location])
-    logged_searches = logged_searches.with_location if @with_location
-
-    if params[:search_ip_address].present?
-      logged_searches = logged_searches.where(ip_address: params[:search_ip_address])
-    end
-    if params[:user_id].present?
-      logged_searches = logged_searches.where(user_id: user_subject&.id || params[:user_id])
-    end
-    if params[:organization_id].present?
-      logged_searches = logged_searches.where(organization_id: params[:organization_id])
-    end
-
-    logged_searches = logged_searches.where.not(user_id: nil) if sort_column == "user_id"
-    logged_searches = logged_searches.where.not(organization_id: nil) if sort_column == "organization_id"
-    logged_searches = logged_searches.where.not(page: nil) if sort_column == "page"
-
-    @time_range_column = sort_column if %w[created_at updated_at].include?(sort_column)
-    @time_range_column ||= "request_at"
-    logged_searches.where(@time_range_column => @time_range)
   end
 end

--- a/app/controllers/admin/mail_snippets_controller.rb
+++ b/app/controllers/admin/mail_snippets_controller.rb
@@ -1,80 +1,82 @@
-class Admin::MailSnippetsController < Admin::BaseController
-  include Binxtils::SortableTable
+module Admin
+  class MailSnippetsController < Admin::BaseController
+    include Binxtils::SortableTable
 
-  before_action :find_snippet, except: [:index, :new, :create]
+    before_action :find_snippet, except: [:index, :new, :create]
 
-  def index
-    @per_page = permitted_per_page
-    @pagy, @mail_snippets = pagy(:countish, matching_mail_snippets.reorder("mail_snippets.#{sort_column} #{sort_direction}")
-      .includes(:organization), limit: @per_page, page: permitted_page)
-  end
+    def index
+      @per_page = permitted_per_page
+      @pagy, @mail_snippets = pagy(:countish, matching_mail_snippets.reorder("mail_snippets.#{sort_column} #{sort_direction}")
+        .includes(:organization), limit: @per_page, page: permitted_page)
+    end
 
-  def show
-    redirect_to edit_admin_mail_snippet_url(@mail_snippet)
-  end
-
-  def edit
-    @organizations = Organization.all
-  end
-
-  def update
-    if @mail_snippet.update(permitted_parameters)
-      flash[:success] = "Snippet Saved!"
+    def show
       redirect_to edit_admin_mail_snippet_url(@mail_snippet)
-    else
-      render action: :edit
     end
-  end
 
-  def new
-    @mail_snippet = MailSnippet.new
-    @organizations = Organization.all
-  end
-
-  def create
-    @mail_snippet = MailSnippet.create(permitted_parameters)
-    if @mail_snippet.save
-      flash[:success] = "Snippet Created!"
-      redirect_to edit_admin_mail_snippet_url(@mail_snippet)
-    else
-      render action: :new
+    def edit
+      @organizations = Organization.all
     end
-  end
 
-  helper_method :matching_mail_snippets
-
-  protected
-
-  def sortable_columns
-    %w[created_at organization_id updated_at kind]
-  end
-
-  def matching_mail_snippets
-    return @matching_mail_snippets if defined?(@matching_mail_snippets)
-
-    matching_mail_snippets = MailSnippet
-    if MailSnippet.kinds.include?(params[:search_kind])
-      @search_kind = params[:search_kind]
-      matching_mail_snippets = matching_mail_snippets.where(kind: @search_kind)
-    else
-      @search_kind = "all"
+    def update
+      if @mail_snippet.update(permitted_parameters)
+        flash[:success] = "Snippet Saved!"
+        redirect_to edit_admin_mail_snippet_url(@mail_snippet)
+      else
+        render action: :edit
+      end
     end
-    if current_organization.present?
-      matching_mail_snippets = matching_mail_snippets.where(organization_id: current_organization.id)
+
+    def new
+      @mail_snippet = MailSnippet.new
+      @organizations = Organization.all
     end
-    @matching_mail_snippets = matching_mail_snippets.where(created_at: @time_range)
-  end
 
-  def permitted_parameters
-    params.require(:mail_snippet).permit(:kind,
-      :subject,
-      :organization_id,
-      :body,
-      :is_enabled,
-      :doorkeeper_app_id)
-  end
+    def create
+      @mail_snippet = MailSnippet.create(permitted_parameters)
+      if @mail_snippet.save
+        flash[:success] = "Snippet Created!"
+        redirect_to edit_admin_mail_snippet_url(@mail_snippet)
+      else
+        render action: :new
+      end
+    end
 
-  def find_snippet
-    @mail_snippet = MailSnippet.find(params[:id])
+    helper_method :matching_mail_snippets
+
+    protected
+
+    def sortable_columns
+      %w[created_at organization_id updated_at kind]
+    end
+
+    def matching_mail_snippets
+      return @matching_mail_snippets if defined?(@matching_mail_snippets)
+
+      matching_mail_snippets = MailSnippet
+      if MailSnippet.kinds.include?(params[:search_kind])
+        @search_kind = params[:search_kind]
+        matching_mail_snippets = matching_mail_snippets.where(kind: @search_kind)
+      else
+        @search_kind = "all"
+      end
+      if current_organization.present?
+        matching_mail_snippets = matching_mail_snippets.where(organization_id: current_organization.id)
+      end
+      @matching_mail_snippets = matching_mail_snippets.where(created_at: @time_range)
+    end
+
+    def permitted_parameters
+      params.require(:mail_snippet).permit(:kind,
+        :subject,
+        :organization_id,
+        :body,
+        :is_enabled,
+        :doorkeeper_app_id)
+    end
+
+    def find_snippet
+      @mail_snippet = MailSnippet.find(params[:id])
+    end
   end
 end

--- a/app/controllers/admin/mailchimp_data_controller.rb
+++ b/app/controllers/admin/mailchimp_data_controller.rb
@@ -1,53 +1,55 @@
-class Admin::MailchimpDataController < Admin::BaseController
-  include Binxtils::SortableTable
+module Admin
+  class MailchimpDataController < Admin::BaseController
+    include Binxtils::SortableTable
 
-  def index
-    @per_page = permitted_per_page(default: 50)
-    @pagy, @mailchimp_data = pagy(:countish, matching_mailchimp_data.includes(:user, :feedbacks)
-      .order(sort_column + " " + sort_direction), limit: @per_page, page: permitted_page)
-  end
-
-  helper_method :matching_mailchimp_data
-
-  protected
-
-  def sortable_columns
-    %w[created_at email updated_at mailchimp_updated_at status]
-  end
-
-  def earliest_period_date
-    Time.at(1621109647) # 2021-05-15 - Pretty sure before any mailchimp stuff
-  end
-
-  def matching_mailchimp_data
-    @search_users = %w[with_user no_user].include?(params[:search_users]) ? params[:search_users] : "all"
-    m_mailchimp_data = if @search_users == "with_user"
-      MailchimpDatum.with_user
-    elsif @search_users == "no_user"
-      MailchimpDatum.no_user
-    else
-      MailchimpDatum
+    def index
+      @per_page = permitted_per_page(default: 50)
+      @pagy, @mailchimp_data = pagy(:countish, matching_mailchimp_data.includes(:user, :feedbacks)
+        .order(sort_column + " " + sort_direction), limit: @per_page, page: permitted_page)
     end
-    if MailchimpValue.lists.include?(params[:search_list])
-      @list = params[:search_list]
-      m_mailchimp_data = m_mailchimp_data.list(@list)
-    else
-      @list = "all"
-    end
-    if MailchimpDatum.statuses.include?(params[:search_status])
-      @status = params[:search_status]
-      m_mailchimp_data = m_mailchimp_data.where(status: @status)
-    elsif params[:search_status] == "not_subscribed"
-      @status = "not_subscribed"
-      m_mailchimp_data = m_mailchimp_data.where.not(status: "subscribed")
-    else
-      @status = "all"
-    end
-    m_mailchimp_data = m_mailchimp_data.where("email ILIKE ?", "%#{params[:query]}%") if params[:query].present?
-    @time_range_column = sort_column if %w[updated_at mailchimp_updated_at].include?(sort_column)
-    @time_range_column ||= "created_at"
 
-    m_mailchimp_data
-      .where(@time_range_column => @time_range)
+    helper_method :matching_mailchimp_data
+
+    protected
+
+    def sortable_columns
+      %w[created_at email updated_at mailchimp_updated_at status]
+    end
+
+    def earliest_period_date
+      Time.at(1621109647) # 2021-05-15 - Pretty sure before any mailchimp stuff
+    end
+
+    def matching_mailchimp_data
+      @search_users = %w[with_user no_user].include?(params[:search_users]) ? params[:search_users] : "all"
+      m_mailchimp_data = if @search_users == "with_user"
+        MailchimpDatum.with_user
+      elsif @search_users == "no_user"
+        MailchimpDatum.no_user
+      else
+        MailchimpDatum
+      end
+      if MailchimpValue.lists.include?(params[:search_list])
+        @list = params[:search_list]
+        m_mailchimp_data = m_mailchimp_data.list(@list)
+      else
+        @list = "all"
+      end
+      if MailchimpDatum.statuses.include?(params[:search_status])
+        @status = params[:search_status]
+        m_mailchimp_data = m_mailchimp_data.where(status: @status)
+      elsif params[:search_status] == "not_subscribed"
+        @status = "not_subscribed"
+        m_mailchimp_data = m_mailchimp_data.where.not(status: "subscribed")
+      else
+        @status = "all"
+      end
+      m_mailchimp_data = m_mailchimp_data.where("email ILIKE ?", "%#{params[:query]}%") if params[:query].present?
+      @time_range_column = sort_column if %w[updated_at mailchimp_updated_at].include?(sort_column)
+      @time_range_column ||= "created_at"
+
+      m_mailchimp_data
+        .where(@time_range_column => @time_range)
+    end
   end
 end

--- a/app/controllers/admin/mailchimp_values_controller.rb
+++ b/app/controllers/admin/mailchimp_values_controller.rb
@@ -1,29 +1,31 @@
-class Admin::MailchimpValuesController < Admin::BaseController
-  include Binxtils::SortableTable
+module Admin
+  class MailchimpValuesController < Admin::BaseController
+    include Binxtils::SortableTable
 
-  def index
-    @mailchimp_values = matching_mailchimp_values.order(sort_column + " " + sort_direction)
-  end
+    def index
+      @mailchimp_values = matching_mailchimp_values.order(sort_column + " " + sort_direction)
+    end
 
-  def create
-    UpdateMailchimpValuesJob.perform_async
-    flash[:success] = "Updating the Mailchimp Values"
-    redirect_back(fallback_location: admin_mailchimp_values_path)
-  end
+    def create
+      UpdateMailchimpValuesJob.perform_async
+      flash[:success] = "Updating the Mailchimp Values"
+      redirect_back(fallback_location: admin_mailchimp_values_path)
+    end
 
-  protected
+    protected
 
-  def sortable_columns
-    %w[name slug list kind created_at updated_at]
-  end
+    def sortable_columns
+      %w[name slug list kind created_at updated_at]
+    end
 
-  def matching_mailchimp_values
-    if MailchimpValue.lists.include?(params[:search_list])
-      @list = params[:search_list]
-      MailchimpValue.where(list: @list)
-    else
-      @list = "all"
-      MailchimpValue
+    def matching_mailchimp_values
+      if MailchimpValue.lists.include?(params[:search_list])
+        @list = params[:search_list]
+        MailchimpValue.where(list: @list)
+      else
+        @list = "all"
+        MailchimpValue
+      end
     end
   end
 end

--- a/app/controllers/admin/manufacturers_controller.rb
+++ b/app/controllers/admin/manufacturers_controller.rb
@@ -1,86 +1,88 @@
-class Admin::ManufacturersController < Admin::BaseController
-  include Binxtils::SortableTable
+module Admin
+  class ManufacturersController < Admin::BaseController
+    include Binxtils::SortableTable
 
-  before_action :find_manufacturer, only: [:edit, :update, :destroy, :show]
+    before_action :find_manufacturer, only: [:edit, :update, :destroy, :show]
 
-  def index
-    @manufacturers = searched_manufacturers.reorder("manufacturers.#{sort_column} #{sort_direction}")
-  end
-
-  def show
-    raise ActionController::RoutingError.new("Not Found") unless @manufacturer.present?
-  end
-
-  def new
-    @manufacturer = Manufacturer.new
-  end
-
-  def edit
-  end
-
-  def update
-    if @manufacturer.update(permitted_parameters)
-      flash[:success] = "Manufacturer Saved!"
-      AutocompleteLoaderJob.perform_async
-      redirect_to admin_manufacturer_url(@manufacturer)
-    else
-      render action: :edit
+    def index
+      @manufacturers = searched_manufacturers.reorder("manufacturers.#{sort_column} #{sort_direction}")
     end
-  end
 
-  def create
-    @manufacturer = Manufacturer.create(permitted_parameters)
-    if @manufacturer.save
-      flash[:success] = "Manufacturer Created!"
-      AutocompleteLoaderJob.perform_async
-      redirect_to admin_manufacturer_url(@manufacturer)
-    else
-      render action: :new
+    def show
+      raise ActionController::RoutingError.new("Not Found") unless @manufacturer.present?
     end
-  end
 
-  def destroy
-    @manufacturer.destroy
-    redirect_to admin_manufacturers_url
-  end
-
-  def import
-    if params[:file]
-      Manufacturer.import(params[:file])
-      flash[:success] = "Manufacturers imported"
-    else
-      flash[:notice] = "You gotta choose a file to import!"
+    def new
+      @manufacturer = Manufacturer.new
     end
-    redirect_to admin_manufacturers_url
-  end
 
-  protected
+    def edit
+    end
 
-  def sortable_columns
-    %w[name created_at frame_maker priority motorized_only]
-  end
+    def update
+      if @manufacturer.update(permitted_parameters)
+        flash[:success] = "Manufacturer Saved!"
+        AutocompleteLoaderJob.perform_async
+        redirect_to admin_manufacturer_url(@manufacturer)
+      else
+        render action: :edit
+      end
+    end
 
-  def default_direction
-    "asc"
-  end
+    def create
+      @manufacturer = Manufacturer.create(permitted_parameters)
+      if @manufacturer.save
+        flash[:success] = "Manufacturer Created!"
+        AutocompleteLoaderJob.perform_async
+        redirect_to admin_manufacturer_url(@manufacturer)
+      else
+        render action: :new
+      end
+    end
 
-  def permitted_parameters
-    params.require(:manufacturer).permit(:name, :slug, :website, :frame_maker,
-      :motorized_only, :total_years_active, :notes, :open_year,
-      :close_year, :logo, :description, :logo_source, :twitter_name)
-  end
+    def destroy
+      @manufacturer.destroy
+      redirect_to admin_manufacturers_url
+    end
 
-  def searched_manufacturers
-    manufacturers = Manufacturer
-    @with_logos = Binxtils::InputNormalizer.boolean(params[:search_with_logos])
-    manufacturers = manufacturers.with_websites if @with_logos
-    @with_websites = Binxtils::InputNormalizer.boolean(params[:search_with_websites])
-    manufacturers = manufacturers.with_logos if @with_logos
-    manufacturers
-  end
+    def import
+      if params[:file]
+        Manufacturer.import(params[:file])
+        flash[:success] = "Manufacturers imported"
+      else
+        flash[:notice] = "You gotta choose a file to import!"
+      end
+      redirect_to admin_manufacturers_url
+    end
 
-  def find_manufacturer
-    @manufacturer = Manufacturer.friendly_find(params[:id])
-    raise ActionController::RoutingError.new("Not Found") unless @manufacturer.present?
+    protected
+
+    def sortable_columns
+      %w[name created_at frame_maker priority motorized_only]
+    end
+
+    def default_direction
+      "asc"
+    end
+
+    def permitted_parameters
+      params.require(:manufacturer).permit(:name, :slug, :website, :frame_maker,
+        :motorized_only, :total_years_active, :notes, :open_year,
+        :close_year, :logo, :description, :logo_source, :twitter_name)
+    end
+
+    def searched_manufacturers
+      manufacturers = Manufacturer
+      @with_logos = Binxtils::InputNormalizer.boolean(params[:search_with_logos])
+      manufacturers = manufacturers.with_websites if @with_logos
+      @with_websites = Binxtils::InputNormalizer.boolean(params[:search_with_websites])
+      manufacturers = manufacturers.with_logos if @with_logos
+      manufacturers
+    end
+
+    def find_manufacturer
+      @manufacturer = Manufacturer.friendly_find(params[:id])
+      raise ActionController::RoutingError.new("Not Found") unless @manufacturer.present?
+    end
   end
 end

--- a/app/controllers/admin/marketplace_listings_controller.rb
+++ b/app/controllers/admin/marketplace_listings_controller.rb
@@ -1,53 +1,55 @@
-class Admin::MarketplaceListingsController < Admin::BaseController
-  include Binxtils::SortableTable
+module Admin
+  class MarketplaceListingsController < Admin::BaseController
+    include Binxtils::SortableTable
 
-  def index
-    @per_page = permitted_per_page(default: 50)
-    @pagy, @collection = pagy(:countish,
-      matching_marketplace_listings.includes(:seller, :item, :buyer, :address_record)
-        .reorder("marketplace_listings.#{sort_column} #{sort_direction}"),
-      limit: @per_page,
-      page: permitted_page)
-  end
-
-  def show
-    @marketplace_listing = MarketplaceListing.find(params[:id])
-    @marketplace_messages = @marketplace_listing.marketplace_messages.order(id: :desc).limit(25)
-  end
-
-  helper_method :matching_marketplace_listings, :searchable_statuses
-
-  protected
-
-  def sortable_columns
-    %w[created_at updated_at published_at end_at item_id amount_cents condition status seller_id buyer_id]
-  end
-
-  def earliest_period_date
-    Time.at(1746075600) # 2025-05-01 00:00 - first message sent this month
-  end
-
-  def searchable_statuses
-    MarketplaceListing.statuses.keys.map(&:to_s) + ["removed_or_sold"]
-  end
-
-  def matching_marketplace_listings
-    marketplace_listings = MarketplaceListing
-    @status = searchable_statuses.include?(params[:search_status]) ? params[:search_status] : nil
-    marketplace_listings = marketplace_listings.send(@status) if @status.present?
-
-    if params[:search_bike_id].present?
-      @bike = Bike.unscoped.find_by(id: params[:search_bike_id])
-
-      marketplace_listings = marketplace_listings.where(item_id: params[:search_bike_id], item_type: "Bike")
+    def index
+      @per_page = permitted_per_page(default: 50)
+      @pagy, @collection = pagy(:countish,
+        matching_marketplace_listings.includes(:seller, :item, :buyer, :address_record)
+          .reorder("marketplace_listings.#{sort_column} #{sort_direction}"),
+        limit: @per_page,
+        page: permitted_page)
     end
 
-    if params[:user_id].present?
-      marketplace_listings = marketplace_listings.for_user(user_subject&.id || params[:user_id])
+    def show
+      @marketplace_listing = MarketplaceListing.find(params[:id])
+      @marketplace_messages = @marketplace_listing.marketplace_messages.order(id: :desc).limit(25)
     end
 
-    @time_range_column = sort_column if %w[updated_at published_at end_at].include?(sort_column)
-    @time_range_column ||= "created_at"
-    marketplace_listings.where(@time_range_column => @time_range)
+    helper_method :matching_marketplace_listings, :searchable_statuses
+
+    protected
+
+    def sortable_columns
+      %w[created_at updated_at published_at end_at item_id amount_cents condition status seller_id buyer_id]
+    end
+
+    def earliest_period_date
+      Time.at(1746075600) # 2025-05-01 00:00 - first message sent this month
+    end
+
+    def searchable_statuses
+      MarketplaceListing.statuses.keys.map(&:to_s) + ["removed_or_sold"]
+    end
+
+    def matching_marketplace_listings
+      marketplace_listings = MarketplaceListing
+      @status = searchable_statuses.include?(params[:search_status]) ? params[:search_status] : nil
+      marketplace_listings = marketplace_listings.send(@status) if @status.present?
+
+      if params[:search_bike_id].present?
+        @bike = Bike.unscoped.find_by(id: params[:search_bike_id])
+
+        marketplace_listings = marketplace_listings.where(item_id: params[:search_bike_id], item_type: "Bike")
+      end
+
+      if params[:user_id].present?
+        marketplace_listings = marketplace_listings.for_user(user_subject&.id || params[:user_id])
+      end
+
+      @time_range_column = sort_column if %w[updated_at published_at end_at].include?(sort_column)
+      @time_range_column ||= "created_at"
+      marketplace_listings.where(@time_range_column => @time_range)
+    end
   end
 end

--- a/app/controllers/admin/marketplace_messages_controller.rb
+++ b/app/controllers/admin/marketplace_messages_controller.rb
@@ -1,58 +1,60 @@
-class Admin::MarketplaceMessagesController < Admin::BaseController
-  include Binxtils::SortableTable
+module Admin
+  class MarketplaceMessagesController < Admin::BaseController
+    include Binxtils::SortableTable
 
-  def index
-    @per_page = permitted_per_page(default: 50)
-    @pagy, @collection = pagy(:countish,
-      matching_marketplace_messages.includes(:marketplace_listing, :sender, :receiver).reorder(sortable_opts),
-      limit: @per_page,
-      page: permitted_page)
-  end
-
-  def show
-    @marketplace_message = MarketplaceMessage.find(params[:id])
-    @marketplace_listing = @marketplace_message.marketplace_listing
-    @marketplace_messages_thread = @marketplace_message.messages_in_thread
-  end
-
-  helper_method :matching_marketplace_messages
-
-  protected
-
-  def earliest_period_date
-    Time.at(1746075600) # 2025-05-01 00:00 - first listing created this month
-  end
-
-  def sortable_columns
-    %w[created_at marketplace_listing kind amount_cents initial_record_id sender_id receiver_id
-      messages_prior_count]
-  end
-
-  def sortable_opts
-    if sort_column == "amount_cents"
-      "marketplace_listing.#{sort_column} #{sort_direction}"
-    else
-      "marketplace_messages.#{sort_column} #{sort_direction}"
-    end
-  end
-
-  def matching_marketplace_messages
-    marketplace_messages = MarketplaceMessage
-
-    if params[:search_bike_id].present?
-      @bike = Bike.unscoped.find_by(id: params[:search_bike_id])
-      marketplace_messages = marketplace_messages.includes(:marketplace_listing)
-        .where(marketplace_listings: {item_type: "Bike", item_id: params[:search_bike_id]})
-    end
-    if params[:search_marketplace_listing_id].present?
-      marketplace_messages = marketplace_messages.where(marketplace_listing_id: params[:search_marketplace_listing_id])
-      @marketplace_listing = MarketplaceListing.find_by(id: params[:search_marketplace_listing_id])
+    def index
+      @per_page = permitted_per_page(default: 50)
+      @pagy, @collection = pagy(:countish,
+        matching_marketplace_messages.includes(:marketplace_listing, :sender, :receiver).reorder(sortable_opts),
+        limit: @per_page,
+        page: permitted_page)
     end
 
-    if params[:user_id].present?
-      marketplace_messages = marketplace_messages.for_user(user_subject&.id || params[:user_id])
+    def show
+      @marketplace_message = MarketplaceMessage.find(params[:id])
+      @marketplace_listing = @marketplace_message.marketplace_listing
+      @marketplace_messages_thread = @marketplace_message.messages_in_thread
     end
 
-    marketplace_messages.where(created_at: @time_range)
+    helper_method :matching_marketplace_messages
+
+    protected
+
+    def earliest_period_date
+      Time.at(1746075600) # 2025-05-01 00:00 - first listing created this month
+    end
+
+    def sortable_columns
+      %w[created_at marketplace_listing kind amount_cents initial_record_id sender_id receiver_id
+        messages_prior_count]
+    end
+
+    def sortable_opts
+      if sort_column == "amount_cents"
+        "marketplace_listing.#{sort_column} #{sort_direction}"
+      else
+        "marketplace_messages.#{sort_column} #{sort_direction}"
+      end
+    end
+
+    def matching_marketplace_messages
+      marketplace_messages = MarketplaceMessage
+
+      if params[:search_bike_id].present?
+        @bike = Bike.unscoped.find_by(id: params[:search_bike_id])
+        marketplace_messages = marketplace_messages.includes(:marketplace_listing)
+          .where(marketplace_listings: {item_type: "Bike", item_id: params[:search_bike_id]})
+      end
+      if params[:search_marketplace_listing_id].present?
+        marketplace_messages = marketplace_messages.where(marketplace_listing_id: params[:search_marketplace_listing_id])
+        @marketplace_listing = MarketplaceListing.find_by(id: params[:search_marketplace_listing_id])
+      end
+
+      if params[:user_id].present?
+        marketplace_messages = marketplace_messages.for_user(user_subject&.id || params[:user_id])
+      end
+
+      marketplace_messages.where(created_at: @time_range)
+    end
   end
 end

--- a/app/controllers/admin/memberships_controller.rb
+++ b/app/controllers/admin/memberships_controller.rb
@@ -1,121 +1,123 @@
 # frozen_string_literal: true
 
-class Admin::MembershipsController < Admin::BaseController
-  include Binxtils::SortableTable
+module Admin
+  class MembershipsController < Admin::BaseController
+    include Binxtils::SortableTable
 
-  before_action :find_membership, only: %i[show update]
+    before_action :find_membership, only: %i[show update]
 
-  def index
-    @per_page = permitted_per_page(default: 50)
-    @pagy, @collection = pagy(:countish,
-      matching_memberships.includes(:user, :creator, :stripe_subscriptions).reorder("memberships.#{sort_column} #{sort_direction}"),
-      limit: @per_page,
-      page: permitted_page)
-  end
-
-  def new
-    @membership = Membership.new
-    @membership.set_calculated_attributes # Sets start_at and level
-
-    if params[:user_id].present?
-      user = User.friendly_find(params[:user_id])
-      @membership.user_email = user.email if user.present?
+    def index
+      @per_page = permitted_per_page(default: 50)
+      @pagy, @collection = pagy(:countish,
+        matching_memberships.includes(:user, :creator, :stripe_subscriptions).reorder("memberships.#{sort_column} #{sort_direction}"),
+        limit: @per_page,
+        page: permitted_page)
     end
-  end
 
-  def create
-    @membership = Membership.new(permitted_create_parameters.merge(creator: current_user))
-    if @membership.save
-      flash[:success] = "Membership Created!"
-      redirect_to admin_membership_url(@membership)
-    else
-      render action: :new
-    end
-  end
+    def new
+      @membership = Membership.new
+      @membership.set_calculated_attributes # Sets start_at and level
 
-  def show
-    @payments = @membership.payments
-    @stripe_subscriptions = @membership.stripe_subscriptions
-  end
-
-  def edit
-    redirect_to admin_membership_path
-  end
-
-  def update
-    if Binxtils::InputNormalizer.boolean(params[:update_from_stripe])
-      if @membership.update_from_stripe!
-        flash[:success] = "Updated membership from Stripe successfully"
+      if params[:user_id].present?
+        user = User.friendly_find(params[:user_id])
+        @membership.user_email = user.email if user.present?
       end
-      redirect_back(fallback_location: admin_membership_url(@membership)) && return
     end
 
-    if @membership.stripe_managed?
-      flash[:error] = "Stripe subscriptions must be edited on stripe"
-      redirect_back(fallback_location: admin_membership_url(@membership)) && return
+    def create
+      @membership = Membership.new(permitted_create_parameters.merge(creator: current_user))
+      if @membership.save
+        flash[:success] = "Membership Created!"
+        redirect_to admin_membership_url(@membership)
+      else
+        render action: :new
+      end
     end
 
-    if @membership.update(permitted_update_parameters)
-      flash[:success] = "Membership Saved!"
-      redirect_to admin_membership_url(@membership)
-    else
-      render action: :show
-    end
-  end
-
-  helper_method :matching_memberships, :searchable_levels, :searchable_statuses, :searchable_managers
-
-  def searchable_statuses
-    Membership.statuses.keys
-  end
-
-  def searchable_levels
-    Membership.levels.keys
-  end
-
-  def searchable_managers
-    %w[stripe_managed admin_managed].freeze
-  end
-
-  protected
-
-  def sortable_columns
-    %w[created_at start_at end_at updated_at level user_id].freeze
-  end
-
-  def earliest_period_date
-    Time.at(1738389600) # 2025-02-1
-  end
-
-  def permitted_create_parameters
-    params.require(:membership).permit(:user_email, :level, :start_at, :end_at)
-  end
-
-  def permitted_update_parameters
-    params.require(:membership).permit(:level, :start_at, :end_at)
-  end
-
-  def find_membership
-    @membership = Membership.find(params[:id])
-  end
-
-  def matching_memberships
-    memberships = Membership.all
-    @status = searchable_statuses.include?(params[:search_status]) ? params[:search_status] : nil
-    memberships = memberships.where(status: @status) if @status.present?
-
-    @level = searchable_levels.include?(params[:search_level]) ? params[:search_level] : nil
-    memberships = memberships.where(level: @level) if @level.present?
-
-    @manager = searchable_managers.include?(params[:search_manager]) ? params[:search_manager] : nil
-    memberships = memberships.send(@manager) if @manager.present?
-
-    if params[:user_id].present?
-      memberships = memberships.where(user_id: user_subject&.id || params[:user_id])
+    def show
+      @payments = @membership.payments
+      @stripe_subscriptions = @membership.stripe_subscriptions
     end
 
-    @time_range_column = sort_column if %w[start_at end_at updated_at].include?(sort_column)
-    @time_range_column ||= "created_at"
-    memberships.where(@time_range_column => @time_range)
+    def edit
+      redirect_to admin_membership_path
+    end
+
+    def update
+      if Binxtils::InputNormalizer.boolean(params[:update_from_stripe])
+        if @membership.update_from_stripe!
+          flash[:success] = "Updated membership from Stripe successfully"
+        end
+        redirect_back(fallback_location: admin_membership_url(@membership)) && return
+      end
+
+      if @membership.stripe_managed?
+        flash[:error] = "Stripe subscriptions must be edited on stripe"
+        redirect_back(fallback_location: admin_membership_url(@membership)) && return
+      end
+
+      if @membership.update(permitted_update_parameters)
+        flash[:success] = "Membership Saved!"
+        redirect_to admin_membership_url(@membership)
+      else
+        render action: :show
+      end
+    end
+
+    helper_method :matching_memberships, :searchable_levels, :searchable_statuses, :searchable_managers
+
+    def searchable_statuses
+      Membership.statuses.keys
+    end
+
+    def searchable_levels
+      Membership.levels.keys
+    end
+
+    def searchable_managers
+      %w[stripe_managed admin_managed].freeze
+    end
+
+    protected
+
+    def sortable_columns
+      %w[created_at start_at end_at updated_at level user_id].freeze
+    end
+
+    def earliest_period_date
+      Time.at(1738389600) # 2025-02-1
+    end
+
+    def permitted_create_parameters
+      params.require(:membership).permit(:user_email, :level, :start_at, :end_at)
+    end
+
+    def permitted_update_parameters
+      params.require(:membership).permit(:level, :start_at, :end_at)
+    end
+
+    def find_membership
+      @membership = Membership.find(params[:id])
+    end
+
+    def matching_memberships
+      memberships = Membership.all
+      @status = searchable_statuses.include?(params[:search_status]) ? params[:search_status] : nil
+      memberships = memberships.where(status: @status) if @status.present?
+
+      @level = searchable_levels.include?(params[:search_level]) ? params[:search_level] : nil
+      memberships = memberships.where(level: @level) if @level.present?
+
+      @manager = searchable_managers.include?(params[:search_manager]) ? params[:search_manager] : nil
+      memberships = memberships.send(@manager) if @manager.present?
+
+      if params[:user_id].present?
+        memberships = memberships.where(user_id: user_subject&.id || params[:user_id])
+      end
+
+      @time_range_column = sort_column if %w[start_at end_at updated_at].include?(sort_column)
+      @time_range_column ||= "created_at"
+      memberships.where(@time_range_column => @time_range)
+    end
   end
 end

--- a/app/controllers/admin/model_attestations_controller.rb
+++ b/app/controllers/admin/model_attestations_controller.rb
@@ -1,38 +1,40 @@
-class Admin::ModelAttestationsController < Admin::BaseController
-  include Binxtils::SortableTable
+module Admin
+  class ModelAttestationsController < Admin::BaseController
+    include Binxtils::SortableTable
 
-  def index
-    @per_page = permitted_per_page(default: 50)
-    @pagy, @model_attestations =
-      pagy(:countish, matching_model_attestations
-        .includes(:model_audit, :user, :organization)
-        .reorder("model_attestations.#{sort_column} #{sort_direction}"), limit: @per_page, page: permitted_page)
-  end
-
-  helper_method :matching_model_attestations
-
-  protected
-
-  def sortable_columns
-    %w[created_at updated_at model_audit_id user_id organization_id kind]
-  end
-
-  def earliest_period_date
-    Time.at(1528767966) # First Model Audit
-  end
-
-  def matching_model_attestations
-    model_attestations = ModelAttestation
-    if current_organization.present?
-      model_attestations = model_attestations.where(organization_id: current_organization.id)
-    end
-    if params[:search_model_audit_id].present?
-      @model_audit = ModelAudit.find(params[:search_model_audit_id])
-      model_attestations = model_attestations.where(model_audit_id: @model_audit.id)
+    def index
+      @per_page = permitted_per_page(default: 50)
+      @pagy, @model_attestations =
+        pagy(:countish, matching_model_attestations
+          .includes(:model_audit, :user, :organization)
+          .reorder("model_attestations.#{sort_column} #{sort_direction}"), limit: @per_page, page: permitted_page)
     end
 
-    @time_range_column = sort_column if %w[updated_at].include?(sort_column)
-    @time_range_column ||= "created_at"
-    model_attestations.where(@time_range_column => @time_range)
+    helper_method :matching_model_attestations
+
+    protected
+
+    def sortable_columns
+      %w[created_at updated_at model_audit_id user_id organization_id kind]
+    end
+
+    def earliest_period_date
+      Time.at(1528767966) # First Model Audit
+    end
+
+    def matching_model_attestations
+      model_attestations = ModelAttestation
+      if current_organization.present?
+        model_attestations = model_attestations.where(organization_id: current_organization.id)
+      end
+      if params[:search_model_audit_id].present?
+        @model_audit = ModelAudit.find(params[:search_model_audit_id])
+        model_attestations = model_attestations.where(model_audit_id: @model_audit.id)
+      end
+
+      @time_range_column = sort_column if %w[updated_at].include?(sort_column)
+      @time_range_column ||= "created_at"
+      model_attestations.where(@time_range_column => @time_range)
+    end
   end
 end

--- a/app/controllers/admin/model_audits_controller.rb
+++ b/app/controllers/admin/model_audits_controller.rb
@@ -1,52 +1,54 @@
-class Admin::ModelAuditsController < Admin::BaseController
-  include Binxtils::SortableTable
+module Admin
+  class ModelAuditsController < Admin::BaseController
+    include Binxtils::SortableTable
 
-  def index
-    @per_page = permitted_per_page(default: 50)
-    @pagy, @model_audits =
-      pagy(:countish, matching_model_audits
-        .includes(:organization_model_audits, :model_attestations)
-        .reorder(sort_ordered), limit: @per_page, page: permitted_page)
-  end
-
-  helper_method :matching_model_audits
-
-  protected
-
-  def sortable_columns
-    %w[created_at updated_at bikes_count mnfg_name frame_model]
-  end
-
-  def earliest_period_date
-    Time.at(1528767966) # First Model Audit
-  end
-
-  def sort_ordered
-    if %w[mnfg_name frame_model].include?(sort_column)
-      ModelAudit.arel_table[sort_column].lower.send(sort_direction)
-    else
-      "model_audits.#{sort_column} #{sort_direction}"
+    def index
+      @per_page = permitted_per_page(default: 50)
+      @pagy, @model_audits =
+        pagy(:countish, matching_model_audits
+          .includes(:organization_model_audits, :model_attestations)
+          .reorder(sort_ordered), limit: @per_page, page: permitted_page)
     end
-  end
 
-  def matching_model_audits
-    model_audits = ModelAudit
-    if params[:search_mnfg_name].present?
-      model_audits = model_audits.where("mnfg_name ILIKE ?", "%#{params[:search_mnfg_name]}%")
-      @manufacturer = Manufacturer.friendly_find(params[:search_mnfg_name])
+    helper_method :matching_model_audits
+
+    protected
+
+    def sortable_columns
+      %w[created_at updated_at bikes_count mnfg_name frame_model]
     end
-    @mnfg_other = Binxtils::InputNormalizer.boolean(params[:search_mnfg_other])
-    if params[:search_frame_model].present?
-      model_audits = if ["unknown", "missing model"].include?(params[:search_frame_model].downcase)
-        model_audits.where(frame_model: nil)
+
+    def earliest_period_date
+      Time.at(1528767966) # First Model Audit
+    end
+
+    def sort_ordered
+      if %w[mnfg_name frame_model].include?(sort_column)
+        ModelAudit.arel_table[sort_column].lower.send(sort_direction)
       else
-        model_audits.where("frame_model ILIKE ?", params[:search_frame_model])
+        "model_audits.#{sort_column} #{sort_direction}"
       end
     end
-    model_audits = model_audits.where.not(manufacturer_other: nil) if @mnfg_other
 
-    @time_range_column = sort_column if %w[updated_at].include?(sort_column)
-    @time_range_column ||= "created_at"
-    model_audits.where(@time_range_column => @time_range)
+    def matching_model_audits
+      model_audits = ModelAudit
+      if params[:search_mnfg_name].present?
+        model_audits = model_audits.where("mnfg_name ILIKE ?", "%#{params[:search_mnfg_name]}%")
+        @manufacturer = Manufacturer.friendly_find(params[:search_mnfg_name])
+      end
+      @mnfg_other = Binxtils::InputNormalizer.boolean(params[:search_mnfg_other])
+      if params[:search_frame_model].present?
+        model_audits = if ["unknown", "missing model"].include?(params[:search_frame_model].downcase)
+          model_audits.where(frame_model: nil)
+        else
+          model_audits.where("frame_model ILIKE ?", params[:search_frame_model])
+        end
+      end
+      model_audits = model_audits.where.not(manufacturer_other: nil) if @mnfg_other
+
+      @time_range_column = sort_column if %w[updated_at].include?(sort_column)
+      @time_range_column ||= "created_at"
+      model_audits.where(@time_range_column => @time_range)
+    end
   end
 end

--- a/app/controllers/admin/news_controller.rb
+++ b/app/controllers/admin/news_controller.rb
@@ -1,124 +1,126 @@
-class Admin::NewsController < Admin::BaseController
-  include Binxtils::SortableTable
+module Admin
+  class NewsController < Admin::BaseController
+    include Binxtils::SortableTable
 
-  before_action :find_blog, only: [:show, :edit, :update, :destroy]
-  before_action :set_dignified_name
+    before_action :find_blog, only: [:show, :edit, :update, :destroy]
+    before_action :set_dignified_name
 
-  def index
-    @blogs = available_blogs.reorder(sort_column + " " + sort_direction)
-      .includes(:user, :content_tags)
-  end
+    def index
+      @blogs = available_blogs.reorder(sort_column + " " + sort_direction)
+        .includes(:user, :content_tags)
+    end
 
-  def new
-    @blog = Blog.new(published_at: Time.current, user_id: current_user.id)
-  end
+    def new
+      @blog = Blog.new(published_at: Time.current, user_id: current_user.id)
+    end
 
-  def image_edit
-    @listicle = Listicle.find(params[:id])
-    @blog = @listicle.blog
-  end
+    def image_edit
+      @listicle = Listicle.find(params[:id])
+      @blog = @listicle.blog
+    end
 
-  def show
-    redirect_to edit_admin_news_url
-  end
+    def show
+      redirect_to edit_admin_news_url
+    end
 
-  def edit
-    @page_title = "Edit: #{@blog.title}"
-  end
+    def edit
+      @page_title = "Edit: #{@blog.title}"
+    end
 
-  def update
-    if @blog.update(permitted_parameters)
-      @blog.reload
+    def update
+      if @blog.update(permitted_parameters)
+        @blog.reload
 
-      if @blog.listicles.present?
-        @blog.listicles.pluck(:id).each { |id| ListicleImageSizeJob.perform_in(1.minutes, id) }
+        if @blog.listicles.present?
+          @blog.listicles.pluck(:id).each { |id| ListicleImageSizeJob.perform_in(1.minutes, id) }
+        end
+
+        flash[:success] = "#{@blog.info? ? "Info post" : "Blog"} saved!"
+        redirect_to edit_admin_news_url(@blog)
+      else
+        render action: :edit
       end
-
-      flash[:success] = "#{@blog.info? ? "Info post" : "Blog"} saved!"
-      redirect_to edit_admin_news_url(@blog)
-    else
-      render action: :edit
     end
-  end
 
-  def create
-    @blog = Blog.create({
-      title: params[:blog][:title],
-      user_id: current_user.id,
-      body: "No content yet, write some now!",
-      published_at: Time.current,
-      is_listicle: false
-    })
-    if @blog.save
-      flash[:success] = "#{@blog.info? ? "Info post" : "Blog"} created!"
-      redirect_to edit_admin_news_url(@blog)
-    else
-      flash[:error] = "#{@blog.info? ? "Info post" : "Blog"} error! #{@blog.errors.full_messages.to_sentence}"
-      redirect_to new_admin_news_path
+    def create
+      @blog = Blog.create({
+        title: params[:blog][:title],
+        user_id: current_user.id,
+        body: "No content yet, write some now!",
+        published_at: Time.current,
+        is_listicle: false
+      })
+      if @blog.save
+        flash[:success] = "#{@blog.info? ? "Info post" : "Blog"} created!"
+        redirect_to edit_admin_news_url(@blog)
+      else
+        flash[:error] = "#{@blog.info? ? "Info post" : "Blog"} error! #{@blog.errors.full_messages.to_sentence}"
+        redirect_to new_admin_news_path
+      end
     end
-  end
 
-  def destroy
-    @blog.destroy
-    redirect_to admin_news_index_url
-  end
-
-  helper_method :available_blogs
-
-  protected
-
-  def sortable_columns
-    %w[created_at published_at user_id updated_at title]
-  end
-
-  def permitted_parameters
-    params.require(:blog).permit(
-      :body,
-      :canonical_url,
-      :description_abbr,
-      :index_image,
-      :index_image_id,
-      :language,
-      :listicles_attributes,
-      :old_title_slug,
-      :post_date,
-      :post_now,
-      :published,
-      :published_at,
-      :timezone,
-      :title,
-      :secondary_title,
-      :update_title,
-      :user_email,
-      :user_id,
-      :info_kind,
-      content_tag_names: []
-    )
-  end
-
-  def available_blogs
-    blogs = Blog
-    if %w[blog info listicle].include?(params[:search_kind])
-      @search_kind = params[:search_kind]
-      blogs = blogs.where(kind: @search_kind)
-    else
-      @search_kind = "all"
+    def destroy
+      @blog.destroy
+      redirect_to admin_news_index_url
     end
-    if params[:search_tags].present?
-      @tags = Array(params[:search_tags]).flatten.map { |i| ContentTag.friendly_find(i) }.compact.uniq
-      blogs = blogs.with_tag_ids(@tags.pluck(:id))
+
+    helper_method :available_blogs
+
+    protected
+
+    def sortable_columns
+      %w[created_at published_at user_id updated_at title]
     end
-    blogs = blogs.published if sort_column == "published_at"
-    @time_range_column = (sort_column == "updated_at") ? "updated_at" : "created_at"
-    blogs.where(@time_range_column => @time_range)
-  end
 
-  def set_dignified_name
-    @dignified_name = "short form creative non-fiction"
-    @dignified_name = "collection of vignettes" if @blog&.is_listicle
-  end
+    def permitted_parameters
+      params.require(:blog).permit(
+        :body,
+        :canonical_url,
+        :description_abbr,
+        :index_image,
+        :index_image_id,
+        :language,
+        :listicles_attributes,
+        :old_title_slug,
+        :post_date,
+        :post_now,
+        :published,
+        :published_at,
+        :timezone,
+        :title,
+        :secondary_title,
+        :update_title,
+        :user_email,
+        :user_id,
+        :info_kind,
+        content_tag_names: []
+      )
+    end
 
-  def find_blog
-    @blog = Blog.friendly_find(params[:id])
+    def available_blogs
+      blogs = Blog
+      if %w[blog info listicle].include?(params[:search_kind])
+        @search_kind = params[:search_kind]
+        blogs = blogs.where(kind: @search_kind)
+      else
+        @search_kind = "all"
+      end
+      if params[:search_tags].present?
+        @tags = Array(params[:search_tags]).flatten.map { |i| ContentTag.friendly_find(i) }.compact.uniq
+        blogs = blogs.with_tag_ids(@tags.pluck(:id))
+      end
+      blogs = blogs.published if sort_column == "published_at"
+      @time_range_column = (sort_column == "updated_at") ? "updated_at" : "created_at"
+      blogs.where(@time_range_column => @time_range)
+    end
+
+    def set_dignified_name
+      @dignified_name = "short form creative non-fiction"
+      @dignified_name = "collection of vignettes" if @blog&.is_listicle
+    end
+
+    def find_blog
+      @blog = Blog.friendly_find(params[:id])
+    end
   end
 end

--- a/app/controllers/admin/notifications_controller.rb
+++ b/app/controllers/admin/notifications_controller.rb
@@ -1,62 +1,64 @@
-class Admin::NotificationsController < Admin::BaseController
-  include Binxtils::SortableTable
+module Admin
+  class NotificationsController < Admin::BaseController
+    include Binxtils::SortableTable
 
-  def index
-    params[:page] || 1
-    @per_page = permitted_per_page(default: 50)
-    @pagy, @notifications = pagy(:countish, matching_notifications.reorder("notifications.#{sort_column} #{sort_direction}")
-      .includes(:bike, :notifiable, :user), limit: @per_page, page: permitted_page)
-    @render_kind_counts = Binxtils::InputNormalizer.boolean(params[:search_kind_counts])
-  end
-
-  helper_method :matching_notifications, :special_kind_scopes
-
-  private
-
-  def sortable_columns
-    %w[created_at updated_at kind user_id bike_id]
-  end
-
-  def earliest_period_date
-    Time.at(1401122000)
-  end
-
-  def special_kind_scopes
-    %w[donation theft_alert impound_claim customer_contact admin]
-  end
-
-  def permitted_scopes
-    Notification.kinds + special_kind_scopes
-  end
-
-  def matching_notifications
-    notifications = Notification
-    if permitted_scopes.include?(params[:search_kind])
-      @kind = params[:search_kind]
-      notifications = notifications.public_send(@kind)
-    else
-      @kind = "all"
+    def index
+      params[:page] || 1
+      @per_page = permitted_per_page(default: 50)
+      @pagy, @notifications = pagy(:countish, matching_notifications.reorder("notifications.#{sort_column} #{sort_direction}")
+        .includes(:bike, :notifiable, :user), limit: @per_page, page: permitted_page)
+      @render_kind_counts = Binxtils::InputNormalizer.boolean(params[:search_kind_counts])
     end
-    if Binxtils::InputNormalizer.boolean(params[:search_with_bike])
-      @with_bike = true
-      notifications = notifications.with_bike
+
+    helper_method :matching_notifications, :special_kind_scopes
+
+    private
+
+    def sortable_columns
+      %w[created_at updated_at kind user_id bike_id]
     end
-    if Binxtils::InputNormalizer.boolean(params[:search_undelivered])
-      @undelivered = true
-      notifications = notifications.not_delivery_success
+
+    def earliest_period_date
+      Time.at(1401122000)
     end
-    if params[:user_id].present?
-      notifications = notifications.notifications_sent_or_received_by(user_subject&.id || params[:user_id])
+
+    def special_kind_scopes
+      %w[donation theft_alert impound_claim customer_contact admin]
     end
-    if params[:search_bike_id].present?
-      @bike = Bike.unscoped.friendly_find(params[:search_bike_id])
-      notifications = notifications.where(bike_id: @bike.id) if @bike.present?
+
+    def permitted_scopes
+      Notification.kinds + special_kind_scopes
     end
-    if params[:query].present?
-      notifications = notifications.search_message_channel_target(params[:query])
+
+    def matching_notifications
+      notifications = Notification
+      if permitted_scopes.include?(params[:search_kind])
+        @kind = params[:search_kind]
+        notifications = notifications.public_send(@kind)
+      else
+        @kind = "all"
+      end
+      if Binxtils::InputNormalizer.boolean(params[:search_with_bike])
+        @with_bike = true
+        notifications = notifications.with_bike
+      end
+      if Binxtils::InputNormalizer.boolean(params[:search_undelivered])
+        @undelivered = true
+        notifications = notifications.not_delivery_success
+      end
+      if params[:user_id].present?
+        notifications = notifications.notifications_sent_or_received_by(user_subject&.id || params[:user_id])
+      end
+      if params[:search_bike_id].present?
+        @bike = Bike.unscoped.friendly_find(params[:search_bike_id])
+        notifications = notifications.where(bike_id: @bike.id) if @bike.present?
+      end
+      if params[:query].present?
+        notifications = notifications.search_message_channel_target(params[:query])
+      end
+      @time_range_column = sort_column if %w[updated_at].include?(sort_column)
+      @time_range_column ||= "created_at"
+      notifications.where(@time_range_column => @time_range)
     end
-    @time_range_column = sort_column if %w[updated_at].include?(sort_column)
-    @time_range_column ||= "created_at"
-    notifications.where(@time_range_column => @time_range)
   end
 end

--- a/app/controllers/admin/organization_features_controller.rb
+++ b/app/controllers/admin/organization_features_controller.rb
@@ -1,65 +1,67 @@
-class Admin::OrganizationFeaturesController < Admin::BaseController
-  include Binxtils::SortableTable
+module Admin
+  class OrganizationFeaturesController < Admin::BaseController
+    include Binxtils::SortableTable
 
-  before_action :find_organization_feature, only: %i[edit update]
+    before_action :find_organization_feature, only: %i[edit update]
 
-  def index
-    @organization_features = OrganizationFeature.order(sort_column + " " + sort_direction)
-  end
+    def index
+      @organization_features = OrganizationFeature.order(sort_column + " " + sort_direction)
+    end
 
-  def new
-    @organization_feature ||= OrganizationFeature.new
-  end
+    def new
+      @organization_feature ||= OrganizationFeature.new
+    end
 
-  def show
-    redirect_to edit_admin_organization_feature_path
-  end
+    def show
+      redirect_to edit_admin_organization_feature_path
+    end
 
-  def edit
-    @invoices = @organization_feature.invoices.includes(:organization, :payments).reorder(id: :desc)
-  end
+    def edit
+      @invoices = @organization_feature.invoices.includes(:organization, :payments).reorder(id: :desc)
+    end
 
-  def update
-    @organization_feature.update(permitted_update_parameters)
-    flash[:success] = "Feature updated" unless flash[:error].present?
-    redirect_to admin_organization_features_path
-  end
-
-  def create
-    @organization_feature = OrganizationFeature.new(permitted_update_parameters)
-    if @organization_feature.save
-      flash[:success] = "Feature created"
+    def update
+      @organization_feature.update(permitted_update_parameters)
+      flash[:success] = "Feature updated" unless flash[:error].present?
       redirect_to admin_organization_features_path
-    else
-      flash[:error] = "Unable to create"
-      render :new
     end
-  end
 
-  protected
-
-  def sortable_columns
-    %w[name created_at kind amount_cents]
-  end
-
-  # Because we start with alpha ordering
-  def default_direction
-    "asc"
-  end
-
-  def permitted_update_parameters
-    permitted_parameters = params.require(:organization_feature).permit(:amount, :description, :details_link, :kind, :name, :currency_enum)
-    if current_user.developer?
-      permitted_parameters.merge(params.require(:organization_feature).permit(:feature_slugs_string))
-    elsif @organization_feature&.id&.present? && @organization_feature.locked?
-      flash[:error] = "Can't update locked organization feature! Please ask Seth"
-      {}
-    else
-      permitted_parameters
+    def create
+      @organization_feature = OrganizationFeature.new(permitted_update_parameters)
+      if @organization_feature.save
+        flash[:success] = "Feature created"
+        redirect_to admin_organization_features_path
+      else
+        flash[:error] = "Unable to create"
+        render :new
+      end
     end
-  end
 
-  def find_organization_feature
-    @organization_feature = OrganizationFeature.find(params[:id])
+    protected
+
+    def sortable_columns
+      %w[name created_at kind amount_cents]
+    end
+
+    # Because we start with alpha ordering
+    def default_direction
+      "asc"
+    end
+
+    def permitted_update_parameters
+      permitted_parameters = params.require(:organization_feature).permit(:amount, :description, :details_link, :kind, :name, :currency_enum)
+      if current_user.developer?
+        permitted_parameters.merge(params.require(:organization_feature).permit(:feature_slugs_string))
+      elsif @organization_feature&.id&.present? && @organization_feature.locked?
+        flash[:error] = "Can't update locked organization feature! Please ask Seth"
+        {}
+      else
+        permitted_parameters
+      end
+    end
+
+    def find_organization_feature
+      @organization_feature = OrganizationFeature.find(params[:id])
+    end
   end
 end

--- a/app/controllers/admin/organization_roles_controller.rb
+++ b/app/controllers/admin/organization_roles_controller.rb
@@ -1,89 +1,91 @@
 # frozen_string_literal: true
 
-class Admin::OrganizationRolesController < Admin::BaseController
-  include Binxtils::SortableTable
+module Admin
+  class OrganizationRolesController < Admin::BaseController
+    include Binxtils::SortableTable
 
-  before_action :find_organization_role, only: %i[show edit update destroy]
-  before_action :find_organizations, except: %i[index destroy]
+    before_action :find_organization_role, only: %i[show edit update destroy]
+    before_action :find_organizations, except: %i[index destroy]
 
-  def index
-    @per_page = permitted_per_page(default: 50)
-    @pagy, @collection = pagy(:countish,
-      matching_organization_roles.includes(:user, :sender, :organization).reorder("organization_roles.#{sort_column} #{sort_direction}"),
-      limit: @per_page,
-      page: permitted_page)
-  end
-
-  def show
-    redirect_to edit_admin_organization_role_path
-  end
-
-  def new
-    @organization_role = OrganizationRole.new(organization_id: current_organization&.id)
-  end
-
-  def edit
-  end
-
-  def update
-    if @organization_role.update(permitted_parameters)
-      flash[:success] = "Organization Role Saved!"
-      redirect_to admin_organization_role_url(@organization_role)
-    else
-      render action: :edit
-    end
-  end
-
-  def create
-    @organization_role = OrganizationRole.new(permitted_parameters.merge(sender: current_user))
-    if @organization_role.save
-      flash[:success] = "Organization Role Created!"
-      redirect_to admin_organization_role_url(@organization_role)
-    else
-      render action: :new
-    end
-  end
-
-  def destroy
-    @organization_role.destroy
-    flash[:success] = "Organization Role deleted successfully"
-    redirect_to admin_organization_roles_url
-  end
-
-  helper_method :matching_organization_roles
-
-  protected
-
-  def sortable_columns
-    %w[created_at invited_email sender_id claimed_at organization_id role deleted_at]
-  end
-
-  def permitted_parameters
-    params.require(:organization_role).permit(:organization_id, :user_id, :role, :invited_email)
-  end
-
-  def find_organization_role
-    @organization_role = OrganizationRole.unscoped.find(params[:id])
-  end
-
-  def find_organizations
-    @organizations = Organization.all
-  end
-
-  def matching_organization_roles
-    organization_roles = if current_organization.present?
-      current_organization.organization_roles
-    else
-      OrganizationRole.all
-    end
-    organization_roles = search_deleted_scope(organization_roles)
-    if !@render_deleted && current_organization&.deleted?
-      @render_deleted = "including"
-      organization_roles = organization_roles.with_deleted
+    def index
+      @per_page = permitted_per_page(default: 50)
+      @pagy, @collection = pagy(:countish,
+        matching_organization_roles.includes(:user, :sender, :organization).reorder("organization_roles.#{sort_column} #{sort_direction}"),
+        limit: @per_page,
+        page: permitted_page)
     end
 
-    @time_range_column = sort_column if %w[claimed_at deleted_at].include?(sort_column)
-    @time_range_column ||= "created_at"
-    organization_roles.where(@time_range_column => @time_range)
+    def show
+      redirect_to edit_admin_organization_role_path
+    end
+
+    def new
+      @organization_role = OrganizationRole.new(organization_id: current_organization&.id)
+    end
+
+    def edit
+    end
+
+    def update
+      if @organization_role.update(permitted_parameters)
+        flash[:success] = "Organization Role Saved!"
+        redirect_to admin_organization_role_url(@organization_role)
+      else
+        render action: :edit
+      end
+    end
+
+    def create
+      @organization_role = OrganizationRole.new(permitted_parameters.merge(sender: current_user))
+      if @organization_role.save
+        flash[:success] = "Organization Role Created!"
+        redirect_to admin_organization_role_url(@organization_role)
+      else
+        render action: :new
+      end
+    end
+
+    def destroy
+      @organization_role.destroy
+      flash[:success] = "Organization Role deleted successfully"
+      redirect_to admin_organization_roles_url
+    end
+
+    helper_method :matching_organization_roles
+
+    protected
+
+    def sortable_columns
+      %w[created_at invited_email sender_id claimed_at organization_id role deleted_at]
+    end
+
+    def permitted_parameters
+      params.require(:organization_role).permit(:organization_id, :user_id, :role, :invited_email)
+    end
+
+    def find_organization_role
+      @organization_role = OrganizationRole.unscoped.find(params[:id])
+    end
+
+    def find_organizations
+      @organizations = Organization.all
+    end
+
+    def matching_organization_roles
+      organization_roles = if current_organization.present?
+        current_organization.organization_roles
+      else
+        OrganizationRole.all
+      end
+      organization_roles = search_deleted_scope(organization_roles)
+      if !@render_deleted && current_organization&.deleted?
+        @render_deleted = "including"
+        organization_roles = organization_roles.with_deleted
+      end
+
+      @time_range_column = sort_column if %w[claimed_at deleted_at].include?(sort_column)
+      @time_range_column ||= "created_at"
+      organization_roles.where(@time_range_column => @time_range)
+    end
   end
 end

--- a/app/controllers/admin/organization_statuses_controller.rb
+++ b/app/controllers/admin/organization_statuses_controller.rb
@@ -1,90 +1,92 @@
 # frozen_string_literal: true
 
-class Admin::OrganizationStatusesController < Admin::BaseController
-  include Binxtils::SortableTable
+module Admin
+  class OrganizationStatusesController < Admin::BaseController
+    include Binxtils::SortableTable
 
-  WITH_POS_GRAPH_PARAMS = {search_pos_kind: "not_no_pos", render_chart: true}.freeze
+    WITH_POS_GRAPH_PARAMS = {search_pos_kind: "not_no_pos", render_chart: true}.freeze
 
-  def index
-    @per_page = permitted_per_page(default: 10)
-    @pagy, @organization_statuses =
-      pagy(:countish, matching_organization_statuses
-        .reorder("organization_statuses.#{sort_column} #{sort_direction}"), limit: @per_page, page: permitted_page)
-  end
-
-  helper_method :matching_organization_statuses_untimed, :matching_organization_statuses, :grouped_pos_kinds, :humanize_pos_kind
-
-  private
-
-  def sortable_columns
-    %w[start_at end_at organization_id pos_kind kind created_at organization_deleted_at].freeze
-  end
-
-  def earliest_period_date
-    OrganizationStatus.minimum(:start_at) || Time.current - 1.day
-  end
-
-  def grouped_pos_kinds
-    %w[not_no_pos broken_pos without_pos with_pos].freeze
-  end
-
-  def humanize_pos_kind(kind)
-    if kind == "all"
-      "All POS kinds"
-    elsif kind == "not_no_pos"
-      "Any POS kind (all but no_pos)"
-    else
-      kind&.humanize
-    end
-  end
-
-  def permitted_pos_kinds
-    Organization.pos_kinds + grouped_pos_kinds
-  end
-
-  def permitted_kinds
-    Organization.kinds + ["not_bike_shop"]
-  end
-
-  # Needs to be a separate method so :at_time can be called on it
-  def matching_organization_statuses_untimed
-    organization_statuses = OrganizationStatus.all
-
-    if current_organization.present?
-      organization_statuses = organization_statuses.where(organization_id: current_organization.id)
+    def index
+      @per_page = permitted_per_page(default: 10)
+      @pagy, @organization_statuses =
+        pagy(:countish, matching_organization_statuses
+          .reorder("organization_statuses.#{sort_column} #{sort_direction}"), limit: @per_page, page: permitted_page)
     end
 
-    if Binxtils::InputNormalizer.boolean(params[:search_current])
-      @current = true
-      organization_statuses = organization_statuses.current
+    helper_method :matching_organization_statuses_untimed, :matching_organization_statuses, :grouped_pos_kinds, :humanize_pos_kind
+
+    private
+
+    def sortable_columns
+      %w[start_at end_at organization_id pos_kind kind created_at organization_deleted_at].freeze
     end
 
-    if Binxtils::InputNormalizer.boolean(params[:search_ended])
-      @ended = true
-      organization_statuses = organization_statuses.ended
+    def earliest_period_date
+      OrganizationStatus.minimum(:start_at) || Time.current - 1.day
     end
 
-    organization_statuses = search_deleted_scope(organization_statuses)
-
-    if permitted_pos_kinds.include?(params[:search_pos_kind])
-      @pos_kind = params[:search_pos_kind]
-      organization_statuses = organization_statuses.public_send(@pos_kind)
-    else
-      @pos_kind = "all"
+    def grouped_pos_kinds
+      %w[not_no_pos broken_pos without_pos with_pos].freeze
     end
 
-    if permitted_kinds.include?(params[:search_kind])
-      @kind = params[:search_kind]
-      organization_statuses = organization_statuses.public_send(@kind)
-    else
-      @kind = "all"
+    def humanize_pos_kind(kind)
+      if kind == "all"
+        "All POS kinds"
+      elsif kind == "not_no_pos"
+        "Any POS kind (all but no_pos)"
+      else
+        kind&.humanize
+      end
     end
-    organization_statuses
-  end
 
-  def matching_organization_statuses
-    @time_range_column = sort_column if %w[end_at created_at deleted_at].include?(sort_column)
-    @time_range_column ||= "start_at"
-    matching_organization_statuses_untimed.where(@time_range_column => @time_range)
+    def permitted_pos_kinds
+      Organization.pos_kinds + grouped_pos_kinds
+    end
+
+    def permitted_kinds
+      Organization.kinds + ["not_bike_shop"]
+    end
+
+    # Needs to be a separate method so :at_time can be called on it
+    def matching_organization_statuses_untimed
+      organization_statuses = OrganizationStatus.all
+
+      if current_organization.present?
+        organization_statuses = organization_statuses.where(organization_id: current_organization.id)
+      end
+
+      if Binxtils::InputNormalizer.boolean(params[:search_current])
+        @current = true
+        organization_statuses = organization_statuses.current
+      end
+
+      if Binxtils::InputNormalizer.boolean(params[:search_ended])
+        @ended = true
+        organization_statuses = organization_statuses.ended
+      end
+
+      organization_statuses = search_deleted_scope(organization_statuses)
+
+      if permitted_pos_kinds.include?(params[:search_pos_kind])
+        @pos_kind = params[:search_pos_kind]
+        organization_statuses = organization_statuses.public_send(@pos_kind)
+      else
+        @pos_kind = "all"
+      end
+
+      if permitted_kinds.include?(params[:search_kind])
+        @kind = params[:search_kind]
+        organization_statuses = organization_statuses.public_send(@kind)
+      else
+        @kind = "all"
+      end
+      organization_statuses
+    end
+
+    def matching_organization_statuses
+      @time_range_column = sort_column if %w[end_at created_at deleted_at].include?(sort_column)
+      @time_range_column ||= "start_at"
+      matching_organization_statuses_untimed.where(@time_range_column => @time_range)
+    end
   end
 end

--- a/app/controllers/admin/organizations/custom_layouts_controller.rb
+++ b/app/controllers/admin/organizations/custom_layouts_controller.rb
@@ -1,53 +1,57 @@
-class Admin::Organizations::CustomLayoutsController < Admin::BaseController
-  before_action :find_and_authorize_organization
+module Admin
+  module Organizations
+    class CustomLayoutsController < Admin::BaseController
+      before_action :find_and_authorize_organization
 
-  def index
-  end
+      def index
+      end
 
-  def edit
-    @edit_template = edit_layout_pages.include?(params[:id]) ? params[:id] : edit_layout_pages.first
-    if @edit_template != "landing_page" # we're rendering a snippet
-      @mail_snippet = @organization.mail_snippets.where(kind: @edit_template).first_or_create
-    end
-  end
+      def edit
+        @edit_template = edit_layout_pages.include?(params[:id]) ? params[:id] : edit_layout_pages.first
+        if @edit_template != "landing_page" # we're rendering a snippet
+          @mail_snippet = @organization.mail_snippets.where(kind: @edit_template).first_or_create
+        end
+      end
 
-  def update
-    if @organization.update(permitted_parameters)
-      flash[:success] = "Layout Saved!"
-      redirect_to edit_admin_organization_custom_layout_path(organization_id: @organization.to_param, id: params[:id])
-    else
-      render action: :edit, id: params[:id]
-    end
-  end
+      def update
+        if @organization.update(permitted_parameters)
+          flash[:success] = "Layout Saved!"
+          redirect_to edit_admin_organization_custom_layout_path(organization_id: @organization.to_param, id: params[:id])
+        else
+          render action: :edit, id: params[:id]
+        end
+      end
 
-  helper_method :layout_kind
+      helper_method :layout_kind
 
-  protected
+      protected
 
-  def permitted_parameters
-    params.require(:organization)
-      .permit(:landing_html, mail_snippets_attributes: [:body, :is_enabled, :id])
-  end
+      def permitted_parameters
+        params.require(:organization)
+          .permit(:landing_html, mail_snippets_attributes: [:body, :is_enabled, :id])
+      end
 
-  def edit_layout_pages
-    @edit_layout_pages ||= MailSnippet.organization_snippet_kinds + %w[landing_page]
-  end
+      def edit_layout_pages
+        @edit_layout_pages ||= MailSnippet.organization_snippet_kinds + %w[landing_page]
+      end
 
-  def layout_kind
-    return "landing_page" if params[:id] == "landing_page"
+      def layout_kind
+        return "landing_page" if params[:id] == "landing_page"
 
-    "mail_snippet"
-  end
+        "mail_snippet"
+      end
 
-  def find_and_authorize_organization
-    @organization = Organization.friendly_find(params[:organization_id])
-    unless current_user.developer?
-      flash[:info] = "Sorry, you must be a developer to access that page."
-      redirect_to(admin_organization_url(@organization)) && return
-    end
-    unless @organization
-      flash[:error] = "Sorry! That organization doesn't exist"
-      redirect_to(admin_organizations_url) && return
+      def find_and_authorize_organization
+        @organization = Organization.friendly_find(params[:organization_id])
+        unless current_user.developer?
+          flash[:info] = "Sorry, you must be a developer to access that page."
+          redirect_to(admin_organization_url(@organization)) && return
+        end
+        unless @organization
+          flash[:error] = "Sorry! That organization doesn't exist"
+          redirect_to(admin_organizations_url) && return
+        end
+      end
     end
   end
 end

--- a/app/controllers/admin/organizations/invoices_controller.rb
+++ b/app/controllers/admin/organizations/invoices_controller.rb
@@ -1,93 +1,97 @@
-class Admin::Organizations::InvoicesController < Admin::BaseController
-  before_action :find_organization
-  before_action :find_invoice, only: %i[edit update destroy]
-  before_action :find_organization_features, only: %i[new edit]
+module Admin
+  module Organizations
+    class InvoicesController < Admin::BaseController
+      before_action :find_organization
+      before_action :find_invoice, only: %i[edit update destroy]
+      before_action :find_organization_features, only: %i[new edit]
 
-  def index
-    @invoices = @organization.invoices.reorder(id: :desc)
-  end
-
-  def new
-    @invoice ||= @organization.invoices.new
-    @invoice.end_at = Binxtils::TimeParser.parse(params[:end_at]) if params[:end_at].present?
-  end
-
-  def show
-    redirect_to edit_admin_organization_invoice_path
-  end
-
-  def edit
-  end
-
-  def create
-    @invoice = @organization.invoices.build(permitted_parameters.except(:organization_feature_ids, :child_enabled_feature_slugs))
-    if @invoice.save
-      # Invoice has to be created before it can get organization_feature_ids
-      @invoice.organization_feature_ids = permitted_parameters[:organization_feature_ids]
-      @invoice.update(child_enabled_feature_slugs_string: permitted_parameters[:child_enabled_feature_slugs_string])
-      flash[:success] = "Invoice created! #{invoice_is_active_notice(@invoice)}"
-      redirect_to admin_organization_invoices_path(organization_id: @organization.to_param)
-    else
-      render :new
-    end
-  end
-
-  def update
-    if params[:create_following_invoice]
-      if @invoice.create_following_invoice
-        flash[:success] = "Invoice updated! #{invoice_is_active_notice(@invoice)}"
-      else
-        flash[:error] = "unable to create following invoice. Was this invoice active?"
+      def index
+        @invoices = @organization.invoices.reorder(id: :desc)
       end
-      redirect_to admin_organization_invoices_path(organization_id: @organization.to_param)
-    elsif @invoice.update(permitted_parameters.except(:child_enabled_feature_slugs_string))
-      @invoice.update(child_enabled_feature_slugs_string: permitted_parameters[:child_enabled_feature_slugs_string])
-      flash[:success] = "Invoice updated! #{invoice_is_active_notice(@invoice)}"
-      redirect_to admin_organization_invoices_path(organization_id: @organization.to_param)
-    else
-      render :edit
-    end
-  end
 
-  def destroy
-    if @invoice.payments.any?
-      flash[:error] = "Not removed! You can't delete invoices with payments"
-    elsif @invoice.destroy
-      flash[:success] = "Invoice deleted!"
-    else
-      flash[:error] = "Not removed! #{@invoice.errors.full_messages.to_sentence}"
-    end
-    redirect_to admin_organization_invoices_path(organization_id: @organization.to_param)
-  end
+      def new
+        @invoice ||= @organization.invoices.new
+        @invoice.end_at = Binxtils::TimeParser.parse(params[:end_at]) if params[:end_at].present?
+      end
 
-  protected
+      def show
+        redirect_to edit_admin_organization_invoice_path
+      end
 
-  def find_organization_features
-    @organization_features = OrganizationFeature.name_ordered
-  end
+      def edit
+      end
 
-  def permitted_parameters
-    params.require(:invoice).permit(:organization_feature_ids, :amount_due, :notes, :timezone, :start_at, :end_at,
-      :child_enabled_feature_slugs_string, :is_endless)
-  end
+      def create
+        @invoice = @organization.invoices.build(permitted_parameters.except(:organization_feature_ids, :child_enabled_feature_slugs))
+        if @invoice.save
+          # Invoice has to be created before it can get organization_feature_ids
+          @invoice.organization_feature_ids = permitted_parameters[:organization_feature_ids]
+          @invoice.update(child_enabled_feature_slugs_string: permitted_parameters[:child_enabled_feature_slugs_string])
+          flash[:success] = "Invoice created! #{invoice_is_active_notice(@invoice)}"
+          redirect_to admin_organization_invoices_path(organization_id: @organization.to_param)
+        else
+          render :new
+        end
+      end
 
-  def find_organization
-    @organization = Organization.friendly_find(params[:organization_id])
-    return true if @organization.present?
+      def update
+        if params[:create_following_invoice]
+          if @invoice.create_following_invoice
+            flash[:success] = "Invoice updated! #{invoice_is_active_notice(@invoice)}"
+          else
+            flash[:error] = "unable to create following invoice. Was this invoice active?"
+          end
+          redirect_to admin_organization_invoices_path(organization_id: @organization.to_param)
+        elsif @invoice.update(permitted_parameters.except(:child_enabled_feature_slugs_string))
+          @invoice.update(child_enabled_feature_slugs_string: permitted_parameters[:child_enabled_feature_slugs_string])
+          flash[:success] = "Invoice updated! #{invoice_is_active_notice(@invoice)}"
+          redirect_to admin_organization_invoices_path(organization_id: @organization.to_param)
+        else
+          render :edit
+        end
+      end
 
-    flash[:error] = "Sorry! That organization doesn't exist"
-    redirect_to(admin_organizations_url) && return
-  end
+      def destroy
+        if @invoice.payments.any?
+          flash[:error] = "Not removed! You can't delete invoices with payments"
+        elsif @invoice.destroy
+          flash[:success] = "Invoice deleted!"
+        else
+          flash[:error] = "Not removed! #{@invoice.errors.full_messages.to_sentence}"
+        end
+        redirect_to admin_organization_invoices_path(organization_id: @organization.to_param)
+      end
 
-  def find_invoice
-    @invoice = @organization.invoices.find(params[:id])
-  end
+      protected
 
-  def invoice_is_active_notice(invoice)
-    if invoice.is_active?
-      "Invoice is ACTIVE"
-    else
-      "Invoice is NOT active"
+      def find_organization_features
+        @organization_features = OrganizationFeature.name_ordered
+      end
+
+      def permitted_parameters
+        params.require(:invoice).permit(:organization_feature_ids, :amount_due, :notes, :timezone, :start_at, :end_at,
+          :child_enabled_feature_slugs_string, :is_endless)
+      end
+
+      def find_organization
+        @organization = Organization.friendly_find(params[:organization_id])
+        return true if @organization.present?
+
+        flash[:error] = "Sorry! That organization doesn't exist"
+        redirect_to(admin_organizations_url) && return
+      end
+
+      def find_invoice
+        @invoice = @organization.invoices.find(params[:id])
+      end
+
+      def invoice_is_active_notice(invoice)
+        if invoice.is_active?
+          "Invoice is ACTIVE"
+        else
+          "Invoice is NOT active"
+        end
+      end
     end
   end
 end

--- a/app/controllers/admin/organizations_controller.rb
+++ b/app/controllers/admin/organizations_controller.rb
@@ -1,208 +1,210 @@
-class Admin::OrganizationsController < Admin::BaseController
-  include Binxtils::SortableTable
+module Admin
+  class OrganizationsController < Admin::BaseController
+    include Binxtils::SortableTable
 
-  before_action :find_organization, only: [:show, :edit, :update, :destroy]
+    before_action :find_organization, only: [:show, :edit, :update, :destroy]
 
-  def index
-    @per_page = permitted_per_page
-    organizations = if sort_column == "bikes"
-      matching_organizations.left_joins(:bikes).group(:id)
-        .order("COUNT(bikes.id) #{sort_direction}")
-    else
-      matching_organizations
-        .reorder("organizations.#{sort_column} #{sort_direction}")
+    def index
+      @per_page = permitted_per_page
+      organizations = if sort_column == "bikes"
+        matching_organizations.left_joins(:bikes).group(:id)
+          .order("COUNT(bikes.id) #{sort_direction}")
+      else
+        matching_organizations
+          .reorder("organizations.#{sort_column} #{sort_direction}")
+      end
+      @pagy, @organizations = pagy(:countish, organizations, limit: @per_page, page: permitted_page)
     end
-    @pagy, @organizations = pagy(:countish, organizations, limit: @per_page, page: permitted_page)
-  end
 
-  def show
-    @locations = @organization.locations
-    @deleted_organization_roles = @organization.deleted? || Binxtils::InputNormalizer.boolean(params[:deleted_organization_roles])
-    bikes = @organization.bikes.reorder("created_at desc")
-    @bikes_count = bikes.size
-    @pagy, @bikes = pagy(:countish, bikes, limit: 10, page: permitted_page)
-  end
+    def show
+      @locations = @organization.locations
+      @deleted_organization_roles = @organization.deleted? || Binxtils::InputNormalizer.boolean(params[:deleted_organization_roles])
+      bikes = @organization.bikes.reorder("created_at desc")
+      @bikes_count = bikes.size
+      @pagy, @bikes = pagy(:countish, bikes, limit: 10, page: permitted_page)
+    end
 
-  def recover
-    @organization = Organization.only_deleted.find(params[:id]).restore(recursive: true)
-    redirect_to admin_organizations_url
-  end
+    def recover
+      @organization = Organization.only_deleted.find(params[:id]).restore(recursive: true)
+      redirect_to admin_organizations_url
+    end
 
-  def new
-    @organization = Organization.new
-  end
+    def new
+      @organization = Organization.new
+    end
 
-  def edit
-    @embedable_email = @organization.auto_user.email if @organization.auto_user
-  end
+    def edit
+      @embedable_email = @organization.auto_user.email if @organization.auto_user
+    end
 
-  def update
-    # Needs to update approved before saving so set_locations_shown is applied on save
+    def update
+      # Needs to update approved before saving so set_locations_shown is applied on save
 
-    # Also, special handling because we need to be able to unset manual_pos_kind
-    manual_pos_kind = params.dig(:organization, :manual_pos_kind)
-    if manual_pos_kind.present?
-      if manual_pos_kind == "not_set"
-        if @organization.manual_pos_kind.present?
+      # Also, special handling because we need to be able to unset manual_pos_kind
+      manual_pos_kind = params.dig(:organization, :manual_pos_kind)
+      if manual_pos_kind.present?
+        if manual_pos_kind == "not_set"
+          if @organization.manual_pos_kind.present?
+            run_update_pos_kind = true
+            @organization.manual_pos_kind = nil
+          end
+        elsif @organization.manual_pos_kind != manual_pos_kind
           run_update_pos_kind = true
-          @organization.manual_pos_kind = nil
+          @organization.manual_pos_kind = manual_pos_kind
         end
-      elsif @organization.manual_pos_kind != manual_pos_kind
-        run_update_pos_kind = true
-        @organization.manual_pos_kind = manual_pos_kind
+      end
+      if @organization.update(permitted_parameters)
+        update_organization_stolen_message
+        flash[:success] = "Organization Saved!"
+        UpdateOrganizationPosKindJob.perform_async(@organization.id) if run_update_pos_kind
+        redirect_to admin_organization_url(@organization)
+      else
+        render action: :edit
       end
     end
-    if @organization.update(permitted_parameters)
-      update_organization_stolen_message
-      flash[:success] = "Organization Saved!"
-      UpdateOrganizationPosKindJob.perform_async(@organization.id) if run_update_pos_kind
-      redirect_to admin_organization_url(@organization)
-    else
-      render action: :edit
+
+    def create
+      @organization = Organization.new(permitted_parameters)
+      @organization.approved = true
+      if @organization.save
+        flash[:success] = "Organization Created!"
+        redirect_to edit_admin_organization_url(@organization)
+      else
+        render action: :new
+      end
     end
-  end
 
-  def create
-    @organization = Organization.new(permitted_parameters)
-    @organization.approved = true
-    if @organization.save
-      flash[:success] = "Organization Created!"
-      redirect_to edit_admin_organization_url(@organization)
-    else
-      render action: :new
+    def destroy
+      @organization.destroy
+      redirect_to admin_organizations_url
     end
-  end
 
-  def destroy
-    @organization.destroy
-    redirect_to admin_organizations_url
-  end
+    helper_method :matching_organizations
 
-  helper_method :matching_organizations
+    protected
 
-  protected
-
-  def permitted_parameters
-    approved_kind = params.dig(:organization, :kind)
-    approved_kind = "other" unless Organization.kinds.include?(approved_kind)
-    params
-      .require(:organization)
-      .permit(
-        :access_token,
-        :api_access_approved,
-        :approved,
-        :ascend_name,
-        :auto_user_id,
-        :available_invitation_count,
-        :avatar,
-        :avatar_cache,
-        :direct_unclaimed_notifications,
-        :embedable_user_email,
-        :graduated_notification_interval_days,
-        :lightspeed_register_with_phone,
-        :lock_show_on_map,
-        :manufacturer_id,
-        :name,
-        :opted_into_theft_survey_2023,
-        :parent_organization_id,
-        :passwordless_user_domain,
-        :previous_slug,
-        :search_radius_miles,
-        :search_radius_kilometers,
-        :short_name,
-        :show_on_map,
-        :slug,
-        :spam_registrations,
-        :website,
-        [locations_attributes:]
-      ).merge(kind: approved_kind)
-      .merge(registration_field_labels: registration_field_labels_val)
-  end
-
-  def matching_organizations
-    return @matching_organizations if defined?(@matching_organizations)
-
-    @search_paid = Binxtils::InputNormalizer.boolean(params[:search_paid])
-    matching_organizations = search_deleted_scope(Organization.all)
-    matching_organizations = matching_organizations.paid if @search_paid
-    matching_organizations = matching_organizations.admin_text_search(params[:search_query]) if params[:search_query].present?
-
-    @features_and_settings_ids = []
-    features_and_settings = Array(params[:search_features_and_settings]).reject(&:blank?)
-    organization_features = OrganizationFeature.where(id: features_and_settings)
-    if organization_features.any? # HACK - doesn't search InvoiceOrganizationFeature, just feature slugs
-      matching_organizations = matching_organizations.with_enabled_feature_slugs(organization_features.feature_slugs)
-      @features_and_settings_ids += organization_features.pluck(:id)
+    def permitted_parameters
+      approved_kind = params.dig(:organization, :kind)
+      approved_kind = "other" unless Organization.kinds.include?(approved_kind)
+      params
+        .require(:organization)
+        .permit(
+          :access_token,
+          :api_access_approved,
+          :approved,
+          :ascend_name,
+          :auto_user_id,
+          :available_invitation_count,
+          :avatar,
+          :avatar_cache,
+          :direct_unclaimed_notifications,
+          :embedable_user_email,
+          :graduated_notification_interval_days,
+          :lightspeed_register_with_phone,
+          :lock_show_on_map,
+          :manufacturer_id,
+          :name,
+          :opted_into_theft_survey_2023,
+          :parent_organization_id,
+          :passwordless_user_domain,
+          :previous_slug,
+          :search_radius_miles,
+          :search_radius_kilometers,
+          :short_name,
+          :show_on_map,
+          :slug,
+          :spam_registrations,
+          :website,
+          [locations_attributes:]
+        ).merge(kind: approved_kind)
+        .merge(registration_field_labels: registration_field_labels_val)
     end
-    selected_settings = organization_settings & features_and_settings
-    if selected_settings.include?("theft_survey")
-      matching_organizations = matching_organizations.where(opted_into_theft_survey_2023: true)
+
+    def matching_organizations
+      return @matching_organizations if defined?(@matching_organizations)
+
+      @search_paid = Binxtils::InputNormalizer.boolean(params[:search_paid])
+      matching_organizations = search_deleted_scope(Organization.all)
+      matching_organizations = matching_organizations.paid if @search_paid
+      matching_organizations = matching_organizations.admin_text_search(params[:search_query]) if params[:search_query].present?
+
+      @features_and_settings_ids = []
+      features_and_settings = Array(params[:search_features_and_settings]).reject(&:blank?)
+      organization_features = OrganizationFeature.where(id: features_and_settings)
+      if organization_features.any? # HACK - doesn't search InvoiceOrganizationFeature, just feature slugs
+        matching_organizations = matching_organizations.with_enabled_feature_slugs(organization_features.feature_slugs)
+        @features_and_settings_ids += organization_features.pluck(:id)
+      end
+      selected_settings = organization_settings & features_and_settings
+      if selected_settings.include?("theft_survey")
+        matching_organizations = matching_organizations.where(opted_into_theft_survey_2023: true)
+      end
+      if selected_settings.include?("with_stolen_message")
+        matching_organizations = matching_organizations.with_stolen_message
+      end
+      if selected_settings.include?("not_approved")
+        matching_organizations = matching_organizations.where(approved: false)
+      end
+      if selected_settings.include?("mapped")
+        matching_organizations = matching_organizations.where(show_on_map: true)
+      elsif selected_settings.include?("not_mapped")
+        matching_organizations = matching_organizations.where(show_on_map: false)
+      end
+      @features_and_settings_ids += selected_settings
+
+      matching_organizations = matching_organizations.where(kind: params[:search_kind]) if params[:search_kind].present?
+      matching_organizations = matching_organizations.where(pos_kind: pos_kind_for_organizations) if params[:search_pos].present?
+      matching_organizations = matching_organizations.where(approved: (sort_direction == "desc")) if sort_column == "approved"
+      @time_range_column = sort_column if %w[updated_at deleted_at].include?(sort_column)
+      @time_range_column ||= "created_at"
+      @matching_organizations = matching_organizations.where(@time_range_column => @time_range)
     end
-    if selected_settings.include?("with_stolen_message")
-      matching_organizations = matching_organizations.with_stolen_message
+
+    def sortable_columns
+      %w[created_at deleted_at name approved pos_kind bikes].freeze
     end
-    if selected_settings.include?("not_approved")
-      matching_organizations = matching_organizations.where(approved: false)
+
+    def organization_settings
+      %w[theft_survey with_stolen_message not_approved mapped not_mapped].freeze
     end
-    if selected_settings.include?("mapped")
-      matching_organizations = matching_organizations.where(show_on_map: true)
-    elsif selected_settings.include?("not_mapped")
-      matching_organizations = matching_organizations.where(show_on_map: false)
+
+    def pos_kind_for_organizations
+      if params[:search_pos] == "with_pos"
+        Organization.with_pos_kinds
+      elsif params[:search_pos] == "without_pos"
+        Organization.without_pos_kinds
+      elsif params[:search_pos] == "broken_pos"
+        Organization.broken_pos_kinds
+      else
+        params[:search_pos]
+      end
     end
-    @features_and_settings_ids += selected_settings
 
-    matching_organizations = matching_organizations.where(kind: params[:search_kind]) if params[:search_kind].present?
-    matching_organizations = matching_organizations.where(pos_kind: pos_kind_for_organizations) if params[:search_pos].present?
-    matching_organizations = matching_organizations.where(approved: (sort_direction == "desc")) if sort_column == "approved"
-    @time_range_column = sort_column if %w[updated_at deleted_at].include?(sort_column)
-    @time_range_column ||= "created_at"
-    @matching_organizations = matching_organizations.where(@time_range_column => @time_range)
-  end
-
-  def sortable_columns
-    %w[created_at deleted_at name approved pos_kind bikes].freeze
-  end
-
-  def organization_settings
-    %w[theft_survey with_stolen_message not_approved mapped not_mapped].freeze
-  end
-
-  def pos_kind_for_organizations
-    if params[:search_pos] == "with_pos"
-      Organization.with_pos_kinds
-    elsif params[:search_pos] == "without_pos"
-      Organization.without_pos_kinds
-    elsif params[:search_pos] == "broken_pos"
-      Organization.broken_pos_kinds
-    else
-      params[:search_pos]
+    def registration_field_labels_val
+      # Get just the reg labels with values
+      params.select { |k, v| k.match?("reg_label-") && v.present? }.as_json
+        .map { |k, v| [k.gsub("reg_label-", ""), v.strip] }.to_h
     end
-  end
 
-  def registration_field_labels_val
-    # Get just the reg labels with values
-    params.select { |k, v| k.match?("reg_label-") && v.present? }.as_json
-      .map { |k, v| [k.gsub("reg_label-", ""), v.strip] }.to_h
-  end
+    def locations_attributes
+      %i[name _destroy id phone email publicly_visible impound_location default_impound_location] +
+        [address_record_attributes: AddressRecord.permitted_params + [:id]]
+    end
 
-  def locations_attributes
-    %i[name _destroy id phone email publicly_visible impound_location default_impound_location] +
-      [address_record_attributes: AddressRecord.permitted_params + [:id]]
-  end
+    def update_organization_stolen_message
+      message_params = {search_radius_miles: params[:organization_stolen_message_search_radius_miles],
+                        kind: params[:organization_stolen_message_kind],
+                        search_radius_kilometers: params[:organization_stolen_message_search_radius_kilometers]}
+      return unless message_params.values.reject(&:blank?).any?
 
-  def update_organization_stolen_message
-    message_params = {search_radius_miles: params[:organization_stolen_message_search_radius_miles],
-                      kind: params[:organization_stolen_message_kind],
-                      search_radius_kilometers: params[:organization_stolen_message_search_radius_kilometers]}
-    return unless message_params.values.reject(&:blank?).any?
+      OrganizationStolenMessage.for(@organization).update(message_params)
+    end
 
-    OrganizationStolenMessage.for(@organization).update(message_params)
-  end
+    def find_organization
+      @organization = Organization.unscoped.friendly_find(params[:id])
+      return true if @organization.present?
 
-  def find_organization
-    @organization = Organization.unscoped.friendly_find(params[:id])
-    return true if @organization.present?
-
-    raise ActiveRecord::RecordNotFound # Because this should have been raised
+      raise ActiveRecord::RecordNotFound # Because this should have been raised
+    end
   end
 end

--- a/app/controllers/admin/ownerships_controller.rb
+++ b/app/controllers/admin/ownerships_controller.rb
@@ -1,95 +1,97 @@
-class Admin::OwnershipsController < Admin::BaseController
-  include Binxtils::SortableTable
+module Admin
+  class OwnershipsController < Admin::BaseController
+    include Binxtils::SortableTable
 
-  before_action :find_ownership, except: [:index]
+    before_action :find_ownership, except: [:index]
 
-  def index
-    @per_page = permitted_per_page(default: 50)
-    @pagy, @ownerships = pagy(:countish, matching_ownerships.reorder("ownerships.#{sort_column} #{sort_direction}")
-      .includes(:bike, :organization, :creator, :user), limit: @per_page, page: permitted_page)
-  end
-
-  def show
-    redirect_to edit_admin_ownership_path
-  end
-
-  def edit
-  end
-
-  def update
-    error_message = []
-    if params[:ownership]
-      if params[:ownership][:user_email].present?
-        params[:ownership][:user_id] = User.friendly_find_id(params[:ownership].delete(:user_email))
-        error_message << "No confirmed user with that User email!" unless params[:ownership][:user_id].present?
-      end
-      if params[:ownership][:creator_email].present?
-        params[:ownership][:creator_id] = User.friendly_find_id(params[:ownership].delete(:creator_email))
-        error_message << "No confirmed user with creator email!" unless params[:ownership][:creator_id].present?
-      end
+    def index
+      @per_page = permitted_per_page(default: 50)
+      @pagy, @ownerships = pagy(:countish, matching_ownerships.reorder("ownerships.#{sort_column} #{sort_direction}")
+        .includes(:bike, :organization, :creator, :user), limit: @per_page, page: permitted_page)
     end
-    if error_message.blank? && params[:ownership].present? && @ownership.update(permitted_parameters)
-      flash[:success] = "Ownership Saved!"
-      redirect_to edit_admin_ownership_url(@ownership.id)
-    else
-      if error_message.present?
-        flash[:error] = error_message.join(" ")
+
+    def show
+      redirect_to edit_admin_ownership_path
+    end
+
+    def edit
+    end
+
+    def update
+      error_message = []
+      if params[:ownership]
+        if params[:ownership][:user_email].present?
+          params[:ownership][:user_id] = User.friendly_find_id(params[:ownership].delete(:user_email))
+          error_message << "No confirmed user with that User email!" unless params[:ownership][:user_id].present?
+        end
+        if params[:ownership][:creator_email].present?
+          params[:ownership][:creator_id] = User.friendly_find_id(params[:ownership].delete(:creator_email))
+          error_message << "No confirmed user with creator email!" unless params[:ownership][:creator_id].present?
+        end
+      end
+      if error_message.blank? && params[:ownership].present? && @ownership.update(permitted_parameters)
+        flash[:success] = "Ownership Saved!"
+        redirect_to edit_admin_ownership_url(@ownership.id)
       else
-        flash[:info] = "No information updated"
-      end
-      render action: :edit
-    end
-  end
-
-  helper_method :matching_ownerships, :organization_kind_options
-
-  private
-
-  def sortable_columns
-    %w[created_at updated_at creator_id owner_email]
-  end
-
-  def ownership_origins
-    Ownership.origins + %w[only_initial]
-  end
-
-  def organization_kind_options
-    %w[without_organization only_with_organization]
-  end
-
-  def matching_ownerships
-    ownerships = Ownership.unscoped
-    if organization_kind_options.include?(params[:search_organization_kind])
-      @search_organization_kind = params[:search_organization_kind]
-      ownerships = if @search_organization_kind == "without_organization"
-        ownerships.where(organization_id: nil)
-      else
-        ownerships.where.not(organization_id: nil)
+        if error_message.present?
+          flash[:error] = error_message.join(" ")
+        else
+          flash[:info] = "No information updated"
+        end
+        render action: :edit
       end
     end
-    ownerships = ownerships.where(organization_id: current_organization.id) if current_organization.present?
 
-    @search_origin = ownership_origins.include?(params[:search_origin]) ? params[:search_origin] : "all"
-    unless @search_origin == "all"
-      ownerships = if @search_origin == "only_initial"
-        ownerships.initial
-      else
-        ownerships.where(origin: @search_origin)
-      end
+    helper_method :matching_ownerships, :organization_kind_options
+
+    private
+
+    def sortable_columns
+      %w[created_at updated_at creator_id owner_email]
     end
-    @time_range_column = sort_column if %w[updated_at].include?(sort_column)
-    @time_range_column ||= "created_at"
-    ownerships.where(@time_range_column => @time_range)
-  end
 
-  def find_ownership
-    @ownership = Ownership.find(params[:id])
-    @bike = Bike.unscoped.find(@ownership.bike_id)
-    @users = User.all
-  end
+    def ownership_origins
+      Ownership.origins + %w[only_initial]
+    end
 
-  def permitted_parameters
-    params.require(:ownership).permit(:bike_id, :user_id, :owner_email, :creator_id, :current,
-      :claimed, :example, :send_email, :user_hidden)
+    def organization_kind_options
+      %w[without_organization only_with_organization]
+    end
+
+    def matching_ownerships
+      ownerships = Ownership.unscoped
+      if organization_kind_options.include?(params[:search_organization_kind])
+        @search_organization_kind = params[:search_organization_kind]
+        ownerships = if @search_organization_kind == "without_organization"
+          ownerships.where(organization_id: nil)
+        else
+          ownerships.where.not(organization_id: nil)
+        end
+      end
+      ownerships = ownerships.where(organization_id: current_organization.id) if current_organization.present?
+
+      @search_origin = ownership_origins.include?(params[:search_origin]) ? params[:search_origin] : "all"
+      unless @search_origin == "all"
+        ownerships = if @search_origin == "only_initial"
+          ownerships.initial
+        else
+          ownerships.where(origin: @search_origin)
+        end
+      end
+      @time_range_column = sort_column if %w[updated_at].include?(sort_column)
+      @time_range_column ||= "created_at"
+      ownerships.where(@time_range_column => @time_range)
+    end
+
+    def find_ownership
+      @ownership = Ownership.find(params[:id])
+      @bike = Bike.unscoped.find(@ownership.bike_id)
+      @users = User.all
+    end
+
+    def permitted_parameters
+      params.require(:ownership).permit(:bike_id, :user_id, :owner_email, :creator_id, :current,
+        :claimed, :example, :send_email, :user_hidden)
+    end
   end
 end

--- a/app/controllers/admin/paints_controller.rb
+++ b/app/controllers/admin/paints_controller.rb
@@ -1,74 +1,76 @@
-class Admin::PaintsController < Admin::BaseController
-  include Binxtils::SortableTable
+module Admin
+  class PaintsController < Admin::BaseController
+    include Binxtils::SortableTable
 
-  before_action :find_paint, only: [:show, :edit, :update, :destroy]
+    before_action :find_paint, only: [:show, :edit, :update, :destroy]
 
-  def index
-    @per_page = permitted_per_page(default: 100)
-    @pagy, @paints = pagy(:countish, matching_paints.reorder("paints.#{sort_column} #{sort_direction}")
-      .includes(:color, :secondary_color, :tertiary_color), limit: @per_page, page: permitted_page)
-  end
+    def index
+      @per_page = permitted_per_page(default: 100)
+      @pagy, @paints = pagy(:countish, matching_paints.reorder("paints.#{sort_column} #{sort_direction}")
+        .includes(:color, :secondary_color, :tertiary_color), limit: @per_page, page: permitted_page)
+    end
 
-  def show
-    redirect_to edit_admin_paint_url(@paint)
-  end
+    def show
+      redirect_to edit_admin_paint_url(@paint)
+    end
 
-  def edit
-    @per_page = permitted_per_page(default: 20)
-    bikes = Bike.unscoped.default_includes.includes(:paint)
-      .where(paint_id: @paint.id).order("created_at desc")
-    @bikes_count = bikes.size
-    @pagy, @bikes = pagy(:countish, bikes, limit: @per_page, page: permitted_page)
-  end
+    def edit
+      @per_page = permitted_per_page(default: 20)
+      bikes = Bike.unscoped.default_includes.includes(:paint)
+        .where(paint_id: @paint.id).order("created_at desc")
+      @bikes_count = bikes.size
+      @pagy, @bikes = pagy(:countish, bikes, limit: @per_page, page: permitted_page)
+    end
 
-  def update
-    if @paint.update(permitted_parameters)
-      UpdatePaintJob.perform_async(@paint.id)
-      flash[:success] = "Paint updating!"
+    def update
+      if @paint.update(permitted_parameters)
+        UpdatePaintJob.perform_async(@paint.id)
+        flash[:success] = "Paint updating!"
+        redirect_to admin_paints_url
+      else
+        render action: :edit
+      end
+    end
+
+    def destroy
+      if @paint.bikes.present?
+        flash[:error] = "Not allowed! Bikes use that paint! How the fuck did you delete that anyway?"
+      else
+        @paint.destroy
+        flash[:success] = "Paint deleted!"
+      end
       redirect_to admin_paints_url
-    else
-      render action: :edit
     end
-  end
 
-  def destroy
-    if @paint.bikes.present?
-      flash[:error] = "Not allowed! Bikes use that paint! How the fuck did you delete that anyway?"
-    else
-      @paint.destroy
-      flash[:success] = "Paint deleted!"
+    helper_method :matching_paints
+
+    protected
+
+    def sortable_columns
+      %w[created_at updated_at name bikes_count]
     end
-    redirect_to admin_paints_url
-  end
 
-  helper_method :matching_paints
-
-  protected
-
-  def sortable_columns
-    %w[created_at updated_at name bikes_count]
-  end
-
-  def earliest_period_date
-    Time.at(1389138422) # Earliest sticker created_at
-  end
-
-  def permitted_parameters
-    params.require(:paint).permit(:color_id, :manufacturer_id, :secondary_color_id, :tertiary_color_id, :bikes_count)
-  end
-
-  def find_paint
-    @paint = Paint.find(params[:id])
-  end
-
-  def matching_paints
-    paints = if params[:search_name]
-      Paint.where("name LIKE ?", "%#{params[:search_name]}%")
-    else
-      Paint
+    def earliest_period_date
+      Time.at(1389138422) # Earliest sticker created_at
     end
-    @search_unlinked = Binxtils::InputNormalizer.boolean(params[:search_unlinked])
-    paints = paints.unlinked if @search_unlinked
-    paints.where(created_at: @time_range)
+
+    def permitted_parameters
+      params.require(:paint).permit(:color_id, :manufacturer_id, :secondary_color_id, :tertiary_color_id, :bikes_count)
+    end
+
+    def find_paint
+      @paint = Paint.find(params[:id])
+    end
+
+    def matching_paints
+      paints = if params[:search_name]
+        Paint.where("name LIKE ?", "%#{params[:search_name]}%")
+      else
+        Paint
+      end
+      @search_unlinked = Binxtils::InputNormalizer.boolean(params[:search_unlinked])
+      paints = paints.unlinked if @search_unlinked
+      paints.where(created_at: @time_range)
+    end
   end
 end

--- a/app/controllers/admin/paper_trail_versions_controller.rb
+++ b/app/controllers/admin/paper_trail_versions_controller.rb
@@ -1,52 +1,54 @@
 # frozen_string_literal: true
 
-class Admin::PaperTrailVersionsController < Admin::BaseController
-  include Binxtils::SortableTable
+module Admin
+  class PaperTrailVersionsController < Admin::BaseController
+    include Binxtils::SortableTable
 
-  def index
-    @per_page = permitted_per_page(default: 50)
-    @pagy, @collection = pagy(:countish,
-      matching_versions.reorder(sortable_opts),
-      limit: @per_page,
-      page: permitted_page)
-  end
-
-  helper_method :matching_versions
-
-  private
-
-  def sortable_columns
-    %w[created_at item_type event].freeze
-  end
-
-  def sortable_opts
-    "versions.#{sort_column} #{sort_direction}"
-  end
-
-  def earliest_period_date
-    Time.at(1773878400)
-  end
-
-  def matching_versions
-    versions = PaperTrail::Version.all
-
-    if params[:search_item_id].present?
-      versions = versions.where(item_id: params[:search_item_id])
+    def index
+      @per_page = permitted_per_page(default: 50)
+      @pagy, @collection = pagy(:countish,
+        matching_versions.reorder(sortable_opts),
+        limit: @per_page,
+        page: permitted_page)
     end
 
-    if params[:search_item_type].present?
-      versions = versions.where(item_type: params[:search_item_type])
+    helper_method :matching_versions
+
+    private
+
+    def sortable_columns
+      %w[created_at item_type event].freeze
     end
 
-    if params[:search_event].present?
-      versions = versions.where(event: params[:search_event])
+    def sortable_opts
+      "versions.#{sort_column} #{sort_direction}"
     end
 
-    if params[:user_id].present?
-      versions = versions.where(whodunnit: (user_subject&.id || params[:user_id]).to_s)
+    def earliest_period_date
+      Time.at(1773878400)
     end
 
-    @time_range_column = "created_at"
-    versions.where(created_at: @time_range)
+    def matching_versions
+      versions = PaperTrail::Version.all
+
+      if params[:search_item_id].present?
+        versions = versions.where(item_id: params[:search_item_id])
+      end
+
+      if params[:search_item_type].present?
+        versions = versions.where(item_type: params[:search_item_type])
+      end
+
+      if params[:search_event].present?
+        versions = versions.where(event: params[:search_event])
+      end
+
+      if params[:user_id].present?
+        versions = versions.where(whodunnit: (user_subject&.id || params[:user_id]).to_s)
+      end
+
+      @time_range_column = "created_at"
+      versions.where(created_at: @time_range)
+    end
   end
 end

--- a/app/controllers/admin/parking_notifications_controller.rb
+++ b/app/controllers/admin/parking_notifications_controller.rb
@@ -1,39 +1,41 @@
-class Admin::ParkingNotificationsController < Admin::BaseController
-  include Binxtils::SortableTable
+module Admin
+  class ParkingNotificationsController < Admin::BaseController
+    include Binxtils::SortableTable
 
-  def index
-    @per_page = permitted_per_page(default: 50)
-    @pagy, @parking_notifications = pagy(:countish, matching_parking_notifications.includes(:user, :organization, :bike)
-      .order(sort_column + " " + sort_direction), limit: @per_page, page: permitted_page)
-  end
-
-  helper_method :matching_parking_notifications
-
-  protected
-
-  def sortable_columns
-    %w[created_at organization_id kind updated_at user_id resolved_at]
-  end
-
-  def earliest_period_date
-    Time.at(1580400881) # 14 days before first parking notification created
-  end
-
-  def matching_parking_notifications
-    return @matching_parking_notifications if defined?(@matching_parking_notifications)
-
-    parking_notifications = ParkingNotification
-    parking_notifications.resolved if sort_column == "resolved_at"
-    if ParkingNotification.statuses.include?(params[:search_status])
-      @search_status = params[:search_status]
-      parking_notifications = parking_notifications.where(status: @search_status)
-    elsif %w[active resolved].include?(params[:search_status])
-      @search_status = params[:search_status]
-      parking_notifications = (@search_status == "active") ? parking_notifications.active : parking_notifications.resolved
-    else
-      @search_status = "all"
+    def index
+      @per_page = permitted_per_page(default: 50)
+      @pagy, @parking_notifications = pagy(:countish, matching_parking_notifications.includes(:user, :organization, :bike)
+        .order(sort_column + " " + sort_direction), limit: @per_page, page: permitted_page)
     end
-    parking_notifications = parking_notifications.where(organization_id: current_organization.id) if current_organization.present?
-    @matching_parking_notifications = parking_notifications.where(created_at: @time_range)
+
+    helper_method :matching_parking_notifications
+
+    protected
+
+    def sortable_columns
+      %w[created_at organization_id kind updated_at user_id resolved_at]
+    end
+
+    def earliest_period_date
+      Time.at(1580400881) # 14 days before first parking notification created
+    end
+
+    def matching_parking_notifications
+      return @matching_parking_notifications if defined?(@matching_parking_notifications)
+
+      parking_notifications = ParkingNotification
+      parking_notifications.resolved if sort_column == "resolved_at"
+      if ParkingNotification.statuses.include?(params[:search_status])
+        @search_status = params[:search_status]
+        parking_notifications = parking_notifications.where(status: @search_status)
+      elsif %w[active resolved].include?(params[:search_status])
+        @search_status = params[:search_status]
+        parking_notifications = (@search_status == "active") ? parking_notifications.active : parking_notifications.resolved
+      else
+        @search_status = "all"
+      end
+      parking_notifications = parking_notifications.where(organization_id: current_organization.id) if current_organization.present?
+      @matching_parking_notifications = parking_notifications.where(created_at: @time_range)
+    end
   end
 end

--- a/app/controllers/admin/payments_controller.rb
+++ b/app/controllers/admin/payments_controller.rb
@@ -1,168 +1,170 @@
-class Admin::PaymentsController < Admin::BaseController
-  include Binxtils::SortableTable
+module Admin
+  class PaymentsController < Admin::BaseController
+    include Binxtils::SortableTable
 
-  before_action :find_payment, only: %i[edit update]
+    before_action :find_payment, only: %i[edit update]
 
-  def index
-    @per_page = permitted_per_page(default: 50)
-    @pagy, @payments = pagy(:countish, matching_payments.includes(:user, :organization, :invoice)
-      .order(sort_column + " " + sort_direction), limit: @per_page, page: permitted_page)
-  end
+    def index
+      @per_page = permitted_per_page(default: 50)
+      @pagy, @payments = pagy(:countish, matching_payments.includes(:user, :organization, :invoice)
+        .order(sort_column + " " + sort_direction), limit: @per_page, page: permitted_page)
+    end
 
-  def new
-    @payment = Payment.new
-  end
+    def new
+      @payment = Payment.new
+    end
 
-  def show
-    redirect_to edit_admin_payment_url
-  end
+    def show
+      redirect_to edit_admin_payment_url
+    end
 
-  def edit
-  end
+    def edit
+    end
 
-  def update
-    if assign_to_membership_param?
-      if @payment.can_assign_to_membership?
-        Users::CreateOrUpdateMembershipFromPaymentJob.new.perform(@payment.id, current_user.id)
+    def update
+      if assign_to_membership_param?
+        if @payment.can_assign_to_membership?
+          Users::CreateOrUpdateMembershipFromPaymentJob.new.perform(@payment.id, current_user.id)
+          flash[:success] = "Payment updated"
+        else
+          flash[:error] = "This payment can't be assigned to a membership - maybe it already has been?"
+        end
+        redirect_back(fallback_location: edit_admin_payment_url(@payment))
+      elsif valid_invoice_parameters?
+        @payment.update(invoice_parameters) # invoice params are the only params permitted for update ;)
         flash[:success] = "Payment updated"
+        redirect_to admin_payments_path
       else
-        flash[:error] = "This payment can't be assigned to a membership - maybe it already has been?"
+        redirect_to edit_admin_payment_url(@payment.attributes = invoice_parameters)
       end
-      redirect_back(fallback_location: edit_admin_payment_url(@payment))
-    elsif valid_invoice_parameters?
-      @payment.update(invoice_parameters) # invoice params are the only params permitted for update ;)
-      flash[:success] = "Payment updated"
-      redirect_to admin_payments_path
-    else
-      redirect_to edit_admin_payment_url(@payment.attributes = invoice_parameters)
     end
-  end
 
-  def create
-    @payment = Payment.new(permitted_create_parameters)
-    @payment.paid_at = @payment.created_at
-    valid_method = Payment.admin_creatable_payment_methods.include?(permitted_create_parameters[:payment_method])
+    def create
+      @payment = Payment.new(permitted_create_parameters)
+      @payment.paid_at = @payment.created_at
+      valid_method = Payment.admin_creatable_payment_methods.include?(permitted_create_parameters[:payment_method])
 
-    if valid_method && valid_invoice_parameters? && @payment.save
-      flash[:success] = "Payment created"
-      redirect_to admin_payments_path
-    else
-      flash[:error] ||= if valid_method
-        "Unable to create"
+      if valid_method && valid_invoice_parameters? && @payment.save
+        flash[:success] = "Payment created"
+        redirect_to admin_payments_path
       else
-        "Not able to create #{permitted_create_parameters[:payment_method]} method of payments"
+        flash[:error] ||= if valid_method
+          "Unable to create"
+        else
+          "Not able to create #{permitted_create_parameters[:payment_method]} method of payments"
+        end
+        render :new
       end
-      render :new
     end
-  end
 
-  helper_method :matching_payments
+    helper_method :matching_payments
 
-  protected
+    protected
 
-  def sortable_columns
-    %w[created_at user_id organization_id kind payment_method invoice_id amount_cents referral_source]
-  end
-
-  def searchable_payment_methods
-    ["show"] + Payment.payment_methods
-  end
-
-  def searchable_kinds
-    ["organization"] + Payment.kinds
-  end
-
-  def matching_payments
-    return @matching_payments if defined?(@matching_payments)
-
-    matching_payments = Payment
-    if sort_column == "invoice_id"
-      matching_payments = matching_payments.where.not(invoice_id: nil)
-    elsif sort_column == "organization_id"
-      matching_payments = matching_payments.where.not(organization_id: nil)
+    def sortable_columns
+      %w[created_at user_id organization_id kind payment_method invoice_id amount_cents referral_source]
     end
-    matching_payments = matching_payments.where(organization_id: current_organization.id) if current_organization.present?
 
-    if %w[all incomplete].include?(params[:search_incompleteness])
-      @incompleteness = params[:search_incompleteness]
-      matching_payments = matching_payments.incomplete if @incompleteness == "only_incomplete"
-    else
-      @incompleteness ||= "paid" # Default to only completed
-      matching_payments = matching_payments.paid
+    def searchable_payment_methods
+      ["show"] + Payment.payment_methods
     end
-    if searchable_kinds.include?(params[:search_kind])
-      @kind = params[:search_kind]
 
-      matching_payments = if @kind == "organization"
-        matching_payments.where.not(organization_id: nil)
+    def searchable_kinds
+      ["organization"] + Payment.kinds
+    end
+
+    def matching_payments
+      return @matching_payments if defined?(@matching_payments)
+
+      matching_payments = Payment
+      if sort_column == "invoice_id"
+        matching_payments = matching_payments.where.not(invoice_id: nil)
+      elsif sort_column == "organization_id"
+        matching_payments = matching_payments.where.not(organization_id: nil)
+      end
+      matching_payments = matching_payments.where(organization_id: current_organization.id) if current_organization.present?
+
+      if %w[all incomplete].include?(params[:search_incompleteness])
+        @incompleteness = params[:search_incompleteness]
+        matching_payments = matching_payments.incomplete if @incompleteness == "only_incomplete"
       else
-        matching_payments.where(kind: @kind)
+        @incompleteness ||= "paid" # Default to only completed
+        matching_payments = matching_payments.paid
       end
-    end
-    if searchable_payment_methods.include?(params[:search_payment_method])
-      @render_method = true
-      @payment_method = params[:search_payment_method]
-      if @payment_method != "show"
-        matching_payments = matching_payments.where(payment_method: @payment_method)
+      if searchable_kinds.include?(params[:search_kind])
+        @kind = params[:search_kind]
+
+        matching_payments = if @kind == "organization"
+          matching_payments.where.not(organization_id: nil)
+        else
+          matching_payments.where(kind: @kind)
+        end
       end
-    else
-      @payment_method = "all"
+      if searchable_payment_methods.include?(params[:search_payment_method])
+        @render_method = true
+        @payment_method = params[:search_payment_method]
+        if @payment_method != "show"
+          matching_payments = matching_payments.where(payment_method: @payment_method)
+        end
+      else
+        @payment_method = "all"
+      end
+      if params[:search_membership_id].present?
+        matching_payments = matching_payments.where(membership_id: params[:search_membership_id])
+      end
+      matching_payments = matching_payments.admin_search(params[:query]) if params[:query].present?
+      if params[:search_email].present?
+        matching_payments = matching_payments.where("email ILIKE ?", "%#{EmailNormalizer.normalize(params[:search_email])}%")
+      end
+      if params[:user_id].present?
+        matching_payments = matching_payments.where(user_id: user_subject&.id || params[:user_id])
+      end
+      @matching_payments = matching_payments.where(created_at: @time_range)
     end
-    if params[:search_membership_id].present?
-      matching_payments = matching_payments.where(membership_id: params[:search_membership_id])
+
+    # Override earliest period date, to use 1 week before first feedback created
+    def earliest_period_date
+      Time.at(1417588530)
     end
-    matching_payments = matching_payments.admin_search(params[:query]) if params[:query].present?
-    if params[:search_email].present?
-      matching_payments = matching_payments.where("email ILIKE ?", "%#{EmailNormalizer.normalize(params[:search_email])}%")
+
+    def default_period
+      "year"
     end
-    if params[:user_id].present?
-      matching_payments = matching_payments.where(user_id: user_subject&.id || params[:user_id])
+
+    def assign_to_membership_param?
+      Binxtils::InputNormalizer.boolean(params[:assign_to_membership])
     end
-    @matching_payments = matching_payments.where(created_at: @time_range)
-  end
 
-  # Override earliest period date, to use 1 week before first feedback created
-  def earliest_period_date
-    Time.at(1417588530)
-  end
+    def valid_invoice_parameters?
+      invoice_parameters # To parse the invoice params
+      return true unless @params_invoice.present?
+      return true if @params_invoice.organization_id&.to_s == invoice_parameters[:organization_id]&.to_s
 
-  def default_period
-    "year"
-  end
-
-  def assign_to_membership_param?
-    Binxtils::InputNormalizer.boolean(params[:assign_to_membership])
-  end
-
-  def valid_invoice_parameters?
-    invoice_parameters # To parse the invoice params
-    return true unless @params_invoice.present?
-    return true if @params_invoice.organization_id&.to_s == invoice_parameters[:organization_id]&.to_s
-
-    organization_name = Organization.friendly_find(invoice_parameters[:organization_id])&.short_name
-    flash[:error] = "Invoice #{invoice_parameters[:invoice_id]} is not owned by #{organization_name}"
-    false
-  end
-
-  def invoice_parameters
-    return @invoice_parameters if defined?(@invoice_parameters)
-
-    iparams = params.require(:payment).permit(:organization_id, :invoice_id, :referral_source)
-    @params_invoice = Invoice.friendly_find(iparams[:invoice_id])
-    if @params_invoice.present?
-      iparams[:organization_id] = @params_invoice.organization_id unless iparams[:organization_id].present?
+      organization_name = Organization.friendly_find(invoice_parameters[:organization_id])&.short_name
+      flash[:error] = "Invoice #{invoice_parameters[:invoice_id]} is not owned by #{organization_name}"
+      false
     end
-    @invoice_parameters = iparams.slice(:organization_id, :referral_source).merge(invoice_id: @params_invoice&.id)
-  end
 
-  def permitted_create_parameters
-    params
-      .require(:payment)
-      .permit(:payment_method, :amount, :email, :currency_enum, :created_at, :referral_source)
-      .merge(invoice_parameters)
-  end
+    def invoice_parameters
+      return @invoice_parameters if defined?(@invoice_parameters)
 
-  def find_payment
-    @payment = Payment.find(params[:id])
+      iparams = params.require(:payment).permit(:organization_id, :invoice_id, :referral_source)
+      @params_invoice = Invoice.friendly_find(iparams[:invoice_id])
+      if @params_invoice.present?
+        iparams[:organization_id] = @params_invoice.organization_id unless iparams[:organization_id].present?
+      end
+      @invoice_parameters = iparams.slice(:organization_id, :referral_source).merge(invoice_id: @params_invoice&.id)
+    end
+
+    def permitted_create_parameters
+      params
+        .require(:payment)
+        .permit(:payment_method, :amount, :email, :currency_enum, :created_at, :referral_source)
+        .merge(invoice_parameters)
+    end
+
+    def find_payment
+      @payment = Payment.find(params[:id])
+    end
   end
 end

--- a/app/controllers/admin/primary_activities_controller.rb
+++ b/app/controllers/admin/primary_activities_controller.rb
@@ -1,61 +1,63 @@
-class Admin::PrimaryActivitiesController < Admin::BaseController
-  include Binxtils::SortableTable
+module Admin
+  class PrimaryActivitiesController < Admin::BaseController
+    include Binxtils::SortableTable
 
-  before_action :find_primary_activity, except: %i[index]
+    before_action :find_primary_activity, except: %i[index]
 
-  def index
-    @per_page = permitted_per_page(default: 60)
-    @search_show_count = Binxtils::InputNormalizer.boolean(params[:search_show_count])
-    @pagy, @collection = pagy(:countish,
-      matching_primary_activities.includes(:primary_activity_family).reorder("primary_activities.#{sort_column} #{sort_direction}"),
-      limit: @per_page,
-      page: permitted_page)
-  end
-
-  def show
-    redirect_to edit_admin_primary_activity_url(@primary_activity)
-  end
-
-  def edit
-    @primary_activity_flavors = @primary_activity.primary_activity_flavors.by_priority.not_top_level
-  end
-
-  def update
-    if @primary_activity.update(permitted_parameters)
-      flash[:success] = "Saved!"
-      redirect_to admin_primary_activities_url
-    else
-      render action: :edit
-    end
-  end
-
-  helper_method :matching_primary_activities, :searchable_scopes
-
-  protected
-
-  def sortable_columns
-    %w[priority created_at name family primary_activity_family_id]
-  end
-
-  def searchable_scopes
-    %w[family flavor top_level]
-  end
-
-  def matching_primary_activities
-    primary_activities = PrimaryActivity
-    if params[:search_scope].present? && searchable_scopes.include?(params[:search_scope])
-      @scope = params[:search_scope]
-      primary_activities = primary_activities.send(@scope)
+    def index
+      @per_page = permitted_per_page(default: 60)
+      @search_show_count = Binxtils::InputNormalizer.boolean(params[:search_show_count])
+      @pagy, @collection = pagy(:countish,
+        matching_primary_activities.includes(:primary_activity_family).reorder("primary_activities.#{sort_column} #{sort_direction}"),
+        limit: @per_page,
+        page: permitted_page)
     end
 
-    primary_activities
-  end
+    def show
+      redirect_to edit_admin_primary_activity_url(@primary_activity)
+    end
 
-  def find_primary_activity
-    @primary_activity = PrimaryActivity.friendly_find(params[:id])
-  end
+    def edit
+      @primary_activity_flavors = @primary_activity.primary_activity_flavors.by_priority.not_top_level
+    end
 
-  def permitted_parameters
-    params.require(:primary_activity).permit(:priority)
+    def update
+      if @primary_activity.update(permitted_parameters)
+        flash[:success] = "Saved!"
+        redirect_to admin_primary_activities_url
+      else
+        render action: :edit
+      end
+    end
+
+    helper_method :matching_primary_activities, :searchable_scopes
+
+    protected
+
+    def sortable_columns
+      %w[priority created_at name family primary_activity_family_id]
+    end
+
+    def searchable_scopes
+      %w[family flavor top_level]
+    end
+
+    def matching_primary_activities
+      primary_activities = PrimaryActivity
+      if params[:search_scope].present? && searchable_scopes.include?(params[:search_scope])
+        @scope = params[:search_scope]
+        primary_activities = primary_activities.send(@scope)
+      end
+
+      primary_activities
+    end
+
+    def find_primary_activity
+      @primary_activity = PrimaryActivity.friendly_find(params[:id])
+    end
+
+    def permitted_parameters
+      params.require(:primary_activity).permit(:priority)
+    end
   end
 end

--- a/app/controllers/admin/recoveries_controller.rb
+++ b/app/controllers/admin/recoveries_controller.rb
@@ -1,91 +1,93 @@
-class Admin::RecoveriesController < Admin::BaseController
-  include Binxtils::SortableTable
+module Admin
+  class RecoveriesController < Admin::BaseController
+    include Binxtils::SortableTable
 
-  helper_method :available_recoveries
+    helper_method :available_recoveries
 
-  def index
-    @per_page = permitted_per_page(default: 50)
-    @pagy, @recoveries = pagy(:countish, available_recoveries.reorder("stolen_records.#{sort_column} #{sort_direction}")
-      .includes(:bike), limit: @per_page, page: permitted_page)
-  end
-
-  def show
-    redirect_to edit_admin_recovery_url
-  end
-
-  def edit
-    @recovery ||= StolenRecord.unscoped.find(params[:id])
-    @bike = Bike.unscoped.find_by_id(@recovery.bike_id)
-  end
-
-  def update
-    @stolen_record = StolenRecord.unscoped.find(params[:id])
-    @stolen_record.bike = Bike.unscoped.find_by_id(@stolen_record.bike_id)
-    if params[:stolen_record][:mark_as_eligible].present?
-      @stolen_record.recovery_display_status = "waiting_on_decision"
-      redirect = new_admin_recovery_display_path(@stolen_record)
-    elsif params[:stolen_record][:is_not_displayable].present?
-      @stolen_record.recovery_display_status = "not_displayed"
+    def index
+      @per_page = permitted_per_page(default: 50)
+      @pagy, @recoveries = pagy(:countish, available_recoveries.reorder("stolen_records.#{sort_column} #{sort_direction}")
+        .includes(:bike), limit: @per_page, page: permitted_page)
     end
 
-    if @stolen_record.update(permitted_parameters)
-      flash[:success] = "Recovery Saved!"
-      redirect_to redirect || admin_recoveries_url
-    else
-      @recovery = @stolen_record
-      render action: :edit
-    end
-  end
-
-  private
-
-  def sortable_columns
-    %w[recovered_at date_stolen created_at recovery_display_status]
-  end
-
-  def available_recoveries
-    recoveries = StolenRecord.recovered
-
-    if params[:search_recovery_display_status] == "all"
-      @recovery_display_status = "all"
-    else
-      # Default to waiting_on_decision
-      @recovery_display_status = params[:search_recovery_display_status]
-      @recovery_display_status = "waiting_on_decision" unless StolenRecord.recovery_display_statuses.include?(@recovery_display_status)
-      recoveries = recoveries.where(recovery_display_status: @recovery_display_status)
+    def show
+      redirect_to edit_admin_recovery_url
     end
 
-    if Binxtils::InputNormalizer.boolean(params[:search_shareable])
-      @shareable = true
-      recoveries = recoveries.can_share_recovery
+    def edit
+      @recovery ||= StolenRecord.unscoped.find(params[:id])
+      @bike = Bike.unscoped.find_by_id(@recovery.bike_id)
     end
 
-    if Binxtils::InputNormalizer.boolean(params[:search_index_helped_recovery])
-      @index_helped_recovery = true
-      recoveries = recoveries.where(index_helped_recovery: true)
-    end
+    def update
+      @stolen_record = StolenRecord.unscoped.find(params[:id])
+      @stolen_record.bike = Bike.unscoped.find_by_id(@stolen_record.bike_id)
+      if params[:stolen_record][:mark_as_eligible].present?
+        @stolen_record.recovery_display_status = "waiting_on_decision"
+        redirect = new_admin_recovery_display_path(@stolen_record)
+      elsif params[:stolen_record][:is_not_displayable].present?
+        @stolen_record.recovery_display_status = "not_displayed"
+      end
 
-    # We always render distance
-    @distance = GeocodeHelper.permitted_distance(params[:search_distance], default_distance: 50)
-    if params[:search_location].present?
-      bounding_box = GeocodeHelper.bounding_box(params[:search_location], @distance)
-      recoveries = recoveries.within_bounding_box(bounding_box)
-    end
-
-    if params[:search_displayed].present?
-      recoveries = if params[:search_displayed] == "displayed"
-        recoveries.with_recovery_display
+      if @stolen_record.update(permitted_parameters)
+        flash[:success] = "Recovery Saved!"
+        redirect_to redirect || admin_recoveries_url
       else
-        recoveries.without_recovery_display
+        @recovery = @stolen_record
+        render action: :edit
       end
     end
 
-    @time_range_column = sort_column if %w[date_stolen created_at].include?(sort_column)
-    @time_range_column ||= "recovered_at"
-    recoveries.where(@time_range_column => @time_range)
-  end
+    private
 
-  def permitted_parameters
-    params.require(:stolen_record).permit(BikeServices::StolenRecordUpdator.old_attr_accessible)
+    def sortable_columns
+      %w[recovered_at date_stolen created_at recovery_display_status]
+    end
+
+    def available_recoveries
+      recoveries = StolenRecord.recovered
+
+      if params[:search_recovery_display_status] == "all"
+        @recovery_display_status = "all"
+      else
+        # Default to waiting_on_decision
+        @recovery_display_status = params[:search_recovery_display_status]
+        @recovery_display_status = "waiting_on_decision" unless StolenRecord.recovery_display_statuses.include?(@recovery_display_status)
+        recoveries = recoveries.where(recovery_display_status: @recovery_display_status)
+      end
+
+      if Binxtils::InputNormalizer.boolean(params[:search_shareable])
+        @shareable = true
+        recoveries = recoveries.can_share_recovery
+      end
+
+      if Binxtils::InputNormalizer.boolean(params[:search_index_helped_recovery])
+        @index_helped_recovery = true
+        recoveries = recoveries.where(index_helped_recovery: true)
+      end
+
+      # We always render distance
+      @distance = GeocodeHelper.permitted_distance(params[:search_distance], default_distance: 50)
+      if params[:search_location].present?
+        bounding_box = GeocodeHelper.bounding_box(params[:search_location], @distance)
+        recoveries = recoveries.within_bounding_box(bounding_box)
+      end
+
+      if params[:search_displayed].present?
+        recoveries = if params[:search_displayed] == "displayed"
+          recoveries.with_recovery_display
+        else
+          recoveries.without_recovery_display
+        end
+      end
+
+      @time_range_column = sort_column if %w[date_stolen created_at].include?(sort_column)
+      @time_range_column ||= "recovered_at"
+      recoveries.where(@time_range_column => @time_range)
+    end
+
+    def permitted_parameters
+      params.require(:stolen_record).permit(BikeServices::StolenRecordUpdator.old_attr_accessible)
+    end
   end
 end

--- a/app/controllers/admin/recovery_displays_controller.rb
+++ b/app/controllers/admin/recovery_displays_controller.rb
@@ -1,92 +1,94 @@
-class Admin::RecoveryDisplaysController < Admin::BaseController
-  include Binxtils::SortableTable
+module Admin
+  class RecoveryDisplaysController < Admin::BaseController
+    include Binxtils::SortableTable
 
-  before_action :find_recovery_displays, only: [:edit, :update, :destroy]
+    before_action :find_recovery_displays, only: [:edit, :update, :destroy]
 
-  helper_method :matching_recovery_displays
+    helper_method :matching_recovery_displays
 
-  def index
-    @per_page = permitted_per_page(default: 50)
-    @pagy, @recovery_displays = pagy(:countish, matching_recovery_displays
-      .order(@time_range_column => sort_direction), limit: @per_page, page: permitted_page)
-  end
+    def index
+      @per_page = permitted_per_page(default: 50)
+      @pagy, @recovery_displays = pagy(:countish, matching_recovery_displays
+        .order(@time_range_column => sort_direction), limit: @per_page, page: permitted_page)
+    end
 
-  def new
-    @recovery_display = RecoveryDisplay.new
-    if params[:stolen_record_id].present?
-      @recovery_display = RecoveryDisplay.from_stolen_record_id(params[:stolen_record_id])
+    def new
+      @recovery_display = RecoveryDisplay.new
+      if params[:stolen_record_id].present?
+        @recovery_display = RecoveryDisplay.from_stolen_record_id(params[:stolen_record_id])
+        @stolen_record = @recovery_display.stolen_record
+        @bike = @recovery_display.bike
+      end
+    end
+
+    def show
+      if params[:id] == "bust_cache"
+        flash[:success] = "Recovery Display Cache busted"
+        redirect_to admin_recovery_displays_path
+      else
+        redirect_to edit_admin_recovery_display_url
+      end
+    end
+
+    def edit
       @stolen_record = @recovery_display.stolen_record
       @bike = @recovery_display.bike
     end
-  end
 
-  def show
-    if params[:id] == "bust_cache"
-      flash[:success] = "Recovery Display Cache busted"
+    def update
+      if @recovery_display.update(permitted_parameters)
+        flash[:success] = "Recovery display saved!"
+        redirect_to admin_recovery_displays_path
+      else
+        render action: :edit
+      end
+    end
+
+    def create
+      @recovery_display = RecoveryDisplay.create(permitted_parameters)
+      if @recovery_display.save
+        flash[:success] = "Recovery display created!"
+        redirect_to admin_recoveries_path
+      else
+        render action: :new
+      end
+    end
+
+    def destroy
+      @recovery_display.destroy
       redirect_to admin_recovery_displays_path
-    else
-      redirect_to edit_admin_recovery_display_url
     end
-  end
 
-  def edit
-    @stolen_record = @recovery_display.stolen_record
-    @bike = @recovery_display.bike
-  end
+    protected
 
-  def update
-    if @recovery_display.update(permitted_parameters)
-      flash[:success] = "Recovery display saved!"
-      redirect_to admin_recovery_displays_path
-    else
-      render action: :edit
+    def sortable_columns
+      %w[recovered_at created_at updated_at]
     end
-  end
 
-  def create
-    @recovery_display = RecoveryDisplay.create(permitted_parameters)
-    if @recovery_display.save
-      flash[:success] = "Recovery display created!"
-      redirect_to admin_recoveries_path
-    else
-      render action: :new
+    def permitted_parameters
+      params.require(:recovery_display)
+        .permit(:stolen_record_id, :quote, :quote_by, :recovered_at, :link,
+          :remote_photo_url, :date_input, :location_string, :photo)
     end
-  end
 
-  def destroy
-    @recovery_display.destroy
-    redirect_to admin_recovery_displays_path
-  end
-
-  protected
-
-  def sortable_columns
-    %w[recovered_at created_at updated_at]
-  end
-
-  def permitted_parameters
-    params.require(:recovery_display)
-      .permit(:stolen_record_id, :quote, :quote_by, :recovered_at, :link,
-        :remote_photo_url, :date_input, :location_string, :photo)
-  end
-
-  def find_recovery_displays
-    @recovery_display = RecoveryDisplay.find(params[:id])
-    raise ActionController::RoutingError.new("Not Found") unless @recovery_display.present?
-  end
-
-  def earliest_period_date
-    Time.at(1412748000)
-  end
-
-  def matching_recovery_displays
-    recovery_displays = RecoveryDisplay.unscoped
-    if params[:search_bike_id].present?
-      @bike = Bike.unscoped.friendly_find(params[:search_bike_id])
-      recovery_displays = recovery_displays.where(stolen_record_id: @bike.recovered_records.pluck(:id)) if @bike.present?
+    def find_recovery_displays
+      @recovery_display = RecoveryDisplay.find(params[:id])
+      raise ActionController::RoutingError.new("Not Found") unless @recovery_display.present?
     end
-    @time_range_column = sort_column if %w[created_at updated_at].include?(sort_column)
-    @time_range_column ||= "recovered_at"
-    recovery_displays.where(@time_range_column => @time_range)
+
+    def earliest_period_date
+      Time.at(1412748000)
+    end
+
+    def matching_recovery_displays
+      recovery_displays = RecoveryDisplay.unscoped
+      if params[:search_bike_id].present?
+        @bike = Bike.unscoped.friendly_find(params[:search_bike_id])
+        recovery_displays = recovery_displays.where(stolen_record_id: @bike.recovered_records.pluck(:id)) if @bike.present?
+      end
+      @time_range_column = sort_column if %w[created_at updated_at].include?(sort_column)
+      @time_range_column ||= "recovered_at"
+      recovery_displays.where(@time_range_column => @time_range)
+    end
   end
 end

--- a/app/controllers/admin/sales_controller.rb
+++ b/app/controllers/admin/sales_controller.rb
@@ -1,57 +1,59 @@
-class Admin::SalesController < Admin::BaseController
-  include Binxtils::SortableTable
+module Admin
+  class SalesController < Admin::BaseController
+    include Binxtils::SortableTable
 
-  def index
-    @per_page = permitted_per_page(default: 50)
-    @pagy, @collection = pagy(:countish,
-      matching_sales.includes(:seller, :ownership).reorder(sortable_opts),
-      limit: @per_page,
-      page: permitted_page)
-  end
-
-  def show
-    @sale = Sale.find(params[:id])
-    @marketplace_listing = @sale.marketplace_listing
-  end
-
-  helper_method :matching_sales
-
-  protected
-
-  def sortable_columns
-    %w[created_at sold_at amount_cents sold_via seller_id ownership_id]
-  end
-
-  def sortable_opts
-    "sales.#{sort_column} #{sort_direction}"
-  end
-
-  def earliest_period_date
-    Time.at(1746075600) # 2025-05-01 00:00 - first listing created this month
-  end
-
-  def matching_sales
-    sales = Sale.all
-
-    if params[:search_bike_id].present?
-      @bike = Bike.unscoped.find_by(id: params[:search_bike_id])
-      sales = sales.joins(:ownership).where(ownerships: {bike_id: params[:search_bike_id]})
+    def index
+      @per_page = permitted_per_page(default: 50)
+      @pagy, @collection = pagy(:countish,
+        matching_sales.includes(:seller, :ownership).reorder(sortable_opts),
+        limit: @per_page,
+        page: permitted_page)
     end
 
-    if params[:search_marketplace_listing_id].present?
-      @marketplace_listing = MarketplaceListing.find_by(id: params[:search_marketplace_listing_id])
-      sales = sales.joins(:marketplace_listing)
-        .where(marketplace_listings: {id: params[:search_marketplace_listing_id]})
+    def show
+      @sale = Sale.find(params[:id])
+      @marketplace_listing = @sale.marketplace_listing
     end
 
-    if params[:user_id].present?
-      sales = sales.where(seller_id: user_subject&.id || params[:user_id])
+    helper_method :matching_sales
+
+    protected
+
+    def sortable_columns
+      %w[created_at sold_at amount_cents sold_via seller_id ownership_id]
     end
 
-    if params[:search_sold_via].present?
-      sales = sales.where(sold_via: params[:search_sold_via])
+    def sortable_opts
+      "sales.#{sort_column} #{sort_direction}"
     end
 
-    sales.where(created_at: @time_range)
+    def earliest_period_date
+      Time.at(1746075600) # 2025-05-01 00:00 - first listing created this month
+    end
+
+    def matching_sales
+      sales = Sale.all
+
+      if params[:search_bike_id].present?
+        @bike = Bike.unscoped.find_by(id: params[:search_bike_id])
+        sales = sales.joins(:ownership).where(ownerships: {bike_id: params[:search_bike_id]})
+      end
+
+      if params[:search_marketplace_listing_id].present?
+        @marketplace_listing = MarketplaceListing.find_by(id: params[:search_marketplace_listing_id])
+        sales = sales.joins(:marketplace_listing)
+          .where(marketplace_listings: {id: params[:search_marketplace_listing_id]})
+      end
+
+      if params[:user_id].present?
+        sales = sales.where(seller_id: user_subject&.id || params[:user_id])
+      end
+
+      if params[:search_sold_via].present?
+        sales = sales.where(sold_via: params[:search_sold_via])
+      end
+
+      sales.where(created_at: @time_range)
+    end
   end
 end

--- a/app/controllers/admin/social_accounts_controller.rb
+++ b/app/controllers/admin/social_accounts_controller.rb
@@ -1,86 +1,88 @@
-class Admin::SocialAccountsController < Admin::BaseController
-  include Binxtils::SortableTable
+module Admin
+  class SocialAccountsController < Admin::BaseController
+    include Binxtils::SortableTable
 
-  before_action :find_social_account, only: %i[show edit update destroy check_credentials]
+    before_action :find_social_account, only: %i[show edit update destroy check_credentials]
 
-  def index
-    @social_accounts = matching_social_accounts
-      .reorder(sort_column + " " + sort_direction)
-  end
+    def index
+      @social_accounts = matching_social_accounts
+        .reorder(sort_column + " " + sort_direction)
+    end
 
-  def show
-  end
+    def show
+    end
 
-  def edit
-  end
+    def edit
+    end
 
-  def update
-    if @social_account.update(permitted_parameters)
-      if Binxtils::InputNormalizer.boolean(params[:check_credentials])
-        @social_account.reload
-        @social_account.check_credentials
+    def update
+      if @social_account.update(permitted_parameters)
+        if Binxtils::InputNormalizer.boolean(params[:check_credentials])
+          @social_account.reload
+          @social_account.check_credentials
+        end
+        flash[:notice] = "Social account saved!"
+        redirect_to admin_social_account_url(@social_account)
+      else
+        render action: :edit
       end
-      flash[:notice] = "Social account saved!"
+    end
+
+    def destroy
+      if @social_account.present? && @social_account.destroy
+        flash[:info] = "Social account deleted."
+        redirect_to admin_social_accounts_url
+      else
+        flash[:error] = "Could not delete social account."
+        redirect_to edit_admin_social_account_url(@social_account)
+      end
+    end
+
+    def check_credentials
+      @social_account.check_credentials
       redirect_to admin_social_account_url(@social_account)
-    else
-      render action: :edit
     end
-  end
 
-  def destroy
-    if @social_account.present? && @social_account.destroy
-      flash[:info] = "Social account deleted."
-      redirect_to admin_social_accounts_url
-    else
-      flash[:error] = "Could not delete social account."
-      redirect_to edit_admin_social_account_url(@social_account)
+    private
+
+    def sortable_columns
+      %w[screen_name created_at email language country city last_error_at national]
     end
-  end
 
-  def check_credentials
-    @social_account.check_credentials
-    redirect_to admin_social_account_url(@social_account)
-  end
-
-  private
-
-  def sortable_columns
-    %w[screen_name created_at email language country city last_error_at national]
-  end
-
-  def permitted_parameters
-    params.require(:social_account).permit(
-      :active,
-      :address_string,
-      :append_block,
-      :city,
-      :consumer_key,
-      :consumer_secret,
-      :country,
-      :default,
-      :language,
-      :latitude,
-      :longitude,
-      :national,
-      :neighborhood,
-      :screen_name,
-      :state,
-      :user_secret,
-      :user_token
-    )
-  end
-
-  def matching_social_accounts
-    if sort_column == "last_error_at" # If sorting by last_error_at, show the error
-      (sort_direction == "desc") ? SocialAccount.errored : SocialAccount.where(last_error_at: nil)
-    elsif sort_column == "national" # If national, show only national one direction, only non the other
-      SocialAccount.where(national: sort_direction == "asc")
-    else
-      SocialAccount
+    def permitted_parameters
+      params.require(:social_account).permit(
+        :active,
+        :address_string,
+        :append_block,
+        :city,
+        :consumer_key,
+        :consumer_secret,
+        :country,
+        :default,
+        :language,
+        :latitude,
+        :longitude,
+        :national,
+        :neighborhood,
+        :screen_name,
+        :state,
+        :user_secret,
+        :user_token
+      )
     end
-  end
 
-  def find_social_account
-    @social_account = SocialAccount.find(params[:id])
+    def matching_social_accounts
+      if sort_column == "last_error_at" # If sorting by last_error_at, show the error
+        (sort_direction == "desc") ? SocialAccount.errored : SocialAccount.where(last_error_at: nil)
+      elsif sort_column == "national" # If national, show only national one direction, only non the other
+        SocialAccount.where(national: sort_direction == "asc")
+      else
+        SocialAccount
+      end
+    end
+
+    def find_social_account
+      @social_account = SocialAccount.find(params[:id])
+    end
   end
 end

--- a/app/controllers/admin/social_posts_controller.rb
+++ b/app/controllers/admin/social_posts_controller.rb
@@ -1,124 +1,126 @@
-class Admin::SocialPostsController < Admin::BaseController
-  include Binxtils::SortableTable
+module Admin
+  class SocialPostsController < Admin::BaseController
+    include Binxtils::SortableTable
 
-  before_action :find_social_post, except: [:new, :create, :index]
+    before_action :find_social_post, except: [:new, :create, :index]
 
-  def index
-    @per_page = permitted_per_page(default: 50)
-    @pagy, @social_posts = pagy(:countish, matching_social_posts
-      .includes(:social_account, :public_images, :stolen_record, :reposts, :original_post)
-      .reorder(sort_column + " " + sort_direction), limit: @per_page, page: permitted_page)
-  end
-
-  def show
-    if @social_post.imported_post?
-      redirect_to edit_admin_social_post_path(params[:id])
-      nil
+    def index
+      @per_page = permitted_per_page(default: 50)
+      @pagy, @social_posts = pagy(:countish, matching_social_posts
+        .includes(:social_account, :public_images, :stolen_record, :reposts, :original_post)
+        .reorder(sort_column + " " + sort_direction), limit: @per_page, page: permitted_page)
     end
-  end
 
-  def edit
-    unless @social_post.imported_post?
-      redirect_to admin_social_post_path(params[:id])
-      nil
-    end
-  end
-
-  def update
-    if @social_post.update(permitted_parameters)
-      flash[:notice] = "Post saved!"
-      redirect_to edit_admin_social_post_url
-    else
-      render action: :edit
-    end
-  end
-
-  def new
-    @social_post ||= SocialPost.new(kind: "app_post")
-  end
-
-  def create
-    @social_post = SocialPost.new(permitted_parameters)
-    if @social_post.kind == "imported_post"
-      @social_post.social_account_id = nil
-      @social_post.body = nil # Blank the attributes that may have been accidentally passed
-      @social_post.platform_response = fetch_platform_response(@social_post.platform_id)
-      @social_post.save
-    elsif @social_post.kind == "app_post"
-      @social_post.platform_id = nil
-      @social_post.save
-      if @social_post.id.present?
-        @social_post.send_post
-        repost_accounts.each { |social_account| @social_post.repost_to_account(social_account) }
+    def show
+      if @social_post.imported_post?
+        redirect_to edit_admin_social_post_path(params[:id])
+        nil
       end
-    else
-      raise StandardError, "Don't know how to create post with kind: '#{@social_post.kind}'"
     end
-    if @social_post.id.present?
-      redirect_to edit_admin_social_post_url(id: @social_post.id)
-    else
-      flash[:error] ||= "Unable to create post"
-      render action: :new
+
+    def edit
+      unless @social_post.imported_post?
+        redirect_to admin_social_post_path(params[:id])
+        nil
+      end
     end
-  end
 
-  def destroy
-    if @social_post.present? && @social_post.destroy
-      flash[:info] = "Post deleted."
-      redirect_to admin_social_posts_url
-    else
-      flash[:error] = "Could not delete post."
-      redirect_to edit_admin_social_post_url(@social_post.id)
+    def update
+      if @social_post.update(permitted_parameters)
+        flash[:notice] = "Post saved!"
+        redirect_to edit_admin_social_post_url
+      else
+        render action: :edit
+      end
     end
-  end
 
-  helper_method :matching_social_posts, :permitted_search_kinds
-
-  private
-
-  def earliest_period_date
-    Time.at(1498672508) # First post
-  end
-
-  def sortable_columns
-    %w[created_at social_account_id kind]
-  end
-
-  def permitted_search_kinds
-    %w[all not_stolen] + SocialPost.kinds
-  end
-
-  def matching_social_posts
-    social_posts = SocialPost
-    social_posts = social_posts.not_repost unless Binxtils::InputNormalizer.boolean(params[:search_repost])
-    @search_kind = permitted_search_kinds.include?(params[:search_kind]) ? params[:search_kind] : "all"
-    social_posts = social_posts.public_send(@search_kind) unless @search_kind == "all"
-
-    if params[:search_social_account_id].present?
-      @social_account = SocialAccount.friendly_find(params[:search_social_account_id])
-      social_posts = social_posts.where(social_account_id: @social_account.id) if @social_account.present?
+    def new
+      @social_post ||= SocialPost.new(kind: "app_post")
     end
-    social_posts = social_posts.admin_search(params[:query]) if params[:query].present?
-    social_posts.where(created_at: @time_range)
-  end
 
-  def permitted_parameters
-    params.require(:social_post).permit(:platform_id, :body_html, :image, :alignment, :body, :social_account_id,
-      :remote_image_url, :remove_image, :kind)
-  end
+    def create
+      @social_post = SocialPost.new(permitted_parameters)
+      if @social_post.kind == "imported_post"
+        @social_post.social_account_id = nil
+        @social_post.body = nil # Blank the attributes that may have been accidentally passed
+        @social_post.platform_response = fetch_platform_response(@social_post.platform_id)
+        @social_post.save
+      elsif @social_post.kind == "app_post"
+        @social_post.platform_id = nil
+        @social_post.save
+        if @social_post.id.present?
+          @social_post.send_post
+          repost_accounts.each { |social_account| @social_post.repost_to_account(social_account) }
+        end
+      else
+        raise StandardError, "Don't know how to create post with kind: '#{@social_post.kind}'"
+      end
+      if @social_post.id.present?
+        redirect_to edit_admin_social_post_url(id: @social_post.id)
+      else
+        flash[:error] ||= "Unable to create post"
+        render action: :new
+      end
+    end
 
-  def find_social_post
-    @social_post ||= SocialPost.friendly_find(params[:id])
-    return @social_post if @social_post.present?
+    def destroy
+      if @social_post.present? && @social_post.destroy
+        flash[:info] = "Post deleted."
+        redirect_to admin_social_posts_url
+      else
+        flash[:error] = "Could not delete post."
+        redirect_to edit_admin_social_post_url(@social_post.id)
+      end
+    end
 
-    raise ActiveRecord::RecordNotFound
-  end
+    helper_method :matching_social_posts, :permitted_search_kinds
 
-  def fetch_platform_response(post_id)
-    SocialAccount.default_account.get_post(post_id).as_json
-  end
+    private
 
-  def repost_accounts
-    (params[:social_account_ids] || []).map { |id| SocialAccount.friendly_find(id) }
+    def earliest_period_date
+      Time.at(1498672508) # First post
+    end
+
+    def sortable_columns
+      %w[created_at social_account_id kind]
+    end
+
+    def permitted_search_kinds
+      %w[all not_stolen] + SocialPost.kinds
+    end
+
+    def matching_social_posts
+      social_posts = SocialPost
+      social_posts = social_posts.not_repost unless Binxtils::InputNormalizer.boolean(params[:search_repost])
+      @search_kind = permitted_search_kinds.include?(params[:search_kind]) ? params[:search_kind] : "all"
+      social_posts = social_posts.public_send(@search_kind) unless @search_kind == "all"
+
+      if params[:search_social_account_id].present?
+        @social_account = SocialAccount.friendly_find(params[:search_social_account_id])
+        social_posts = social_posts.where(social_account_id: @social_account.id) if @social_account.present?
+      end
+      social_posts = social_posts.admin_search(params[:query]) if params[:query].present?
+      social_posts.where(created_at: @time_range)
+    end
+
+    def permitted_parameters
+      params.require(:social_post).permit(:platform_id, :body_html, :image, :alignment, :body, :social_account_id,
+        :remote_image_url, :remove_image, :kind)
+    end
+
+    def find_social_post
+      @social_post ||= SocialPost.friendly_find(params[:id])
+      return @social_post if @social_post.present?
+
+      raise ActiveRecord::RecordNotFound
+    end
+
+    def fetch_platform_response(post_id)
+      SocialAccount.default_account.get_post(post_id).as_json
+    end
+
+    def repost_accounts
+      (params[:social_account_ids] || []).map { |id| SocialAccount.friendly_find(id) }
+    end
   end
 end

--- a/app/controllers/admin/stolen_bikes_controller.rb
+++ b/app/controllers/admin/stolen_bikes_controller.rb
@@ -1,134 +1,136 @@
-class Admin::StolenBikesController < Admin::BaseController
-  include Binxtils::SortableTable
+module Admin
+  class StolenBikesController < Admin::BaseController
+    include Binxtils::SortableTable
 
-  before_action :find_bike, only: %i[edit update]
-  helper_method :available_stolen_records
+    before_action :find_bike, only: %i[edit update]
+    helper_method :available_stolen_records
 
-  def index
-    @per_page = permitted_per_page(default: 50)
-    @pagy, @stolen_records = pagy(:countish, available_stolen_records.includes(:bike)
-      .reorder("stolen_records.#{sort_column} #{sort_direction}"), limit: @per_page, page: permitted_page)
-  end
+    def index
+      @per_page = permitted_per_page(default: 50)
+      @pagy, @stolen_records = pagy(:countish, available_stolen_records.includes(:bike)
+        .reorder("stolen_records.#{sort_column} #{sort_direction}"), limit: @per_page, page: permitted_page)
+    end
 
-  def approve
-    if params[:id] == "multi_approve"
-      stolen_record_ids = defined?(params[:sr_selected].keys) ? params[:sr_selected].keys : params[:sr_selected]
-      if stolen_record_ids.any?
-        stolen_record_ids.each do |id|
-          stolen_record = StolenRecord.unscoped.find(id)
-          stolen_record.update_attribute :approved, true
-          StolenBike::ApproveStolenListingJob.perform_async(stolen_record.bike_id)
+    def approve
+      if params[:id] == "multi_approve"
+        stolen_record_ids = defined?(params[:sr_selected].keys) ? params[:sr_selected].keys : params[:sr_selected]
+        if stolen_record_ids.any?
+          stolen_record_ids.each do |id|
+            stolen_record = StolenRecord.unscoped.find(id)
+            stolen_record.update_attribute :approved, true
+            StolenBike::ApproveStolenListingJob.perform_async(stolen_record.bike_id)
+          end
+          # Lazy pluralize hack
+          flash[:success] = "#{stolen_record_ids.count} stolen #{(stolen_record_ids.count == 1) ? "bike" : "bikes"} approved!"
+        else
+          flash[:error] = "No stolen records selected to approve!"
         end
-        # Lazy pluralize hack
-        flash[:success] = "#{stolen_record_ids.count} stolen #{(stolen_record_ids.count == 1) ? "bike" : "bikes"} approved!"
+        redirect_back(fallback_location: admin_stolen_bikes_url)
       else
-        flash[:error] = "No stolen records selected to approve!"
+        find_bike
+        @bike.current_stolen_record.update_attribute :approved, true
+        StolenBike::ApproveStolenListingJob.perform_async(@bike.id)
+        flash[:success] = "Stolen Bike was approved"
+        redirect_to edit_admin_stolen_bike_url(@bike)
       end
-      redirect_back(fallback_location: admin_stolen_bikes_url)
-    else
-      find_bike
-      @bike.current_stolen_record.update_attribute :approved, true
-      StolenBike::ApproveStolenListingJob.perform_async(@bike.id)
-      flash[:success] = "Stolen Bike was approved"
-      redirect_to edit_admin_stolen_bike_url(@bike)
-    end
-  end
-
-  def show
-    redirect_to edit_admin_stolen_bike_url(id: params[:id], stolen_record_id: params[:stolen_record_id])
-  end
-
-  def edit
-    @customer_contact = CustomerContact.new(user_email: @bike.owner_email)
-  end
-
-  def update
-    if %w[regenerate_alert_image delete].include?(params[:update_action])
-      update_image
-    else
-      flash[:error] = "Unknown update action! Please let Seth know where you encountered this!"
-    end
-    redirect_back(fallback_location: edit_admin_stolen_bike_url(@bike))
-  end
-
-  protected
-
-  def sortable_columns
-    %w[created_at date_stolen]
-  end
-
-  def permitted_parameters
-    params.require(:bike).permit(BikeServices::Creator.old_attr_accessible)
-  end
-
-  def find_bike
-    if Binxtils::InputNormalizer.boolean(params[:stolen_record_id])
-      @stolen_record = StolenRecord.unscoped.find(params[:id])
-      @bike = Bike.unscoped.find_by_id(@stolen_record.bike_id)
-    else
-      @bike = Bike.unscoped.find_by_id(params[:id])
-      @stolen_record = @bike.current_stolen_record
-    end
-    @current_stolen_record = @stolen_record.present? && @stolen_record.id == @bike.current_stolen_record&.id
-    @bike
-  end
-
-  def update_image
-    selected_image = @bike.public_images.find_by_id(params[:public_image_id])
-
-    if params[:public_image_id].present? && selected_image.blank?
-      flash[:error] = "Unable to find that image!"
-      return
-    elsif params[:update_action] == "delete"
-      selected_image.skip_update = true # Prevent autorunning of job
-      selected_image.destroy
-      flash[:success] = "Image deleted"
-      selected_image = nil
-    elsif params[:update_action] != "regenerate_alert_image"
-      flash[:error] = "Unknown action!"
-      return
     end
 
-    # Running this inline causes the server to break. So background it
-    StolenBike::AfterStolenRecordSaveJob.perform_async(@bike.current_stolen_record_id, true,
-      selected_image&.id)
-    # Lazy hack to wait for it to process
-    sleep 1
-    flash[:success] ||= "Promoted alert bike image updated."
-  end
+    def show
+      redirect_to edit_admin_stolen_bike_url(id: params[:id], stolen_record_id: params[:stolen_record_id])
+    end
 
-  def available_stolen_records
-    return @available_stolen_records if defined?(@available_stolen_records)
+    def edit
+      @customer_contact = CustomerContact.new(user_email: @bike.owner_email)
+    end
 
-    @unapproved_only = !Binxtils::InputNormalizer.boolean(params[:search_unapproved])
-    @only_without_location = Binxtils::InputNormalizer.boolean(params[:search_without_location])
-    if @unapproved_only
-      available_stolen_records = StolenRecord.current.unapproved
-      unless @only_without_location
-        @unapproved_without_location_count = available_stolen_records.without_location.count
-        available_stolen_records = available_stolen_records.with_location
+    def update
+      if %w[regenerate_alert_image delete].include?(params[:update_action])
+        update_image
+      else
+        flash[:error] = "Unknown update action! Please let Seth know where you encountered this!"
       end
-    else
-      available_stolen_records = StolenRecord
-    end
-    unless Binxtils::InputNormalizer.boolean(params[:search_include_spam])
-      available_stolen_records = available_stolen_records.not_spam
+      redirect_back(fallback_location: edit_admin_stolen_bike_url(@bike))
     end
 
-    @with_promoted_alert = Binxtils::InputNormalizer.boolean(params[:search_with_promoted_alert])
-    if @with_promoted_alert
-      available_stolen_records = available_stolen_records.with_theft_alerts_paid_or_admin
+    protected
+
+    def sortable_columns
+      %w[created_at date_stolen]
     end
 
-    # We always render distance
-    @distance = GeocodeHelper.permitted_distance(params[:search_distance], default_distance: 50)
-    if !@only_without_location && params[:search_location].present?
-      bounding_box = GeocodeHelper.bounding_box(params[:search_location], @distance)
-      available_stolen_records = available_stolen_records.within_bounding_box(bounding_box)
+    def permitted_parameters
+      params.require(:bike).permit(BikeServices::Creator.old_attr_accessible)
     end
 
-    @time_range_column = sort_column if %w[date_stolen].include?(sort_column)
-    @time_range_column ||= "created_at"
-    @available_stolen_records = available_stolen_records.where(@time_range_column => @time_range)
+    def find_bike
+      if Binxtils::InputNormalizer.boolean(params[:stolen_record_id])
+        @stolen_record = StolenRecord.unscoped.find(params[:id])
+        @bike = Bike.unscoped.find_by_id(@stolen_record.bike_id)
+      else
+        @bike = Bike.unscoped.find_by_id(params[:id])
+        @stolen_record = @bike.current_stolen_record
+      end
+      @current_stolen_record = @stolen_record.present? && @stolen_record.id == @bike.current_stolen_record&.id
+      @bike
+    end
+
+    def update_image
+      selected_image = @bike.public_images.find_by_id(params[:public_image_id])
+
+      if params[:public_image_id].present? && selected_image.blank?
+        flash[:error] = "Unable to find that image!"
+        return
+      elsif params[:update_action] == "delete"
+        selected_image.skip_update = true # Prevent autorunning of job
+        selected_image.destroy
+        flash[:success] = "Image deleted"
+        selected_image = nil
+      elsif params[:update_action] != "regenerate_alert_image"
+        flash[:error] = "Unknown action!"
+        return
+      end
+
+      # Running this inline causes the server to break. So background it
+      StolenBike::AfterStolenRecordSaveJob.perform_async(@bike.current_stolen_record_id, true,
+        selected_image&.id)
+      # Lazy hack to wait for it to process
+      sleep 1
+      flash[:success] ||= "Promoted alert bike image updated."
+    end
+
+    def available_stolen_records
+      return @available_stolen_records if defined?(@available_stolen_records)
+
+      @unapproved_only = !Binxtils::InputNormalizer.boolean(params[:search_unapproved])
+      @only_without_location = Binxtils::InputNormalizer.boolean(params[:search_without_location])
+      if @unapproved_only
+        available_stolen_records = StolenRecord.current.unapproved
+        unless @only_without_location
+          @unapproved_without_location_count = available_stolen_records.without_location.count
+          available_stolen_records = available_stolen_records.with_location
+        end
+      else
+        available_stolen_records = StolenRecord
+      end
+      unless Binxtils::InputNormalizer.boolean(params[:search_include_spam])
+        available_stolen_records = available_stolen_records.not_spam
+      end
+
+      @with_promoted_alert = Binxtils::InputNormalizer.boolean(params[:search_with_promoted_alert])
+      if @with_promoted_alert
+        available_stolen_records = available_stolen_records.with_theft_alerts_paid_or_admin
+      end
+
+      # We always render distance
+      @distance = GeocodeHelper.permitted_distance(params[:search_distance], default_distance: 50)
+      if !@only_without_location && params[:search_location].present?
+        bounding_box = GeocodeHelper.bounding_box(params[:search_location], @distance)
+        available_stolen_records = available_stolen_records.within_bounding_box(bounding_box)
+      end
+
+      @time_range_column = sort_column if %w[date_stolen].include?(sort_column)
+      @time_range_column ||= "created_at"
+      @available_stolen_records = available_stolen_records.where(@time_range_column => @time_range)
+    end
   end
 end

--- a/app/controllers/admin/stolen_notifications_controller.rb
+++ b/app/controllers/admin/stolen_notifications_controller.rb
@@ -1,51 +1,53 @@
-class Admin::StolenNotificationsController < Admin::BaseController
-  include Binxtils::SortableTable
+module Admin
+  class StolenNotificationsController < Admin::BaseController
+    include Binxtils::SortableTable
 
-  before_action :find_notification, only: [:show, :resend]
+    before_action :find_notification, only: [:show, :resend]
 
-  def index
-    @per_page = permitted_per_page(default: 100)
-    @pagy, @stolen_notifications = pagy(:countish, searched_stolen_notifications
-      .reorder("#{sort_column} #{sort_direction}")
-      .includes(:bike), limit: @per_page, page: permitted_page)
-  end
-
-  def resend
-    if (@stolen_notification.send_dates_parsed.count == 0) || params[:pretty_please]
-      Email::StolenNotificationJob.perform_async(@stolen_notification.id, true)
-      flash[:success] = "Notification resent!"
-      redirect_to admin_stolen_notifications_url
-    else
-      flash[:success] = "Notification has already been resent! If you actually want to resend AGAIN, click the button on this page"
-      redirect_to admin_stolen_notification_url(@stolen_notification)
-    end
-  end
-
-  def show
-    @bike = @stolen_notification.bike
-  end
-
-  def find_notification
-    @stolen_notification = StolenNotification.find(params[:id])
-  end
-
-  helper_method :searched_stolen_notifications
-
-  private
-
-  def sortable_columns
-    %w[created_at updated_at sender_id receiver_id bike_id]
-  end
-
-  def searched_stolen_notifications
-    stolen_notifications = StolenNotification
-
-    @time_range_column = if %w[updated_at].include?(sort_column)
-      sort_column
-    else
-      "created_at"
+    def index
+      @per_page = permitted_per_page(default: 100)
+      @pagy, @stolen_notifications = pagy(:countish, searched_stolen_notifications
+        .reorder("#{sort_column} #{sort_direction}")
+        .includes(:bike), limit: @per_page, page: permitted_page)
     end
 
-    stolen_notifications.where(@time_range_column => @time_range)
+    def resend
+      if (@stolen_notification.send_dates_parsed.count == 0) || params[:pretty_please]
+        Email::StolenNotificationJob.perform_async(@stolen_notification.id, true)
+        flash[:success] = "Notification resent!"
+        redirect_to admin_stolen_notifications_url
+      else
+        flash[:success] = "Notification has already been resent! If you actually want to resend AGAIN, click the button on this page"
+        redirect_to admin_stolen_notification_url(@stolen_notification)
+      end
+    end
+
+    def show
+      @bike = @stolen_notification.bike
+    end
+
+    def find_notification
+      @stolen_notification = StolenNotification.find(params[:id])
+    end
+
+    helper_method :searched_stolen_notifications
+
+    private
+
+    def sortable_columns
+      %w[created_at updated_at sender_id receiver_id bike_id]
+    end
+
+    def searched_stolen_notifications
+      stolen_notifications = StolenNotification
+
+      @time_range_column = if %w[updated_at].include?(sort_column)
+        sort_column
+      else
+        "created_at"
+      end
+
+      stolen_notifications.where(@time_range_column => @time_range)
+    end
   end
 end

--- a/app/controllers/admin/strava_activities_controller.rb
+++ b/app/controllers/admin/strava_activities_controller.rb
@@ -1,61 +1,63 @@
 # frozen_string_literal: true
 
-class Admin::StravaActivitiesController < Admin::BaseController
-  include Binxtils::SortableTable
+module Admin
+  class StravaActivitiesController < Admin::BaseController
+    include Binxtils::SortableTable
 
-  def index
-    @per_page = permitted_per_page(default: 50)
-    @pagy, @collection = pagy(:countish,
-      matching_strava_activities.includes(strava_integration: %i[user strava_gears]).reorder(sortable_opts),
-      limit: @per_page,
-      page: permitted_page)
-  end
-
-  helper_method :matching_strava_activities
-
-  private
-
-  def sortable_columns
-    %w[created_at updated_at start_date activity_type distance_meters strava_integration_id enriched_at]
-  end
-
-  def sortable_opts
-    "strava_activities.#{sort_column} #{sort_direction}"
-  end
-
-  def earliest_period_date
-    return Time.at(1262304000) if sort_column == "start_date" # 2010-01-01
-    Time.at(1738368000) # 2025-02-01
-  end
-
-  def matching_strava_activities
-    strava_activities = StravaActivity.all
-
-    if params[:user_id].present?
-      strava_activities = strava_activities.joins(:strava_integration).where(strava_integrations: {user_id: user_subject&.id || params[:user_id]})
+    def index
+      @per_page = permitted_per_page(default: 50)
+      @pagy, @collection = pagy(:countish,
+        matching_strava_activities.includes(strava_integration: %i[user strava_gears]).reorder(sortable_opts),
+        limit: @per_page,
+        page: permitted_page)
     end
 
-    if params[:search_strava_integration_id].present?
-      strava_activities = strava_activities.where(strava_integration_id: params[:search_strava_integration_id])
+    helper_method :matching_strava_activities
+
+    private
+
+    def sortable_columns
+      %w[created_at updated_at start_date activity_type distance_meters strava_integration_id enriched_at]
     end
 
-    @with_gear = Binxtils::InputNormalizer.boolean(params[:search_with_gear])
-    strava_activities = strava_activities.with_gear if @with_gear
-
-    @searched_activity_type = params[:search_activity_type]
-    if @searched_activity_type.present?
-      strava_activities = strava_activities.where(activity_type: @searched_activity_type)
+    def sortable_opts
+      "strava_activities.#{sort_column} #{sort_direction}"
     end
 
-    @searched_enriched = params[:search_enriched]
-    if @searched_enriched == "true"
-      strava_activities = strava_activities.enriched
-    elsif @searched_enriched == "false"
-      strava_activities = strava_activities.not_enriched
+    def earliest_period_date
+      return Time.at(1262304000) if sort_column == "start_date" # 2010-01-01
+      Time.at(1738368000) # 2025-02-01
     end
 
-    @time_range_column = sort_column if %w[updated_at start_date enriched_at].include?(sort_column)
-    @time_range_column ||= "created_at"
-    strava_activities.where(@time_range_column => @time_range)
+    def matching_strava_activities
+      strava_activities = StravaActivity.all
+
+      if params[:user_id].present?
+        strava_activities = strava_activities.joins(:strava_integration).where(strava_integrations: {user_id: user_subject&.id || params[:user_id]})
+      end
+
+      if params[:search_strava_integration_id].present?
+        strava_activities = strava_activities.where(strava_integration_id: params[:search_strava_integration_id])
+      end
+
+      @with_gear = Binxtils::InputNormalizer.boolean(params[:search_with_gear])
+      strava_activities = strava_activities.with_gear if @with_gear
+
+      @searched_activity_type = params[:search_activity_type]
+      if @searched_activity_type.present?
+        strava_activities = strava_activities.where(activity_type: @searched_activity_type)
+      end
+
+      @searched_enriched = params[:search_enriched]
+      if @searched_enriched == "true"
+        strava_activities = strava_activities.enriched
+      elsif @searched_enriched == "false"
+        strava_activities = strava_activities.not_enriched
+      end
+
+      @time_range_column = sort_column if %w[updated_at start_date enriched_at].include?(sort_column)
+      @time_range_column ||= "created_at"
+      strava_activities.where(@time_range_column => @time_range)
+    end
   end
 end

--- a/app/controllers/admin/strava_gears_controller.rb
+++ b/app/controllers/admin/strava_gears_controller.rb
@@ -1,49 +1,51 @@
 # frozen_string_literal: true
 
-class Admin::StravaGearsController < Admin::BaseController
-  include Binxtils::SortableTable
+module Admin
+  class StravaGearsController < Admin::BaseController
+    include Binxtils::SortableTable
 
-  def index
-    @per_page = permitted_per_page(default: 50)
-    @pagy, @collection = pagy(:countish,
-      matching_strava_gears.includes(strava_integration: :user).reorder(sortable_opts),
-      limit: @per_page,
-      page: permitted_page)
-  end
-
-  helper_method :matching_strava_gears
-
-  private
-
-  def sortable_columns
-    %w[created_at updated_at gear_type strava_integration_id total_distance_kilometers]
-  end
-
-  def sortable_opts
-    "strava_gears.#{sort_column} #{sort_direction}"
-  end
-
-  def earliest_period_date
-    Time.at(1738368000) # 2025-02-01
-  end
-
-  def matching_strava_gears
-    strava_gears = StravaGear.all
-
-    if params[:user_id].present?
-      strava_gears = strava_gears.joins(:strava_integration).where(strava_integrations: {user_id: user_subject&.id || params[:user_id]})
+    def index
+      @per_page = permitted_per_page(default: 50)
+      @pagy, @collection = pagy(:countish,
+        matching_strava_gears.includes(strava_integration: :user).reorder(sortable_opts),
+        limit: @per_page,
+        page: permitted_page)
     end
 
-    if params[:search_strava_integration_id].present?
-      strava_gears = strava_gears.where(strava_integration_id: params[:search_strava_integration_id])
+    helper_method :matching_strava_gears
+
+    private
+
+    def sortable_columns
+      %w[created_at updated_at gear_type strava_integration_id total_distance_kilometers]
     end
 
-    if params[:search_gear_type].present?
-      strava_gears = strava_gears.where(gear_type: params[:search_gear_type])
+    def sortable_opts
+      "strava_gears.#{sort_column} #{sort_direction}"
     end
 
-    @time_range_column = "updated_at" if sort_column == "updated_at"
-    @time_range_column ||= "created_at"
-    strava_gears.where(@time_range_column => @time_range)
+    def earliest_period_date
+      Time.at(1738368000) # 2025-02-01
+    end
+
+    def matching_strava_gears
+      strava_gears = StravaGear.all
+
+      if params[:user_id].present?
+        strava_gears = strava_gears.joins(:strava_integration).where(strava_integrations: {user_id: user_subject&.id || params[:user_id]})
+      end
+
+      if params[:search_strava_integration_id].present?
+        strava_gears = strava_gears.where(strava_integration_id: params[:search_strava_integration_id])
+      end
+
+      if params[:search_gear_type].present?
+        strava_gears = strava_gears.where(gear_type: params[:search_gear_type])
+      end
+
+      @time_range_column = "updated_at" if sort_column == "updated_at"
+      @time_range_column ||= "created_at"
+      strava_gears.where(@time_range_column => @time_range)
+    end
   end
 end

--- a/app/controllers/admin/strava_integrations_controller.rb
+++ b/app/controllers/admin/strava_integrations_controller.rb
@@ -1,58 +1,60 @@
 # frozen_string_literal: true
 
-class Admin::StravaIntegrationsController < Admin::BaseController
-  include Binxtils::SortableTable
+module Admin
+  class StravaIntegrationsController < Admin::BaseController
+    include Binxtils::SortableTable
 
-  def index
-    @per_page = permitted_per_page(default: 50)
-    @pagy, @collection = pagy(:countish,
-      matching_strava_integrations.includes(:user).reorder(sortable_opts),
-      limit: @per_page,
-      page: permitted_page)
-  end
-
-  def show
-    @strava_integration = StravaIntegration.unscoped.find(params[:id])
-  end
-
-  helper_method :matching_strava_integrations, :permission_levels
-
-  private
-
-  def sortable_columns
-    %w[created_at updated_at deleted_at last_updated_activities_at user_id status activities_downloaded_count].freeze
-  end
-
-  def sortable_opts
-    "strava_integrations.#{sort_column} #{sort_direction}"
-  end
-
-  def permission_levels
-    %w[default less more].freeze
-  end
-
-  def earliest_period_date
-    Time.at(1738368000) # 2025-02-01
-  end
-
-  def matching_strava_integrations
-    strava_integrations = search_deleted_scope(StravaIntegration.all)
-
-    if params[:user_id].present?
-      strava_integrations = strava_integrations.where(user_id: user_subject&.id || params[:user_id])
+    def index
+      @per_page = permitted_per_page(default: 50)
+      @pagy, @collection = pagy(:countish,
+        matching_strava_integrations.includes(:user).reorder(sortable_opts),
+        limit: @per_page,
+        page: permitted_page)
     end
 
-    if params[:search_status].present?
-      strava_integrations = strava_integrations.where(status: params[:search_status])
+    def show
+      @strava_integration = StravaIntegration.unscoped.find(params[:id])
     end
 
-    @search_permissions = params[:search_permissions].presence if permission_levels.include?(params[:search_permissions])
-    if @search_permissions.present?
-      strava_integrations = strava_integrations.send(:"permissions_#{@search_permissions}")
+    helper_method :matching_strava_integrations, :permission_levels
+
+    private
+
+    def sortable_columns
+      %w[created_at updated_at deleted_at last_updated_activities_at user_id status activities_downloaded_count].freeze
     end
 
-    @time_range_column = sort_column if %w[updated_at deleted_at last_updated_activities_at].include?(sort_column)
-    @time_range_column ||= "created_at"
-    strava_integrations.where(@time_range_column => @time_range)
+    def sortable_opts
+      "strava_integrations.#{sort_column} #{sort_direction}"
+    end
+
+    def permission_levels
+      %w[default less more].freeze
+    end
+
+    def earliest_period_date
+      Time.at(1738368000) # 2025-02-01
+    end
+
+    def matching_strava_integrations
+      strava_integrations = search_deleted_scope(StravaIntegration.all)
+
+      if params[:user_id].present?
+        strava_integrations = strava_integrations.where(user_id: user_subject&.id || params[:user_id])
+      end
+
+      if params[:search_status].present?
+        strava_integrations = strava_integrations.where(status: params[:search_status])
+      end
+
+      @search_permissions = params[:search_permissions].presence if permission_levels.include?(params[:search_permissions])
+      if @search_permissions.present?
+        strava_integrations = strava_integrations.send(:"permissions_#{@search_permissions}")
+      end
+
+      @time_range_column = sort_column if %w[updated_at deleted_at last_updated_activities_at].include?(sort_column)
+      @time_range_column ||= "created_at"
+      strava_integrations.where(@time_range_column => @time_range)
+    end
   end
 end

--- a/app/controllers/admin/strava_requests_controller.rb
+++ b/app/controllers/admin/strava_requests_controller.rb
@@ -1,68 +1,70 @@
 # frozen_string_literal: true
 
-class Admin::StravaRequestsController < Admin::BaseController
-  include Binxtils::SortableTable
+module Admin
+  class StravaRequestsController < Admin::BaseController
+    include Binxtils::SortableTable
 
-  def index
-    @per_page = permitted_per_page(default: 50)
-    @pagy, @collection = pagy(:countish,
-      matching_strava_requests.reorder(sortable_opts),
-      limit: @per_page,
-      page: permitted_page)
-  end
-
-  helper_method :matching_strava_requests
-
-  private
-
-  def sortable_columns
-    %w[updated_at created_at requested_at request_type response_status strava_integration_id priority]
-  end
-
-  def sortable_opts
-    "strava_requests.#{sort_column} #{sort_direction}"
-  end
-
-  def earliest_period_date
-    Time.at(1738368000) # 2025-02-01
-  end
-
-  def matching_strava_requests
-    strava_requests = StravaRequest.all
-
-    if params[:search_id].present?
-      strava_requests = strava_requests.where(id: params[:search_id])
+    def index
+      @per_page = permitted_per_page(default: 50)
+      @pagy, @collection = pagy(:countish,
+        matching_strava_requests.reorder(sortable_opts),
+        limit: @per_page,
+        page: permitted_page)
     end
 
-    if params[:search_request_type].present?
-      strava_requests = strava_requests.where(request_type: params[:search_request_type])
+    helper_method :matching_strava_requests
+
+    private
+
+    def sortable_columns
+      %w[updated_at created_at requested_at request_type response_status strava_integration_id priority]
     end
 
-    if params[:search_response_status].present?
-      strava_requests = case params[:search_response_status]
-      when "pending_or_success" then strava_requests.where(response_status: StravaRequest::PENDING_OR_SUCCESS)
-      when "not_successful" then strava_requests.where(response_status: StravaRequest::NOT_SUCCESSFUL)
-      when "only_binx_response" then strava_requests.where(response_status: StravaRequest::BINX_RESPONSE)
-      when "only_strava_response" then strava_requests.strava_response
-      else strava_requests.where(response_status: params[:search_response_status])
+    def sortable_opts
+      "strava_requests.#{sort_column} #{sort_direction}"
+    end
+
+    def earliest_period_date
+      Time.at(1738368000) # 2025-02-01
+    end
+
+    def matching_strava_requests
+      strava_requests = StravaRequest.all
+
+      if params[:search_id].present?
+        strava_requests = strava_requests.where(id: params[:search_id])
       end
-    end
 
-    @proxy_request = Binxtils::InputNormalizer.boolean(params[:search_proxy_requests])
-    if @proxy_request
-      strava_requests = strava_requests.proxy_request
-    end
+      if params[:search_request_type].present?
+        strava_requests = strava_requests.where(request_type: params[:search_request_type])
+      end
 
-    if params[:search_strava_integration_id].present?
-      strava_requests = strava_requests.where(strava_integration_id: params[:search_strava_integration_id])
-    end
+      if params[:search_response_status].present?
+        strava_requests = case params[:search_response_status]
+        when "pending_or_success" then strava_requests.where(response_status: StravaRequest::PENDING_OR_SUCCESS)
+        when "not_successful" then strava_requests.where(response_status: StravaRequest::NOT_SUCCESSFUL)
+        when "only_binx_response" then strava_requests.where(response_status: StravaRequest::BINX_RESPONSE)
+        when "only_strava_response" then strava_requests.strava_response
+        else strava_requests.where(response_status: params[:search_response_status])
+        end
+      end
 
-    if params[:user_id].present?
-      strava_requests = strava_requests.where(user_id: user_subject&.id || params[:user_id])
-    end
+      @proxy_request = Binxtils::InputNormalizer.boolean(params[:search_proxy_requests])
+      if @proxy_request
+        strava_requests = strava_requests.proxy_request
+      end
 
-    @time_range_column = sort_column if %w[updated_at requested_at].include?(sort_column)
-    @time_range_column ||= "created_at"
-    strava_requests.where(@time_range_column => @time_range)
+      if params[:search_strava_integration_id].present?
+        strava_requests = strava_requests.where(strava_integration_id: params[:search_strava_integration_id])
+      end
+
+      if params[:user_id].present?
+        strava_requests = strava_requests.where(user_id: user_subject&.id || params[:user_id])
+      end
+
+      @time_range_column = sort_column if %w[updated_at requested_at].include?(sort_column)
+      @time_range_column ||= "created_at"
+      strava_requests.where(@time_range_column => @time_range)
+    end
   end
 end

--- a/app/controllers/admin/stripe_prices_controller.rb
+++ b/app/controllers/admin/stripe_prices_controller.rb
@@ -1,23 +1,25 @@
-class Admin::StripePricesController < Admin::BaseController
-  include Binxtils::SortableTable
+module Admin
+  class StripePricesController < Admin::BaseController
+    include Binxtils::SortableTable
 
-  def index
-    @per_page = permitted_per_page(default: 50)
-    @pagy, @collection = pagy(:countish,
-      matching_stripe_prices.reorder("stripe_prices.#{sort_column} #{sort_direction}"),
-      limit: @per_page,
-      page: permitted_page)
-  end
+    def index
+      @per_page = permitted_per_page(default: 50)
+      @pagy, @collection = pagy(:countish,
+        matching_stripe_prices.reorder("stripe_prices.#{sort_column} #{sort_direction}"),
+        limit: @per_page,
+        page: permitted_page)
+    end
 
-  helper_method :matching_stripe_prices
+    helper_method :matching_stripe_prices
 
-  protected
+    protected
 
-  def sortable_columns
-    %w[created_at membership_level amount_cents currency_enum interval]
-  end
+    def sortable_columns
+      %w[created_at membership_level amount_cents currency_enum interval]
+    end
 
-  def matching_stripe_prices
-    StripePrice
+    def matching_stripe_prices
+      StripePrice
+    end
   end
 end

--- a/app/controllers/admin/stripe_subscriptions_controller.rb
+++ b/app/controllers/admin/stripe_subscriptions_controller.rb
@@ -1,27 +1,29 @@
-class Admin::StripeSubscriptionsController < Admin::BaseController
-  include Binxtils::SortableTable
+module Admin
+  class StripeSubscriptionsController < Admin::BaseController
+    include Binxtils::SortableTable
 
-  def index
-    @per_page = permitted_per_page(default: 50)
-    @pagy, @collection = pagy(:countish,
-      matching_stripe_subscriptions.includes(:user, :stripe_price, :payments).reorder("stripe_subscriptions.#{sort_column} #{sort_direction}"),
-      limit: @per_page,
-      page: permitted_page)
-  end
+    def index
+      @per_page = permitted_per_page(default: 50)
+      @pagy, @collection = pagy(:countish,
+        matching_stripe_subscriptions.includes(:user, :stripe_price, :payments).reorder("stripe_subscriptions.#{sort_column} #{sort_direction}"),
+        limit: @per_page,
+        page: permitted_page)
+    end
 
-  helper_method :matching_stripe_subscriptions
+    helper_method :matching_stripe_subscriptions
 
-  protected
+    protected
 
-  def sortable_columns
-    %w[created_at stripe_price_stripe_id start_at end_at user_id stripe_status]
-  end
+    def sortable_columns
+      %w[created_at stripe_price_stripe_id start_at end_at user_id stripe_status]
+    end
 
-  def matching_stripe_subscriptions
-    stripe_subscriptions = StripeSubscription
+    def matching_stripe_subscriptions
+      stripe_subscriptions = StripeSubscription
 
-    @time_range_column = sort_column if %w[start_at end_at].include?(sort_column)
-    @time_range_column ||= "created_at"
-    stripe_subscriptions.where(@time_range_column => @time_range)
+      @time_range_column = sort_column if %w[start_at end_at].include?(sort_column)
+      @time_range_column ||= "created_at"
+      stripe_subscriptions.where(@time_range_column => @time_range)
+    end
   end
 end

--- a/app/controllers/admin/superuser_abilities_controller.rb
+++ b/app/controllers/admin/superuser_abilities_controller.rb
@@ -1,67 +1,69 @@
-class Admin::SuperuserAbilitiesController < Admin::BaseController
-  include Binxtils::SortableTable
+module Admin
+  class SuperuserAbilitiesController < Admin::BaseController
+    include Binxtils::SortableTable
 
-  before_action :find_superuser_ability, except: [:index]
+    before_action :find_superuser_ability, except: [:index]
 
-  def index
-    @per_page = permitted_per_page(default: 50)
-    @pagy, @collection = pagy(:countish, searched_superuser_abilities.reorder("superuser_abilities.#{sort_column} #{sort_direction}")
-      .includes(:user), limit: @per_page, page: permitted_page)
-  end
-
-  def edit
-  end
-
-  def update
-    if @superuser_ability.update(permitted_parameters)
-      flash[:success] = "Superuser Ability saved!"
-      redirect_to edit_admin_superuser_ability_path(@superuser_ability)
-    else
-      render action: :edit
-    end
-  end
-
-  helper_method :searched_superuser_abilities, :permitted_kinds
-
-  private
-
-  def find_superuser_ability
-    @superuser_ability = SuperuserAbility.find(params[:id])
-  end
-
-  def sortable_columns
-    %w[created_at updated_at kind user_id controller_name action_name]
-  end
-
-  def earliest_period_date
-    Date.parse("2013-1-1").beginning_of_day # First user created 2013-1-11
-  end
-
-  def permitted_kinds
-    SuperuserAbility.kinds
-  end
-
-  def searched_superuser_abilities
-    superuser_abilities = search_deleted_scope(SuperuserAbility.all)
-
-    if SuperuserAbility.kinds.include?(params[:search_kind])
-      @kind = params[:search_kind]
-      superuser_abilities = superuser_abilities.public_send(@kind)
-    else
-      @kind = "all"
-    end
-    if params[:user_id].present?
-      superuser_abilities = superuser_abilities.where(user_id: user_subject&.id || params[:user_id])
+    def index
+      @per_page = permitted_per_page(default: 50)
+      @pagy, @collection = pagy(:countish, searched_superuser_abilities.reorder("superuser_abilities.#{sort_column} #{sort_direction}")
+        .includes(:user), limit: @per_page, page: permitted_page)
     end
 
-    @time_range_column = sort_column if %w[updated_at].include?(sort_column)
-    @time_range_column ||= "created_at"
-    superuser_abilities.where(@time_range_column => @time_range)
-  end
+    def edit
+    end
 
-  def permitted_parameters
-    su_options = params.permit(*SuperuserAbility::SU_OPTIONS)
-      .select { |so| Binxtils::InputNormalizer.boolean(params[so]) }
-    {su_options: su_options.keys}
+    def update
+      if @superuser_ability.update(permitted_parameters)
+        flash[:success] = "Superuser Ability saved!"
+        redirect_to edit_admin_superuser_ability_path(@superuser_ability)
+      else
+        render action: :edit
+      end
+    end
+
+    helper_method :searched_superuser_abilities, :permitted_kinds
+
+    private
+
+    def find_superuser_ability
+      @superuser_ability = SuperuserAbility.find(params[:id])
+    end
+
+    def sortable_columns
+      %w[created_at updated_at kind user_id controller_name action_name]
+    end
+
+    def earliest_period_date
+      Date.parse("2013-1-1").beginning_of_day # First user created 2013-1-11
+    end
+
+    def permitted_kinds
+      SuperuserAbility.kinds
+    end
+
+    def searched_superuser_abilities
+      superuser_abilities = search_deleted_scope(SuperuserAbility.all)
+
+      if SuperuserAbility.kinds.include?(params[:search_kind])
+        @kind = params[:search_kind]
+        superuser_abilities = superuser_abilities.public_send(@kind)
+      else
+        @kind = "all"
+      end
+      if params[:user_id].present?
+        superuser_abilities = superuser_abilities.where(user_id: user_subject&.id || params[:user_id])
+      end
+
+      @time_range_column = sort_column if %w[updated_at].include?(sort_column)
+      @time_range_column ||= "created_at"
+      superuser_abilities.where(@time_range_column => @time_range)
+    end
+
+    def permitted_parameters
+      su_options = params.permit(*SuperuserAbility::SU_OPTIONS)
+        .select { |so| Binxtils::InputNormalizer.boolean(params[so]) }
+      {su_options: su_options.keys}
+    end
   end
 end

--- a/app/controllers/admin/theft_alert_plans_controller.rb
+++ b/app/controllers/admin/theft_alert_plans_controller.rb
@@ -1,44 +1,46 @@
-class Admin::TheftAlertPlansController < Admin::BaseController
-  def index
-    @theft_alert_plans = TheftAlertPlan.order(:amount_cents)
-  end
-
-  def new
-    @theft_alert_plan = TheftAlertPlan.new
-  end
-
-  def create
-    @theft_alert_plan = TheftAlertPlan.new(theft_alert_plan_params)
-
-    if @theft_alert_plan.save
-      redirect_to(edit_admin_theft_alert_plan_path(@theft_alert_plan))
-    else
-      flash[:errors] = @theft_alert_plan.errors.full_messages
-      render :new
+module Admin
+  class TheftAlertPlansController < Admin::BaseController
+    def index
+      @theft_alert_plans = TheftAlertPlan.order(:amount_cents)
     end
-  end
 
-  def edit
-    @theft_alert_plan = TheftAlertPlan.find(params[:id])
-  end
-
-  def update
-    @theft_alert_plan = TheftAlertPlan.find(params[:id])
-
-    if @theft_alert_plan.update(theft_alert_plan_params)
-      redirect_to(admin_theft_alert_plans_path)
-    else
-      flash[:errors] = @theft_alert_plan.errors.full_messages
-      render :edit
+    def new
+      @theft_alert_plan = TheftAlertPlan.new
     end
-  end
 
-  private
+    def create
+      @theft_alert_plan = TheftAlertPlan.new(theft_alert_plan_params)
 
-  def theft_alert_plan_params
-    params
-      .require(:theft_alert_plan)
-      .permit(:name, :amount_cents, :views, :duration_days, :description, :active, :language,
-        :currency_enum, :amount_cents_facebook, :ad_radius_miles)
+      if @theft_alert_plan.save
+        redirect_to(edit_admin_theft_alert_plan_path(@theft_alert_plan))
+      else
+        flash[:errors] = @theft_alert_plan.errors.full_messages
+        render :new
+      end
+    end
+
+    def edit
+      @theft_alert_plan = TheftAlertPlan.find(params[:id])
+    end
+
+    def update
+      @theft_alert_plan = TheftAlertPlan.find(params[:id])
+
+      if @theft_alert_plan.update(theft_alert_plan_params)
+        redirect_to(admin_theft_alert_plans_path)
+      else
+        flash[:errors] = @theft_alert_plan.errors.full_messages
+        render :edit
+      end
+    end
+
+    private
+
+    def theft_alert_plan_params
+      params
+        .require(:theft_alert_plan)
+        .permit(:name, :amount_cents, :views, :duration_days, :description, :active, :language,
+          :currency_enum, :amount_cents_facebook, :ad_radius_miles)
+    end
   end
 end

--- a/app/controllers/admin/theft_alerts_controller.rb
+++ b/app/controllers/admin/theft_alerts_controller.rb
@@ -1,188 +1,190 @@
-class Admin::TheftAlertsController < Admin::BaseController
-  include Binxtils::SortableTable
+module Admin
+  class TheftAlertsController < Admin::BaseController
+    include Binxtils::SortableTable
 
-  before_action :find_theft_alert, only: [:edit, :update]
+    before_action :find_theft_alert, only: [:edit, :update]
 
-  def index
-    @per_page = permitted_per_page
-    @pagy, @theft_alerts =
-      pagy(:countish, searched_theft_alerts.reorder("theft_alerts.#{sort_column} #{sort_direction}")
-        .includes(:theft_alert_plan, :stolen_record), limit: @per_page, page: permitted_page)
-    @page_title = "Admin | Promoted alerts"
-    @location_counts = Binxtils::InputNormalizer.boolean(params[:search_location_counts])
-  end
-
-  def show
-    redirect_to edit_admin_theft_alert_path
-  end
-
-  def edit
-  end
-
-  def update
-    if Binxtils::InputNormalizer.boolean(params[:activate_theft_alert])
-      new_data = @theft_alert.facebook_data || {}
-      @theft_alert.update(facebook_data: new_data.merge(activating_at: Time.current.to_i))
-      StolenBike::ActivateTheftAlertJob.perform_async(@theft_alert.id, true)
-      flash[:success] = "Activating, please wait"
-      redirect_to admin_theft_alert_path(@theft_alert)
-    elsif Binxtils::InputNormalizer.boolean(params[:update_theft_alert])
-      StolenBike::UpdateTheftAlertFacebookJob.new.perform(@theft_alert.id)
-      flash[:success] = "Updating Facebook data"
-      redirect_to admin_theft_alerts_path
-    elsif @theft_alert.update(permitted_update_params)
-      flash[:success] = "Success!"
-      redirect_to admin_theft_alerts_path
-    else
-      flash[:error] = @theft_alert.errors.to_a
-      render :edit
+    def index
+      @per_page = permitted_per_page
+      @pagy, @theft_alerts =
+        pagy(:countish, searched_theft_alerts.reorder("theft_alerts.#{sort_column} #{sort_direction}")
+          .includes(:theft_alert_plan, :stolen_record), limit: @per_page, page: permitted_page)
+      @page_title = "Admin | Promoted alerts"
+      @location_counts = Binxtils::InputNormalizer.boolean(params[:search_location_counts])
     end
-  end
 
-  def new
-    @bike = Bike.unscoped.find_by_id(params[:bike_id])
-    unless @bike.present?
-      flash[:info] = "Unable to find that bike. Select a bike to create a new promoted alert"
-      redirect_to admin_theft_alerts_path
-      return
+    def show
+      redirect_to edit_admin_theft_alert_path
     end
-    @stolen_record = @bike.current_stolen_record
-    @theft_alerts = @stolen_record&.theft_alerts || []
 
-    @theft_alert_plans = TheftAlertPlan.active.price_ordered_asc.in_language(I18n.locale)
-
-    @theft_alert = TheftAlert.new(stolen_record: @stolen_record,
-      theft_alert_plan: @theft_alert_plans.first,
-      user: current_user,
-      admin: true)
-    @theft_alert.set_calculated_attributes # Set some stuff
-  end
-
-  def create
-    @theft_alert = TheftAlert.new(permitted_create_params)
-    if @theft_alert.save
-      StolenBike::ActivateTheftAlertJob.perform_async(@theft_alert.id) if @theft_alert.activateable?
-      flash[:success] = "Promoted alert created!"
-      redirect_to edit_admin_theft_alert_path(@theft_alert)
-    else
-      render :new
+    def edit
     end
-  end
 
-  helper_method :searched_theft_alerts, :available_statuses, :available_paid_admin
-
-  private
-
-  def find_theft_alert
-    @theft_alert ||= TheftAlert.find(params[:id])
-    @stolen_record ||= @theft_alert.stolen_record
-    @bike ||= Bike.unscoped.find(@stolen_record.bike_id)
-  end
-
-  def permitted_update_params
-    params.require(:theft_alert).permit(:notes)
-  end
-
-  def permitted_create_params
-    params.require(:theft_alert).permit(:notes,
-      :stolen_record_id,
-      :ad_radius_miles,
-      :theft_alert_plan_id)
-      .merge(user: current_user, admin: true)
-  end
-
-  # Override, set one week before earliest created theft alert
-  def earliest_period_date
-    if @search_facebook_data
-      Time.at(1624982189)
-    else
-      Time.at(1560805519)
-    end
-  end
-
-  def sortable_columns
-    %w[created_at theft_alert_plan_id amount_cents_facebook_spent reach status start_at end_at]
-  end
-
-  def available_statuses
-    TheftAlert.statuses + %w[posted failed_to_activate]
-  end
-
-  def available_paid_admin
-    %w[paid_or_admin paid admin unpaid paid_and_unpaid]
-  end
-
-  def searched_theft_alerts
-    @search_recovered = Binxtils::InputNormalizer.boolean(params[:search_recovered])
-    theft_alerts = if @search_recovered
-      stolen_record_ids = StolenRecord.recovered.with_theft_alerts
-        .where(theft_alerts: {created_at: @time_range}).pluck(:id)
-      TheftAlert.where(stolen_record_id: stolen_record_ids)
-    else
-      TheftAlert
-    end
-    if params[:user_id].present?
-      theft_alerts = theft_alerts.where(user_id: user_subject&.id || params[:user_id])
-    end
-    if params[:search_bike_id].present?
-      @bike = Bike.unscoped.friendly_find(params[:search_bike_id])
-      theft_alerts = theft_alerts.where(bike_id: @bike.id) if @bike.present?
-    end
-    @search_paid_admin = if available_paid_admin.include?(params[:search_paid_admin])
-      params[:search_paid_admin]
-    elsif user_subject.present? || @bike.present?
-      "paid_and_unpaid" # by default, include all paid and unpaid if user or bike is searched
-    else
-      available_paid_admin.first
-    end
-    # paid_and_unpaid is "all"
-    theft_alerts = theft_alerts.public_send(@search_paid_admin) if @search_paid_admin != "paid_and_unpaid"
-
-    @search_facebook_data = Binxtils::InputNormalizer.boolean(params[:search_facebook_data])
-    theft_alerts = theft_alerts.facebook_updateable if @search_facebook_data
-
-    if available_statuses.include?(params[:search_status])
-      @status = params[:search_status]
-      theft_alerts = if TheftAlert.statuses.include?(@status)
-        theft_alerts.where(status: @status)
-      else # It must be one of the special statuses - which must be valid to send!
-        theft_alerts.send(@status)
+    def update
+      if Binxtils::InputNormalizer.boolean(params[:activate_theft_alert])
+        new_data = @theft_alert.facebook_data || {}
+        @theft_alert.update(facebook_data: new_data.merge(activating_at: Time.current.to_i))
+        StolenBike::ActivateTheftAlertJob.perform_async(@theft_alert.id, true)
+        flash[:success] = "Activating, please wait"
+        redirect_to admin_theft_alert_path(@theft_alert)
+      elsif Binxtils::InputNormalizer.boolean(params[:update_theft_alert])
+        StolenBike::UpdateTheftAlertFacebookJob.new.perform(@theft_alert.id)
+        flash[:success] = "Updating Facebook data"
+        redirect_to admin_theft_alerts_path
+      elsif @theft_alert.update(permitted_update_params)
+        flash[:success] = "Success!"
+        redirect_to admin_theft_alerts_path
+      else
+        flash[:error] = @theft_alert.errors.to_a
+        render :edit
       end
-    else
-      @status = "all"
-    end
-    # We always render distance
-    @distance = GeocodeHelper.permitted_distance(params[:search_distance], default_distance: 50)
-    if params[:search_location].present?
-      bounding_box = GeocodeHelper.bounding_box(params[:search_location], @distance)
-      theft_alerts = theft_alerts.within_bounding_box(bounding_box)
     end
 
-    # Only handling created_at now
-    @time_range_column ||= "created_at"
-    theft_alerts.where(@time_range_column => @time_range)
-  end
+    def new
+      @bike = Bike.unscoped.find_by_id(params[:bike_id])
+      unless @bike.present?
+        flash[:info] = "Unable to find that bike. Select a bike to create a new promoted alert"
+        redirect_to admin_theft_alerts_path
+        return
+      end
+      @stolen_record = @bike.current_stolen_record
+      @theft_alerts = @stolen_record&.theft_alerts || []
 
-  # Deprecated - should be removed soon.
-  def set_alert_timestamps(theft_alert_attrs)
-    currently_pending = @theft_alert.status == "pending"
-    transitioning_to_active = theft_alert_attrs[:status] == "active"
-    transitioning_to_pending = theft_alert_attrs[:status] == "pending"
+      @theft_alert_plans = TheftAlertPlan.active.price_ordered_asc.in_language(I18n.locale)
 
-    if currently_pending && transitioning_to_active
-      theft_alert_plan = TheftAlertPlan.find(theft_alert_attrs[:theft_alert_plan_id])
-      now = Time.current
-      theft_alert_attrs[:start_at] = now
-      theft_alert_attrs[:end_at] = now + theft_alert_plan.duration_days.days
-    elsif transitioning_to_pending
-      theft_alert_attrs[:start_at] = nil
-      theft_alert_attrs[:end_at] = nil
-    else
-      timezone = Binxtils::TimeZoneParser.parse(params[:timezone])
-      theft_alert_attrs[:start_at] = Binxtils::TimeParser.parse(theft_alert_attrs[:start_at], timezone)
-      theft_alert_attrs[:end_at] = Binxtils::TimeParser.parse(theft_alert_attrs[:end_at], timezone)
+      @theft_alert = TheftAlert.new(stolen_record: @stolen_record,
+        theft_alert_plan: @theft_alert_plans.first,
+        user: current_user,
+        admin: true)
+      @theft_alert.set_calculated_attributes # Set some stuff
     end
 
-    theft_alert_attrs
+    def create
+      @theft_alert = TheftAlert.new(permitted_create_params)
+      if @theft_alert.save
+        StolenBike::ActivateTheftAlertJob.perform_async(@theft_alert.id) if @theft_alert.activateable?
+        flash[:success] = "Promoted alert created!"
+        redirect_to edit_admin_theft_alert_path(@theft_alert)
+      else
+        render :new
+      end
+    end
+
+    helper_method :searched_theft_alerts, :available_statuses, :available_paid_admin
+
+    private
+
+    def find_theft_alert
+      @theft_alert ||= TheftAlert.find(params[:id])
+      @stolen_record ||= @theft_alert.stolen_record
+      @bike ||= Bike.unscoped.find(@stolen_record.bike_id)
+    end
+
+    def permitted_update_params
+      params.require(:theft_alert).permit(:notes)
+    end
+
+    def permitted_create_params
+      params.require(:theft_alert).permit(:notes,
+        :stolen_record_id,
+        :ad_radius_miles,
+        :theft_alert_plan_id)
+        .merge(user: current_user, admin: true)
+    end
+
+    # Override, set one week before earliest created theft alert
+    def earliest_period_date
+      if @search_facebook_data
+        Time.at(1624982189)
+      else
+        Time.at(1560805519)
+      end
+    end
+
+    def sortable_columns
+      %w[created_at theft_alert_plan_id amount_cents_facebook_spent reach status start_at end_at]
+    end
+
+    def available_statuses
+      TheftAlert.statuses + %w[posted failed_to_activate]
+    end
+
+    def available_paid_admin
+      %w[paid_or_admin paid admin unpaid paid_and_unpaid]
+    end
+
+    def searched_theft_alerts
+      @search_recovered = Binxtils::InputNormalizer.boolean(params[:search_recovered])
+      theft_alerts = if @search_recovered
+        stolen_record_ids = StolenRecord.recovered.with_theft_alerts
+          .where(theft_alerts: {created_at: @time_range}).pluck(:id)
+        TheftAlert.where(stolen_record_id: stolen_record_ids)
+      else
+        TheftAlert
+      end
+      if params[:user_id].present?
+        theft_alerts = theft_alerts.where(user_id: user_subject&.id || params[:user_id])
+      end
+      if params[:search_bike_id].present?
+        @bike = Bike.unscoped.friendly_find(params[:search_bike_id])
+        theft_alerts = theft_alerts.where(bike_id: @bike.id) if @bike.present?
+      end
+      @search_paid_admin = if available_paid_admin.include?(params[:search_paid_admin])
+        params[:search_paid_admin]
+      elsif user_subject.present? || @bike.present?
+        "paid_and_unpaid" # by default, include all paid and unpaid if user or bike is searched
+      else
+        available_paid_admin.first
+      end
+      # paid_and_unpaid is "all"
+      theft_alerts = theft_alerts.public_send(@search_paid_admin) if @search_paid_admin != "paid_and_unpaid"
+
+      @search_facebook_data = Binxtils::InputNormalizer.boolean(params[:search_facebook_data])
+      theft_alerts = theft_alerts.facebook_updateable if @search_facebook_data
+
+      if available_statuses.include?(params[:search_status])
+        @status = params[:search_status]
+        theft_alerts = if TheftAlert.statuses.include?(@status)
+          theft_alerts.where(status: @status)
+        else # It must be one of the special statuses - which must be valid to send!
+          theft_alerts.send(@status)
+        end
+      else
+        @status = "all"
+      end
+      # We always render distance
+      @distance = GeocodeHelper.permitted_distance(params[:search_distance], default_distance: 50)
+      if params[:search_location].present?
+        bounding_box = GeocodeHelper.bounding_box(params[:search_location], @distance)
+        theft_alerts = theft_alerts.within_bounding_box(bounding_box)
+      end
+
+      # Only handling created_at now
+      @time_range_column ||= "created_at"
+      theft_alerts.where(@time_range_column => @time_range)
+    end
+
+    # Deprecated - should be removed soon.
+    def set_alert_timestamps(theft_alert_attrs)
+      currently_pending = @theft_alert.status == "pending"
+      transitioning_to_active = theft_alert_attrs[:status] == "active"
+      transitioning_to_pending = theft_alert_attrs[:status] == "pending"
+
+      if currently_pending && transitioning_to_active
+        theft_alert_plan = TheftAlertPlan.find(theft_alert_attrs[:theft_alert_plan_id])
+        now = Time.current
+        theft_alert_attrs[:start_at] = now
+        theft_alert_attrs[:end_at] = now + theft_alert_plan.duration_days.days
+      elsif transitioning_to_pending
+        theft_alert_attrs[:start_at] = nil
+        theft_alert_attrs[:end_at] = nil
+      else
+        timezone = Binxtils::TimeZoneParser.parse(params[:timezone])
+        theft_alert_attrs[:start_at] = Binxtils::TimeParser.parse(theft_alert_attrs[:start_at], timezone)
+        theft_alert_attrs[:end_at] = Binxtils::TimeParser.parse(theft_alert_attrs[:end_at], timezone)
+      end
+
+      theft_alert_attrs
+    end
   end
 end

--- a/app/controllers/admin/user_alerts_controller.rb
+++ b/app/controllers/admin/user_alerts_controller.rb
@@ -1,52 +1,54 @@
-class Admin::UserAlertsController < Admin::BaseController
-  include Binxtils::SortableTable
+module Admin
+  class UserAlertsController < Admin::BaseController
+    include Binxtils::SortableTable
 
-  def index
-    @per_page = permitted_per_page(default: 50)
-    @pagy, @collection = pagy(:countish, matching_user_alerts.order(sort_column => sort_direction), limit: @per_page, page: permitted_page)
-    @render_kind_counts = Binxtils::InputNormalizer.boolean(params[:search_kind_counts])
-  end
-
-  helper_method :matching_user_alerts
-
-  private
-
-  def sortable_columns
-    %w[created_at updated_at resolved_at dismissed_at kind user_id]
-  end
-
-  def matching_user_alerts
-    user_alerts = UserAlert
-    if UserAlert.kinds.include?(params[:search_kind])
-      @kind = params[:search_kind]
-      user_alerts = user_alerts.where(kind: @kind)
-    else
-      @kind = "all"
+    def index
+      @per_page = permitted_per_page(default: 50)
+      @pagy, @collection = pagy(:countish, matching_user_alerts.order(sort_column => sort_direction), limit: @per_page, page: permitted_page)
+      @render_kind_counts = Binxtils::InputNormalizer.boolean(params[:search_kind_counts])
     end
-    if %w[active inactive dismissed resolved].include?(params[:search_activeness])
-      @activeness = params[:search_activeness]
-      user_alerts = user_alerts.send(@activeness)
-    else
-      @activeness = "all"
-    end
-    if params[:user_id].present?
-      user_alerts = user_alerts.where(user_id: user_subject&.id || params[:user_id])
-    end
-    if params[:search_bike_id].present?
-      @bike = Bike.unscoped.find(params[:search_bike_id])
-      user_alerts = user_alerts.where(bike_id: @bike.id) if @bike.present?
-    end
-    @with_notification = Binxtils::InputNormalizer.boolean(params[:search_with_notification])
-    user_alerts = user_alerts.with_notification if @with_notification
-    if params[:organization_id].present? && current_organization.present?
-      user_alerts = user_alerts.where(organization_id: current_organization.id)
-    end
-    @time_range_column = sort_column if %w[updated_at resolved_at dismissed_at].include?(sort_column)
-    @time_range_column ||= "created_at"
-    user_alerts.where(@time_range_column => @time_range)
-  end
 
-  def earliest_period_date
-    Time.at(1624820303)
+    helper_method :matching_user_alerts
+
+    private
+
+    def sortable_columns
+      %w[created_at updated_at resolved_at dismissed_at kind user_id]
+    end
+
+    def matching_user_alerts
+      user_alerts = UserAlert
+      if UserAlert.kinds.include?(params[:search_kind])
+        @kind = params[:search_kind]
+        user_alerts = user_alerts.where(kind: @kind)
+      else
+        @kind = "all"
+      end
+      if %w[active inactive dismissed resolved].include?(params[:search_activeness])
+        @activeness = params[:search_activeness]
+        user_alerts = user_alerts.send(@activeness)
+      else
+        @activeness = "all"
+      end
+      if params[:user_id].present?
+        user_alerts = user_alerts.where(user_id: user_subject&.id || params[:user_id])
+      end
+      if params[:search_bike_id].present?
+        @bike = Bike.unscoped.find(params[:search_bike_id])
+        user_alerts = user_alerts.where(bike_id: @bike.id) if @bike.present?
+      end
+      @with_notification = Binxtils::InputNormalizer.boolean(params[:search_with_notification])
+      user_alerts = user_alerts.with_notification if @with_notification
+      if params[:organization_id].present? && current_organization.present?
+        user_alerts = user_alerts.where(organization_id: current_organization.id)
+      end
+      @time_range_column = sort_column if %w[updated_at resolved_at dismissed_at].include?(sort_column)
+      @time_range_column ||= "created_at"
+      user_alerts.where(@time_range_column => @time_range)
+    end
+
+    def earliest_period_date
+      Time.at(1624820303)
+    end
   end
 end

--- a/app/controllers/admin/user_bans_controller.rb
+++ b/app/controllers/admin/user_bans_controller.rb
@@ -1,36 +1,38 @@
-class Admin::UserBansController < Admin::BaseController
-  include Binxtils::SortableTable
+module Admin
+  class UserBansController < Admin::BaseController
+    include Binxtils::SortableTable
 
-  def index
-    @per_page = permitted_per_page(default: 50)
-    @pagy, @collection = pagy(:countish,
-      matching_user_bans.includes(:user, :creator).reorder("user_bans.#{sort_column} #{sort_direction}"),
-      limit: @per_page,
-      page: permitted_page)
-  end
-
-  helper_method :matching_user_bans
-
-  protected
-
-  def sortable_columns
-    %w[created_at reason user_id creator_id]
-  end
-
-  def earliest_period_date
-    Time.at(1665173442) # 2022-10-01 00:00 - user ban model added
-  end
-
-  def viewing_deleted?
-  end
-
-  def matching_user_bans
-    user_bans = search_deleted_scope(UserBan.all)
-
-    if params[:user_id].present?
-      user_bans = user_bans.where(creator_id: user_subject&.id || params[:user_id])
+    def index
+      @per_page = permitted_per_page(default: 50)
+      @pagy, @collection = pagy(:countish,
+        matching_user_bans.includes(:user, :creator).reorder("user_bans.#{sort_column} #{sort_direction}"),
+        limit: @per_page,
+        page: permitted_page)
     end
 
-    user_bans.where(created_at: @time_range)
+    helper_method :matching_user_bans
+
+    protected
+
+    def sortable_columns
+      %w[created_at reason user_id creator_id]
+    end
+
+    def earliest_period_date
+      Time.at(1665173442) # 2022-10-01 00:00 - user ban model added
+    end
+
+    def viewing_deleted?
+    end
+
+    def matching_user_bans
+      user_bans = search_deleted_scope(UserBan.all)
+
+      if params[:user_id].present?
+        user_bans = user_bans.where(creator_id: user_subject&.id || params[:user_id])
+      end
+
+      user_bans.where(created_at: @time_range)
+    end
   end
 end

--- a/app/controllers/admin/user_registration_organizations_controller.rb
+++ b/app/controllers/admin/user_registration_organizations_controller.rb
@@ -1,40 +1,42 @@
-class Admin::UserRegistrationOrganizationsController < Admin::BaseController
-  include Binxtils::SortableTable
+module Admin
+  class UserRegistrationOrganizationsController < Admin::BaseController
+    include Binxtils::SortableTable
 
-  def index
-    @per_page = permitted_per_page(default: 50)
-    @pagy, @user_registration_organizations = pagy(:countish, matching_user_registration_organizations
-      .reorder("user_registration_organizations.#{sort_column} #{sort_direction}")
-      .includes(:user, :organization), limit: @per_page, page: permitted_page)
-    @render_org_counts = Binxtils::InputNormalizer.boolean(params[:search_org_counts])
-  end
-
-  helper_method :matching_user_registration_organizations
-
-  private
-
-  def sortable_columns
-    %w[created_at updated_at user_id organization_id]
-  end
-
-  def earliest_period_date
-    Time.at(1641448800)
-  end
-
-  def matching_user_registration_organizations
-    user_registration_organizations = UserRegistrationOrganization
-    if params[:user_id].present?
-      user_registration_organizations = user_registration_organizations.where(user_id: user_subject&.id || params[:user_id])
+    def index
+      @per_page = permitted_per_page(default: 50)
+      @pagy, @user_registration_organizations = pagy(:countish, matching_user_registration_organizations
+        .reorder("user_registration_organizations.#{sort_column} #{sort_direction}")
+        .includes(:user, :organization), limit: @per_page, page: permitted_page)
+      @render_org_counts = Binxtils::InputNormalizer.boolean(params[:search_org_counts])
     end
-    if current_organization.present?
-      user_registration_organizations = user_registration_organizations.where(organization_id: current_organization.id)
+
+    helper_method :matching_user_registration_organizations
+
+    private
+
+    def sortable_columns
+      %w[created_at updated_at user_id organization_id]
     end
-    @with_registration_info = Binxtils::InputNormalizer.boolean(params[:search_with_registration_info])
-    if @with_registration_info
-      user_registration_organizations = user_registration_organizations.where.not(registration_info: {})
+
+    def earliest_period_date
+      Time.at(1641448800)
     end
-    @time_range_column = sort_column if %w[updated_at].include?(sort_column)
-    @time_range_column ||= "created_at"
-    user_registration_organizations.where(@time_range_column => @time_range)
+
+    def matching_user_registration_organizations
+      user_registration_organizations = UserRegistrationOrganization
+      if params[:user_id].present?
+        user_registration_organizations = user_registration_organizations.where(user_id: user_subject&.id || params[:user_id])
+      end
+      if current_organization.present?
+        user_registration_organizations = user_registration_organizations.where(organization_id: current_organization.id)
+      end
+      @with_registration_info = Binxtils::InputNormalizer.boolean(params[:search_with_registration_info])
+      if @with_registration_info
+        user_registration_organizations = user_registration_organizations.where.not(registration_info: {})
+      end
+      @time_range_column = sort_column if %w[updated_at].include?(sort_column)
+      @time_range_column ||= "created_at"
+      user_registration_organizations.where(@time_range_column => @time_range)
+    end
   end
 end

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -1,174 +1,176 @@
-class Admin::UsersController < Admin::BaseController
-  include Binxtils::SortableTable
+module Admin
+  class UsersController < Admin::BaseController
+    include Binxtils::SortableTable
 
-  before_action :find_user, only: %i[show edit update destroy]
-  helper_method :invalid_user_options
+    before_action :find_user, only: %i[show edit update destroy]
+    helper_method :invalid_user_options
 
-  def index
-    @per_page = permitted_per_page
-    @pagy, @collection = pagy(:countish, matching_users.reorder("users.#{sort_column} #{sort_direction}")
-      .includes(:ownerships, :superuser_abilities, :payments, :user_emails, :organization_roles, :ambassador_tasks, :email_bans_active),
-      limit: @per_page, page: permitted_page)
-  end
-
-  def show
-    redirect_to edit_admin_user_url(params[:id])
-  end
-
-  def edit
-    # urls with user IDs rather than usernames are more helpful in superadmin
-    if params[:id] == @user.username
-      redirect_to edit_admin_user_path(@user.id)
-      return
+    def index
+      @per_page = permitted_per_page
+      @pagy, @collection = pagy(:countish, matching_users.reorder("users.#{sort_column} #{sort_direction}")
+        .includes(:ownerships, :superuser_abilities, :payments, :user_emails, :organization_roles, :ambassador_tasks, :email_bans_active),
+        limit: @per_page, page: permitted_page)
     end
-    calculate_user_bikes
-  end
 
-  def update
-    if params[:force_merge_email].present?
-      force_merge_users(params[:force_merge_email])
-    else
-      @user.name = params[:user][:name]
-      @user.email = params[:user][:email]
-      if Binxtils::InputNormalizer.boolean(params[:user][:superuser])
-        @user.superuser_abilities.find_or_create_by(controller_name: nil, action_name: nil)
+    def show
+      redirect_to edit_admin_user_url(params[:id])
+    end
+
+    def edit
+      # urls with user IDs rather than usernames are more helpful in superadmin
+      if params[:id] == @user.username
+        redirect_to edit_admin_user_path(@user.id)
+        return
+      end
+      calculate_user_bikes
+    end
+
+    def update
+      if params[:force_merge_email].present?
+        force_merge_users(params[:force_merge_email])
       else
-        @user.superuser_abilities.universal.destroy_all
+        @user.name = params[:user][:name]
+        @user.email = params[:user][:email]
+        if Binxtils::InputNormalizer.boolean(params[:user][:superuser])
+          @user.superuser_abilities.find_or_create_by(controller_name: nil, action_name: nil)
+        else
+          @user.superuser_abilities.universal.destroy_all
+        end
+        @user.developer = params[:user][:developer] if current_user.developer? && params[:user].key?(:developer)
+        @user.banned = params[:user][:banned]
+        if @user.banned && permitted_ban_parameters[:reason].present?
+          UserBan.create!(permitted_ban_parameters)
+        end
+        @user.username = params[:user][:username]
+        @user.can_send_many_stolen_notifications = params[:user][:can_send_many_stolen_notifications]
+        @user.can_send_many_marketplace_messages = params[:user][:can_send_many_marketplace_messages]
+        @user.phone = params[:user][:phone]
+        if @user.save
+          @user.confirm(@user.confirmation_token) if params[:user][:confirmed]
+          redirect_to admin_users_url, notice: "User Updated"
+        else
+          calculate_user_bikes
+          render action: :edit
+        end
       end
-      @user.developer = params[:user][:developer] if current_user.developer? && params[:user].key?(:developer)
-      @user.banned = params[:user][:banned]
-      if @user.banned && permitted_ban_parameters[:reason].present?
-        UserBan.create!(permitted_ban_parameters)
-      end
-      @user.username = params[:user][:username]
-      @user.can_send_many_stolen_notifications = params[:user][:can_send_many_stolen_notifications]
-      @user.can_send_many_marketplace_messages = params[:user][:can_send_many_marketplace_messages]
-      @user.phone = params[:user][:phone]
-      if @user.save
-        @user.confirm(@user.confirmation_token) if params[:user][:confirmed]
-        redirect_to admin_users_url, notice: "User Updated"
+    end
+
+    def destroy
+      @user.destroy
+      redirect_to admin_users_url, notice: "User Deleted."
+    end
+
+    helper_method :matching_users
+
+    private
+
+    def sortable_columns
+      %w[created_at email updated_at deleted_at]
+    end
+
+    def earliest_period_date
+      Time.at(1357912007)
+    end
+
+    def invalid_user_options
+      %w[valid_users banned_only email_banned_only deleted_only all_except_deleted all].freeze
+    end
+
+    def find_user
+      @user = User.unscoped.friendly_find(params[:id])
+      raise ActiveRecord::RecordNotFound unless @user.present?
+    end
+
+    def permitted_ban_parameters
+      params.require(:user).permit(user_ban_attributes: %i[reason description])
+        &.dig(:user_ban_attributes)
+        &.merge(creator_id: current_user.id, user_id: @user.id)
+    end
+
+    def force_merge_users(email)
+      email = EmailNormalizer.normalize(email)
+      secondary_user = User.fuzzy_confirmed_or_unconfirmed_email_find(email)
+      if secondary_user.present?
+        if secondary_user.unconfirmed?
+          secondary_user.confirm(secondary_user.confirmation_token)
+          secondary_user.reload
+        end
+        @user.confirm(@user.confirmation_token) if @user.unconfirmed?
+
+        user_email = @user.user_emails.find_by_email(email)
+        # Manually confirm the user
+        user_email.update(confirmation_token: nil) if user_email&.unconfirmed?
+        user_email ||= @user.user_emails.create(email: email)
+        if Users::MergeAdditionalEmailJob.new.perform(user_email.id)
+          flash[:success] = "User #{@user.display_name} merged with '#{email}'"
+        else
+          flash[:error] = "Unable to merge users!"
+        end
       else
-        calculate_user_bikes
-        render action: :edit
+        flash[:error] = "Unable to find user with email: '#{email}', did not merge"
       end
+      redirect_to admin_user_path(@user)
     end
-  end
 
-  def destroy
-    @user.destroy
-    redirect_to admin_users_url, notice: "User Deleted."
-  end
-
-  helper_method :matching_users
-
-  private
-
-  def sortable_columns
-    %w[created_at email updated_at deleted_at]
-  end
-
-  def earliest_period_date
-    Time.at(1357912007)
-  end
-
-  def invalid_user_options
-    %w[valid_users banned_only email_banned_only deleted_only all_except_deleted all].freeze
-  end
-
-  def find_user
-    @user = User.unscoped.friendly_find(params[:id])
-    raise ActiveRecord::RecordNotFound unless @user.present?
-  end
-
-  def permitted_ban_parameters
-    params.require(:user).permit(user_ban_attributes: %i[reason description])
-      &.dig(:user_ban_attributes)
-      &.merge(creator_id: current_user.id, user_id: @user.id)
-  end
-
-  def force_merge_users(email)
-    email = EmailNormalizer.normalize(email)
-    secondary_user = User.fuzzy_confirmed_or_unconfirmed_email_find(email)
-    if secondary_user.present?
-      if secondary_user.unconfirmed?
-        secondary_user.confirm(secondary_user.confirmation_token)
-        secondary_user.reload
-      end
-      @user.confirm(@user.confirmation_token) if @user.unconfirmed?
-
-      user_email = @user.user_emails.find_by_email(email)
-      # Manually confirm the user
-      user_email.update(confirmation_token: nil) if user_email&.unconfirmed?
-      user_email ||= @user.user_emails.create(email: email)
-      if Users::MergeAdditionalEmailJob.new.perform(user_email.id)
-        flash[:success] = "User #{@user.display_name} merged with '#{email}'"
+    def matching_users
+      @search_ambassadors = Binxtils::InputNormalizer.boolean(params[:search_ambassadors])
+      @search_superusers = Binxtils::InputNormalizer.boolean(params[:search_superusers])
+      @search_developers = Binxtils::InputNormalizer.boolean(params[:search_developers])
+      @search_with_organization = Binxtils::InputNormalizer.boolean(params[:search_with_organization])
+      @updated_at = Binxtils::InputNormalizer.boolean(params[:search_updated_at])
+      @search_unconfirmed = Binxtils::InputNormalizer.boolean(params[:search_unconfirmed])
+      @search_confirmed = @search_unconfirmed ? false : Binxtils::InputNormalizer.boolean(params[:search_confirmed])
+      users = if current_organization.present?
+        current_organization.users
       else
-        flash[:error] = "Unable to merge users!"
+        User
       end
-    else
-      flash[:error] = "Unable to find user with email: '#{email}', did not merge"
-    end
-    redirect_to admin_user_path(@user)
-  end
+      @invalid = if invalid_user_options.include?(params[:search_invalid])
+        params[:search_invalid]
+      else
+        invalid_user_options.first
+      end
+      users = users.send(invalidness_scope(@invalid))
+      users = users.ambassadors if @search_ambassadors
+      users = users.admins if @search_superusers
+      users = users.where(developer: true) if @search_developers
+      users = users.where(id: OrganizationRole.select(:user_id)) if @search_with_organization
+      users = users.unconfirmed if @search_unconfirmed
+      users = users.confirmed if @search_confirmed
 
-  def matching_users
-    @search_ambassadors = Binxtils::InputNormalizer.boolean(params[:search_ambassadors])
-    @search_superusers = Binxtils::InputNormalizer.boolean(params[:search_superusers])
-    @search_developers = Binxtils::InputNormalizer.boolean(params[:search_developers])
-    @search_with_organization = Binxtils::InputNormalizer.boolean(params[:search_with_organization])
-    @updated_at = Binxtils::InputNormalizer.boolean(params[:search_updated_at])
-    @search_unconfirmed = Binxtils::InputNormalizer.boolean(params[:search_unconfirmed])
-    @search_confirmed = @search_unconfirmed ? false : Binxtils::InputNormalizer.boolean(params[:search_confirmed])
-    users = if current_organization.present?
-      current_organization.users
-    else
-      User
-    end
-    @invalid = if invalid_user_options.include?(params[:search_invalid])
-      params[:search_invalid]
-    else
-      invalid_user_options.first
-    end
-    users = users.send(invalidness_scope(@invalid))
-    users = users.ambassadors if @search_ambassadors
-    users = users.admins if @search_superusers
-    users = users.where(developer: true) if @search_developers
-    users = users.where(id: OrganizationRole.select(:user_id)) if @search_with_organization
-    users = users.unconfirmed if @search_unconfirmed
-    users = users.confirmed if @search_confirmed
+      users = users.admin_text_search(params[:query]) if params[:query].present?
+      if params[:search_phone].present?
+        users = users.search_phone(params[:search_phone])
+      end
+      if params[:search_domain].present?
+        users = users.matching_domain(params[:search_domain])
+      end
 
-    users = users.admin_text_search(params[:query]) if params[:query].present?
-    if params[:search_phone].present?
-      users = users.search_phone(params[:search_phone])
-    end
-    if params[:search_domain].present?
-      users = users.matching_domain(params[:search_domain])
+      @time_range_column = sort_column if %w[updated_at deleted_at].include?(sort_column)
+      @time_range_column = nil if @time_range_column == "deleted_at" && !@search_deleted
+      @time_range_column ||= "created_at"
+      users.where("users.#{@time_range_column}" => @time_range)
     end
 
-    @time_range_column = sort_column if %w[updated_at deleted_at].include?(sort_column)
-    @time_range_column = nil if @time_range_column == "deleted_at" && !@search_deleted
-    @time_range_column ||= "created_at"
-    users.where("users.#{@time_range_column}" => @time_range)
-  end
+    def invalidness_scope(invalidness)
+      @deleted = %w[deleted_only all].include?(invalidness) # Gross side effect :/
 
-  def invalidness_scope(invalidness)
-    @deleted = %w[deleted_only all].include?(invalidness) # Gross side effect :/
-
-    case invalidness
-    when "all_except_deleted" then :all
-    when "all" then :unscoped
-    when "deleted_only" then :only_deleted
-    when "banned_only" then :banned
-    when "email_banned_only" then :email_banned
-    else
-      :valid_only
+      case invalidness
+      when "all_except_deleted" then :all
+      when "all" then :unscoped
+      when "deleted_only" then :only_deleted
+      when "banned_only" then :banned
+      when "email_banned_only" then :email_banned
+      else
+        :valid_only
+      end
     end
-  end
 
-  def calculate_user_bikes
-    # If the user has a bunch of bikes, it can cause timeouts. In those cases, use rough approximation
-    bikes = @user.bikes
-    @bikescount = @user.bikes.count
-    @bikes = bikes.reorder(created_at: :desc).limit(10)
+    def calculate_user_bikes
+      # If the user has a bunch of bikes, it can cause timeouts. In those cases, use rough approximation
+      bikes = @user.bikes
+      @bikescount = @user.bikes.count
+      @bikes = bikes.reorder(created_at: :desc).limit(10)
+    end
   end
 end

--- a/app/controllers/bike_versions/edits_controller.rb
+++ b/app/controllers/bike_versions/edits_controller.rb
@@ -1,22 +1,24 @@
-class BikeVersions::EditsController < BikeVersionsController
-  include BikeEditable
+module BikeVersions
+  class EditsController < BikeVersionsController
+    include BikeEditable
 
-  before_action :ensure_user_allowed_to_edit_version
+    before_action :ensure_user_allowed_to_edit_version
 
-  def show
-    @page_errors = @bike.errors
-    return unless setup_edit_template(params[:edit_template]) # Returns nil if redirecting
+    def show
+      @page_errors = @bike.errors
+      return unless setup_edit_template(params[:edit_template]) # Returns nil if redirecting
 
-    @page_title = page_title_for(@edit_template, @bike)
+      @page_title = page_title_for(@edit_template, @bike)
 
-    if @edit_template == "photos"
-      @private_images = PublicImage
-        .unscoped
-        .where(imageable_type: "BikeVersion")
-        .where(imageable_id: @bike_version.id)
-        .where(is_private: true)
+      if @edit_template == "photos"
+        @private_images = PublicImage
+          .unscoped
+          .where(imageable_type: "BikeVersion")
+          .where(imageable_id: @bike_version.id)
+          .where(is_private: true)
+      end
+
+      render :"/bikes_edit/#{@edit_template}"
     end
-
-    render :"/bikes_edit/#{@edit_template}"
   end
 end

--- a/app/controllers/bikes/base_controller.rb
+++ b/app/controllers/bikes/base_controller.rb
@@ -1,172 +1,176 @@
 class OwnershipNotSavedError < StandardError
 end
 
-class BikeServices::UpdatorError < StandardError
+module BikeServices
+  class UpdatorError < StandardError
+  end
 end
 
-class Bikes::BaseController < ApplicationController
-  before_action :find_bike
-  before_action :assign_current_organization
-  before_action :ensure_user_allowed_to_edit
+module Bikes
+  class BaseController < ApplicationController
+    before_action :find_bike
+    before_action :assign_current_organization
+    before_action :ensure_user_allowed_to_edit
 
-  protected
+    protected
 
-  # Make it possible to assign organization for a view by passing the organization_id parameter - mainly useful for superusers
-  # Also provides testable protection against seeing organization info on bikes
-  def assign_current_organization
-    org = current_organization || passive_organization # actually call #current_organization first
-    # If forced false, or no user present, skip everything else
-    return true if @current_organization_force_blank || current_user.blank?
+    # Make it possible to assign organization for a view by passing the organization_id parameter - mainly useful for superusers
+    # Also provides testable protection against seeing organization info on bikes
+    def assign_current_organization
+      org = current_organization || passive_organization # actually call #current_organization first
+      # If forced false, or no user present, skip everything else
+      return true if @current_organization_force_blank || current_user.blank?
 
-    # If there was an organization_id passed, and the user isn't authorized for that org, reset passive_organization to something they can access
-    # ... Particularly relevant for scanned stickers, which may be scanned by child orgs - but I think it's the behavior users expect regardless
-    if current_user.default_organization.present? && params[:organization_id].present?
-      return true if org.present? && current_user.authorized?(org)
+      # If there was an organization_id passed, and the user isn't authorized for that org, reset passive_organization to something they can access
+      # ... Particularly relevant for scanned stickers, which may be scanned by child orgs - but I think it's the behavior users expect regardless
+      if current_user.default_organization.present? && params[:organization_id].present?
+        return true if org.present? && current_user.authorized?(org)
 
-      set_passive_organization(current_user.default_organization)
-    else
-      # If current_user isn't authorized for the organization, force assign nil
-      return true if org.blank? || org.present? && current_user.authorized?(org)
-
-      set_passive_organization(nil)
-    end
-  end
-
-  def find_bike
-    # Fix issue with sticker batches #35 & #38
-    if params[:id].present? && params[:id].match?(/scanned(uc|ui)\d+/i)
-      permitted_params = params.except(:action, :controller, :id).as_json
-        .merge(id: params[:id].gsub("scanned", ""))
-      redirect_to(scanned_bike_path(permitted_params))
-      return
-    end
-    begin
-      @bike = Bike.unscoped.find(params[:bike_id] || params[:id])
-    rescue ActiveRecord::StatementInvalid => e
-      raise e.to_s.match?(/PG..NumericValueOutOfRange/) ? ActiveRecord::RecordNotFound : e
-    end
-    return @bike if @bike.visible_by?(current_user)
-
-    fail ActiveRecord::RecordNotFound
-  end
-
-  def find_or_new_b_param
-    token = params[:b_param_token]
-    token ||= params.dig(:bike, :b_param_id_token)
-    @bike_sticker = BikeSticker.lookup_with_fallback(params[:bike_sticker], user: current_user)
-    @b_param = BParam.find_or_new_from_token(token, user_id: current_user&.id, bike_sticker: @bike_sticker)
-  end
-
-  def ensure_user_allowed_to_edit
-    @current_ownership = @bike.current_ownership
-    type = @bike&.type || "bike"
-
-    return true if @bike.authorize_and_claim_for_user(current_user)
-
-    if @bike.current_impound_record.present?
-      error = if @bike.current_impound_record.organized?
-        translation(:bike_impounded_by_organization, bike_type: type, org_name: @bike.current_impound_record.organization.name,
-          scope: [:controllers, :bikes, :ensure_user_allowed_to_edit])
+        set_passive_organization(current_user.default_organization)
       else
-        translation(:bike_impounded, bike_type: type,
-          scope: [:controllers, :bikes, :ensure_user_allowed_to_edit])
-      end
-    elsif current_user.present?
-      error = translation(:you_dont_own_that, bike_type: type,
-        scope: [:controllers, :bikes, :ensure_user_allowed_to_edit])
-    else
-      store_return_to
-      error = if @current_ownership && @bike.current_ownership.claimed
-        translation(:you_have_to_sign_in, bike_type: type,
-          scope: [:controllers, :bikes, :ensure_user_allowed_to_edit])
-      else
-        translation(:bike_has_not_been_claimed_yet, bike_type: type,
-          scope: [:controllers, :bikes, :ensure_user_allowed_to_edit])
+        # If current_user isn't authorized for the organization, force assign nil
+        return true if org.blank? || org.present? && current_user.authorized?(org)
+
+        set_passive_organization(nil)
       end
     end
 
-    return true unless error.present? # Can't assign directly to flash here, sometimes kick out of edit because other flash error
+    def find_bike
+      # Fix issue with sticker batches #35 & #38
+      if params[:id].present? && params[:id].match?(/scanned(uc|ui)\d+/i)
+        permitted_params = params.except(:action, :controller, :id).as_json
+          .merge(id: params[:id].gsub("scanned", ""))
+        redirect_to(scanned_bike_path(permitted_params))
+        return
+      end
+      begin
+        @bike = Bike.unscoped.find(params[:bike_id] || params[:id])
+      rescue ActiveRecord::StatementInvalid => e
+        raise e.to_s.match?(/PG..NumericValueOutOfRange/) ? ActiveRecord::RecordNotFound : e
+      end
+      return @bike if @bike.visible_by?(current_user)
 
-    flash[:error] = error
-    redirect_to(bike_path(@bike)) && return
-  end
-
-  def update_organizations_can_edit_claimed(bike, organization_ids)
-    organization_ids = Array(organization_ids).map(&:to_i)
-    bike.bike_organizations.each do |bike_organization|
-      bike_organization.update_attribute :can_not_edit_claimed, !organization_ids.include?(bike_organization.organization_id)
-    end
-  end
-
-  def assign_strava_gear
-    strava_integration = current_user&.strava_integration
-    unless strava_integration&.show_gear_link?
-      flash[:error] = "No synced Strava integration found."
-      return
+      fail ActiveRecord::RecordNotFound
     end
 
-    strava_gear_id = params[:strava_gear_id]
-    if strava_gear_id.blank?
+    def find_or_new_b_param
+      token = params[:b_param_token]
+      token ||= params.dig(:bike, :b_param_id_token)
+      @bike_sticker = BikeSticker.lookup_with_fallback(params[:bike_sticker], user: current_user)
+      @b_param = BParam.find_or_new_from_token(token, user_id: current_user&.id, bike_sticker: @bike_sticker)
+    end
+
+    def ensure_user_allowed_to_edit
+      @current_ownership = @bike.current_ownership
+      type = @bike&.type || "bike"
+
+      return true if @bike.authorize_and_claim_for_user(current_user)
+
+      if @bike.current_impound_record.present?
+        error = if @bike.current_impound_record.organized?
+          translation(:bike_impounded_by_organization, bike_type: type, org_name: @bike.current_impound_record.organization.name,
+            scope: [:controllers, :bikes, :ensure_user_allowed_to_edit])
+        else
+          translation(:bike_impounded, bike_type: type,
+            scope: [:controllers, :bikes, :ensure_user_allowed_to_edit])
+        end
+      elsif current_user.present?
+        error = translation(:you_dont_own_that, bike_type: type,
+          scope: [:controllers, :bikes, :ensure_user_allowed_to_edit])
+      else
+        store_return_to
+        error = if @current_ownership && @bike.current_ownership.claimed
+          translation(:you_have_to_sign_in, bike_type: type,
+            scope: [:controllers, :bikes, :ensure_user_allowed_to_edit])
+        else
+          translation(:bike_has_not_been_claimed_yet, bike_type: type,
+            scope: [:controllers, :bikes, :ensure_user_allowed_to_edit])
+        end
+      end
+
+      return true unless error.present? # Can't assign directly to flash here, sometimes kick out of edit because other flash error
+
+      flash[:error] = error
+      redirect_to(bike_path(@bike)) && return
+    end
+
+    def update_organizations_can_edit_claimed(bike, organization_ids)
+      organization_ids = Array(organization_ids).map(&:to_i)
+      bike.bike_organizations.each do |bike_organization|
+        bike_organization.update_attribute :can_not_edit_claimed, !organization_ids.include?(bike_organization.organization_id)
+      end
+    end
+
+    def assign_strava_gear
+      strava_integration = current_user&.strava_integration
+      unless strava_integration&.show_gear_link?
+        flash[:error] = "No synced Strava integration found."
+        return
+      end
+
+      strava_gear_id = params[:strava_gear_id]
+      if strava_gear_id.blank?
+        @bike.strava_gear&.update(item: nil)
+        flash[:success] = "Strava gear disconnected."
+        return
+      end
+
+      strava_gear = strava_integration.strava_gears.find_by(strava_id: strava_gear_id)
+      unless strava_gear
+        flash[:error] = "Strava gear not found."
+        return
+      end
+
       @bike.strava_gear&.update(item: nil)
-      flash[:success] = "Strava gear disconnected."
-      return
+      strava_gear.item = @bike
+      if strava_gear.save
+        flash[:success] = "Bike connected to Strava gear: #{strava_gear.strava_gear_display_name}"
+      else
+        flash[:error] = strava_gear.errors.full_messages.join(", ")
+      end
     end
 
-    strava_gear = strava_integration.strava_gears.find_by(strava_id: strava_gear_id)
-    unless strava_gear
-      flash[:error] = "Strava gear not found."
-      return
+    def assign_bike_stickers(bike_sticker)
+      bike_sticker = BikeSticker.lookup_with_fallback(bike_sticker)
+      unless bike_sticker.present?
+        return flash[:error] = translation(:unable_to_find_sticker, bike_sticker: bike_sticker,
+          scope: [:controllers, :bikes, :assign_bike_stickers])
+      end
+      bike_sticker.claim_if_permitted(user: current_user, bike: @bike)
+      if bike_sticker.errors.any?
+        flash[:error] = bike_sticker.errors.full_messages
+      else
+        flash[:success] = translation(:sticker_assigned, bike_sticker: bike_sticker.pretty_code, bike_type: @bike.type,
+          scope: [:controllers, :bikes, :assign_bike_stickers])
+      end
     end
 
-    @bike.strava_gear&.update(item: nil)
-    strava_gear.item = @bike
-    if strava_gear.save
-      flash[:success] = "Bike connected to Strava gear: #{strava_gear.strava_gear_display_name}"
-    else
-      flash[:error] = strava_gear.errors.full_messages.join(", ")
-    end
-  end
+    def find_token
+      # First, deal with claim_token
+      if params[:t].present? && @bike.current_ownership.token == params[:t]
+        @claim_message = @bike.current_ownership&.claim_message
+      end
+      # Then deal with parking notification and graduated notification tokens
+      @token = params[:parking_notification_retrieved].presence || params[:graduated_notification_remaining].presence
+      return false if @token.blank?
 
-  def assign_bike_stickers(bike_sticker)
-    bike_sticker = BikeSticker.lookup_with_fallback(bike_sticker)
-    unless bike_sticker.present?
-      return flash[:error] = translation(:unable_to_find_sticker, bike_sticker: bike_sticker,
-        scope: [:controllers, :bikes, :assign_bike_stickers])
+      if params[:parking_notification_retrieved].present?
+        @matching_notification = @bike.parking_notifications.where(retrieval_link_token: @token).first
+        @token_type = @matching_notification&.kind
+      elsif params[:graduated_notification_remaining].present?
+        @matching_notification = GraduatedNotification.where(bike_id: @bike.id, marked_remaining_link_token: @token).first
+        @token_type = "graduated_notification"
+      end
+      @token_type ||= "parked_incorrectly_notification" # Fallback
     end
-    bike_sticker.claim_if_permitted(user: current_user, bike: @bike)
-    if bike_sticker.errors.any?
-      flash[:error] = bike_sticker.errors.full_messages
-    else
-      flash[:success] = translation(:sticker_assigned, bike_sticker: bike_sticker.pretty_code, bike_type: @bike.type,
-        scope: [:controllers, :bikes, :assign_bike_stickers])
+
+    def scanned_id
+      params[:id] || params[:scanned_id] || params[:card_id]
     end
-  end
 
-  def find_token
-    # First, deal with claim_token
-    if params[:t].present? && @bike.current_ownership.token == params[:t]
-      @claim_message = @bike.current_ownership&.claim_message
+    # still manually managing permission of params, so skip it
+    def permitted_bparams
+      params.except(:parking_notification).as_json # We only want to include parking_notification in authorized endpoints
     end
-    # Then deal with parking notification and graduated notification tokens
-    @token = params[:parking_notification_retrieved].presence || params[:graduated_notification_remaining].presence
-    return false if @token.blank?
-
-    if params[:parking_notification_retrieved].present?
-      @matching_notification = @bike.parking_notifications.where(retrieval_link_token: @token).first
-      @token_type = @matching_notification&.kind
-    elsif params[:graduated_notification_remaining].present?
-      @matching_notification = GraduatedNotification.where(bike_id: @bike.id, marked_remaining_link_token: @token).first
-      @token_type = "graduated_notification"
-    end
-    @token_type ||= "parked_incorrectly_notification" # Fallback
-  end
-
-  def scanned_id
-    params[:id] || params[:scanned_id] || params[:card_id]
-  end
-
-  # still manually managing permission of params, so skip it
-  def permitted_bparams
-    params.except(:parking_notification).as_json # We only want to include parking_notification in authorized endpoints
   end
 end

--- a/app/controllers/bikes/edits_controller.rb
+++ b/app/controllers/bikes/edits_controller.rb
@@ -1,30 +1,32 @@
 # Note: Created this controller in #2133 so that it could be shared with bike_versions
 # ... also because it was nice to break out the existing setup
-class Bikes::EditsController < Bikes::BaseController
-  include BikeEditable
+module Bikes
+  class EditsController < Bikes::BaseController
+    include BikeEditable
 
-  def show
-    @page_errors = @bike.errors
-    return unless setup_edit_template(params[:edit_template]) # Returns nil if redirecting
+    def show
+      @page_errors = @bike.errors
+      return unless setup_edit_template(params[:edit_template]) # Returns nil if redirecting
 
-    @page_title = page_title_for(@edit_template, @bike)
+      @page_title = page_title_for(@edit_template, @bike)
 
-    if @edit_template == "photos"
-      @private_images = PublicImage
-        .unscoped
-        .where(imageable_type: "Bike")
-        .where(imageable_id: @bike.id)
-        .where(is_private: true)
-    elsif @edit_template == "remove"
-      @new_email_assigned = params[:owner_email].present? && @bike.owner_email != params[:owner_email]
-      if @new_email_assigned
-        @og_email = @bike.owner_email # so that edit_bike_skeleton doesn't show the wrong value
-        @bike.owner_email = params[:owner_email]
+      if @edit_template == "photos"
+        @private_images = PublicImage
+          .unscoped
+          .where(imageable_type: "Bike")
+          .where(imageable_id: @bike.id)
+          .where(is_private: true)
+      elsif @edit_template == "remove"
+        @new_email_assigned = params[:owner_email].present? && @bike.owner_email != params[:owner_email]
+        if @new_email_assigned
+          @og_email = @bike.owner_email # so that edit_bike_skeleton doesn't show the wrong value
+          @bike.owner_email = params[:owner_email]
+        end
       end
+
+      render :"/bikes_edit/#{@edit_template}"
     end
 
-    render :"/bikes_edit/#{@edit_template}"
+    private
   end
-
-  private
 end

--- a/app/controllers/bikes/recovery_controller.rb
+++ b/app/controllers/bikes/recovery_controller.rb
@@ -1,46 +1,48 @@
-class Bikes::RecoveryController < Bikes::BaseController
-  skip_before_action :ensure_user_allowed_to_edit
-  before_action :ensure_token_match!
+module Bikes
+  class RecoveryController < Bikes::BaseController
+    skip_before_action :ensure_user_allowed_to_edit
+    before_action :ensure_token_match!
 
-  def edit
-    # redirect to bike show and set session - so the token isn't available to on page js
-    # and so we can render show with a modal
-    session[:recovery_link_token] = params[:token]
-    redirect_to bike_path(@bike)
-  end
-
-  def update
-    if @stolen_record.add_recovery_information(permitted_params.to_h)
-      Email::RecoveredFromLinkJob.perform_async(@stolen_record.id)
-      flash[:success] = translation(:bike_recovered)
-    else
+    def edit
+      # redirect to bike show and set session - so the token isn't available to on page js
+      # and so we can render show with a modal
       session[:recovery_link_token] = params[:token]
+      redirect_to bike_path(@bike)
     end
-    redirect_to bike_path(@bike)
-  end
 
-  private
-
-  def permitted_params
-    params.require(:stolen_record).permit(
-      :recovered_at,
-      :timezone,
-      :recovered_description,
-      :index_helped_recovery,
-      :can_share_recovery
-    ).merge(recovering_user_id: current_user&.id)
-  end
-
-  def ensure_token_match!
-    @stolen_record = StolenRecord.find_matching_token(bike_id: @bike&.id,
-      recovery_link_token: params[:token])
-    if @stolen_record.present?
-      return true if @bike.status_stolen?
-
-      flash[:info] = translation(:already_recovered)
-    else
-      flash[:error] = translation(:incorrect_token)
+    def update
+      if @stolen_record.add_recovery_information(permitted_params.to_h)
+        Email::RecoveredFromLinkJob.perform_async(@stolen_record.id)
+        flash[:success] = translation(:bike_recovered)
+      else
+        session[:recovery_link_token] = params[:token]
+      end
+      redirect_to bike_path(@bike)
     end
-    redirect_to(bike_path(@bike)) && return
+
+    private
+
+    def permitted_params
+      params.require(:stolen_record).permit(
+        :recovered_at,
+        :timezone,
+        :recovered_description,
+        :index_helped_recovery,
+        :can_share_recovery
+      ).merge(recovering_user_id: current_user&.id)
+    end
+
+    def ensure_token_match!
+      @stolen_record = StolenRecord.find_matching_token(bike_id: @bike&.id,
+        recovery_link_token: params[:token])
+      if @stolen_record.present?
+        return true if @bike.status_stolen?
+
+        flash[:info] = translation(:already_recovered)
+      else
+        flash[:error] = translation(:incorrect_token)
+      end
+      redirect_to(bike_path(@bike)) && return
+    end
   end
 end

--- a/app/controllers/bikes/theft_alerts_controller.rb
+++ b/app/controllers/bikes/theft_alerts_controller.rb
@@ -1,87 +1,89 @@
-class Bikes::TheftAlertsController < Bikes::BaseController
-  include BikeEditable
+module Bikes
+  class TheftAlertsController < Bikes::BaseController
+    include BikeEditable
 
-  before_action :get_existing_theft_alerts, except: [:create]
+    before_action :get_existing_theft_alerts, except: [:create]
 
-  def new
-    return unless setup_edit_template("alert")
+    def new
+      return unless setup_edit_template("alert")
 
-    @theft_alert_plans = TheftAlertPlan.active.price_ordered_asc.in_language(I18n.locale)
-    @selected_theft_alert_plan =
-      @theft_alert_plans.find_by(id: params[:selected_plan_id]) ||
-      @theft_alert_plans.order(:amount_cents).second
-  end
-
-  def show
-    @payment = if params[:session_id].present?
-      Payment.where(stripe_id: params[:session_id]).first
+      @theft_alert_plans = TheftAlertPlan.active.price_ordered_asc.in_language(I18n.locale)
+      @selected_theft_alert_plan =
+        @theft_alert_plans.find_by(id: params[:selected_plan_id]) ||
+        @theft_alert_plans.order(:amount_cents).second
     end
 
-    redirect_to new_bike_theft_alert_path(bike_id: @bike.id) unless @payment.present?
-    return unless setup_edit_template("alert_purchase_confirmation")
+    def show
+      @payment = if params[:session_id].present?
+        Payment.where(stripe_id: params[:session_id]).first
+      end
 
-    @payment&.update_from_stripe!
-    if @payment.theft_alert&.activateable?
-      StolenBike::ActivateTheftAlertJob.perform_async(@payment.theft_alert.id)
+      redirect_to new_bike_theft_alert_path(bike_id: @bike.id) unless @payment.present?
+      return unless setup_edit_template("alert_purchase_confirmation")
+
+      @payment&.update_from_stripe!
+      if @payment.theft_alert&.activateable?
+        StolenBike::ActivateTheftAlertJob.perform_async(@payment.theft_alert.id)
+      end
     end
-  end
 
-  def create
-    theft_alert_plan = TheftAlertPlan.find(params[:theft_alert_plan_id])
-    theft_alert = TheftAlert.create!(
-      stolen_record: @bike.current_stolen_record,
-      theft_alert_plan: theft_alert_plan,
-      user: current_user
-    )
-    @payment = Payment.new(create_parameters(theft_alert))
-    @payment.stripe_checkout_session(item_name: product_description(theft_alert))
+    def create
+      theft_alert_plan = TheftAlertPlan.find(params[:theft_alert_plan_id])
+      theft_alert = TheftAlert.create!(
+        stolen_record: @bike.current_stolen_record,
+        theft_alert_plan: theft_alert_plan,
+        user: current_user
+      )
+      @payment = Payment.new(create_parameters(theft_alert))
+      @payment.stripe_checkout_session(item_name: product_description(theft_alert))
 
-    theft_alert.update(payment: @payment)
+      theft_alert.update(payment: @payment)
 
-    # Enqueue creation of the image with the specified image
-    StolenBike::AfterStolenRecordSaveJob.perform_async(@bike.current_stolen_record_id, false,
-      params[:selected_bike_image_id])
+      # Enqueue creation of the image with the specified image
+      StolenBike::AfterStolenRecordSaveJob.perform_async(@bike.current_stolen_record_id, false,
+        params[:selected_bike_image_id])
 
-    redirect_to @payment.stripe_checkout_session.url, allow_other_host: true
-  end
+      redirect_to @payment.stripe_checkout_session.url, allow_other_host: true
+    end
 
-  private
+    private
 
-  def create_parameters(theft_alert)
-    {
-      kind: "theft_alert",
-      payment_method: "stripe",
-      theft_alert: theft_alert,
-      amount_cents: theft_alert.amount_cents,
-      user_id: current_user.id,
-      email: current_user.email,
-      currency: params[:currency] || Currency.default.name # TODO: handle this better
-    }
-  end
+    def create_parameters(theft_alert)
+      {
+        kind: "theft_alert",
+        payment_method: "stripe",
+        theft_alert: theft_alert,
+        amount_cents: theft_alert.amount_cents,
+        user_id: current_user.id,
+        email: current_user.email,
+        currency: params[:currency] || Currency.default.name # TODO: handle this better
+      }
+    end
 
-  def current_customer_data
-    return {customer_email: current_user.email} if current_user.stripe_id.blank?
+    def current_customer_data
+      return {customer_email: current_user.email} if current_user.stripe_id.blank?
 
-    {customer: current_user.stripe_id}
-  end
+      {customer: current_user.stripe_id}
+    end
 
-  def product_description(theft_alert)
-    return params[:description] if params[:description].present?
+    def product_description(theft_alert)
+      return params[:description] if params[:description].present?
 
-    theft_alert.theft_alert_plan&.name
-  end
+      theft_alert.theft_alert_plan&.name
+    end
 
-  def get_existing_theft_alerts
-    return unless @bike&.current_stolen_record.present?
+    def get_existing_theft_alerts
+      return unless @bike&.current_stolen_record.present?
 
-    @theft_alerts = @bike.current_stolen_record
-      .theft_alerts
-      .includes(:theft_alert_plan)
-      .creation_ordered_desc
-      .references(:theft_alert_plan)
-    # Only show non-user theft_alerts to superuser
-    return @theft_alerts if current_user.superuser?
+      @theft_alerts = @bike.current_stolen_record
+        .theft_alerts
+        .includes(:theft_alert_plan)
+        .creation_ordered_desc
+        .references(:theft_alert_plan)
+      # Only show non-user theft_alerts to superuser
+      return @theft_alerts if current_user.superuser?
 
-    @theft_alerts = @theft_alerts.where(user: current_user)
+      @theft_alerts = @theft_alerts.where(user: current_user)
+    end
   end
 end

--- a/app/controllers/my_accounts/marketplace_listings_controller.rb
+++ b/app/controllers/my_accounts/marketplace_listings_controller.rb
@@ -1,76 +1,78 @@
 # frozen_string_literal: true
 
-class MyAccounts::MarketplaceListingsController < ApplicationController
-  before_action :find_marketplace_listing
-  before_action :ensure_user_allowed_to_edit!
+module MyAccounts
+  class MarketplaceListingsController < ApplicationController
+    before_action :find_marketplace_listing
+    before_action :ensure_user_allowed_to_edit!
 
-  def update
-    if @marketplace_listing.update(permitted_params_with_permitted_address)
-      if @marketplace_listing.just_published?
-        flash[:success] = translation(:item_published_for_sale, item_type: @bike&.type)
-      elsif @marketplace_listing.just_failed_to_publish?
-        @marketplace_listing.validate_publishable!
-        flash[:error] = translation(:unable_to_publish, item_type: @bike&.type,
-          errors: @marketplace_listing.errors.full_messages.to_sentence)
+    def update
+      if @marketplace_listing.update(permitted_params_with_permitted_address)
+        if @marketplace_listing.just_published?
+          flash[:success] = translation(:item_published_for_sale, item_type: @bike&.type)
+        elsif @marketplace_listing.just_failed_to_publish?
+          @marketplace_listing.validate_publishable!
+          flash[:error] = translation(:unable_to_publish, item_type: @bike&.type,
+            errors: @marketplace_listing.errors.full_messages.to_sentence)
+        else
+          flash[:success] ||= translation(:marketplace_listing_updated)
+        end
       else
-        flash[:success] ||= translation(:marketplace_listing_updated)
+        flash[:error] = translation(:unable_to_update, item_type: @bike&.type,
+          errors: @marketplace_listing.errors.full_messages.to_sentence)
       end
-    else
-      flash[:error] = translation(:unable_to_update, item_type: @bike&.type,
-        errors: @marketplace_listing.errors.full_messages.to_sentence)
+      return if return_to_if_present
+
+      edit_template = params[:edit_template] || "marketplace"
+      redirect_to edit_bike_url(@bike, edit_template:)
     end
-    return if return_to_if_present
 
-    edit_template = params[:edit_template] || "marketplace"
-    redirect_to edit_bike_url(@bike, edit_template:)
-  end
+    private
 
-  private
+    def permitted_params_with_permitted_address
+      pparams = permitted_params
 
-  def permitted_params_with_permitted_address
-    pparams = permitted_params
-
-    # Delete the address attributes if :user_account_address is set
-    if Binxtils::InputNormalizer.boolean(pparams[:address_record_attributes][:user_account_address])
-      pparams.delete(:address_record_attributes)
-      # NOTE: Not user, or else admin edits overwrite the user's address
-      pparams[:address_record_id] = @bike.user&.address_record_id
-    end
-    # Only update the address if it's a marketplace_listing address by the item's user
-    if (address_record_id = pparams.dig(:address_record_attributes, :id))
-      unless AddressRecord.marketplace_listing.where(user_id: @bike.user&.id, id: address_record_id).any?
-        pparams[:address_record_attributes].delete(:id)
-        # reassign to the marketplace_listing's address_record ID if that's what should be done
-        if @marketplace_listing.address_record&.kind == "marketplace_listing"
-          pparams[:address_record_attributes][:id] = @marketplace_listing.address_record_id
+      # Delete the address attributes if :user_account_address is set
+      if Binxtils::InputNormalizer.boolean(pparams[:address_record_attributes][:user_account_address])
+        pparams.delete(:address_record_attributes)
+        # NOTE: Not user, or else admin edits overwrite the user's address
+        pparams[:address_record_id] = @bike.user&.address_record_id
+      end
+      # Only update the address if it's a marketplace_listing address by the item's user
+      if (address_record_id = pparams.dig(:address_record_attributes, :id))
+        unless AddressRecord.marketplace_listing.where(user_id: @bike.user&.id, id: address_record_id).any?
+          pparams[:address_record_attributes].delete(:id)
+          # reassign to the marketplace_listing's address_record ID if that's what should be done
+          if @marketplace_listing.address_record&.kind == "marketplace_listing"
+            pparams[:address_record_attributes][:id] = @marketplace_listing.address_record_id
+          end
         end
       end
+      pparams.delete(:status) unless %w[draft for_sale].include?(pparams[:status])
+
+      pparams
     end
-    pparams.delete(:status) unless %w[draft for_sale].include?(pparams[:status])
 
-    pparams
-  end
+    def permitted_params
+      params.require(:marketplace_listing)
+        .permit(:condition, :amount_with_nil, :price_negotiable, :description, :status,
+          :primary_activity_id,
+          address_record_attributes: (AddressRecord.permitted_params + %i[id user_account_address]))
+    end
 
-  def permitted_params
-    params.require(:marketplace_listing)
-      .permit(:condition, :amount_with_nil, :price_negotiable, :description, :status,
-        :primary_activity_id,
-        address_record_attributes: (AddressRecord.permitted_params + %i[id user_account_address]))
-  end
+    def find_marketplace_listing
+      @bike = Bike.unscoped.find(params[:id].delete_prefix("b"))
+      ml_id = params.dig(:marketplace_listing, :id)
 
-  def find_marketplace_listing
-    @bike = Bike.unscoped.find(params[:id].delete_prefix("b"))
-    ml_id = params.dig(:marketplace_listing, :id)
+      @marketplace_listing = @bike.marketplace_listings.find_by(id: ml_id) if ml_id.present?
+      @marketplace_listing ||= MarketplaceListing.find_or_build_current_for(@bike)
+    end
 
-    @marketplace_listing = @bike.marketplace_listings.find_by(id: ml_id) if ml_id.present?
-    @marketplace_listing ||= MarketplaceListing.find_or_build_current_for(@bike)
-  end
+    def ensure_user_allowed_to_edit!
+      # return if @marketplace_listing&.authorized?(current_user)
+      return if @bike&.authorized?(current_user)
 
-  def ensure_user_allowed_to_edit!
-    # return if @marketplace_listing&.authorized?(current_user)
-    return if @bike&.authorized?(current_user)
-
-    flash[:error] = translation(:you_dont_own_that, item_type: @bike&.type)
-    redirect_back(fallback_location: user_root_url) && return
+      flash[:error] = translation(:you_dont_own_that, item_type: @bike&.type)
+      redirect_back(fallback_location: user_root_url) && return
+    end
   end
 end

--- a/app/controllers/my_accounts/messages_controller.rb
+++ b/app/controllers/my_accounts/messages_controller.rb
@@ -1,93 +1,95 @@
-class MyAccounts::MessagesController < ApplicationController
-  include Sessionable
+module MyAccounts
+  class MessagesController < ApplicationController
+    include Sessionable
 
-  before_action :authenticate_user_for_my_accounts_controller
+    before_action :authenticate_user_for_my_accounts_controller
 
-  def index
-    params[:page] || 1
-    @per_page = permitted_per_page(default: 50)
-    @marketplace_messages = matching_marketplace_messages
-    @pagy, @marketplace_messages = pagy(:countish, matching_marketplace_messages
-      .includes(:marketplace_listing, :sender, :receiver, :initial_record), limit: @per_page, page: permitted_page)
-  end
-
-  def show
-    if new_message_to_self?
-      flash[:notice] = translation(:sorry_that_is_you)
-      redirect_back(fallback_location: bike_path(@marketplace_listing.item_id)) && return
+    def index
+      params[:page] || 1
+      @per_page = permitted_per_page(default: 50)
+      @marketplace_messages = matching_marketplace_messages
+      @pagy, @marketplace_messages = pagy(:countish, matching_marketplace_messages
+        .includes(:marketplace_listing, :sender, :receiver, :initial_record), limit: @per_page, page: permitted_page)
     end
 
-    @marketplace_messages = matching_marketplace_thread
-    @initial_record = @marketplace_messages.first
+    def show
+      if new_message_to_self?
+        flash[:notice] = translation(:sorry_that_is_you)
+        redirect_back(fallback_location: bike_path(@marketplace_listing.item_id)) && return
+      end
 
-    @marketplace_listing = if @marketplace_messages.none?
-      decoded_marketplace_listing
-    else
-      @initial_record.marketplace_listing
+      @marketplace_messages = matching_marketplace_thread
+      @initial_record = @marketplace_messages.first
+
+      @marketplace_listing = if @marketplace_messages.none?
+        decoded_marketplace_listing
+      else
+        @initial_record.marketplace_listing
+      end
+
+      # raises if can't see
+      @can_send_message = verify_can_see_message!(@marketplace_listing, @initial_record)
+
+      if @can_send_message
+        @marketplace_message = MarketplaceMessage.new(marketplace_listing_id: @marketplace_listing.id, initial_record_id: @initial_record&.id)
+      end
     end
 
-    # raises if can't see
-    @can_send_message = verify_can_see_message!(@marketplace_listing, @initial_record)
+    def create
+      @marketplace_message = MarketplaceMessage.new(permitted_params)
 
-    if @can_send_message
-      @marketplace_message = MarketplaceMessage.new(marketplace_listing_id: @marketplace_listing.id, initial_record_id: @initial_record&.id)
+      @marketplace_listing ||= @marketplace_message.marketplace_listing # enables rendering!
+
+      # raises if can't see
+      @can_send_message = verify_can_see_message!(@marketplace_listing, @marketplace_message)
+
+      if !@marketplace_message.can_send?
+        flash[:error] = translation(:can_not_send_message)
+        render :show
+      elsif @marketplace_message.ignored_duplicate? || @marketplace_message.save
+        flash[:success] = translation(:message_sent)
+        redirect_to my_account_messages_path
+      else
+        render :show
+      end
     end
-  end
 
-  def create
-    @marketplace_message = MarketplaceMessage.new(permitted_params)
+    private
 
-    @marketplace_listing ||= @marketplace_message.marketplace_listing # enables rendering!
-
-    # raises if can't see
-    @can_send_message = verify_can_see_message!(@marketplace_listing, @marketplace_message)
-
-    if !@marketplace_message.can_send?
-      flash[:error] = translation(:can_not_send_message)
-      render :show
-    elsif @marketplace_message.ignored_duplicate? || @marketplace_message.save
-      flash[:success] = translation(:message_sent)
-      redirect_to my_account_messages_path
-    else
-      render :show
+    def permitted_params
+      params.require(:marketplace_message)
+        .permit(:initial_record_id, :marketplace_listing_id, :subject, :body)
+        .merge(sender_id: current_user.id)
     end
-  end
 
-  private
+    def verify_can_see_message!(marketplace_listing, marketplace_message)
+      raise ActiveRecord::RecordNotFound unless MarketplaceMessage.can_see_messages?(
+        user: current_user, marketplace_listing:, marketplace_message:
+      )
 
-  def permitted_params
-    params.require(:marketplace_message)
-      .permit(:initial_record_id, :marketplace_listing_id, :subject, :body)
-      .merge(sender_id: current_user.id)
-  end
+      MarketplaceMessage.can_send_message?(user: current_user, marketplace_listing:, marketplace_message:)
+    end
 
-  def verify_can_see_message!(marketplace_listing, marketplace_message)
-    raise ActiveRecord::RecordNotFound unless MarketplaceMessage.can_see_messages?(
-      user: current_user, marketplace_listing:, marketplace_message:
-    )
+    def decoded_marketplace_listing
+      MarketplaceListing.find(
+        MarketplaceMessage.decoded_marketplace_listing_id(user: current_user, id: params[:id])
+      )
+    end
 
-    MarketplaceMessage.can_send_message?(user: current_user, marketplace_listing:, marketplace_message:)
-  end
+    def matching_marketplace_thread
+      MarketplaceMessage.thread_for!(user: current_user, id: params[:id])
+    end
 
-  def decoded_marketplace_listing
-    MarketplaceListing.find(
-      MarketplaceMessage.decoded_marketplace_listing_id(user: current_user, id: params[:id])
-    )
-  end
+    def matching_marketplace_messages
+      MarketplaceMessage.threads_for_user(current_user)
+    end
 
-  def matching_marketplace_thread
-    MarketplaceMessage.thread_for!(user: current_user, id: params[:id])
-  end
+    def new_message_to_self?
+      marketplace_listing_id = MarketplaceMessage.decoded_marketplace_listing_id(id: params[:id])
+      return false if marketplace_listing_id.blank?
 
-  def matching_marketplace_messages
-    MarketplaceMessage.threads_for_user(current_user)
-  end
-
-  def new_message_to_self?
-    marketplace_listing_id = MarketplaceMessage.decoded_marketplace_listing_id(id: params[:id])
-    return false if marketplace_listing_id.blank?
-
-    @marketplace_listing = MarketplaceListing.find_by_id(marketplace_listing_id)
-    @marketplace_listing&.seller_id == current_user.id
+      @marketplace_listing = MarketplaceListing.find_by_id(marketplace_listing_id)
+      @marketplace_listing&.seller_id == current_user.id
+    end
   end
 end

--- a/app/controllers/search/marketplace_controller.rb
+++ b/app/controllers/search/marketplace_controller.rb
@@ -1,107 +1,109 @@
 # frozen_string_literal: true
 
-class Search::MarketplaceController < ApplicationController
-  MAX_INDEX_PAGE = 100
-  DEFAULT_DISTANCE = 50
-  before_action :render_ad
-  before_action :set_interpreted_params
-  around_action :set_reading_role
+module Search
+  class MarketplaceController < ApplicationController
+    MAX_INDEX_PAGE = 100
+    DEFAULT_DISTANCE = 50
+    before_action :render_ad
+    before_action :set_interpreted_params
+    around_action :set_reading_role
 
-  def index
-    @render_results = Binxtils::InputNormalizer.boolean(params[:search_no_js]) || turbo_request?
-    @is_marketplace = true
+    def index
+      @render_results = Binxtils::InputNormalizer.boolean(params[:search_no_js]) || turbo_request?
+      @is_marketplace = true
 
-    if @render_results
-      @pagy, @bikes = pagy(:countish, searched_bikes.reorder("marketplace_listings.published_at DESC"),
-        limit: 12, page: @page, max_pages: MAX_INDEX_PAGE)
+      if @render_results
+        @pagy, @bikes = pagy(:countish, searched_bikes.reorder("marketplace_listings.published_at DESC"),
+          limit: 12, page: @page, max_pages: MAX_INDEX_PAGE)
+      end
+
+      respond_to do |format|
+        format.html
+        format.turbo_stream
+      end
     end
 
-    respond_to do |format|
-      format.html
-      format.turbo_stream
-    end
-  end
-
-  def counts
-    render json: {
-      for_sale: searched_bikes_not_proximity.count, for_sale_proximity: searched_bikes_proximity.count
-    }
-  end
-
-  private
-
-  def permitted_scopes
-    %w[for_sale for_sale_proximity].freeze
-  end
-
-  def searched_bikes
-    @interpreted_params[:bounding_box].blank? ? searched_bikes_not_proximity : searched_bikes_proximity
-  end
-
-  def searched_bikes_not_proximity
-    bikes = Bike.search(@interpreted_params).for_sale
-
-    # Not doing anything with currency yet, so always use default
-    @currency = Currency.default
-    @price_min_amount = amount_for(listing_search_params[:price_min_amount])
-    @price_max_amount = amount_for(listing_search_params[:price_max_amount])
-
-    MarketplaceListing.search(bikes, price_min_amount: @price_min_amount, price_max_amount: @price_max_amount)
-  end
-
-  def searched_bikes_proximity
-    searched_bikes_not_proximity.within_bounding_box(@interpreted_params[:bounding_box])
-  end
-
-  def proximity_hash
-    location, coordinates = BikeSearchable.search_location(params[:location], forwarded_ip_address)
-    return {} if location.blank?
-
-    distance = GeocodeHelper.permitted_distance(params[:distance], default_distance: DEFAULT_DISTANCE)
-    bounding_box = if coordinates.present?
-      GeocodeHelper.bounding_box(coordinates, distance)
-    else
-      GeocodeHelper.bounding_box(location, distance)
-    end
-    return {} if bounding_box.empty?
-
-    {distance:, location:, bounding_box:}
-  end
-
-  def set_interpreted_params
-    @interpreted_params = BikeSearchable.searchable_interpreted_params(permitted_search_params, ip: forwarded_ip_address)
-    @marketplace_scope = permitted_scopes.include?(params[:marketplace_scope]) ? params[:marketplace_scope] : permitted_scopes.first
-    if @marketplace_scope == "for_sale_proximity" || action_name == "counts"
-      @interpreted_params.merge!(proximity_hash)
+    def counts
+      render json: {
+        for_sale: searched_bikes_not_proximity.count, for_sale_proximity: searched_bikes_proximity.count
+      }
     end
 
-    if @marketplace_scope == "for_sale_proximity" && @interpreted_params[:bounding_box].blank?
-      flash.now[:notice] = translation(:we_dont_know_location, location: params[:location])
+    private
+
+    def permitted_scopes
+      %w[for_sale for_sale_proximity].freeze
     end
 
-    @page = permitted_page(max: MAX_INDEX_PAGE)
-    @search_kind = :marketplace
-    @search_obj_name = "Listings"
-    @result_view = SearchResults::Container::Component
-      .permitted_result_view(params[:search_result_view], default: :thumbnail)
-  end
+    def searched_bikes
+      @interpreted_params[:bounding_box].blank? ? searched_bikes_not_proximity : searched_bikes_proximity
+    end
 
-  def permitted_search_params
-    # Switching to for_sale will get location, but it doesn't currently work
-    params.permit(*Bike.permitted_search_params).merge(stolenness: "all")
-  end
+    def searched_bikes_not_proximity
+      bikes = Bike.search(@interpreted_params).for_sale
 
-  def listing_search_params
-    params.permit(:currency, :price_min_amount, :price_max_amount)
-  end
+      # Not doing anything with currency yet, so always use default
+      @currency = Currency.default
+      @price_min_amount = amount_for(listing_search_params[:price_min_amount])
+      @price_max_amount = amount_for(listing_search_params[:price_max_amount])
 
-  def amount_for(value)
-    return nil if value.blank?
+      MarketplaceListing.search(bikes, price_min_amount: @price_min_amount, price_max_amount: @price_max_amount)
+    end
 
-    value.to_f
-  end
+    def searched_bikes_proximity
+      searched_bikes_not_proximity.within_bounding_box(@interpreted_params[:bounding_box])
+    end
 
-  def render_ad
-    @ad = true
+    def proximity_hash
+      location, coordinates = BikeSearchable.search_location(params[:location], forwarded_ip_address)
+      return {} if location.blank?
+
+      distance = GeocodeHelper.permitted_distance(params[:distance], default_distance: DEFAULT_DISTANCE)
+      bounding_box = if coordinates.present?
+        GeocodeHelper.bounding_box(coordinates, distance)
+      else
+        GeocodeHelper.bounding_box(location, distance)
+      end
+      return {} if bounding_box.empty?
+
+      {distance:, location:, bounding_box:}
+    end
+
+    def set_interpreted_params
+      @interpreted_params = BikeSearchable.searchable_interpreted_params(permitted_search_params, ip: forwarded_ip_address)
+      @marketplace_scope = permitted_scopes.include?(params[:marketplace_scope]) ? params[:marketplace_scope] : permitted_scopes.first
+      if @marketplace_scope == "for_sale_proximity" || action_name == "counts"
+        @interpreted_params.merge!(proximity_hash)
+      end
+
+      if @marketplace_scope == "for_sale_proximity" && @interpreted_params[:bounding_box].blank?
+        flash.now[:notice] = translation(:we_dont_know_location, location: params[:location])
+      end
+
+      @page = permitted_page(max: MAX_INDEX_PAGE)
+      @search_kind = :marketplace
+      @search_obj_name = "Listings"
+      @result_view = SearchResults::Container::Component
+        .permitted_result_view(params[:search_result_view], default: :thumbnail)
+    end
+
+    def permitted_search_params
+      # Switching to for_sale will get location, but it doesn't currently work
+      params.permit(*Bike.permitted_search_params).merge(stolenness: "all")
+    end
+
+    def listing_search_params
+      params.permit(:currency, :price_min_amount, :price_max_amount)
+    end
+
+    def amount_for(value)
+      return nil if value.blank?
+
+      value.to_f
+    end
+
+    def render_ad
+      @ad = true
+    end
   end
 end

--- a/app/controllers/search/registrations_controller.rb
+++ b/app/controllers/search/registrations_controller.rb
@@ -1,65 +1,67 @@
-class Search::RegistrationsController < ApplicationController
-  MAX_INDEX_PAGE = 100
-  before_action :render_ad
-  before_action :set_interpreted_params
-  around_action :set_reading_role
+module Search
+  class RegistrationsController < ApplicationController
+    MAX_INDEX_PAGE = 100
+    before_action :render_ad
+    before_action :set_interpreted_params
+    around_action :set_reading_role
 
-  def index
-    if params[:stolenness] == "for_sale"
-      redirect_to search_marketplace_path(marketplace_redirect_params) and return
+    def index
+      if params[:stolenness] == "for_sale"
+        redirect_to search_marketplace_path(marketplace_redirect_params) and return
+      end
+
+      @render_results = Binxtils::InputNormalizer.boolean(params[:search_no_js]) || turbo_request?
+
+      if @render_results
+        @pagy, @bikes = pagy(:countish, Bike.search(@interpreted_params), limit:, page: @page,
+          max_pages: MAX_INDEX_PAGE)
+      end
+
+      respond_to do |format|
+        format.html
+        format.turbo_stream
+      end
     end
 
-    @render_results = Binxtils::InputNormalizer.boolean(params[:search_no_js]) || turbo_request?
-
-    if @render_results
-      @pagy, @bikes = pagy(:countish, Bike.search(@interpreted_params), limit:, page: @page,
+    def similar_serials
+      @pagy, @bikes = pagy(:countish, Bike.search_close_serials(@interpreted_params), limit:, page: @page,
         max_pages: MAX_INDEX_PAGE)
     end
 
-    respond_to do |format|
-      format.html
-      format.turbo_stream
-    end
-  end
-
-  def similar_serials
-    @pagy, @bikes = pagy(:countish, Bike.search_close_serials(@interpreted_params), limit:, page: @page,
-      max_pages: MAX_INDEX_PAGE)
-  end
-
-  def serials_containing
-    @pagy, @bikes = pagy(:countish, Bike.search_serials_containing(@interpreted_params), limit:, page: @page,
-      max_pages: MAX_INDEX_PAGE)
-  end
-
-  private
-
-  def limit
-    10
-  end
-
-  def set_interpreted_params
-    @interpreted_params = BikeSearchable.searchable_interpreted_params(permitted_search_params, ip: forwarded_ip_address)
-
-    if params[:stolenness] == "proximity" && @interpreted_params[:stolenness] != "proximity"
-      flash.now[:notice] = translation(:we_dont_know_location, location: params[:location])
+    def serials_containing
+      @pagy, @bikes = pagy(:countish, Bike.search_serials_containing(@interpreted_params), limit:, page: @page,
+        max_pages: MAX_INDEX_PAGE)
     end
 
-    @page = permitted_page(max: MAX_INDEX_PAGE)
-    @search_kind = :registration
-    @result_view = params[:search_result_view] || :bike_boxes
-    @result_view = SearchResults::Container::Component.permitted_result_view(params[:search_result_view])
-  end
+    private
 
-  def permitted_search_params
-    params.permit(*Bike.permitted_search_params)
-  end
+    def limit
+      10
+    end
 
-  def render_ad
-    @ad = true
-  end
+    def set_interpreted_params
+      @interpreted_params = BikeSearchable.searchable_interpreted_params(permitted_search_params, ip: forwarded_ip_address)
 
-  def marketplace_redirect_params
-    @interpreted_params.except(:stolenness).merge(search_no_js: params[:search_no_js]).to_h
+      if params[:stolenness] == "proximity" && @interpreted_params[:stolenness] != "proximity"
+        flash.now[:notice] = translation(:we_dont_know_location, location: params[:location])
+      end
+
+      @page = permitted_page(max: MAX_INDEX_PAGE)
+      @search_kind = :registration
+      @result_view = params[:search_result_view] || :bike_boxes
+      @result_view = SearchResults::Container::Component.permitted_result_view(params[:search_result_view])
+    end
+
+    def permitted_search_params
+      params.permit(*Bike.permitted_search_params)
+    end
+
+    def render_ad
+      @ad = true
+    end
+
+    def marketplace_redirect_params
+      @interpreted_params.except(:stolenness).merge(search_no_js: params[:search_no_js]).to_h
+    end
   end
 end

--- a/app/helpers/admin/external_registry_credential_helper.rb
+++ b/app/helpers/admin/external_registry_credential_helper.rb
@@ -1,17 +1,19 @@
-module Admin::ExternalRegistryCredentialHelper
-  def external_registry_type_options(selected:)
-    types = ExternalRegistryCredential.types
-    labels = types.map { |type| type.split("::").last }
-    options_for_select(labels.zip(types), selected)
-  end
+module Admin
+  module ExternalRegistryCredentialHelper
+    def external_registry_type_options(selected:)
+      types = ExternalRegistryCredential.types
+      labels = types.map { |type| type.split("::").last }
+      options_for_select(labels.zip(types), selected)
+    end
 
-  def external_registry_credential_expires_in(external_registry_credential)
-    expiration_dt = external_registry_credential.access_token_expires_at
+    def external_registry_credential_expires_in(external_registry_credential)
+      expiration_dt = external_registry_credential.access_token_expires_at
 
-    return if expiration_dt.blank?
-    return "unset" if external_registry_credential.access_token.blank?
-    return "expired" unless external_registry_credential.access_token_valid?
+      return if expiration_dt.blank?
+      return "unset" if external_registry_credential.access_token.blank?
+      return "expired" unless external_registry_credential.access_token_valid?
 
-    distance_of_time_in_words(Time.current, expiration_dt)
+      distance_of_time_in_words(Time.current, expiration_dt)
+    end
   end
 end

--- a/app/jobs/backfills/address_record_force_geocode_job.rb
+++ b/app/jobs/backfills/address_record_force_geocode_job.rb
@@ -1,11 +1,13 @@
 # frozen_string_literal: true
 
-class Backfills::AddressRecordForceGeocodeJob < ApplicationJob
-  sidekiq_options queue: "low_priority", retry: false
+module Backfills
+  class AddressRecordForceGeocodeJob < ApplicationJob
+    sidekiq_options queue: "low_priority", retry: false
 
-  def perform(id)
-    address_record = AddressRecord.find(id)
+    def perform(id)
+      address_record = AddressRecord.find(id)
 
-    address_record.update(force_geocoding: true)
+      address_record.update(force_geocoding: true)
+    end
   end
 end

--- a/app/jobs/callback_job/address_record_update_associations_job.rb
+++ b/app/jobs/callback_job/address_record_update_associations_job.rb
@@ -1,49 +1,51 @@
 # frozen_string_literal: true
 
-class CallbackJob::AddressRecordUpdateAssociationsJob < ApplicationJob
-  sidekiq_options queue: "med_priority"
+module CallbackJob
+  class AddressRecordUpdateAssociationsJob < ApplicationJob
+    sidekiq_options queue: "med_priority"
 
-  def perform(address_record_id)
-    address_record = AddressRecord.find_by(id: address_record_id)
-    return if address_record.blank?
+    def perform(address_record_id)
+      address_record = AddressRecord.find_by(id: address_record_id)
+      return if address_record.blank?
 
-    if address_record.user? && address_record.user.present?
-      address_record.user.address_record_id ||= address_record.id
+      if address_record.user? && address_record.user.present?
+        address_record.user.address_record_id ||= address_record.id
 
-      if address_record.user.address_record_id == address_record.id
-        update_association(address_record, address_record.user)
+        if address_record.user.address_record_id == address_record.id
+          update_association(address_record, address_record.user)
+        end
+      elsif address_record.organization?
+        location = Location.find_by(address_record_id: address_record.id)
+        update_association(address_record, location) if location.present?
+      elsif address_record.impounded_from?
+        update_from_impound_record(address_record)
+      elsif address_record.kind.blank?
+        # Currently just handles marketplace_listings, but can be easily updated!
+        if address_record.marketplace_listings.any?
+          address_record.kind = :marketplace_listing
+          address_record.user_id ||= address_record.marketplace_listings.first.seller_id
+          address_record.update(skip_callback_job: true)
+        end
       end
-    elsif address_record.organization?
-      location = Location.find_by(address_record_id: address_record.id)
-      update_association(address_record, location) if location.present?
-    elsif address_record.impounded_from?
-      update_from_impound_record(address_record)
-    elsif address_record.kind.blank?
-      # Currently just handles marketplace_listings, but can be easily updated!
-      if address_record.marketplace_listings.any?
-        address_record.kind = :marketplace_listing
-        address_record.user_id ||= address_record.marketplace_listings.first.seller_id
-        address_record.update(skip_callback_job: true)
-      end
+
+      address_record.marketplace_listings.each { update_association(address_record, it) }
     end
 
-    address_record.marketplace_listings.each { update_association(address_record, it) }
-  end
+    private
 
-  private
+    def update_association(address_record, association)
+      association.latitude = address_record.latitude
+      association.longitude = address_record.longitude
+      association.update(skip_update: true) if association.changed?
+    end
 
-  def update_association(address_record, association)
-    association.latitude = address_record.latitude
-    association.longitude = address_record.longitude
-    association.update(skip_update: true) if association.changed?
-  end
+    def update_from_impound_record(address_record)
+      impound_record = ImpoundRecord.find_by(impounded_from_address_record_id: address_record.id)
+      return unless impound_record.present?
 
-  def update_from_impound_record(address_record)
-    impound_record = ImpoundRecord.find_by(impounded_from_address_record_id: address_record.id)
-    return unless impound_record.present?
-
-    address_record.bike_id ||= impound_record.bike_id
-    address_record.user_id ||= impound_record.user_id
-    address_record.save if address_record.changed?
+      address_record.bike_id ||= impound_record.bike_id
+      address_record.user_id ||= impound_record.user_id
+      address_record.save if address_record.changed?
+    end
   end
 end

--- a/app/jobs/callback_job/after_bike_save_job.rb
+++ b/app/jobs/callback_job/after_bike_save_job.rb
@@ -1,118 +1,120 @@
 # frozen_string_literal: true
 
-class CallbackJob::AfterBikeSaveJob < ApplicationJob
-  sidekiq_options retry: false
+module CallbackJob
+  class AfterBikeSaveJob < ApplicationJob
+    sidekiq_options retry: false
 
-  POST_URL = ENV["BIKE_WEBHOOK_URL"]
-  AUTH_TOKEN = ENV["BIKE_WEBHOOK_AUTH_TOKEN"]
+    POST_URL = ENV["BIKE_WEBHOOK_URL"]
+    AUTH_TOKEN = ENV["BIKE_WEBHOOK_AUTH_TOKEN"]
 
-  def perform(bike_id, skip_user_update = false, resave_bike = false)
-    bike = Bike.unscoped.where(id: bike_id).first
-    return true unless bike.present?
+    def perform(bike_id, skip_user_update = false, resave_bike = false)
+      bike = Bike.unscoped.where(id: bike_id).first
+      return true unless bike.present?
 
-    bike.update(updated_at: Time.current) && bike.reload if resave_bike
-    bike.load_external_images
-    update_matching_partial_registrations(bike)
-    DuplicateBikeFinderJob.perform_async(bike_id)
-    if bike.present? && bike.listing_order != bike.calculated_listing_order
-      bike.update_attribute :listing_order, bike.calculated_listing_order
+      bike.update(updated_at: Time.current) && bike.reload if resave_bike
+      bike.load_external_images
+      update_matching_partial_registrations(bike)
+      DuplicateBikeFinderJob.perform_async(bike_id)
+      if bike.present? && bike.listing_order != bike.calculated_listing_order
+        bike.update_attribute :listing_order, bike.calculated_listing_order
+      end
+      create_user_registration_organizations(bike)
+      update_ownership(bike)
+      update_coordinates(bike)
+      unless skip_user_update
+        # Update the user to update any user alerts relevant to bikes
+        CallbackJob::AfterUserChangeJob.new.perform(bike.owner.id, bike.owner.reload, true) if bike.owner.present?
+      end
+      bike.bike_versions.each do |bike_version|
+        bike_version.set_calculated_attributes
+        bike_version.save if bike_version.changed?
+      end
+      bike.update_column :credibility_score, bike.credibility_scorer.score
+      if FindOrCreateModelAuditJob.enqueue_for?(bike)
+        FindOrCreateModelAuditJob.perform_async(bike.id)
+      end
+      # Bump marketplace_listing to bust caches
+      bike.current_marketplace_listing&.update(updated_at: Time.current)
+      return true unless bike.status_stolen? # For now, only hooking on stolen bikes
+
+      StolenBike::AfterStolenRecordSaveJob.perform_async(bike.current_stolen_record_id)
+      post_bike_to_webhook(serialized(bike))
     end
-    create_user_registration_organizations(bike)
-    update_ownership(bike)
-    update_coordinates(bike)
-    unless skip_user_update
-      # Update the user to update any user alerts relevant to bikes
-      CallbackJob::AfterUserChangeJob.new.perform(bike.owner.id, bike.owner.reload, true) if bike.owner.present?
-    end
-    bike.bike_versions.each do |bike_version|
-      bike_version.set_calculated_attributes
-      bike_version.save if bike_version.changed?
-    end
-    bike.update_column :credibility_score, bike.credibility_scorer.score
-    if FindOrCreateModelAuditJob.enqueue_for?(bike)
-      FindOrCreateModelAuditJob.perform_async(bike.id)
-    end
-    # Bump marketplace_listing to bust caches
-    bike.current_marketplace_listing&.update(updated_at: Time.current)
-    return true unless bike.status_stolen? # For now, only hooking on stolen bikes
 
-    StolenBike::AfterStolenRecordSaveJob.perform_async(bike.current_stolen_record_id)
-    post_bike_to_webhook(serialized(bike))
-  end
+    def post_bike_to_webhook(post_body)
+      return true unless POST_URL.present?
 
-  def post_bike_to_webhook(post_body)
-    return true unless POST_URL.present?
-
-    Faraday.new(url: POST_URL).post do |req|
-      req.headers["Content-Type"] = "application/json"
-      req.body = post_body.to_json
-    end
-  end
-
-  def serialized(bike)
-    {
-      auth_token: AUTH_TOKEN,
-      bike: BikeV2ShowSerializer.new(bike, root: false).as_json,
-      update: bike.created_at > Time.current - 30.seconds
-    }
-  end
-
-  def update_matching_partial_registrations(bike)
-    return true unless bike.created_at > Time.current - 5.minutes # skip unless new bike
-
-    matches = BParam.partial_registrations.without_bike.where("email ilike ?", "%#{bike.owner_email}%")
-      .reorder(:created_at)
-    if matches.count > 1
-      # Try to make it a little more accurate lookup
-      best_matches = matches.select { |b_param| b_param.manufacturer_id == bike.manufacturer_id }
-      matches = best_matches if matches.any?
-    end
-    matching_b_param = matches.last # Because we want the last created
-    return true unless matching_b_param.present?
-
-    matching_b_param.update(created_bike_id: bike.id)
-    # Only set ownership
-    ownership = bike.current_ownership
-    if ownership.present? && ownership.origin == "web" && ownership.organization_id.blank?
-      ownership.organization_id = matching_b_param.organization_id
-      ownership.origin = matching_b_param.origin if (Ownership.origins - ["web"]).include?(matching_b_param.origin)
-      ownership.save
-      if matching_b_param.organization_id.present?
-        bike.update(creation_organization_id: matching_b_param.organization_id)
-        bike.bike_organizations.create(organization_id: matching_b_param.organization_id)
+      Faraday.new(url: POST_URL).post do |req|
+        req.headers["Content-Type"] = "application/json"
+        req.body = post_body.to_json
       end
     end
-  end
 
-  # Bump registration_info attributes on ownerships
-  def update_ownership(bike)
-    bike.current_ownership&.update(updated_at: Time.current)
-  end
-
-  # If the bike address_record was geocoded after save, update the bike
-  def update_coordinates(bike)
-    return if bike.address_record.blank? ||
-      %w[bike_update initial_creation].exclude?(BikeServices::CalculateLocation.registration_address_source(bike)) ||
-      bike.address_record.latitude == bike.latitude && bike.address_record.longitude == bike.longitude
-
-    bike.update_columns(latitude: bike.address_record.latitude, longitude: bike.address_record.longitude)
-  end
-
-  def create_user_registration_organizations(bike)
-    return if bike.reload.user.blank?
-
-    bike.bike_organizations.each do |bike_organization|
-      # If there is notification that is graduated for the organization, don't create new reg organizations
-      organization = bike_organization.organization
-      next if organization.blank? || UserRegistrationOrganization.unscoped
-        .where(user_id: bike.user.id, organization_id: organization.id).any?
-
-      user_registration_organization = UserRegistrationOrganization.new(user_id: bike.user.id, organization_id: organization.id)
-      user_registration_organization.all_bikes = organization.user_registration_all_bikes?
-      user_registration_organization.can_not_edit_claimed = bike_organization.can_not_edit_claimed
-      user_registration_organization.set_initial_registration_info
-      user_registration_organization.update(skip_after_user_change_worker: true)
+    def serialized(bike)
+      {
+        auth_token: AUTH_TOKEN,
+        bike: BikeV2ShowSerializer.new(bike, root: false).as_json,
+        update: bike.created_at > Time.current - 30.seconds
+      }
     end
-    bike.reload
+
+    def update_matching_partial_registrations(bike)
+      return true unless bike.created_at > Time.current - 5.minutes # skip unless new bike
+
+      matches = BParam.partial_registrations.without_bike.where("email ilike ?", "%#{bike.owner_email}%")
+        .reorder(:created_at)
+      if matches.count > 1
+        # Try to make it a little more accurate lookup
+        best_matches = matches.select { |b_param| b_param.manufacturer_id == bike.manufacturer_id }
+        matches = best_matches if matches.any?
+      end
+      matching_b_param = matches.last # Because we want the last created
+      return true unless matching_b_param.present?
+
+      matching_b_param.update(created_bike_id: bike.id)
+      # Only set ownership
+      ownership = bike.current_ownership
+      if ownership.present? && ownership.origin == "web" && ownership.organization_id.blank?
+        ownership.organization_id = matching_b_param.organization_id
+        ownership.origin = matching_b_param.origin if (Ownership.origins - ["web"]).include?(matching_b_param.origin)
+        ownership.save
+        if matching_b_param.organization_id.present?
+          bike.update(creation_organization_id: matching_b_param.organization_id)
+          bike.bike_organizations.create(organization_id: matching_b_param.organization_id)
+        end
+      end
+    end
+
+    # Bump registration_info attributes on ownerships
+    def update_ownership(bike)
+      bike.current_ownership&.update(updated_at: Time.current)
+    end
+
+    # If the bike address_record was geocoded after save, update the bike
+    def update_coordinates(bike)
+      return if bike.address_record.blank? ||
+        %w[bike_update initial_creation].exclude?(BikeServices::CalculateLocation.registration_address_source(bike)) ||
+        bike.address_record.latitude == bike.latitude && bike.address_record.longitude == bike.longitude
+
+      bike.update_columns(latitude: bike.address_record.latitude, longitude: bike.address_record.longitude)
+    end
+
+    def create_user_registration_organizations(bike)
+      return if bike.reload.user.blank?
+
+      bike.bike_organizations.each do |bike_organization|
+        # If there is notification that is graduated for the organization, don't create new reg organizations
+        organization = bike_organization.organization
+        next if organization.blank? || UserRegistrationOrganization.unscoped
+          .where(user_id: bike.user.id, organization_id: organization.id).any?
+
+        user_registration_organization = UserRegistrationOrganization.new(user_id: bike.user.id, organization_id: organization.id)
+        user_registration_organization.all_bikes = organization.user_registration_all_bikes?
+        user_registration_organization.can_not_edit_claimed = bike_organization.can_not_edit_claimed
+        user_registration_organization.set_initial_registration_info
+        user_registration_organization.update(skip_after_user_change_worker: true)
+      end
+      bike.reload
+    end
   end
 end

--- a/app/jobs/callback_job/after_manufacturer_change_job.rb
+++ b/app/jobs/callback_job/after_manufacturer_change_job.rb
@@ -1,47 +1,49 @@
 # frozen_string_literal: true
 
-class CallbackJob::AfterManufacturerChangeJob < ApplicationJob
-  sidekiq_options queue: "low_priority"
+module CallbackJob
+  class AfterManufacturerChangeJob < ApplicationJob
+    sidekiq_options queue: "low_priority"
 
-  def perform(manufacturer_id)
-    manufacturer = Manufacturer.find(manufacturer_id)
-    return unless manufacturer.present?
+    def perform(manufacturer_id)
+      manufacturer = Manufacturer.find(manufacturer_id)
+      return unless manufacturer.present?
 
-    Bike.unscoped.where("manufacturer_other ILIKE ?", manufacturer.short_name)
-      .find_each { |bike| update_bike(bike, manufacturer_id) }
-    Component.unscoped.where("manufacturer_other ILIKE ?", manufacturer.short_name)
-      .find_each { |component| update_component(component, manufacturer_id) }
-
-    # Important for names with prefixes like "bike"
-    if manufacturer.slug != manufacturer.short_name.downcase
-      Bike.unscoped.where("manufacturer_other ILIKE ?", manufacturer.slug)
+      Bike.unscoped.where("manufacturer_other ILIKE ?", manufacturer.short_name)
         .find_each { |bike| update_bike(bike, manufacturer_id) }
-      Component.unscoped.where("manufacturer_other ILIKE ?", manufacturer.slug)
+      Component.unscoped.where("manufacturer_other ILIKE ?", manufacturer.short_name)
         .find_each { |component| update_component(component, manufacturer_id) }
+
+      # Important for names with prefixes like "bike"
+      if manufacturer.slug != manufacturer.short_name.downcase
+        Bike.unscoped.where("manufacturer_other ILIKE ?", manufacturer.slug)
+          .find_each { |bike| update_bike(bike, manufacturer_id) }
+        Component.unscoped.where("manufacturer_other ILIKE ?", manufacturer.slug)
+          .find_each { |component| update_component(component, manufacturer_id) }
+      end
+
+      if manufacturer.secondary_name.present?
+        Bike.unscoped.where("manufacturer_other ILIKE ?", manufacturer.secondary_name)
+          .find_each { |bike| update_bike(bike, manufacturer_id) }
+        Component.unscoped.where("manufacturer_other ILIKE ?", manufacturer.secondary_name)
+          .find_each { |component| update_component(component, manufacturer_id) }
+      end
+
+      # Bump manufacturer in case the priority changed
+      # callback job is only run if manufacturer name changed
+      manufacturer.update(updated_at: Time.current)
     end
 
-    if manufacturer.secondary_name.present?
-      Bike.unscoped.where("manufacturer_other ILIKE ?", manufacturer.secondary_name)
-        .find_each { |bike| update_bike(bike, manufacturer_id) }
-      Component.unscoped.where("manufacturer_other ILIKE ?", manufacturer.secondary_name)
-        .find_each { |component| update_component(component, manufacturer_id) }
+    private
+
+    def update_bike(bike, manufacturer_id)
+      bike.update(manufacturer_id: manufacturer_id, manufacturer_other: nil)
+
+      # Needs to happen after the manufacturer has been assigned to everything
+      UpdateModelAuditJob.perform_in(5.minutes, bike.model_audit_id) if bike.model_audit_id.present?
     end
 
-    # Bump manufacturer in case the priority changed
-    # callback job is only run if manufacturer name changed
-    manufacturer.update(updated_at: Time.current)
-  end
-
-  private
-
-  def update_bike(bike, manufacturer_id)
-    bike.update(manufacturer_id: manufacturer_id, manufacturer_other: nil)
-
-    # Needs to happen after the manufacturer has been assigned to everything
-    UpdateModelAuditJob.perform_in(5.minutes, bike.model_audit_id) if bike.model_audit_id.present?
-  end
-
-  def update_component(component, manufacturer_id)
-    component.update(manufacturer_id: manufacturer_id, manufacturer_other: nil)
+    def update_component(component, manufacturer_id)
+      component.update(manufacturer_id: manufacturer_id, manufacturer_other: nil)
+    end
   end
 end

--- a/app/jobs/callback_job/after_phone_confirmed_job.rb
+++ b/app/jobs/callback_job/after_phone_confirmed_job.rb
@@ -1,16 +1,18 @@
-class CallbackJob::AfterPhoneConfirmedJob < ApplicationJob
-  sidekiq_options queue: "high_priority"
+module CallbackJob
+  class AfterPhoneConfirmedJob < ApplicationJob
+    sidekiq_options queue: "high_priority"
 
-  def perform(user_phone_id)
-    user_phone = UserPhone.find(user_phone_id)
-    return true unless user_phone.confirmed?
+    def perform(user_phone_id)
+      user_phone = UserPhone.find(user_phone_id)
+      return true unless user_phone.confirmed?
 
-    # Add the bikes to the user
-    Bike.where(is_phone: true, owner_email: user_phone.phone).each do |bike|
-      bike.current_ownership.create_user_registration_for_phone_registration!(user_phone.user)
+      # Add the bikes to the user
+      Bike.where(is_phone: true, owner_email: user_phone.phone).each do |bike|
+        bike.current_ownership.create_user_registration_for_phone_registration!(user_phone.user)
+      end
+
+      # Manually run after user change to update user alerts
+      CallbackJob::AfterUserChangeJob.new.perform(user_phone.user_id, user_phone.user)
     end
-
-    # Manually run after user change to update user alerts
-    CallbackJob::AfterUserChangeJob.new.perform(user_phone.user_id, user_phone.user)
   end
 end

--- a/app/jobs/callback_job/after_sale_create_job.rb
+++ b/app/jobs/callback_job/after_sale_create_job.rb
@@ -1,45 +1,47 @@
-class CallbackJob::AfterSaleCreateJob < ApplicationJob
-  sidekiq_options queue: "high_priority"
+module CallbackJob
+  class AfterSaleCreateJob < ApplicationJob
+    sidekiq_options queue: "high_priority"
 
-  def perform(sale_id)
-    sale = Sale.find_by_id(sale_id)
-    return if sale.blank?
+    def perform(sale_id)
+      sale = Sale.find_by_id(sale_id)
+      return if sale.blank?
 
-    bike_version = create_bike_version(sale)
-    create_new_ownership(sale)
-    update_marketplace_listing(sale, bike_version)
-  end
-
-  private
-
-  def create_bike_version(sale)
-    return unless sale.item.is_a?(Bike)
-
-    bike_version = BikeVersionCreatorJob.new.perform(sale.item_id, sale.ownership.user_id)
-    sale.update(item: bike_version)
-    bike_version
-  end
-
-  def create_new_ownership(sale)
-    return if sale.new_ownership.present?
-
-    bike = sale.ownership.bike
-    if bike.current_ownership_id == sale.ownership_id
-      # It hasn't been updated yet! Transfer the bike
-      BikeServices::OwnershipTransferer.find_or_create(bike, updator: sale.seller,
-        new_owner_email: sale.new_owner_email, sale_id: sale.id)
-    elsif bike.current_ownership&.owner_email == sale.new_owner_email
-      # Ownership was transferred to the same person the sale is to -
-      # so update the ownership to be
-      bike.current_ownership.update(sale_id: sale.id)
+      bike_version = create_bike_version(sale)
+      create_new_ownership(sale)
+      update_marketplace_listing(sale, bike_version)
     end
-  end
 
-  def update_marketplace_listing(sale, bike_version = nil)
-    marketplace_listing = sale.marketplace_message&.marketplace_listing
-    return unless marketplace_listing.present? && !marketplace_listing.sold?
+    private
 
-    marketplace_listing.item = bike_version if bike_version.present?
-    marketplace_listing.update(sale:, status: :sold, buyer_id: sale.buyer&.id)
+    def create_bike_version(sale)
+      return unless sale.item.is_a?(Bike)
+
+      bike_version = BikeVersionCreatorJob.new.perform(sale.item_id, sale.ownership.user_id)
+      sale.update(item: bike_version)
+      bike_version
+    end
+
+    def create_new_ownership(sale)
+      return if sale.new_ownership.present?
+
+      bike = sale.ownership.bike
+      if bike.current_ownership_id == sale.ownership_id
+        # It hasn't been updated yet! Transfer the bike
+        BikeServices::OwnershipTransferer.find_or_create(bike, updator: sale.seller,
+          new_owner_email: sale.new_owner_email, sale_id: sale.id)
+      elsif bike.current_ownership&.owner_email == sale.new_owner_email
+        # Ownership was transferred to the same person the sale is to -
+        # so update the ownership to be
+        bike.current_ownership.update(sale_id: sale.id)
+      end
+    end
+
+    def update_marketplace_listing(sale, bike_version = nil)
+      marketplace_listing = sale.marketplace_message&.marketplace_listing
+      return unless marketplace_listing.present? && !marketplace_listing.sold?
+
+      marketplace_listing.item = bike_version if bike_version.present?
+      marketplace_listing.update(sale:, status: :sold, buyer_id: sale.buyer&.id)
+    end
   end
 end

--- a/app/jobs/callback_job/after_user_change_job.rb
+++ b/app/jobs/callback_job/after_user_change_job.rb
@@ -1,117 +1,119 @@
-class CallbackJob::AfterUserChangeJob < ApplicationJob
-  sidekiq_options retry: false
+module CallbackJob
+  class AfterUserChangeJob < ApplicationJob
+    sidekiq_options retry: false
 
-  def perform(user_id, user = nil, skip_bike_update = false)
-    user ||= User.unscoped.find_by_id(user_id)
-    return false unless user.present?
+    def perform(user_id, user = nil, skip_bike_update = false)
+      user ||= User.unscoped.find_by_id(user_id)
+      return false unless user.present?
 
-    # Bump updated_at to bust cache
-    user.update(updated_at: Time.current, skip_update: true) unless user.deleted?
-    add_phones_for_verification(user)
+      # Bump updated_at to bust cache
+      user.update(updated_at: Time.current, skip_update: true) unless user.deleted?
+      add_phones_for_verification(user)
 
-    associate_feedbacks(user)
+      associate_feedbacks(user)
 
-    # Create a new mailchimp datum if it's deserved
-    MailchimpDatum.find_and_update_or_create_for(user)
+      # Create a new mailchimp datum if it's deserved
+      MailchimpDatum.find_and_update_or_create_for(user)
 
-    user.no_address = user.bike_organizations.with_enabled_feature_slugs("no_address").any?
-    if !user.no_address && !user.address_set_manually # If user.address_set_manually bikes pick it up on save
-      UserServices::Updator.assign_address_from_bikes(user)
-    end
-    user.update(skip_update: true) if user.changed?
+      user.no_address = user.bike_organizations.with_enabled_feature_slugs("no_address").any?
+      if !user.no_address && !user.address_set_manually # If user.address_set_manually bikes pick it up on save
+        UserServices::Updator.assign_address_from_bikes(user)
+      end
+      user.update(skip_update: true) if user.changed?
 
-    update_user_alerts(user)
-    current_alerts = user_alert_slugs(user)
-    unless user.alert_slugs == current_alerts
-      user.update(alert_slugs: current_alerts, skip_update: true)
-    end
+      update_user_alerts(user)
+      current_alerts = user_alert_slugs(user)
+      unless user.alert_slugs == current_alerts
+        user.update(alert_slugs: current_alerts, skip_update: true)
+      end
 
-    # Activate activateable theft alerts!
-    user.theft_alerts.paid.where(start_at: nil).each do |theft_alert|
-      next unless theft_alert.activateable?
+      # Activate activateable theft alerts!
+      user.theft_alerts.paid.where(start_at: nil).each do |theft_alert|
+        next unless theft_alert.activateable?
 
-      StolenBike::ActivateTheftAlertJob.perform_async(theft_alert.id)
-    end
+        StolenBike::ActivateTheftAlertJob.perform_async(theft_alert.id)
+      end
 
-    process_user_registration_organizations(user)
+      process_user_registration_organizations(user)
 
-    user.user_ban.delete if user.user_ban.present? && !user.banned?
+      user.user_ban.delete if user.user_ban.present? && !user.banned?
 
-    process_bikes(user) unless skip_bike_update
-  end
-
-  def user_alert_slugs(user)
-    # Access via UserAlert query so we don't need to reload user
-    UserAlert.where(user_id: user.id).active.distinct.pluck(:kind).sort
-  end
-
-  def update_user_alerts(user)
-    # Add user phone alerts
-    user.user_phones.each do |user_phone|
-      UserAlert.update_phone_waiting_confirmation(user: user, user_phone: user_phone)
+      process_bikes(user) unless skip_bike_update
     end
 
-    # Ignore alerts below for superusers
-    if user.superuser?
-      user.user_alerts.active.ignored_superuser.each { |user_alert| user_alert.resolve! }
-      return
+    def user_alert_slugs(user)
+      # Access via UserAlert query so we don't need to reload user
+      UserAlert.where(user_id: user.id).active.distinct.pluck(:kind).sort
     end
 
-    user.theft_alerts.each do |theft_alert|
-      UserAlert.update_theft_alert_without_photo(user: user, theft_alert: theft_alert)
-    end
+    def update_user_alerts(user)
+      # Add user phone alerts
+      user.user_phones.each do |user_phone|
+        UserAlert.update_phone_waiting_confirmation(user: user, user_phone: user_phone)
+      end
 
-    # Ignore alerts below for org members, otherwise they might get a lot of useless ones
-    if user.organization_roles.any?
-      user.user_alerts.active.ignored_member.each { |user_alert| user_alert.resolve! }
-      return
-    end
+      # Ignore alerts below for superusers
+      if user.superuser?
+        user.user_alerts.active.ignored_superuser.each { |user_alert| user_alert.resolve! }
+        return
+      end
 
-    user.bike_organizations.select { |o| o.paid_money? }.each do |organization|
-      user.bikes.each do |bike|
-        UserAlert.update_unassigned_bike_org(user: user, organization: organization, bike: bike)
+      user.theft_alerts.each do |theft_alert|
+        UserAlert.update_theft_alert_without_photo(user: user, theft_alert: theft_alert)
+      end
+
+      # Ignore alerts below for org members, otherwise they might get a lot of useless ones
+      if user.organization_roles.any?
+        user.user_alerts.active.ignored_member.each { |user_alert| user_alert.resolve! }
+        return
+      end
+
+      user.bike_organizations.select { |o| o.paid_money? }.each do |organization|
+        user.bikes.each do |bike|
+          UserAlert.update_unassigned_bike_org(user: user, organization: organization, bike: bike)
+        end
+      end
+
+      user.bikes.status_stolen.each do |bike|
+        UserAlert.update_stolen_bike_without_location(user: user, bike: bike)
       end
     end
 
-    user.bikes.status_stolen.each do |bike|
-      UserAlert.update_stolen_bike_without_location(user: user, bike: bike)
+    def associate_feedbacks(user)
+      Feedback.no_user.where(email: user.confirmed_emails).each { |f|
+        f.update(user_id: user.id)
+      }
     end
-  end
 
-  def associate_feedbacks(user)
-    Feedback.no_user.where(email: user.confirmed_emails).each { |f|
-      f.update(user_id: user.id)
-    }
-  end
+    def add_phones_for_verification(user)
+      return false if user.phone.blank?
+      return false if UserPhone.unscoped.where(user_id: user.id, phone: user.phone).present?
 
-  def add_phones_for_verification(user)
-    return false if user.phone.blank?
-    return false if UserPhone.unscoped.where(user_id: user.id, phone: user.phone).present?
+      user_phone = user.user_phones.create(phone: user.phone)
+      # Run this in the same process, rather than a different job, so we update the user alerts
+      UserPhoneConfirmationJob.new.perform(user_phone.id, true)
 
-    user_phone = user.user_phones.create(phone: user.phone)
-    # Run this in the same process, rather than a different job, so we update the user alerts
-    UserPhoneConfirmationJob.new.perform(user_phone.id, true)
-
-    user.reload
-    true
-  end
-
-  def process_user_registration_organizations(user)
-    # Process user_registration_organizations
-    user.user_registration_organizations.order(:id).each do |u|
-      # Delete dupe user_registration_organizations
-      user.user_registration_organizations
-        .where(organization_id: u.organization_id).where("id > ?", u.id)
-        .each { |other| other.really_destroy! }
-      u.create_or_update_bike_organizations
+      user.reload
+      true
     end
-  end
 
-  def process_bikes(user)
-    if user.deleted?
-      user.bike_ids.each { |id| BikeDeleterJob.perform_async(id, false, user.id) }
-    else
-      user.bike_ids.each { |id| CallbackJob::AfterBikeSaveJob.perform_async(id, true, true) }
+    def process_user_registration_organizations(user)
+      # Process user_registration_organizations
+      user.user_registration_organizations.order(:id).each do |u|
+        # Delete dupe user_registration_organizations
+        user.user_registration_organizations
+          .where(organization_id: u.organization_id).where("id > ?", u.id)
+          .each { |other| other.really_destroy! }
+        u.create_or_update_bike_organizations
+      end
+    end
+
+    def process_bikes(user)
+      if user.deleted?
+        user.bike_ids.each { |id| BikeDeleterJob.perform_async(id, false, user.id) }
+      else
+        user.bike_ids.each { |id| CallbackJob::AfterBikeSaveJob.perform_async(id, true, true) }
+      end
     end
   end
 end

--- a/app/jobs/callback_job/after_user_create_job.rb
+++ b/app/jobs/callback_job/after_user_create_job.rb
@@ -1,115 +1,117 @@
 # TODO: eventually this should merge with after_user_change_worker.rb, or something
-class CallbackJob::AfterUserCreateJob < ApplicationJob
-  sidekiq_options queue: "high_priority"
+module CallbackJob
+  class AfterUserCreateJob < ApplicationJob
+    sidekiq_options queue: "high_priority"
 
-  # Generally, this is called inline - so it makes sense to pass in the user rather than just the user_id
-  def perform(user_id, job_stage, user: nil, email: nil)
-    user ||= User.find(user_id)
-    user.skip_update = true
-    email ||= user.email
-    if job_stage == "new"
-      perform_create_jobs(user, email)
-    elsif job_stage == "confirmed"
-      perform_confirmed_jobs(user, email)
-    elsif job_stage == "merged"
-      perform_merged_jobs(user, email)
-    elsif job_stage == "async"
-      perform_async_jobs(user, email)
+    # Generally, this is called inline - so it makes sense to pass in the user rather than just the user_id
+    def perform(user_id, job_stage, user: nil, email: nil)
+      user ||= User.find(user_id)
+      user.skip_update = true
+      email ||= user.email
+      if job_stage == "new"
+        perform_create_jobs(user, email)
+      elsif job_stage == "confirmed"
+        perform_confirmed_jobs(user, email)
+      elsif job_stage == "merged"
+        perform_merged_jobs(user, email)
+      elsif job_stage == "async"
+        perform_async_jobs(user, email)
+      end
     end
-  end
 
-  def perform_create_jobs(user, email)
-    # This may confirm the user. We auto-confirm users that belong to orgs.
-    # Auto confirming the user actually ends up running perform_confirmed_jobs.
-    associate_organization_role_invites(user, email)
-    send_welcoming_email(user)
-    CallbackJob::AfterUserCreateJob.perform_async(user.id, "async")
-  end
+    def perform_create_jobs(user, email)
+      # This may confirm the user. We auto-confirm users that belong to orgs.
+      # Auto confirming the user actually ends up running perform_confirmed_jobs.
+      associate_organization_role_invites(user, email)
+      send_welcoming_email(user)
+      CallbackJob::AfterUserCreateJob.perform_async(user.id, "async")
+    end
 
-  def perform_merged_jobs(user, email)
-    # This is already performing in a background job, so we don't need to run async
-    # Also, we we need to process with the previous email, not the user's current email
-    associate_organization_role_invites(user, email, skip_confirm: true)
-    associate_ownerships(user, email)
-  end
-
-  def perform_confirmed_jobs(user, email)
-    UserEmail.create_confirmed_primary_email(user)
-    create_passwordless_domain_organization_roles(user)
-    CallbackJob::AfterUserCreateJob.perform_async(user.id, "async")
-  end
-
-  def perform_async_jobs(user, email)
-    # These jobs don't need to happen immediately
-    import_user_attributes(user)
-    if user.confirmed?
+    def perform_merged_jobs(user, email)
+      # This is already performing in a background job, so we don't need to run async
+      # Also, we we need to process with the previous email, not the user's current email
+      associate_organization_role_invites(user, email, skip_confirm: true)
       associate_ownerships(user, email)
-      associate_graduated_notifications(user.reload)
-    end
-  end
-
-  def send_welcoming_email(user)
-    # If the user is confirmed, send the welcome email, otherwise send the confirmation email
-    if user.confirmed?
-      Email::WelcomeJob.perform_async(user.id)
-    else
-      Email::ConfirmationJob.perform_in(1.second, user.id)
-    end
-  end
-
-  def associate_ownerships(user, email)
-    Ownership.where(owner_email: email).each do |ownership|
-      ownership.update(user_id: user.id)
-    end
-  end
-
-  def associate_graduated_notifications(user)
-    GraduatedNotification.where(bike_id: user.bike_ids, user_id: nil)
-      .update_all(user_id: user.id)
-  end
-
-  def associate_organization_role_invites(user, email, skip_confirm: false)
-    organization_roles = OrganizationRole.unclaimed.where(invited_email: email)
-    return false unless organization_roles.any?
-
-    first, *rest = organization_roles.pluck(:id)
-    Users::ProcessOrganizationRoleJob.new.perform(first, user.id)
-
-    # We want to do the first one inline so we can redirect
-    # the user to the org page
-    rest.each do |organization_role_id|
-      Users::ProcessOrganizationRoleJob.perform_async(organization_role_id, user.id)
     end
 
-    user.confirm(user.confirmation_token) unless skip_confirm
-  end
-
-  def import_user_attributes(user)
-    if user.phone.blank?
-      user.phone = user_bikes_for_attrs(user.id).map { |b| b.phone }.reject(&:blank?).last
-      user.save if user.phone.present?
+    def perform_confirmed_jobs(user, email)
+      UserEmail.create_confirmed_primary_email(user)
+      create_passwordless_domain_organization_roles(user)
+      CallbackJob::AfterUserCreateJob.perform_async(user.id, "async")
     end
-    # Only do address import if the user doesn't have an address present
-    unless user.address_present?
-      UserServices::Updator.assign_address_from_bikes(user, bikes: user_bikes_for_attrs(user.id), save_user: true)
+
+    def perform_async_jobs(user, email)
+      # These jobs don't need to happen immediately
+      import_user_attributes(user)
+      if user.confirmed?
+        associate_ownerships(user, email)
+        associate_graduated_notifications(user.reload)
+      end
     end
-  end
 
-  private
+    def send_welcoming_email(user)
+      # If the user is confirmed, send the welcome email, otherwise send the confirmation email
+      if user.confirmed?
+        Email::WelcomeJob.perform_async(user.id)
+      else
+        Email::ConfirmationJob.perform_in(1.second, user.id)
+      end
+    end
 
-  def user_bikes_for_attrs(user_id)
-    # Deal with example bikes
-    bike_ids = Ownership.where(user_id: user_id).where.not(user_id: nil).order(:created_at).limit(100).pluck(:bike_id)
-    Bike.unscoped.where(id: bike_ids)
-  end
+    def associate_ownerships(user, email)
+      Ownership.where(owner_email: email).each do |ownership|
+        ownership.update(user_id: user.id)
+      end
+    end
 
-  def create_passwordless_domain_organization_roles(user)
-    matching_organization = Organization.passwordless_email_matching(user.email)
-    return false unless matching_organization.present?
-    return false if user.organization_roles.pluck(:organization_id).include?(matching_organization.id)
+    def associate_graduated_notifications(user)
+      GraduatedNotification.where(bike_id: user.bike_ids, user_id: nil)
+        .update_all(user_id: user.id)
+    end
 
-    OrganizationRole.create_passwordless(organization_id: matching_organization.id,
-      invited_email: user.email)
-    user.reload
+    def associate_organization_role_invites(user, email, skip_confirm: false)
+      organization_roles = OrganizationRole.unclaimed.where(invited_email: email)
+      return false unless organization_roles.any?
+
+      first, *rest = organization_roles.pluck(:id)
+      Users::ProcessOrganizationRoleJob.new.perform(first, user.id)
+
+      # We want to do the first one inline so we can redirect
+      # the user to the org page
+      rest.each do |organization_role_id|
+        Users::ProcessOrganizationRoleJob.perform_async(organization_role_id, user.id)
+      end
+
+      user.confirm(user.confirmation_token) unless skip_confirm
+    end
+
+    def import_user_attributes(user)
+      if user.phone.blank?
+        user.phone = user_bikes_for_attrs(user.id).map { |b| b.phone }.reject(&:blank?).last
+        user.save if user.phone.present?
+      end
+      # Only do address import if the user doesn't have an address present
+      unless user.address_present?
+        UserServices::Updator.assign_address_from_bikes(user, bikes: user_bikes_for_attrs(user.id), save_user: true)
+      end
+    end
+
+    private
+
+    def user_bikes_for_attrs(user_id)
+      # Deal with example bikes
+      bike_ids = Ownership.where(user_id: user_id).where.not(user_id: nil).order(:created_at).limit(100).pluck(:bike_id)
+      Bike.unscoped.where(id: bike_ids)
+    end
+
+    def create_passwordless_domain_organization_roles(user)
+      matching_organization = Organization.passwordless_email_matching(user.email)
+      return false unless matching_organization.present?
+      return false if user.organization_roles.pluck(:organization_id).include?(matching_organization.id)
+
+      OrganizationRole.create_passwordless(organization_id: matching_organization.id,
+        invited_email: user.email)
+      user.reload
+    end
   end
 end

--- a/app/jobs/callback_job/ambassador_task_after_create_job.rb
+++ b/app/jobs/callback_job/ambassador_task_after_create_job.rb
@@ -1,28 +1,30 @@
-class CallbackJob::AmbassadorTaskAfterCreateJob < ApplicationJob
-  sidekiq_options queue: "high_priority"
+module CallbackJob
+  class AmbassadorTaskAfterCreateJob < ApplicationJob
+    sidekiq_options queue: "high_priority"
 
-  def self.assign_task_to_all_ambassadors(ambassador_task)
-    already_assigned_ambassador_ids =
-      Ambassador
-        .includes(ambassador_task_assignments: :ambassador_task)
-        .where(ambassador_task_assignments: {ambassador_task: ambassador_task})
-        .select(:id)
+    def self.assign_task_to_all_ambassadors(ambassador_task)
+      already_assigned_ambassador_ids =
+        Ambassador
+          .includes(ambassador_task_assignments: :ambassador_task)
+          .where(ambassador_task_assignments: {ambassador_task: ambassador_task})
+          .select(:id)
 
-    unassigned_ambassadors =
-      Ambassador
-        .includes(:ambassador_task_assignments)
-        .where
-        .not(id: already_assigned_ambassador_ids)
-        .references(:ambassador_task_assignments)
+      unassigned_ambassadors =
+        Ambassador
+          .includes(:ambassador_task_assignments)
+          .where
+          .not(id: already_assigned_ambassador_ids)
+          .references(:ambassador_task_assignments)
 
-    unassigned_ambassadors.find_each do |ambassador|
-      ambassador_task.assign_to(ambassador)
+      unassigned_ambassadors.find_each do |ambassador|
+        ambassador_task.assign_to(ambassador)
+      end
     end
-  end
 
-  def perform(ambassador_task_id)
-    ambassador_task = AmbassadorTask.find(ambassador_task_id)
+    def perform(ambassador_task_id)
+      ambassador_task = AmbassadorTask.find(ambassador_task_id)
 
-    self.class.assign_task_to_all_ambassadors(ambassador_task)
+      self.class.assign_task_to_all_ambassadors(ambassador_task)
+    end
   end
 end

--- a/app/jobs/email/additional_email_confirmation_job.rb
+++ b/app/jobs/email/additional_email_confirmation_job.rb
@@ -1,10 +1,12 @@
-class Email::AdditionalEmailConfirmationJob < ApplicationJob
-  sidekiq_options queue: "notify"
+module Email
+  class AdditionalEmailConfirmationJob < ApplicationJob
+    sidekiq_options queue: "notify"
 
-  def perform(user_email_id)
-    user_email = UserEmail.find_by(id: user_email_id)
-    return if user_email.blank?
+    def perform(user_email_id)
+      user_email = UserEmail.find_by(id: user_email_id)
+      return if user_email.blank?
 
-    CustomerMailer.additional_email_confirmation(user_email).deliver_now
+      CustomerMailer.additional_email_confirmation(user_email).deliver_now
+    end
   end
 end

--- a/app/jobs/email/admin_contact_stolen_job.rb
+++ b/app/jobs/email/admin_contact_stolen_job.rb
@@ -1,10 +1,12 @@
 # frozen_string_literal: true
 
-class Email::AdminContactStolenJob < ApplicationJob
-  sidekiq_options queue: "notify", retry: 3
+module Email
+  class AdminContactStolenJob < ApplicationJob
+    sidekiq_options queue: "notify", retry: 3
 
-  def perform(customer_contact_id)
-    customer_contact = CustomerContact.find(customer_contact_id)
-    CustomerMailer.admin_contact_stolen_email(customer_contact).deliver_now
+    def perform(customer_contact_id)
+      customer_contact = CustomerContact.find(customer_contact_id)
+      CustomerMailer.admin_contact_stolen_email(customer_contact).deliver_now
+    end
   end
 end

--- a/app/jobs/email/bike_possibly_found_notification_job.rb
+++ b/app/jobs/email/bike_possibly_found_notification_job.rb
@@ -1,20 +1,22 @@
 # frozen_string_literal: true
 
-class Email::BikePossiblyFoundNotificationJob < ApplicationJob
-  sidekiq_options queue: "notify", retry: 3
+module Email
+  class BikePossiblyFoundNotificationJob < ApplicationJob
+    sidekiq_options queue: "notify", retry: 3
 
-  def perform(bike_id, match_class, match_id)
-    bike = Bike.find(bike_id)
-    matched_bike = match_class.to_s.constantize.find(match_id)
+    def perform(bike_id, match_class, match_id)
+      bike = Bike.find(bike_id)
+      matched_bike = match_class.to_s.constantize.find(match_id)
 
-    return if bike == matched_bike
-    return if CustomerContact.possibly_found_notification_sent?(bike, matched_bike)
+      return if bike == matched_bike
+      return if CustomerContact.possibly_found_notification_sent?(bike, matched_bike)
 
-    contact = CustomerContact.build_bike_possibly_found_notification(bike, matched_bike)
-    return unless contact.receives_stolen_bike_notifications?
+      contact = CustomerContact.build_bike_possibly_found_notification(bike, matched_bike)
+      return unless contact.receives_stolen_bike_notifications?
 
-    email = CustomerMailer.bike_possibly_found_email(contact)
-    contact.email = email
-    email.deliver_now if contact.save
+      email = CustomerMailer.bike_possibly_found_email(contact)
+      contact.email = email
+      email.deliver_now if contact.save
+    end
   end
 end

--- a/app/jobs/email/confirmation_job.rb
+++ b/app/jobs/email/confirmation_job.rb
@@ -1,31 +1,33 @@
 # frozen_string_literal: true
 
-class Email::ConfirmationJob < ApplicationJob
-  sidekiq_options queue: "notify", retry: 3
+module Email
+  class ConfirmationJob < ApplicationJob
+    sidekiq_options queue: "notify", retry: 3
 
-  def perform(user_id)
-    user = User.find_by(id: user_id)
-    return if user.blank?
+    def perform(user_id)
+      user = User.find_by(id: user_id)
+      return if user.blank?
 
-    # Don't send an email if the email is blocked
-    return if EmailBan.ban?(user)
-    # Clean up situations where there are two users created
-    return user.really_destroy! if duplicate_user?(user)
+      # Don't send an email if the email is blocked
+      return if EmailBan.ban?(user)
+      # Clean up situations where there are two users created
+      return user.really_destroy! if duplicate_user?(user)
 
-    notifications = user.notifications.confirmation_email.where("created_at > ?", Time.current - 1.minute)
-    # If we just sent it, don't send again
-    return false if notifications.delivery_success.any?
+      notifications = user.notifications.confirmation_email.where("created_at > ?", Time.current - 1.minute)
+      # If we just sent it, don't send again
+      return false if notifications.delivery_success.any?
 
-    notification = notifications.last || Notification.create(user_id: user.id, kind: "confirmation_email")
+      notification = notifications.last || Notification.create(user_id: user.id, kind: "confirmation_email")
 
-    notification.track_email_delivery do
-      CustomerMailer.confirmation_email(user).deliver_now
+      notification.track_email_delivery do
+        CustomerMailer.confirmation_email(user).deliver_now
+      end
     end
-  end
 
-  private
+    private
 
-  def duplicate_user?(user)
-    User.where(email: user.email).where("id < ?", user.id).present?
+    def duplicate_user?(user)
+      User.where(email: user.email).where("id < ?", user.id).present?
+    end
   end
 end

--- a/app/jobs/email/donation_job.rb
+++ b/app/jobs/email/donation_job.rb
@@ -1,82 +1,84 @@
 # frozen_string_literal: true
 
-class Email::DonationJob < ApplicationJob
-  sidekiq_options queue: "notify", retry: 3
+module Email
+  class DonationJob < ApplicationJob
+    sidekiq_options queue: "notify", retry: 3
 
-  def perform(id)
-    payment = Payment.find(id)
-    return unless payment.present? && payment.donation?
+    def perform(id)
+      payment = Payment.find(id)
+      return unless payment.present? && payment.donation?
 
-    @user = payment.user
-    notification_kind = calculated_notification_kind(payment)
-    notification = payment.notifications.where(kind: notification_kind).first
-    notification ||= Notification.create(kind: notification_kind, notifiable: payment,
-      bike: bike_for_notification(payment, notification_kind))
+      @user = payment.user
+      notification_kind = calculated_notification_kind(payment)
+      notification = payment.notifications.where(kind: notification_kind).first
+      notification ||= Notification.create(kind: notification_kind, notifiable: payment,
+        bike: bike_for_notification(payment, notification_kind))
 
-    notification.track_email_delivery do
-      DonationMailer.donation_email(notification_kind, payment).deliver_now
-    end
-  end
-
-  def calculated_notification_kind(payment)
-    user = payment.user
-    return "donation_standard" if user.blank?
-
-    # Return recovered if there's a relevant recovery - higher priority than theft_alert
-    if matching_recovered_bikes(payment).any?
-      return "donation_recovered"
+      notification.track_email_delivery do
+        DonationMailer.donation_email(notification_kind, payment).deliver_now
+      end
     end
 
-    # theft_alert is higher priority than anything else
-    if user.theft_alerts.paid.where(created_at: relevant_period(payment)).any?
-      return "donation_theft_alert"
+    def calculated_notification_kind(payment)
+      user = payment.user
+      return "donation_standard" if user.blank?
+
+      # Return recovered if there's a relevant recovery - higher priority than theft_alert
+      if matching_recovered_bikes(payment).any?
+        return "donation_recovered"
+      end
+
+      # theft_alert is higher priority than anything else
+      if user.theft_alerts.paid.where(created_at: relevant_period(payment)).any?
+        return "donation_theft_alert"
+      end
+
+      if matching_stolen_bikes(payment).any?
+        "donation_stolen"
+      elsif user.payments.donation.where("id < ?", payment.id).any?
+        "donation_second"
+      else
+        "donation_standard"
+      end
     end
 
-    if matching_stolen_bikes(payment).any?
-      "donation_stolen"
-    elsif user.payments.donation.where("id < ?", payment.id).any?
-      "donation_second"
-    else
-      "donation_standard"
+    def relevant_period(obj = nil)
+      time = obj&.created_at || Time.current
+      (time - 50.days)..(time + 1.day)
     end
-  end
 
-  def relevant_period(obj = nil)
-    time = obj&.created_at || Time.current
-    (time - 50.days)..(time + 1.day)
-  end
-
-  def bike_for_notification(payment, notification_kind)
-    if notification_kind == "donation_recovered"
-      matching_recovered_bikes(payment).last
-    elsif notification_kind == "donation_stolen"
-      matching_stolen_bikes(payment).last
-    elsif notification_kind == "donation_theft_alert"
-      matching_theft_alert_bikes(payment).last
+    def bike_for_notification(payment, notification_kind)
+      if notification_kind == "donation_recovered"
+        matching_recovered_bikes(payment).last
+      elsif notification_kind == "donation_stolen"
+        matching_stolen_bikes(payment).last
+      elsif notification_kind == "donation_theft_alert"
+        matching_theft_alert_bikes(payment).last
+      end
     end
-  end
 
-  def matching_recovered_bikes(payment)
-    return [] if payment.user.blank?
+    def matching_recovered_bikes(payment)
+      return [] if payment.user.blank?
 
-    payment.user.bikes.select do |b|
-      b.stolen_recovery? && b.recovered_records.where(recovered_at: relevant_period(payment)).any?
-    end.sort_by { |bike| bike.recovered_records.first.recovered_at }
-  end
+      payment.user.bikes.select do |b|
+        b.stolen_recovery? && b.recovered_records.where(recovered_at: relevant_period(payment)).any?
+      end.sort_by { |bike| bike.recovered_records.first.recovered_at }
+    end
 
-  def matching_stolen_bikes(payment)
-    return [] if payment.user.blank?
+    def matching_stolen_bikes(payment)
+      return [] if payment.user.blank?
 
-    payment.user.bikes.status_stolen.map(&:current_stolen_record).reject(&:blank?)
-      .select { |s| relevant_period(payment).cover?(s.date_stolen) }
-      .sort_by(&:date_stolen) # most recent stolen
-      .map(&:bike)
-  end
+      payment.user.bikes.status_stolen.map(&:current_stolen_record).reject(&:blank?)
+        .select { |s| relevant_period(payment).cover?(s.date_stolen) }
+        .sort_by(&:date_stolen) # most recent stolen
+        .map(&:bike)
+    end
 
-  def matching_theft_alert_bikes(payment)
-    return [] if payment.user.blank?
+    def matching_theft_alert_bikes(payment)
+      return [] if payment.user.blank?
 
-    payment.user.theft_alerts.paid.where(created_at: relevant_period(payment)).order(:created_at)
-      .map(&:bike)
+      payment.user.theft_alerts.paid.where(created_at: relevant_period(payment)).order(:created_at)
+        .map(&:bike)
+    end
   end
 end

--- a/app/jobs/email/feedback_notification_job.rb
+++ b/app/jobs/email/feedback_notification_job.rb
@@ -1,10 +1,12 @@
 # frozen_string_literal: true
 
-class Email::FeedbackNotificationJob < ApplicationJob
-  sidekiq_options queue: "notify", retry: 1
+module Email
+  class FeedbackNotificationJob < ApplicationJob
+    sidekiq_options queue: "notify", retry: 1
 
-  def perform(feedback_id)
-    @feedback = Feedback.find(feedback_id)
-    AdminMailer.feedback_notification_email(@feedback).deliver_now
+    def perform(feedback_id)
+      @feedback = Feedback.find(feedback_id)
+      AdminMailer.feedback_notification_email(@feedback).deliver_now
+    end
   end
 end

--- a/app/jobs/email/impound_claim_job.rb
+++ b/app/jobs/email/impound_claim_job.rb
@@ -1,33 +1,35 @@
 # frozen_string_literal: true
 
-class Email::ImpoundClaimJob < ApplicationJob
-  sidekiq_options queue: "notify", retry: 3
+module Email
+  class ImpoundClaimJob < ApplicationJob
+    sidekiq_options queue: "notify", retry: 3
 
-  def perform(impound_claim_id)
-    impound_claim = ImpoundClaim.find(impound_claim_id)
+    def perform(impound_claim_id)
+      impound_claim = ImpoundClaim.find(impound_claim_id)
 
-    email_to_send = calculated_email_to_send(impound_claim)
-    return nil if email_to_send.blank?
+      email_to_send = calculated_email_to_send(impound_claim)
+      return nil if email_to_send.blank?
 
-    notification = Notification.create(kind: "impound_claim_#{email_to_send}",
-      notifiable: impound_claim,
-      bike_id: impound_claim.bike_claimed_id)
+      notification = Notification.create(kind: "impound_claim_#{email_to_send}",
+        notifiable: impound_claim,
+        bike_id: impound_claim.bike_claimed_id)
 
-    notification.track_email_delivery do
-      if email_to_send == "submitting"
-        OrganizedMailer.impound_claim_submitted(impound_claim).deliver_now
-      else
-        OrganizedMailer.impound_claim_approved_or_denied(impound_claim).deliver_now
+      notification.track_email_delivery do
+        if email_to_send == "submitting"
+          OrganizedMailer.impound_claim_submitted(impound_claim).deliver_now
+        else
+          OrganizedMailer.impound_claim_approved_or_denied(impound_claim).deliver_now
+        end
       end
+
+      CallbackJob::AfterUserChangeJob.perform_async(impound_claim.user_id)
     end
 
-    CallbackJob::AfterUserChangeJob.perform_async(impound_claim.user_id)
-  end
-
-  def calculated_email_to_send(impound_claim)
-    if %w[submitting approved denied].include?(impound_claim.status) &&
-        impound_claim.notifications.where(kind: "impound_claim_#{impound_claim.status}").none?
-      impound_claim.status
+    def calculated_email_to_send(impound_claim)
+      if %w[submitting approved denied].include?(impound_claim.status) &&
+          impound_claim.notifications.where(kind: "impound_claim_#{impound_claim.status}").none?
+        impound_claim.status
+      end
     end
   end
 end

--- a/app/jobs/email/lightspeed_notification_job.rb
+++ b/app/jobs/email/lightspeed_notification_job.rb
@@ -1,11 +1,13 @@
 # frozen_string_literal: true
 
-class Email::LightspeedNotificationJob < ApplicationJob
-  sidekiq_options queue: "notify", retry: 3
+module Email
+  class LightspeedNotificationJob < ApplicationJob
+    sidekiq_options queue: "notify", retry: 3
 
-  def perform(organization_id, api_key)
-    @api_key = api_key
-    @organization = Organization.find(organization_id)
-    AdminMailer.lightspeed_notification_email(@organization, @api_key).deliver_now
+    def perform(organization_id, api_key)
+      @api_key = api_key
+      @organization = Organization.find(organization_id)
+      AdminMailer.lightspeed_notification_email(@organization, @api_key).deliver_now
+    end
   end
 end

--- a/app/jobs/email/magic_login_link_job.rb
+++ b/app/jobs/email/magic_login_link_job.rb
@@ -1,14 +1,16 @@
 # frozen_string_literal: true
 
-class Email::MagicLoginLinkJob < ApplicationJob
-  sidekiq_options queue: "notify", retry: 3
+module Email
+  class MagicLoginLinkJob < ApplicationJob
+    sidekiq_options queue: "notify", retry: 3
 
-  def perform(user_id)
-    user = User.find(user_id)
-    unless user.magic_link_token.present?
-      raise StandardError, "User #{user_id} does not have a magic_link_token"
+    def perform(user_id)
+      user = User.find(user_id)
+      unless user.magic_link_token.present?
+        raise StandardError, "User #{user_id} does not have a magic_link_token"
+      end
+
+      CustomerMailer.magic_login_link_email(user).deliver_now
     end
-
-    CustomerMailer.magic_login_link_email(user).deliver_now
   end
 end

--- a/app/jobs/email/marketplace_message_job.rb
+++ b/app/jobs/email/marketplace_message_job.rb
@@ -1,41 +1,43 @@
 # frozen_string_literal: true
 
-class Email::MarketplaceMessageJob < ApplicationJob
-  sidekiq_options queue: "notify", retry: 3
+module Email
+  class MarketplaceMessageJob < ApplicationJob
+    sidekiq_options queue: "notify", retry: 3
 
-  def perform(id)
-    marketplace_message = MarketplaceMessage.find_by(id:)
-    return if marketplace_message.blank?
+    def perform(id)
+      marketplace_message = MarketplaceMessage.find_by(id:)
+      return if marketplace_message.blank?
 
-    likely_spam = marketplace_message.likely_spam?
-    # Don't send a notification if there are already notifications in the past 24 hours
-    if likely_spam
-      return if Notification.marketplace_message_blocked
-        .where(user_id: marketplace_message.sender_id).where(created_at: (Time.current - 24.hours)..)
-        .count > 0
-    end
-
-    kind = likely_spam ? :marketplace_message_blocked : :marketplace_message
-    notification = marketplace_message.notifications.first
-    notification ||= Notification.create(kind:, notifiable: marketplace_message,
-      user_id: likely_spam ? marketplace_message.sender_id : marketplace_message.receiver_id)
-    # track_email_delivery returns if delivery_success, but return early here to prevent updating the cache
-    return if notification.delivery_success?
-
-    delivery = nil
-    notification.track_email_delivery do
-      delivery = if likely_spam
-        AdminMailer.blocked_marketplace_message_email(marketplace_message).deliver_now
-      else
-        CustomerMailer.marketplace_message_notification(marketplace_message).deliver_now
+      likely_spam = marketplace_message.likely_spam?
+      # Don't send a notification if there are already notifications in the past 24 hours
+      if likely_spam
+        return if Notification.marketplace_message_blocked
+          .where(user_id: marketplace_message.sender_id).where(created_at: (Time.current - 24.hours)..)
+          .count > 0
       end
-    end
-    return if delivery.blank?
 
-    # Bust caches on the associations
-    marketplace_message.sender&.update(updated_at: Time.current)
-    marketplace_message.receiver&.update(updated_at: Time.current)
-    marketplace_message.marketplace_listing&.update(updated_at: Time.current)
-    delivery
+      kind = likely_spam ? :marketplace_message_blocked : :marketplace_message
+      notification = marketplace_message.notifications.first
+      notification ||= Notification.create(kind:, notifiable: marketplace_message,
+        user_id: likely_spam ? marketplace_message.sender_id : marketplace_message.receiver_id)
+      # track_email_delivery returns if delivery_success, but return early here to prevent updating the cache
+      return if notification.delivery_success?
+
+      delivery = nil
+      notification.track_email_delivery do
+        delivery = if likely_spam
+          AdminMailer.blocked_marketplace_message_email(marketplace_message).deliver_now
+        else
+          CustomerMailer.marketplace_message_notification(marketplace_message).deliver_now
+        end
+      end
+      return if delivery.blank?
+
+      # Bust caches on the associations
+      marketplace_message.sender&.update(updated_at: Time.current)
+      marketplace_message.receiver&.update(updated_at: Time.current)
+      marketplace_message.marketplace_listing&.update(updated_at: Time.current)
+      delivery
+    end
   end
 end

--- a/app/jobs/email/newsletter_job.rb
+++ b/app/jobs/email/newsletter_job.rb
@@ -1,41 +1,43 @@
 # frozen_string_literal: true
 
-class Email::NewsletterJob < ApplicationJob
-  sidekiq_options queue: "low_priority", retry: 1
+module Email
+  class NewsletterJob < ApplicationJob
+    sidekiq_options queue: "low_priority", retry: 1
 
-  class << self
-    def enqueue_for(mail_snippet_id, limit: 1_000)
-      users_to_send(mail_snippet_id).limit(limit).pluck(:id)
-        .each { |id| Email::NewsletterJob.perform_async(id, mail_snippet_id) }
+    class << self
+      def enqueue_for(mail_snippet_id, limit: 1_000)
+        users_to_send(mail_snippet_id).limit(limit).pluck(:id)
+          .each { |id| Email::NewsletterJob.perform_async(id, mail_snippet_id) }
+      end
+
+      def users_to_send(mail_snippet_id)
+        User.confirmed.valid_only.where(notification_newsletters: true)
+          .where.not(id: Notification.delivery_success.newsletter.where(notifiable_id: mail_snippet_id).select(:user_id))
+      end
     end
 
-    def users_to_send(mail_snippet_id)
-      User.confirmed.valid_only.where(notification_newsletters: true)
-        .where.not(id: Notification.delivery_success.newsletter.where(notifiable_id: mail_snippet_id).select(:user_id))
-    end
-  end
+    def perform(user_id, mail_snippet_id, force_send = false)
+      user = User.find_by(id: user_id)
+      mail_snippet = MailSnippet.newsletter.find(mail_snippet_id)
+      return if user.blank? || mail_snippet.blank?
 
-  def perform(user_id, mail_snippet_id, force_send = false)
-    user = User.find_by(id: user_id)
-    mail_snippet = MailSnippet.newsletter.find(mail_snippet_id)
-    return if user.blank? || mail_snippet.blank?
+      unless force_send
+        # Don't send an email if the email is blocked
+        return if EmailBan.ban?(user) || !user.notification_newsletters
 
-    unless force_send
-      # Don't send an email if the email is blocked
-      return if EmailBan.ban?(user) || !user.notification_newsletters
+        notifications = user.notifications.newsletter.where(notifiable_id: mail_snippet_id)
 
-      notifications = user.notifications.newsletter.where(notifiable_id: mail_snippet_id)
+        # If we sent already, don't send again
+        return false if notifications.delivery_success.any?
 
-      # If we sent already, don't send again
-      return false if notifications.delivery_success.any?
+        notification = notifications.last
+      end
 
-      notification = notifications.last
-    end
+      notification ||= Notification.create(user_id: user.id, kind: :newsletter, notifiable: mail_snippet)
 
-    notification ||= Notification.create(user_id: user.id, kind: :newsletter, notifiable: mail_snippet)
-
-    notification.track_email_delivery do
-      CustomerMailer.newsletter(user:, mail_snippet:).deliver_now
+      notification.track_email_delivery do
+        CustomerMailer.newsletter(user:, mail_snippet:).deliver_now
+      end
     end
   end
 end

--- a/app/jobs/email/no_admins_notification_job.rb
+++ b/app/jobs/email/no_admins_notification_job.rb
@@ -1,10 +1,12 @@
 # frozen_string_literal: true
 
-class Email::NoAdminsNotificationJob < ApplicationJob
-  sidekiq_options queue: "notify", retry: 3
+module Email
+  class NoAdminsNotificationJob < ApplicationJob
+    sidekiq_options queue: "notify", retry: 3
 
-  def perform(organization_id)
-    @organization = Organization.find(organization_id)
-    AdminMailer.no_admins_notification_email(@organization).deliver_now
+    def perform(organization_id)
+      @organization = Organization.find(organization_id)
+      AdminMailer.no_admins_notification_email(@organization).deliver_now
+    end
   end
 end

--- a/app/jobs/email/ownership_invitation_job.rb
+++ b/app/jobs/email/ownership_invitation_job.rb
@@ -1,45 +1,47 @@
 # frozen_string_literal: true
 
-class Email::OwnershipInvitationJob < ApplicationJob
-  sidekiq_options queue: "notify", retry: 3
+module Email
+  class OwnershipInvitationJob < ApplicationJob
+    sidekiq_options queue: "notify", retry: 3
 
-  def perform(ownership_id)
-    ownership = Ownership.find_by_id(ownership_id)
-    return true unless ownership.present? && ownership.bike.present?
+    def perform(ownership_id)
+      ownership = Ownership.find_by_id(ownership_id)
+      return true unless ownership.present? && ownership.bike.present?
 
-    update_current_marketplace_listings(ownership.bike)
+      update_current_marketplace_listings(ownership.bike)
 
-    # recalculate spaminess, to verify that bike should be emailed
-    if SpamEstimator.estimate_bike(ownership.bike) > SpamEstimator::MARK_SPAM_PERCENT
-      ownership.bike.update(likely_spam: true) unless ownership.bike.likely_spam?
+      # recalculate spaminess, to verify that bike should be emailed
+      if SpamEstimator.estimate_bike(ownership.bike) > SpamEstimator::MARK_SPAM_PERCENT
+        ownership.bike.update(likely_spam: true) unless ownership.bike.likely_spam?
+      end
+      ownership.bike&.update(updated_at: Time.current)
+      ownership.reload
+
+      if ownership.calculated_send_email != ownership.send_email
+        # Update the ownership to have send email set
+        ownership.update_attribute(:skip_email, !ownership.calculated_send_email)
+      end
+      return if ownership.skip_email
+
+      notification = Notification.find_or_create_by(notifiable: ownership,
+        kind: "finished_registration")
+
+      notification.track_email_delivery do
+        OrganizedMailer.finished_registration(ownership).deliver_now
+      end
     end
-    ownership.bike&.update(updated_at: Time.current)
-    ownership.reload
 
-    if ownership.calculated_send_email != ownership.send_email
-      # Update the ownership to have send email set
-      ownership.update_attribute(:skip_email, !ownership.calculated_send_email)
+    private
+
+    def update_current_marketplace_listings(bike)
+      marketplace_listing = bike.current_marketplace_listing
+      return if marketplace_listing.blank? ||
+        marketplace_listing.bike_ownership&.id == bike.current_ownership&.id
+
+      # mark any marketplace listing that was published as sold - the user might have unpublished it
+      update_status = marketplace_listing.published_at.present? ? :sold : :removed
+
+      marketplace_listing.update(status: update_status, end_at: Time.current)
     end
-    return if ownership.skip_email
-
-    notification = Notification.find_or_create_by(notifiable: ownership,
-      kind: "finished_registration")
-
-    notification.track_email_delivery do
-      OrganizedMailer.finished_registration(ownership).deliver_now
-    end
-  end
-
-  private
-
-  def update_current_marketplace_listings(bike)
-    marketplace_listing = bike.current_marketplace_listing
-    return if marketplace_listing.blank? ||
-      marketplace_listing.bike_ownership&.id == bike.current_ownership&.id
-
-    # mark any marketplace listing that was published as sold - the user might have unpublished it
-    update_status = marketplace_listing.published_at.present? ? :sold : :removed
-
-    marketplace_listing.update(status: update_status, end_at: Time.current)
   end
 end

--- a/app/jobs/email/partial_registration_job.rb
+++ b/app/jobs/email/partial_registration_job.rb
@@ -1,28 +1,30 @@
 # frozen_string_literal: true
 
-class Email::PartialRegistrationJob < ApplicationJob
-  sidekiq_options queue: "notify", retry: 3
+module Email
+  class PartialRegistrationJob < ApplicationJob
+    sidekiq_options queue: "notify", retry: 3
 
-  # When we started creating notifications when sending partial registration emails PR#2368
-  NOTIFICATION_STARTED = Time.at(1690677345).freeze # 2023-07-29 17:35:45
+    # When we started creating notifications when sending partial registration emails PR#2368
+    NOTIFICATION_STARTED = Time.at(1690677345).freeze # 2023-07-29 17:35:45
 
-  def perform(b_param_id)
-    b_param = BParam.find(b_param_id)
-    return if b_param.blank?
+    def perform(b_param_id)
+      b_param = BParam.find(b_param_id)
+      return if b_param.blank?
 
-    if EmailDomain::VERIFICATION_ENABLED
-      email_domain = EmailDomain.find_or_create_for(b_param.owner_email)
+      if EmailDomain::VERIFICATION_ENABLED
+        email_domain = EmailDomain.find_or_create_for(b_param.owner_email)
 
-      return b_param.destroy if email_domain&.banned?
-      return if email_domain&.provisional_ban?
-    end
+        return b_param.destroy if email_domain&.banned?
+        return if email_domain&.provisional_ban?
+      end
 
-    notification = Notification.create(kind: "partial_registration",
-      message_channel: "email",
-      notifiable: b_param)
+      notification = Notification.create(kind: "partial_registration",
+        message_channel: "email",
+        notifiable: b_param)
 
-    notification.track_email_delivery do
-      OrganizedMailer.partial_registration(b_param).deliver_now
+      notification.track_email_delivery do
+        OrganizedMailer.partial_registration(b_param).deliver_now
+      end
     end
   end
 end

--- a/app/jobs/email/receipt_job.rb
+++ b/app/jobs/email/receipt_job.rb
@@ -1,17 +1,19 @@
 # frozen_string_literal: true
 
-class Email::ReceiptJob < ApplicationJob
-  sidekiq_options queue: "notify", retry: 3
+module Email
+  class ReceiptJob < ApplicationJob
+    sidekiq_options queue: "notify", retry: 3
 
-  def perform(id)
-    payment = Payment.find(id)
-    notification = payment.notifications.receipt.first
-    notification ||= Notification.create(kind: "receipt", notifiable: payment)
-    notification.track_email_delivery do
-      CustomerMailer.invoice_email(payment).deliver_now
+    def perform(id)
+      payment = Payment.find(id)
+      notification = payment.notifications.receipt.first
+      notification ||= Notification.create(kind: "receipt", notifiable: payment)
+      notification.track_email_delivery do
+        CustomerMailer.invoice_email(payment).deliver_now
+      end
+      return unless payment.donation?
+
+      Email::DonationJob.perform_in(1.2.hours + (rand(9..55) * 60), payment.id)
     end
-    return unless payment.donation?
-
-    Email::DonationJob.perform_in(1.2.hours + (rand(9..55) * 60), payment.id)
   end
 end

--- a/app/jobs/email/recovered_from_link_job.rb
+++ b/app/jobs/email/recovered_from_link_job.rb
@@ -1,10 +1,12 @@
 # frozen_string_literal: true
 
-class Email::RecoveredFromLinkJob < ApplicationJob
-  sidekiq_options queue: "notify", retry: 3
+module Email
+  class RecoveredFromLinkJob < ApplicationJob
+    sidekiq_options queue: "notify", retry: 3
 
-  def perform(stolen_record_id)
-    stolen_record = StolenRecord.current_and_not.find(stolen_record_id)
-    CustomerMailer.recovered_from_link(stolen_record).deliver_now
+    def perform(stolen_record_id)
+      stolen_record = StolenRecord.current_and_not.find(stolen_record_id)
+      CustomerMailer.recovered_from_link(stolen_record).deliver_now
+    end
   end
 end

--- a/app/jobs/email/reset_password_job.rb
+++ b/app/jobs/email/reset_password_job.rb
@@ -1,29 +1,31 @@
 # frozen_string_literal: true
 
-class Email::ResetPasswordJob < ApplicationJob
-  sidekiq_options queue: "notify", retry: 3
+module Email
+  class ResetPasswordJob < ApplicationJob
+    sidekiq_options queue: "notify", retry: 3
 
-  NOTIFICATION_KIND = "password_reset"
+    NOTIFICATION_KIND = "password_reset"
 
-  def perform(user_id)
-    user = User.find(user_id)
-    unless user.token_for_password_reset.present?
-      raise StandardError, "User #{user_id} does not have a token_for_password_reset"
+    def perform(user_id)
+      user = User.find(user_id)
+      unless user.token_for_password_reset.present?
+        raise StandardError, "User #{user_id} does not have a token_for_password_reset"
+      end
+      # We dnn't send email to banned users
+      return if user.banned?
+
+      notification_for_password_reset_token(user).track_email_delivery do
+        CustomerMailer.password_reset_email(user).deliver_now
+      end
     end
-    # We dnn't send email to banned users
-    return if user.banned?
 
-    notification_for_password_reset_token(user).track_email_delivery do
-      CustomerMailer.password_reset_email(user).deliver_now
+    private
+
+    def notification_for_password_reset_token(user)
+      token_time = user.auth_token_time("token_for_password_reset")
+      Notification.where(user_id: user.id, kind: NOTIFICATION_KIND)
+        .where("created_at > ?", token_time).first ||
+        Notification.create(user_id: user.id, kind: NOTIFICATION_KIND)
     end
-  end
-
-  private
-
-  def notification_for_password_reset_token(user)
-    token_time = user.auth_token_time("token_for_password_reset")
-    Notification.where(user_id: user.id, kind: NOTIFICATION_KIND)
-      .where("created_at > ?", token_time).first ||
-      Notification.create(user_id: user.id, kind: NOTIFICATION_KIND)
   end
 end

--- a/app/jobs/email/scheduled_survey_job.rb
+++ b/app/jobs/email/scheduled_survey_job.rb
@@ -1,91 +1,93 @@
-class Email::ScheduledSurveyJob < ScheduledJob
-  prepend ScheduledJobRecorder
+module Email
+  class ScheduledSurveyJob < ScheduledJob
+    prepend ScheduledJobRecorder
 
-  sidekiq_options retry: 2
-  SURVEY_COUNT = (ENV["THEFT_SURVEY_COUNT"] || 200).to_i
+    sidekiq_options retry: 2
+    SURVEY_COUNT = (ENV["THEFT_SURVEY_COUNT"] || 200).to_i
 
-  def self.frequency
-    24.hours
-  end
-
-  def perform(bike_id = nil, force_send = false)
-    return enqueue_workers(SURVEY_COUNT) if bike_id.blank?
-
-    bike = Bike.unscoped.find(bike_id)
-    return if !force_send && no_survey?(bike)
-
-    notification = Notification.create(kind: :theft_survey_2023, bike: bike, user: bike.user)
-    notification.track_email_delivery do
-      CustomerMailer.theft_survey(notification).deliver_now
+    def self.frequency
+      24.hours
     end
-  end
 
-  def send_survey?(bike = nil)
-    return false if bike.blank?
+    def perform(bike_id = nil, force_send = false)
+      return enqueue_workers(SURVEY_COUNT) if bike_id.blank?
 
-    if bike.user_id.present?
-      return false if notifications.where(user_id: bike.user_id).limit(1).any?
-      return false if bike.user&.no_non_theft_notification
+      bike = Bike.unscoped.find(bike_id)
+      return if !force_send && no_survey?(bike)
+
+      notification = Notification.create(kind: :theft_survey_2023, bike: bike, user: bike.user)
+      notification.track_email_delivery do
+        CustomerMailer.theft_survey(notification).deliver_now
+      end
     end
-    # Verify there are no theft survey notifications with the email
-    return false if notifications.where(message_channel_target: bike.owner_email).limit(1).any?
 
-    # Update 2024-5 -> only sending to stolen registrants
-    potential_stolen_records.where(bike_id: bike.id).any?
-  end
+    def send_survey?(bike = nil)
+      return false if bike.blank?
 
-  def no_survey?(bike)
-    !send_survey?(bike)
-  end
+      if bike.user_id.present?
+        return false if notifications.where(user_id: bike.user_id).limit(1).any?
+        return false if bike.user&.no_non_theft_notification
+      end
+      # Verify there are no theft survey notifications with the email
+      return false if notifications.where(message_channel_target: bike.owner_email).limit(1).any?
 
-  def enqueue_workers(enqueue_limit)
-    return if enqueue_limit == 0
-
-    # Some "potential" bikes that are no_survey, so add 200 to cover
-    enqueue_count = enqueue_limit + 200
-    sent = 0
-    potential_recovered_bikes.limit(enqueue_count).find_each do |bike|
-      next if no_survey?(bike)
-      break if sent > enqueue_limit
-
-      Email::ScheduledSurveyJob.perform_in((enqueue_count + sent) * 5, bike.id)
-      sent += 1
+      # Update 2024-5 -> only sending to stolen registrants
+      potential_stolen_records.where(bike_id: bike.id).any?
     end
-    potential_stolen_bikes.limit(enqueue_count - sent).find_each do |bike|
-      next if no_survey?(bike)
-      break if sent > enqueue_limit
 
-      Email::ScheduledSurveyJob.perform_in((enqueue_count + sent) * 5, bike.id)
-      sent += 1
+    def no_survey?(bike)
+      !send_survey?(bike)
     end
-  end
 
-  def stolen_survey_period
-    (Time.current - 10.years)..(Time.current - 1.week)
-  end
+    def enqueue_workers(enqueue_limit)
+      return if enqueue_limit == 0
 
-  # Split out to make it easier to individually send messages
-  def potential_stolen_bikes
-    unsurveyed_bikes.joins(:stolen_records).merge(potential_stolen_records)
-  end
+      # Some "potential" bikes that are no_survey, so add 200 to cover
+      enqueue_count = enqueue_limit + 200
+      sent = 0
+      potential_recovered_bikes.limit(enqueue_count).find_each do |bike|
+        next if no_survey?(bike)
+        break if sent > enqueue_limit
 
-  def potential_recovered_bikes
-    unsurveyed_bikes.joins(:recovered_records).merge(potential_stolen_records)
-  end
+        Email::ScheduledSurveyJob.perform_in((enqueue_count + sent) * 5, bike.id)
+        sent += 1
+      end
+      potential_stolen_bikes.limit(enqueue_count - sent).find_each do |bike|
+        next if no_survey?(bike)
+        break if sent > enqueue_limit
 
-  private
+        Email::ScheduledSurveyJob.perform_in((enqueue_count + sent) * 5, bike.id)
+        sent += 1
+      end
+    end
 
-  def notifications
-    Notification.theft_survey
-  end
+    def stolen_survey_period
+      (Time.current - 10.years)..(Time.current - 1.week)
+    end
 
-  def unsurveyed_bikes
-    Bike.unscoped.left_joins(:theft_surveys).where(notifications: {bike_id: nil})
-  end
+    # Split out to make it easier to individually send messages
+    def potential_stolen_bikes
+      unsurveyed_bikes.joins(:stolen_records).merge(potential_stolen_records)
+    end
 
-  # Split out to make it easier to individually send messages
-  def potential_stolen_records
-    StolenRecord.unscoped.where(no_notify: false, date_stolen: stolen_survey_period)
-      .where(country_id: [nil, Country.united_states_id, Country.canada_id])
+    def potential_recovered_bikes
+      unsurveyed_bikes.joins(:recovered_records).merge(potential_stolen_records)
+    end
+
+    private
+
+    def notifications
+      Notification.theft_survey
+    end
+
+    def unsurveyed_bikes
+      Bike.unscoped.left_joins(:theft_surveys).where(notifications: {bike_id: nil})
+    end
+
+    # Split out to make it easier to individually send messages
+    def potential_stolen_records
+      StolenRecord.unscoped.where(no_notify: false, date_stolen: stolen_survey_period)
+        .where(country_id: [nil, Country.united_states_id, Country.canada_id])
+    end
   end
 end

--- a/app/jobs/email/stolen_notification_job.rb
+++ b/app/jobs/email/stolen_notification_job.rb
@@ -1,29 +1,31 @@
 # frozen_string_literal: true
 
-class Email::StolenNotificationJob < ApplicationJob
-  sidekiq_options queue: "notify", retry: 3
+module Email
+  class StolenNotificationJob < ApplicationJob
+    sidekiq_options queue: "notify", retry: 3
 
-  def perform(stolen_notification_id, force_send = false)
-    stolen_notification = StolenNotification.find(stolen_notification_id)
-    return if stolen_notification.bike.blank?
+    def perform(stolen_notification_id, force_send = false)
+      stolen_notification = StolenNotification.find(stolen_notification_id)
+      return if stolen_notification.bike.blank?
 
-    kind = if force_send || stolen_notification.permitted_send?
-      "stolen_notification_sent"
-    else
-      "stolen_notification_blocked"
-    end
-
-    notification = if force_send
-      Notification.create(notifiable: stolen_notification, kind:)
-    else
-      Notification.find_or_create_by(notifiable: stolen_notification, kind:)
-    end
-
-    notification.track_email_delivery do
-      if notification.kind == "stolen_notification_sent"
-        CustomerMailer.stolen_notification_email(stolen_notification).deliver_now
+      kind = if force_send || stolen_notification.permitted_send?
+        "stolen_notification_sent"
       else
-        AdminMailer.blocked_stolen_notification_email(stolen_notification).deliver_now
+        "stolen_notification_blocked"
+      end
+
+      notification = if force_send
+        Notification.create(notifiable: stolen_notification, kind:)
+      else
+        Notification.find_or_create_by(notifiable: stolen_notification, kind:)
+      end
+
+      notification.track_email_delivery do
+        if notification.kind == "stolen_notification_sent"
+          CustomerMailer.stolen_notification_email(stolen_notification).deliver_now
+        else
+          AdminMailer.blocked_stolen_notification_email(stolen_notification).deliver_now
+        end
       end
     end
   end

--- a/app/jobs/email/theft_alert_notification_job.rb
+++ b/app/jobs/email/theft_alert_notification_job.rb
@@ -1,24 +1,26 @@
 # frozen_string_literal: true
 
-class Email::TheftAlertNotificationJob < ApplicationJob
-  sidekiq_options queue: "notify", retry: 3
+module Email
+  class TheftAlertNotificationJob < ApplicationJob
+    sidekiq_options queue: "notify", retry: 3
 
-  def perform(theft_alert_id, kind, theft_alert = nil)
-    theft_alert ||= TheftAlert.find(theft_alert_id)
+    def perform(theft_alert_id, kind, theft_alert = nil)
+      theft_alert ||= TheftAlert.find(theft_alert_id)
 
-    notification = theft_alert.notifications.where(kind: kind).first
-    notification ||= Notification.create(user: theft_alert.user,
-      kind: kind,
-      message_channel: "email",
-      notifiable: theft_alert,
-      bike: theft_alert.bike)
+      notification = theft_alert.notifications.where(kind: kind).first
+      notification ||= Notification.create(user: theft_alert.user,
+        kind: kind,
+        message_channel: "email",
+        notifiable: theft_alert,
+        bike: theft_alert.bike)
 
-    notification.track_email_delivery do
-      if kind == "theft_alert_recovered"
-        AdminMailer.theft_alert_notification(theft_alert, notification_type: kind)
-          .deliver_now
-      else
-        CustomerMailer.theft_alert_email(theft_alert, notification).deliver_now
+      notification.track_email_delivery do
+        if kind == "theft_alert_recovered"
+          AdminMailer.theft_alert_notification(theft_alert, notification_type: kind)
+            .deliver_now
+        else
+          CustomerMailer.theft_alert_email(theft_alert, notification).deliver_now
+        end
       end
     end
   end

--- a/app/jobs/email/updated_terms_job.rb
+++ b/app/jobs/email/updated_terms_job.rb
@@ -1,30 +1,32 @@
 # frozen_string_literal: true
 
-class Email::UpdatedTermsJob < ApplicationJob
-  sidekiq_options queue: "low_priority"
-  sidekiq_options retry: false
+module Email
+  class UpdatedTermsJob < ApplicationJob
+    sidekiq_options queue: "low_priority"
+    sidekiq_options retry: false
 
-  def perform
-    return true unless redis.llen(enqueued_emails_key) > 0
+    def perform
+      return true unless redis.llen(enqueued_emails_key) > 0
 
-    begin
-      user_id = redis.lpop enqueued_emails_key
-      user = User.where(id: user_id).first if user_id.present?
-      return true unless user_id.present? && user.present?
+      begin
+        user_id = redis.lpop enqueued_emails_key
+        user = User.where(id: user_id).first if user_id.present?
+        return true unless user_id.present? && user.present?
 
-      CustomerMailer.updated_terms_email(user).deliver_now
-    rescue => e
-      # rpush so that if we run into an error, we don't keep running the exact same one
-      redis.rpush(enqueued_emails_key, user_id)
-      raise e
+        CustomerMailer.updated_terms_email(user).deliver_now
+      rescue => e
+        # rpush so that if we run into an error, we don't keep running the exact same one
+        redis.rpush(enqueued_emails_key, user_id)
+        raise e
+      end
     end
-  end
 
-  def enqueued_emails_key
-    "#{Rails.env[0..2]}_email_updated_terms_user_ids"
-  end
+    def enqueued_emails_key
+      "#{Rails.env[0..2]}_email_updated_terms_user_ids"
+    end
 
-  def redis
-    @redis ||= Redis.new # TODO: Switch to connection pool, preferred way of accessing redis
+    def redis
+      @redis ||= Redis.new # TODO: Switch to connection pool, preferred way of accessing redis
+    end
   end
 end

--- a/app/jobs/email/welcome_job.rb
+++ b/app/jobs/email/welcome_job.rb
@@ -1,10 +1,12 @@
 # frozen_string_literal: true
 
-class Email::WelcomeJob < ApplicationJob
-  sidekiq_options queue: "notify", retry: 3
+module Email
+  class WelcomeJob < ApplicationJob
+    sidekiq_options queue: "notify", retry: 3
 
-  def perform(user_id)
-    user = User.find(user_id)
-    CustomerMailer.welcome_email(user).deliver_now
+    def perform(user_id)
+      user = User.find(user_id)
+      CustomerMailer.welcome_email(user).deliver_now
+    end
   end
 end

--- a/app/jobs/images/associator_job.rb
+++ b/app/jobs/images/associator_job.rb
@@ -1,9 +1,11 @@
-class Images::AssociatorJob < ApplicationJob
-  sidekiq_options queue: "high_priority"
+module Images
+  class AssociatorJob < ApplicationJob
+    sidekiq_options queue: "high_priority"
 
-  def perform
-    BParam.unprocessed_image.with_bike.each do |b_param|
-      BikeServices::Creator.new.attach_photo(b_param, b_param.created_bike)
+    def perform
+      BParam.unprocessed_image.with_bike.each do |b_param|
+        BikeServices::Creator.new.attach_photo(b_param, b_param.created_bike)
+      end
     end
   end
 end

--- a/app/jobs/images/external_url_store_job.rb
+++ b/app/jobs/images/external_url_store_job.rb
@@ -1,10 +1,12 @@
-class Images::ExternalUrlStoreJob < ApplicationJob
-  sidekiq_options queue: "med_priority"
+module Images
+  class ExternalUrlStoreJob < ApplicationJob
+    sidekiq_options queue: "med_priority"
 
-  def perform(public_image_id)
-    public_image = PublicImage.unscoped.find_by(id: public_image_id)
-    return if public_image.blank? || public_image.image.present? || public_image.external_image_url.blank?
+    def perform(public_image_id)
+      public_image = PublicImage.unscoped.find_by(id: public_image_id)
+      return if public_image.blank? || public_image.image.present? || public_image.external_image_url.blank?
 
-    public_image.update(remote_image_url: public_image.external_image_url)
+      public_image.update(remote_image_url: public_image.external_image_url)
+    end
   end
 end

--- a/app/jobs/images/process_recovery_display_photo_job.rb
+++ b/app/jobs/images/process_recovery_display_photo_job.rb
@@ -2,58 +2,60 @@
 
 require "image_processing/vips"
 
-class Images::ProcessRecoveryDisplayPhotoJob < ApplicationJob
-  DIMENSIONS = [800, 800].freeze
+module Images
+  class ProcessRecoveryDisplayPhotoJob < ApplicationJob
+    DIMENSIONS = [800, 800].freeze
 
-  sidekiq_options retry: false
+    sidekiq_options retry: false
 
-  def perform(recovery_display_id, remote_photo_url = nil, force_regenerate = false)
-    recovery_display = RecoveryDisplay.find_by_id(recovery_display_id)
-    return unless recovery_display.present?
+    def perform(recovery_display_id, remote_photo_url = nil, force_regenerate = false)
+      recovery_display = RecoveryDisplay.find_by_id(recovery_display_id)
+      return unless recovery_display.present?
 
-    recovery_display.skip_callback_job = true
+      recovery_display.skip_callback_job = true
 
-    # Prevent touching the recovery_display, which kicks off a job
-    ActiveRecord::Base.no_touching do
-      # If remote_photo_url is provided, download and attach it
-      if attach_remote_photo_url?(recovery_display:, remote_photo_url:, force_regenerate:)
-        downloaded_image = Down.download(remote_photo_url)
-        recovery_display.photo.attach(io: downloaded_image, filename: "recovery-#{recovery_display_id}")
+      # Prevent touching the recovery_display, which kicks off a job
+      ActiveRecord::Base.no_touching do
+        # If remote_photo_url is provided, download and attach it
+        if attach_remote_photo_url?(recovery_display:, remote_photo_url:, force_regenerate:)
+          downloaded_image = Down.download(remote_photo_url)
+          recovery_display.photo.attach(io: downloaded_image, filename: "recovery-#{recovery_display_id}")
+        end
+
+        # Process the photo to create photo_processed
+        process_photo(recovery_display, force_regenerate:)
       end
-
-      # Process the photo to create photo_processed
-      process_photo(recovery_display, force_regenerate:)
     end
-  end
 
-  private
+    private
 
-  def attach_remote_photo_url?(recovery_display:, remote_photo_url:, force_regenerate:)
-    return false if remote_photo_url.blank?
+    def attach_remote_photo_url?(recovery_display:, remote_photo_url:, force_regenerate:)
+      return false if remote_photo_url.blank?
 
-    force_regenerate || !recovery_display.photo.attached?
-  end
+      force_regenerate || !recovery_display.photo.attached?
+    end
 
-  def process_photo(recovery_display, force_regenerate: false)
-    return unless recovery_display.photo.attached?
-    return if recovery_display.photo_processed.attached? && !force_regenerate
+    def process_photo(recovery_display, force_regenerate: false)
+      return unless recovery_display.photo.attached?
+      return if recovery_display.photo_processed.attached? && !force_regenerate
 
-    processed_blob = ActiveStorage::Blob.create_and_upload!(
-      io: generate_square_image(recovery_display.photo),
-      filename: "square_recovery-#{recovery_display.id}.jpeg"
-    )
-    processed_blob.analyze
+      processed_blob = ActiveStorage::Blob.create_and_upload!(
+        io: generate_square_image(recovery_display.photo),
+        filename: "square_recovery-#{recovery_display.id}.jpeg"
+      )
+      processed_blob.analyze
 
-    recovery_display.photo_processed.attach(processed_blob)
-    recovery_display
-  end
+      recovery_display.photo_processed.attach(processed_blob)
+      recovery_display
+    end
 
-  def generate_square_image(photo)
-    photo.blob.open do |file|
-      ImageProcessing::Vips.source(file)
-        .resize_to_fill(*DIMENSIONS)
-        .convert("jpeg")
-        .call
+    def generate_square_image(photo)
+      photo.blob.open do |file|
+        ImageProcessing::Vips.source(file)
+          .resize_to_fill(*DIMENSIONS)
+          .convert("jpeg")
+          .call
+      end
     end
   end
 end

--- a/app/jobs/spreadsheets/tsv_creator_job.rb
+++ b/app/jobs/spreadsheets/tsv_creator_job.rb
@@ -1,33 +1,35 @@
-class Spreadsheets::TsvCreatorJob < ScheduledJob
-  prepend ScheduledJobRecorder
+module Spreadsheets
+  class TsvCreatorJob < ScheduledJob
+    prepend ScheduledJobRecorder
 
-  def self.frequency
-    24.hours
-  end
-
-  def perform(tsv_method = nil, true_and_false = false)
-    if tsv_method.blank?
-      enqueue_scheduled_jobs
-    else
-      create_tsv(tsv_method, true_and_false)
+    def self.frequency
+      24.hours
     end
-  end
 
-  def create_tsv(tsv_method, true_and_false)
-    creator = Spreadsheets::TsvCreator.new
-
-    if true_and_false
-      creator.send(tsv_method, true)
-      creator.send(tsv_method, false)
-    else
-      creator.send(tsv_method)
+    def perform(tsv_method = nil, true_and_false = false)
+      if tsv_method.blank?
+        enqueue_scheduled_jobs
+      else
+        create_tsv(tsv_method, true_and_false)
+      end
     end
-  end
 
-  def enqueue_scheduled_jobs
-    Spreadsheets::TsvCreatorJob.perform_async("create_manufacturer")
-    Spreadsheets::TsvCreatorJob.perform_async("create_daily_tsvs")
-    Spreadsheets::TsvCreatorJob.perform_in(20.minutes, "create_stolen_with_reports", true)
-    Spreadsheets::TsvCreatorJob.perform_in(1.hour, "create_stolen", true)
+    def create_tsv(tsv_method, true_and_false)
+      creator = Spreadsheets::TsvCreator.new
+
+      if true_and_false
+        creator.send(tsv_method, true)
+        creator.send(tsv_method, false)
+      else
+        creator.send(tsv_method)
+      end
+    end
+
+    def enqueue_scheduled_jobs
+      Spreadsheets::TsvCreatorJob.perform_async("create_manufacturer")
+      Spreadsheets::TsvCreatorJob.perform_async("create_daily_tsvs")
+      Spreadsheets::TsvCreatorJob.perform_in(20.minutes, "create_stolen_with_reports", true)
+      Spreadsheets::TsvCreatorJob.perform_in(1.hour, "create_stolen", true)
+    end
   end
 end

--- a/app/jobs/stolen_bike/activate_theft_alert_job.rb
+++ b/app/jobs/stolen_bike/activate_theft_alert_job.rb
@@ -1,24 +1,26 @@
-class StolenBike::ActivateTheftAlertJob < ApplicationJob
-  sidekiq_options retry: 4 # It will retry because of StolenBike::UpdateTheftAlertFacebookJob
+module StolenBike
+  class ActivateTheftAlertJob < ApplicationJob
+    sidekiq_options retry: 4 # It will retry because of StolenBike::UpdateTheftAlertFacebookJob
 
-  def perform(theft_alert_id, force_activate = false)
-    theft_alert = TheftAlert.find(theft_alert_id)
-    return false unless theft_alert.pending?
-    return false unless theft_alert.activateable? || force_activate
+    def perform(theft_alert_id, force_activate = false)
+      theft_alert = TheftAlert.find(theft_alert_id)
+      return false unless theft_alert.pending?
+      return false unless theft_alert.activateable? || force_activate
 
-    if theft_alert.activating_at.blank?
-      new_data = theft_alert.facebook_data || {}
-      theft_alert.update(facebook_data: new_data.merge(activating_at: Time.current.to_i))
+      if theft_alert.activating_at.blank?
+        new_data = theft_alert.facebook_data || {}
+        theft_alert.update(facebook_data: new_data.merge(activating_at: Time.current.to_i))
+      end
+
+      Facebook::AdsIntegration.new.create_for(theft_alert)
+
+      theft_alert.reload
+      # And mark the theft alert active
+      theft_alert.update(start_at: theft_alert.start_at_with_fallback,
+        end_at: theft_alert.calculated_end_at,
+        status: "active")
+      # Generally, there is information that didn't get saved when the ad was created, so enqueue update
+      StolenBike::UpdateTheftAlertFacebookJob.perform_in(15.seconds, theft_alert.id)
     end
-
-    Facebook::AdsIntegration.new.create_for(theft_alert)
-
-    theft_alert.reload
-    # And mark the theft alert active
-    theft_alert.update(start_at: theft_alert.start_at_with_fallback,
-      end_at: theft_alert.calculated_end_at,
-      status: "active")
-    # Generally, there is information that didn't get saved when the ad was created, so enqueue update
-    StolenBike::UpdateTheftAlertFacebookJob.perform_in(15.seconds, theft_alert.id)
   end
 end

--- a/app/jobs/stolen_bike/after_stolen_record_save_job.rb
+++ b/app/jobs/stolen_bike/after_stolen_record_save_job.rb
@@ -1,28 +1,30 @@
-class StolenBike::AfterStolenRecordSaveJob < ApplicationJob
-  sidekiq_options retry: false
+module StolenBike
+  class AfterStolenRecordSaveJob < ApplicationJob
+    sidekiq_options retry: false
 
-  def perform(stolen_record_id, force_regenerate_images = false, public_image_id = nil)
-    stolen_record = StolenRecord.unscoped.find_by_id(stolen_record_id)
-    return if stolen_record.blank?
+    def perform(stolen_record_id, force_regenerate_images = false, public_image_id = nil)
+      stolen_record = StolenRecord.unscoped.find_by_id(stolen_record_id)
+      return if stolen_record.blank?
 
-    stolen_record.skip_update = true
+      stolen_record.skip_update = true
 
-    stolen_record.theft_alerts.each { |t| t.update(updated_at: Time.current) }
-    if stolen_record.current
-      StolenRecord.unscoped.where(bike_id: stolen_record.bike_id).where.not(id: stolen_record.id)
-        .each { |s| s.update(current: false, skip_update: true) }
-    end
-
-    if stolen_record.organization_stolen_message.blank?
-      stolen_message = OrganizationStolenMessage.for_stolen_record(stolen_record)
-      if stolen_message.present?
-        stolen_record.update(organization_stolen_message_id: stolen_message.id, skip_update: true)
+      stolen_record.theft_alerts.each { |t| t.update(updated_at: Time.current) }
+      if stolen_record.current
+        StolenRecord.unscoped.where(bike_id: stolen_record.bike_id).where.not(id: stolen_record.id)
+          .each { |s| s.update(current: false, skip_update: true) }
       end
-    end
-    stolen_record.find_or_create_recovery_link_token
 
-    Images::StolenProcessor.update_alert_images(stolen_record,
-      force_regenerate: force_regenerate_images,
-      public_image_id:)
+      if stolen_record.organization_stolen_message.blank?
+        stolen_message = OrganizationStolenMessage.for_stolen_record(stolen_record)
+        if stolen_message.present?
+          stolen_record.update(organization_stolen_message_id: stolen_message.id, skip_update: true)
+        end
+      end
+      stolen_record.find_or_create_recovery_link_token
+
+      Images::StolenProcessor.update_alert_images(stolen_record,
+        force_regenerate: force_regenerate_images,
+        public_image_id:)
+    end
   end
 end

--- a/app/jobs/stolen_bike/approve_stolen_listing_job.rb
+++ b/app/jobs/stolen_bike/approve_stolen_listing_job.rb
@@ -1,52 +1,54 @@
-class StolenBike::ApproveStolenListingJob < ApplicationJob
-  sidekiq_options queue: "notify", retry: 1
+module StolenBike
+  class ApproveStolenListingJob < ApplicationJob
+    sidekiq_options queue: "notify", retry: 1
 
-  TWEETING_DISABLED = ENV["TWITTER_IS_FUCKED"].present?
+    TWEETING_DISABLED = ENV["TWITTER_IS_FUCKED"].present?
 
-  def perform(bike_id)
-    return if TWEETING_DISABLED
+    def perform(bike_id)
+      return if TWEETING_DISABLED
 
-    bike = Bike.find(bike_id)
-    new_post = Integrations::SocialPoster.new(bike).create_post
-    send_stolen_bike_alert_email(bike, new_post)
-  end
-
-  def send_stolen_bike_alert_email(bike, post)
-    if bike.current_stolen_record.blank? || post.blank?
-      raise ArgumentError, error_context(bike, post)
+      bike = Bike.find(bike_id)
+      new_post = Integrations::SocialPoster.new(bike).create_post
+      send_stolen_bike_alert_email(bike, new_post)
     end
 
-    title_string =
-      if bike.status_abandoned?
-        "We tweeted about the bike you found!"
-      else
-        "We tweeted about your stolen bike!"
+    def send_stolen_bike_alert_email(bike, post)
+      if bike.current_stolen_record.blank? || post.blank?
+        raise ArgumentError, error_context(bike, post)
       end
 
-    customer_contact =
-      CustomerContact.new(
-        body: "EMPTY",
-        bike_id: bike.id,
-        kind: :stolen_twitter_alerter,
-        title: title_string,
-        user_email: bike.owner_email,
-        creator_email: "bryan@bikeindex.org",
-        info_hash: post.details_hash
-      )
+      title_string =
+        if bike.status_abandoned?
+          "We tweeted about the bike you found!"
+        else
+          "We tweeted about your stolen bike!"
+        end
 
-    if customer_contact.save
-      EmailStolenBikeAlertJob.perform_async(customer_contact.id)
-    else
-      raise ArgumentError, error_context(bike, post, customer_contact.errors.full_messages)
+      customer_contact =
+        CustomerContact.new(
+          body: "EMPTY",
+          bike_id: bike.id,
+          kind: :stolen_twitter_alerter,
+          title: title_string,
+          user_email: bike.owner_email,
+          creator_email: "bryan@bikeindex.org",
+          info_hash: post.details_hash
+        )
+
+      if customer_contact.save
+        EmailStolenBikeAlertJob.perform_async(customer_contact.id)
+      else
+        raise ArgumentError, error_context(bike, post, customer_contact.errors.full_messages)
+      end
     end
-  end
 
-  def error_context(bike, post, errors = [])
-    {
-      message: "failed creating alert for stolen listing",
-      bike: bike&.id,
-      post: post&.id,
-      errors: errors
-    }
+    def error_context(bike, post, errors = [])
+      {
+        message: "failed creating alert for stolen listing",
+        bike: bike&.id,
+        post: post&.id,
+        errors: errors
+      }
+    end
   end
 end

--- a/app/jobs/stolen_bike/deactivate_expired_theft_alert_job.rb
+++ b/app/jobs/stolen_bike/deactivate_expired_theft_alert_job.rb
@@ -1,13 +1,15 @@
-class StolenBike::DeactivateExpiredTheftAlertJob < ScheduledJob
-  prepend ScheduledJobRecorder
+module StolenBike
+  class DeactivateExpiredTheftAlertJob < ScheduledJob
+    prepend ScheduledJobRecorder
 
-  def self.frequency
-    23.5.hours
-  end
+    def self.frequency
+      23.5.hours
+    end
 
-  def perform
-    TheftAlert
-      .should_expire
-      .update_all(status: "inactive")
+    def perform
+      TheftAlert
+        .should_expire
+        .update_all(status: "inactive")
+    end
   end
 end

--- a/app/jobs/stolen_bike/remove_orphaned_images_job.rb
+++ b/app/jobs/stolen_bike/remove_orphaned_images_job.rb
@@ -2,76 +2,78 @@
 
 # Images are linked by external sources - so don't purge them in Images::StolenProcessor
 # Do it after a delay (and after we've verified the new images are correct)
-class StolenBike::RemoveOrphanedImagesJob < ScheduledJob
-  prepend ScheduledJobRecorder
+module StolenBike
+  class RemoveOrphanedImagesJob < ScheduledJob
+    prepend ScheduledJobRecorder
 
-  class << self
-    def frequency
-      30.hours
+    class << self
+      def frequency
+        30.hours
+      end
+
+      def check_period
+        1.week.ago..1.day.ago
+      end
+
+      def blobs_for(stolen_record_id)
+        ActiveStorage::Blob.where("filename ILIKE ?", "stolen-#{stolen_record_id}-%")
+          .where("created_at < ?", check_period.last)
+      end
     end
 
-    def check_period
-      1.week.ago..1.day.ago
-    end
+    def perform(stolen_record_id = nil)
+      return enqueue_workers unless stolen_record_id.present?
 
-    def blobs_for(stolen_record_id)
-      ActiveStorage::Blob.where("filename ILIKE ?", "stolen-#{stolen_record_id}-%")
-        .where("created_at < ?", check_period.last)
-    end
-  end
+      stolen_record = StolenRecord.find_by(id: stolen_record_id)
 
-  def perform(stolen_record_id = nil)
-    return enqueue_workers unless stolen_record_id.present?
-
-    stolen_record = StolenRecord.find_by(id: stolen_record_id)
-
-    if stolen_record.present?
-      if stolen_record.images_attached?
-        delete_alert_images!(stolen_record_id)
-        delete_outdated_blobs!(stolen_record_id)
-      elsif stolen_record.bike_main_image.blank?
+      if stolen_record.present?
+        if stolen_record.images_attached?
+          delete_alert_images!(stolen_record_id)
+          delete_outdated_blobs!(stolen_record_id)
+        elsif stolen_record.bike_main_image.blank?
+          delete_all_images!(stolen_record_id)
+        end
+      else
         delete_all_images!(stolen_record_id)
       end
-    else
-      delete_all_images!(stolen_record_id)
     end
-  end
 
-  private
+    private
 
-  def delete_all_images!(stolen_record_id)
-    delete_alert_images!(stolen_record_id)
-    self.class.blobs_for(stolen_record_id).each { |blob| blob.purge }
-    # Use delete_all to skip after_commit callbacks that crash when record is gone
-    attachments(stolen_record_id).delete_all
-  end
+    def delete_all_images!(stolen_record_id)
+      delete_alert_images!(stolen_record_id)
+      self.class.blobs_for(stolen_record_id).each { |blob| blob.purge }
+      # Use delete_all to skip after_commit callbacks that crash when record is gone
+      attachments(stolen_record_id).delete_all
+    end
 
-  def delete_alert_images!(stolen_record_id)
-    AlertImage.where(stolen_record_id:).destroy_all
-  end
+    def delete_alert_images!(stolen_record_id)
+      AlertImage.where(stolen_record_id:).destroy_all
+    end
 
-  def delete_outdated_blobs!(stolen_record_id)
-    self.class.blobs_for(stolen_record_id).where.not(id: attachments(stolen_record_id)
-      .pluck(:blob_id))
-      .each { |blob| blob.purge }
-  end
+    def delete_outdated_blobs!(stolen_record_id)
+      self.class.blobs_for(stolen_record_id).where.not(id: attachments(stolen_record_id)
+        .pluck(:blob_id))
+        .each { |blob| blob.purge }
+    end
 
-  def attachments(record_id)
-    ActiveStorage::Attachment.where(record_type: "StolenRecord", record_id:)
-  end
+    def attachments(record_id)
+      ActiveStorage::Attachment.where(record_type: "StolenRecord", record_id:)
+    end
 
-  def enqueue_workers
-    Bike.unscoped.joins(:stolen_records)
-      .where(deleted_at: self.class.check_period)
-      .pluck("stolen_records.id")
-      .each { |id| self.class.perform_async(id) }
+    def enqueue_workers
+      Bike.unscoped.joins(:stolen_records)
+        .where(deleted_at: self.class.check_period)
+        .pluck("stolen_records.id")
+        .each { |id| self.class.perform_async(id) }
 
-    ActiveStorage::Attachment.where(record_type: "StolenRecord")
-      .where(created_at: self.class.check_period).distinct.pluck(:record_id)
-      .each { |id| self.class.perform_async(id) }
+      ActiveStorage::Attachment.where(record_type: "StolenRecord")
+        .where(created_at: self.class.check_period).distinct.pluck(:record_id)
+        .each { |id| self.class.perform_async(id) }
 
-    # Enqueue these *after* active storage attachment, there might be some overlap with deleted
-    StolenRecord.unscoped.where(recovered_at: self.class.check_period).pluck(:id)
-      .each { |id| self.class.perform_async(id) }
+      # Enqueue these *after* active storage attachment, there might be some overlap with deleted
+      StolenRecord.unscoped.where(recovered_at: self.class.check_period).pluck(:id)
+        .each { |id| self.class.perform_async(id) }
+    end
   end
 end

--- a/app/jobs/stolen_bike/update_theft_alert_facebook_job.rb
+++ b/app/jobs/stolen_bike/update_theft_alert_facebook_job.rb
@@ -1,42 +1,44 @@
-class StolenBike::UpdateTheftAlertFacebookJob < ScheduledJob
-  prepend ScheduledJobRecorder
+module StolenBike
+  class UpdateTheftAlertFacebookJob < ScheduledJob
+    prepend ScheduledJobRecorder
 
-  sidekiq_options queue: "low_priority", retry: 3 # It will retry because of scheduling
+    sidekiq_options queue: "low_priority", retry: 3 # It will retry because of scheduling
 
-  def self.frequency
-    34.minutes
-  end
-
-  def perform(theft_alert_id = nil)
-    return enqueue_workers if theft_alert_id.blank?
-
-    theft_alert = TheftAlert.find(theft_alert_id)
-    return if theft_alert.manual_override_inactive?
-
-    # If the ad_id is blank, we need to activate the ad
-    if theft_alert.facebook_data&.dig("ad_id").blank? || theft_alert.failed_to_activate?
-      return StolenBike::ActivateTheftAlertJob.perform_async(theft_alert_id)
+    def self.frequency
+      34.minutes
     end
 
-    Facebook::AdsIntegration.new.update_facebook_data(theft_alert)
+    def perform(theft_alert_id = nil)
+      return enqueue_workers if theft_alert_id.blank?
 
-    return true unless theft_alert.notify? &&
-      theft_alert.notifications.theft_alert_posted.none?
+      theft_alert = TheftAlert.find(theft_alert_id)
+      return if theft_alert.manual_override_inactive?
 
-    # Perform inline rather than re-querying for objects
-    Email::TheftAlertNotificationJob.new.perform(theft_alert_id, "theft_alert_posted", theft_alert)
-  end
+      # If the ad_id is blank, we need to activate the ad
+      if theft_alert.facebook_data&.dig("ad_id").blank? || theft_alert.failed_to_activate?
+        return StolenBike::ActivateTheftAlertJob.perform_async(theft_alert_id)
+      end
 
-  def enqueue_workers
-    TheftAlert.should_update_facebook.where(facebook_updated_at: nil).pluck(:id)
-      .each { |i| self.class.perform_async(i) }
+      Facebook::AdsIntegration.new.update_facebook_data(theft_alert)
 
-    # Try to avoid overrunning our rate limits
-    TheftAlert.failed_to_activate.pluck(:id)
-      .each { |i| self.class.perform_in(2.minutes, i) }
+      return true unless theft_alert.notify? &&
+        theft_alert.notifications.theft_alert_posted.none?
 
-    TheftAlert.should_update_facebook.where.not(facebook_updated_at: nil)
-      .order(:facebook_updated_at).limit(20).pluck(:id)
-      .each_with_index { |i, inx| self.class.perform_in(3.minutes + inx.minutes, i) }
+      # Perform inline rather than re-querying for objects
+      Email::TheftAlertNotificationJob.new.perform(theft_alert_id, "theft_alert_posted", theft_alert)
+    end
+
+    def enqueue_workers
+      TheftAlert.should_update_facebook.where(facebook_updated_at: nil).pluck(:id)
+        .each { |i| self.class.perform_async(i) }
+
+      # Try to avoid overrunning our rate limits
+      TheftAlert.failed_to_activate.pluck(:id)
+        .each { |i| self.class.perform_in(2.minutes, i) }
+
+      TheftAlert.should_update_facebook.where.not(facebook_updated_at: nil)
+        .order(:facebook_updated_at).limit(20).pluck(:id)
+        .each_with_index { |i, inx| self.class.perform_in(3.minutes + inx.minutes, i) }
+    end
   end
 end

--- a/app/jobs/stripe/update_prices_job.rb
+++ b/app/jobs/stripe/update_prices_job.rb
@@ -1,47 +1,49 @@
 # frozen_string_literal: true
 
-class Stripe::UpdatePricesJob < ApplicationJob
-  def perform
-    updated_ids = []
+module Stripe
+  class UpdatePricesJob < ApplicationJob
+    def perform
+      updated_ids = []
 
-    Stripe::Price.list({limit: 100}).each do |price|
-      stripe_price = StripePrice.find_by(stripe_id: price.id) || StripePrice.new(stripe_id: price.id)
-      new_attributes = {
-        currency: price.currency,
-        amount_cents: price.unit_amount,
-        membership_level: product_membership_level[price.product],
-        interval: "#{price.recurring["interval"]}ly",
-        live: price.livemode,
-        active: active?(price.active, price.livemode)
-      }
+      ::Stripe::Price.list({limit: 100}).each do |price|
+        stripe_price = StripePrice.find_by(stripe_id: price.id) || StripePrice.new(stripe_id: price.id)
+        new_attributes = {
+          currency: price.currency,
+          amount_cents: price.unit_amount,
+          membership_level: product_membership_level[price.product],
+          interval: "#{price.recurring["interval"]}ly",
+          live: price.livemode,
+          active: active?(price.active, price.livemode)
+        }
 
-      # Only create if we know the membership kind
-      if new_attributes[:membership_level].present?
-        stripe_price.update!(new_attributes)
-        updated_ids << stripe_price.id
+        # Only create if we know the membership kind
+        if new_attributes[:membership_level].present?
+          stripe_price.update!(new_attributes)
+          updated_ids << stripe_price.id
+        end
       end
+
+      StripePrice.where.not(id: updated_ids).each { |stripe_price| stripe_price.update(active: false) }
     end
 
-    StripePrice.where.not(id: updated_ids).each { |stripe_price| stripe_price.update(active: false) }
-  end
+    private
 
-  private
+    # Only mark it active if it's active and the livemode matches current system livemode
+    def active?(active, live)
+      active && live == STRIPE_LIVE_MODE
+    end
 
-  # Only mark it active if it's active and the livemode matches current system livemode
-  def active?(active, live)
-    active && live == STRIPE_LIVE_MODE
-  end
+    def product_membership_level
+      return @product_membership_level if defined?(@product_membership_level)
 
-  def product_membership_level
-    return @product_membership_level if defined?(@product_membership_level)
+      membership_products = ::Stripe::Product.list({active: true, limit: 100})
+        .select { it.name.match?(/member/i) }
 
-    membership_products = Stripe::Product.list({active: true, limit: 100})
-      .select { it.name.match?(/member/i) }
-
-    @product_membership_level = [
-      [membership_products.find { it.name.downcase == "membership" }&.id, :basic],
-      [membership_products.find { it.name.match?(/plus|\+/i) }&.id, :plus],
-      [membership_products.find { it.name.match?(/patron/i) }&.id, :patron]
-    ].to_h
+      @product_membership_level = [
+        [membership_products.find { it.name.downcase == "membership" }&.id, :basic],
+        [membership_products.find { it.name.match?(/plus|\+/i) }&.id, :plus],
+        [membership_products.find { it.name.match?(/patron/i) }&.id, :patron]
+      ].to_h
+    end
   end
 end

--- a/app/jobs/users/create_or_update_membership_from_payment_job.rb
+++ b/app/jobs/users/create_or_update_membership_from_payment_job.rb
@@ -1,44 +1,46 @@
 # frozen_string_literal: true
 
 # NOTE: This job creates admin managed memberships
-class Users::CreateOrUpdateMembershipFromPaymentJob < ApplicationJob
-  def perform(payment_id, admin_id = nil)
-    payment = Payment.find(payment_id)
-    return if payment.membership_id.present?
+module Users
+  class CreateOrUpdateMembershipFromPaymentJob < ApplicationJob
+    def perform(payment_id, admin_id = nil)
+      payment = Payment.find(payment_id)
+      return if payment.membership_id.present?
 
-    membership = Membership.where(user_id: payment.user_id).time_ordered.active.last
-    if membership.present?
-      membership.update!(period_from_amount(payment.amount_cents, start_at: membership.start_at,
-        end_at: membership.end_at))
-    else
-      membership = Membership.new(user_id: payment.user_id, creator_id: admin_id)
-      membership.level = level_from_amount(payment.amount_cents)
-      membership.update!(period_from_amount(payment.amount_cents))
-    end
-    payment.update!(membership_id: membership.id)
-  end
-
-  private
-
-  # for simplicity, just do basic and patron - plus is just for extra gifts
-  def level_from_amount(amount_cents)
-    (amount_cents < 5000) ? "basic" : "patron"
-  end
-
-  def period_from_amount(amount_cents, start_at: nil, end_at: nil)
-    start_at ||= Time.current
-    end_at ||= start_at
-
-    extension = if amount_cents < 999
-      1.month
-    elsif amount_cents < 2500
-      3.months
-    elsif amount_cents < 4999
-      6.months
-    else
-      1.year
+      membership = Membership.where(user_id: payment.user_id).time_ordered.active.last
+      if membership.present?
+        membership.update!(period_from_amount(payment.amount_cents, start_at: membership.start_at,
+          end_at: membership.end_at))
+      else
+        membership = Membership.new(user_id: payment.user_id, creator_id: admin_id)
+        membership.level = level_from_amount(payment.amount_cents)
+        membership.update!(period_from_amount(payment.amount_cents))
+      end
+      payment.update!(membership_id: membership.id)
     end
 
-    {start_at:, end_at: end_at + extension}
+    private
+
+    # for simplicity, just do basic and patron - plus is just for extra gifts
+    def level_from_amount(amount_cents)
+      (amount_cents < 5000) ? "basic" : "patron"
+    end
+
+    def period_from_amount(amount_cents, start_at: nil, end_at: nil)
+      start_at ||= Time.current
+      end_at ||= start_at
+
+      extension = if amount_cents < 999
+        1.month
+      elsif amount_cents < 2500
+        3.months
+      elsif amount_cents < 4999
+        6.months
+      else
+        1.year
+      end
+
+      {start_at:, end_at: end_at + extension}
+    end
   end
 end

--- a/app/jobs/users/merge_additional_email_job.rb
+++ b/app/jobs/users/merge_additional_email_job.rb
@@ -1,96 +1,98 @@
-class Users::MergeAdditionalEmailJob < ApplicationJob
-  sidekiq_options queue: "high_priority"
+module Users
+  class MergeAdditionalEmailJob < ApplicationJob
+    sidekiq_options queue: "high_priority"
 
-  def perform(user_email_id)
-    user_email = UserEmail.find(user_email_id)
-    return true unless user_email.confirmed?
+    def perform(user_email_id)
+      user_email = UserEmail.find(user_email_id)
+      return true unless user_email.confirmed?
 
-    old_user = find_old_user(user_email.email, user_email.user_id)
-    merge_old_user(user_email, old_user) if old_user.present?
-    CallbackJob::AfterUserCreateJob.new.perform(user_email.user_id, "merged", user: user_email.user, email: user_email.email)
-  end
-
-  def merge_old_user(user_email, old_user)
-    user_email.update_attribute(:old_user_id, old_user.id)
-    merge_user_organization_roles(user_email, old_user)
-    user_id = user_email.user_id
-    old_user.ownerships.each { |i| i.update_attribute(:user_id, user_id) }
-    old_user.created_ownerships.each { |i| i.update_attribute(:creator_id, user_id) }
-    old_user.created_bikes.each { |i| i.update_attribute(:creator_id, user_id) }
-
-    old_user.user_phones.update_all(user_id:)
-    old_user.locks.update_all(user_id:)
-    old_user.payments.update_all(user_id:)
-    old_user.stripe_subscriptions.update_all(user_id:)
-    old_user.memberships.update_all(user_id:)
-    old_user.integrations.update_all(user_id:)
-    old_user.sent_stolen_notifications.update_all(sender_id: user_id)
-    old_user.received_stolen_notifications.update_all(receiver_id: user_id)
-    old_user.theft_alerts.update_all(user_id:)
-    old_user.bike_sticker_updates.update_all(user_id:)
-    old_user.email_bans.each { |eb| eb.update(user_id:) }
-
-    BikeVersion.unscoped.where(owner_id: old_user.id).each { |i| i.update(owner_id: user_id) }
-    Doorkeeper::Application.where(owner_id: old_user.id).each { |i| i.update_attribute(:owner_id, user_id) }
-    ImpoundRecord.where(user_id: old_user.id).each { |i| i.update_attribute(:user_id, user_id) }
-    GraduatedNotification.where(user_id: old_user.id).each { |i| i.update_attribute(:user_id, user_id) }
-    ParkingNotification.where(user_id: old_user.id).each { |i| i.update_attribute(:user_id, user_id) }
-    CustomerContact.where(user_id: old_user.id).each { |i| i.update_attribute(:user_id, user_id) }
-    CustomerContact.where(creator_id: old_user.id).each { |i| i.update_attribute(:creator_id, user_id) }
-    update_address_records(user_id, old_user.id)
-
-    # Marketplace things
-    MarketplaceListing.unscoped.where(seller_id: old_user.id).each { |i| i.update(seller_id: user_id) }
-    MarketplaceListing.unscoped.where(buyer_id: old_user.id).each { |i| i.update(buyer_id: user_id) }
-    update_marketplace_messages(user_id, old_user.id)
-
-    # No index, so update all
-    BikeSticker.where(user_id: old_user.id).update_all(user_id:)
-
-    if user_email.user.stripe_id.blank? && old_user.stripe_id.present?
-      user_email.user.update(stripe_id: old_user.stripe_id)
+      old_user = find_old_user(user_email.email, user_email.user_id)
+      merge_old_user(user_email, old_user) if old_user.present?
+      CallbackJob::AfterUserCreateJob.new.perform(user_email.user_id, "merged", user: user_email.user, email: user_email.email)
     end
-    user_email.user.update(banned: true) if old_user.banned?
 
-    old_user.reload # so we don't trigger dependent destroys
-    old_user.destroy
-  end
+    def merge_old_user(user_email, old_user)
+      user_email.update_attribute(:old_user_id, old_user.id)
+      merge_user_organization_roles(user_email, old_user)
+      user_id = user_email.user_id
+      old_user.ownerships.each { |i| i.update_attribute(:user_id, user_id) }
+      old_user.created_ownerships.each { |i| i.update_attribute(:creator_id, user_id) }
+      old_user.created_bikes.each { |i| i.update_attribute(:creator_id, user_id) }
 
-  private
+      old_user.user_phones.update_all(user_id:)
+      old_user.locks.update_all(user_id:)
+      old_user.payments.update_all(user_id:)
+      old_user.stripe_subscriptions.update_all(user_id:)
+      old_user.memberships.update_all(user_id:)
+      old_user.integrations.update_all(user_id:)
+      old_user.sent_stolen_notifications.update_all(sender_id: user_id)
+      old_user.received_stolen_notifications.update_all(receiver_id: user_id)
+      old_user.theft_alerts.update_all(user_id:)
+      old_user.bike_sticker_updates.update_all(user_id:)
+      old_user.email_bans.each { |eb| eb.update(user_id:) }
 
-  def update_address_records(user_id, old_user_id)
-    # If the new user has no address record, assign the old records over, otherwise orphan them
-    if AddressRecord.user.where(user_id:).none?
-      AddressRecord.user.where(user_id: old_user_id).each { |i| i.update(user_id:) }
+      BikeVersion.unscoped.where(owner_id: old_user.id).each { |i| i.update(owner_id: user_id) }
+      Doorkeeper::Application.where(owner_id: old_user.id).each { |i| i.update_attribute(:owner_id, user_id) }
+      ImpoundRecord.where(user_id: old_user.id).each { |i| i.update_attribute(:user_id, user_id) }
+      GraduatedNotification.where(user_id: old_user.id).each { |i| i.update_attribute(:user_id, user_id) }
+      ParkingNotification.where(user_id: old_user.id).each { |i| i.update_attribute(:user_id, user_id) }
+      CustomerContact.where(user_id: old_user.id).each { |i| i.update_attribute(:user_id, user_id) }
+      CustomerContact.where(creator_id: old_user.id).each { |i| i.update_attribute(:creator_id, user_id) }
+      update_address_records(user_id, old_user.id)
+
+      # Marketplace things
+      MarketplaceListing.unscoped.where(seller_id: old_user.id).each { |i| i.update(seller_id: user_id) }
+      MarketplaceListing.unscoped.where(buyer_id: old_user.id).each { |i| i.update(buyer_id: user_id) }
+      update_marketplace_messages(user_id, old_user.id)
+
+      # No index, so update all
+      BikeSticker.where(user_id: old_user.id).update_all(user_id:)
+
+      if user_email.user.stripe_id.blank? && old_user.stripe_id.present?
+        user_email.user.update(stripe_id: old_user.stripe_id)
+      end
+      user_email.user.update(banned: true) if old_user.banned?
+
+      old_user.reload # so we don't trigger dependent destroys
+      old_user.destroy
     end
-    AddressRecord.not_user.where(user_id: old_user_id).each { |i| i.update(user_id:) }
-  end
 
-  def update_marketplace_messages(user_id, old_user_id)
-    # Have to update initial_message first or validations fail on reply updates
-    MarketplaceMessage.unscoped.initial_message.where(sender_id: old_user_id).each { |i| i.update(sender_id: user_id) }
-    MarketplaceMessage.unscoped.where(sender_id: old_user_id).each { |i| i.update(sender_id: user_id) }
-    MarketplaceMessage.unscoped.initial_message.where(receiver_id: old_user_id).each { |i| i.update(receiver_id: user_id) }
-    MarketplaceMessage.unscoped.where(receiver_id: old_user_id).each { |i| i.update(receiver_id: user_id) }
-  end
+    private
 
-  def merge_user_organization_roles(user_email, old_user)
-    Organization.where(auto_user_id: old_user.id).each { |i| i.update_attribute :auto_user_id, user_email.user_id }
-    OrganizationRole.where(sender_id: old_user.id).each { |i| i.update_attribute :sender_id, user_email.user_id }
-    old_user.organization_roles.each do |organization_role|
-      if user_email.user.organizations.include?(organization_role.organization)
-        organization_role.delete
-      else
-        organization_role.update_attribute :user_id, user_email.user_id
+    def update_address_records(user_id, old_user_id)
+      # If the new user has no address record, assign the old records over, otherwise orphan them
+      if AddressRecord.user.where(user_id:).none?
+        AddressRecord.user.where(user_id: old_user_id).each { |i| i.update(user_id:) }
+      end
+      AddressRecord.not_user.where(user_id: old_user_id).each { |i| i.update(user_id:) }
+    end
+
+    def update_marketplace_messages(user_id, old_user_id)
+      # Have to update initial_message first or validations fail on reply updates
+      MarketplaceMessage.unscoped.initial_message.where(sender_id: old_user_id).each { |i| i.update(sender_id: user_id) }
+      MarketplaceMessage.unscoped.where(sender_id: old_user_id).each { |i| i.update(sender_id: user_id) }
+      MarketplaceMessage.unscoped.initial_message.where(receiver_id: old_user_id).each { |i| i.update(receiver_id: user_id) }
+      MarketplaceMessage.unscoped.where(receiver_id: old_user_id).each { |i| i.update(receiver_id: user_id) }
+    end
+
+    def merge_user_organization_roles(user_email, old_user)
+      Organization.where(auto_user_id: old_user.id).each { |i| i.update_attribute :auto_user_id, user_email.user_id }
+      OrganizationRole.where(sender_id: old_user.id).each { |i| i.update_attribute :sender_id, user_email.user_id }
+      old_user.organization_roles.each do |organization_role|
+        if user_email.user.organizations.include?(organization_role.organization)
+          organization_role.delete
+        else
+          organization_role.update_attribute :user_id, user_email.user_id
+        end
       end
     end
-  end
 
-  def find_old_user(email, user_id)
-    user = User.fuzzy_unconfirmed_primary_email_find(email)
-    return user if user.present?
+    def find_old_user(email, user_id)
+      user = User.fuzzy_unconfirmed_primary_email_find(email)
+      return user if user.present?
 
-    user_email = UserEmail.where("user_id != ?", user_id).where(email: email).first
-    user_email&.user
+      user_email = UserEmail.where("user_id != ?", user_id).where(email: email).first
+      user_email&.user
+    end
   end
 end

--- a/app/jobs/users/process_organization_role_job.rb
+++ b/app/jobs/users/process_organization_role_job.rb
@@ -1,80 +1,82 @@
-class Users::ProcessOrganizationRoleJob < ApplicationJob
-  sidekiq_options queue: "high_priority"
+module Users
+  class ProcessOrganizationRoleJob < ApplicationJob
+    sidekiq_options queue: "high_priority"
 
-  def perform(organization_role_id, user_id = nil)
-    organization_role = OrganizationRole.find_by(id: organization_role_id)
-    return if organization_role.blank?
+    def perform(organization_role_id, user_id = nil)
+      organization_role = OrganizationRole.find_by(id: organization_role_id)
+      return if organization_role.blank?
 
-    assign_organization_role_user(organization_role, user_id) if organization_role.user.blank?
-    return false if remove_duplicated_organization_role!(organization_role)
+      assign_organization_role_user(organization_role, user_id) if organization_role.user.blank?
+      return false if remove_duplicated_organization_role!(organization_role)
 
-    auto_generate_user_for_organization(organization_role)
-    if organization_role.send_invitation_email?
-      OrganizedMailer.organization_invitation(organization_role).deliver_now
-      organization_role.update(email_invitation_sent_at: Time.current, skip_processing: true)
+      auto_generate_user_for_organization(organization_role)
+      if organization_role.send_invitation_email?
+        OrganizedMailer.organization_invitation(organization_role).deliver_now
+        organization_role.update(email_invitation_sent_at: Time.current, skip_processing: true)
+      end
+
+      # Bust cache keys on user and organization
+      organization_role.user&.update(updated_at: Time.current, skip_update: true)
+      organization_role.organization.update(updated_at: Time.current, skip_update: true) if organization_role.organization.present?
+
+      # Assign ambassador tasks too
+      if organization_role.ambassador? && organization_role.user.present?
+        assign_all_ambassador_tasks_to(organization_role)
+      end
     end
 
-    # Bust cache keys on user and organization
-    organization_role.user&.update(updated_at: Time.current, skip_update: true)
-    organization_role.organization.update(updated_at: Time.current, skip_update: true) if organization_role.organization.present?
+    def assign_organization_role_user(organization_role, user_id)
+      user_id ||= User.fuzzy_confirmed_or_unconfirmed_email_find(organization_role.invited_email)&.id
+      return false unless user_id.present?
 
-    # Assign ambassador tasks too
-    if organization_role.ambassador? && organization_role.user.present?
-      assign_all_ambassador_tasks_to(organization_role)
+      organization_role.update(user_id: user_id)
+      organization_role.reload
+      User.find_by_id(user_id)&.update(updated_at: Time.current)
     end
-  end
 
-  def assign_organization_role_user(organization_role, user_id)
-    user_id ||= User.fuzzy_confirmed_or_unconfirmed_email_find(organization_role.invited_email)&.id
-    return false unless user_id.present?
+    def remove_duplicated_organization_role!(organization_role)
+      return false unless organization_role.user.present? &&
+        organization_role.user.organization_roles.where.not(id: organization_role.id)
+          .where(organization_id: organization_role.organization_id).any?
 
-    organization_role.update(user_id: user_id)
-    organization_role.reload
-    User.find_by_id(user_id)&.update(updated_at: Time.current)
-  end
+      organization_role.destroy
+    end
 
-  def remove_duplicated_organization_role!(organization_role)
-    return false unless organization_role.user.present? &&
-      organization_role.user.organization_roles.where.not(id: organization_role.id)
-        .where(organization_id: organization_role.organization_id).any?
+    def auto_generate_user_for_organization(organization_role)
+      return false unless organization_role.organization.enabled?("passwordless_users") &&
+        organization_role.user.blank?
 
-    organization_role.destroy
-  end
+      password = SecurityTokenizer.new_password_token
+      user = User.new(skip_update: true,
+        email: organization_role.invited_email,
+        password: password,
+        password_confirmation: password)
+      user.save!
+      user.confirm(user.confirmation_token)
+      # We don't want to send users emails in this situation.
+      organization_role.update(user_id: user.id, email_invitation_sent_at: Time.current)
+      organization_role.reload
+    end
 
-  def auto_generate_user_for_organization(organization_role)
-    return false unless organization_role.organization.enabled?("passwordless_users") &&
-      organization_role.user.blank?
+    def assign_all_ambassador_tasks_to(organization_role)
+      ambassador = organization_role.user.becomes(Ambassador)
 
-    password = SecurityTokenizer.new_password_token
-    user = User.new(skip_update: true,
-      email: organization_role.invited_email,
-      password: password,
-      password_confirmation: password)
-    user.save!
-    user.confirm(user.confirmation_token)
-    # We don't want to send users emails in this situation.
-    organization_role.update(user_id: user.id, email_invitation_sent_at: Time.current)
-    organization_role.reload
-  end
+      already_assigned_task_ids =
+        AmbassadorTask
+          .includes(ambassador_task_assignments: :ambassador)
+          .where(ambassador_task_assignments: {user_id: ambassador.id})
+          .select(:id)
 
-  def assign_all_ambassador_tasks_to(organization_role)
-    ambassador = organization_role.user.becomes(Ambassador)
+      new_assignments =
+        AmbassadorTask
+          .includes(:ambassador_task_assignments)
+          .where
+          .not(id: already_assigned_task_ids)
+          .references(:ambassador_task_assignments)
 
-    already_assigned_task_ids =
-      AmbassadorTask
-        .includes(ambassador_task_assignments: :ambassador)
-        .where(ambassador_task_assignments: {user_id: ambassador.id})
-        .select(:id)
-
-    new_assignments =
-      AmbassadorTask
-        .includes(:ambassador_task_assignments)
-        .where
-        .not(id: already_assigned_task_ids)
-        .references(:ambassador_task_assignments)
-
-    new_assignments.find_each do |ambassador_task|
-      ambassador_task.assign_to(ambassador)
+      new_assignments.find_each do |ambassador_task|
+        ambassador_task.assign_to(ambassador)
+      end
     end
   end
 end

--- a/app/jobs/users/remove_unconfirmed_job.rb
+++ b/app/jobs/users/remove_unconfirmed_job.rb
@@ -1,25 +1,27 @@
-class Users::RemoveUnconfirmedJob < ScheduledJob
-  prepend ScheduledJobRecorder
+module Users
+  class RemoveUnconfirmedJob < ScheduledJob
+    prepend ScheduledJobRecorder
 
-  REMOVE_DELAY = 2.days
+    REMOVE_DELAY = 2.days
 
-  def self.frequency
-    23.hours
-  end
-
-  def perform
-    unconfirmed_users_to_remove.find_each { |user| user.really_destroy! }
-
-    banned_email_domains.each do |domain|
-      User.matching_domain(domain).find_each { |user| user.really_destroy! }
+    def self.frequency
+      23.hours
     end
-  end
 
-  def unconfirmed_users_to_remove
-    User.where("created_at < ?", Time.current - REMOVE_DELAY).unconfirmed
-  end
+    def perform
+      unconfirmed_users_to_remove.find_each { |user| user.really_destroy! }
 
-  def banned_email_domains
-    EmailDomain.banned.pluck(:domain)
+      banned_email_domains.each do |domain|
+        User.matching_domain(domain).find_each { |user| user.really_destroy! }
+      end
+    end
+
+    def unconfirmed_users_to_remove
+      User.where("created_at < ?", Time.current - REMOVE_DELAY).unconfirmed
+    end
+
+    def banned_email_domains
+      EmailDomain.banned.pluck(:domain)
+    end
   end
 end

--- a/app/models/external_registry_bike/project529_bike.rb
+++ b/app/models/external_registry_bike/project529_bike.rb
@@ -31,107 +31,109 @@
 #  index_external_registry_bikes_on_serial_normalized  (serial_normalized)
 #  index_external_registry_bikes_on_type               (type)
 #
-class ExternalRegistryBike::Project529Bike < ExternalRegistryBike
-  def registry_url
-    "https://project529.com"
-  end
-
-  def url
-    info_hash["url"]
-  end
-
-  def image_url
-    info_hash["image_url"]
-  end
-
-  def thumb_url
-    info_hash["thumb_url"]
-  end
-
-  class << self
-    def updated_since_date
-      [
-        maximum(:external_updated_at) || Time.current - 3.years,
-        Time.current - 1.day
-      ].min
+class ExternalRegistryBike
+  class Project529Bike < ExternalRegistryBike
+    def registry_url
+      "https://project529.com"
     end
 
-    def build_from_api_response(attrs = {})
-      return if attrs["status"]&.downcase == "recovered"
-
-      bike = find_or_initialize_by(
-        external_id: attrs["id"],
-        serial_number: attrs["serial_number"],
-        type: to_s
-      )
-
-      bike.cycle_type = "bike"
-      bike.status = ExternalRegistryBike.status_converter(attrs["status"])
-      bike.frame_model = attrs["model_string"]
-      bike.mnfg_name = attrs["manufacturer_string"]
-      bike.location_found = attrs.dig("active_incident", "location_address")
-      bike.frame_colors = frame_colors(attrs)
-      bike.description = description(attrs)
-      bike.date_stolen = StolenRecord.corrected_date_stolen(date_stolen(attrs))
-      bike.country = country(attrs)
-      bike.info_hash = info_hash(attrs)
-      bike.external_updated_at = Binxtils::TimeParser.parse(attrs["updated_at"])
-
-      bike
+    def url
+      info_hash["url"]
     end
 
-    private
-
-    def info_hash(attrs)
-      photo = primary_photo(attrs)
-
-      {
-        url: attrs["url"],
-        image_url: photo["original_url"],
-        thumb_url: photo["medium_url"]
-      }
+    def image_url
+      info_hash["image_url"]
     end
 
-    def country(attrs)
-      name = attrs.dig("active_incident", "location_address")&.split(",")&.last
-      Country.friendly_find(name)
+    def thumb_url
+      info_hash["thumb_url"]
     end
 
-    def frame_colors(attrs)
-      %w[primary_color secondary_color]
-        .map { |key| attrs[key] }
-        .select(&:present?)
-        .join(", ")
-    end
+    class << self
+      def updated_since_date
+        [
+          maximum(:external_updated_at) || Time.current - 3.years,
+          Time.current - 1.day
+        ].min
+      end
 
-    def description(attrs)
-      attrs["description"].presence ||
-        %w[model_year manufacturer_string model_string]
+      def build_from_api_response(attrs = {})
+        return if attrs["status"]&.downcase == "recovered"
+
+        bike = find_or_initialize_by(
+          external_id: attrs["id"],
+          serial_number: attrs["serial_number"],
+          type: to_s
+        )
+
+        bike.cycle_type = "bike"
+        bike.status = ExternalRegistryBike.status_converter(attrs["status"])
+        bike.frame_model = attrs["model_string"]
+        bike.mnfg_name = attrs["manufacturer_string"]
+        bike.location_found = attrs.dig("active_incident", "location_address")
+        bike.frame_colors = frame_colors(attrs)
+        bike.description = description(attrs)
+        bike.date_stolen = StolenRecord.corrected_date_stolen(date_stolen(attrs))
+        bike.country = country(attrs)
+        bike.info_hash = info_hash(attrs)
+        bike.external_updated_at = Binxtils::TimeParser.parse(attrs["updated_at"])
+
+        bike
+      end
+
+      private
+
+      def info_hash(attrs)
+        photo = primary_photo(attrs)
+
+        {
+          url: attrs["url"],
+          image_url: photo["original_url"],
+          thumb_url: photo["medium_url"]
+        }
+      end
+
+      def country(attrs)
+        name = attrs.dig("active_incident", "location_address")&.split(",")&.last
+        Country.friendly_find(name)
+      end
+
+      def frame_colors(attrs)
+        %w[primary_color secondary_color]
           .map { |key| attrs[key] }
           .select(&:present?)
-          .join(" ")
-    end
+          .join(", ")
+      end
 
-    def date_stolen(attrs)
-      attrs.dig("active_incident", "last_seen").presence ||
-        attrs.dig("active_incident", "created_at")
-    end
+      def description(attrs)
+        attrs["description"].presence ||
+          %w[model_year manufacturer_string model_string]
+            .map { |key| attrs[key] }
+            .select(&:present?)
+            .join(" ")
+      end
 
-    def primary_photo(attrs)
-      all_photos =
-        attrs["bike_photos"]
-          .to_a
-          .group_by { |ph| ph["photo_type"] }
-          .map { |photo_type, photos| [photo_type.downcase, photos.first] }
-          .reject { |photo_type, _photos| photo_type.in?(["serial number", "shield"]) }
-          .to_h
+      def date_stolen(attrs)
+        attrs.dig("active_incident", "last_seen").presence ||
+          attrs.dig("active_incident", "created_at")
+      end
 
-      photo =
-        all_photos["side"] ||
-        all_photos["what to look for"] ||
-        all_photos.values.flatten.first
+      def primary_photo(attrs)
+        all_photos =
+          attrs["bike_photos"]
+            .to_a
+            .group_by { |ph| ph["photo_type"] }
+            .map { |photo_type, photos| [photo_type.downcase, photos.first] }
+            .reject { |photo_type, _photos| photo_type.in?(["serial number", "shield"]) }
+            .to_h
 
-      photo || {}
+        photo =
+          all_photos["side"] ||
+          all_photos["what to look for"] ||
+          all_photos.values.flatten.first
+
+        photo || {}
+      end
     end
   end
 end

--- a/app/models/external_registry_bike/stop_heling_bike.rb
+++ b/app/models/external_registry_bike/stop_heling_bike.rb
@@ -31,55 +31,57 @@
 #  index_external_registry_bikes_on_serial_normalized  (serial_normalized)
 #  index_external_registry_bikes_on_type               (type)
 #
-class ExternalRegistryBike::StopHelingBike < ExternalRegistryBike
-  def registry_url
-    "https://www.stopheling.nl"
-  end
-
-  def url
-    registry_url
-  end
-
-  class << self
-    def build_from_api_response(attrs = {})
-      is_bike = attrs[:object]&.match?(/fiets/i)
-      return unless is_bike
-
-      bike = find_or_initialize_by(
-        external_id: attrs[:registration_number].presence,
-        serial_number: serial_number(attrs),
-        type: to_s
-      )
-
-      bike.cycle_type = "bike"
-      bike.status = "status_stolen" # No need for converter, they all come in as stolen
-      bike.country = Country.netherlands
-
-      bike.frame_colors = colors(attrs[:color])
-      bike.location_found = parse_location(attrs[:source_name], bike.country.iso)
-
-      bike.date_stolen = attrs[:insert_date].to_datetime
-      bike.frame_model = attrs[:brand_type].presence
-      bike.mnfg_name = attrs[:brand].presence
-
-      bike
+class ExternalRegistryBike
+  class StopHelingBike < ExternalRegistryBike
+    def registry_url
+      "https://www.stopheling.nl"
     end
 
-    private
-
-    def serial_number(attrs)
-      attrs[:chassis_number].presence ||
-        attrs[:license_plate_number].presence ||
-        "absent"
+    def url
+      registry_url
     end
 
-    def parse_location(source_name, country_iso)
-      return if source_name.blank?
+    class << self
+      def build_from_api_response(attrs = {})
+        is_bike = attrs[:object]&.match?(/fiets/i)
+        return unless is_bike
 
-      [
-        source_name.sub(/politie/i, "").strip&.titleize,
-        country_iso
-      ].select(&:present?).join(" - ")
+        bike = find_or_initialize_by(
+          external_id: attrs[:registration_number].presence,
+          serial_number: serial_number(attrs),
+          type: to_s
+        )
+
+        bike.cycle_type = "bike"
+        bike.status = "status_stolen" # No need for converter, they all come in as stolen
+        bike.country = Country.netherlands
+
+        bike.frame_colors = colors(attrs[:color])
+        bike.location_found = parse_location(attrs[:source_name], bike.country.iso)
+
+        bike.date_stolen = attrs[:insert_date].to_datetime
+        bike.frame_model = attrs[:brand_type].presence
+        bike.mnfg_name = attrs[:brand].presence
+
+        bike
+      end
+
+      private
+
+      def serial_number(attrs)
+        attrs[:chassis_number].presence ||
+          attrs[:license_plate_number].presence ||
+          "absent"
+      end
+
+      def parse_location(source_name, country_iso)
+        return if source_name.blank?
+
+        [
+          source_name.sub(/politie/i, "").strip&.titleize,
+          country_iso
+        ].select(&:present?).join(" - ")
+      end
     end
   end
 end

--- a/app/models/external_registry_bike/verloren_of_gevonden_bike.rb
+++ b/app/models/external_registry_bike/verloren_of_gevonden_bike.rb
@@ -31,92 +31,94 @@
 #  index_external_registry_bikes_on_serial_normalized  (serial_normalized)
 #  index_external_registry_bikes_on_type               (type)
 #
-class ExternalRegistryBike::VerlorenOfGevondenBike < ExternalRegistryBike
-  DATE_REGEX = %r{overgebracht .+ op (?<day>\d{1,2})-(?<month>\d{1,2})-(?<year>\d{4})}
-  LOCATION_REGEX = %r{Locatie gevonden: (.+?)\.}
-  SERIAL_NUMBER_REGEX = %r{framenummer '(?:<strong>)?(.+)(?:</strong>)?'}
+class ExternalRegistryBike
+  class VerlorenOfGevondenBike < ExternalRegistryBike
+    DATE_REGEX = %r{overgebracht .+ op (?<day>\d{1,2})-(?<month>\d{1,2})-(?<year>\d{4})}
+    LOCATION_REGEX = %r{Locatie gevonden: (.+?)\.}
+    SERIAL_NUMBER_REGEX = %r{framenummer '(?:<strong>)?(.+)(?:</strong>)?'}
 
-  class << self
-    def build_from_api_response(attrs = {})
-      is_bike = attrs["Category"] == "fiets"
-      return unless is_bike
+    class << self
+      def build_from_api_response(attrs = {})
+        is_bike = attrs["Category"] == "fiets"
+        return unless is_bike
 
-      description = attrs["Description"].presence
+        description = attrs["Description"].presence
 
-      bike = find_or_initialize_by(
-        external_id: attrs["ObjectNumber"].presence,
-        serial_number: parse_serial_number(description),
-        type: to_s
-      )
+        bike = find_or_initialize_by(
+          external_id: attrs["ObjectNumber"].presence,
+          serial_number: parse_serial_number(description),
+          type: to_s
+        )
 
-      bike.cycle_type = "bike"
-      bike.status = "status_impounded" # No need for converter, they all come in as abandoned
-      bike.country = Country.netherlands
-      bike.description = description
-      bike.frame_model = attrs["SubCategory"].presence
-      bike.date_stolen = parse_date_found(description, attrs["RegistrationDate"].presence)
-      bike.mnfg_name = brand(attrs["Brand"].presence)
-      bike.frame_colors = colors(attrs["Color"].presence)
-      bike.info_hash = {object_id: attrs["ObjectId"]}
+        bike.cycle_type = "bike"
+        bike.status = "status_impounded" # No need for converter, they all come in as abandoned
+        bike.country = Country.netherlands
+        bike.description = description
+        bike.frame_model = attrs["SubCategory"].presence
+        bike.date_stolen = parse_date_found(description, attrs["RegistrationDate"].presence)
+        bike.mnfg_name = brand(attrs["Brand"].presence)
+        bike.frame_colors = colors(attrs["Color"].presence)
+        bike.info_hash = {object_id: attrs["ObjectId"]}
 
-      bike.location_found = [
-        parse_location_found(description, attrs["StorageLocation"]),
-        bike.country.iso
-      ].select(&:present?).join(" - ")
+        bike.location_found = [
+          parse_location_found(description, attrs["StorageLocation"]),
+          bike.country.iso
+        ].select(&:present?).join(" - ")
 
-      bike
+        bike
+      end
+
+      def impounded_kind
+        ImpoundRecord.impounded_kind
+      end
+
+      private
+
+      def parse_date_found(description, registration_date)
+        match_data = DATE_REGEX.match(description)
+        return registration_date.to_datetime if registration_date && !match_data
+
+        %i[year month day]
+          .map { |m| match_data[m] }
+          .join("-")
+          .to_datetime
+      end
+
+      def parse_location_found(description, storage_location)
+        match_data = LOCATION_REGEX.match(description)
+        return match_data[1].strip if match_data
+        return storage_location&.strip&.titleize if storage_location.is_a?(String)
+
+        %w[Name City]
+          .map { |key| storage_location[key]&.strip&.titleize }
+          .select(&:present?)
+          .join(", ")
+      end
+
+      def parse_serial_number(description)
+        match_data = SERIAL_NUMBER_REGEX.match(description)
+        return "absent" if match_data.blank? || absent?(match_data[1])
+
+        match_data[1]
+      end
     end
 
-    def impounded_kind
-      ImpoundRecord.impounded_kind
+    def registry_url
+      "https://verlorenofgevonden.nl"
     end
 
-    private
-
-    def parse_date_found(description, registration_date)
-      match_data = DATE_REGEX.match(description)
-      return registration_date.to_datetime if registration_date && !match_data
-
-      %i[year month day]
-        .map { |m| match_data[m] }
-        .join("-")
-        .to_datetime
+    def url
+      [registry_url, "overzicht?search=#{external_id}"].join("/")
     end
 
-    def parse_location_found(description, storage_location)
-      match_data = LOCATION_REGEX.match(description)
-      return match_data[1].strip if match_data
-      return storage_location&.strip&.titleize if storage_location.is_a?(String)
+    def image_url
+      return if info_hash["object_id"].blank?
 
-      %w[Name City]
-        .map { |key| storage_location[key]&.strip&.titleize }
-        .select(&:present?)
-        .join(", ")
+      [registry_url, "assets", "image", info_hash["object_id"]].join("/")
     end
 
-    def parse_serial_number(description)
-      match_data = SERIAL_NUMBER_REGEX.match(description)
-      return "absent" if match_data.blank? || absent?(match_data[1])
-
-      match_data[1]
+    def thumb_url
+      image_url
     end
-  end
-
-  def registry_url
-    "https://verlorenofgevonden.nl"
-  end
-
-  def url
-    [registry_url, "overzicht?search=#{external_id}"].join("/")
-  end
-
-  def image_url
-    return if info_hash["object_id"].blank?
-
-    [registry_url, "assets", "image", info_hash["object_id"]].join("/")
-  end
-
-  def thumb_url
-    image_url
   end
 end

--- a/app/models/external_registry_client/project529_client.rb
+++ b/app/models/external_registry_client/project529_client.rb
@@ -1,75 +1,77 @@
 # frozen_string_literal: true
 
-class ExternalRegistryClient::Project529Client < ExternalRegistryClient
-  BASE_URL = ENV.fetch("PROJECT_529_BASE_URL", "https://project529.com/garage")
+class ExternalRegistryClient
+  class Project529Client < ExternalRegistryClient
+    BASE_URL = ENV.fetch("PROJECT_529_BASE_URL", "https://project529.com/garage")
 
-  def initialize(base_url: BASE_URL)
-    self.base_url = base_url
-  end
-
-  def get_oauth_token
-    response = conn.post("oauth/token") { |req|
-      req.headers["Content-Type"] = "application/json"
-      req.params = {
-        grant_type: "refresh_token",
-        client_id: credentials.app_id,
-        refresh_token: credentials.refresh_token
-      }
-    }
-
-    unless response.status == 200 && response.body.is_a?(Hash)
-      raise Project529ClientError, response.body
+    def initialize(base_url: BASE_URL)
+      self.base_url = base_url
     end
 
-    response.body.with_indifferent_access
-  end
+    def get_oauth_token
+      response = conn.post("oauth/token") { |req|
+        req.headers["Content-Type"] = "application/json"
+        req.params = {
+          grant_type: "refresh_token",
+          client_id: credentials.app_id,
+          refresh_token: credentials.refresh_token
+        }
+      }
 
-  def bikes(page: 1, per_page: 10, updated_at: nil)
-    # Exclude non-bikes, any bikes without serial numbers, since we won't be
-    # searching for these.
-    bike_attrs =
-      request_bikes(page, per_page, updated_at)
-        .map { |attrs| ExternalRegistryBike::Project529Bike.build_from_api_response(attrs) }
-        .compact
+      unless response.status == 200 && response.body.is_a?(Hash)
+        raise Project529ClientError, response.body
+      end
 
-    saved_bikes = bike_attrs.each(&:save).select(&:persisted?)
+      response.body.with_indifferent_access
+    end
 
-    ExternalRegistryBike.where(id: saved_bikes.map(&:id))
-  rescue Faraday::TimeoutError
-    ExternalRegistryBike.none
-  end
+    def bikes(page: 1, per_page: 10, updated_at: nil)
+      # Exclude non-bikes, any bikes without serial numbers, since we won't be
+      # searching for these.
+      bike_attrs =
+        request_bikes(page, per_page, updated_at)
+          .map { |attrs| ExternalRegistryBike::Project529Bike.build_from_api_response(attrs) }
+          .compact
 
-  def request_bikes(page, per_page, updated_at = nil)
-    credentials.set_access_token unless credentials.access_token_valid?
-    # Always parse, because we need to strftime
-    updated_at = Binxtils::TimeParser.parse(updated_at.presence || Time.current - 20.days)
+      saved_bikes = bike_attrs.each(&:save).select(&:persisted?)
 
-    req_params = {
-      updated_at: updated_at.strftime("%Y-%m-%d"),
-      page: page,
-      per_page: per_page
-    }
+      ExternalRegistryBike.where(id: saved_bikes.map(&:id))
+    rescue Faraday::TimeoutError
+      ExternalRegistryBike.none
+    end
 
-    cache_key = [self.class.to_s, __method__.to_s, req_params]
+    def request_bikes(page, per_page, updated_at = nil)
+      credentials.set_access_token unless credentials.access_token_valid?
+      # Always parse, because we need to strftime
+      updated_at = Binxtils::TimeParser.parse(updated_at.presence || Time.current - 20.days)
 
-    cached_response =
-      Rails.cache.fetch(cache_key, expires_in: TTL_HOURS) {
-        response = conn.get("services/v1/bikes") { |req|
-          req.headers["Content-Type"] = "application/json"
-          req.params = req_params.merge(access_token: credentials.access_token)
+      req_params = {
+        updated_at: updated_at.strftime("%Y-%m-%d"),
+        page: page,
+        per_page: per_page
+      }
+
+      cache_key = [self.class.to_s, __method__.to_s, req_params]
+
+      cached_response =
+        Rails.cache.fetch(cache_key, expires_in: TTL_HOURS) {
+          response = conn.get("services/v1/bikes") { |req|
+            req.headers["Content-Type"] = "application/json"
+            req.params = req_params.merge(access_token: credentials.access_token)
+          }
+
+          {status: response.status, body: response.body}
         }
 
-        {status: response.status, body: response.body}
-      }
-
-    if cached_response[:status] == 200 && cached_response[:body].is_a?(Hash)
-      cached_response[:body].with_indifferent_access[:bikes]
-    else
-      raise Project529ClientError, cached_response
+      if cached_response[:status] == 200 && cached_response[:body].is_a?(Hash)
+        cached_response[:body].with_indifferent_access[:bikes]
+      else
+        raise Project529ClientError, cached_response
+      end
     end
+
+    class Project529ClientError < StandardError; end
+
+    class Project529ClientInvalidCredentialsError < Project529ClientError; end
   end
-
-  class Project529ClientError < StandardError; end
-
-  class Project529ClientInvalidCredentialsError < Project529ClientError; end
 end

--- a/app/models/external_registry_client/stop_heling_client.rb
+++ b/app/models/external_registry_client/stop_heling_client.rb
@@ -1,103 +1,105 @@
 # frozen_string_literal: true
 
-class ExternalRegistryClient::StopHelingClient < ExternalRegistryClient
-  BASE_URL = ENV["STOP_HELING_BASE_URL"]
+class ExternalRegistryClient
+  class StopHelingClient < ExternalRegistryClient
+    BASE_URL = ENV["STOP_HELING_BASE_URL"]
 
-  KEY_TRANSLATION = {
-    "Korpscode" => :corps_code,
-    "Registratienummer" => :registration_number,
-    "Kleur" => :color,
-    "Merk" => :brand,
-    "Merktype" => :brand_type,
-    "Categorie" => :category,
-    "Object" => :object,
-    "Kenteken_regnr" => :license_plate_number,
-    "Motor_serienr" => :engine_serial_number,
-    "Chassis_graveer" => :chassis_number,
-    "Uniek_nummer" => :unique_number,
-    "Datuminvoer" => :date_input,
-    "Datumwijziging" => :change_of_date,
-    "Insertdate" => :insert_date,
-    "Bron" => :source,
-    "BronNaam" => :source_name,
-    "BronUniekID" => :source_unique_id,
-    "MatchType" => :match_type
-  }
-  def initialize(base_url: BASE_URL)
-    self.base_url = base_url
-  end
+    KEY_TRANSLATION = {
+      "Korpscode" => :corps_code,
+      "Registratienummer" => :registration_number,
+      "Kleur" => :color,
+      "Merk" => :brand,
+      "Merktype" => :brand_type,
+      "Categorie" => :category,
+      "Object" => :object,
+      "Kenteken_regnr" => :license_plate_number,
+      "Motor_serienr" => :engine_serial_number,
+      "Chassis_graveer" => :chassis_number,
+      "Uniek_nummer" => :unique_number,
+      "Datuminvoer" => :date_input,
+      "Datumwijziging" => :change_of_date,
+      "Insertdate" => :insert_date,
+      "Bron" => :source,
+      "BronNaam" => :source_name,
+      "BronUniekID" => :source_unique_id,
+      "MatchType" => :match_type
+    }
+    def initialize(base_url: BASE_URL)
+      self.base_url = base_url
+    end
 
-  # GET /GetSearchItems
-  #
-  # Query Params:
-  #
-  # ApplicationID   integer [required]
-  # Hmac            string  [required]
-  # SearchTerm      string  [required]
-  # Loc             string
-  # IpAddress       string
-  # SearchMerk      string
-  #
-  # Returns an Array, any present entries of which are Hashes.
-  def search(search_term, brand: nil, ip_address: nil, location: nil)
-    endpoint = "GetSearchItems"
-    req_params = request_params(search_term, brand, ip_address, location)
-    cache_key = ["stopheling.nl", endpoint, req_params]
+    # GET /GetSearchItems
+    #
+    # Query Params:
+    #
+    # ApplicationID   integer [required]
+    # Hmac            string  [required]
+    # SearchTerm      string  [required]
+    # Loc             string
+    # IpAddress       string
+    # SearchMerk      string
+    #
+    # Returns an Array, any present entries of which are Hashes.
+    def search(search_term, brand: nil, ip_address: nil, location: nil)
+      endpoint = "GetSearchItems"
+      req_params = request_params(search_term, brand, ip_address, location)
+      cache_key = ["stopheling.nl", endpoint, req_params]
 
-    response_body =
-      Rails.cache.fetch(cache_key, expires_in: TTL_HOURS) {
-        response = conn.get(endpoint) { |req|
-          req.headers["Content-Type"] = "application/json;charset=UTF-8"
-          req.params = req_params
+      response_body =
+        Rails.cache.fetch(cache_key, expires_in: TTL_HOURS) {
+          response = conn.get(endpoint) { |req|
+            req.headers["Content-Type"] = "application/json;charset=UTF-8"
+            req.params = req_params
+          }
+          response.body
         }
-        response.body
+
+      results_from(response_body: response_body, request_params: req_params)
+    end
+
+    private
+
+    def request_params(search_term, brand, ip_address, location)
+      query = {}
+      query["ApplicationID"] = credentials.app_id
+      query["Hmac"] = credentials.hmac_key(search_term)
+      query["SearchTerm"] = search_term
+
+      query["SearchMerk"] = brand if brand.present?
+      query["IpAddress"] = ip_address if ip_address.present?
+      query["Loc"] = location if location.present?
+      query
+    end
+
+    def results_from(response_body:, request_params:)
+      case response_body
+      when Array
+        # Exclude non-bikes, any bikes without serial numbers, since we won't be
+        # searching for these.
+        response_body
+          .map { |result| translate_keys(result) }
+          .map { |attrs| ExternalRegistryBike::StopHelingBike.build_from_api_response(attrs) }
+          .compact
+      else
+        if Rails.env.production?
+          # Fail gracefully but notify Honeybadger if the request fails.
+          # Typically an HMAC key error message will be returned as a Hash.
+          Honeybadger.notify("StopHeling API request failed", {
+            error_class: self.class.to_s,
+            context: {request: request_params, response: response_body}
+          })
+        end
+        []
+      end
+    end
+
+    def translate_keys(result)
+      translated = result.map { |key, val|
+        t_key = KEY_TRANSLATION.fetch(key, key.underscore.tr(" ", "_").to_sym)
+        [t_key, val]
       }
 
-    results_from(response_body: response_body, request_params: req_params)
-  end
-
-  private
-
-  def request_params(search_term, brand, ip_address, location)
-    query = {}
-    query["ApplicationID"] = credentials.app_id
-    query["Hmac"] = credentials.hmac_key(search_term)
-    query["SearchTerm"] = search_term
-
-    query["SearchMerk"] = brand if brand.present?
-    query["IpAddress"] = ip_address if ip_address.present?
-    query["Loc"] = location if location.present?
-    query
-  end
-
-  def results_from(response_body:, request_params:)
-    case response_body
-    when Array
-      # Exclude non-bikes, any bikes without serial numbers, since we won't be
-      # searching for these.
-      response_body
-        .map { |result| translate_keys(result) }
-        .map { |attrs| ExternalRegistryBike::StopHelingBike.build_from_api_response(attrs) }
-        .compact
-    else
-      if Rails.env.production?
-        # Fail gracefully but notify Honeybadger if the request fails.
-        # Typically an HMAC key error message will be returned as a Hash.
-        Honeybadger.notify("StopHeling API request failed", {
-          error_class: self.class.to_s,
-          context: {request: request_params, response: response_body}
-        })
-      end
-      []
+      translated.to_h
     end
-  end
-
-  def translate_keys(result)
-    translated = result.map { |key, val|
-      t_key = KEY_TRANSLATION.fetch(key, key.underscore.tr(" ", "_").to_sym)
-      [t_key, val]
-    }
-
-    translated.to_h
   end
 end

--- a/app/models/external_registry_client/verloren_of_gevonden_client.rb
+++ b/app/models/external_registry_client/verloren_of_gevonden_client.rb
@@ -1,108 +1,110 @@
 # frozen_string_literal: true
 
-class ExternalRegistryClient::VerlorenOfGevondenClient < ExternalRegistryClient
-  BASE_URL = ENV["VERLOREN_OF_GEVONDEN_BASE_URL"]
+class ExternalRegistryClient
+  class VerlorenOfGevondenClient < ExternalRegistryClient
+    BASE_URL = ENV["VERLOREN_OF_GEVONDEN_BASE_URL"]
 
-  # The API responds with 10 items per page of results
-  ITEMS_RECEIVED_PER_PAGE = 10
-  MINIMUM_QUERY_LENGTH = 3
-  START_DATE = 1.year.ago.beginning_of_month
+    # The API responds with 10 items per page of results
+    ITEMS_RECEIVED_PER_PAGE = 10
+    MINIMUM_QUERY_LENGTH = 3
+    START_DATE = 1.year.ago.beginning_of_month
 
-  attr_accessor \
-    :backoff,
-    :backoff_factor,
-    :backoff_max,
-    :result_pages,
-    :retry_pages,
-    :total_pages,
-    :total_results
+    attr_accessor \
+      :backoff,
+      :backoff_factor,
+      :backoff_max,
+      :result_pages,
+      :retry_pages,
+      :total_pages,
+      :total_results
 
-  def initialize(base_url: BASE_URL)
-    self.base_url = base_url
-    self.backoff = 0
-    self.backoff_max = 60
-    self.backoff_factor = 5
-    self.retry_pages = []
-    self.result_pages = {}
-  end
-
-  # Return an Array of Hashes
-  def search(query)
-    return [] if query.to_s.length < MINIMUM_QUERY_LENGTH
-
-    get_page(query)
-
-    # Exclude non-bikes, any bikes without serial numbers, since we won't be
-    # searching for these.
-    result_pages
-      .values
-      .flatten
-      .compact
-      .map { |result| ExternalRegistryBike::VerlorenOfGevondenBike.build_from_api_response(result) }
-      .compact
-  end
-
-  private
-
-  # Query for the results page `page_num`.
-  #
-  # NB: VOG endpoint expects lowercase letters in the query string and matches
-  # case-sensitively
-  #
-  # Return the JSON response body as a Hash
-  def get_page(query, page: 1, per_page: ITEMS_RECEIVED_PER_PAGE)
-    Rails.logger.info("Requesting page #{page}")
-    req_params = request_params(query.to_s.downcase, page, per_page)
-    cache_key = ["verlorenofgevonden.nl", query, req_params]
-
-    response_json =
-      Rails.cache.fetch(cache_key, expires_in: TTL_HOURS) {
-        response = conn.post("ez.php") { |req|
-          req.params = req_params
-          req.params["timestamp"] = Time.current.to_i
-        }
-        response.body
-      }
-
-    if response_json.is_a?(String)
-      Rails.cache.delete(cache_key)
-      self.backoff += 1
-      wait_time = [self.backoff * backoff_factor, backoff_max].min
-      sleep(wait_time)
-      Rails.logger.info("Enqueued page #{page} for retry. Waiting #{wait_time}s...")
-      retry_pages << page
-    elsif response_json.is_a?(Hash)
+    def initialize(base_url: BASE_URL)
+      self.base_url = base_url
       self.backoff = 0
-      set_total(response_json)
-      add_page(page, response_json)
+      self.backoff_max = 60
+      self.backoff_factor = 5
+      self.retry_pages = []
+      self.result_pages = {}
     end
-  rescue Faraday::ConnectionFailed
-    add_page(page, {})
-    set_total(response_json)
-  end
 
-  def request_params(query, page, per_page)
-    params = {}
-    params["q"] = query
-    params["org"] = ""
-    params["date_from"] = START_DATE.strftime("%d-%m-%Y")
-    params["date_to"] = Time.current.strftime("%d-%m-%Y")
-    params["from"] = per_page * (page - 1)
-    params["site"] = "nl"
-    params
-  end
+    # Return an Array of Hashes
+    def search(query)
+      return [] if query.to_s.length < MINIMUM_QUERY_LENGTH
 
-  def set_total(response, per_page: ITEMS_RECEIVED_PER_PAGE)
-    return if response.blank?
+      get_page(query)
 
-    self.total_results ||= response.dig("hits", "total").presence || 0
-    self.total_pages ||= (self.total_results / per_page.to_f).ceil
-  end
+      # Exclude non-bikes, any bikes without serial numbers, since we won't be
+      # searching for these.
+      result_pages
+        .values
+        .flatten
+        .compact
+        .map { |result| ExternalRegistryBike::VerlorenOfGevondenBike.build_from_api_response(result) }
+        .compact
+    end
 
-  def add_page(page, response)
-    return unless response.present?
+    private
 
-    matches = response.dig("hits", "hits").presence || []
-    result_pages[page] = matches.map { |hit| hit["_source"] }
+    # Query for the results page `page_num`.
+    #
+    # NB: VOG endpoint expects lowercase letters in the query string and matches
+    # case-sensitively
+    #
+    # Return the JSON response body as a Hash
+    def get_page(query, page: 1, per_page: ITEMS_RECEIVED_PER_PAGE)
+      Rails.logger.info("Requesting page #{page}")
+      req_params = request_params(query.to_s.downcase, page, per_page)
+      cache_key = ["verlorenofgevonden.nl", query, req_params]
+
+      response_json =
+        Rails.cache.fetch(cache_key, expires_in: TTL_HOURS) {
+          response = conn.post("ez.php") { |req|
+            req.params = req_params
+            req.params["timestamp"] = Time.current.to_i
+          }
+          response.body
+        }
+
+      if response_json.is_a?(String)
+        Rails.cache.delete(cache_key)
+        self.backoff += 1
+        wait_time = [self.backoff * backoff_factor, backoff_max].min
+        sleep(wait_time)
+        Rails.logger.info("Enqueued page #{page} for retry. Waiting #{wait_time}s...")
+        retry_pages << page
+      elsif response_json.is_a?(Hash)
+        self.backoff = 0
+        set_total(response_json)
+        add_page(page, response_json)
+      end
+    rescue Faraday::ConnectionFailed
+      add_page(page, {})
+      set_total(response_json)
+    end
+
+    def request_params(query, page, per_page)
+      params = {}
+      params["q"] = query
+      params["org"] = ""
+      params["date_from"] = START_DATE.strftime("%d-%m-%Y")
+      params["date_to"] = Time.current.strftime("%d-%m-%Y")
+      params["from"] = per_page * (page - 1)
+      params["site"] = "nl"
+      params
+    end
+
+    def set_total(response, per_page: ITEMS_RECEIVED_PER_PAGE)
+      return if response.blank?
+
+      self.total_results ||= response.dig("hits", "total").presence || 0
+      self.total_pages ||= (self.total_results / per_page.to_f).ceil
+    end
+
+    def add_page(page, response)
+      return unless response.present?
+
+      matches = response.dig("hits", "hits").presence || []
+      result_pages[page] = matches.map { |hit| hit["_source"] }
+    end
   end
 end

--- a/app/models/external_registry_credential/project529_credential.rb
+++ b/app/models/external_registry_credential/project529_credential.rb
@@ -17,27 +17,29 @@
 #
 #  index_external_registry_credentials_on_type  (type)
 #
-class ExternalRegistryCredential::Project529Credential < ExternalRegistryCredential
-  validates :app_id, :refresh_token, presence: true
+class ExternalRegistryCredential
+  class Project529Credential < ExternalRegistryCredential
+    validates :app_id, :refresh_token, presence: true
 
-  # Our credential thought it was expired, but apparently it wasn't. See PR#2076
-  def set_access_token
-    return unless access_token_can_be_reset?
+    # Our credential thought it was expired, but apparently it wasn't. See PR#2076
+    def set_access_token
+      return unless access_token_can_be_reset?
 
-    credentials = api&.get_oauth_token
-    expires_at_unix =
-      %i[created_at expires_in]
-        .map { |k| credentials[k] }
-        .sum
+      credentials = api&.get_oauth_token
+      expires_at_unix =
+        %i[created_at expires_in]
+          .map { |k| credentials[k] }
+          .sum
 
-    update(
-      refresh_token: credentials[:refresh_token],
-      access_token: credentials[:access_token],
-      access_token_expires_at: Time.at(expires_at_unix).utc
-    )
-  end
+      update(
+        refresh_token: credentials[:refresh_token],
+        access_token: credentials[:access_token],
+        access_token_expires_at: Time.at(expires_at_unix).utc
+      )
+    end
 
-  def api
-    @api ||= ExternalRegistryClient::Project529Client.new
+    def api
+      @api ||= ExternalRegistryClient::Project529Client.new
+    end
   end
 end

--- a/app/models/external_registry_credential/stop_heling_credential.rb
+++ b/app/models/external_registry_credential/stop_heling_credential.rb
@@ -17,24 +17,26 @@
 #
 #  index_external_registry_credentials_on_type  (type)
 #
-class ExternalRegistryCredential::StopHelingCredential < ExternalRegistryCredential
-  validates :app_id, :access_token, presence: true
+class ExternalRegistryCredential
+  class StopHelingCredential < ExternalRegistryCredential
+    validates :app_id, :access_token, presence: true
 
-  def access_token_valid?
-    true
-  end
+    def access_token_valid?
+      true
+    end
 
-  def access_token_can_be_reset?
-    false
-  end
+    def access_token_can_be_reset?
+      false
+    end
 
-  def hmac_key(search_term)
-    raise ArgumentError, "search term required" if search_term.blank?
+    def hmac_key(search_term)
+      raise ArgumentError, "search term required" if search_term.blank?
 
-    date = Time.now.in_time_zone("Amsterdam").strftime("%Y%m%d")
-    data = "#{search_term}#{date}#{app_id}"
+      date = Time.now.in_time_zone("Amsterdam").strftime("%Y%m%d")
+      data = "#{search_term}#{date}#{app_id}"
 
-    digest = OpenSSL::Digest.new("md5")
-    OpenSSL::HMAC.hexdigest(digest, access_token, data).upcase
+      digest = OpenSSL::Digest.new("md5")
+      OpenSSL::HMAC.hexdigest(digest, access_token, data).upcase
+    end
   end
 end

--- a/app/services/autocomplete/loader.rb
+++ b/app/services/autocomplete/loader.rb
@@ -1,231 +1,233 @@
-module Autocomplete::Loader
-  extend Functionable
+module Autocomplete
+  module Loader
+    extend Functionable
 
-  DEFAULT_ITEM = {
-    category: "default",
-    priority: 100,
-    term: nil,
-    data: {}
-  }.freeze
+    DEFAULT_ITEM = {
+      category: "default",
+      priority: 100,
+      term: nil,
+      data: {}
+    }.freeze
 
-  # Generally, the cache should be cleared, but it doesn't need to be cleared if just adding new data
-  def clear_redis(skip_clearing_cache = false)
-    delete_categories_and_item_data
-    delete_data
-    # Clear cache at the end, to reduce disruption (hopefully the majority of the cache matches)
-    clear_cache unless skip_clearing_cache
-  end
+    # Generally, the cache should be cleared, but it doesn't need to be cleared if just adding new data
+    def clear_redis(skip_clearing_cache = false)
+      delete_categories_and_item_data
+      delete_data
+      # Clear cache at the end, to reduce disruption (hopefully the majority of the cache matches)
+      clear_cache unless skip_clearing_cache
+    end
 
-  def load_all(kinds = nil, print_counts: false)
-    store_category_combos
-    kinds ||= %w[Color CycleType Manufacturer PropulsionType]
-    total_count = 0
+    def load_all(kinds = nil, print_counts: false)
+      store_category_combos
+      kinds ||= %w[Color CycleType Manufacturer PropulsionType]
+      total_count = 0
 
-    if kinds.include?("Color")
-      colors_count = store_items(Color.all.map { |c| c.autocomplete_hash })
-      total_count += colors_count
-      if print_counts
-        puts "Total Colors added (including combinatorial categories):         #{colors_count}"
+      if kinds.include?("Color")
+        colors_count = store_items(Color.all.map { |c| c.autocomplete_hash })
+        total_count += colors_count
+        if print_counts
+          puts "Total Colors added (including combinatorial categories):         #{colors_count}"
+        end
+      end
+
+      if kinds.include?("PropulsionType")
+        pro_count = store_items(PropulsionType.autocomplete_hashes)
+        total_count += pro_count
+        if print_counts
+          puts "Total Propulsion Types added (including combinatorial categories):         #{pro_count}"
+        end
+      end
+
+      if kinds.include?("CycleType")
+        c_type_count = store_items(CycleType.all.map { |c| c.autocomplete_hash })
+        total_count += c_type_count
+        if print_counts
+          puts "Total Cycle Types added (including combinatorial categories):    #{c_type_count}"
+        end
+      end
+
+      # TODO: find in batches
+      if kinds.include?("Manufacturer")
+        mnfg_count = store_items(Manufacturer.all.map { |m| m.autocomplete_hash })
+        total_count += mnfg_count
+        if print_counts
+          puts "Total Manufacturers added (including combinatorial categories):  #{mnfg_count}"
+        end
+      end
+
+      puts "Total added:                                                     #{total_count}" if print_counts
+      total_count
+    end
+
+    def info
+      RedisPool.conn do |r|
+        # NOTE: if you add in more DBs, include the keys here
+        included_info = r.info.slice("used_memory_human", "used_memory_peak_human", "db0")
+          .map { |k, v| [k.gsub("_human", "").to_sym, v] }.to_h
+        {
+          category_keys: fetch_category_keys(r).count,
+          cache_keys: fetch_cache_keys(r).count
+        }.merge(included_info)
       end
     end
 
-    if kinds.include?("PropulsionType")
-      pro_count = store_items(PropulsionType.autocomplete_hashes)
-      total_count += pro_count
-      if print_counts
-        puts "Total Propulsion Types added (including combinatorial categories):         #{pro_count}"
+    def frame_mnfg_count
+      RedisPool.conn do |r|
+        r.scan_each(match: "#{Autocomplete.category_key("frame_mnfg")}*")
+      end.count
+    end
+
+    #
+    # private below here
+    #
+
+    def store_items(items)
+      i = 0
+      items = items.map { |i| clean_hash(i) }
+      combinatored_category_array.each do |category_combo|
+        items.each do |item|
+          next unless category_combo.match?(item[:category]) || category_combo == "all"
+
+          # Only add item data once (when in the exact matching category)
+          store_item(item, Autocomplete.category_key(category_combo), category_combo != item[:category])
+          i += 1
+        end
+      end
+      i
+    end
+
+    def store_item(item, category_base_key = nil, skip_item_data = false)
+      category_base_key ||= Autocomplete.category_key(item[:category])
+      priority = -1 * item[:priority]
+      # pipeline doesn't reduce network requests, my understanding is wrapping all (as oppose to individual items)
+      # in pipeline wouldn't improve functionality and might actually cause longer blocking
+      RedisPool.conn do |r|
+        r.pipelined do |pipeline|
+          # Add to master set for queryless searches
+          pipeline.zadd(Autocomplete.no_query_key(category_base_key), priority, item[:term])
+          # store the raw data in a separate key (no need to have for each category)
+          pipeline.hset(Autocomplete.items_data_key, item[:term], item[:data].to_json) unless skip_item_data
+          # Store all the prefixes
+          prefixes_for_phrase(item[:term]).each do |prefix|
+            pipeline.sadd(base_key, prefix) unless skip_item_data # remember prefix in a master set
+            # store the normalized term in the index for each of the categories
+            pipeline.zadd("#{category_base_key}#{prefix}", priority, item[:term])
+          end
+        end
+      end
+      item
+    end
+
+    def base_key
+      Autocomplete::BASE_KEY
+    end
+
+    def prefixes_for_phrase(phrase)
+      Autocomplete.normalize(phrase).split(" ").reject do |w|
+        Autocomplete::STOP_WORDS.include?(w)
+      end.map do |w|
+        (0..(w.length - 1)).map { |l| w[0..l] }
+      end.flatten.uniq
+    end
+
+    # Assume this is memoized, during load_all - so use it instead of #category_combos
+    def combinatored_category_array
+      return @combinatored_category_array if defined?(@combinatored_category_array)
+
+      array = 1.upto(Autocomplete.sorted_category_array.size).flat_map do |n|
+        Autocomplete.sorted_category_array.combination(n)
+          .map { |el| el.join("") }
+      end
+      array.last.replace("all") # Last category is the combination of every one
+      @combinatored_category_array = array
+    end
+
+    def store_category_combos
+      RedisPool.conn do |r|
+        r.sadd(Autocomplete.category_combos_key, combinatored_category_array)
       end
     end
 
-    if kinds.include?("CycleType")
-      c_type_count = store_items(CycleType.all.map { |c| c.autocomplete_hash })
-      total_count += c_type_count
-      if print_counts
-        puts "Total Cycle Types added (including combinatorial categories):    #{c_type_count}"
+    def items_hash(text, category = "default")
+      i_hash = DEFAULT_ITEM.merge(term: Autocomplete.normalize(text), category: Autocomplete.normalize(category))
+      i_hash.merge(data: {text: text, category: i_hash[:category]})
+    end
+
+    def clean_hash(item)
+      if item[:text].blank?
+        raise ArgumentError, "Items must have text. Missing from: #{item}"
       end
-    end
 
-    # TODO: find in batches
-    if kinds.include?("Manufacturer")
-      mnfg_count = store_items(Manufacturer.all.map { |m| m.autocomplete_hash })
-      total_count += mnfg_count
-      if print_counts
-        puts "Total Manufacturers added (including combinatorial categories):  #{mnfg_count}"
+      i_hash = items_hash(item[:text], item[:category])
+      unless Autocomplete.sorted_category_array.include?(i_hash[:category])
+        raise ArgumentError, "Items must have one of the accepted categories, not included in: #{item}"
       end
+
+      i_hash[:data] = i_hash[:data].merge(item[:data]) if item[:data].present?
+      i_hash[:priority] = item[:priority].to_f if item[:priority].present?
+      i_hash[:data][:id] = item[:id] if item[:id].present?
+      i_hash
     end
 
-    puts "Total added:                                                     #{total_count}" if print_counts
-    total_count
-  end
+    def clear_cache
+      RedisPool.conn do |r|
+        # can't be pipelined, requires the response
+        keys = fetch_cache_keys(r).to_a
 
-  def info
-    RedisPool.conn do |r|
-      # NOTE: if you add in more DBs, include the keys here
-      included_info = r.info.slice("used_memory_human", "used_memory_peak_human", "db0")
-        .map { |k, v| [k.gsub("_human", "").to_sym, v] }.to_h
-      {
-        category_keys: fetch_category_keys(r).count,
-        cache_keys: fetch_cache_keys(r).count
-      }.merge(included_info)
-    end
-  end
-
-  def frame_mnfg_count
-    RedisPool.conn do |r|
-      r.scan_each(match: "#{Autocomplete.category_key("frame_mnfg")}*")
-    end.count
-  end
-
-  #
-  # private below here
-  #
-
-  def store_items(items)
-    i = 0
-    items = items.map { |i| clean_hash(i) }
-    combinatored_category_array.each do |category_combo|
-      items.each do |item|
-        next unless category_combo.match?(item[:category]) || category_combo == "all"
-
-        # Only add item data once (when in the exact matching category)
-        store_item(item, Autocomplete.category_key(category_combo), category_combo != item[:category])
-        i += 1
-      end
-    end
-    i
-  end
-
-  def store_item(item, category_base_key = nil, skip_item_data = false)
-    category_base_key ||= Autocomplete.category_key(item[:category])
-    priority = -1 * item[:priority]
-    # pipeline doesn't reduce network requests, my understanding is wrapping all (as oppose to individual items)
-    # in pipeline wouldn't improve functionality and might actually cause longer blocking
-    RedisPool.conn do |r|
-      r.pipelined do |pipeline|
-        # Add to master set for queryless searches
-        pipeline.zadd(Autocomplete.no_query_key(category_base_key), priority, item[:term])
-        # store the raw data in a separate key (no need to have for each category)
-        pipeline.hset(Autocomplete.items_data_key, item[:term], item[:data].to_json) unless skip_item_data
-        # Store all the prefixes
-        prefixes_for_phrase(item[:term]).each do |prefix|
-          pipeline.sadd(base_key, prefix) unless skip_item_data # remember prefix in a master set
-          # store the normalized term in the index for each of the categories
-          pipeline.zadd("#{category_base_key}#{prefix}", priority, item[:term])
+        r.pipelined do |pipeline|
+          keys.each { |k| pipeline.expire(k, 0) }
         end
       end
     end
-    item
-  end
 
-  def base_key
-    Autocomplete::BASE_KEY
-  end
+    def delete_categories_and_item_data
+      RedisPool.conn do |r|
+        # Get all the matching keys for category typeahead
+        keys = fetch_category_keys(r).to_a
 
-  def prefixes_for_phrase(phrase)
-    Autocomplete.normalize(phrase).split(" ").reject do |w|
-      Autocomplete::STOP_WORDS.include?(w)
-    end.map do |w|
-      (0..(w.length - 1)).map { |l| w[0..l] }
-    end.flatten.uniq
-  end
+        r.pipelined do |pipeline|
+          # Use static categories, so it doesn't rely on data in Redis
+          combinatored_category_array.each do |cat|
+            pipeline.expire(Autocomplete.no_query_key(Autocomplete.category_key(cat)), 0)
+          end
+          pipeline.expire(Autocomplete.category_combos_key, 0)
 
-  # Assume this is memoized, during load_all - so use it instead of #category_combos
-  def combinatored_category_array
-    return @combinatored_category_array if defined?(@combinatored_category_array)
+          # Delete the items data values
+          # pipeline.expire(Autocomplete.items_data_key, 0)
+          pipeline.del(Autocomplete.items_data_key)
 
-    array = 1.upto(Autocomplete.sorted_category_array.size).flat_map do |n|
-      Autocomplete.sorted_category_array.combination(n)
-        .map { |el| el.join("") }
-    end
-    array.last.replace("all") # Last category is the combination of every one
-    @combinatored_category_array = array
-  end
-
-  def store_category_combos
-    RedisPool.conn do |r|
-      r.sadd(Autocomplete.category_combos_key, combinatored_category_array)
-    end
-  end
-
-  def items_hash(text, category = "default")
-    i_hash = DEFAULT_ITEM.merge(term: Autocomplete.normalize(text), category: Autocomplete.normalize(category))
-    i_hash.merge(data: {text: text, category: i_hash[:category]})
-  end
-
-  def clean_hash(item)
-    if item[:text].blank?
-      raise ArgumentError, "Items must have text. Missing from: #{item}"
-    end
-
-    i_hash = items_hash(item[:text], item[:category])
-    unless Autocomplete.sorted_category_array.include?(i_hash[:category])
-      raise ArgumentError, "Items must have one of the accepted categories, not included in: #{item}"
-    end
-
-    i_hash[:data] = i_hash[:data].merge(item[:data]) if item[:data].present?
-    i_hash[:priority] = item[:priority].to_f if item[:priority].present?
-    i_hash[:data][:id] = item[:id] if item[:id].present?
-    i_hash
-  end
-
-  def clear_cache
-    RedisPool.conn do |r|
-      # can't be pipelined, requires the response
-      keys = fetch_cache_keys(r).to_a
-
-      r.pipelined do |pipeline|
-        keys.each { |k| pipeline.expire(k, 0) }
-      end
-    end
-  end
-
-  def delete_categories_and_item_data
-    RedisPool.conn do |r|
-      # Get all the matching keys for category typeahead
-      keys = fetch_category_keys(r).to_a
-
-      r.pipelined do |pipeline|
-        # Use static categories, so it doesn't rely on data in Redis
-        combinatored_category_array.each do |cat|
-          pipeline.expire(Autocomplete.no_query_key(Autocomplete.category_key(cat)), 0)
+          # Expire all the typeahead keys
+          keys.each { |k| pipeline.expire(k, 0) }
         end
-        pipeline.expire(Autocomplete.category_combos_key, 0)
-
-        # Delete the items data values
-        # pipeline.expire(Autocomplete.items_data_key, 0)
-        pipeline.del(Autocomplete.items_data_key)
-
-        # Expire all the typeahead keys
-        keys.each { |k| pipeline.expire(k, 0) }
       end
     end
-  end
 
-  def fetch_category_keys(redis_block)
-    redis_block.scan_each(match: Autocomplete.category_key.gsub(/all:\z/, "*"))
-  end
-
-  def fetch_cache_keys(redis_block)
-    redis_block.scan_each(match: Autocomplete.cache_key.gsub(/all:\z/, "*"))
-  end
-
-  def delete_data(id = nil)
-    id ||= "#{base_key}:"
-    # delete the sorted sets for this type
-    RedisPool.conn do |r|
-      phrases = r.smembers(base_key)
-      r.pipelined do |pipeline|
-        phrases.each { |phrase| pipeline.del("#{id}#{phrase}") }
-        pipeline.del(id)
-      end
+    def fetch_category_keys(redis_block)
+      redis_block.scan_each(match: Autocomplete.category_key.gsub(/all:\z/, "*"))
     end
-    # Redis can continue serving cached requests while the reload is
-    # occurring. Some requests may be cached incorrectly as empty set (for requests
-    # which come in after the above delete, but before the loading completes). But
-    # everything will work itself out as soon as the cache expires again.
-  end
 
-  conceal :store_items, :store_item, :base_key, :prefixes_for_phrase, :combinatored_category_array,
-    :store_category_combos, :items_hash, :clean_hash, :clear_cache, :delete_categories_and_item_data,
-    :fetch_category_keys, :fetch_cache_keys, :delete_data
+    def fetch_cache_keys(redis_block)
+      redis_block.scan_each(match: Autocomplete.cache_key.gsub(/all:\z/, "*"))
+    end
+
+    def delete_data(id = nil)
+      id ||= "#{base_key}:"
+      # delete the sorted sets for this type
+      RedisPool.conn do |r|
+        phrases = r.smembers(base_key)
+        r.pipelined do |pipeline|
+          phrases.each { |phrase| pipeline.del("#{id}#{phrase}") }
+          pipeline.del(id)
+        end
+      end
+      # Redis can continue serving cached requests while the reload is
+      # occurring. Some requests may be cached incorrectly as empty set (for requests
+      # which come in after the above delete, but before the loading completes). But
+      # everything will work itself out as soon as the cache expires again.
+    end
+
+    conceal :store_items, :store_item, :base_key, :prefixes_for_phrase, :combinatored_category_array,
+      :store_category_combos, :items_hash, :clean_hash, :clear_cache, :delete_categories_and_item_data,
+      :fetch_category_keys, :fetch_cache_keys, :delete_data
+  end
 end

--- a/app/services/autocomplete/matcher.rb
+++ b/app/services/autocomplete/matcher.rb
@@ -1,117 +1,119 @@
-module Autocomplete::Matcher
-  extend Functionable
+module Autocomplete
+  module Matcher
+    extend Functionable
 
-  DEFAULT_PARAMS = {
-    page: 1,
-    per_page: 5,
-    categories: [],
-    q: "", # Query
-    cache: true
-  }.freeze
+    DEFAULT_PARAMS = {
+      page: 1,
+      per_page: 5,
+      categories: [],
+      q: "", # Query
+      cache: true
+    }.freeze
 
-  def search(pparms = {}, opts = nil)
-    opts ||= params_to_opts(pparms)
-    # It always responds with the cache - if cache: false, store the cache - or, if there isn't a cached
-    if !opts[:cache] || not_in_cache?(opts[:cache_key])
-      store_search_in_cache(opts[:cache_key], opts[:interkeys])
+    def search(pparms = {}, opts = nil)
+      opts ||= params_to_opts(pparms)
+      # It always responds with the cache - if cache: false, store the cache - or, if there isn't a cached
+      if !opts[:cache] || not_in_cache?(opts[:cache_key])
+        store_search_in_cache(opts[:cache_key], opts[:interkeys])
+      end
+      terms = RedisPool.conn { |r| r.zrange(opts[:cache_key], opts[:offset], opts[:limit]) }
+      matching_hashes(terms)
     end
-    terms = RedisPool.conn { |r| r.zrange(opts[:cache_key], opts[:offset], opts[:limit]) }
-    matching_hashes(terms)
-  end
 
-  def params_to_opts(pparms = {})
-    per_page = pparms.dig(:per_page)&.to_i || DEFAULT_PARAMS[:per_page]
-    page = pparms.dig(:page)&.to_i || DEFAULT_PARAMS[:page]
-    offset = (page - 1) * per_page
-    limit = per_page + offset - 1
-    categories = categories_array(pparms[:categories])
+    def params_to_opts(pparms = {})
+      per_page = pparms.dig(:per_page)&.to_i || DEFAULT_PARAMS[:per_page]
+      page = pparms.dig(:page)&.to_i || DEFAULT_PARAMS[:page]
+      offset = (page - 1) * per_page
+      limit = per_page + offset - 1
+      categories = categories_array(pparms[:categories])
 
-    opts = {
-      categories: categories,
-      q_array: query_array(pparms[:q]),
-      category_cache_key: category_key_from_opts(categories)
-    }
-    opts.merge(
-      cache: pparms[:cache].present? ? Binxtils::InputNormalizer.boolean(pparms[:cache]) : DEFAULT_PARAMS[:cache],
-      cache_key: cache_key_from_opts(categories, opts[:q_array]),
-      interkeys: interkeys_from_opts(opts[:category_cache_key], opts[:q_array]),
-      offset: offset,
-      limit: (limit < 0) ? 0 : limit
-    )
-  end
-
-  #
-  # private below here
-  #
-
-  def not_in_cache?(cache_key)
-    cached_result = RedisPool.conn { |r| r.exists(cache_key) }
-    cached_result.blank? || cached_result == 0
-  end
-
-  def query_array(query)
-    if query.is_a?(Array)
-      query.map { |q| Autocomplete.normalize(q) }
-    else
-      Autocomplete.normalize(query).split(" ")
+      opts = {
+        categories: categories,
+        q_array: query_array(pparms[:q]),
+        category_cache_key: category_key_from_opts(categories)
+      }
+      opts.merge(
+        cache: pparms[:cache].present? ? Binxtils::InputNormalizer.boolean(pparms[:cache]) : DEFAULT_PARAMS[:cache],
+        cache_key: cache_key_from_opts(categories, opts[:q_array]),
+        interkeys: interkeys_from_opts(opts[:category_cache_key], opts[:q_array]),
+        offset: offset,
+        limit: (limit < 0) ? 0 : limit
+      )
     end
-  end
 
-  def categories_array(categories = [])
-    return [] if categories.blank?
+    #
+    # private below here
+    #
 
-    categories = categories.split(/,|\+/) if !categories.is_a?(Array)
-    permitted_categories = Autocomplete.sorted_category_array
-    categories = permitted_categories & categories.map { |s| Autocomplete.normalize(s) }
-    return [] if categories.length == permitted_categories.length
-
-    categories
-  end
-
-  def total_categories_count
-    # Can be a static call, now that categories are static
-    Autocomplete.sorted_category_array.count
-  end
-
-  def categories_string(categories)
-    categories.empty? ? "all" : categories.join("")
-  end
-
-  def category_key_from_opts(categories)
-    Autocomplete.category_key(categories_string(categories))
-  end
-
-  def cache_key_from_opts(categories, q_array)
-    [
-      Autocomplete.cache_key(categories_string(categories)),
-      q_array.join(":")
-    ].reject(&:blank?).join("")
-  end
-
-  def interkeys_from_opts(category_cache_key, q_array)
-    # If there isn't a query, we use a special key in redis
-    if q_array.empty?
-      [Autocomplete.no_query_key(category_cache_key)]
-    else
-      q_array.map { |w| "#{category_cache_key}#{w}" }
+    def not_in_cache?(cache_key)
+      cached_result = RedisPool.conn { |r| r.exists(cache_key) }
+      cached_result.blank? || cached_result == 0
     end
-  end
 
-  def store_search_in_cache(cache_key, interkeys)
-    RedisPool.conn do |r|
-      r.zinterstore(cache_key, interkeys)
-      r.expire(cache_key, Autocomplete.cache_duration)
+    def query_array(query)
+      if query.is_a?(Array)
+        query.map { |q| Autocomplete.normalize(q) }
+      else
+        Autocomplete.normalize(query).split(" ")
+      end
     end
+
+    def categories_array(categories = [])
+      return [] if categories.blank?
+
+      categories = categories.split(/,|\+/) if !categories.is_a?(Array)
+      permitted_categories = Autocomplete.sorted_category_array
+      categories = permitted_categories & categories.map { |s| Autocomplete.normalize(s) }
+      return [] if categories.length == permitted_categories.length
+
+      categories
+    end
+
+    def total_categories_count
+      # Can be a static call, now that categories are static
+      Autocomplete.sorted_category_array.count
+    end
+
+    def categories_string(categories)
+      categories.empty? ? "all" : categories.join("")
+    end
+
+    def category_key_from_opts(categories)
+      Autocomplete.category_key(categories_string(categories))
+    end
+
+    def cache_key_from_opts(categories, q_array)
+      [
+        Autocomplete.cache_key(categories_string(categories)),
+        q_array.join(":")
+      ].reject(&:blank?).join("")
+    end
+
+    def interkeys_from_opts(category_cache_key, q_array)
+      # If there isn't a query, we use a special key in redis
+      if q_array.empty?
+        [Autocomplete.no_query_key(category_cache_key)]
+      else
+        q_array.map { |w| "#{category_cache_key}#{w}" }
+      end
+    end
+
+    def store_search_in_cache(cache_key, interkeys)
+      RedisPool.conn do |r|
+        r.zinterstore(cache_key, interkeys)
+        r.expire(cache_key, Autocomplete.cache_duration)
+      end
+    end
+
+    def matching_hashes(terms)
+      return [] unless terms.size > 0
+
+      RedisPool.conn { |r| r.hmget(Autocomplete.items_data_key, *terms) }
+        .reject(&:blank?).map { |r| JSON.parse(r) }
+    end
+
+    conceal :not_in_cache?, :query_array, :categories_array, :total_categories_count,
+      :categories_string, :category_key_from_opts, :cache_key_from_opts, :interkeys_from_opts,
+      :store_search_in_cache, :matching_hashes
   end
-
-  def matching_hashes(terms)
-    return [] unless terms.size > 0
-
-    RedisPool.conn { |r| r.hmget(Autocomplete.items_data_key, *terms) }
-      .reject(&:blank?).map { |r| JSON.parse(r) }
-  end
-
-  conceal :not_in_cache?, :query_array, :categories_array, :total_categories_count,
-    :categories_string, :category_key_from_opts, :cache_key_from_opts, :interkeys_from_opts,
-    :store_search_in_cache, :matching_hashes
 end

--- a/app/services/bike_services/builder.rb
+++ b/app/services/bike_services/builder.rb
@@ -1,140 +1,142 @@
 # frozen_string_literal: true
 
-module BikeServices::Builder
-  extend Functionable
+module BikeServices
+  module Builder
+    extend Functionable
 
-  def include_address_record?(organization = nil, user = nil)
-    return false if organization.blank?
-    return false if user&.address_set_manually?
+    def include_address_record?(organization = nil, user = nil)
+      return false if organization.blank?
+      return false if user&.address_set_manually?
 
-    organization.additional_registration_fields.include?("reg_address")
-  end
+      organization.additional_registration_fields.include?("reg_address")
+    end
 
-  def build(b_param, new_attrs = nil)
-    new_attrs ||= {}
-    # Default attributes
-    bike = Bike.new(cycle_type: "bike")
-    # passed_organization is assigned unless b_param has an organization
-    passed_organization = new_attrs.delete(:organization)
-    bike.attributes = b_param.safe_bike_attrs(new_attrs)
+    def build(b_param, new_attrs = nil)
+      new_attrs ||= {}
+      # Default attributes
+      bike = Bike.new(cycle_type: "bike")
+      # passed_organization is assigned unless b_param has an organization
+      passed_organization = new_attrs.delete(:organization)
+      bike.attributes = b_param.safe_bike_attrs(new_attrs)
 
-    bike.address_record&.bike = bike # Kinda gross, but gotta get it both ways!
+      bike.address_record&.bike = bike # Kinda gross, but gotta get it both ways!
 
-    # If manufacturer_other is an existing manufacturer, reassign it
-    if bike.manufacturer_id == Manufacturer.other.id
-      manufacturer = Manufacturer.friendly_find(bike.manufacturer_other)
-      if manufacturer.present?
-        bike.attributes = {manufacturer_id: manufacturer.id, manufacturer_other: nil}
+      # If manufacturer_other is an existing manufacturer, reassign it
+      if bike.manufacturer_id == Manufacturer.other.id
+        manufacturer = Manufacturer.friendly_find(bike.manufacturer_other)
+        if manufacturer.present?
+          bike.attributes = {manufacturer_id: manufacturer.id, manufacturer_other: nil}
+        end
       end
-    end
-    # Use bike status because it takes into account new_attrs
-    bike.build_new_stolen_record(b_param.stolen_attrs) if bike.status_stolen?
-    bike = check_organization(b_param, bike)
-    bike.creation_organization ||= passed_organization
-    if bike.status_impounded?
-      bike.current_impound_record = build_new_impound_record(bike, b_param.impound_attrs, bike.creation_organization_id)
-    end
-    bike = check_example(b_param, bike)
-    if b_param.unregistered_parking_notification?
-      bike.attributes = default_parking_notification_attrs(b_param, bike)
-    elsif include_address_record?(bike.creation_organization)
-      bike.address_record ||= org_address_record(bike)
-    end
-    bike.bike_sticker = b_param.bike_sticker_code
-    if bike.rear_wheel_size_id.present? && bike.front_wheel_size_id.blank?
-      bike.attributes = {front_wheel_size_id: bike.rear_wheel_size_id, front_tire_narrow: bike.rear_tire_narrow}
-    end
-    bike
-  end
-
-  def find_or_build(b_param)
-    return b_param.created_bike if b_param&.created_bike&.present?
-
-    bike = build(b_param)
-    bike.set_calculated_unassociated_attributes
-
-    if b_param.no_duplicate?
-      # If a dupe is found, return that rather than the just built bike
-      dupe = BikeServices::OwnerDuplicateFinder.matching(serial: bike.serial_number,
-        owner_email: bike.owner_email, manufacturer_id: bike.manufacturer_id).first
-
-      if dupe.present?
-        b_param.update(created_bike_id: dupe.id)
-        return dupe
+      # Use bike status because it takes into account new_attrs
+      bike.build_new_stolen_record(b_param.stolen_attrs) if bike.status_stolen?
+      bike = check_organization(b_param, bike)
+      bike.creation_organization ||= passed_organization
+      if bike.status_impounded?
+        bike.current_impound_record = build_new_impound_record(bike, b_param.impound_attrs, bike.creation_organization_id)
       end
+      bike = check_example(b_param, bike)
+      if b_param.unregistered_parking_notification?
+        bike.attributes = default_parking_notification_attrs(b_param, bike)
+      elsif include_address_record?(bike.creation_organization)
+        bike.address_record ||= org_address_record(bike)
+      end
+      bike.bike_sticker = b_param.bike_sticker_code
+      if bike.rear_wheel_size_id.present? && bike.front_wheel_size_id.blank?
+        bike.attributes = {front_wheel_size_id: bike.rear_wheel_size_id, front_tire_narrow: bike.rear_tire_narrow}
+      end
+      bike
     end
-    bike
-  end
 
-  #
-  # private below here
-  #
+    def find_or_build(b_param)
+      return b_param.created_bike if b_param&.created_bike&.present?
 
-  # previously BikeServices::CreatorOrganizer
-  def check_organization(b_param, bike)
-    organization_id = b_param.params.dig("creation_organization_id").presence ||
-      b_param.params.dig("bike", "creation_organization_id")
-    organization = Organization.friendly_find(organization_id)
-    if organization.present?
-      bike.creation_organization = organization
-      # TODO: I believe this can be removed, but verify
-      # bike.creation_organization_id = organization.id
-      bike.creator_id ||= organization.auto_user_id
-    else
-      # Since there wasn't a valid organization, blank the organization
-      bike.creation_organization_id = nil
+      bike = build(b_param)
+      bike.set_calculated_unassociated_attributes
+
+      if b_param.no_duplicate?
+        # If a dupe is found, return that rather than the just built bike
+        dupe = BikeServices::OwnerDuplicateFinder.matching(serial: bike.serial_number,
+          owner_email: bike.owner_email, manufacturer_id: bike.manufacturer_id).first
+
+        if dupe.present?
+          b_param.update(created_bike_id: dupe.id)
+          return dupe
+        end
+      end
+      bike
     end
-    bike
-  end
 
-  def check_example(b_param, bike)
-    example_org = Organization.example
-    bike.creation_organization_id = example_org.id if b_param.params && b_param.params["test"]
-    if bike.creation_organization_id.present? && example_org.present?
-      bike.example = true if bike.creation_organization_id == example_org.id
-    else
-      bike.example = false
+    #
+    # private below here
+    #
+
+    # previously BikeServices::CreatorOrganizer
+    def check_organization(b_param, bike)
+      organization_id = b_param.params.dig("creation_organization_id").presence ||
+        b_param.params.dig("bike", "creation_organization_id")
+      organization = Organization.friendly_find(organization_id)
+      if organization.present?
+        bike.creation_organization = organization
+        # TODO: I believe this can be removed, but verify
+        # bike.creation_organization_id = organization.id
+        bike.creator_id ||= organization.auto_user_id
+      else
+        # Since there wasn't a valid organization, blank the organization
+        bike.creation_organization_id = nil
+      end
+      bike
     end
-    bike
-  end
 
-  def default_parking_notification_attrs(b_param, bike)
-    attrs = {
-      skip_status_update: true,
-      status: "unregistered_parking_notification",
-      marked_user_hidden: true
-    }
-    # We want to force not sending email
-    if b_param.params.dig("bike", "send_email").blank?
-      b_param.update_attribute :params, b_param.params.merge("bike" => b_param.params["bike"].merge("send_email" => "false"))
+    def check_example(b_param, bike)
+      example_org = Organization.example
+      bike.creation_organization_id = example_org.id if b_param.params && b_param.params["test"]
+      if bike.creation_organization_id.present? && example_org.present?
+        bike.example = true if bike.creation_organization_id == example_org.id
+      else
+        bike.example = false
+      end
+      bike
     end
-    if bike.owner_email.blank?
-      attrs[:owner_email] = b_param.creation_organization&.auto_user&.email.presence || b_param.creator.email
+
+    def default_parking_notification_attrs(b_param, bike)
+      attrs = {
+        skip_status_update: true,
+        status: "unregistered_parking_notification",
+        marked_user_hidden: true
+      }
+      # We want to force not sending email
+      if b_param.params.dig("bike", "send_email").blank?
+        b_param.update_attribute :params, b_param.params.merge("bike" => b_param.params["bike"].merge("send_email" => "false"))
+      end
+      if bike.owner_email.blank?
+        attrs[:owner_email] = b_param.creation_organization&.auto_user&.email.presence || b_param.creator.email
+      end
+      attrs[:serial_number] = "unknown" unless bike.serial_number.present?
+      attrs
     end
-    attrs[:serial_number] = "unknown" unless bike.serial_number.present?
-    attrs
+
+    def org_address_record(bike)
+      org_address = bike.creation_organization.default_address_record
+      return if org_address.blank?
+
+      AddressRecord.new(org_address.attributes
+        .slice("city", "region_record_id", "country_id")
+        .merge(kind: :ownership, bike:))
+    end
+
+    def build_new_impound_record(bike, impound_attrs, organization_id)
+      impound_params = ActionController::Parameters.new(impound_attrs)
+        .permit(*BikeServices::Creator::PERMITTED_IMPOUND_ATTRS)
+        .merge(status: "current", user_id: bike.creator_id, organization_id:)
+
+      impound_record = bike.impound_records.build(impound_params)
+      impound_record.impounded_at ||= Time.current # in case a blank value was passed in impound_attrs
+      impound_record.address_record&.kind = :impounded_from
+      impound_record
+    end
+
+    conceal :check_organization, :check_example, :default_parking_notification_attrs,
+      :org_address_record, :build_new_impound_record
   end
-
-  def org_address_record(bike)
-    org_address = bike.creation_organization.default_address_record
-    return if org_address.blank?
-
-    AddressRecord.new(org_address.attributes
-      .slice("city", "region_record_id", "country_id")
-      .merge(kind: :ownership, bike:))
-  end
-
-  def build_new_impound_record(bike, impound_attrs, organization_id)
-    impound_params = ActionController::Parameters.new(impound_attrs)
-      .permit(*BikeServices::Creator::PERMITTED_IMPOUND_ATTRS)
-      .merge(status: "current", user_id: bike.creator_id, organization_id:)
-
-    impound_record = bike.impound_records.build(impound_params)
-    impound_record.impounded_at ||= Time.current # in case a blank value was passed in impound_attrs
-    impound_record.address_record&.kind = :impounded_from
-    impound_record
-  end
-
-  conceal :check_organization, :check_example, :default_parking_notification_attrs,
-    :org_address_record, :build_new_impound_record
 end

--- a/app/services/bike_services/calculate_location.rb
+++ b/app/services/bike_services/calculate_location.rb
@@ -1,79 +1,81 @@
-module BikeServices::CalculateLocation
-  extend Functionable
+module BikeServices
+  module CalculateLocation
+    extend Functionable
 
-  def registration_address_source(bike)
-    # NOTE: Marketplace Listing and User address are the preferred addresses!
-    # If either is set, address fields don't show on bike!
-    if bike.is_for_sale && bike.current_marketplace_listing.present?
-      "marketplace_listing"
-    elsif bike.user&.address_set_manually
-      "user"
-    elsif bike.address_set_manually
-      "bike_update"
-    elsif bike.current_ownership&.address_record?
-      "initial_creation"
-    end
-  end
-
-  def registration_address_record(bike)
-    case registration_address_source(bike)
-    when "marketplace_listing" then bike.current_marketplace_listing.address_record
-    when "user" then bike.user&.address_record
-    when "bike_update" then bike.address_record
-    when "initial_creation" then bike.current_ownership.address_record
-    end
-  end
-
-  def registration_address_hash(bike, address_record_id: false)
-    (registration_address_record(bike)&.address_hash_legacy(address_record_id:) || {})
-      .with_indifferent_access
-  end
-
-  # Set the bike's location data (lat/long, city, postal code, country, etc.)
-  #
-  # Geolocate based on the full current stolen record address, if available.
-  # Otherwise, use the data set by location_record_address_hash
-  # Sets lat/long, will avoid a geocode API call if coordinates are found
-  def stored_location_attrs(bike)
-    if bike.current_stolen_record.present?
-      # If there is a current stolen - even if it has a blank location - use it
-      # It's used for searching and displaying stolen bikes, we don't want other information leaking
-      bike.current_stolen_record.attributes.slice("latitude", "longitude")
-    else
-      attrs = {}
-      # If address is comes from the user record, address_set_manually is no longer correct!
-      if bike.address_set_manually && bike.user&.address_set_manually
-        attrs[:address_set_manually] = false
+    def registration_address_source(bike)
+      # NOTE: Marketplace Listing and User address are the preferred addresses!
+      # If either is set, address fields don't show on bike!
+      if bike.is_for_sale && bike.current_marketplace_listing.present?
+        "marketplace_listing"
+      elsif bike.user&.address_set_manually
+        "user"
+      elsif bike.address_set_manually
+        "bike_update"
+      elsif bike.current_ownership&.address_record?
+        "initial_creation"
       end
-      attrs.merge(location_record_coordinates(bike))
     end
+
+    def registration_address_record(bike)
+      case registration_address_source(bike)
+      when "marketplace_listing" then bike.current_marketplace_listing.address_record
+      when "user" then bike.user&.address_record
+      when "bike_update" then bike.address_record
+      when "initial_creation" then bike.current_ownership.address_record
+      end
+    end
+
+    def registration_address_hash(bike, address_record_id: false)
+      (registration_address_record(bike)&.address_hash_legacy(address_record_id:) || {})
+        .with_indifferent_access
+    end
+
+    # Set the bike's location data (lat/long, city, postal code, country, etc.)
+    #
+    # Geolocate based on the full current stolen record address, if available.
+    # Otherwise, use the data set by location_record_address_hash
+    # Sets lat/long, will avoid a geocode API call if coordinates are found
+    def stored_location_attrs(bike)
+      if bike.current_stolen_record.present?
+        # If there is a current stolen - even if it has a blank location - use it
+        # It's used for searching and displaying stolen bikes, we don't want other information leaking
+        bike.current_stolen_record.attributes.slice("latitude", "longitude")
+      else
+        attrs = {}
+        # If address is comes from the user record, address_set_manually is no longer correct!
+        if bike.address_set_manually && bike.user&.address_set_manually
+          attrs[:address_set_manually] = false
+        end
+        attrs.merge(location_record_coordinates(bike))
+      end
+    end
+
+    #
+    # private below here
+    #
+
+    # Select the source from which to derive location data, in the following order
+    # of precedence:
+    #
+    # 1. The current parking notification/impound record, if one is present
+    # 2. #registration_address (which prioritizes user address)
+    # 3. The creation organization address (so we have a general area for the bike)
+    # prefer with street address, fallback to anything with a latitude, use hashes (not obj) because registration_address
+    def location_record_coordinates(bike)
+      l_hashes = [
+        bike.current_impound_record&.address_hash_legacy,
+        bike.current_parking_notification&.address_hash_legacy,
+        bike.registration_address(true, address_record_id: true), # temporary cludge?
+        bike.creation_organization&.default_location&.address_hash_legacy
+      ].compact
+      l_hash = l_hashes.find { |rec| rec&.dig("street").present? } ||
+        l_hashes.find { |rec| rec&.dig("latitude").present? }
+      return {} unless l_hash.present?
+
+      # Only ever respond with the coordinates
+      l_hash.slice("latitude", "longitude", "address_record_id")
+    end
+
+    conceal :location_record_coordinates
   end
-
-  #
-  # private below here
-  #
-
-  # Select the source from which to derive location data, in the following order
-  # of precedence:
-  #
-  # 1. The current parking notification/impound record, if one is present
-  # 2. #registration_address (which prioritizes user address)
-  # 3. The creation organization address (so we have a general area for the bike)
-  # prefer with street address, fallback to anything with a latitude, use hashes (not obj) because registration_address
-  def location_record_coordinates(bike)
-    l_hashes = [
-      bike.current_impound_record&.address_hash_legacy,
-      bike.current_parking_notification&.address_hash_legacy,
-      bike.registration_address(true, address_record_id: true), # temporary cludge?
-      bike.creation_organization&.default_location&.address_hash_legacy
-    ].compact
-    l_hash = l_hashes.find { |rec| rec&.dig("street").present? } ||
-      l_hashes.find { |rec| rec&.dig("latitude").present? }
-    return {} unless l_hash.present?
-
-    # Only ever respond with the coordinates
-    l_hash.slice("latitude", "longitude", "address_record_id")
-  end
-
-  conceal :location_record_coordinates
 end

--- a/app/services/bike_services/creator.rb
+++ b/app/services/bike_services/creator.rb
@@ -1,290 +1,292 @@
 # frozen_string_literal: true
 
-class BikeServices::Creator
-  PERMITTED_ATTRS = %i[
-    abandoned
-    approved_stolen
-    b_param_id
-    b_param_id_token
-    belt_drive
-    bike_organization_ids
-    coaster_brake
-    components_attributes
-    creation_organization_id
-    creator
-    creator_id
-    current_stolen_record_id
-    cycle_type
-    date_stolen
-    description
-    embeded
-    embeded_extended
-    example
-    extra_registration_number
-    frame_material
-    frame_model
-    frame_size
-    frame_size_number
-    frame_size_unit
-    front_gear_type_id
-    front_gear_type_slug
-    front_tire_narrow
-    front_wheel_size_id
-    handlebar_type
-    image
-    is_for_sale
-    listing_order
-    made_without_serial
-    manufacturer
-    manufacturer_id
-    manufacturer_other
-    marked_user_hidden
-    marked_user_unhidden
-    name
-    number_of_seats
-    organization_affiliation
-    owner_email
-    paint_id
-    paint_name
-    pdf
-    phone
-    primary_activity_id
-    primary_frame_color_id
-    propulsion_type
-    rear_gear_type_id
-    rear_gear_type_slug
-    rear_tire_narrow
-    rear_wheel_size_id
-    receive_notifications
-    secondary_frame_color_id
-    send_email
-    serial_normalized
-    serial_number
-    skip_email
-    stock_photo_url
-    student_id
-    tertiary_frame_color_id
-    thumb_path
-    timezone
-    year
-  ].freeze
-  PERMITTED_IMPOUND_ATTRS = [
-    :display_id,
-    :impounded_at,
-    :impounded_at_with_timezone,
-    :impounded_description,
-    :timezone,
-    address_record_attributes: (AddressRecord.permitted_params + [:id, :skip_geocoding])
-  ].freeze
-  # Used to be in Bike - but now it's here. Eventually, we should actually do permitted params handling in here
-  # ... and have separate permitted params in bikeupdator
-  def self.old_attr_accessible
-    (PERMITTED_ATTRS + [
-      stolen_records_attributes: BikeServices::StolenRecordUpdator.old_attr_accessible,
-      impound_records_attributes: PERMITTED_IMPOUND_ATTRS,
-      components_attributes: Component.permitted_attributes,
-      address_record_attributes: AddressRecord.permitted_params
-    ]).freeze
-  end
-
-  def initialize(ip_address: nil)
-    @ip_address = ip_address
-  end
-
-  def create_bike(b_param)
-    add_bike_book_data(b_param)
-    bike = BikeServices::Builder.find_or_build(b_param)
-
-    # Skip processing if this bike is already created
-    return bike if bike.id.present? && bike.id == b_param.created_bike_id
-
-    # There could be errors during the build - or during the save
-    bike = save_bike(b_param, bike) if bike.errors.none?
-    if bike.errors.any?
-      b_param&.update(bike_errors: bike.cleaned_error_messages)
+module BikeServices
+  class Creator
+    PERMITTED_ATTRS = %i[
+      abandoned
+      approved_stolen
+      b_param_id
+      b_param_id_token
+      belt_drive
+      bike_organization_ids
+      coaster_brake
+      components_attributes
+      creation_organization_id
+      creator
+      creator_id
+      current_stolen_record_id
+      cycle_type
+      date_stolen
+      description
+      embeded
+      embeded_extended
+      example
+      extra_registration_number
+      frame_material
+      frame_model
+      frame_size
+      frame_size_number
+      frame_size_unit
+      front_gear_type_id
+      front_gear_type_slug
+      front_tire_narrow
+      front_wheel_size_id
+      handlebar_type
+      image
+      is_for_sale
+      listing_order
+      made_without_serial
+      manufacturer
+      manufacturer_id
+      manufacturer_other
+      marked_user_hidden
+      marked_user_unhidden
+      name
+      number_of_seats
+      organization_affiliation
+      owner_email
+      paint_id
+      paint_name
+      pdf
+      phone
+      primary_activity_id
+      primary_frame_color_id
+      propulsion_type
+      rear_gear_type_id
+      rear_gear_type_slug
+      rear_tire_narrow
+      rear_wheel_size_id
+      receive_notifications
+      secondary_frame_color_id
+      send_email
+      serial_normalized
+      serial_number
+      skip_email
+      stock_photo_url
+      student_id
+      tertiary_frame_color_id
+      thumb_path
+      timezone
+      year
+    ].freeze
+    PERMITTED_IMPOUND_ATTRS = [
+      :display_id,
+      :impounded_at,
+      :impounded_at_with_timezone,
+      :impounded_description,
+      :timezone,
+      address_record_attributes: (AddressRecord.permitted_params + [:id, :skip_geocoding])
+    ].freeze
+    # Used to be in Bike - but now it's here. Eventually, we should actually do permitted params handling in here
+    # ... and have separate permitted params in bikeupdator
+    def self.old_attr_accessible
+      (PERMITTED_ATTRS + [
+        stolen_records_attributes: BikeServices::StolenRecordUpdator.old_attr_accessible,
+        impound_records_attributes: PERMITTED_IMPOUND_ATTRS,
+        components_attributes: Component.permitted_attributes,
+        address_record_attributes: AddressRecord.permitted_params
+      ]).freeze
     end
-    bike
-  end
 
-  # Called from ImageAssociatorJob, so can't be private
-  def attach_photo(b_param, bike)
-    return true unless b_param.image.present?
-
-    public_image = PublicImage.new(image: b_param.image)
-    public_image.imageable = bike
-    public_image.save
-    b_param.update(image_processed: true)
-    bike.reload
-  end
-
-  private
-
-  # Previously all of this stuff was public.
-  # In an effort to refactor and simplify, anything not accessed outside of this class was explicitly made private (PR#1478)
-
-  def add_bike_book_data(b_param = nil)
-    return nil unless b_param&.bike.present? && b_param.manufacturer_id.present?
-    return nil unless b_param.bike["frame_model"].present? && b_param.bike["year"].present?
-
-    bb_data = Integrations::BikeBook.new.get_model({
-      manufacturer: Manufacturer.find(b_param.bike["manufacturer_id"]).name,
-      year: b_param.bike["year"],
-      frame_model: b_param.bike["frame_model"]
-    })
-
-    return true unless bb_data && bb_data["bike"].present?
-
-    b_param.params["bike"]["cycle_type"] = bb_data["bike"]["cycle_type"] if bb_data["bike"] && bb_data["bike"]["cycle_type"].present?
-    if bb_data["bike"]["paint_description"].present?
-      b_param.params["bike"]["paint_name"] = bb_data["bike"]["paint_description"] unless b_param.params["bike"]["paint_name"].present?
+    def initialize(ip_address: nil)
+      @ip_address = ip_address
     end
-    if bb_data["bike"]["description"].present?
-      if b_param.params["bike"]["description"].present?
-        b_param.params["bike"]["description"] += " #{bb_data["bike"]["description"]}"
-      else
-        b_param.params["bike"]["description"] = bb_data["bike"]["description"]
+
+    def create_bike(b_param)
+      add_bike_book_data(b_param)
+      bike = BikeServices::Builder.find_or_build(b_param)
+
+      # Skip processing if this bike is already created
+      return bike if bike.id.present? && bike.id == b_param.created_bike_id
+
+      # There could be errors during the build - or during the save
+      bike = save_bike(b_param, bike) if bike.errors.none?
+      if bike.errors.any?
+        b_param&.update(bike_errors: bike.cleaned_error_messages)
+      end
+      bike
+    end
+
+    # Called from ImageAssociatorJob, so can't be private
+    def attach_photo(b_param, bike)
+      return true unless b_param.image.present?
+
+      public_image = PublicImage.new(image: b_param.image)
+      public_image.imageable = bike
+      public_image.save
+      b_param.update(image_processed: true)
+      bike.reload
+    end
+
+    private
+
+    # Previously all of this stuff was public.
+    # In an effort to refactor and simplify, anything not accessed outside of this class was explicitly made private (PR#1478)
+
+    def add_bike_book_data(b_param = nil)
+      return nil unless b_param&.bike.present? && b_param.manufacturer_id.present?
+      return nil unless b_param.bike["frame_model"].present? && b_param.bike["year"].present?
+
+      bb_data = Integrations::BikeBook.new.get_model({
+        manufacturer: Manufacturer.find(b_param.bike["manufacturer_id"]).name,
+        year: b_param.bike["year"],
+        frame_model: b_param.bike["frame_model"]
+      })
+
+      return true unless bb_data && bb_data["bike"].present?
+
+      b_param.params["bike"]["cycle_type"] = bb_data["bike"]["cycle_type"] if bb_data["bike"] && bb_data["bike"]["cycle_type"].present?
+      if bb_data["bike"]["paint_description"].present?
+        b_param.params["bike"]["paint_name"] = bb_data["bike"]["paint_description"] unless b_param.params["bike"]["paint_name"].present?
+      end
+      if bb_data["bike"]["description"].present?
+        if b_param.params["bike"]["description"].present?
+          b_param.params["bike"]["description"] += " #{bb_data["bike"]["description"]}"
+        else
+          b_param.params["bike"]["description"] = bb_data["bike"]["description"]
+        end
+      end
+      b_param.params["bike"]["rear_wheel_bsd"] = bb_data["bike"]["rear_wheel_bsd"] if bb_data["bike"]["rear_wheel_bsd"].present?
+      b_param.params["bike"]["rear_tire_narrow"] = bb_data["bike"]["rear_tire_narrow"] if bb_data["bike"]["rear_tire_narrow"].present?
+      b_param.params["bike"]["stock_photo_url"] = bb_data["bike"]["stock_photo_url"] if bb_data["bike"]["stock_photo_url"].present?
+      b_param.params["components"] = bb_data["components"] && bb_data["components"].map { |c| c.merge("is_stock" => true) }
+      b_param.clean_params # if we just rely on the before_save filter, b_param needs to be reloaded
+      b_param.save if b_param.id.present?
+      b_param
+    end
+
+    def clear_bike(b_param, bike)
+      built_bike = BikeServices::Builder.find_or_build(b_param)
+      bike.errors.messages.each do |message|
+        built_bike.errors.add(message[0], message[1][0])
+      end
+      bike.ownerships.destroy_all
+      bike.bike_organizations.destroy_all
+      bike.impound_records.destroy_all
+      bike.parking_notifications.destroy_all
+      bike.destroy
+      built_bike
+    end
+
+    def validate_record(b_param, bike)
+      return clear_bike(b_param, bike) if bike.errors.present?
+
+      if b_param.created_bike_id.present? && b_param.created_bike_id != bike.id
+        clear_bike(b_param, bike)
+        return b_param.created_bike
+      elsif b_param.id.present? # Only update b_param if it exists
+        b_param.update(created_bike_id: bike.id, bike_errors: nil)
+      end
+      bike
+    end
+
+    def save_bike(b_param, bike)
+      bike.save
+
+      ownership = create_ownership(b_param, bike)
+      bike = associate(b_param, bike, ownership) unless bike.errors.any?
+      bike = validate_record(b_param, bike)
+      return bike unless bike.present? && bike.id.present?
+
+      # NOTE: spaminess is recalculated in Email::OwnershipInvitationJob as a failsafe
+      if SpamEstimator.estimate_bike(bike) > SpamEstimator::MARK_SPAM_PERCENT
+        bike.update(likely_spam: true)
+      end
+      CallbackJob::AfterBikeSaveJob.perform_async(bike.id)
+      if b_param.bike_sticker_code.present? && bike.creation_organization.present?
+        bike_sticker = BikeSticker.lookup_with_fallback(b_param.bike_sticker_code, organization_id: bike.creation_organization.id)
+        bike_sticker&.claim_if_permitted(user: bike.creator, bike: bike.id,
+          organization: bike.creation_organization, creator_kind: "creator_bike_creation")
+      end
+
+      bike.reload
+    end
+
+    def associate(b_param, bike, ownership)
+      create_parking_notification(b_param, bike) if b_param&.status_abandoned? || b_param&.unregistered_parking_notification?
+      create_bike_organizations(ownership)
+      ComponentCreator.new(bike: bike, b_param: b_param).create_components_from_params
+      bike.create_normalized_serial_segments
+      assign_user_attributes(bike, ownership&.user)
+      BikeServices::StolenRecordUpdator.new(bike: bike, b_param: b_param).update_records
+      attach_photo(b_param, bike)
+      attach_photos(b_param, bike)
+      bike.save
+      bike
+    end
+
+    def ownership_creation_attributes(b_param, bike)
+      {
+        is_new: b_param.is_new,
+        pos_kind: b_param.pos_kind,
+        origin: b_param.origin,
+        status: b_param.status,
+        doorkeeper_app_id: b_param.doorkeeper_app_id,
+        bulk_import_id: b_param.params["bulk_import_id"],
+        creator_id: b_param.creator_id,
+        can_edit_claimed: bike.creation_organization_id.present?,
+        organization_id: bike.creation_organization_id,
+        address_record_id: bike.address_record_id
+      }.merge(registration_info: b_param.registration_info_attrs.merge(ip_address: @ip_address))
+    end
+
+    def create_ownership(b_param, bike)
+      ownership = bike.ownerships.new(creator: b_param.creator, skip_email: b_param.skip_email?)
+      ownership.attributes = ownership_creation_attributes(b_param, bike)
+      unless ownership.save
+        ownership.errors.messages.each { |msg| bike.errors.add(msg[0], msg[1][0]) }
+      end
+      ownership
+    end
+
+    def create_bike_organizations(ownership)
+      organization = ownership.organization
+      return true unless organization.present?
+
+      unless BikeOrganization.where(bike_id: ownership.bike_id, organization_id: organization.id).present?
+        BikeOrganization.create(bike_id: ownership.bike_id, organization_id: organization.id, can_edit_claimed: ownership.can_edit_claimed)
+      end
+      if organization.parent_organization.present? && BikeOrganization.where(bike_id: ownership.bike_id, organization_id: organization.parent_organization_id).blank?
+        BikeOrganization.create(bike_id: ownership.bike_id, organization_id: organization.parent_organization_id, can_edit_claimed: ownership.can_edit_claimed)
       end
     end
-    b_param.params["bike"]["rear_wheel_bsd"] = bb_data["bike"]["rear_wheel_bsd"] if bb_data["bike"]["rear_wheel_bsd"].present?
-    b_param.params["bike"]["rear_tire_narrow"] = bb_data["bike"]["rear_tire_narrow"] if bb_data["bike"]["rear_tire_narrow"].present?
-    b_param.params["bike"]["stock_photo_url"] = bb_data["bike"]["stock_photo_url"] if bb_data["bike"]["stock_photo_url"].present?
-    b_param.params["components"] = bb_data["components"] && bb_data["components"].map { |c| c.merge("is_stock" => true) }
-    b_param.clean_params # if we just rely on the before_save filter, b_param needs to be reloaded
-    b_param.save if b_param.id.present?
-    b_param
-  end
 
-  def clear_bike(b_param, bike)
-    built_bike = BikeServices::Builder.find_or_build(b_param)
-    bike.errors.messages.each do |message|
-      built_bike.errors.add(message[0], message[1][0])
-    end
-    bike.ownerships.destroy_all
-    bike.bike_organizations.destroy_all
-    bike.impound_records.destroy_all
-    bike.parking_notifications.destroy_all
-    bike.destroy
-    built_bike
-  end
-
-  def validate_record(b_param, bike)
-    return clear_bike(b_param, bike) if bike.errors.present?
-
-    if b_param.created_bike_id.present? && b_param.created_bike_id != bike.id
-      clear_bike(b_param, bike)
-      return b_param.created_bike
-    elsif b_param.id.present? # Only update b_param if it exists
-      b_param.update(created_bike_id: bike.id, bike_errors: nil)
-    end
-    bike
-  end
-
-  def save_bike(b_param, bike)
-    bike.save
-
-    ownership = create_ownership(b_param, bike)
-    bike = associate(b_param, bike, ownership) unless bike.errors.any?
-    bike = validate_record(b_param, bike)
-    return bike unless bike.present? && bike.id.present?
-
-    # NOTE: spaminess is recalculated in Email::OwnershipInvitationJob as a failsafe
-    if SpamEstimator.estimate_bike(bike) > SpamEstimator::MARK_SPAM_PERCENT
-      bike.update(likely_spam: true)
-    end
-    CallbackJob::AfterBikeSaveJob.perform_async(bike.id)
-    if b_param.bike_sticker_code.present? && bike.creation_organization.present?
-      bike_sticker = BikeSticker.lookup_with_fallback(b_param.bike_sticker_code, organization_id: bike.creation_organization.id)
-      bike_sticker&.claim_if_permitted(user: bike.creator, bike: bike.id,
-        organization: bike.creation_organization, creator_kind: "creator_bike_creation")
+    def create_parking_notification(b_param, bike)
+      if b_param.unregistered_parking_notification?
+        # We skipped setting address, with Builder.default_parking_notification_attrs,
+        # notification will update it
+        ParkingNotification.create!(b_param.parking_notification_params.merge(bike_id: bike.id))
+      else
+        parking_notification_attrs = bike.address_hash_legacy
+        parking_notification_attrs.merge!(kind: b_param.bike["parking_notification_kind"],
+          bike_id: bike.id,
+          user_id: bike.creator.id,
+          organization_id: b_param.creation_organization_id)
+        ParkingNotification.create(parking_notification_attrs)
+      end
+      # Reload to pick up changes from ProcessParkingNotificationJob (e.g. user_hidden cleared by impound).
+      # attr_accessors persist through reload, so clear marked_user_hidden for impound notifications
+      # to prevent the subsequent bike.save from overwriting the impound job's user_hidden=false
+      bike.reload
+      bike.marked_user_hidden = nil if bike.current_impound_record.present?
     end
 
-    bike.reload
-  end
+    def assign_user_attributes(bike, user = nil)
+      user ||= bike.user
+      return true unless user.present?
 
-  def associate(b_param, bike, ownership)
-    create_parking_notification(b_param, bike) if b_param&.status_abandoned? || b_param&.unregistered_parking_notification?
-    create_bike_organizations(ownership)
-    ComponentCreator.new(bike: bike, b_param: b_param).create_components_from_params
-    bike.create_normalized_serial_segments
-    assign_user_attributes(bike, ownership&.user)
-    BikeServices::StolenRecordUpdator.new(bike: bike, b_param: b_param).update_records
-    attach_photo(b_param, bike)
-    attach_photos(b_param, bike)
-    bike.save
-    bike
-  end
-
-  def ownership_creation_attributes(b_param, bike)
-    {
-      is_new: b_param.is_new,
-      pos_kind: b_param.pos_kind,
-      origin: b_param.origin,
-      status: b_param.status,
-      doorkeeper_app_id: b_param.doorkeeper_app_id,
-      bulk_import_id: b_param.params["bulk_import_id"],
-      creator_id: b_param.creator_id,
-      can_edit_claimed: bike.creation_organization_id.present?,
-      organization_id: bike.creation_organization_id,
-      address_record_id: bike.address_record_id
-    }.merge(registration_info: b_param.registration_info_attrs.merge(ip_address: @ip_address))
-  end
-
-  def create_ownership(b_param, bike)
-    ownership = bike.ownerships.new(creator: b_param.creator, skip_email: b_param.skip_email?)
-    ownership.attributes = ownership_creation_attributes(b_param, bike)
-    unless ownership.save
-      ownership.errors.messages.each { |msg| bike.errors.add(msg[0], msg[1][0]) }
+      if bike.phone.present?
+        user.phone = bike.phone if user.phone.blank?
+      end
+      user.save if user.changed? # Because we're also going to set the address and the name here
+      bike
     end
-    ownership
-  end
 
-  def create_bike_organizations(ownership)
-    organization = ownership.organization
-    return true unless organization.present?
+    def attach_photos(b_param, bike)
+      return nil unless b_param.params["photos"].present?
 
-    unless BikeOrganization.where(bike_id: ownership.bike_id, organization_id: organization.id).present?
-      BikeOrganization.create(bike_id: ownership.bike_id, organization_id: organization.id, can_edit_claimed: ownership.can_edit_claimed)
+      photos = b_param.params["photos"].uniq.take(7)
+      photos.each { |p| PublicImage.create(imageable: bike, remote_image_url: p) }
     end
-    if organization.parent_organization.present? && BikeOrganization.where(bike_id: ownership.bike_id, organization_id: organization.parent_organization_id).blank?
-      BikeOrganization.create(bike_id: ownership.bike_id, organization_id: organization.parent_organization_id, can_edit_claimed: ownership.can_edit_claimed)
-    end
-  end
-
-  def create_parking_notification(b_param, bike)
-    if b_param.unregistered_parking_notification?
-      # We skipped setting address, with Builder.default_parking_notification_attrs,
-      # notification will update it
-      ParkingNotification.create!(b_param.parking_notification_params.merge(bike_id: bike.id))
-    else
-      parking_notification_attrs = bike.address_hash_legacy
-      parking_notification_attrs.merge!(kind: b_param.bike["parking_notification_kind"],
-        bike_id: bike.id,
-        user_id: bike.creator.id,
-        organization_id: b_param.creation_organization_id)
-      ParkingNotification.create(parking_notification_attrs)
-    end
-    # Reload to pick up changes from ProcessParkingNotificationJob (e.g. user_hidden cleared by impound).
-    # attr_accessors persist through reload, so clear marked_user_hidden for impound notifications
-    # to prevent the subsequent bike.save from overwriting the impound job's user_hidden=false
-    bike.reload
-    bike.marked_user_hidden = nil if bike.current_impound_record.present?
-  end
-
-  def assign_user_attributes(bike, user = nil)
-    user ||= bike.user
-    return true unless user.present?
-
-    if bike.phone.present?
-      user.phone = bike.phone if user.phone.blank?
-    end
-    user.save if user.changed? # Because we're also going to set the address and the name here
-    bike
-  end
-
-  def attach_photos(b_param, bike)
-    return nil unless b_param.params["photos"].present?
-
-    photos = b_param.params["photos"].uniq.take(7)
-    photos.each { |p| PublicImage.create(imageable: bike, remote_image_url: p) }
   end
 end

--- a/app/services/bike_services/displayer.rb
+++ b/app/services/bike_services/displayer.rb
@@ -1,155 +1,157 @@
 # Contains methods used for display, which don't return HTML.
 # Use BikeHelper for methods that do return HTML
 
-module BikeServices::Displayer
-  extend Functionable
+module BikeServices
+  module Displayer
+    extend Functionable
 
-  # This is just a quick hack, will improve
-  def vehicle_search?(params_and_interpreted_params)
-    return true if (%i[propulsion_type cycle_type] & params_and_interpreted_params.keys).any? ||
-      params_and_interpreted_params[:search_model_audit_id].present?
+    # This is just a quick hack, will improve
+    def vehicle_search?(params_and_interpreted_params)
+      return true if (%i[propulsion_type cycle_type] & params_and_interpreted_params.keys).any? ||
+        params_and_interpreted_params[:search_model_audit_id].present?
 
-    # Vehicle or propulsion type query items
-    (params_and_interpreted_params[:query_items] || [])
-      .any? { it.start_with?("v_", "p_") }
-  end
-
-  # user arg because all methods have it
-  def paint_description?(bike, _user = nil)
-    bike.pos? && bike.paint.present?
-  end
-
-  # Users send unstolen notifications through the organized_access_panel
-  # The contact owner box only shows up for stolen bikes
-  def display_contact_owner?(bike, user = nil)
-    bike.current_stolen_record.present?
-  end
-
-  def display_impound_claim?(bike, user = nil)
-    return false if bike.owner.present? && bike.owner == user
-    return true if bike.current_impound_record.present?
-    return false if user.blank?
-
-    bike.impound_claims_submitting.active.where(user_id: user.id).any? ||
-      bike.impound_claims_claimed.active.where(user_id: user.id).any?
-  end
-
-  def display_marketplace_message?(bike, _user = nil)
-    bike.status_with_owner? && bike.is_for_sale? && bike.current_marketplace_listing.present?
-  end
-
-  def display_sticker_edit?(bike, user = nil)
-    return false unless user.present? && !bike.version?
-    return true if user.superuser? || user.enabled?("bike_stickers")
-    # user_can_claim_sticker? checks if they've made too many sticker updates
-    return false unless BikeSticker.user_can_claim_sticker?(user)
-    return true if bike.bike_stickers.any?(&:user_editable?) ||
-      user.updated_bike_stickers.any?(&:user_editable?)
-
-    bike_ids = user.bike_ids
-    # Return false if no bikes
-    return false if bike_ids.none?
-
-    sticker_ids = BikeStickerUpdate.where(bike_id: bike_ids).distinct.pluck(:bike_sticker_id)
-    return true if BikeSticker.where(id: sticker_ids).any?(&:user_editable?)
-
-    # Any organizations, for any bikes from user, with stickers
-    Organization.where(id: BikeOrganization.where(bike_id: bike_ids).pluck(:organization_id))
-      .with_enabled_feature_slugs("bike_stickers_user_editable").any?
-  end
-
-  def display_edit_address_fields?(bike, user = nil)
-    return false unless user_edit_bike_address?(bike, user)
-    # Make absolutely sure with stolen bikes
-    return false if bike.version? || bike.current_stolen_record_id.present? ||
-      BikeServices::CalculateLocation.registration_address_source(bike) == "marketplace_listing"
-
-    # parking notifications, impounded, stolen etc use the associated record for their address
-    %w[status_impounded unregistered_parking_notification status_stolen].exclude?(bike.status)
-  end
-
-  def edit_street_address?(bike, user = nil)
-    return false if bike.user&.no_address? || bike.creation_organization&.enabled?("no_address")
-
-    bike.address_record&.street.present? || bike.creation_organization&.enabled?("reg_address")
-  end
-
-  def thumb_image_url(bike)
-    return bike.thumb_path if bike.thumb_path.present?
-    return nil if bike.stock_photo_url.blank?
-
-    small = bike.stock_photo_url.split("/")
-    ext = "/small_" + small.pop
-    small.join("/") + ext
-  end
-
-  def header_image_urls(bike)
-    if bike.thumb_path.blank?
-      return single_image_hash(bike.stock_photo_url) if bike.stock_photo_url.present?
-
-      return false # Because there are no images
+      # Vehicle or propulsion type query items
+      (params_and_interpreted_params[:query_items] || [])
+        .any? { it.start_with?("v_", "p_") }
     end
 
-    if (stolen_record = bike.current_stolen_record).present?
-      if stolen_record.images_attached?
-        return {
-          square: BlobUrl.for(stolen_record.image_square),
-          facebook: BlobUrl.for(stolen_record.image_opengraph),
-          twitter: BlobUrl.for(stolen_record.image_opengraph)
-        }
+    # user arg because all methods have it
+    def paint_description?(bike, _user = nil)
+      bike.pos? && bike.paint.present?
+    end
+
+    # Users send unstolen notifications through the organized_access_panel
+    # The contact owner box only shows up for stolen bikes
+    def display_contact_owner?(bike, user = nil)
+      bike.current_stolen_record.present?
+    end
+
+    def display_impound_claim?(bike, user = nil)
+      return false if bike.owner.present? && bike.owner == user
+      return true if bike.current_impound_record.present?
+      return false if user.blank?
+
+      bike.impound_claims_submitting.active.where(user_id: user.id).any? ||
+        bike.impound_claims_claimed.active.where(user_id: user.id).any?
+    end
+
+    def display_marketplace_message?(bike, _user = nil)
+      bike.status_with_owner? && bike.is_for_sale? && bike.current_marketplace_listing.present?
+    end
+
+    def display_sticker_edit?(bike, user = nil)
+      return false unless user.present? && !bike.version?
+      return true if user.superuser? || user.enabled?("bike_stickers")
+      # user_can_claim_sticker? checks if they've made too many sticker updates
+      return false unless BikeSticker.user_can_claim_sticker?(user)
+      return true if bike.bike_stickers.any?(&:user_editable?) ||
+        user.updated_bike_stickers.any?(&:user_editable?)
+
+      bike_ids = user.bike_ids
+      # Return false if no bikes
+      return false if bike_ids.none?
+
+      sticker_ids = BikeStickerUpdate.where(bike_id: bike_ids).distinct.pluck(:bike_sticker_id)
+      return true if BikeSticker.where(id: sticker_ids).any?(&:user_editable?)
+
+      # Any organizations, for any bikes from user, with stickers
+      Organization.where(id: BikeOrganization.where(bike_id: bike_ids).pluck(:organization_id))
+        .with_enabled_feature_slugs("bike_stickers_user_editable").any?
+    end
+
+    def display_edit_address_fields?(bike, user = nil)
+      return false unless user_edit_bike_address?(bike, user)
+      # Make absolutely sure with stolen bikes
+      return false if bike.version? || bike.current_stolen_record_id.present? ||
+        BikeServices::CalculateLocation.registration_address_source(bike) == "marketplace_listing"
+
+      # parking notifications, impounded, stolen etc use the associated record for their address
+      %w[status_impounded unregistered_parking_notification status_stolen].exclude?(bike.status)
+    end
+
+    def edit_street_address?(bike, user = nil)
+      return false if bike.user&.no_address? || bike.creation_organization&.enabled?("no_address")
+
+      bike.address_record&.street.present? || bike.creation_organization&.enabled?("reg_address")
+    end
+
+    def thumb_image_url(bike)
+      return bike.thumb_path if bike.thumb_path.present?
+      return nil if bike.stock_photo_url.blank?
+
+      small = bike.stock_photo_url.split("/")
+      ext = "/small_" + small.pop
+      small.join("/") + ext
+    end
+
+    def header_image_urls(bike)
+      if bike.thumb_path.blank?
+        return single_image_hash(bike.stock_photo_url) if bike.stock_photo_url.present?
+
+        return false # Because there are no images
       end
 
-      facebook_image = stolen_record.alert_image&.image_url(:facebook)
-      if facebook_image.present?
-        return {
-          square: facebook_image,
-          facebook: facebook_image,
-          twitter: stolen_record.alert_image.image_url(:twitter)
-        }
+      if (stolen_record = bike.current_stolen_record).present?
+        if stolen_record.images_attached?
+          return {
+            square: BlobUrl.for(stolen_record.image_square),
+            facebook: BlobUrl.for(stolen_record.image_opengraph),
+            twitter: BlobUrl.for(stolen_record.image_opengraph)
+          }
+        end
+
+        facebook_image = stolen_record.alert_image&.image_url(:facebook)
+        if facebook_image.present?
+          return {
+            square: facebook_image,
+            facebook: facebook_image,
+            twitter: stolen_record.alert_image.image_url(:twitter)
+          }
+        end
+      end
+      single_image_hash(bike.public_images.limit(1)&.first&.image_url(:large))
+    end
+
+    def origin_title(creation_description)
+      return nil unless creation_description.present?
+
+      extended_description = {
+        "web" => "Registered with self registration process",
+        "org reg" => "Registered by internal, organization member form",
+        "landing page" => "Registration began with incomplete registration, via organization landing page",
+        "bulk reg" => "Registered by spreadsheet import"
+      }
+      if %w[Lightspeed Ascend].include?(creation_description)
+        "Automatically registered by bike shop point of sale (#{creation_description} POS)"
+      else
+        extended_description[creation_description] || "Registered via #{creation_description}"
       end
     end
-    single_image_hash(bike.public_images.limit(1)&.first&.image_url(:large))
-  end
 
-  def origin_title(creation_description)
-    return nil unless creation_description.present?
+    #
+    # private below here
+    #
 
-    extended_description = {
-      "web" => "Registered with self registration process",
-      "org reg" => "Registered by internal, organization member form",
-      "landing page" => "Registration began with incomplete registration, via organization landing page",
-      "bulk reg" => "Registered by spreadsheet import"
-    }
-    if %w[Lightspeed Ascend].include?(creation_description)
-      "Automatically registered by bike shop point of sale (#{creation_description} POS)"
-    else
-      extended_description[creation_description] || "Registered via #{creation_description}"
-    end
-  end
+    def user_edit_bike_address?(bike, user = nil)
+      return false if user.blank?
 
-  #
-  # private below here
-  #
-
-  def user_edit_bike_address?(bike, user = nil)
-    return false if user.blank?
-
-    if bike.user.present?
-      # If the user has set their address, that's the only way to update bike addresses
-      return false if bike.user.address_set_manually
-      if bike.user == user
-        # If user is bike owner, check for user_registration_organizations with reg_address -
-        # because then they need to edit address via their account page
-        return user.uro_organizations.with_enabled_feature_slugs("reg_address").none?
+      if bike.user.present?
+        # If the user has set their address, that's the only way to update bike addresses
+        return false if bike.user.address_set_manually
+        if bike.user == user
+          # If user is bike owner, check for user_registration_organizations with reg_address -
+          # because then they need to edit address via their account page
+          return user.uro_organizations.with_enabled_feature_slugs("reg_address").none?
+        end
       end
+      # otherwise if bike is new, for superusers or users authorized by organization
+      bike.id.blank? || user.superuser? || bike.authorized_by_organization?(u: user)
     end
-    # otherwise if bike is new, for superusers or users authorized by organization
-    bike.id.blank? || user.superuser? || bike.authorized_by_organization?(u: user)
-  end
 
-  def single_image_hash(image_url)
-    {square: image_url, twitter: image_url, facebook: image_url}
-  end
+    def single_image_hash(image_url)
+      {square: image_url, twitter: image_url, facebook: image_url}
+    end
 
-  conceal :user_edit_bike_address?, :single_image_hash
+    conceal :user_edit_bike_address?, :single_image_hash
+  end
 end

--- a/app/services/bike_services/geojsoner.rb
+++ b/app/services/bike_services/geojsoner.rb
@@ -1,40 +1,42 @@
-module BikeServices::Geojsoner
-  extend Functionable
+module BikeServices
+  module Geojsoner
+    extend Functionable
 
-  def feature(bike, extended_properties = false)
-    return nil unless bike.status_stolen?
+    def feature(bike, extended_properties = false)
+      return nil unless bike.status_stolen?
 
-    date_stolen = bike.occurred_at || Time.current
-    properties = {id: bike.id, at: date_stolen.to_date.to_s}
-    if extended_properties
-      properties.merge!(kind: "theft",
-        occurred_at: date_stolen.to_i,
-        title: bike.title_string)
+      date_stolen = bike.occurred_at || Time.current
+      properties = {id: bike.id, at: date_stolen.to_date.to_s}
+      if extended_properties
+        properties.merge!(kind: "theft",
+          occurred_at: date_stolen.to_i,
+          title: bike.title_string)
+      end
+      {
+        type: "Feature",
+        properties: properties,
+        geometry: {
+          type: "Point",
+          coordinates: [
+            bike.current_stolen_record.longitude_public,
+            bike.current_stolen_record.latitude_public
+          ]
+        }
+      }
     end
-    {
-      type: "Feature",
-      properties: properties,
-      geometry: {
-        type: "Point",
-        coordinates: [
-          bike.current_stolen_record.longitude_public,
-          bike.current_stolen_record.latitude_public
-        ]
-      }
-    }
-  end
 
-  def feature_from_plucked(id, occurred_at, latitude, longitude)
-    {
-      type: "Feature",
-      properties: {id: id, at: occurred_at.to_date.to_s},
-      geometry: {
-        type: "Point",
-        coordinates: [
-          longitude.round(Bike::PUBLIC_COORD_LENGTH),
-          latitude.round(Bike::PUBLIC_COORD_LENGTH)
-        ]
+    def feature_from_plucked(id, occurred_at, latitude, longitude)
+      {
+        type: "Feature",
+        properties: {id: id, at: occurred_at.to_date.to_s},
+        geometry: {
+          type: "Point",
+          coordinates: [
+            longitude.round(Bike::PUBLIC_COORD_LENGTH),
+            latitude.round(Bike::PUBLIC_COORD_LENGTH)
+          ]
+        }
       }
-    }
+    end
   end
 end

--- a/app/services/bike_services/organized_search.rb
+++ b/app/services/bike_services/organized_search.rb
@@ -1,23 +1,25 @@
 # frozen_string_literal: true
 
-module BikeServices::OrganizedSearch
-  extend Functionable
+module BikeServices
+  module OrganizedSearch
+    extend Functionable
 
-  def email_and_name(bikes, query)
-    return bikes unless query.present?
+    def email_and_name(bikes, query)
+      return bikes unless query.present?
 
-    query_string = "%#{query.strip}%"
-    bikes.includes(:current_ownership)
-      .where("bikes.owner_email ilike ? OR ownerships.owner_name ilike ?", query_string, query_string)
-      .references(:current_ownership)
-  end
+      query_string = "%#{query.strip}%"
+      bikes.includes(:current_ownership)
+        .where("bikes.owner_email ilike ? OR ownerships.owner_name ilike ?", query_string, query_string)
+        .references(:current_ownership)
+    end
 
-  def notes(bikes, query, organization)
-    return bikes unless query.present?
+    def notes(bikes, query, organization)
+      return bikes unless query.present?
 
-    query_string = "%#{query.strip}%"
-    bikes.joins(:bike_organization_notes)
-      .where(bike_organization_notes: {organization_id: organization.id})
-      .where("bike_organization_notes.body ILIKE ?", query_string)
+      query_string = "%#{query.strip}%"
+      bikes.joins(:bike_organization_notes)
+        .where(bike_organization_notes: {organization_id: organization.id})
+        .where("bike_organization_notes.body ILIKE ?", query_string)
+    end
   end
 end

--- a/app/services/bike_services/owner_duplicate_finder.rb
+++ b/app/services/bike_services/owner_duplicate_finder.rb
@@ -1,54 +1,56 @@
 # Used when registering new bikes, to prevent registering duplicate bikes
-module BikeServices::OwnerDuplicateFinder
-  # Finds bikes with the given serial number `serial` associated with email
-  # address `owner_email`.
-  #
-  # Matches based on the normalized serial number, and `owner_email` should be
-  # found via:
-  #
-  # - the bike's owner_email attribute (whether it's a phone or email)
-  # - the email attribute of any of the bike's owner's (user / creator: via bike.ownerships)
-  # - any email associated with any owner (via user.user_emails)
-  # - the phone attribute of any of the bike's owner's (user / creator: via bike.ownerships)
-  # - the phone associated with any owner (via user.user_phones)
-  #
-  # Return a Bike object, or nil
-  def self.matching(serial: nil, owner_email: nil, phone: nil, b_param: nil, manufacturer_id: nil, bikes: nil)
-    email = EmailNormalizer.normalize(owner_email)
-    phone = Phonifyer.phonify(phone)
-    serial_normalized = SerialNormalizer.normalized_and_corrected(serial)
-    return Bike.none if serial_normalized.blank?
+module BikeServices
+  module OwnerDuplicateFinder
+    # Finds bikes with the given serial number `serial` associated with email
+    # address `owner_email`.
+    #
+    # Matches based on the normalized serial number, and `owner_email` should be
+    # found via:
+    #
+    # - the bike's owner_email attribute (whether it's a phone or email)
+    # - the email attribute of any of the bike's owner's (user / creator: via bike.ownerships)
+    # - any email associated with any owner (via user.user_emails)
+    # - the phone attribute of any of the bike's owner's (user / creator: via bike.ownerships)
+    # - the phone associated with any owner (via user.user_phones)
+    #
+    # Return a Bike object, or nil
+    def self.matching(serial: nil, owner_email: nil, phone: nil, b_param: nil, manufacturer_id: nil, bikes: nil)
+      email = EmailNormalizer.normalize(owner_email)
+      phone = Phonifyer.phonify(phone)
+      serial_normalized = SerialNormalizer.normalized_and_corrected(serial)
+      return Bike.none if serial_normalized.blank?
 
-    candidate_user_ids = find_matching_user_ids(email, phone)
+      candidate_user_ids = find_matching_user_ids(email, phone)
 
-    bikes ||= Bike.with_user_hidden
-    matching_bikes = bikes.matching_serial(serial_normalized)
-    # Only search by manufacturer_id if it's passed
-    matching_bikes = matching_bikes.where(manufacturer_id: manufacturer_id) if manufacturer_id.present?
-    matching_bikes.joins("LEFT JOIN ownerships ON bikes.id = ownerships.bike_id")
-      .where(
-        "bikes.owner_email = ? OR bikes.owner_email = ? OR ownerships.owner_email = ? OR ownerships.owner_email = ? OR ownerships.user_id IN (?)",
-        email,
-        phone,
-        email,
-        phone,
-        candidate_user_ids
-      )
+      bikes ||= Bike.with_user_hidden
+      matching_bikes = bikes.matching_serial(serial_normalized)
+      # Only search by manufacturer_id if it's passed
+      matching_bikes = matching_bikes.where(manufacturer_id: manufacturer_id) if manufacturer_id.present?
+      matching_bikes.joins("LEFT JOIN ownerships ON bikes.id = ownerships.bike_id")
+        .where(
+          "bikes.owner_email = ? OR bikes.owner_email = ? OR ownerships.owner_email = ? OR ownerships.owner_email = ? OR ownerships.user_id IN (?)",
+          email,
+          phone,
+          email,
+          phone,
+          candidate_user_ids
+        )
+    end
+
+    def self.find_matching_user_ids(email = nil, phone = nil)
+      return [] if email.blank? && phone.blank?
+
+      users = User.joins("LEFT JOIN user_emails ON user_emails.user_id = users.id")
+        .joins("LEFT JOIN user_phones ON user_phones.user_id = users.id")
+      if email.present? && phone.present?
+        users.where("users.email = ? OR user_emails.email = ? OR users.phone = ? OR user_phones.phone = ?", email, email, phone, phone)
+      elsif email.present?
+        users.where("users.email = ? OR user_emails.email = ?", email, email)
+      elsif phone.present?
+        users.where("users.phone = ? OR user_phones.phone = ?", phone, phone)
+      end.distinct.pluck(:id)
+    end
+
+    private_class_method :find_matching_user_ids
   end
-
-  def self.find_matching_user_ids(email = nil, phone = nil)
-    return [] if email.blank? && phone.blank?
-
-    users = User.joins("LEFT JOIN user_emails ON user_emails.user_id = users.id")
-      .joins("LEFT JOIN user_phones ON user_phones.user_id = users.id")
-    if email.present? && phone.present?
-      users.where("users.email = ? OR user_emails.email = ? OR users.phone = ? OR user_phones.phone = ?", email, email, phone, phone)
-    elsif email.present?
-      users.where("users.email = ? OR user_emails.email = ?", email, email)
-    elsif phone.present?
-      users.where("users.phone = ? OR user_phones.phone = ?", phone, phone)
-    end.distinct.pluck(:id)
-  end
-
-  private_class_method :find_matching_user_ids
 end

--- a/app/services/bike_services/ownership_transferer.rb
+++ b/app/services/bike_services/ownership_transferer.rb
@@ -1,86 +1,88 @@
 # frozen_string_literal: true
 
-module BikeServices::OwnershipTransferer
-  extend Functionable
+module BikeServices
+  module OwnershipTransferer
+    extend Functionable
 
-  def registration_info_from_params(params)
-    params.dig("bike")&.slice(*BParam::REGISTRATION_INFO_ATTRS) || {}
-  end
-
-  # Returns an Ownership (either a new one or the existing one if the email is the same)
-  # does NOT authorize creation, just creates with the parameters given
-  def find_or_create(
-    bike,
-    updator:,
-    new_owner_email: nil,
-    doorkeeper_app_id: nil,
-    registration_info: {},
-    sale_id: nil,
-    processing_impound_record_id: nil,
-    skip_bike_save: false,
-    skip_email: false
-  )
-    new_owner_email = EmailNormalizer.normalize(new_owner_email)
-    return bike.current_ownership if new_owner_email.blank? || bike.owner_email == new_owner_email
-
-    impound_record_id = processing_impound_record_id || bike.current_impound_record_id
-    bike.attributes = updated_bike_attrs(new_owner_email, updator)
-
-    if bike.current_parking_notification.present? || bike.current_impound_record.present?
-      update_impound_and_parking_notifications(bike, updator) unless processing_impound_record_id.present?
-      bike.status = "status_with_owner"
-      skip_bike_save = false # always save if an active parking_notification or impound_record
+    def registration_info_from_params(params)
+      params.dig("bike")&.slice(*BParam::REGISTRATION_INFO_ATTRS) || {}
     end
 
-    # If updator is a member of the creation organization, add org to the new ownership!
-    ownership_org = bike.current_ownership&.organization
-
-    new_ownership = bike.ownerships.create(current: true,
-      owner_email: new_owner_email,
-      creator: updator,
-      origin: processing_impound_record_id.present? ? :impound_process : :transferred_ownership,
-      organization: updator&.member_of?(ownership_org) ? ownership_org : nil,
-      status: bike.status, # bike.status might be assigned but not saved, it's calculated in ownership
-      user_hidden: false,
-      registration_info:,
-      doorkeeper_app_id:,
-      impound_record_id:,
-      sale_id:,
-      skip_email:)
-
-    bike.save unless skip_bike_save
-
-    new_ownership
-  end
-
-  #
-  # private below here
-  #
-
-  def updated_bike_attrs(owner_email, updator)
-    BikeServices::Updator.updator_attrs(updator).merge(
-      owner_email:,
-      delete_address_record: true,
-      is_phone: false, # TODO: base on new ownership, but phone regs aren't being used
-      user_hidden: false,
-      is_for_sale: false
+    # Returns an Ownership (either a new one or the existing one if the email is the same)
+    # does NOT authorize creation, just creates with the parameters given
+    def find_or_create(
+      bike,
+      updator:,
+      new_owner_email: nil,
+      doorkeeper_app_id: nil,
+      registration_info: {},
+      sale_id: nil,
+      processing_impound_record_id: nil,
+      skip_bike_save: false,
+      skip_email: false
     )
-  end
+      new_owner_email = EmailNormalizer.normalize(new_owner_email)
+      return bike.current_ownership if new_owner_email.blank? || bike.owner_email == new_owner_email
 
-  def update_impound_and_parking_notifications(bike, updator)
-    if bike.current_impound_record.present?
-      # NOTE: ProcessImpoundUpdatesJob will call this class - but, since the email's the same, it's a no-op
-      bike.current_impound_record.impound_record_updates.create(
-        kind: :transferred_to_new_owner,
-        user_id: updator.id,
-        transfer_email: bike.owner_email
-      )
+      impound_record_id = processing_impound_record_id || bike.current_impound_record_id
+      bike.attributes = updated_bike_attrs(new_owner_email, updator)
 
-    elsif bike.current_parking_notification.present? # impound records resolve parking notifications (if both present)
-      bike.current_parking_notification.mark_retrieved!(retrieved_kind: :ownership_transfer,
-        retrieved_by_id: updator.id)
+      if bike.current_parking_notification.present? || bike.current_impound_record.present?
+        update_impound_and_parking_notifications(bike, updator) unless processing_impound_record_id.present?
+        bike.status = "status_with_owner"
+        skip_bike_save = false # always save if an active parking_notification or impound_record
+      end
+
+      # If updator is a member of the creation organization, add org to the new ownership!
+      ownership_org = bike.current_ownership&.organization
+
+      new_ownership = bike.ownerships.create(current: true,
+        owner_email: new_owner_email,
+        creator: updator,
+        origin: processing_impound_record_id.present? ? :impound_process : :transferred_ownership,
+        organization: updator&.member_of?(ownership_org) ? ownership_org : nil,
+        status: bike.status, # bike.status might be assigned but not saved, it's calculated in ownership
+        user_hidden: false,
+        registration_info:,
+        doorkeeper_app_id:,
+        impound_record_id:,
+        sale_id:,
+        skip_email:)
+
+      bike.save unless skip_bike_save
+
+      new_ownership
     end
-  end
 
-  conceal :updated_bike_attrs, :update_impound_and_parking_notifications
+    #
+    # private below here
+    #
+
+    def updated_bike_attrs(owner_email, updator)
+      BikeServices::Updator.updator_attrs(updator).merge(
+        owner_email:,
+        delete_address_record: true,
+        is_phone: false, # TODO: base on new ownership, but phone regs aren't being used
+        user_hidden: false,
+        is_for_sale: false
+      )
+    end
+
+    def update_impound_and_parking_notifications(bike, updator)
+      if bike.current_impound_record.present?
+        # NOTE: ProcessImpoundUpdatesJob will call this class - but, since the email's the same, it's a no-op
+        bike.current_impound_record.impound_record_updates.create(
+          kind: :transferred_to_new_owner,
+          user_id: updator.id,
+          transfer_email: bike.owner_email
+        )
+
+      elsif bike.current_parking_notification.present? # impound records resolve parking notifications (if both present)
+        bike.current_parking_notification.mark_retrieved!(retrieved_kind: :ownership_transfer,
+          retrieved_by_id: updator.id)
+      end
+    end
+
+    conceal :updated_bike_attrs, :update_impound_and_parking_notifications
+  end
 end

--- a/app/services/bike_services/searcher.rb
+++ b/app/services/bike_services/searcher.rb
@@ -1,241 +1,243 @@
 # THIS IS DEPRECATED!!!
 # Use BikeSearchable instead
-class BikeServices::Searcher
-  attr_accessor :params, :location
+module BikeServices
+  class Searcher
+    attr_accessor :params, :location
 
-  def initialize(creation_params = {}, reverse_geocode = nil)
-    # override reverse_geocode if passed as params
-    @params = creation_params.merge(reverse_geocode: reverse_geocode)
-    @bikes = params[:api_search] ? Bike.not_abandoned : Bike.all
-    if @params[:search_type].present?
-      if @params[:search_type] == "serial"
-        @params[:serial] = @params[:query_typed]
-      else
-        @params[:query] = @params[:query_typed]
+    def initialize(creation_params = {}, reverse_geocode = nil)
+      # override reverse_geocode if passed as params
+      @params = creation_params.merge(reverse_geocode: reverse_geocode)
+      @bikes = params[:api_search] ? Bike.not_abandoned : Bike.all
+      if @params[:search_type].present?
+        if @params[:search_type] == "serial"
+          @params[:serial] = @params[:query_typed]
+        else
+          @params[:query] = @params[:query_typed]
+        end
+      end
+      @params = interpreted_params(@params)
+      if @params[:serial].present?
+        if @params[:query].present?
+          @params[:query] = @params[:query].gsub(/,?#,?/, "")
+        end
+        @normer = SerialNormalizer.new(serial: @params[:serial])
       end
     end
-    @params = interpreted_params(@params)
-    if @params[:serial].present?
-      if @params[:query].present?
-        @params[:query] = @params[:query].gsub(/,?#,?/, "")
+
+    def interpreted_params(i_params)
+      query = (i_params[:query] || "").gsub("%23", "#") # ... ensure string so we can gsub it
+      return i_params unless query.present?
+
+      # serial segment looks like s#SERIAL#
+      serial_matcher = /s#[^#]*#/i
+      query.gsub!(serial_matcher) do |match|
+        # Set the serial to the match, with the first part chopped and the last part chopped
+        i_params[:serial] = match.delete_prefix("s#").delete_suffix("#")
+        "" # remove it from query
       end
-      @normer = SerialNormalizer.new(serial: @params[:serial])
+      i_params.merge(query: query)
     end
-  end
 
-  def interpreted_params(i_params)
-    query = (i_params[:query] || "").gsub("%23", "#") # ... ensure string so we can gsub it
-    return i_params unless query.present?
-
-    # serial segment looks like s#SERIAL#
-    serial_matcher = /s#[^#]*#/i
-    query.gsub!(serial_matcher) do |match|
-      # Set the serial to the match, with the first part chopped and the last part chopped
-      i_params[:serial] = match.delete_prefix("s#").delete_suffix("#")
-      "" # remove it from query
+    # Remove the encoding tricks we use with selectize
+    def stripped_query
+      @params[:query]
+        .gsub(/m_\d+/, "") # manufacturers
+        .gsub(/c_\d+/, "") # colors
+        .gsub(/%2C/i, ",") # unencode commas
     end
-    i_params.merge(query: query)
-  end
 
-  # Remove the encoding tricks we use with selectize
-  def stripped_query
-    @params[:query]
-      .gsub(/m_\d+/, "") # manufacturers
-      .gsub(/c_\d+/, "") # colors
-      .gsub(/%2C/i, ",") # unencode commas
-  end
-
-  def selectize_items
-    items = []
-    if @params[:manufacturer_id].present?
-      items << Manufacturer.find(@params[:manufacturer_id]).autocomplete_result_hash
+    def selectize_items
+      items = []
+      if @params[:manufacturer_id].present?
+        items << Manufacturer.find(@params[:manufacturer_id]).autocomplete_result_hash
+      end
+      if @color_ids.present?
+        @color_ids.each { |c_id| items << Color.find(c_id).autocomplete_result_hash }
+      end
+      if @params[:serial].present?
+        items << {id: "serial", search_id: "s##{@params[:serial]}#", text: @params[:serial]}.as_json
+      end
+      if @params[:query]
+        stripped_query.split(",").reject(&:blank?)
+          .each { |q| items << {search_id: q, text: q}.as_json }
+      end
+      items
     end
-    if @color_ids.present?
-      @color_ids.each { |c_id| items << Color.find(c_id).autocomplete_result_hash }
+
+    def stolenness
+      return nil unless @params[:non_stolen].present? || @params[:stolen].present?
+      return "stolen" if @params[:stolen].present? && @params[:stolen]
+
+      "non_stolen" if @params[:non_stolen].present? && @params[:non_stolen]
     end
-    if @params[:serial].present?
-      items << {id: "serial", search_id: "s##{@params[:serial]}#", text: @params[:serial]}.as_json
+
+    def is_proximity
+      return false if @params[:non_proximity]&.present?
+
+      params[:proximity].present?
     end
-    if @params[:query]
-      stripped_query.split(",").reject(&:blank?)
-        .each { |q| items << {search_id: q, text: q}.as_json }
+
+    def stolenness_type
+      return "all" unless stolenness.present?
+      return "stolen_proximity" if stolenness == "stolen" && is_proximity
+
+      stolenness
     end
-    items
-  end
 
-  def stolenness
-    return nil unless @params[:non_stolen].present? || @params[:stolen].present?
-    return "stolen" if @params[:stolen].present? && @params[:stolen]
+    def matching_stolenness(bikes)
+      return @bikes unless stolenness.present?
 
-    "non_stolen" if @params[:non_stolen].present? && @params[:non_stolen]
-  end
-
-  def is_proximity
-    return false if @params[:non_proximity]&.present?
-
-    params[:proximity].present?
-  end
-
-  def stolenness_type
-    return "all" unless stolenness.present?
-    return "stolen_proximity" if stolenness == "stolen" && is_proximity
-
-    stolenness
-  end
-
-  def matching_stolenness(bikes)
-    return @bikes unless stolenness.present?
-
-    @bikes = (stolenness == "stolen") ? bikes.status_stolen : bikes.not_stolen
-  end
-
-  def parsed_attributes
-    if @params[:find_bike_attributes]
-      attr_ids = @params[:find_bike_attributes][:ids].reject(&:empty?)
-      return attr_ids if attr_ids.any?
-
-      nil
+      @bikes = (stolenness == "stolen") ? bikes.status_stolen : bikes.not_stolen
     end
-  end
 
-  def matching_query(bikes)
-    return nil unless @params[:query].present?
+    def parsed_attributes
+      if @params[:find_bike_attributes]
+        attr_ids = @params[:find_bike_attributes][:ids].reject(&:empty?)
+        return attr_ids if attr_ids.any?
 
-    @bikes = bikes.text_search(stripped_query.tr(",", " "))
-    @bikes
-  end
-
-  def matching_serial
-    if @params[:serial].present?
-      @bikes = Bike.where("serial_normalized @@ ?", @normer.normalized)
-    end
-    @bikes
-  end
-
-  def matching_manufacturer(bikes)
-    if @params[:manufacturer].present?
-      manufacturer = Manufacturer.friendly_find(@params[:manufacturer])
-      @params[:manufacturer_id] = if manufacturer.present?
-        manufacturer.id
-      else
-        0
+        nil
       end
     end
-    if @params[:query]&.match(/(,?m_\d+)/)
-      @params[:manufacturer_id] = @params[:query].match(/(,?m_\d+)/)[0].gsub(/,?m_/, "")
-    end
-    @bikes = bikes.where(manufacturer_id: @params[:manufacturer_id]) if @params[:manufacturer_id].present?
-    @bikes
-  end
 
-  def matching_colors(bikes)
-    if @params[:colors].present?
-      @color_ids = @params[:colors].split(",")
-        .collect { |c| Color.friendly_find(c)&.id }
-    elsif @params[:query]&.match(/(,?c_\d+)/)
-      @color_ids = @params[:query].scan(/(,?c_\d+)/).flatten
-        .map { |c| c.gsub(/(,?c_)/, "") }
+    def matching_query(bikes)
+      return nil unless @params[:query].present?
+
+      @bikes = bikes.text_search(stripped_query.tr(",", " "))
+      @bikes
     end
-    if @color_ids.present?
-      @color_ids.compact.each do |c_id|
-        @bikes = bikes.where("primary_frame_color_id = ? OR secondary_frame_color_id = ? OR tertiary_frame_color_id = ?", c_id, c_id, c_id)
+
+    def matching_serial
+      if @params[:serial].present?
+        @bikes = Bike.where("serial_normalized @@ ?", @normer.normalized)
       end
+      @bikes
     end
-    @bikes
-  end
 
-  def friendly_find_serial_ids(bike_ids = [])
-    @normer.normalized_segments.each do |seg|
-      next unless seg.length > 3
-
-      bike_ids += NormalizedSerialSegment.where("LEVENSHTEIN(segment, ?) < 3", seg).map(&:bike_id)
+    def matching_manufacturer(bikes)
+      if @params[:manufacturer].present?
+        manufacturer = Manufacturer.friendly_find(@params[:manufacturer])
+        @params[:manufacturer_id] = if manufacturer.present?
+          manufacturer.id
+        else
+          0
+        end
+      end
+      if @params[:query]&.match(/(,?m_\d+)/)
+        @params[:manufacturer_id] = @params[:query].match(/(,?m_\d+)/)[0].gsub(/,?m_/, "")
+      end
+      @bikes = bikes.where(manufacturer_id: @params[:manufacturer_id]) if @params[:manufacturer_id].present?
+      @bikes
     end
-    bike_ids
-  end
 
-  def friendly_find_serial
-    return [] unless @normer.normalized_segments.present?
-
-    bike_ids = friendly_find_serial_ids
-    # Don't return exact matches
-    bike_ids = bike_ids.uniq - matching_serial.map(&:id)
-    Bike.where(id: bike_ids)
-  end
-
-  def by_proximity
-    return unless is_proximity
-
-    stolen_ids = @bikes.pluck(:current_stolen_record_id)
-    return unless stolen_ids.present?
-
-    if @params[:proximity_radius].present? && @params[:proximity_radius].to_i > 1
-      radius = @params[:proximity_radius].to_i
+    def matching_colors(bikes)
+      if @params[:colors].present?
+        @color_ids = @params[:colors].split(",")
+          .collect { |c| Color.friendly_find(c)&.id }
+      elsif @params[:query]&.match(/(,?c_\d+)/)
+        @color_ids = @params[:query].scan(/(,?c_\d+)/).flatten
+          .map { |c| c.gsub(/(,?c_)/, "") }
+      end
+      if @color_ids.present?
+        @color_ids.compact.each do |c_id|
+          @bikes = bikes.where("primary_frame_color_id = ? OR secondary_frame_color_id = ? OR tertiary_frame_color_id = ?", c_id, c_id, c_id)
+        end
+      end
+      @bikes
     end
-    radius ||= 100
-    location = GeocodeHelper.address_string_for(@params[:proximity]) if @params[:reverse_geocode]
-    box = GeocodeHelper.bounding_box(location || @params[:proximity], radius)
-    unless box[0].nan?
-      bike_ids = StolenRecord.where(id: stolen_ids).within_bounding_box(box).pluck(:bike_id)
-      @bikes = @bikes.where(id: bike_ids)
-    end
-    @bikes
-  end
 
-  def by_date
-    return unless stolenness == "stolen"
-    return @bikes unless @params[:stolen_before].present? || @params[:stolen_after].present?
+    def friendly_find_serial_ids(bike_ids = [])
+      @normer.normalized_segments.each do |seg|
+        next unless seg.length > 3
 
-    stolen_records = StolenRecord.where(id: @bikes.pluck(:current_stolen_record_id))
-    if @params[:stolen_before].present?
-      before = Time.at(@params[:stolen_before]).utc.to_datetime
-      stolen_records = stolen_records.where("date_stolen <= ?", before)
+        bike_ids += NormalizedSerialSegment.where("LEVENSHTEIN(segment, ?) < 3", seg).map(&:bike_id)
+      end
+      bike_ids
     end
-    if @params[:stolen_after].present?
-      after = Time.at(@params[:stolen_after]).utc.to_datetime
-      stolen_records = stolen_records.where("date_stolen >= ?", after)
-    end
-    @bikes = @bikes.where(id: stolen_records.pluck(:bike_id))
-  end
 
-  def find_bikes
-    @bikes = matching_serial
-    matching_stolenness(@bikes)
-    matching_manufacturer(@bikes)
-    matching_colors(@bikes)
-    matching_query(@bikes)
-    if stolenness == "stolen"
-      by_proximity
+    def friendly_find_serial
+      return [] unless @normer.normalized_segments.present?
+
+      bike_ids = friendly_find_serial_ids
+      # Don't return exact matches
+      bike_ids = bike_ids.uniq - matching_serial.map(&:id)
+      Bike.where(id: bike_ids)
+    end
+
+    def by_proximity
+      return unless is_proximity
+
+      stolen_ids = @bikes.pluck(:current_stolen_record_id)
+      return unless stolen_ids.present?
+
+      if @params[:proximity_radius].present? && @params[:proximity_radius].to_i > 1
+        radius = @params[:proximity_radius].to_i
+      end
+      radius ||= 100
+      location = GeocodeHelper.address_string_for(@params[:proximity]) if @params[:reverse_geocode]
+      box = GeocodeHelper.bounding_box(location || @params[:proximity], radius)
+      unless box[0].nan?
+        bike_ids = StolenRecord.where(id: stolen_ids).within_bounding_box(box).pluck(:bike_id)
+        @bikes = @bikes.where(id: bike_ids)
+      end
+      @bikes
+    end
+
+    def by_date
+      return unless stolenness == "stolen"
+      return @bikes unless @params[:stolen_before].present? || @params[:stolen_after].present?
+
+      stolen_records = StolenRecord.where(id: @bikes.pluck(:current_stolen_record_id))
+      if @params[:stolen_before].present?
+        before = Time.at(@params[:stolen_before]).utc.to_datetime
+        stolen_records = stolen_records.where("date_stolen <= ?", before)
+      end
+      if @params[:stolen_after].present?
+        after = Time.at(@params[:stolen_after]).utc.to_datetime
+        stolen_records = stolen_records.where("date_stolen >= ?", after)
+      end
+      @bikes = @bikes.where(id: stolen_records.pluck(:bike_id))
+    end
+
+    def find_bikes
+      @bikes = matching_serial
+      matching_stolenness(@bikes)
+      matching_manufacturer(@bikes)
+      matching_colors(@bikes)
+      matching_query(@bikes)
+      if stolenness == "stolen"
+        by_proximity
+        by_date
+      end
+      @bikes
+    end
+
+    def find_bike_counts
+      @params[:non_stolen] = false
+      @params[:non_proximity] = false
+      @bikes = matching_serial
+      matching_manufacturer(@bikes)
+      matching_colors(@bikes)
+      matching_query(@bikes)
+      result = {non_stolen: @bikes.not_stolen.count}
+      if @params[:serial].present?
+        result[:close_serials] = friendly_find_serial.count
+      end
+      @params[:stolen] = true
+      matching_stolenness(@bikes)
       by_date
+
+      result[:stolen] = @bikes.count
+
+      by_proximity
+      result.merge(proximity: @bikes.count)
     end
-    @bikes
-  end
 
-  def find_bike_counts
-    @params[:non_stolen] = false
-    @params[:non_proximity] = false
-    @bikes = matching_serial
-    matching_manufacturer(@bikes)
-    matching_colors(@bikes)
-    matching_query(@bikes)
-    result = {non_stolen: @bikes.not_stolen.count}
-    if @params[:serial].present?
-      result[:close_serials] = friendly_find_serial.count
+    def close_serials
+      @bikes = friendly_find_serial
+      matching_stolenness(@bikes)
+      matching_query(@bikes)
+      by_proximity
+      @bikes
     end
-    @params[:stolen] = true
-    matching_stolenness(@bikes)
-    by_date
-
-    result[:stolen] = @bikes.count
-
-    by_proximity
-    result.merge(proximity: @bikes.count)
-  end
-
-  def close_serials
-    @bikes = friendly_find_serial
-    matching_stolenness(@bikes)
-    matching_query(@bikes)
-    by_proximity
-    @bikes
   end
 end

--- a/app/services/bike_services/stolen_record_updator.rb
+++ b/app/services/bike_services/stolen_record_updator.rb
@@ -1,67 +1,69 @@
-class BikeServices::StolenRecordUpdator
-  attr_reader :stolen_params
+module BikeServices
+  class StolenRecordUpdator
+    attr_reader :stolen_params
 
-  # Used to be in StolenRecord - but now it's here. Eventually, I'd like to actually do permitted params handling in here
-  def self.old_attr_accessible
-    # recovery_tweet, recovery_share # We edit this in the admin panel
-    %i[police_report_number police_report_department locking_description lock_defeat_description
-      timezone date_stolen bike creation_organization_id country_id state_id street zipcode city latitude
-      longitude theft_description current phone secondary_phone phone_for_everyone
-      phone_for_users phone_for_shops phone_for_police receive_notifications proof_of_ownership
-      approved recovered_at recovered_description index_helped_recovery can_share_recovery
-      recovery_posted tsved_at estimated_value].freeze
-  end
-
-  def initialize(bike: nil, b_param: nil, params: nil)
-    @bike = bike
-    b_param ||= BParam.new(params:)
-    @stolen_params = b_param&.stolen_attrs
-  end
-
-  def update_records
-    return if @stolen_params.blank? || @bike.id.blank? # If no bike ID, bike has errored
-
-    @bike.reload
-    stolen_record = @bike.fetch_current_stolen_record
-    stolen_record ||= @bike.build_new_stolen_record
-    stolen_record = update_with_params(stolen_record)
-    stolen_record.save
-    @bike.reload
-    stolen_record
-  end
-
-  private
-
-  def update_with_params(stolen_record)
-    return stolen_record unless @stolen_params.present?
-
-    stolen_record.attributes = permitted_attributes(@stolen_params)
-
-    if @stolen_params["date_stolen"].present?
-      stolen_record.date_stolen = Binxtils::TimeParser.parse(@stolen_params["date_stolen"], @stolen_params["timezone"])
+    # Used to be in StolenRecord - but now it's here. Eventually, I'd like to actually do permitted params handling in here
+    def self.old_attr_accessible
+      # recovery_tweet, recovery_share # We edit this in the admin panel
+      %i[police_report_number police_report_department locking_description lock_defeat_description
+        timezone date_stolen bike creation_organization_id country_id state_id street zipcode city latitude
+        longitude theft_description current phone secondary_phone phone_for_everyone
+        phone_for_users phone_for_shops phone_for_police receive_notifications proof_of_ownership
+        approved recovered_at recovered_description index_helped_recovery can_share_recovery
+        recovery_posted tsved_at estimated_value].freeze
     end
 
-    if @stolen_params["country"].present?
-      stolen_record.country = Country.friendly_find(@stolen_params["country"])
+    def initialize(bike: nil, b_param: nil, params: nil)
+      @bike = bike
+      b_param ||= BParam.new(params:)
+      @stolen_params = b_param&.stolen_attrs
     end
 
-    stolen_record.state_id = State.fuzzy_abbr_find(@stolen_params["state"])&.id if @stolen_params["state"].present?
-    if @stolen_params["phone_no_show"]
-      stolen_record.attributes = {
-        phone_for_everyone: false,
-        phone_for_users: false,
-        phone_for_shops: false,
-        phone_for_police: false
-      }
-    end
-    stolen_record
-  end
+    def update_records
+      return if @stolen_params.blank? || @bike.id.blank? # If no bike ID, bike has errored
 
-  def permitted_attributes(params)
-    ActionController::Parameters.new(params).permit(:phone, :secondary_phone, :street, :city, :zipcode,
-      :country_id, :state_id, :police_report_number, :police_report_department, :estimated_value,
-      :theft_description, :locking_description, :lock_defeat_description, :proof_of_ownership,
-      :receive_notifications, :phone_for_everyone, :phone_for_users,
-      :phone_for_shops, :phone_for_police, :skip_geocoding)
+      @bike.reload
+      stolen_record = @bike.fetch_current_stolen_record
+      stolen_record ||= @bike.build_new_stolen_record
+      stolen_record = update_with_params(stolen_record)
+      stolen_record.save
+      @bike.reload
+      stolen_record
+    end
+
+    private
+
+    def update_with_params(stolen_record)
+      return stolen_record unless @stolen_params.present?
+
+      stolen_record.attributes = permitted_attributes(@stolen_params)
+
+      if @stolen_params["date_stolen"].present?
+        stolen_record.date_stolen = Binxtils::TimeParser.parse(@stolen_params["date_stolen"], @stolen_params["timezone"])
+      end
+
+      if @stolen_params["country"].present?
+        stolen_record.country = Country.friendly_find(@stolen_params["country"])
+      end
+
+      stolen_record.state_id = State.fuzzy_abbr_find(@stolen_params["state"])&.id if @stolen_params["state"].present?
+      if @stolen_params["phone_no_show"]
+        stolen_record.attributes = {
+          phone_for_everyone: false,
+          phone_for_users: false,
+          phone_for_shops: false,
+          phone_for_police: false
+        }
+      end
+      stolen_record
+    end
+
+    def permitted_attributes(params)
+      ActionController::Parameters.new(params).permit(:phone, :secondary_phone, :street, :city, :zipcode,
+        :country_id, :state_id, :police_report_number, :police_report_department, :estimated_value,
+        :theft_description, :locking_description, :lock_defeat_description, :proof_of_ownership,
+        :receive_notifications, :phone_for_everyone, :phone_for_users,
+        :phone_for_shops, :phone_for_police, :skip_geocoding)
+    end
   end
 end

--- a/app/services/bike_services/updator.rb
+++ b/app/services/bike_services/updator.rb
@@ -1,129 +1,133 @@
-class BikeServices::UpdatorError < StandardError
+module BikeServices
+  class UpdatorError < StandardError
+  end
 end
 
-class BikeServices::Updator
-  class << self
-    def permitted_params(params, bike, user)
-      # TODO: improve this entire thing. Maybe using BParam.safe_bike_attrs
-      # IMPORTANT - needs to handle propulsion_type > propulsion_type_slug coercion
-      {
-        bike: params.require(:bike).permit(BikeServices::Creator.old_attr_accessible)
-      }.as_json
+module BikeServices
+  class Updator
+    class << self
+      def permitted_params(params, bike, user)
+        # TODO: improve this entire thing. Maybe using BParam.safe_bike_attrs
+        # IMPORTANT - needs to handle propulsion_type > propulsion_type_slug coercion
+        {
+          bike: params.require(:bike).permit(BikeServices::Creator.old_attr_accessible)
+        }.as_json
+      end
+
+      def updator_attrs(user)
+        {updated_by_user_at: Time.current}.merge(user.present? ? {updator_id: user.id} : {})
+      end
     end
 
-    def updator_attrs(user)
-      {updated_by_user_at: Time.current}.merge(user.present? ? {updator_id: user.id} : {})
-    end
-  end
-
-  def initialize(user:, bike:, current_ownership: nil, params: nil, permitted_params: nil, doorkeeper_app_id: nil)
-    @user = user
-    @bike = bike
-    @bike_params = permitted_params || self.class.permitted_params(params, bike, user)
-    @doorkeeper_app_id = doorkeeper_app_id
-    @current_ownership = current_ownership
-    @currently_stolen = @bike.status_stolen?
-  end
-
-  def update_api_components
-    ComponentCreator.new(bike: @bike, b_param: @bike_params).update_components_from_params
-  end
-
-  def update_available_attributes
-    ensure_ownership!
-    set_protected_attributes
-    update_ownership
-    update_api_components if @bike_params["components"].present?
-    # Skips a few REGISTRATION_INFO_ATTRS
-    update_attrs = @bike_params["bike"].except("stolen_records_attributes", "impound_records_attributes",
-      "ios_version", "is_bulk", "is_new", "is_pos")
-    update_attrs.merge!(address_record_attributes(@bike_params["bike"]["address_record_attributes"]))
-
-    propulsion_updates = update_attrs.keys & %w[cycle_type cycle_type_name propulsion_type propulsion_type_slug]
-    if propulsion_updates.any?
-      # Ensure valid propulsion type
-      cycle_type = update_attrs["cycle_type"] || update_attrs["cycle_type_name"] || @bike.cycle_type
-      @bike.cycle_type = CycleType.friendly_find(cycle_type)&.slug || "bike"
-      @bike.propulsion_type_slug = update_attrs["propulsion_type"] || update_attrs["propulsion_type_slug"] || @bike.propulsion_type
-      update_attrs = update_attrs.except(*propulsion_updates)
+    def initialize(user:, bike:, current_ownership: nil, params: nil, permitted_params: nil, doorkeeper_app_id: nil)
+      @user = user
+      @bike = bike
+      @bike_params = permitted_params || self.class.permitted_params(params, bike, user)
+      @doorkeeper_app_id = doorkeeper_app_id
+      @current_ownership = current_ownership
+      @currently_stolen = @bike.status_stolen?
     end
 
-    if @bike.update(update_attrs.merge(self.class.updator_attrs(@user)))
-      BikeServices::StolenRecordUpdator.new(bike: @bike, b_param: BParam.new(params: @bike_params))
-        .update_records
-      update_impound_record
+    def update_api_components
+      ComponentCreator.new(bike: @bike, b_param: @bike_params).update_components_from_params
     end
-    CallbackJob::AfterBikeSaveJob.perform_async(@bike.id) if @bike.present? # run immediately
-    remove_blank_components
-    @bike
-  end
 
-  private
+    def update_available_attributes
+      ensure_ownership!
+      set_protected_attributes
+      update_ownership
+      update_api_components if @bike_params["components"].present?
+      # Skips a few REGISTRATION_INFO_ATTRS
+      update_attrs = @bike_params["bike"].except("stolen_records_attributes", "impound_records_attributes",
+        "ios_version", "is_bulk", "is_new", "is_pos")
+      update_attrs.merge!(address_record_attributes(@bike_params["bike"]["address_record_attributes"]))
 
-  def update_ownership
-    registration_info = BikeServices::OwnershipTransferer.registration_info_from_params(@bike_params)
-    ownership_id = @bike.current_ownership_id
-    new_ownership = BikeServices::OwnershipTransferer.find_or_create(@bike, updator: @user,
-      new_owner_email: @bike_params["bike"].delete("owner_email"),
-      doorkeeper_app_id: @doorkeeper_app_id, skip_bike_save: true, registration_info:)
-    # Don't update bike_params unless new ownership was created
-    return if ownership_unchanged?(new_ownership, ownership_id)
+      propulsion_updates = update_attrs.keys & %w[cycle_type cycle_type_name propulsion_type propulsion_type_slug]
+      if propulsion_updates.any?
+        # Ensure valid propulsion type
+        cycle_type = update_attrs["cycle_type"] || update_attrs["cycle_type_name"] || @bike.cycle_type
+        @bike.cycle_type = CycleType.friendly_find(cycle_type)&.slug || "bike"
+        @bike.propulsion_type_slug = update_attrs["propulsion_type"] || update_attrs["propulsion_type_slug"] || @bike.propulsion_type
+        update_attrs = update_attrs.except(*propulsion_updates)
+      end
 
-    # OwnershipTransferer updates these attributes - remove the parameters in case they were set automatically
-    @bike_params["bike"]["is_for_sale"] = false
-    @bike_params["bike"]["address_set_manually"] = false
-  end
-
-  def ensure_ownership!
-    return true if @current_ownership && @current_ownership.owner == @user # So we can pass in ownership and skip query
-    return true if @bike.authorized?(@user)
-
-    raise BikeServices::UpdatorError, "Oh no! It looks like you don't own that bike."
-  end
-
-  def ownership_unchanged?(new_ownership, previous_ownership_id)
-    return true unless new_ownership.valid?
-
-    new_ownership.id == previous_ownership_id
-  end
-
-  def set_protected_attributes
-    @bike_params["bike"]["serial_number"] = @bike.serial_number
-    @bike_params["bike"]["manufacturer_id"] = @bike.manufacturer_id
-    @bike_params["bike"]["manufacturer_other"] = @bike.manufacturer_other
-    @bike_params["bike"]["creation_organization_id"] = @bike.creation_organization_id
-    @bike_params["bike"]["example"] = @bike.example
-    @bike_params["bike"].delete("creator")
-    @bike_params["bike"].delete("user_hidden")
-  end
-
-  def remove_blank_components
-    return false unless @bike.components.any?
-
-    @bike.components.each do |c|
-      c.destroy unless c.ctype_id.present? || c.description.present?
+      if @bike.update(update_attrs.merge(self.class.updator_attrs(@user)))
+        BikeServices::StolenRecordUpdator.new(bike: @bike, b_param: BParam.new(params: @bike_params))
+          .update_records
+        update_impound_record
+      end
+      CallbackJob::AfterBikeSaveJob.perform_async(@bike.id) if @bike.present? # run immediately
+      remove_blank_components
+      @bike
     end
-  end
 
-  # This is very hacky, but it's something. Improve sometime
-  def update_impound_record
-    # These are sanitized - because they're actually permitted in the bikes controller action
-    impound_params = @bike_params.dig("bike", "impound_records_attributes")&.values&.reject(&:blank?)&.first
-    impound_record = @bike.current_impound_record
-    return unless impound_params.present? && impound_record.present?
+    private
 
-    impound_record.timezone = impound_params.delete("timezone") if impound_params["timezone"].present?
-    impound_record.update(impound_params)
-  end
+    def update_ownership
+      registration_info = BikeServices::OwnershipTransferer.registration_info_from_params(@bike_params)
+      ownership_id = @bike.current_ownership_id
+      new_ownership = BikeServices::OwnershipTransferer.find_or_create(@bike, updator: @user,
+        new_owner_email: @bike_params["bike"].delete("owner_email"),
+        doorkeeper_app_id: @doorkeeper_app_id, skip_bike_save: true, registration_info:)
+      # Don't update bike_params unless new ownership was created
+      return if ownership_unchanged?(new_ownership, ownership_id)
 
-  def address_record_attributes(address_record_attributes)
-    return {} if address_record_attributes.blank? || address_record_attributes.values.reject(&:blank?).none?
+      # OwnershipTransferer updates these attributes - remove the parameters in case they were set automatically
+      @bike_params["bike"]["is_for_sale"] = false
+      @bike_params["bike"]["address_set_manually"] = false
+    end
 
-    address_record_attributes["kind"] = "bike"
-    address_record_attributes["bike_id"] = @bike.id
-    address_record_attributes["id"] = (@bike.address_record&.kind == "bike") ? @bike.address_record_id : nil
-    address_set_manually = address_record_attributes.slice("street", "city", "postal_code").values.reject(&:blank?).any?
+    def ensure_ownership!
+      return true if @current_ownership && @current_ownership.owner == @user # So we can pass in ownership and skip query
+      return true if @bike.authorized?(@user)
 
-    {address_record_attributes:}.merge(address_set_manually ? {address_set_manually: true} : {})
+      raise BikeServices::UpdatorError, "Oh no! It looks like you don't own that bike."
+    end
+
+    def ownership_unchanged?(new_ownership, previous_ownership_id)
+      return true unless new_ownership.valid?
+
+      new_ownership.id == previous_ownership_id
+    end
+
+    def set_protected_attributes
+      @bike_params["bike"]["serial_number"] = @bike.serial_number
+      @bike_params["bike"]["manufacturer_id"] = @bike.manufacturer_id
+      @bike_params["bike"]["manufacturer_other"] = @bike.manufacturer_other
+      @bike_params["bike"]["creation_organization_id"] = @bike.creation_organization_id
+      @bike_params["bike"]["example"] = @bike.example
+      @bike_params["bike"].delete("creator")
+      @bike_params["bike"].delete("user_hidden")
+    end
+
+    def remove_blank_components
+      return false unless @bike.components.any?
+
+      @bike.components.each do |c|
+        c.destroy unless c.ctype_id.present? || c.description.present?
+      end
+    end
+
+    # This is very hacky, but it's something. Improve sometime
+    def update_impound_record
+      # These are sanitized - because they're actually permitted in the bikes controller action
+      impound_params = @bike_params.dig("bike", "impound_records_attributes")&.values&.reject(&:blank?)&.first
+      impound_record = @bike.current_impound_record
+      return unless impound_params.present? && impound_record.present?
+
+      impound_record.timezone = impound_params.delete("timezone") if impound_params["timezone"].present?
+      impound_record.update(impound_params)
+    end
+
+    def address_record_attributes(address_record_attributes)
+      return {} if address_record_attributes.blank? || address_record_attributes.values.reject(&:blank?).none?
+
+      address_record_attributes["kind"] = "bike"
+      address_record_attributes["bike_id"] = @bike.id
+      address_record_attributes["id"] = (@bike.address_record&.kind == "bike") ? @bike.address_record_id : nil
+      address_set_manually = address_record_attributes.slice("street", "city", "postal_code").values.reject(&:blank?).any?
+
+      {address_record_attributes:}.merge(address_set_manually ? {address_set_manually: true} : {})
+    end
   end
 end

--- a/app/services/images/stolen_processor.rb
+++ b/app/services/images/stolen_processor.rb
@@ -3,236 +3,238 @@
 require "image_processing/vips"
 require "vips"
 
-module Images::StolenProcessor
-  extend Functionable
+module Images
+  module StolenProcessor
+    extend Functionable
 
-  PROMOTED_ALERTS_PATH = "app/assets/images/promoted_alerts"
-  # 4:5 and square are the recommended sizes per facebook ads guide 2025-2-27
-  # facebook.com/business/ads-guide/update/image - 4:5 seems like the preferred
-  TEMPLATE_CONFIG = {
-    four_by_five: {topbar: :horizontal, dimensions: [1440, 1800]},
-    square: {topbar: :horizontal, dimensions: [1440, 1440]},
-    opengraph: {topbar: :vertical, dimensions: [1200, 630]}
-  }.freeze
+    PROMOTED_ALERTS_PATH = "app/assets/images/promoted_alerts"
+    # 4:5 and square are the recommended sizes per facebook ads guide 2025-2-27
+    # facebook.com/business/ads-guide/update/image - 4:5 seems like the preferred
+    TEMPLATE_CONFIG = {
+      four_by_five: {topbar: :horizontal, dimensions: [1440, 1800]},
+      square: {topbar: :horizontal, dimensions: [1440, 1440]},
+      opengraph: {topbar: :vertical, dimensions: [1200, 630]}
+    }.freeze
 
-  # topbar is 170px tall, right side is 120px tall - so the minimum height is 120
-  TOPBAR_HORIZONTAL_HEIGHT = 120
-  # topbar vertical is 82px wide, right side is 106px wide
-  # ... It looks better when the image doesn't overlap with the bar
-  TOPBAR_VERTICAL_WIDTH = 190
+    # topbar is 170px tall, right side is 120px tall - so the minimum height is 120
+    TOPBAR_HORIZONTAL_HEIGHT = 120
+    # topbar vertical is 82px wide, right side is 106px wide
+    # ... It looks better when the image doesn't overlap with the bar
+    TOPBAR_VERTICAL_WIDTH = 190
 
-  # NOTE: This doesn't delete images - that's handled by StolenBike::RemoveOrphanedImagesJob
+    # NOTE: This doesn't delete images - that's handled by StolenBike::RemoveOrphanedImagesJob
 
-  # Previously, we would set the image via passing it. That's a pain to track!
-  # Instead, when overriding the image in admin, let's update the image we're overriding with
-  # and make it the first image
-  def update_alert_images(stolen_record, force_regenerate: false, public_image_id: nil)
-    image, image_id = image_and_id(stolen_record, public_image_id)
+    # Previously, we would set the image via passing it. That's a pain to track!
+    # Instead, when overriding the image in admin, let's update the image we're overriding with
+    # and make it the first image
+    def update_alert_images(stolen_record, force_regenerate: false, public_image_id: nil)
+      image, image_id = image_and_id(stolen_record, public_image_id)
 
-    stolen_record.skip_update = true
-    if image.present?
-      return if !force_regenerate && stolen_record.images_attached_id == image_id
+      stolen_record.skip_update = true
+      if image.present?
+        return if !force_regenerate && stolen_record.images_attached_id == image_id
 
-      # Prevent touching the stolen record, which kicks off a job
-      ActiveRecord::Base.no_touching do
-        attach_images(stolen_record, image, stolen_record_location(stolen_record))
-        stolen_record.image_four_by_five.blob.metadata["image_id"] = image_id
-        stolen_record.image_four_by_five.blob.save
+        # Prevent touching the stolen record, which kicks off a job
+        ActiveRecord::Base.no_touching do
+          attach_images(stolen_record, image, stolen_record_location(stolen_record))
+          stolen_record.image_four_by_five.blob.metadata["image_id"] = image_id
+          stolen_record.image_four_by_five.blob.save
+        end
+      elsif (existing_blob = stolen_record.image_four_by_five&.blob)
+        existing_blob.metadata["removed"] = true
+        # We don't want to update the bike.updated_at unless this is a change
+        return unless existing_blob.changed?
+
+        existing_blob.save
       end
-    elsif (existing_blob = stolen_record.image_four_by_five&.blob)
-      existing_blob.metadata["removed"] = true
-      # We don't want to update the bike.updated_at unless this is a change
-      return unless existing_blob.changed?
-
-      existing_blob.save
+      stolen_record.bike&.update(updated_at: Time.current)
+      stolen_record
     end
-    stolen_record.bike&.update(updated_at: Time.current)
-    stolen_record
-  end
 
-  #
-  # private below here
-  #
+    #
+    # private below here
+    #
 
-  def image_and_id(stolen_record, public_image_id)
-    if public_image_id.present?
-      public_image = PublicImage.unscoped.find_by_id(public_image_id)
-    elsif use_stolen_images_override_id?(stolen_record)
-      # Image ID is overridden, use the assigned ID
-      return image_and_id(stolen_record, stolen_record.images_attached_id)
+    def image_and_id(stolen_record, public_image_id)
+      if public_image_id.present?
+        public_image = PublicImage.unscoped.find_by_id(public_image_id)
+      elsif use_stolen_images_override_id?(stolen_record)
+        # Image ID is overridden, use the assigned ID
+        return image_and_id(stolen_record, stolen_record.images_attached_id)
+      end
+      public_image ||= stolen_record.bike_main_image
+      return [public_image&.open_file, public_image.id] if public_image.present?
+
+      stock_photo_url = Bike.unscoped.find_by(id: stolen_record.bike_id)&.stock_photo_url
+      if stock_photo_url.present?
+        [URI.parse(stock_photo_url).open, "b#{stolen_record.bike_id}"]
+      else
+        [nil, nil]
+      end
     end
-    public_image ||= stolen_record.bike_main_image
-    return [public_image&.open_file, public_image.id] if public_image.present?
 
-    stock_photo_url = Bike.unscoped.find_by(id: stolen_record.bike_id)&.stock_photo_url
-    if stock_photo_url.present?
-      [URI.parse(stock_photo_url).open, "b#{stolen_record.bike_id}"]
-    else
-      [nil, nil]
+    # If the existing attached image was created after the bike's public images were updated
+    # use the existing public image (it was assigned manually)
+    def use_stolen_images_override_id?(stolen_record)
+      images_updated = PublicImage.unscoped.where(imageable_type: "Bike", imageable_id: stolen_record.bike_id).maximum(:updated_at)
+      return false if images_updated.blank? || stolen_record.image_four_by_five&.blob&.created_at.blank? ||
+        stolen_record.images_attached_id.blank? # handle if metadata is overwritten
+
+      stolen_record.image_four_by_five.blob.created_at > images_updated
     end
-  end
 
-  # If the existing attached image was created after the bike's public images were updated
-  # use the existing public image (it was assigned manually)
-  def use_stolen_images_override_id?(stolen_record)
-    images_updated = PublicImage.unscoped.where(imageable_type: "Bike", imageable_id: stolen_record.bike_id).maximum(:updated_at)
-    return false if images_updated.blank? || stolen_record.image_four_by_five&.blob&.created_at.blank? ||
-      stolen_record.images_attached_id.blank? # handle if metadata is overwritten
+    def attach_images(stolen_record, image, location_text)
+      four_by_five = ActiveStorage::Blob.create_and_upload!(
+        io: generate_alert(template: :four_by_five, image:, location_text:),
+        filename: "stolen-#{stolen_record.id}-four_by_five.jpeg"
+      )
+      four_by_five.analyze
 
-    stolen_record.image_four_by_five.blob.created_at > images_updated
-  end
+      square = ActiveStorage::Blob.create_and_upload!(
+        io: generate_alert(template: :square, image:, location_text:),
+        filename: "stolen-#{stolen_record.id}-square.jpeg"
+      )
+      square.analyze
 
-  def attach_images(stolen_record, image, location_text)
-    four_by_five = ActiveStorage::Blob.create_and_upload!(
-      io: generate_alert(template: :four_by_five, image:, location_text:),
-      filename: "stolen-#{stolen_record.id}-four_by_five.jpeg"
-    )
-    four_by_five.analyze
+      opengraph = ActiveStorage::Blob.create_and_upload!(
+        io: generate_alert(template: :opengraph, image:, location_text:),
+        filename: "stolen-#{stolen_record.id}-opengraph.jpeg"
+      )
+      opengraph.analyze
 
-    square = ActiveStorage::Blob.create_and_upload!(
-      io: generate_alert(template: :square, image:, location_text:),
-      filename: "stolen-#{stolen_record.id}-square.jpeg"
-    )
-    square.analyze
-
-    opengraph = ActiveStorage::Blob.create_and_upload!(
-      io: generate_alert(template: :opengraph, image:, location_text:),
-      filename: "stolen-#{stolen_record.id}-opengraph.jpeg"
-    )
-    opengraph.analyze
-
-    stolen_record.image_square.attach(square)
-    stolen_record.image_opengraph.attach(opengraph)
-    # Attach 4 by five last, it's what sets images_attached?
-    stolen_record.image_four_by_five.attach(four_by_five)
-  end
-
-  def generate_alert(template:, image:, location_text:, convert: "jpeg")
-    config = TEMPLATE_CONFIG[template]
-    raise "Unknown template (#{template})!" unless config.present?
-
-    # URI.open returns StringIO for small files, which Vips can't process directly
-    image = to_tempfile(image) if image.is_a?(StringIO)
-
-    bike_image = ImageProcessing::Vips.source(image)
-      .resize_to_limit(*bike_image_dimensions_for(config))
-      .call(save: false)
-    # using save: false enables calculating the dimensions & we don't need the intermediary images
-
-    # Put bike image onto the alert template
-    alert_image = ImageProcessing::Vips.source(template_path(template))
-      .composite(bike_image,
-        mode: :over,
-        offset: bike_image_offset(config, bike_image.width, bike_image.height)).call(save: false)
-
-    # Add the topbar
-    alert_image = ImageProcessing::Vips.source(alert_image)
-      .composite(topbar_path(config[:topbar]),
-        mode: :over,
-        offset: [0, 0])
-    return alert_image.convert(convert).call if location_text.blank?
-
-    # Add the location
-    location_image = caption_overlay(location_text)
-    ImageProcessing::Vips.source(alert_image.call(save: false))
-      .composite(location_image,
-        mode: :over,
-        gravity: "south-east",
-        offset: [0, 40]).convert(convert).call
-  end
-
-  def template_path(template_sym)
-    Rails.root.join(PROMOTED_ALERTS_PATH, "template-#{template_sym}.png").to_s
-  end
-
-  def topbar_path(variety)
-    filename = (variety == :horizontal) ? "topbar" : "topbar-vertical"
-    Rails.root.join(PROMOTED_ALERTS_PATH, "#{filename}.png").to_s
-  end
-
-  def bike_image_dimensions_for(config)
-    if config[:topbar] == :horizontal
-      [config[:dimensions].first,
-        config[:dimensions].last - TOPBAR_HORIZONTAL_HEIGHT]
-    else
-      [config[:dimensions].first - TOPBAR_VERTICAL_WIDTH,
-        config[:dimensions].last]
+      stolen_record.image_square.attach(square)
+      stolen_record.image_opengraph.attach(opengraph)
+      # Attach 4 by five last, it's what sets images_attached?
+      stolen_record.image_four_by_five.attach(four_by_five)
     end
-  end
 
-  def bike_image_offset(config, bike_image_width, bike_image_height)
-    # for some reason, :centre and offset fails - so get the dimensions and manually center the image
-    left_offset = (config[:dimensions].first - bike_image_width) / 2
-    top_offset = (config[:dimensions].last - bike_image_height) / 2
-    if config[:topbar] === :horizontal
-      # opengraph images look better vertically centered in the template. If offset is < top-bar height,
-      # the image takes up the whole visible area - so use the top-bar min height. Otherwise, use the
-      # offset (which vertically centers the image).
-      top_offset = TOPBAR_HORIZONTAL_HEIGHT if top_offset < TOPBAR_HORIZONTAL_HEIGHT
-    elsif left_offset < TOPBAR_VERTICAL_WIDTH
-      left_offset = TOPBAR_VERTICAL_WIDTH
+    def generate_alert(template:, image:, location_text:, convert: "jpeg")
+      config = TEMPLATE_CONFIG[template]
+      raise "Unknown template (#{template})!" unless config.present?
+
+      # URI.open returns StringIO for small files, which Vips can't process directly
+      image = to_tempfile(image) if image.is_a?(StringIO)
+
+      bike_image = ImageProcessing::Vips.source(image)
+        .resize_to_limit(*bike_image_dimensions_for(config))
+        .call(save: false)
+      # using save: false enables calculating the dimensions & we don't need the intermediary images
+
+      # Put bike image onto the alert template
+      alert_image = ImageProcessing::Vips.source(template_path(template))
+        .composite(bike_image,
+          mode: :over,
+          offset: bike_image_offset(config, bike_image.width, bike_image.height)).call(save: false)
+
+      # Add the topbar
+      alert_image = ImageProcessing::Vips.source(alert_image)
+        .composite(topbar_path(config[:topbar]),
+          mode: :over,
+          offset: [0, 0])
+      return alert_image.convert(convert).call if location_text.blank?
+
+      # Add the location
+      location_image = caption_overlay(location_text)
+      ImageProcessing::Vips.source(alert_image.call(save: false))
+        .composite(location_image,
+          mode: :over,
+          gravity: "south-east",
+          offset: [0, 40]).convert(convert).call
     end
-    # update the left offset
 
-    [left_offset, top_offset]
-  end
-
-  # enable passing in DPI because if the caption is too large, it should
-  def caption_overlay(text, dpi: 400, border_width: 20)
-    # Add the text to the image
-    text_overlay = Vips::Image.text(text, font:, dpi:)
-
-    bg_color = [0, 0, 0] # topbar is 26, 26, 26
-    text_with_bg = text_overlay.ifthenelse([255, 255, 255], bg_color, blend: true)
-    text_with_bg.embed(
-      border_width,                           # Left margin
-      border_width,                           # Top margin
-      text_with_bg.width + 2 * border_width,    # New width (original + left + right margin)
-      text_with_bg.height + 1.5 * border_width, # New height (bottom border smaller because comma expands lower coverage)
-      background: bg_color          # Border color
-    ).copy(interpretation: :srgb)   # Convert to a colorspace that can combine with the other image
-  end
-
-  # The font to use in the caption. Set fallbacks since different environments
-  # have different fonts available.
-  def font
-    if fc_list_has?("Helvetica", "Oblique")
-      "Helvetica Oblique"
-    elsif fc_list_has?("Arial", "Italic")
-      "Arial Italic"
-    elsif fc_list_has?("Lato", "Italic")
-      "Lato Italic"
-    elsif fc_list_has?("DejaVu Sans")
-      "DejaVu Sans"
+    def template_path(template_sym)
+      Rails.root.join(PROMOTED_ALERTS_PATH, "template-#{template_sym}.png").to_s
     end
+
+    def topbar_path(variety)
+      filename = (variety == :horizontal) ? "topbar" : "topbar-vertical"
+      Rails.root.join(PROMOTED_ALERTS_PATH, "#{filename}.png").to_s
+    end
+
+    def bike_image_dimensions_for(config)
+      if config[:topbar] == :horizontal
+        [config[:dimensions].first,
+          config[:dimensions].last - TOPBAR_HORIZONTAL_HEIGHT]
+      else
+        [config[:dimensions].first - TOPBAR_VERTICAL_WIDTH,
+          config[:dimensions].last]
+      end
+    end
+
+    def bike_image_offset(config, bike_image_width, bike_image_height)
+      # for some reason, :centre and offset fails - so get the dimensions and manually center the image
+      left_offset = (config[:dimensions].first - bike_image_width) / 2
+      top_offset = (config[:dimensions].last - bike_image_height) / 2
+      if config[:topbar] === :horizontal
+        # opengraph images look better vertically centered in the template. If offset is < top-bar height,
+        # the image takes up the whole visible area - so use the top-bar min height. Otherwise, use the
+        # offset (which vertically centers the image).
+        top_offset = TOPBAR_HORIZONTAL_HEIGHT if top_offset < TOPBAR_HORIZONTAL_HEIGHT
+      elsif left_offset < TOPBAR_VERTICAL_WIDTH
+        left_offset = TOPBAR_VERTICAL_WIDTH
+      end
+      # update the left offset
+
+      [left_offset, top_offset]
+    end
+
+    # enable passing in DPI because if the caption is too large, it should
+    def caption_overlay(text, dpi: 400, border_width: 20)
+      # Add the text to the image
+      text_overlay = Vips::Image.text(text, font:, dpi:)
+
+      bg_color = [0, 0, 0] # topbar is 26, 26, 26
+      text_with_bg = text_overlay.ifthenelse([255, 255, 255], bg_color, blend: true)
+      text_with_bg.embed(
+        border_width,                           # Left margin
+        border_width,                           # Top margin
+        text_with_bg.width + 2 * border_width,    # New width (original + left + right margin)
+        text_with_bg.height + 1.5 * border_width, # New height (bottom border smaller because comma expands lower coverage)
+        background: bg_color          # Border color
+      ).copy(interpretation: :srgb)   # Convert to a colorspace that can combine with the other image
+    end
+
+    # The font to use in the caption. Set fallbacks since different environments
+    # have different fonts available.
+    def font
+      if fc_list_has?("Helvetica", "Oblique")
+        "Helvetica Oblique"
+      elsif fc_list_has?("Arial", "Italic")
+        "Arial Italic"
+      elsif fc_list_has?("Lato", "Italic")
+        "Lato Italic"
+      elsif fc_list_has?("DejaVu Sans")
+        "DejaVu Sans"
+      end
+    end
+
+    def fc_list_output
+      @fc_list_output ||= `fc-list`.to_s
+    end
+
+    def fc_list_has?(*terms)
+      terms.all? { |term| fc_list_output.match?(/#{Regexp.escape(term)}/i) }
+    end
+
+    # The stolen location to be displayed on the promoted alert image
+    # Escape single-quotes in the location text
+    def stolen_record_location(stolen_record)
+      return nil unless stolen_record.to_coordinates.any?
+
+      GeocodeableLegacy.address(stolen_record, street: false, zipcode: false, country: [:skip_default, :name])
+        .gsub("'", "\\'")
+    end
+
+    def to_tempfile(string_io)
+      tempfile = Tempfile.new(["stolen_image", ".jpeg"])
+      tempfile.binmode
+      tempfile.write(string_io.read)
+      tempfile.rewind
+      tempfile
+    end
+
+    conceal :image_and_id, :use_stolen_images_override_id?, :attach_images, :generate_alert,
+      :template_path, :topbar_path, :bike_image_dimensions_for, :bike_image_offset,
+      :caption_overlay, :font, :fc_list_output, :fc_list_has?, :stolen_record_location, :to_tempfile
   end
-
-  def fc_list_output
-    @fc_list_output ||= `fc-list`.to_s
-  end
-
-  def fc_list_has?(*terms)
-    terms.all? { |term| fc_list_output.match?(/#{Regexp.escape(term)}/i) }
-  end
-
-  # The stolen location to be displayed on the promoted alert image
-  # Escape single-quotes in the location text
-  def stolen_record_location(stolen_record)
-    return nil unless stolen_record.to_coordinates.any?
-
-    GeocodeableLegacy.address(stolen_record, street: false, zipcode: false, country: [:skip_default, :name])
-      .gsub("'", "\\'")
-  end
-
-  def to_tempfile(string_io)
-    tempfile = Tempfile.new(["stolen_image", ".jpeg"])
-    tempfile.binmode
-    tempfile.write(string_io.read)
-    tempfile.rewind
-    tempfile
-  end
-
-  conceal :image_and_id, :use_stolen_images_override_id?, :attach_images, :generate_alert,
-    :template_path, :topbar_path, :bike_image_dimensions_for, :bike_image_offset,
-    :caption_overlay, :font, :fc_list_output, :fc_list_has?, :stolen_record_location, :to_tempfile
 end

--- a/app/services/integrations/bike_book.rb
+++ b/app/services/integrations/bike_book.rb
@@ -1,46 +1,48 @@
-class Integrations::BikeBook
-  require "net/http"
+module Integrations
+  class BikeBook
+    require "net/http"
 
-  def make_request(query, method = nil)
-    begin
-      uri = URI("http://bikebook.io#{method}")
-      uri.query = URI.encode_www_form(query)
-      res = Net::HTTP.get_response(uri)
-    rescue
-      return nil
+    def make_request(query, method = nil)
+      begin
+        uri = URI("http://bikebook.io#{method}")
+        uri.query = URI.encode_www_form(query)
+        res = Net::HTTP.get_response(uri)
+      rescue
+        return nil
+      end
+      return nil unless res.is_a?(Net::HTTPSuccess)
+
+      response = JSON.parse(res.body)
+      return response if response.is_a?(Array)
+
+      response.with_indifferent_access
     end
-    return nil unless res.is_a?(Net::HTTPSuccess)
 
-    response = JSON.parse(res.body)
-    return response if response.is_a?(Array)
+    def get_model(options = {})
+      if options.is_a?(Bike)
+        options = {
+          year: options.year,
+          manufacturer: options.manufacturer.name,
+          frame_model: options.frame_model
+        }
+      end
+      return nil unless options[:year].present? && options[:manufacturer].present? && options[:frame_model].present?
 
-    response.with_indifferent_access
-  end
+      # We're book sluging everything because, url safe (It's the same method bikebook uses)
+      query = {manufacturer: Slugifyer.manufacturer(options[:manufacturer]),
+               year: options[:year],
+               frame_model: Slugifyer.book_slug(options[:frame_model])}
 
-  def get_model(options = {})
-    if options.is_a?(Bike)
-      options = {
-        year: options.year,
-        manufacturer: options.manufacturer.name,
-        frame_model: options.frame_model
-      }
+      make_request(query)
     end
-    return nil unless options[:year].present? && options[:manufacturer].present? && options[:frame_model].present?
 
-    # We're book sluging everything because, url safe (It's the same method bikebook uses)
-    query = {manufacturer: Slugifyer.manufacturer(options[:manufacturer]),
-             year: options[:year],
-             frame_model: Slugifyer.book_slug(options[:frame_model])}
+    def get_model_list(options = {})
+      return nil unless options[:manufacturer].present?
 
-    make_request(query)
-  end
+      query = {manufacturer: Slugifyer.manufacturer(options[:manufacturer])}
+      query[:year] = options[:year] if options[:year].present?
 
-  def get_model_list(options = {})
-    return nil unless options[:manufacturer].present?
-
-    query = {manufacturer: Slugifyer.manufacturer(options[:manufacturer])}
-    query[:year] = options[:year] if options[:year].present?
-
-    make_request(query, "/model_list/")
+      make_request(query, "/model_list/")
+    end
   end
 end

--- a/app/services/integrations/cloudflare.rb
+++ b/app/services/integrations/cloudflare.rb
@@ -1,22 +1,24 @@
-class Integrations::Cloudflare
-  API_TOKEN = ENV["CLOUDFLARE_TOKEN"]
-  ZONE = "82c727a79571ff204a7ddc188d1806ec"
+module Integrations
+  class Cloudflare
+    API_TOKEN = ENV["CLOUDFLARE_TOKEN"]
+    ZONE = "82c727a79571ff204a7ddc188d1806ec"
 
-  require "net/http"
+    require "net/http"
 
-  def connection
-    @connection ||= Faraday.new(url: "https://api.cloudflare.com") do |conn|
-      conn.headers["Content-Type"] = "application/json"
-      conn.headers["Authorization"] = "Bearer #{API_TOKEN}"
-      conn.adapter Faraday.default_adapter
+    def connection
+      @connection ||= Faraday.new(url: "https://api.cloudflare.com") do |conn|
+        conn.headers["Content-Type"] = "application/json"
+        conn.headers["Authorization"] = "Bearer #{API_TOKEN}"
+        conn.adapter Faraday.default_adapter
+      end
     end
-  end
 
-  def expire_cache(url_or_url_array)
-    urls = Array(url_or_url_array)
-    result = connection.post("/client/v4/zones/#{ZONE}/purge_cache") do |req|
-      req.body = {files: urls}.to_json
+    def expire_cache(url_or_url_array)
+      urls = Array(url_or_url_array)
+      result = connection.post("/client/v4/zones/#{ZONE}/purge_cache") do |req|
+        req.body = {files: urls}.to_json
+      end
+      JSON.parse(result.body)
     end
-    JSON.parse(result.body)
   end
 end

--- a/app/services/integrations/exchange_rate_api_client.rb
+++ b/app/services/integrations/exchange_rate_api_client.rb
@@ -1,36 +1,38 @@
 # frozen_string_literal: true
 
-class Integrations::ExchangeRateAPIClient
-  BASE_URL = ENV.fetch("EXCHANGE_RATE_API_BASE_URL", "https://api.exchangeratesapi.io")
-  API_KEY = ENV["EXCHANGE_RATE_API_KEY"]
+module Integrations
+  class ExchangeRateAPIClient
+    BASE_URL = ENV.fetch("EXCHANGE_RATE_API_BASE_URL", "https://api.exchangeratesapi.io")
+    API_KEY = ENV["EXCHANGE_RATE_API_KEY"]
 
-  attr_accessor :base_iso, :base_url, :cache_key
+    attr_accessor :base_iso, :base_url, :cache_key
 
-  def initialize(base_iso = "USD")
-    self.base_iso = base_iso
-    self.base_url = BASE_URL
-    self.cache_key = ["exchange_rate", Date.current].join("::")
-  end
-
-  def latest
-    Rails.cache.fetch(cache_key, expires_in: 24.hours) do
-      resp = conn.get("latest") { |req|
-        req.params = {"base" => base_iso, :access_key => API_KEY}
-      }
-
-      raise(StandardError, resp.body) unless resp.status == 200 && resp.body.is_a?(Hash)
-
-      resp.body.with_indifferent_access
+    def initialize(base_iso = "USD")
+      self.base_iso = base_iso
+      self.base_url = BASE_URL
+      self.cache_key = ["exchange_rate", Date.current].join("::")
     end
-  end
 
-  private
+    def latest
+      Rails.cache.fetch(cache_key, expires_in: 24.hours) do
+        resp = conn.get("latest") { |req|
+          req.params = {"base" => base_iso, :access_key => API_KEY}
+        }
 
-  def conn
-    @conn ||= Faraday.new(url: base_url) do |con|
-      con.response :json, content_type: /\bjson$/
-      con.adapter Faraday.default_adapter
-      con.options.timeout = 5
+        raise(StandardError, resp.body) unless resp.status == 200 && resp.body.is_a?(Hash)
+
+        resp.body.with_indifferent_access
+      end
+    end
+
+    private
+
+    def conn
+      @conn ||= Faraday.new(url: base_url) do |con|
+        con.response :json, content_type: /\bjson$/
+        con.adapter Faraday.default_adapter
+        con.options.timeout = 5
+      end
     end
   end
 end

--- a/app/services/integrations/mailchimp.rb
+++ b/app/services/integrations/mailchimp.rb
@@ -1,107 +1,109 @@
 require "MailchimpMarketing"
 
-class Integrations::Mailchimp
-  API_KEY = ENV["MAILCHIMP_KEY"]
-  SERVER_PREFIX = "us6" # I don't think this changes?
+module Integrations
+  class Mailchimp
+    API_KEY = ENV["MAILCHIMP_KEY"]
+    SERVER_PREFIX = "us6" # I don't think this changes?
 
-  LISTS = {
-    organization: "b675299293",
-    individual: "180a1141a4"
-  }
+    LISTS = {
+      organization: "b675299293",
+      individual: "180a1141a4"
+    }
 
-  attr_accessor :total_items # For paginated lookups
+    attr_accessor :total_items # For paginated lookups
 
-  def self.list_id(str)
-    LISTS[str&.to_sym]
-  end
+    def self.list_id(str)
+      LISTS[str&.to_sym]
+    end
 
-  def get_tags(list)
-    result = client.lists.tag_search(self.class.list_id(list))
-    @total_items = result["total_items"]
-    result.dig("tags").map { |l| l.except("_links") }
-  end
+    def get_tags(list)
+      result = client.lists.tag_search(self.class.list_id(list))
+      @total_items = result["total_items"]
+      result.dig("tags").map { |l| l.except("_links") }
+    end
 
-  def get_merge_fields(list)
-    client.lists.get_list_merge_fields(self.class.list_id(list), count: 1000)
-      .dig("merge_fields").map { |l| l.except("_links") }
-  end
+    def get_merge_fields(list)
+      client.lists.get_list_merge_fields(self.class.list_id(list), count: 1000)
+        .dig("merge_fields").map { |l| l.except("_links") }
+    end
 
-  def get_interest_categories(list)
-    client.lists.get_list_interest_categories(self.class.list_id(list))
-      .dig("categories").map { |l| l.except("_links") }
-  end
+    def get_interest_categories(list)
+      client.lists.get_list_interest_categories(self.class.list_id(list))
+        .dig("categories").map { |l| l.except("_links") }
+    end
 
-  # requires a interest_category mailchimp_value
-  def get_interests(mailchimp_value)
-    client.lists.list_interest_category_interests(self.class.list_id(mailchimp_value.list), mailchimp_value.mailchimp_id)
-      .dig("interests").map { |l| l.except("_links") }
-  end
+    # requires a interest_category mailchimp_value
+    def get_interests(mailchimp_value)
+      client.lists.list_interest_category_interests(self.class.list_id(mailchimp_value.list), mailchimp_value.mailchimp_id)
+        .dig("interests").map { |l| l.except("_links") }
+    end
 
-  def get_members(list, page:, count:)
-    result = client.lists.get_list_members_info(self.class.list_id(list),
-      offset: (count * page), count: count)
-    @total_items = result["total_items"]
-    result.dig("members").map { |l| l.except("_links") }
-  end
+    def get_members(list, page:, count:)
+      result = client.lists.get_list_members_info(self.class.list_id(list),
+        offset: (count * page), count: count)
+      @total_items = result["total_items"]
+      result.dig("members").map { |l| l.except("_links") }
+    end
 
-  def get_member(mailchimp_datum, list = nil)
-    list ||= mailchimp_datum.lists.first
-    begin
-      client.lists.get_list_member(self.class.list_id(list),
-        mailchimp_datum.subscriber_hash)
+    def get_member(mailchimp_datum, list = nil)
+      list ||= mailchimp_datum.lists.first
+      begin
+        client.lists.get_list_member(self.class.list_id(list),
+          mailchimp_datum.subscriber_hash)
+      rescue MailchimpMarketing::ApiError => e
+        return if e.status == 404
+
+        raise e # re-raise if it isn't a 404
+      end
+    end
+
+    def update_member(mailchimp_datum, list)
+      client.lists.set_list_member(self.class.list_id(list), mailchimp_datum.subscriber_hash,
+        member_update_hash(mailchimp_datum, list))
+        .except("_links")
+    rescue MailchimpMarketing::ApiError => e
+      if e.status == 400 && e.to_s.match(/looks fake/i)
+        # SHIT method to get error detail. e.detail returns nil
+        return {"error" => e.to_s.gsub(/\A.*detail/, "").gsub(/",.*/, "").gsub(/\\+/, "")}
+      end
+
+      raise e # re-raise if it isn't a 404
+    end
+
+    def member_update_hash(mailchimp_datum, list)
+      {
+        email_address: mailchimp_datum.email,
+        full_name: mailchimp_datum.full_name,
+        status_if_new: mailchimp_datum.mailchimp_status,
+        merge_fields: mailchimp_datum.mailchimp_merge_fields(list),
+        interests: mailchimp_datum.mailchimp_interests(list)
+      }
+    end
+
+    def update_member_tags(mailchimp_datum, list)
+      client.lists.update_list_member_tags(self.class.list_id(list), mailchimp_datum.subscriber_hash,
+        {tags: mailchimp_datum.mailchimp_tags(list)}.as_json)
+    end
+
+    def archive_member(mailchimp_datum, list)
+      client.lists.delete_list_member(self.class.list_id(list), mailchimp_datum.subscriber_hash)
     rescue MailchimpMarketing::ApiError => e
       return if e.status == 404
 
       raise e # re-raise if it isn't a 404
     end
-  end
 
-  def update_member(mailchimp_datum, list)
-    client.lists.set_list_member(self.class.list_id(list), mailchimp_datum.subscriber_hash,
-      member_update_hash(mailchimp_datum, list))
-      .except("_links")
-  rescue MailchimpMarketing::ApiError => e
-    if e.status == 400 && e.to_s.match(/looks fake/i)
-      # SHIT method to get error detail. e.detail returns nil
-      return {"error" => e.to_s.gsub(/\A.*detail/, "").gsub(/",.*/, "").gsub(/\\+/, "")}
+    def client
+      @client ||= MailchimpMarketing::Client.new(
+        api_key: API_KEY,
+        server: SERVER_PREFIX
+      )
     end
 
-    raise e # re-raise if it isn't a 404
-  end
-
-  def member_update_hash(mailchimp_datum, list)
-    {
-      email_address: mailchimp_datum.email,
-      full_name: mailchimp_datum.full_name,
-      status_if_new: mailchimp_datum.mailchimp_status,
-      merge_fields: mailchimp_datum.mailchimp_merge_fields(list),
-      interests: mailchimp_datum.mailchimp_interests(list)
-    }
-  end
-
-  def update_member_tags(mailchimp_datum, list)
-    client.lists.update_list_member_tags(self.class.list_id(list), mailchimp_datum.subscriber_hash,
-      {tags: mailchimp_datum.mailchimp_tags(list)}.as_json)
-  end
-
-  def archive_member(mailchimp_datum, list)
-    client.lists.delete_list_member(self.class.list_id(list), mailchimp_datum.subscriber_hash)
-  rescue MailchimpMarketing::ApiError => e
-    return if e.status == 404
-
-    raise e # re-raise if it isn't a 404
-  end
-
-  def client
-    @client ||= MailchimpMarketing::Client.new(
-      api_key: API_KEY,
-      server: SERVER_PREFIX
-    )
-  end
-
-  # Lists are called "Audiences" outside of the API
-  def get_lists
-    client.lists.get_all_lists.as_json
-      .dig("lists").map { |l| l.slice("id", "name") }
+    # Lists are called "Audiences" outside of the API
+    def get_lists
+      client.lists.get_all_lists.as_json
+        .dig("lists").map { |l| l.slice("id", "name") }
+    end
   end
 end

--- a/app/services/integrations/social_poster.rb
+++ b/app/services/integrations/social_poster.rb
@@ -2,200 +2,202 @@ require "twitter"
 require "tempfile"
 require "open-uri"
 
-class Integrations::SocialPoster
-  TWEET_LENGTH = 280
-  MAX_REPOST_COUNT = (ENV["MAX_RETWEET_COUNT"] || 3).to_i
+module Integrations
+  class SocialPoster
+    TWEET_LENGTH = 280
+    MAX_REPOST_COUNT = (ENV["MAX_RETWEET_COUNT"] || 3).to_i
 
-  attr_accessor \
-    :bike,
-    :bike_photo_url,
-    :city,
-    :close_social_accounts,
-    :max_char,
-    :nearest_social_account,
-    :neighborhood,
-    :reposts,
-    :state,
-    :stolen_record,
-    :post
+    attr_accessor \
+      :bike,
+      :bike_photo_url,
+      :city,
+      :close_social_accounts,
+      :max_char,
+      :nearest_social_account,
+      :neighborhood,
+      :reposts,
+      :state,
+      :stolen_record,
+      :post
 
-  def initialize(bike)
-    self.bike = bike
-    self.stolen_record = bike.current_stolen_record
-    if bike.image_url.present?
-      self.bike_photo_url = bike.image_url(:large)
-    end
-    self.close_social_accounts = SocialAccount.in_proximity(stolen_record)
-    self.nearest_social_account = close_social_accounts.find { |i| i.not_national? } || close_social_accounts.first
-    self.city = stolen_record&.city
-    self.state = stolen_record&.state&.abbreviation
-    self.neighborhood = stolen_record&.neighborhood
-  end
-
-  # To manually send a post (e.g. if authentication failed)
-  # Integrations::SocialPoster.new(Bike.find(XXX)).create_post
-  def create_post
-    return if stolen_record.blank? || nearest_social_account.blank?
-
-    posted =
-      post_with_account(nearest_social_account,
-        build_bike_status,
-        lat: stolen_record.latitude,
-        long: stolen_record.longitude,
-        display_coordinates: "true")
-
-    return if posted.blank?
-
-    self.post = SocialPost.new(
-      platform_id: posted.id,
-      social_account_id: nearest_social_account&.id,
-      stolen_record_id: stolen_record&.id,
-      platform_response: posted,
-      kind: "stolen_post"
-    )
-
-    unless post.save
-      nearest_social_account.set_error(post.errors.full_messages.to_sentence)
+    def initialize(bike)
+      self.bike = bike
+      self.stolen_record = bike.current_stolen_record
+      if bike.image_url.present?
+        self.bike_photo_url = bike.image_url(:large)
+      end
+      self.close_social_accounts = SocialAccount.in_proximity(stolen_record)
+      self.nearest_social_account = close_social_accounts.find { |i| i.not_national? } || close_social_accounts.first
+      self.city = stolen_record&.city
+      self.state = stolen_record&.state&.abbreviation
+      self.neighborhood = stolen_record&.neighborhood
     end
 
-    repost(posted)
-    post
-  end
+    # To manually send a post (e.g. if authentication failed)
+    # Integrations::SocialPoster.new(Bike.find(XXX)).create_post
+    def create_post
+      return if stolen_record.blank? || nearest_social_account.blank?
 
-  def repostable_accounts
-    return [] if MAX_REPOST_COUNT < 1
+      posted =
+        post_with_account(nearest_social_account,
+          build_bike_status,
+          lat: stolen_record.latitude,
+          long: stolen_record.longitude,
+          display_coordinates: "true")
 
-    close_social_accounts.reject { |t| t.id == nearest_social_account.id }[0..MAX_REPOST_COUNT]
-  end
+      return if posted.blank?
 
-  def repost(posted)
-    self.reposts = [post]
+      self.post = SocialPost.new(
+        platform_id: posted.id,
+        social_account_id: nearest_social_account&.id,
+        stolen_record_id: stolen_record&.id,
+        platform_response: posted,
+        kind: "stolen_post"
+      )
 
-    repostable_accounts.each do |social_account|
-      reposted = post.repost_to_account(social_account)
-      reposts << reposted if reposted.present?
+      unless post.save
+        nearest_social_account.set_error(post.errors.full_messages.to_sentence)
+      end
+
+      repost(posted)
+      post
     end
 
-    reposts
-  end
+    def repostable_accounts
+      return [] if MAX_REPOST_COUNT < 1
 
-  def stolen_slug
-    if !bike.status_stolen? || bike.status_abandoned?
-      "FOUND -"
-    else
-      "STOLEN -"
-    end
-  end
-
-  def compute_max_char
-    # TODO store these constants in the database and update them once a day with
-    # a REST client.configuration call
-    #
-    # spaces between slugs
-    # max_char = TWEET_LENGTH - https_length - at_screen_name.length - 3
-
-    https_length = 23
-    media_length = 23
-
-    # spaces between slugs
-    max = TWEET_LENGTH - https_length - stolen_slug.size - 3
-    max -= bike_photo_url ? media_length : 0
-
-    max
-  end
-
-  def post_string(stolen_slug, bike_slug, url)
-    "#{stolen_slug} #{bike_slug} #{url}"
-  end
-
-  def post_string_with_options(stolen_slug, bike_slug, url)
-    ts = post_string(stolen_slug, bike_slug, url)
-
-    if close_social_accounts&.first&.append_block.present?
-      block = nearest_social_account.append_block
-      ts << " #{block}" if (ts.length + block.length) < max_char
+      close_social_accounts.reject { |t| t.id == nearest_social_account.id }[0..MAX_REPOST_COUNT]
     end
 
-    ts
-  end
+    def repost(posted)
+      self.reposts = [post]
 
-  # Perform the conditional text processing to create a reply string
-  # that fits twitter's limits
-  #
-  # param bike [Hash] bike hash as delivered by BikeIndex that we're going to post about
-  def build_bike_status
-    self.max_char = compute_max_char
+      repostable_accounts.each do |social_account|
+        reposted = post.repost_to_account(social_account)
+        reposts << reposted if reposted.present?
+      end
 
-    location = ""
-    if !close_social_accounts&.first&.default? && neighborhood.present?
-      location = "in #{neighborhood}"
-    elsif city.present? && state.present?
-      location = "in #{city}, #{state}"
+      reposts
     end
 
-    color = bike.frame_colors.first
-    if color.start_with?("Silver")
-      color = "Gray"
-    elsif color.start_with?("Yellow")
-      color = "Yellow"
-    elsif color.start_with?("Sticker")
-      color = "Stickers"
-    end
-
-    manufacturer = bike.mnfg_name
-    model = bike.frame_model
-
-    full_length =
-      [color, model, manufacturer, location]
-        .select(&:present?)
-        .map(&:size)
-        .sum + 3
-
-    components =
-      if full_length <= max_char
-        [color, manufacturer, model, location]
-      elsif full_length - color&.size.to_i - 1 <= max_char
-        [manufacturer, model, location]
-      elsif full_length - manufacturer&.size.to_i - 1 <= max_char
-        [color, model, location]
-      elsif full_length - model&.size.to_i - 1 <= max_char
-        [color, manufacturer, location]
-      elsif model&.size.to_i + 2 <= max_char
-        ["a", model]
-      elsif manufacturer&.size.to_i + 2 <= max_char
-        ["a", manufacturer]
-      elsif color&.size.to_i + 5 <= max_char
-        [color, "bike"]
+    def stolen_slug
+      if !bike.status_stolen? || bike.status_abandoned?
+        "FOUND -"
       else
-        []
+        "STOLEN -"
       end
-
-    bike_slug = components.select(&:present?).join(" ")
-    post_string_with_options(stolen_slug, bike_slug, bike_url(bike))
-  end
-
-  private
-
-  def bike_url(bike)
-    "https://bikeindex.org/bikes/#{bike.id}"
-  end
-
-  def post_with_account(account, text, **opts)
-    return if account.blank?
-
-    posted = nil
-
-    if bike_photo_url.present?
-      Tempfile.open("foto.jpg") do |foto|
-        foto.binmode
-        foto.write URI.parse(bike_photo_url).open.read # TODO: Refactor this.
-        foto.rewind
-        posted = account.post(text, foto, opts)
-      end
-    else
-      posted = account.post(text, opts)
     end
 
-    posted
+    def compute_max_char
+      # TODO store these constants in the database and update them once a day with
+      # a REST client.configuration call
+      #
+      # spaces between slugs
+      # max_char = TWEET_LENGTH - https_length - at_screen_name.length - 3
+
+      https_length = 23
+      media_length = 23
+
+      # spaces between slugs
+      max = TWEET_LENGTH - https_length - stolen_slug.size - 3
+      max -= bike_photo_url ? media_length : 0
+
+      max
+    end
+
+    def post_string(stolen_slug, bike_slug, url)
+      "#{stolen_slug} #{bike_slug} #{url}"
+    end
+
+    def post_string_with_options(stolen_slug, bike_slug, url)
+      ts = post_string(stolen_slug, bike_slug, url)
+
+      if close_social_accounts&.first&.append_block.present?
+        block = nearest_social_account.append_block
+        ts << " #{block}" if (ts.length + block.length) < max_char
+      end
+
+      ts
+    end
+
+    # Perform the conditional text processing to create a reply string
+    # that fits twitter's limits
+    #
+    # param bike [Hash] bike hash as delivered by BikeIndex that we're going to post about
+    def build_bike_status
+      self.max_char = compute_max_char
+
+      location = ""
+      if !close_social_accounts&.first&.default? && neighborhood.present?
+        location = "in #{neighborhood}"
+      elsif city.present? && state.present?
+        location = "in #{city}, #{state}"
+      end
+
+      color = bike.frame_colors.first
+      if color.start_with?("Silver")
+        color = "Gray"
+      elsif color.start_with?("Yellow")
+        color = "Yellow"
+      elsif color.start_with?("Sticker")
+        color = "Stickers"
+      end
+
+      manufacturer = bike.mnfg_name
+      model = bike.frame_model
+
+      full_length =
+        [color, model, manufacturer, location]
+          .select(&:present?)
+          .map(&:size)
+          .sum + 3
+
+      components =
+        if full_length <= max_char
+          [color, manufacturer, model, location]
+        elsif full_length - color&.size.to_i - 1 <= max_char
+          [manufacturer, model, location]
+        elsif full_length - manufacturer&.size.to_i - 1 <= max_char
+          [color, model, location]
+        elsif full_length - model&.size.to_i - 1 <= max_char
+          [color, manufacturer, location]
+        elsif model&.size.to_i + 2 <= max_char
+          ["a", model]
+        elsif manufacturer&.size.to_i + 2 <= max_char
+          ["a", manufacturer]
+        elsif color&.size.to_i + 5 <= max_char
+          [color, "bike"]
+        else
+          []
+        end
+
+      bike_slug = components.select(&:present?).join(" ")
+      post_string_with_options(stolen_slug, bike_slug, bike_url(bike))
+    end
+
+    private
+
+    def bike_url(bike)
+      "https://bikeindex.org/bikes/#{bike.id}"
+    end
+
+    def post_with_account(account, text, **opts)
+      return if account.blank?
+
+      posted = nil
+
+      if bike_photo_url.present?
+        Tempfile.open("foto.jpg") do |foto|
+          foto.binmode
+          foto.write URI.parse(bike_photo_url).open.read # TODO: Refactor this.
+          foto.rewind
+          posted = account.post(text, foto, opts)
+        end
+      else
+        posted = account.post(text, opts)
+      end
+
+      posted
+    end
   end
 end

--- a/app/services/integrations/strava/client.rb
+++ b/app/services/integrations/strava/client.rb
@@ -1,189 +1,193 @@
 # frozen_string_literal: true
 
-module Integrations::Strava::Client
-  extend Functionable
+module Integrations
+  module Strava
+    module Client
+      extend Functionable
 
-  BASE_URL = "https://www.strava.com"
-  API_URL = "https://www.strava.com/api/v3"
-  DEFAULT_SCOPE = "read,activity:read_all,profile:read_all"
-  STRAVA_SEARCH_SCOPE = "#{DEFAULT_SCOPE},activity:write"
-  STRAVA_KEY = ENV["STRAVA_KEY"]
-  STRAVA_SECRET = ENV["STRAVA_SECRET"]
-  STRAVA_WEBHOOK_TOKEN = ENV["STRAVA_WEBHOOK_VERIFY_TOKEN"]
-  ACTIVITIES_PER_PAGE = 200
-  RATE_LIMIT_HEADROOM = ENV.fetch("STRAVA_CLIENT_HEADROOM", 10).to_i
-  FETCH_ACTIVITY_SHORT_HEADROOM = ENV.fetch("STRAVA_CLIENT_FETCH_ACTIVITY_SHORT_HEADROOM", 100).to_i
-  FETCH_ACTIVITY_LONG_HEADROOM = ENV.fetch("STRAVA_CLIENT_FETCH_ACTIVITY_LONG_HEADROOM", 500).to_i
-  RATE_LIMITED_RESPONSE_BODY = {
-    "message" => "Rate Limit Exceeded",
-    "errors" => [{"resource" => "Application", "field" => "rate limit", "code" => "exceeded"}]
-  }.freeze
+      BASE_URL = "https://www.strava.com"
+      API_URL = "https://www.strava.com/api/v3"
+      DEFAULT_SCOPE = "read,activity:read_all,profile:read_all"
+      STRAVA_SEARCH_SCOPE = "#{DEFAULT_SCOPE},activity:write"
+      STRAVA_KEY = ENV["STRAVA_KEY"]
+      STRAVA_SECRET = ENV["STRAVA_SECRET"]
+      STRAVA_WEBHOOK_TOKEN = ENV["STRAVA_WEBHOOK_VERIFY_TOKEN"]
+      ACTIVITIES_PER_PAGE = 200
+      RATE_LIMIT_HEADROOM = ENV.fetch("STRAVA_CLIENT_HEADROOM", 10).to_i
+      FETCH_ACTIVITY_SHORT_HEADROOM = ENV.fetch("STRAVA_CLIENT_FETCH_ACTIVITY_SHORT_HEADROOM", 100).to_i
+      FETCH_ACTIVITY_LONG_HEADROOM = ENV.fetch("STRAVA_CLIENT_FETCH_ACTIVITY_LONG_HEADROOM", 500).to_i
+      RATE_LIMITED_RESPONSE_BODY = {
+        "message" => "Rate Limit Exceeded",
+        "errors" => [{"resource" => "Application", "field" => "rate limit", "code" => "exceeded"}]
+      }.freeze
 
-  def currently_rate_limited?(request_method = nil, headroom: nil, request_type: nil)
-    rate_limit = StravaRequest.estimated_current_rate_limit
+      def currently_rate_limited?(request_method = nil, headroom: nil, request_type: nil)
+        rate_limit = StravaRequest.estimated_current_rate_limit
 
-    if request_type&.to_sym == :fetch_activity
-      (rate_limit[:read_short_limit] - rate_limit[:read_short_usage]) < FETCH_ACTIVITY_SHORT_HEADROOM ||
-        (rate_limit[:read_long_limit] - rate_limit[:read_long_usage]) < FETCH_ACTIVITY_LONG_HEADROOM
-    elsif request_method.blank? || request_method.upcase == "GET"
-      headroom ||= RATE_LIMIT_HEADROOM
-      (rate_limit[:read_short_limit] - rate_limit[:read_short_usage]) < headroom ||
-        (rate_limit[:read_long_limit] - rate_limit[:read_long_usage]) < headroom
-    else
-      headroom ||= RATE_LIMIT_HEADROOM
-      (rate_limit[:short_limit] - rate_limit[:short_usage]) < headroom ||
-        (rate_limit[:long_limit] - rate_limit[:long_usage]) < headroom
+        if request_type&.to_sym == :fetch_activity
+          (rate_limit[:read_short_limit] - rate_limit[:read_short_usage]) < FETCH_ACTIVITY_SHORT_HEADROOM ||
+            (rate_limit[:read_long_limit] - rate_limit[:read_long_usage]) < FETCH_ACTIVITY_LONG_HEADROOM
+        elsif request_method.blank? || request_method.upcase == "GET"
+          headroom ||= RATE_LIMIT_HEADROOM
+          (rate_limit[:read_short_limit] - rate_limit[:read_short_usage]) < headroom ||
+            (rate_limit[:read_long_limit] - rate_limit[:read_long_usage]) < headroom
+        else
+          headroom ||= RATE_LIMIT_HEADROOM
+          (rate_limit[:short_limit] - rate_limit[:short_usage]) < headroom ||
+            (rate_limit[:long_limit] - rate_limit[:long_usage]) < headroom
+        end
+      end
+
+      def exchange_token(code)
+        conn = oauth_connection
+        resp = conn.post("oauth/token") do |req|
+          req.body = {
+            client_id: STRAVA_KEY,
+            client_secret: STRAVA_SECRET,
+            code:,
+            grant_type: "authorization_code"
+          }
+        end
+        return nil unless resp.success?
+        resp.body
+      end
+
+      def authorization_url(state:, scope: nil)
+        params = {
+          client_id: STRAVA_KEY,
+          response_type: "code",
+          redirect_uri: Rails.application.routes.url_helpers.callback_strava_integration_url,
+          scope: scope || DEFAULT_SCOPE,
+          approval_prompt: "auto",
+          state:
+        }
+        "#{BASE_URL}/oauth/authorize?#{params.to_query}"
+      end
+
+      def fetch_athlete(strava_integration)
+        get(strava_integration, "athlete")
+      end
+
+      def fetch_athlete_stats(strava_integration)
+        get(strava_integration, "athletes/#{strava_integration.strava_id}/stats")
+      end
+
+      def list_activities(strava_integration, per_page: ACTIVITIES_PER_PAGE, page: nil, after: nil)
+        params = {per_page:}
+        params[:page] = page if page.present?
+        params[:after] = after if after.present?
+        get(strava_integration, "athlete/activities", **params)
+      end
+
+      def fetch_activity(strava_integration, strava_id)
+        get(strava_integration, "activities/#{strava_id}")
+      end
+
+      def fetch_gear(strava_integration, strava_gear_id)
+        get(strava_integration, "gear/#{strava_gear_id}")
+      end
+
+      def create_webhook_subscription
+        oauth_connection.post("api/v3/push_subscriptions") do |req|
+          req.body = {
+            client_id: STRAVA_KEY,
+            client_secret: STRAVA_SECRET,
+            callback_url: Rails.application.routes.url_helpers.strava_webhooks_url,
+            verify_token: STRAVA_WEBHOOK_TOKEN
+          }
+        end
+      end
+
+      def view_webhook_subscriptions
+        oauth_connection.get("api/v3/push_subscriptions") do |req|
+          req.params = {client_id: STRAVA_KEY, client_secret: STRAVA_SECRET}
+        end
+      end
+
+      def proxy_request(strava_integration, path, method: "GET", body: nil)
+        raise ArgumentError, "Invalid proxy path" if path.blank? || path.match?(%r{://|\A//|(\A|/)\.\.(/|\z)})
+
+        path = path.delete_prefix("/")
+        ensure_valid_token!(strava_integration)
+        execute_proxy_request(strava_integration, path, method:, body:)
+      end
+
+      def delete_webhook_subscription(subscription_id)
+        oauth_connection.delete("api/v3/push_subscriptions/#{subscription_id}") do |req|
+          req.body = {client_id: STRAVA_KEY, client_secret: STRAVA_SECRET}
+        end
+      end
+
+      def ensure_valid_token!(strava_integration)
+        return unless strava_integration.token_expired?
+
+        refresh_token!(strava_integration)
+      end
+
+      #
+      # private below here
+      #
+
+      def refresh_token!(strava_integration)
+        conn = oauth_connection
+        resp = conn.post("oauth/token") do |req|
+          req.body = {
+            client_id: STRAVA_KEY,
+            client_secret: STRAVA_SECRET,
+            grant_type: "refresh_token",
+            refresh_token: strava_integration.refresh_token
+          }
+        end
+        if resp.success?
+          data = resp.body
+          strava_integration.update(
+            access_token: data["access_token"],
+            refresh_token: data["refresh_token"],
+            token_expires_at: Time.at(data["expires_at"])
+          )
+          strava_integration.reload
+        else
+          strava_integration.update(status: "error")
+          false
+        end
+      end
+
+      def execute_proxy_request(strava_integration, path, method: "GET", body: nil)
+        conn = api_connection(strava_integration)
+        case method.to_s.upcase
+        when "POST" then conn.post(path) { |req| req.body = body if body }
+        when "PUT" then conn.put(path) { |req| req.body = body if body }
+        else conn.get(path)
+        end
+      end
+
+      def get(strava_integration, path, **params)
+        ensure_valid_token!(strava_integration)
+        api_connection(strava_integration).get(path) do |req|
+          req.params = params
+        end
+      end
+
+      def api_connection(strava_integration)
+        Faraday.new(url: API_URL) do |conn|
+          conn.request :json
+          conn.response :json, content_type: /\bjson$/
+          conn.adapter Faraday.default_adapter
+          conn.headers["Authorization"] = "Bearer #{strava_integration.access_token}"
+          conn.options.timeout = 30
+        end
+      end
+
+      def oauth_connection
+        Faraday.new(url: BASE_URL) do |conn|
+          conn.request :url_encoded
+          conn.response :json, content_type: /\bjson$/
+          conn.adapter Faraday.default_adapter
+          conn.options.timeout = 15
+        end
+      end
+
+      conceal :refresh_token!, :execute_proxy_request, :get, :api_connection, :oauth_connection
     end
   end
-
-  def exchange_token(code)
-    conn = oauth_connection
-    resp = conn.post("oauth/token") do |req|
-      req.body = {
-        client_id: STRAVA_KEY,
-        client_secret: STRAVA_SECRET,
-        code:,
-        grant_type: "authorization_code"
-      }
-    end
-    return nil unless resp.success?
-    resp.body
-  end
-
-  def authorization_url(state:, scope: nil)
-    params = {
-      client_id: STRAVA_KEY,
-      response_type: "code",
-      redirect_uri: Rails.application.routes.url_helpers.callback_strava_integration_url,
-      scope: scope || DEFAULT_SCOPE,
-      approval_prompt: "auto",
-      state:
-    }
-    "#{BASE_URL}/oauth/authorize?#{params.to_query}"
-  end
-
-  def fetch_athlete(strava_integration)
-    get(strava_integration, "athlete")
-  end
-
-  def fetch_athlete_stats(strava_integration)
-    get(strava_integration, "athletes/#{strava_integration.strava_id}/stats")
-  end
-
-  def list_activities(strava_integration, per_page: ACTIVITIES_PER_PAGE, page: nil, after: nil)
-    params = {per_page:}
-    params[:page] = page if page.present?
-    params[:after] = after if after.present?
-    get(strava_integration, "athlete/activities", **params)
-  end
-
-  def fetch_activity(strava_integration, strava_id)
-    get(strava_integration, "activities/#{strava_id}")
-  end
-
-  def fetch_gear(strava_integration, strava_gear_id)
-    get(strava_integration, "gear/#{strava_gear_id}")
-  end
-
-  def create_webhook_subscription
-    oauth_connection.post("api/v3/push_subscriptions") do |req|
-      req.body = {
-        client_id: STRAVA_KEY,
-        client_secret: STRAVA_SECRET,
-        callback_url: Rails.application.routes.url_helpers.strava_webhooks_url,
-        verify_token: STRAVA_WEBHOOK_TOKEN
-      }
-    end
-  end
-
-  def view_webhook_subscriptions
-    oauth_connection.get("api/v3/push_subscriptions") do |req|
-      req.params = {client_id: STRAVA_KEY, client_secret: STRAVA_SECRET}
-    end
-  end
-
-  def proxy_request(strava_integration, path, method: "GET", body: nil)
-    raise ArgumentError, "Invalid proxy path" if path.blank? || path.match?(%r{://|\A//|(\A|/)\.\.(/|\z)})
-
-    path = path.delete_prefix("/")
-    ensure_valid_token!(strava_integration)
-    execute_proxy_request(strava_integration, path, method:, body:)
-  end
-
-  def delete_webhook_subscription(subscription_id)
-    oauth_connection.delete("api/v3/push_subscriptions/#{subscription_id}") do |req|
-      req.body = {client_id: STRAVA_KEY, client_secret: STRAVA_SECRET}
-    end
-  end
-
-  def ensure_valid_token!(strava_integration)
-    return unless strava_integration.token_expired?
-
-    refresh_token!(strava_integration)
-  end
-
-  #
-  # private below here
-  #
-
-  def refresh_token!(strava_integration)
-    conn = oauth_connection
-    resp = conn.post("oauth/token") do |req|
-      req.body = {
-        client_id: STRAVA_KEY,
-        client_secret: STRAVA_SECRET,
-        grant_type: "refresh_token",
-        refresh_token: strava_integration.refresh_token
-      }
-    end
-    if resp.success?
-      data = resp.body
-      strava_integration.update(
-        access_token: data["access_token"],
-        refresh_token: data["refresh_token"],
-        token_expires_at: Time.at(data["expires_at"])
-      )
-      strava_integration.reload
-    else
-      strava_integration.update(status: "error")
-      false
-    end
-  end
-
-  def execute_proxy_request(strava_integration, path, method: "GET", body: nil)
-    conn = api_connection(strava_integration)
-    case method.to_s.upcase
-    when "POST" then conn.post(path) { |req| req.body = body if body }
-    when "PUT" then conn.put(path) { |req| req.body = body if body }
-    else conn.get(path)
-    end
-  end
-
-  def get(strava_integration, path, **params)
-    ensure_valid_token!(strava_integration)
-    api_connection(strava_integration).get(path) do |req|
-      req.params = params
-    end
-  end
-
-  def api_connection(strava_integration)
-    Faraday.new(url: API_URL) do |conn|
-      conn.request :json
-      conn.response :json, content_type: /\bjson$/
-      conn.adapter Faraday.default_adapter
-      conn.headers["Authorization"] = "Bearer #{strava_integration.access_token}"
-      conn.options.timeout = 30
-    end
-  end
-
-  def oauth_connection
-    Faraday.new(url: BASE_URL) do |conn|
-      conn.request :url_encoded
-      conn.response :json, content_type: /\bjson$/
-      conn.adapter Faraday.default_adapter
-      conn.options.timeout = 15
-    end
-  end
-
-  conceal :refresh_token!, :execute_proxy_request, :get, :api_connection, :oauth_connection
 end

--- a/app/services/integrations/strava/proxy_requester.rb
+++ b/app/services/integrations/strava/proxy_requester.rb
@@ -1,161 +1,165 @@
 # frozen_string_literal: true
 
-module Integrations::Strava::ProxyRequester
-  extend Functionable
+module Integrations
+  module Strava
+    module ProxyRequester
+      extend Functionable
 
-  STRAVA_DOORKEEPER_APP_ID = ENV.fetch("STRAVA_DOORKEEPER_APP_ID", 3).to_i
-  SENSITIVE_KEYS = %w[access_token refresh_token token client_secret].freeze
+      STRAVA_DOORKEEPER_APP_ID = ENV.fetch("STRAVA_DOORKEEPER_APP_ID", 3).to_i
+      SENSITIVE_KEYS = %w[access_token refresh_token token client_secret].freeze
 
-  # returns {user:, strava_integration:} if valid
-  # otherwise {error: message, status: status_code}
-  def authorize_user_and_strava_integration(access_token)
-    return {status: 401, error: "OAuth token required"} unless access_token&.accessible?
-    return {status: 403, error: "Unauthorized application"} unless authorized_app?(access_token)
+      # returns {user:, strava_integration:} if valid
+      # otherwise {error: message, status: status_code}
+      def authorize_user_and_strava_integration(access_token)
+        return {status: 401, error: "OAuth token required"} unless access_token&.accessible?
+        return {status: 403, error: "Unauthorized application"} unless authorized_app?(access_token)
 
-    user = User.find_by(id: access_token.resource_owner_id)
-    return {error: "User not found", status: 401} unless user
+        user = User.find_by(id: access_token.resource_owner_id)
+        return {error: "User not found", status: 401} unless user
 
-    strava_integration = user.strava_integration
-    return {error: "No Strava integration", status: 404} unless strava_integration
-    return {error: "Strava authorization failed. Please re-authenticate with Strava.", status: 401} if strava_integration.error?
+        strava_integration = user.strava_integration
+        return {error: "No Strava integration", status: 404} unless strava_integration
+        return {error: "Strava authorization failed. Please re-authenticate with Strava.", status: 401} if strava_integration.error?
 
-    {user:, strava_integration:}
-  end
-
-  def sync_status(strava_integration)
-    {
-      sync_status: {
-        status: strava_integration.status,
-        activities_downloaded_count: strava_integration.activities_downloaded_count,
-        athlete_activity_count: strava_integration.athlete_activity_count,
-        progress_percent: strava_integration.sync_progress_percent,
-        rate_limited: !StravaJobs::ScheduledRequestEnqueuer.rate_limit_allows_batch?
-      }
-    }
-  end
-
-  def create_and_execute(strava_integration:, user:, url:, method: nil, body: nil)
-    validate_url!(url)
-    request_method = method&.strip&.upcase
-    request_method = nil if request_method == "GET"
-
-    strava_request = StravaRequest.create!(
-      strava_integration:,
-      user:,
-      proxy_request: true,
-      request_type: proxy_request_type(url, request_method),
-      parameters: {url:, method: request_method, body:}.compact
-    )
-
-    return internal_response!(strava_request) if internal_response?(strava_request)
-
-    response = StravaJobs::RequestRunner.new.perform(strava_request.id, strava_request:, no_skip: true)
-    strava_request.reload
-
-    return {json: Integrations::Strava::Client::RATE_LIMITED_RESPONSE_BODY, status: 429} if response == :rate_limited
-
-    json = if strava_request.success?
-      serialize_proxy_response(strava_integration, response.body, method: strava_request.request_method)
-    else
-      sanitize_response_body(response.body)
-    end
-
-    {json:, status: response.status}
-  end
-
-  # Returns an existing valid token, or revokes the most recent expired one
-  # and creates a new one (matches Doorkeeper's refresh flow)
-  def find_or_create_access_token(resource_owner_id)
-    application_id = STRAVA_DOORKEEPER_APP_ID
-    access_token = Doorkeeper::AccessToken
-      .where(application_id:, resource_owner_id:)
-      .order(id: :desc)
-      .detect(&:accessible?)
-    return access_token if access_token.present?
-
-    # Revoke and refresh otherwise
-    Doorkeeper::AccessToken
-      .where(application_id:, resource_owner_id:, revoked_at: nil)
-      .order(id: :desc)
-      .first&.revoke
-    Doorkeeper::AccessToken.create!(
-      application_id:,
-      resource_owner_id:,
-      scopes: "public",
-      expires_in: Doorkeeper.configuration.access_token_expires_in
-    )
-  end
-
-  #
-  # private below here
-  #
-
-  def internal_response?(strava_request)
-    strava_request.fetch_athlete? || strava_request.list_activities?
-  end
-
-  def internal_response!(strava_request)
-    strava_request.update(response_status: :binx_response, requested_at: Time.current)
-
-    json = if strava_request.fetch_athlete?
-      strava_request.strava_integration.proxy_serialized
-    else
-      page = (strava_request.parameters["url"][/\Wpage=(\d+)/, 1] || 1).to_i - 1
-      limit = Integrations::Strava::Client::ACTIVITIES_PER_PAGE
-
-      strava_activities = StravaActivity.where(strava_integration_id: strava_request.strava_integration_id).strava_ordered
-      return {json: [], status: 200} if strava_activities.count < page * limit
-
-      strava_activities.offset(page * limit).limit(limit).map(&:proxy_serialized)
-    end
-    {json:, status: 200}
-  end
-
-  def authorized_app?(token)
-    token.application_id == STRAVA_DOORKEEPER_APP_ID
-  end
-
-  def proxy_request_type(url, request_method)
-    return :update_activity if %w[PUT POST].include?(request_method&.upcase)
-
-    case url
-    when /\Aathlete(\/\d+)?\z/ then :fetch_athlete
-    when /\Aathlete\/activities/ then :list_activities
-    when /\Aactivities\/\d+/ then :fetch_activity
-    when /\Agear\// then :fetch_gear
-    else
-      raise ArgumentError, "Unknown proxy request type for: #{url}, method: #{request_method}"
-    end
-  end
-
-  def validate_url!(url)
-    raise ArgumentError, "Invalid proxy path" if url.blank? || url.match?(%r{://|\A//|(\A|/)\.\.(/|\z)})
-  end
-
-  def serialize_proxy_response(strava_integration, body, method: nil)
-    if body.is_a?(Array)
-      body.map { |summary| StravaActivity.create_or_update_from_strava_response(strava_integration, summary).proxy_serialized }
-    elsif body.is_a?(Hash) && body["sport_type"].present?
-      strava_activity = StravaActivity.create_or_update_from_strava_response(strava_integration, body)
-      if method.to_s.casecmp?("put")
-        strava_activity.update_from_strava!(run_inline: true)
-        strava_activity.reload
+        {user:, strava_integration:}
       end
-      strava_activity.proxy_serialized
-    elsif body.is_a?(Hash) && (body["gear_type"].present? || body.key?("frame_type"))
-      StravaGear.update_from_strava(strava_integration, body)
-    else
-      body
+
+      def sync_status(strava_integration)
+        {
+          sync_status: {
+            status: strava_integration.status,
+            activities_downloaded_count: strava_integration.activities_downloaded_count,
+            athlete_activity_count: strava_integration.athlete_activity_count,
+            progress_percent: strava_integration.sync_progress_percent,
+            rate_limited: !StravaJobs::ScheduledRequestEnqueuer.rate_limit_allows_batch?
+          }
+        }
+      end
+
+      def create_and_execute(strava_integration:, user:, url:, method: nil, body: nil)
+        validate_url!(url)
+        request_method = method&.strip&.upcase
+        request_method = nil if request_method == "GET"
+
+        strava_request = StravaRequest.create!(
+          strava_integration:,
+          user:,
+          proxy_request: true,
+          request_type: proxy_request_type(url, request_method),
+          parameters: {url:, method: request_method, body:}.compact
+        )
+
+        return internal_response!(strava_request) if internal_response?(strava_request)
+
+        response = StravaJobs::RequestRunner.new.perform(strava_request.id, strava_request:, no_skip: true)
+        strava_request.reload
+
+        return {json: Integrations::Strava::Client::RATE_LIMITED_RESPONSE_BODY, status: 429} if response == :rate_limited
+
+        json = if strava_request.success?
+          serialize_proxy_response(strava_integration, response.body, method: strava_request.request_method)
+        else
+          sanitize_response_body(response.body)
+        end
+
+        {json:, status: response.status}
+      end
+
+      # Returns an existing valid token, or revokes the most recent expired one
+      # and creates a new one (matches Doorkeeper's refresh flow)
+      def find_or_create_access_token(resource_owner_id)
+        application_id = STRAVA_DOORKEEPER_APP_ID
+        access_token = Doorkeeper::AccessToken
+          .where(application_id:, resource_owner_id:)
+          .order(id: :desc)
+          .detect(&:accessible?)
+        return access_token if access_token.present?
+
+        # Revoke and refresh otherwise
+        Doorkeeper::AccessToken
+          .where(application_id:, resource_owner_id:, revoked_at: nil)
+          .order(id: :desc)
+          .first&.revoke
+        Doorkeeper::AccessToken.create!(
+          application_id:,
+          resource_owner_id:,
+          scopes: "public",
+          expires_in: Doorkeeper.configuration.access_token_expires_in
+        )
+      end
+
+      #
+      # private below here
+      #
+
+      def internal_response?(strava_request)
+        strava_request.fetch_athlete? || strava_request.list_activities?
+      end
+
+      def internal_response!(strava_request)
+        strava_request.update(response_status: :binx_response, requested_at: Time.current)
+
+        json = if strava_request.fetch_athlete?
+          strava_request.strava_integration.proxy_serialized
+        else
+          page = (strava_request.parameters["url"][/\Wpage=(\d+)/, 1] || 1).to_i - 1
+          limit = Integrations::Strava::Client::ACTIVITIES_PER_PAGE
+
+          strava_activities = StravaActivity.where(strava_integration_id: strava_request.strava_integration_id).strava_ordered
+          return {json: [], status: 200} if strava_activities.count < page * limit
+
+          strava_activities.offset(page * limit).limit(limit).map(&:proxy_serialized)
+        end
+        {json:, status: 200}
+      end
+
+      def authorized_app?(token)
+        token.application_id == STRAVA_DOORKEEPER_APP_ID
+      end
+
+      def proxy_request_type(url, request_method)
+        return :update_activity if %w[PUT POST].include?(request_method&.upcase)
+
+        case url
+        when /\Aathlete(\/\d+)?\z/ then :fetch_athlete
+        when /\Aathlete\/activities/ then :list_activities
+        when /\Aactivities\/\d+/ then :fetch_activity
+        when /\Agear\// then :fetch_gear
+        else
+          raise ArgumentError, "Unknown proxy request type for: #{url}, method: #{request_method}"
+        end
+      end
+
+      def validate_url!(url)
+        raise ArgumentError, "Invalid proxy path" if url.blank? || url.match?(%r{://|\A//|(\A|/)\.\.(/|\z)})
+      end
+
+      def serialize_proxy_response(strava_integration, body, method: nil)
+        if body.is_a?(Array)
+          body.map { |summary| StravaActivity.create_or_update_from_strava_response(strava_integration, summary).proxy_serialized }
+        elsif body.is_a?(Hash) && body["sport_type"].present?
+          strava_activity = StravaActivity.create_or_update_from_strava_response(strava_integration, body)
+          if method.to_s.casecmp?("put")
+            strava_activity.update_from_strava!(run_inline: true)
+            strava_activity.reload
+          end
+          strava_activity.proxy_serialized
+        elsif body.is_a?(Hash) && (body["gear_type"].present? || body.key?("frame_type"))
+          StravaGear.update_from_strava(strava_integration, body)
+        else
+          body
+        end
+      end
+
+      def sanitize_response_body(body)
+        return {error: "unknown error"} unless body.is_a?(Hash)
+
+        body.except(*SENSITIVE_KEYS)
+      end
+
+      conceal :internal_response?, :internal_response!,
+        :authorized_app?, :proxy_request_type, :validate_url!,
+        :serialize_proxy_response, :sanitize_response_body
     end
   end
-
-  def sanitize_response_body(body)
-    return {error: "unknown error"} unless body.is_a?(Hash)
-
-    body.except(*SENSITIVE_KEYS)
-  end
-
-  conceal :internal_response?, :internal_response!,
-    :authorized_app?, :proxy_request_type, :validate_url!,
-    :serialize_proxy_response, :sanitize_response_body
 end

--- a/app/services/integrations/strava/segment_locations.rb
+++ b/app/services/integrations/strava/segment_locations.rb
@@ -1,75 +1,79 @@
 # frozen_string_literal: true
 
-module Integrations::Strava::SegmentLocations
-  extend Functionable
+module Integrations
+  module Strava
+    module SegmentLocations
+      extend Functionable
 
-  def locations_for(segments)
-    return {} if segments.blank?
+      def locations_for(segments)
+        return {} if segments.blank?
 
-    region_cache = {}
-    country_cache = {}
+        region_cache = {}
+        country_cache = {}
 
-    locations = segments.filter_map do |segment|
-      next if segment["segment"].blank?
+        locations = segments.filter_map do |segment|
+          next if segment["segment"].blank?
 
-      region = segment.dig("segment", "state").presence
-      region_cache[region] ||= find_region_abbreviation(region)
+          region = segment.dig("segment", "state").presence
+          region_cache[region] ||= find_region_abbreviation(region)
 
-      country = segment.dig("segment", "country").presence
-      country_cache[country] ||= find_country_abbreviation(country)
+          country = segment.dig("segment", "country").presence
+          country_cache[country] ||= find_country_abbreviation(country)
 
-      segment_location(segment["segment"], region_cache.dig(region, :abbreviation),
-        country_cache.dig(country, :abbreviation))
-    end.compact.uniq
+          segment_location(segment["segment"], region_cache.dig(region, :abbreviation),
+            country_cache.dig(country, :abbreviation))
+        end.compact.uniq
 
-    regions = region_cache.values.compact.reject { |v| v[:name] == v[:abbreviation] }
-      .to_h { |v| [v[:name], v[:abbreviation]] }
-    countries = country_cache.values.compact.reject { |v| v[:name] == v[:abbreviation] }
-      .to_h { |v| [v[:name], v[:abbreviation]] }
+        regions = region_cache.values.compact.reject { |v| v[:name] == v[:abbreviation] }
+          .to_h { |v| [v[:name], v[:abbreviation]] }
+        countries = country_cache.values.compact.reject { |v| v[:name] == v[:abbreviation] }
+          .to_h { |v| [v[:name], v[:abbreviation]] }
 
-    {locations:, regions: regions.presence, countries: countries.presence}.compact
-  end
+        {locations:, regions: regions.presence, countries: countries.presence}.compact
+      end
 
-  #
-  # private below here
-  #
+      #
+      # private below here
+      #
 
-  def segment_location(segment, region, country)
-    city = segment["city"].presence&.strip
+      def segment_location(segment, region, country)
+        city = segment["city"].presence&.strip
 
-    # Remove country from the end of the city
-    city = city&.gsub(/, #{country}\z/i, "")
-    city = city&.gsub(/, usa\z/i, "") if country == "US"
-    # Remove region from the end of the city
-    city = city&.gsub(/, #{region}\z/i, "")
+        # Remove country from the end of the city
+        city = city&.gsub(/, #{country}\z/i, "")
+        city = city&.gsub(/, usa\z/i, "") if country == "US"
+        # Remove region from the end of the city
+        city = city&.gsub(/, #{region}\z/i, "")
 
-    {city:, region:, country:}.compact.presence
-  end
+        {city:, region:, country:}.compact.presence
+      end
 
-  def find_region_abbreviation(raw_value)
-    return if raw_value.blank?
+      def find_region_abbreviation(raw_value)
+        return if raw_value.blank?
 
-    state = State.friendly_find(raw_value)
-    if state
-      {name: state.name, abbreviation: state.abbreviation}
-    else
-      {name: raw_value, abbreviation: raw_value}
+        state = State.friendly_find(raw_value)
+        if state
+          {name: state.name, abbreviation: state.abbreviation}
+        else
+          {name: raw_value, abbreviation: raw_value}
+        end
+      end
+
+      def find_country_abbreviation(raw_value)
+        return if raw_value.blank?
+
+        country = Country.friendly_find(raw_value)
+        return {name: country.name, abbreviation: country.abbreviation} if country
+
+        sac_hash = StatesAndCountries.countries.detect { |sac| sac[:self_name] == raw_value }
+        if sac_hash.present?
+          {name: sac_hash[:name], abbreviation: sac_hash[:iso]}
+        else
+          {name: raw_value, abbreviation: raw_value}
+        end
+      end
+
+      conceal :segment_location, :find_region_abbreviation, :find_country_abbreviation
     end
   end
-
-  def find_country_abbreviation(raw_value)
-    return if raw_value.blank?
-
-    country = Country.friendly_find(raw_value)
-    return {name: country.name, abbreviation: country.abbreviation} if country
-
-    sac_hash = StatesAndCountries.countries.detect { |sac| sac[:self_name] == raw_value }
-    if sac_hash.present?
-      {name: sac_hash[:name], abbreviation: sac_hash[:iso]}
-    else
-      {name: raw_value, abbreviation: raw_value}
-    end
-  end
-
-  conceal :segment_location, :find_region_abbreviation, :find_country_abbreviation
 end

--- a/app/services/integrations/twilio.rb
+++ b/app/services/integrations/twilio.rb
@@ -1,44 +1,46 @@
 require "twilio-ruby"
 
-class Integrations::Twilio
-  ACCOUNT_SID = ENV["TWILIO_SID"]
-  AUTH_TOKEN = ENV["TWILIO_TOKEN"]
-  OUTGOING_NUMBER = ENV["TWILIO_NUMBER"]
+module Integrations
+  class Twilio
+    ACCOUNT_SID = ENV["TWILIO_SID"]
+    AUTH_TOKEN = ENV["TWILIO_TOKEN"]
+    OUTGOING_NUMBER = ENV["TWILIO_NUMBER"]
 
-  def self.twilio_formatted(str)
-    str.gsub(/\A0+/, "")
-  end
-
-  def client
-    @client ||= Twilio::REST::Client.new ACCOUNT_SID, AUTH_TOKEN
-  end
-
-  def send_message(to:, body:)
-    client.messages.create(body: body,
-      from: OUTGOING_NUMBER,
-      to: self.class.twilio_formatted(to))
-  end
-
-  def get_message(sid)
-    client.messages(sid).fetch
-  end
-
-  def send_notification(notification, to:, body:)
-    notification.message_channel_target = "text"
-    if notification.twilio_sid.present?
-      result = get_message(notification.twilio_sid)
-      notification.update(delivery_status: result.status)
-    else
-      result = send_message(to: to, body: body)
-      delivery_status = if result.status == "queued"
-        "delivery_pending"
-      else
-        result.status
-      end
-      notification.update(message_channel_target: to,
-        twilio_sid: result.sid,
-        delivery_status:)
+    def self.twilio_formatted(str)
+      str.gsub(/\A0+/, "")
     end
-    result
+
+    def client
+      @client ||= ::Twilio::REST::Client.new ACCOUNT_SID, AUTH_TOKEN
+    end
+
+    def send_message(to:, body:)
+      client.messages.create(body: body,
+        from: OUTGOING_NUMBER,
+        to: self.class.twilio_formatted(to))
+    end
+
+    def get_message(sid)
+      client.messages(sid).fetch
+    end
+
+    def send_notification(notification, to:, body:)
+      notification.message_channel_target = "text"
+      if notification.twilio_sid.present?
+        result = get_message(notification.twilio_sid)
+        notification.update(delivery_status: result.status)
+      else
+        result = send_message(to: to, body: body)
+        delivery_status = if result.status == "queued"
+          "delivery_pending"
+        else
+          result.status
+        end
+        notification.update(message_channel_target: to,
+          twilio_sid: result.sid,
+          delivery_status:)
+      end
+      result
+    end
   end
 end

--- a/app/services/log_searcher/parser.rb
+++ b/app/services/log_searcher/parser.rb
@@ -1,130 +1,132 @@
 # This module parses bike search log lines
-module LogSearcher::Parser
-  extend Functionable
+module LogSearcher
+  module Parser
+    extend Functionable
 
-  CONTROLLER_ENDPOINTS = {
-    "API::V1::BikesController#index" => :api_v1_bikes,
-    "API::V1::BikesController#stolen_ids" => :api_v1_stolen_ids,
-    "API::V1::BikesController#close_serials" => :api_v1_close_serials,
-    "Organized::BikesController#index" => :org_bikes,
-    "Admin::BikesController#index" => :admin_bikes,
-    "OrgPublic::ImpoundedBikesController#index" => :org_public_impounded,
-    "Organized::ImpoundRecordsController#index" => :org_impounded,
-    "Organized::ParkingNotificationsController#index" => :org_parking_notifications,
-    "Search::RegistrationsController#index" => :web_bikes,
-    "Search::RegistrationsController#serials_containing" => :web_serials_containing,
-    "Search::RegistrationsController#similar_serials" => :web_close_serials,
-    "Search::MarketplaceController#index" => :web_marketplace,
-    "Search::MarketplaceController#counts" => :web_marketplace_count
-  }.freeze
+    CONTROLLER_ENDPOINTS = {
+      "API::V1::BikesController#index" => :api_v1_bikes,
+      "API::V1::BikesController#stolen_ids" => :api_v1_stolen_ids,
+      "API::V1::BikesController#close_serials" => :api_v1_close_serials,
+      "Organized::BikesController#index" => :org_bikes,
+      "Admin::BikesController#index" => :admin_bikes,
+      "OrgPublic::ImpoundedBikesController#index" => :org_public_impounded,
+      "Organized::ImpoundRecordsController#index" => :org_impounded,
+      "Organized::ParkingNotificationsController#index" => :org_parking_notifications,
+      "Search::RegistrationsController#index" => :web_bikes,
+      "Search::RegistrationsController#serials_containing" => :web_serials_containing,
+      "Search::RegistrationsController#similar_serials" => :web_close_serials,
+      "Search::MarketplaceController#index" => :web_marketplace,
+      "Search::MarketplaceController#counts" => :web_marketplace_count
+    }.freeze
 
-  ROUTE_ENDPOINTS = {
-    "/api/v2/bikes_search/count" => :api_v2_count,
-    "/api/v2/bikes_search/close_serials" => :api_v2_close_serials,
-    "/api/v2/bikes/check_if_registered" => :api_v2_check_if_registered,
-    "/api/v3/search" => :api_v3_bikes,
-    "/api/v3/search/count" => :api_v3_count,
-    "/api/v3/search/close_serials" => :api_v3_close_serials,
-    "/api/v3/search/serials_containing" => :api_v3_serials_containing,
-    "/api/v3/search/external_registries" => :api_v3_external_registries,
-    "/api/v3/bikes/check_if_registered" => :api_v3_check_if_registered
-  }.freeze
+    ROUTE_ENDPOINTS = {
+      "/api/v2/bikes_search/count" => :api_v2_count,
+      "/api/v2/bikes_search/close_serials" => :api_v2_close_serials,
+      "/api/v2/bikes/check_if_registered" => :api_v2_check_if_registered,
+      "/api/v3/search" => :api_v3_bikes,
+      "/api/v3/search/count" => :api_v3_count,
+      "/api/v3/search/close_serials" => :api_v3_close_serials,
+      "/api/v3/search/serials_containing" => :api_v3_serials_containing,
+      "/api/v3/search/external_registries" => :api_v3_external_registries,
+      "/api/v3/bikes/check_if_registered" => :api_v3_check_if_registered
+    }.freeze
 
-  FILTERED_PARAMS = %w[access_token page].freeze
-  NON_QUERY_ITEMS = (
-    FILTERED_PARAMS +
-    %w[stolenness location distance locale organization_id organization_slug sort sort_direction render_chart utf8]
-  ).freeze
+    FILTERED_PARAMS = %w[access_token page].freeze
+    NON_QUERY_ITEMS = (
+      FILTERED_PARAMS +
+      %w[stolenness location distance locale organization_id organization_slug sort sort_direction render_chart utf8]
+    ).freeze
 
-  def parse_log_line(log_line)
-    raise "Multiple line_data matches for log line #{log_line}" if log_line.match?(/\] \{.*\] \{/)
+    def parse_log_line(log_line)
+      raise "Multiple line_data matches for log line #{log_line}" if log_line.match?(/\] \{.*\] \{/)
 
-    line_data, opts = log_line.split("] {")
-    opts = JSON.parse("{#{opts}")
-    endpoint = parse_endpoint(opts)
-    return nil unless LoggedSearch.endpoints_sym.include?(endpoint)
+      line_data, opts = log_line.split("] {")
+      opts = JSON.parse("{#{opts}")
+      endpoint = parse_endpoint(opts)
+      return nil unless LoggedSearch.endpoints_sym.include?(endpoint)
 
-    query_items = (opts["params"] || {}).select { |_, value| value.present? }
-    if query_items["search_secondary"].present? && query_items["search_secondary"].is_a?(Array) &&
-        query_items["search_secondary"].reject(&:blank?).none?
+      query_items = (opts["params"] || {}).select { |_, value| value.present? }
+      if query_items["search_secondary"].present? && query_items["search_secondary"].is_a?(Array) &&
+          query_items["search_secondary"].reject(&:blank?).none?
 
-      query_items = query_items.except("search_secondary")
-    end
-
-    {
-      request_at: parse_request_time(line_data),
-      request_id: line_data.split("[").last,
-      duration_ms: opts["duration"]&.to_f&.round,
-      user_id: opts["u_id"],
-      organization_id: organization_from_params(opts.dig("params")),
-      endpoint: endpoint,
-      ip_address: opts["remote_ip"],
-      query_items: query_items.except(*FILTERED_PARAMS),
-      stolenness: stolenness_for(endpoint, opts),
-      serial_normalized: SerialNormalizer.normalized_and_corrected(query_items["serial"]),
-      includes_query: includes_query?(query_items),
-      page: [nil, "1", "undefined"].include?(query_items["page"]) ? nil : query_items["page"].to_i
-    }
-  end
-
-  #
-  # private below here
-  #
-
-  def includes_query?(query_items)
-    query_items.except(*NON_QUERY_ITEMS).present?
-  end
-
-  def parse_endpoint(opts)
-    if opts["message"].present?
-      controller_action = opts["message"].split("(").last.delete(")")
-      CONTROLLER_ENDPOINTS[controller_action]
-    elsif %w[/api/v2/bikes_search /api/v2/bikes_search/stolen
-      /api/v2/bikes_search/non_stolen].include?(opts["path"])
-      :api_v2_bikes
-    else
-      ROUTE_ENDPOINTS[opts["path"]]
-    end
-  end
-
-  def organization_from_params(params)
-    return nil if params.blank?
-
-    Organization.friendly_find_id(params["organization_id"] || params["organization_slug"])
-  end
-
-  def parse_request_time(line_data)
-    time_str = line_data.gsub("I, [", "").split(" #").first
-    Time.parse("#{time_str} UTC")
-  end
-
-  def stolenness_for(endpoint, opts)
-    if endpoint == :api_v2_bikes
-      case opts["path"]
-      when "/api/v2/bikes_search" then :all
-      when "/api/v2/bikes_search/stolen" then :stolen
-      when "/api/v2/bikes_search/non_stolen" then :non
+        query_items = query_items.except("search_secondary")
       end
-    elsif %i[org_impounded org_public_impounded].include?(endpoint)
-      :impounded
-    elsif endpoint == :api_v1_stolen_ids
-      :stolen
-    elsif endpoint.match?(/marketplace/)
-      :for_sale
-    else
-      case opts.dig("params", "stolenness")
-      when "stolen", "proximity" then :stolen
-      when "non" then :non
-      when "found", "impounded" then :impounded
+
+      {
+        request_at: parse_request_time(line_data),
+        request_id: line_data.split("[").last,
+        duration_ms: opts["duration"]&.to_f&.round,
+        user_id: opts["u_id"],
+        organization_id: organization_from_params(opts.dig("params")),
+        endpoint: endpoint,
+        ip_address: opts["remote_ip"],
+        query_items: query_items.except(*FILTERED_PARAMS),
+        stolenness: stolenness_for(endpoint, opts),
+        serial_normalized: SerialNormalizer.normalized_and_corrected(query_items["serial"]),
+        includes_query: includes_query?(query_items),
+        page: [nil, "1", "undefined"].include?(query_items["page"]) ? nil : query_items["page"].to_i
+      }
+    end
+
+    #
+    # private below here
+    #
+
+    def includes_query?(query_items)
+      query_items.except(*NON_QUERY_ITEMS).present?
+    end
+
+    def parse_endpoint(opts)
+      if opts["message"].present?
+        controller_action = opts["message"].split("(").last.delete(")")
+        CONTROLLER_ENDPOINTS[controller_action]
+      elsif %w[/api/v2/bikes_search /api/v2/bikes_search/stolen
+        /api/v2/bikes_search/non_stolen].include?(opts["path"])
+        :api_v2_bikes
       else
-        if opts.dig("params", "stolen").present? && Binxtils::InputNormalizer.boolean(opts.dig("params", "stolen"))
-          :stolen
+        ROUTE_ENDPOINTS[opts["path"]]
+      end
+    end
+
+    def organization_from_params(params)
+      return nil if params.blank?
+
+      Organization.friendly_find_id(params["organization_id"] || params["organization_slug"])
+    end
+
+    def parse_request_time(line_data)
+      time_str = line_data.gsub("I, [", "").split(" #").first
+      Time.parse("#{time_str} UTC")
+    end
+
+    def stolenness_for(endpoint, opts)
+      if endpoint == :api_v2_bikes
+        case opts["path"]
+        when "/api/v2/bikes_search" then :all
+        when "/api/v2/bikes_search/stolen" then :stolen
+        when "/api/v2/bikes_search/non_stolen" then :non
+        end
+      elsif %i[org_impounded org_public_impounded].include?(endpoint)
+        :impounded
+      elsif endpoint == :api_v1_stolen_ids
+        :stolen
+      elsif endpoint.match?(/marketplace/)
+        :for_sale
+      else
+        case opts.dig("params", "stolenness")
+        when "stolen", "proximity" then :stolen
+        when "non" then :non
+        when "found", "impounded" then :impounded
         else
-          :all
+          if opts.dig("params", "stolen").present? && Binxtils::InputNormalizer.boolean(opts.dig("params", "stolen"))
+            :stolen
+          else
+            :all
+          end
         end
       end
     end
-  end
 
-  conceal :includes_query?, :parse_endpoint, :organization_from_params, :parse_request_time, :stolenness_for
+    conceal :includes_query?, :parse_endpoint, :organization_from_params, :parse_request_time, :stolenness_for
+  end
 end

--- a/app/services/log_searcher/reader.rb
+++ b/app/services/log_searcher/reader.rb
@@ -1,67 +1,69 @@
-module LogSearcher::Reader
-  extend Functionable
+module LogSearcher
+  module Reader
+    extend Functionable
 
-  KEY = "logSrch#{":test" if Rails.env.test?}:".freeze
-  DEFAULT_LOG_PATH = (ENV["LOG_SEARCH_PATH"] || "#{Rails.root}/log/#{Rails.env}.log").freeze
-  SEARCHES_MATCHES = %w[api/v2/bikes_search
-    api/v2/bikes/check_if_registered
-    api/v3/search
-    api/v3/bikes/check_if_registered
-    API::V1::BikesController#index
-    API::V1::BikesController#stolen_ids
-    API::V1::BikesController#close_serial
-    Organized::BikesController#index
-    Admin::BikesController#index
-    OrgPublic::ImpoundedBikesController#index
-    Organized::ImpoundRecordsController#index
-    ParkingNotificationsController#index
-    Search::].freeze
+    KEY = "logSrch#{":test" if Rails.env.test?}:".freeze
+    DEFAULT_LOG_PATH = (ENV["LOG_SEARCH_PATH"] || "#{Rails.root}/log/#{Rails.env}.log").freeze
+    SEARCHES_MATCHES = %w[api/v2/bikes_search
+      api/v2/bikes/check_if_registered
+      api/v3/search
+      api/v3/bikes/check_if_registered
+      API::V1::BikesController#index
+      API::V1::BikesController#stolen_ids
+      API::V1::BikesController#close_serial
+      Organized::BikesController#index
+      Admin::BikesController#index
+      OrgPublic::ImpoundedBikesController#index
+      Organized::ImpoundRecordsController#index
+      ParkingNotificationsController#index
+      Search::].freeze
 
-  # Remove search matches that contain bikesController index (which are already matched)
-  # Including them for clarity/documentation
-  def searches_regex
-    SEARCHES_MATCHES.reject { |s| s.match?(/.BikesController#index/) }.join("|")
-  end
+    # Remove search matches that contain bikesController index (which are already matched)
+    # Including them for clarity/documentation
+    def searches_regex
+      SEARCHES_MATCHES.reject { |s| s.match?(/.BikesController#index/) }.join("|")
+    end
 
-  # If a time is included, it returns lines that occurred in the hour of the time
-  # If no time is included, it returns all the lines from the file
-  def rgrep_command_str(time = nil, log_path: nil)
-    log_path ||= DEFAULT_LOG_PATH
-    "rg '#{searches_regex}' '#{log_path}'" + time_rgrep(time) + " | sort -u"
-  end
+    # If a time is included, it returns lines that occurred in the hour of the time
+    # If no time is included, it returns all the lines from the file
+    def rgrep_command_str(time = nil, log_path: nil)
+      log_path ||= DEFAULT_LOG_PATH
+      "rg '#{searches_regex}' '#{log_path}'" + time_rgrep(time) + " | sort -u"
+    end
 
-  # This is for diagnostics, to count how many are returned
-  def rgrep_log_lines_count(time = nil, log_path: nil, rgrep_command: nil)
-    rgrep_command ||= rgrep_command_str(time, log_path: log_path)
-    `#{rgrep_command} | wc -l`.strip.to_i
-  end
+    # This is for diagnostics, to count how many are returned
+    def rgrep_log_lines_count(time = nil, log_path: nil, rgrep_command: nil)
+      rgrep_command ||= rgrep_command_str(time, log_path: log_path)
+      `#{rgrep_command} | wc -l`.strip.to_i
+    end
 
-  def write_log_lines(time = nil, log_path: nil, rgrep_command: nil)
-    rgrep_command ||= rgrep_command_str(time, log_path: log_path)
-    RedisPool.conn do |r|
-      r.pipelined do |pipeline|
-        IO.popen(rgrep_command) { |io| io.each { |l| pipeline.lpush(KEY, l) } }
+    def write_log_lines(time = nil, log_path: nil, rgrep_command: nil)
+      rgrep_command ||= rgrep_command_str(time, log_path: log_path)
+      RedisPool.conn do |r|
+        r.pipelined do |pipeline|
+          IO.popen(rgrep_command) { |io| io.each { |l| pipeline.lpush(KEY, l) } }
+        end
       end
     end
+
+    def get_log_line
+      RedisPool.conn { |r| r.rpop(KEY) }
+    end
+
+    def log_lines_in_redis
+      RedisPool.conn { |r| r.llen(KEY) }
+    end
+
+    #
+    # private below here
+    #
+
+    def time_rgrep(time)
+      return "" if time.blank?
+
+      " | rg '\\AI,\\s\\[#{time.utc.strftime("%Y-%m-%dT%H")}'"
+    end
+
+    conceal :time_rgrep
   end
-
-  def get_log_line
-    RedisPool.conn { |r| r.rpop(KEY) }
-  end
-
-  def log_lines_in_redis
-    RedisPool.conn { |r| r.llen(KEY) }
-  end
-
-  #
-  # private below here
-  #
-
-  def time_rgrep(time)
-    return "" if time.blank?
-
-    " | rg '\\AI,\\s\\[#{time.utc.strftime("%Y-%m-%dT%H")}'"
-  end
-
-  conceal :time_rgrep
 end

--- a/app/services/spreadsheets/manufacturers.rb
+++ b/app/services/spreadsheets/manufacturers.rb
@@ -2,75 +2,77 @@
 
 require "csv"
 
-module Spreadsheets::Manufacturers
-  extend Functionable
+module Spreadsheets
+  module Manufacturers
+    extend Functionable
 
-  EXPORT_COLUMNS = %i[name alternate_name website makes_frames ebike_only open_year close_year
-    logo_url].freeze
+    EXPORT_COLUMNS = %i[name alternate_name website makes_frames ebike_only open_year close_year
+      logo_url].freeze
 
-  def to_csv(manufacturers = nil)
-    manufacturers ||= Manufacturer.except_other
+    def to_csv(manufacturers = nil)
+      manufacturers ||= Manufacturer.except_other
 
-    CSV.generate do |csv|
-      csv << EXPORT_COLUMNS
-      manufacturers.each { csv << row_for(it) }
-    end
-  end
-
-  def import(csv)
-    CSV.foreach(csv, headers: true, header_converters: :symbol) do |row|
-      update_or_create_for!(row)
-    end
-  end
-
-  #
-  # private below here
-  #
-
-  def update_or_create_for!(row)
-    manufacturer = Manufacturer.friendly_find(row[:name])
-    manufacturer ||= Manufacturer.friendly_find(row[:alternate_name]) if row[:alternate_name].present?
-    manufacturer ||= Manufacturer.new
-    manufacturer.name = if row[:alternate_name].present?
-      "#{row[:name]} (#{row[:alternate_name]})"
-    else
-      row[:name]
-    end
-    manufacturer.frame_maker = Binxtils::InputNormalizer.boolean(row[:makes_frames])
-    manufacturer.motorized_only = Binxtils::InputNormalizer.boolean(row[:ebike_only])
-    manufacturer.open_year = row[:open_year]
-    manufacturer.close_year = row[:close_year]
-    manufacturer.website = row[:website]
-    # Ignoring logo for now
-    manufacturer.save! if manufacturer.changed?
-  end
-
-  def row_for(manufacturer)
-    export_column_methods.map do |meth|
-      next if meth.blank?
-
-      result = manufacturer.send(meth)
-      if meth == :logo_url && result == ManufacturerLogoUploader::FALLBACK_IMAGE
-        nil
-      else
-        result
+      CSV.generate do |csv|
+        csv << EXPORT_COLUMNS
+        manufacturers.each { csv << row_for(it) }
       end
     end
-  end
 
-  def export_column_methods
-    EXPORT_COLUMNS.map do |key|
-      case key
-      when :name then :short_name
-      when :alternate_name then :secondary_name
-      when :ebike_only then :motorized_only
-      when :makes_frames then :frame_maker
-      when :logo_url then :logo_url
-      else
-        key
+    def import(csv)
+      CSV.foreach(csv, headers: true, header_converters: :symbol) do |row|
+        update_or_create_for!(row)
       end
     end
-  end
 
-  conceal :update_or_create_for!, :row_for, :export_column_methods
+    #
+    # private below here
+    #
+
+    def update_or_create_for!(row)
+      manufacturer = Manufacturer.friendly_find(row[:name])
+      manufacturer ||= Manufacturer.friendly_find(row[:alternate_name]) if row[:alternate_name].present?
+      manufacturer ||= Manufacturer.new
+      manufacturer.name = if row[:alternate_name].present?
+        "#{row[:name]} (#{row[:alternate_name]})"
+      else
+        row[:name]
+      end
+      manufacturer.frame_maker = Binxtils::InputNormalizer.boolean(row[:makes_frames])
+      manufacturer.motorized_only = Binxtils::InputNormalizer.boolean(row[:ebike_only])
+      manufacturer.open_year = row[:open_year]
+      manufacturer.close_year = row[:close_year]
+      manufacturer.website = row[:website]
+      # Ignoring logo for now
+      manufacturer.save! if manufacturer.changed?
+    end
+
+    def row_for(manufacturer)
+      export_column_methods.map do |meth|
+        next if meth.blank?
+
+        result = manufacturer.send(meth)
+        if meth == :logo_url && result == ManufacturerLogoUploader::FALLBACK_IMAGE
+          nil
+        else
+          result
+        end
+      end
+    end
+
+    def export_column_methods
+      EXPORT_COLUMNS.map do |key|
+        case key
+        when :name then :short_name
+        when :alternate_name then :secondary_name
+        when :ebike_only then :motorized_only
+        when :makes_frames then :frame_maker
+        when :logo_url then :logo_url
+        else
+          key
+        end
+      end
+    end
+
+    conceal :update_or_create_for!, :row_for, :export_column_methods
+  end
 end

--- a/app/services/spreadsheets/primary_activities.rb
+++ b/app/services/spreadsheets/primary_activities.rb
@@ -2,60 +2,62 @@
 
 require "csv"
 
-module Spreadsheets::PrimaryActivities
-  extend Functionable
+module Spreadsheets
+  module PrimaryActivities
+    extend Functionable
 
-  EXPORT_COLUMNS = %i[flavor families].freeze
+    EXPORT_COLUMNS = %i[flavor families].freeze
 
-  def to_csv(primary_activities = nil)
-    primary_activities ||= PrimaryActivity.by_priority
+    def to_csv(primary_activities = nil)
+      primary_activities ||= PrimaryActivity.by_priority
 
-    CSV.generate do |csv|
-      csv << EXPORT_COLUMNS
-      names_and_families(primary_activities).each { csv << it }
-    end
-  end
-
-  def import(csv)
-    CSV.foreach(csv, headers: true, header_converters: :symbol) do |row|
-      update_or_create_for!(row)
-    end
-  end
-
-  #
-  # private below here
-  #
-
-  def names_and_families(primary_activities)
-    flavors_families = {}
-
-    primary_activities.flavor.each do |primary_activity|
-      family_name = primary_activity.top_level? ? nil : primary_activity.family_name
-      flavors_families[primary_activity.name] ||= family_name
-      next if flavors_families[primary_activity.name] == family_name
-
-      # If the name wasn't assigned in this block, add it
-      flavors_families[primary_activity.name] += " & #{family_name}"
-    end
-
-    flavors_families.to_a
-  end
-
-  def update_or_create_for!(row)
-    family_ids = if row[:families].present?
-      # Find or create the matching families
-      row[:families].split("&").map do |name|
-        PrimaryActivity.family.friendly_find(name)&.id ||
-          PrimaryActivity.create!(name:, family: true).id
+      CSV.generate do |csv|
+        csv << EXPORT_COLUMNS
+        names_and_families(primary_activities).each { csv << it }
       end
     end
-    return if row[:flavor].blank?
 
-    (family_ids || [nil]).each do |primary_activity_family_id|
-      PrimaryActivity.where(primary_activity_family_id:).friendly_find(row[:flavor]) ||
-        PrimaryActivity.create(name: row[:flavor], primary_activity_family_id:, family: false)
+    def import(csv)
+      CSV.foreach(csv, headers: true, header_converters: :symbol) do |row|
+        update_or_create_for!(row)
+      end
     end
-  end
 
-  conceal :names_and_families, :update_or_create_for!
+    #
+    # private below here
+    #
+
+    def names_and_families(primary_activities)
+      flavors_families = {}
+
+      primary_activities.flavor.each do |primary_activity|
+        family_name = primary_activity.top_level? ? nil : primary_activity.family_name
+        flavors_families[primary_activity.name] ||= family_name
+        next if flavors_families[primary_activity.name] == family_name
+
+        # If the name wasn't assigned in this block, add it
+        flavors_families[primary_activity.name] += " & #{family_name}"
+      end
+
+      flavors_families.to_a
+    end
+
+    def update_or_create_for!(row)
+      family_ids = if row[:families].present?
+        # Find or create the matching families
+        row[:families].split("&").map do |name|
+          PrimaryActivity.family.friendly_find(name)&.id ||
+            PrimaryActivity.create!(name:, family: true).id
+        end
+      end
+      return if row[:flavor].blank?
+
+      (family_ids || [nil]).each do |primary_activity_family_id|
+        PrimaryActivity.where(primary_activity_family_id:).friendly_find(row[:flavor]) ||
+          PrimaryActivity.create(name: row[:flavor], primary_activity_family_id:, family: false)
+      end
+    end
+
+    conceal :names_and_families, :update_or_create_for!
+  end
 end

--- a/app/services/spreadsheets/tsv_creator.rb
+++ b/app/services/spreadsheets/tsv_creator.rb
@@ -1,128 +1,130 @@
-class Spreadsheets::TsvCreator
-  attr_reader :file_prefix
+module Spreadsheets
+  class TsvCreator
+    attr_reader :file_prefix
 
-  def initialize
-    @file_prefix = Rails.env.test? ? "/spec/fixtures/tsv_creation/" : ""
-  end
-
-  def manufacturers_header
-    "id\ttext\tcategory\tpriority\twebsite\tlogo\n"
-  end
-
-  def stolen_header
-    "Make\tModel\tSerial\tDescription\tArticleOrGun\tDateOfTheft\tCaseNumber\tLEName\tLEContact\tComments\n"
-  end
-
-  def stolen_with_reports_header
-    "StolenCity\tStolenState\tMake\tModel\tSerial\tDescription\tDateOfTheft\tCaseNumber\tLEName\tLEContact\tComments\n"
-  end
-
-  def org_counts_header
-    "Date\tStolen?\tName\tEmail\tlink\n"
-  end
-
-  def org_count_row(bike)
-    row = bike.created_at.strftime("%m.%d.%Y")
-    row << "\t"
-    row << "true" if bike.status_stolen?
-    row << "\t"
-    row << bike.first_ownership.user&.name if bike.first_ownership.user
-    row << "\t#{bike.first_owner_email}"
-    row << "\t#{ENV["BASE_URL"]}/bikes/#{bike.id}\n"
-    row.to_s
-  end
-
-  def manufacturer_row(mnfg)
-    popularity = mnfg.bikes.count + 1
-    popularity = 500 if popularity > 500
-    popularity = 250 if popularity.between?(250, 499)
-    popularity = 100 if popularity.between?(100, 249)
-    popularity = 10 if popularity.between?(2, 99)
-    row = "#{mnfg.id}\t#{mnfg.name}\t"
-    row << (mnfg.frame_maker ? "Frame manufacturer" : "Manufacturer")
-    row << "\t"
-    row << popularity.to_s
-    row << "\t"
-    row << mnfg.website.to_s
-    row << "\t"
-    row << mnfg.logo.to_s if mnfg.logo.present?
-    row.to_s
-  end
-
-  def create_org_count(organization, start_date = nil)
-    start_date ||= Time.current.beginning_of_year
-    obikes = organization.bikes.where("bikes.created_at >= ?", start_date)
-    out_file = File.join(Rails.root, "#{@file_prefix}org_count_bikes.tsv")
-    output = File.open(out_file, "w")
-    output.puts org_counts_header
-    obikes.find_each { |b| output.puts org_count_row(b) }
-    send_to_uploader(output)
-  end
-
-  # Not tested. Needs to be tested and made useful before use
-  # def create_org_total_count(organization, start_date=nil)
-  #   return "organization has no location" unless organization.locations.present?
-  #   start_date ||= Time.current.beginning_of_year
-  #   obikes = organization.bikes.where("created_at >= ?", start_date)
-  #   organization_bikes = obikes.count
-  #   box = GeocodeHelper.bounding_box(organization.locations.first, 50)
-  #   stolen_ids = StolenRecord.within_bounding_box(box).pluck(:bike_id)
-  #   non_org_stolen_count = (stolen_ids - obikes.pluck(:ids)).count
-  # end
-
-  def create_manufacturer
-    out_file = File.join(Rails.root, "#{@file_prefix}manufacturers.tsv")
-    output = File.open(out_file, "w")
-    output.puts manufacturers_header
-    Manufacturer.all.find_each { |m| output.puts manufacturer_row(m) }
-    send_to_uploader(output)
-  end
-
-  def create_stolen(blocklist = false, stolen_records: nil)
-    stolen_records ||= StolenRecord.approveds
-    filename = "#{@file_prefix}#{"approved_" if blocklist}current_stolen_bikes.tsv"
-    out_file = File.join(Rails.root, filename)
-    output = File.open(out_file, "w")
-    output.puts stolen_header
-    stolen_records.includes(:bike).find_each do |sr|
-      output.puts sr.tsv_row if sr.tsv_row.present?
+    def initialize
+      @file_prefix = Rails.env.test? ? "/spec/fixtures/tsv_creation/" : ""
     end
-    send_to_uploader(output)
-  end
 
-  def create_stolen_with_reports(blocklist = false, stolen_records: nil)
-    stolen_records ||= StolenRecord.approveds_with_reports
-    filename = "#{@file_prefix}#{"approved_" if blocklist}current_stolen_with_reports.tsv"
-    out_file = File.join(Rails.root, filename)
-    output = File.open(out_file, "w")
-    output.puts stolen_with_reports_header
-    stolen_records.joins(:bike, :state).merge(Bike.with_known_serial).find_each do |sr|
-      next unless sr.police_report_number.present?
-
-      row = sr.tsv_row(false, with_stolen_locations: true)
-      output.puts row if row.present?
+    def manufacturers_header
+      "id\ttext\tcategory\tpriority\twebsite\tlogo\n"
     end
-    send_to_uploader(output)
-  end
 
-  def send_to_uploader(output)
-    uploader = TsvUploader.new
-    uploader.store!(output)
-    output.close
-    path = if /fog/i.match?(TsvUploader.storage.to_s) # If we're in fog, we need to open via a URL
-      uploader.url
-    else
-      uploader.current_path
+    def stolen_header
+      "Make\tModel\tSerial\tDescription\tArticleOrGun\tDateOfTheft\tCaseNumber\tLEName\tLEContact\tComments\n"
     end
-    FileCacheMaintainer.update_file_info(path)
-    output
-  end
 
-  def create_daily_tsvs
-    @file_prefix = "#{@file_prefix}#{Time.current.strftime("%Y_%-m_%-d")}_"
-    create_stolen(true, stolen_records: StolenRecord.approveds.tsv_today)
-    create_stolen_with_reports(true, stolen_records: StolenRecord.approveds_with_reports.tsv_today)
-    t = Time.current
-    StolenRecord.tsv_today.map { |sr| sr.update_attribute :tsved_at, t }
+    def stolen_with_reports_header
+      "StolenCity\tStolenState\tMake\tModel\tSerial\tDescription\tDateOfTheft\tCaseNumber\tLEName\tLEContact\tComments\n"
+    end
+
+    def org_counts_header
+      "Date\tStolen?\tName\tEmail\tlink\n"
+    end
+
+    def org_count_row(bike)
+      row = bike.created_at.strftime("%m.%d.%Y")
+      row << "\t"
+      row << "true" if bike.status_stolen?
+      row << "\t"
+      row << bike.first_ownership.user&.name if bike.first_ownership.user
+      row << "\t#{bike.first_owner_email}"
+      row << "\t#{ENV["BASE_URL"]}/bikes/#{bike.id}\n"
+      row.to_s
+    end
+
+    def manufacturer_row(mnfg)
+      popularity = mnfg.bikes.count + 1
+      popularity = 500 if popularity > 500
+      popularity = 250 if popularity.between?(250, 499)
+      popularity = 100 if popularity.between?(100, 249)
+      popularity = 10 if popularity.between?(2, 99)
+      row = "#{mnfg.id}\t#{mnfg.name}\t"
+      row << (mnfg.frame_maker ? "Frame manufacturer" : "Manufacturer")
+      row << "\t"
+      row << popularity.to_s
+      row << "\t"
+      row << mnfg.website.to_s
+      row << "\t"
+      row << mnfg.logo.to_s if mnfg.logo.present?
+      row.to_s
+    end
+
+    def create_org_count(organization, start_date = nil)
+      start_date ||= Time.current.beginning_of_year
+      obikes = organization.bikes.where("bikes.created_at >= ?", start_date)
+      out_file = File.join(Rails.root, "#{@file_prefix}org_count_bikes.tsv")
+      output = File.open(out_file, "w")
+      output.puts org_counts_header
+      obikes.find_each { |b| output.puts org_count_row(b) }
+      send_to_uploader(output)
+    end
+
+    # Not tested. Needs to be tested and made useful before use
+    # def create_org_total_count(organization, start_date=nil)
+    #   return "organization has no location" unless organization.locations.present?
+    #   start_date ||= Time.current.beginning_of_year
+    #   obikes = organization.bikes.where("created_at >= ?", start_date)
+    #   organization_bikes = obikes.count
+    #   box = GeocodeHelper.bounding_box(organization.locations.first, 50)
+    #   stolen_ids = StolenRecord.within_bounding_box(box).pluck(:bike_id)
+    #   non_org_stolen_count = (stolen_ids - obikes.pluck(:ids)).count
+    # end
+
+    def create_manufacturer
+      out_file = File.join(Rails.root, "#{@file_prefix}manufacturers.tsv")
+      output = File.open(out_file, "w")
+      output.puts manufacturers_header
+      Manufacturer.all.find_each { |m| output.puts manufacturer_row(m) }
+      send_to_uploader(output)
+    end
+
+    def create_stolen(blocklist = false, stolen_records: nil)
+      stolen_records ||= StolenRecord.approveds
+      filename = "#{@file_prefix}#{"approved_" if blocklist}current_stolen_bikes.tsv"
+      out_file = File.join(Rails.root, filename)
+      output = File.open(out_file, "w")
+      output.puts stolen_header
+      stolen_records.includes(:bike).find_each do |sr|
+        output.puts sr.tsv_row if sr.tsv_row.present?
+      end
+      send_to_uploader(output)
+    end
+
+    def create_stolen_with_reports(blocklist = false, stolen_records: nil)
+      stolen_records ||= StolenRecord.approveds_with_reports
+      filename = "#{@file_prefix}#{"approved_" if blocklist}current_stolen_with_reports.tsv"
+      out_file = File.join(Rails.root, filename)
+      output = File.open(out_file, "w")
+      output.puts stolen_with_reports_header
+      stolen_records.joins(:bike, :state).merge(Bike.with_known_serial).find_each do |sr|
+        next unless sr.police_report_number.present?
+
+        row = sr.tsv_row(false, with_stolen_locations: true)
+        output.puts row if row.present?
+      end
+      send_to_uploader(output)
+    end
+
+    def send_to_uploader(output)
+      uploader = TsvUploader.new
+      uploader.store!(output)
+      output.close
+      path = if /fog/i.match?(TsvUploader.storage.to_s) # If we're in fog, we need to open via a URL
+        uploader.url
+      else
+        uploader.current_path
+      end
+      FileCacheMaintainer.update_file_info(path)
+      output
+    end
+
+    def create_daily_tsvs
+      @file_prefix = "#{@file_prefix}#{Time.current.strftime("%Y_%-m_%-d")}_"
+      create_stolen(true, stolen_records: StolenRecord.approveds.tsv_today)
+      create_stolen_with_reports(true, stolen_records: StolenRecord.approveds_with_reports.tsv_today)
+      t = Time.current
+      StolenRecord.tsv_today.map { |sr| sr.update_attribute :tsved_at, t }
+    end
   end
 end

--- a/app/services/user_services/updator.rb
+++ b/app/services/user_services/updator.rb
@@ -1,25 +1,27 @@
-class UserServices::Updator
-  class << self
-    def assign_address_from_bikes(user, bikes: nil, save_user: false)
-      bikes ||= user.bikes
-      address_bike = bikes.with_street.first || bikes.with_location.first
-      return if address_bike.blank?
+module UserServices
+  class Updator
+    class << self
+      def assign_address_from_bikes(user, bikes: nil, save_user: false)
+        bikes ||= user.bikes
+        address_bike = bikes.with_street.first || bikes.with_location.first
+        return if address_bike.blank?
 
-      address_record = user.address_record || AddressRecord.new
-      address_record.update(
-        Geocodeable.attrs_to_duplicate(address_bike).merge(user_id: user.id, kind: :user)
-      )
-      if address_bike.address_record? && address_bike.address_record.user_id.blank?
-        address_bike.address_record.update(user_id: user.id)
+        address_record = user.address_record || AddressRecord.new
+        address_record.update(
+          Geocodeable.attrs_to_duplicate(address_bike).merge(user_id: user.id, kind: :user)
+        )
+        if address_bike.address_record? && address_bike.address_record.user_id.blank?
+          address_bike.address_record.update(user_id: user.id)
+        end
+        user.attributes = {
+          address_record_id: address_record.id,
+          latitude: address_record.latitude,
+          longitude: address_record.longitude,
+          address_set_manually: address_bike.address_set_manually
+        }
+        user.update(skip_update: true) if save_user
+        user
       end
-      user.attributes = {
-        address_record_id: address_record.id,
-        latitude: address_record.latitude,
-        longitude: address_record.longitude,
-        address_set_manually: address_bike.address_set_manually
-      }
-      user.update(skip_update: true) if save_user
-      user
     end
   end
 end


### PR DESCRIPTION
Convert ~270 files from compact (`class Foo::Bar`) to nested (`module Foo; class Bar`) module/class definitions per the [flat-modules antipattern](https://alchemists.io/articles/ruby_antipatterns#_flat_modules), and add `Style/ClassAndModuleChildren` to `.rubocop_custom.yml` to prevent regressions (rack_attack initializer is excluded since it reopens a gem class).

Also fixes constant-lookup collisions exposed by the conversion: `::Twilio::REST` in `Integrations::Twilio`, `::Stripe::Price/Product` in `Stripe::UpdatePricesJob`, and `::Time.current` in several `UI::*` files (shadowed by the `UI::Time` component). STI subclasses (ExternalRegistryBike/Credential/Client) use `class` for their parent rather than `module`.