### PR TITLE
Fail bin/screenshot_dev on page JS console errors

### DIFF
--- a/.claude/skills/github-upload-image-to-pr/SKILL.md
+++ b/.claude/skills/github-upload-image-to-pr/SKILL.md
@@ -8,7 +8,6 @@ description: >-
   Always use this skill when the user wants to visually document changes in a pull request,
   even if they don't use the word "upload" — phrases like "put the screenshot in the PR" or
   "show the image in the PR" should trigger this skill.
-  Supports Playwright MCP (preferred) / Chrome DevTools MCP / agent-browser as browser automation backends.
 allowed-tools: Bash(agent-browser:*), Bash(gh:*), Bash(npx:*), Bash(cp:*), ToolSearch, Read, Glob, Write
 ---
 
@@ -16,11 +15,13 @@ allowed-tools: Bash(agent-browser:*), Bash(gh:*), Bash(npx:*), Bash(cp:*), ToolS
 
 Upload local images to a GitHub PR and embed them in the description or comments using browser automation tools.
 
+Supported backends: Playwright MCP (preferred), Chrome DevTools MCP, agent-browser (CLI).
+
 ## How It Works
 
 Since the GitHub API does not support direct image uploads, this skill uses the **PR comment textarea as a staging area for GitHub's image hosting** — uploading files there to obtain persistent `user-attachments/assets/` URLs, then updating the PR description or posting a comment via the `gh` CLI.
 
-## Step 0: Resolve PR context
+## Step 1: Resolve PR context
 
 If the user didn't specify a PR number or URL, auto-detect it:
 
@@ -38,7 +39,7 @@ Also, normalize the image paths to absolute paths. If a path contains special ch
 cp /path/to/CleanShot*keyword*.png /tmp/screenshot.png
 ```
 
-## Tool Detection and Selection
+## Step 2: Pick a browser tool
 
 ### Priority Order
 
@@ -68,7 +69,7 @@ claude mcp add playwright -- npx -y @playwright/mcp@latest
 
 After install, the Claude Code session must be restarted for `mcp__playwright__*` tools to register. Do not suggest Chrome DevTools MCP or agent-browser unless the user explicitly asks for an alternative.
 
-## Tool Compatibility Matrix
+### Tool Compatibility Matrix
 
 | Operation | Playwright MCP | Chrome DevTools MCP | agent-browser (CLI/Bash) |
 |-----------|----------------|---------------------|--------------------------|
@@ -80,20 +81,25 @@ After install, the Claude Code session must be restarted for `mcp__playwright__*
 | **JS Eval** | `browser_evaluate` (function) | `evaluate_script` (function) | `agent-browser eval '{js}'` |
 | **Login State** | Persists across calls; sign in once | Persists across calls; sign in once | Preserved with `--profile` |
 
-## Steps
-
-### Step 1: Navigate to PR page and check login state
+## Step 3: Navigate to PR page and check login state
 
 Navigate to the PR page and immediately take a snapshot to verify login state.
 
-```javascript
-// Playwright MCP (preferred)
+Playwright MCP (preferred):
+
+```js
 browser_navigate({ url: "https://github.com/{owner}/{repo}/pull/{number}" })
+```
 
-// Chrome DevTools MCP (fallback)
+Chrome DevTools MCP (fallback):
+
+```js
 navigate_page({ url: "https://github.com/{owner}/{repo}/pull/{number}", type: "url" })
+```
 
-// agent-browser (use --profile to persist login state)
+agent-browser — use `--profile` to persist login state:
+
+```bash
 agent-browser --headed --profile ~/.agent-browser-github open "https://github.com/{owner}/{repo}/pull/{number}"
 ```
 
@@ -104,7 +110,7 @@ agent-browser --headed --profile ~/.agent-browser-github open "https://github.co
 2. Ask the user to log in manually in the headed browser window.
 3. Wait for user confirmation, then navigate back to the PR page.
 
-### Step 2: Locate the file upload input
+## Step 4: Locate the file upload input
 
 Take a snapshot/screenshot and scroll to the bottom to find the comment area.
 
@@ -129,21 +135,19 @@ GitHub renders a file upload input in the comment form. Try these selectors in o
 
 For Playwright MCP and Chrome DevTools MCP, you can also take a snapshot to find the `ref`/`uid` of the file upload element directly.
 
-### Step 3: Upload images one by one
+## Step 5: Upload images one by one
 
 Upload each image file using the detected tool. Wait **2–3 seconds between uploads** to allow GitHub to process each file.
 
 For multiple images, upload them all to the same comment textarea before extracting URLs — this is more efficient than navigating between uploads.
 
-```javascript
-// Playwright MCP: browser_file_upload takes the element ref and file path(s) array
-// Chrome DevTools MCP: upload_file requires the uid of the input element
-// agent-browser: agent-browser upload {ref} {absolute_path}
-```
+- **Playwright MCP**: `browser_file_upload` takes the element ref and a file paths array.
+- **Chrome DevTools MCP**: `upload_file` requires the `uid` of the input element.
+- **agent-browser**: `agent-browser upload {ref} {absolute_path}`.
 
 **Important:** Always use absolute file paths.
 
-### Step 4: Retrieve uploaded image URLs
+## Step 6: Retrieve uploaded image URLs
 
 Wait **3–5 seconds** after the last upload, then read the textarea value. GitHub injects markdown image syntax like `![description](https://github.com/user-attachments/assets/...)` into the textarea:
 
@@ -168,7 +172,7 @@ The response contains URLs in the format:
 
 Extract all image URLs/markdown from the textarea value before clearing it.
 
-### Step 5: Clear the textarea (do not submit the comment)
+## Step 7: Clear the textarea (do not submit the comment)
 
 ```javascript
 // MCP-based tools
@@ -185,7 +189,7 @@ Extract all image URLs/markdown from the textarea value before clearing it.
 agent-browser eval 'const ta = document.getElementById("new_comment_field") || document.querySelector("textarea[id*=comment]"); if(ta){ta.value=""} "cleared"'
 ```
 
-### Step 6: Embed images in the PR
+## Step 8: Embed images in the PR
 
 **Option A — Update PR description** (append images to existing body):
 ```bash
@@ -203,7 +207,7 @@ gh pr comment {PR_NUMBER} --body "## Screenshots
 
 Use Option A by default unless the user explicitly asks for a comment, or if the PR description is already long and a comment would be cleaner.
 
-### Step 7: Verify the result
+## Step 9: Verify the result
 
 Reload the page and take a screenshot to confirm the images are displayed correctly.
 

--- a/bin/screenshot_dev
+++ b/bin/screenshot_dev
@@ -6,8 +6,8 @@
 #
 # Mobile uses real device emulation (viewport, DPR, touch, mobile UA) because
 # Chrome's CLI --window-size has a ~500px minimum on macOS and doesn't trigger
-# responsive CSS. --channel chrome reuses the system Chrome install; first
-# invocation downloads the playwright npm package via npx.
+# responsive CSS. --channel chrome reuses the system Chrome install; playwright
+# itself is a devDependency in package.json.
 #
 # Exits non-zero if any JS console errors or uncaught page errors occur.
 #
@@ -28,13 +28,7 @@ mkdir -p "$out_dir"
 rm -f "${out_dir}/${branch_slug}-${page_slug}"-*.png
 desktop_path="${out_dir}/${branch_slug}-${page_slug}-${timestamp}-desktop.png"
 mobile_path="${out_dir}/${branch_slug}-${page_slug}-${timestamp}-mobile.png"
-# Cache playwright in a stable location so we can require() it from node -e.
-cache_dir="${TMPDIR:-/tmp}/bikeindex_screenshot_dev"
-if [ ! -d "${cache_dir}/node_modules/playwright" ]; then
-  mkdir -p "$cache_dir"
-  (cd "$cache_dir" && npm install --silent --no-save --no-audit --no-fund --prefix "$cache_dir" playwright@latest >&2)
-fi
-NODE_PATH="${cache_dir}/node_modules" node -e "$(cat <<'JS'
+node -e "$(cat <<'JS'
 const { chromium, devices } = require('playwright');
 const [url, desktopPath, mobilePath] = process.argv.slice(1);
 (async () => {

--- a/bin/screenshot_dev
+++ b/bin/screenshot_dev
@@ -9,39 +9,58 @@
 # responsive CSS. --channel chrome reuses the system Chrome install; first
 # invocation downloads the playwright npm package via npx.
 #
+# Exits non-zero if any JS console errors or uncaught page errors occur.
+#
 # Prints the two paths on stdout, one per line.
-
 set -eu
-
 if [ $# -ne 2 ]; then
   echo "Usage: $0 <url-path> <page-slug>" >&2
   exit 1
 fi
-
 eval "$(ruby "$(dirname "$0")/env" --export)"
-
 url_path="$1"
 page_slug="$2"
 branch_slug="$(git rev-parse --abbrev-ref HEAD | tr '/' '-')"
 timestamp="$(date +%Y%m%d-%H%M%S)"
 out_dir="tmp/pr_screenshots"
 url="${BASE_URL}${url_path}"
-
 mkdir -p "$out_dir"
 rm -f "${out_dir}/${branch_slug}-${page_slug}"-*.png
-
 desktop_path="${out_dir}/${branch_slug}-${page_slug}-${timestamp}-desktop.png"
 mobile_path="${out_dir}/${branch_slug}-${page_slug}-${timestamp}-mobile.png"
-
-npx -y playwright@latest screenshot \
-  --channel chrome \
-  --viewport-size=1440,900 \
-  "$url" "$desktop_path"
-
-npx -y playwright@latest screenshot \
-  --channel chrome \
-  --device "Pixel 7" \
-  "$url" "$mobile_path"
-
+# Cache playwright in a stable location so we can require() it from node -e.
+cache_dir="${TMPDIR:-/tmp}/bikeindex_screenshot_dev"
+if [ ! -d "${cache_dir}/node_modules/playwright" ]; then
+  mkdir -p "$cache_dir"
+  (cd "$cache_dir" && npm install --silent --no-save --no-audit --no-fund --prefix "$cache_dir" playwright@latest >&2)
+fi
+NODE_PATH="${cache_dir}/node_modules" node -e "$(cat <<'JS'
+const { chromium, devices } = require('playwright');
+const [url, desktopPath, mobilePath] = process.argv.slice(1);
+(async () => {
+  const browser = await chromium.launch({ channel: 'chrome' });
+  const errors = [];
+  const capture = async (contextOptions, path, label) => {
+    const context = await browser.newContext(contextOptions);
+    const page = await context.newPage();
+    page.on('console', (msg) => { if (msg.type() === 'error') errors.push(`[${label}] console: ${msg.text()}`); });
+    page.on('pageerror', (err) => errors.push(`[${label}] pageerror: ${err.message}`));
+    console.error(`Navigating to ${url}`);
+    await page.goto(url, { waitUntil: 'load' });
+    console.error(`Capturing screenshot into ${path}`);
+    await page.screenshot({ path });
+    await context.close();
+  };
+  await capture({ viewport: { width: 1440, height: 900 } }, desktopPath, 'desktop');
+  await capture(devices['Pixel 7'], mobilePath, 'mobile');
+  await browser.close();
+  if (errors.length) {
+    console.error('Console errors detected:');
+    for (const e of errors) console.error('  ' + e);
+    process.exit(1);
+  }
+})();
+JS
+)" "$url" "$desktop_path" "$mobile_path"
 echo "$desktop_path"
 echo "$mobile_path"

--- a/bin/setup
+++ b/bin/setup
@@ -44,6 +44,13 @@ chdir APP_ROOT do
       ln_sf root_storage, "storage"
     end
 
+    # Symlink node_modules so every workspace shares one install
+    root_node_modules = File.join(root, "node_modules")
+    mkdir_p root_node_modules unless Dir.exist?(root_node_modules)
+    puts "Symlinking node_modules from #{root_node_modules}..."
+    rm_rf "node_modules"
+    ln_sf root_node_modules, "node_modules"
+
     # Copy Facebook VCR cassettes
     fb_cassettes = File.join(root, "spec/vcr_cassettes/facebook")
     if Dir.exist?(fb_cassettes)

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "devDependencies": {
         "@herb-tools/formatter": "^0.9.2",
         "@herb-tools/linter": "^0.9.2",
+        "playwright": "^1.59.1",
         "standard": "*"
       }
     },
@@ -1732,6 +1733,21 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
     "node_modules/function-bind": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
@@ -3142,6 +3158,38 @@
       "license": "MIT",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
+      "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
+      "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/possible-typed-array-names": {

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "devDependencies": {
     "@herb-tools/formatter": "^0.9.2",
     "@herb-tools/linter": "^0.9.2",
+    "playwright": "^1.59.1",
     "standard": "*"
   },
   "scripts": {


### PR DESCRIPTION
- Replace the two `npx playwright screenshot` CLI calls with a single `node -e` script that uses the Playwright API so it can subscribe to `console` (error-level) and `pageerror` events.
- Cache the playwright npm package under `$TMPDIR/bikeindex_screenshot_dev/node_modules` so subsequent runs don't reinstall.
- Preserve the original contract: same navigation/capture log lines on stderr, and the two screenshot paths on stdout.
- Exit non-zero if any console error or uncaught exception fires on either viewport, so `/pr` surfaces page JS failures instead of silently embedding a broken screenshot.
