### PR TITLE
Stagger UpdateEmailDomainJob fanout, add pg_trgm GIN indexes

### DIFF
--- a/app/jobs/update_email_domain_job.rb
+++ b/app/jobs/update_email_domain_job.rb
@@ -4,6 +4,7 @@ class UpdateEmailDomainJob < ScheduledJob
   prepend ScheduledJobRecorder
 
   CREATE_TLD_SUBDOMAIN_COUNT = 3
+  STAGGER_INTERVAL = 5.seconds
   SENDGRID_VALIDATION_KEY = ENV["SENDGRID_EMAIL_VALIDATION_KEY"].freeze
   VALIDATE_WITH_SENDGRID = EmailDomain::VERIFICATION_ENABLED && SENDGRID_VALIDATION_KEY.present?
   SENDGRID_VALIDATION_URL = "https://api.sendgrid.com/v3/validations/email"
@@ -48,7 +49,7 @@ class UpdateEmailDomainJob < ScheduledJob
       email_domain.calculated_users.find_each { |user| user.really_destroy! }
     elsif email_domain.provisional_ban? && email_domain.tld_matches_subdomains?
       email_domain.calculated_subdomains.where.not(status: email_domain.status).pluck(:id)
-        .each { UpdateEmailDomainJob.perform_async(it) }
+        .each_with_index { |id, inx| UpdateEmailDomainJob.perform_in(STAGGER_INTERVAL * inx, id) }
     end
     email_domain
   end
@@ -56,7 +57,9 @@ class UpdateEmailDomainJob < ScheduledJob
   private
 
   def enqueue_workers
-    EmailDomain.pluck(:id).each { |id| self.class.perform_async(id) }
+    EmailDomain.pluck(:id).each_with_index do |id, inx|
+      self.class.perform_in(STAGGER_INTERVAL * inx, id)
+    end
   end
 
   def calculated_data(email_domain)

--- a/app/models/ambassador.rb
+++ b/app/models/ambassador.rb
@@ -58,6 +58,7 @@
 #  index_users_on_address_record_id         (address_record_id)
 #  index_users_on_auth_token                (auth_token)
 #  index_users_on_email                     (email) WHERE (deleted_at IS NULL)
+#  index_users_on_email_trgm                (email) WHERE (deleted_at IS NULL) USING gin
 #  index_users_on_token_for_password_reset  (token_for_password_reset)
 #  index_users_on_username                  (username) WHERE (deleted_at IS NULL)
 #

--- a/app/models/b_param.rb
+++ b/app/models/b_param.rb
@@ -22,8 +22,9 @@
 #
 # Indexes
 #
-#  index_b_params_on_created_bike_id  (created_bike_id)
-#  index_b_params_on_organization_id  (organization_id)
+#  index_b_params_on_bike_owner_email_trgm  ((((params -> 'bike'::text) ->> 'owner_email'::text)) gin_trgm_ops) USING gin
+#  index_b_params_on_created_bike_id        (created_bike_id)
+#  index_b_params_on_organization_id        (organization_id)
 #
 
 # b_param stands for Bike param

--- a/app/models/bike.rb
+++ b/app/models/bike.rb
@@ -85,6 +85,7 @@
 #  index_bikes_on_lower_mnfg_name            (lower((mnfg_name)::text))
 #  index_bikes_on_manufacturer_id            (manufacturer_id)
 #  index_bikes_on_model_audit_id             (model_audit_id) WHERE (model_audit_id IS NOT NULL)
+#  index_bikes_on_owner_email_trgm           (owner_email) USING gin
 #  index_bikes_on_paint_id                   (paint_id) WHERE (paint_id IS NOT NULL)
 #  index_bikes_on_primary_activity_id        (primary_activity_id) WHERE (primary_activity_id IS NOT NULL)
 #  index_bikes_on_primary_frame_color_id     (primary_frame_color_id)

--- a/app/models/email_domain.rb
+++ b/app/models/email_domain.rb
@@ -18,7 +18,8 @@
 #
 # Indexes
 #
-#  index_email_domains_on_creator_id  (creator_id)
+#  index_email_domains_on_creator_id   (creator_id)
+#  index_email_domains_on_domain_trgm  (domain) USING gin
 #
 class EmailDomain < ApplicationRecord
   include StatusHumanizable

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -23,6 +23,7 @@
 # Indexes
 #
 #  index_notifications_on_bike_id                            (bike_id)
+#  index_notifications_on_message_channel_target_trgm        (message_channel_target) USING gin
 #  index_notifications_on_notifiable_type_and_notifiable_id  (notifiable_type,notifiable_id)
 #  index_notifications_on_user_id                            (user_id)
 #

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -58,6 +58,7 @@
 #  index_users_on_address_record_id         (address_record_id)
 #  index_users_on_auth_token                (auth_token)
 #  index_users_on_email                     (email) WHERE (deleted_at IS NULL)
+#  index_users_on_email_trgm                (email) WHERE (deleted_at IS NULL) USING gin
 #  index_users_on_token_for_password_reset  (token_for_password_reset)
 #  index_users_on_username                  (username) WHERE (deleted_at IS NULL)
 #

--- a/db/migrate/20260424000001_enable_pg_trgm.rb
+++ b/db/migrate/20260424000001_enable_pg_trgm.rb
@@ -1,0 +1,5 @@
+class EnablePgTrgm < ActiveRecord::Migration[8.1]
+  def change
+    enable_extension :pg_trgm
+  end
+end

--- a/db/migrate/20260424000002_add_trigram_indexes_for_email_domain_queries.rb
+++ b/db/migrate/20260424000002_add_trigram_indexes_for_email_domain_queries.rb
@@ -1,0 +1,43 @@
+class AddTrigramIndexesForEmailDomainQueries < ActiveRecord::Migration[8.1]
+  disable_ddl_transaction!
+
+  def up
+    add_index :email_domains, :domain,
+      using: :gin, opclass: :gin_trgm_ops,
+      name: :index_email_domains_on_domain_trgm,
+      algorithm: :concurrently, if_not_exists: true
+
+    add_index :users, :email,
+      using: :gin, opclass: :gin_trgm_ops,
+      where: "deleted_at IS NULL",
+      name: :index_users_on_email_trgm,
+      algorithm: :concurrently, if_not_exists: true
+
+    add_index :bikes, :owner_email,
+      using: :gin, opclass: :gin_trgm_ops,
+      name: :index_bikes_on_owner_email_trgm,
+      algorithm: :concurrently, if_not_exists: true
+
+    add_index :notifications, :message_channel_target,
+      using: :gin, opclass: :gin_trgm_ops,
+      name: :index_notifications_on_message_channel_target_trgm,
+      algorithm: :concurrently, if_not_exists: true
+
+    execute <<~SQL.squish
+      CREATE INDEX CONCURRENTLY IF NOT EXISTS index_b_params_on_bike_owner_email_trgm
+      ON b_params USING gin ((params -> 'bike' ->> 'owner_email') gin_trgm_ops)
+    SQL
+  end
+
+  def down
+    execute "DROP INDEX CONCURRENTLY IF EXISTS index_b_params_on_bike_owner_email_trgm"
+    remove_index :notifications, name: :index_notifications_on_message_channel_target_trgm,
+      algorithm: :concurrently, if_exists: true
+    remove_index :bikes, name: :index_bikes_on_owner_email_trgm,
+      algorithm: :concurrently, if_exists: true
+    remove_index :users, name: :index_users_on_email_trgm,
+      algorithm: :concurrently, if_exists: true
+    remove_index :email_domains, name: :index_email_domains_on_domain_trgm,
+      algorithm: :concurrently, if_exists: true
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -37,6 +37,20 @@ CREATE EXTENSION IF NOT EXISTS pg_stat_statements WITH SCHEMA public;
 COMMENT ON EXTENSION pg_stat_statements IS 'track planning and execution statistics of all SQL statements executed';
 
 
+--
+-- Name: pg_trgm; Type: EXTENSION; Schema: -; Owner: -
+--
+
+CREATE EXTENSION IF NOT EXISTS pg_trgm WITH SCHEMA public;
+
+
+--
+-- Name: EXTENSION pg_trgm; Type: COMMENT; Schema: -; Owner: -
+--
+
+COMMENT ON EXTENSION pg_trgm IS 'text similarity measurement and index searching based on trigrams';
+
+
 SET default_tablespace = '';
 
 SET default_table_access_method = heap;
@@ -5816,6 +5830,13 @@ CREATE UNIQUE INDEX index_ambassador_tasks_on_title ON public.ambassador_tasks U
 
 
 --
+-- Name: index_b_params_on_bike_owner_email_trgm; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_b_params_on_bike_owner_email_trgm ON public.b_params USING gin ((((params -> 'bike'::text) ->> 'owner_email'::text)) public.gin_trgm_ops);
+
+
+--
 -- Name: index_b_params_on_created_bike_id; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -6124,6 +6145,13 @@ CREATE INDEX index_bikes_on_model_audit_id ON public.bikes USING btree (model_au
 
 
 --
+-- Name: index_bikes_on_owner_email_trgm; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_bikes_on_owner_email_trgm ON public.bikes USING gin (owner_email public.gin_trgm_ops);
+
+
+--
 -- Name: index_bikes_on_paint_id; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -6219,6 +6247,13 @@ CREATE INDEX index_email_bans_on_user_id ON public.email_bans USING btree (user_
 --
 
 CREATE INDEX index_email_domains_on_creator_id ON public.email_domains USING btree (creator_id);
+
+
+--
+-- Name: index_email_domains_on_domain_trgm; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_email_domains_on_domain_trgm ON public.email_domains USING gin (domain public.gin_trgm_ops);
 
 
 --
@@ -6688,6 +6723,13 @@ CREATE INDEX index_normalized_serial_segments_on_segment ON public.normalized_se
 --
 
 CREATE INDEX index_notifications_on_bike_id ON public.notifications USING btree (bike_id);
+
+
+--
+-- Name: index_notifications_on_message_channel_target_trgm; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_notifications_on_message_channel_target_trgm ON public.notifications USING gin (message_channel_target public.gin_trgm_ops);
 
 
 --
@@ -7370,6 +7412,13 @@ CREATE INDEX index_users_on_email ON public.users USING btree (email) WHERE (del
 
 
 --
+-- Name: index_users_on_email_trgm; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_users_on_email_trgm ON public.users USING gin (email public.gin_trgm_ops) WHERE (deleted_at IS NULL);
+
+
+--
 -- Name: index_users_on_token_for_password_reset; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -7476,6 +7525,8 @@ ALTER TABLE ONLY public.ambassador_task_assignments
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20260424000002'),
+('20260424000001'),
 ('20260412183446'),
 ('20260401211310'),
 ('20260331160943'),

--- a/spec/jobs/update_email_domain_job_spec.rb
+++ b/spec/jobs/update_email_domain_job_spec.rb
@@ -9,6 +9,19 @@ RSpec.describe UpdateEmailDomainJob, type: :lib do
     expect(described_class.frequency).to be > 20.hours
   end
 
+  describe "enqueue_workers" do
+    let!(:email_domains) { FactoryBot.create_list(:email_domain, 3) }
+
+    it "staggers per-domain jobs to avoid overwhelming the database" do
+      Sidekiq::Job.clear_all
+      described_class.new.perform
+      jobs = described_class.jobs.sort_by { |j| j["at"] || 0 }
+      expect(jobs.map { |j| j["args"] }.flatten).to eq(email_domains.map(&:id))
+      ats = jobs.map { |j| j["at"] || Time.current.to_f }
+      expect(ats.each_cons(2).map { |a, b| (b - a).round }).to all(eq(described_class::STAGGER_INTERVAL.to_i))
+    end
+  end
+
   describe "perform" do
     let(:instance) { described_class.new }
     let!(:user) { FactoryBot.create(:user_confirmed, email: "example@#{user_domain}") }


### PR DESCRIPTION
`UpdateEmailDomainJob` was fanning out one `perform_async` per `EmailDomain`, and each worker ran several leading-wildcard `ILIKE`/`LIKE` queries against `users`, `bikes`, `b_params`, and `notifications` with no supporting indexes — combined load drove the primary database to ~3.5x capacity.

- `enqueue_workers` and the per-tld subdomain fanout now space jobs via `perform_in` at `STAGGER_INTERVAL` (5s) increments instead of all-at-once.
- Enable `pg_trgm` and add GIN trigram indexes on `email_domains.domain`, `users.email` (partial `WHERE deleted_at IS NULL` to mirror the existing btree), `bikes.owner_email`, `notifications.message_channel_target`, and a functional index on `b_params (params -> 'bike' ->> 'owner_email')` — these cover every leading-wildcard search the job runs per execution.
- Indexes are added concurrently and the migration is reversible.
