### PR TITLE
Add bin/fix_structure for Conductor setup

### DIFF
--- a/bin/fix_structure
+++ b/bin/fix_structure
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+sed -i '' -e '/SET transaction_timeout = 0;/d' -e '/^\\restrict /d' -e '/^\\unrestrict /d' db/*.sql

--- a/conductor.json
+++ b/conductor.json
@@ -1,5 +1,5 @@
 {
-  "setup": "bin/setup",
+  "setup": "bin/setup --without_seeds && bin/fix_structure",
   "server": "bin/dev",
   "teardown": "bin/conductor_teardown"
 }


### PR DESCRIPTION
Fresh Conductor workspaces fail setup because the configured script calls a `fix_structure` zsh alias that isn't available in non-interactive shells. Adds `bin/fix_structure` (the alias's sed command, wrapped in a bash shebang) and chains it after `bin/setup --without_seeds` in `conductor.json`.

- `bin/fix_structure`: strips Postgres 17 pg_dump artifacts (`SET transaction_timeout = 0;`, `\restrict`, `\unrestrict`) from `db/*.sql`, mirroring the existing cleanup in `lib/tasks/parallel_migrate.rake`.
- `conductor.json`: setup is now `bin/setup --without_seeds && bin/fix_structure` so the cleanup runs (and is skipped if setup itself fails).
