### PR TITLE
Order EmailDomain ids in UpdateEmailDomainJob fanout

### DIFF
--- a/app/jobs/update_email_domain_job.rb
+++ b/app/jobs/update_email_domain_job.rb
@@ -57,7 +57,7 @@ class UpdateEmailDomainJob < ScheduledJob
   private
 
   def enqueue_workers
-    EmailDomain.pluck(:id).each_with_index do |id, inx|
+    EmailDomain.order(:id).pluck(:id).each_with_index do |id, inx|
       self.class.perform_in(STAGGER_INTERVAL * inx, id)
     end
   end


### PR DESCRIPTION
`UpdateEmailDomainJob#enqueue_workers` plucked `EmailDomain` ids without an `ORDER BY`, so Postgres was free to return them in any order. That flaked the staggering spec when rows came back permuted, and made the production fanout order non-deterministic. Adding `.order(:id)` fixes both.
