### PR TITLE
Add indexes for pghero slow queries (b_params.email, customer_contacts.bike_id)

### DIFF
--- a/app/models/b_param.rb
+++ b/app/models/b_param.rb
@@ -24,6 +24,7 @@
 #
 #  index_b_params_on_bike_owner_email_trgm  ((((params -> 'bike'::text) ->> 'owner_email'::text)) gin_trgm_ops) USING gin
 #  index_b_params_on_created_bike_id        (created_bike_id)
+#  index_b_params_on_email_trgm             (email) WHERE (created_bike_id IS NULL) USING gin
 #  index_b_params_on_organization_id        (organization_id)
 #
 

--- a/app/models/customer_contact.rb
+++ b/app/models/customer_contact.rb
@@ -16,6 +16,10 @@
 #  creator_id    :integer
 #  user_id       :integer
 #
+# Indexes
+#
+#  index_customer_contacts_on_bike_id  (bike_id)
+#
 class CustomerContact < ApplicationRecord
   KIND_ENUM = {
     stolen_contact: 0,

--- a/db/migrate/20260425103043_add_indexes_for_slow_queries.rb
+++ b/db/migrate/20260425103043_add_indexes_for_slow_queries.rb
@@ -1,0 +1,22 @@
+class AddIndexesForSlowQueries < ActiveRecord::Migration[8.1]
+  disable_ddl_transaction!
+
+  def up
+    add_index :b_params, :email,
+      using: :gin, opclass: :gin_trgm_ops,
+      where: "created_bike_id IS NULL",
+      name: :index_b_params_on_email_trgm,
+      algorithm: :concurrently, if_not_exists: true
+
+    add_index :customer_contacts, :bike_id,
+      algorithm: :concurrently, if_not_exists: true
+  end
+
+  def down
+    remove_index :customer_contacts, :bike_id,
+      algorithm: :concurrently, if_exists: true
+
+    remove_index :b_params, name: :index_b_params_on_email_trgm,
+      algorithm: :concurrently, if_exists: true
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -5844,6 +5844,13 @@ CREATE INDEX index_b_params_on_created_bike_id ON public.b_params USING btree (c
 
 
 --
+-- Name: index_b_params_on_email_trgm; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_b_params_on_email_trgm ON public.b_params USING gin (email public.gin_trgm_ops) WHERE (created_bike_id IS NULL);
+
+
+--
 -- Name: index_b_params_on_organization_id; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -6233,6 +6240,13 @@ CREATE INDEX index_components_on_bike_version_id ON public.components USING btre
 --
 
 CREATE INDEX index_components_on_manufacturer_id ON public.components USING btree (manufacturer_id);
+
+
+--
+-- Name: index_customer_contacts_on_bike_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_customer_contacts_on_bike_id ON public.customer_contacts USING btree (bike_id);
 
 
 --
@@ -7525,6 +7539,7 @@ ALTER TABLE ONLY public.ambassador_task_assignments
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20260425103043'),
 ('20260424000002'),
 ('20260424000001'),
 ('20260412183446'),


### PR DESCRIPTION
Adds two indexes to address the top pghero slow queries.

- `index_b_params_on_email_trgm` — partial GIN trigram index on `b_params.email` (where `created_bike_id IS NULL`) to back the partial-registration `email_search` ilike scope (~2.6 min/day in pghero).
- `index_customer_contacts_on_bike_id` — btree index on `customer_contacts.bike_id`. The table previously had no indexes, so `CustomerContact.possibly_found_notification_sent?` was sequential-scanning on every call (~1k calls/day).

The other slow queries on `bikes` (default-scope `listing_order DESC`) are bottlenecked by deep `OFFSET` rather than a missing index, and the `organization_model_audits` DISTINCT scan is already covered by the existing `organization_id` btree.
