### PR TITLE
Fix bike edit groups crash when an organization is soft-deleted

### DIFF
--- a/app/views/bikes_edit/groups.html.haml
+++ b/app/views/bikes_edit/groups.html.haml
@@ -21,6 +21,7 @@
 
               - displayed_other_organizations = false
               - @bike.bike_organizations.reorder(:created_at).each_with_index do |bike_organization, index|
+                - next if bike_organization.organization.blank?
                 - next if bike_organization.organization == @bike.creation_organization
                 - main_label = displayed_other_organizations ? nil : t(".other_organizations")
                 - displayed_other_organizations = true

--- a/spec/requests/bikes/edits_request_spec.rb
+++ b/spec/requests/bikes/edits_request_spec.rb
@@ -106,6 +106,32 @@ RSpec.describe Bikes::EditsController, type: :request do
       expect(response.body).to match(/<title>Versions: #{bike.title_string}/)
     end
   end
+  describe "groups edit_template" do
+    let(:bike) { FactoryBot.create(:bike_organized, :with_ownership_claimed, user: bike_creator) }
+    let!(:other_organization) { FactoryBot.create(:organization) }
+    let!(:other_bike_organization) { FactoryBot.create(:bike_organization, bike:, organization: other_organization) }
+
+    it "renders" do
+      get "#{base_url}/groups"
+      expect(response.status).to eq 200
+      expect(response).to render_template(:groups)
+      expect(response.body).to include(bike.creation_organization.name)
+      expect(response.body).to include(other_organization.name)
+    end
+
+    context "with a soft-deleted non-creation organization" do
+      before { other_organization.destroy }
+
+      it "renders without the deleted organization" do
+        expect(other_bike_organization.reload.organization).to be_nil
+        get "#{base_url}/groups"
+        expect(response.status).to eq 200
+        expect(response).to render_template(:groups)
+        expect(response.body).to include(bike.creation_organization.name)
+        expect(response.body).to_not include(other_organization.name)
+      end
+    end
+  end
   describe "marketplace" do
     # TODO: update when MARKETPLACE_FREE_UNTIL changes
     # it "redirects" do


### PR DESCRIPTION
- Fixes Honeybadger [#122120277](https://app.honeybadger.io/projects/35931/faults/122120277): `NoMethodError: undefined method 'id' for nil` in `_edit_bike_organization.html.haml:11`.
- `bike_organization.organization` returns nil when the organization has been soft-deleted (`acts_as_paranoid`). The existing `next if bike_organization.organization == @bike.creation_organization` only masked this when the creation org was also nil, so a live creation org plus a separate soft-deleted org crashed the groups edit view.