### PR TITLE
Cache Bike.current.count callers to cut replica load

### DIFF
--- a/app/controllers/api/v3/search.rb
+++ b/app/controllers/api/v3/search.rb
@@ -81,22 +81,23 @@ module API
         get "/count" do
           max_limit = 11_000
           ActiveRecord::Base.connected_to(role: :reading) do
-            # Doing extra stuff to make this query more efficient, since this is called all the time
             interpreted_params = BikeSearchable.searchable_interpreted_params(params.merge(stolenness: "proximity"), ip: forwarded_ip_address)
-            # Un-scope to remove the unnecessary eager loading
-            bikes = Bike.unscoped.current.search(interpreted_params.merge(stolenness: "all"))
-            # And then execute the specific BikeSearchable#search_matching_stolenness query for each
-            proximity = if interpreted_params[:bounding_box].present?
-              bikes.stolen_or_impounded.within_bounding_box(interpreted_params[:bounding_box]).limit(max_limit).count
-            else # we're probably in testing, but regardless, just skip
-              0
+            Rails.cache.fetch(["api/v3/search/count", interpreted_params], expires_in: 5.minutes) do
+              # Un-scope to remove the unnecessary eager loading
+              bikes = Bike.unscoped.current.search(interpreted_params.merge(stolenness: "all"))
+              # And then execute the specific BikeSearchable#search_matching_stolenness query for each
+              proximity = if interpreted_params[:bounding_box].present?
+                bikes.stolen_or_impounded.within_bounding_box(interpreted_params[:bounding_box]).limit(max_limit).count
+              else # we're probably in testing, but regardless, just skip
+                0
+              end
+              {
+                non: bikes.status_with_owner.limit(max_limit).count,
+                stolen: bikes.stolen_or_impounded.limit(max_limit).count,
+                proximity:,
+                for_sale: bikes.for_sale.limit(max_limit).count
+              }
             end
-            {
-              non: bikes.status_with_owner.limit(max_limit).count,
-              stolen: bikes.stolen_or_impounded.limit(max_limit).count,
-              proximity:,
-              for_sale: bikes.for_sale.limit(max_limit).count
-            }
           end
         end
 

--- a/app/views/info/about.html.haml
+++ b/app/views/info/about.html.haml
@@ -1,5 +1,5 @@
-- bikes_count = number_with_precision(Bike.count.round(-3), precision: 0, delimiter: ",")
-- partners_count = number_with_precision(Organization.count.round(-1), precision: 0, delimiter: ",")
+- bikes_count = number_with_precision(Counts.total_bikes.round(-3), precision: 0, delimiter: ",")
+- partners_count = number_with_precision(Counts.organizations.round(-1), precision: 0, delimiter: ",")
 - nonprofit_blog_link = link_to(t(".nonprofit_status"), news_path("bike-index--now-a-nonprofit"))
 
 %h1= t(".about_bike_index")

--- a/spec/requests/api/v3/search_request_spec.rb
+++ b/spec/requests/api/v3/search_request_spec.rb
@@ -193,6 +193,8 @@ RSpec.describe "Search API V3", type: :request do
   end
 
   describe "/count" do
+    before { Rails.cache.clear }
+
     context "incorrect stolenness value" do
       it "returns an error message" do
         get "/api/v3/search/count", params: {stolenness: "something else", format: :json}


### PR DESCRIPTION
Caches the `Bike.current.count` queries that dominated the read-replica's pghero slow-query report (~3 minutes of replica time per day across the top three queries).

- `info/about` view now reads `Counts.total_bikes` / `Counts.organizations` (already refreshed hourly by `UpdateCountsJob`) instead of running `Bike.count` / `Organization.count` on every page load.
- `api/v3/search/count` wraps its 4 count queries in a 5-minute `Rails.cache.fetch` keyed by `interpreted_params`, so repeat calls with the same search params (including the same geocoded bounding box) are served from cache.
- Spec adds `Rails.cache.clear` before each `/count` example to keep tests isolated under the file-store cache used in test env.
