### PR TITLE
Add partial indexes to strava_requests for hot pghero queries

### DIFF
--- a/app/models/strava_request.rb
+++ b/app/models/strava_request.rb
@@ -20,8 +20,10 @@
 #
 # Indexes
 #
+#  index_strava_requests_on_requested_at_with_rate_limit            (requested_at) WHERE (rate_limit IS NOT NULL)
 #  index_strava_requests_on_strava_integration_id_and_requested_at  (strava_integration_id,requested_at)
 #  index_strava_requests_on_user_id                                 (user_id)
+#  index_strava_requests_pending_on_integration_id_request_type     (strava_integration_id,request_type) WHERE (response_status = 0)
 #
 class StravaRequest < AnalyticsRecord
   REQUEST_TYPE_ENUM = {

--- a/db/analytics_migrate/20260425121709_add_partial_indexes_to_strava_requests.rb
+++ b/db/analytics_migrate/20260425121709_add_partial_indexes_to_strava_requests.rb
@@ -1,0 +1,26 @@
+class AddPartialIndexesToStravaRequests < ActiveRecord::Migration[8.1]
+  disable_ddl_transaction!
+
+  def up
+    add_index :strava_requests, :requested_at,
+      order: {requested_at: :desc},
+      where: "rate_limit IS NOT NULL",
+      name: :index_strava_requests_on_requested_at_with_rate_limit,
+      algorithm: :concurrently, if_not_exists: true
+
+    add_index :strava_requests, [:strava_integration_id, :request_type],
+      where: "response_status = 0",
+      name: :index_strava_requests_pending_on_integration_id_request_type,
+      algorithm: :concurrently, if_not_exists: true
+  end
+
+  def down
+    remove_index :strava_requests,
+      name: :index_strava_requests_pending_on_integration_id_request_type,
+      algorithm: :concurrently, if_exists: true
+
+    remove_index :strava_requests,
+      name: :index_strava_requests_on_requested_at_with_rate_limit,
+      algorithm: :concurrently, if_exists: true
+  end
+end

--- a/db/analytics_structure.sql
+++ b/db/analytics_structure.sql
@@ -315,6 +315,13 @@ CREATE INDEX index_organization_statuses_on_organization_id ON public.organizati
 
 
 --
+-- Name: index_strava_requests_on_requested_at_with_rate_limit; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_strava_requests_on_requested_at_with_rate_limit ON public.strava_requests USING btree (requested_at DESC) WHERE (rate_limit IS NOT NULL);
+
+
+--
 -- Name: index_strava_requests_on_strava_integration_id_and_requested_at; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -326,6 +333,13 @@ CREATE INDEX index_strava_requests_on_strava_integration_id_and_requested_at ON 
 --
 
 CREATE INDEX index_strava_requests_on_user_id ON public.strava_requests USING btree (user_id);
+
+
+--
+-- Name: index_strava_requests_pending_on_integration_id_request_type; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_strava_requests_pending_on_integration_id_request_type ON public.strava_requests USING btree (strava_integration_id, request_type) WHERE (response_status = 0);
 
 
 --
@@ -342,6 +356,7 @@ CREATE INDEX index_versions_on_item_type_and_item_id ON public.versions USING bt
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20260425121709'),
 ('20260318174948'),
 ('20260306001002'),
 ('20260303050228'),


### PR DESCRIPTION
Adds two partial indexes on the analytics `strava_requests` table to address the top two slow queries flagged in pghero.

- `index_strava_requests_on_requested_at_with_rate_limit` — `(requested_at DESC) WHERE rate_limit IS NOT NULL` — covers `StravaRequest.estimated_current_rate_limit`, called every 15s by the request enqueuer and on every proxy request (~50ms × 842 calls).
- `index_strava_requests_pending_on_integration_id_request_type` — `(strava_integration_id, request_type) WHERE response_status = 0` — covers the per-batch `DISTINCT strava_integration_id` lookup in `ScheduledRequestEnqueuer#ensure_valid_tokens_for_batch` (~25ms × 522 calls).

Both indexes are partial to stay small relative to the table. Migration uses `algorithm: :concurrently` with `if_not_exists`/`if_exists`.
