### PR TITLE
Add partial index for Bike.current and route searches to read replica

### DIFF
--- a/app/controllers/bike_versions_controller.rb
+++ b/app/controllers/bike_versions_controller.rb
@@ -2,6 +2,7 @@ class BikeVersionsController < ApplicationController
   before_action :render_ad, only: %i[index show]
   before_action :find_bike_version, except: %i[index create]
   before_action :ensure_user_allowed_to_edit_version, except: %i[index show create]
+  around_action :set_reading_role, only: :index
 
   def index
     @interpreted_params = BikeSearchable.searchable_interpreted_params(permitted_search_params)

--- a/app/controllers/org_public/impounded_bikes_controller.rb
+++ b/app/controllers/org_public/impounded_bikes_controller.rb
@@ -3,6 +3,7 @@ module OrgPublic
     include Binxtils::SortableTable
 
     before_action :ensure_public_impound_bikes!
+    around_action :set_reading_role
 
     def index
       @per_page = permitted_per_page

--- a/app/controllers/organized/graduated_notifications_controller.rb
+++ b/app/controllers/organized/graduated_notifications_controller.rb
@@ -5,6 +5,7 @@ module Organized
     before_action :ensure_access_to_graduated_notifications!
 
     before_action :find_graduated_notification, except: [:index]
+    around_action :set_reading_role, only: :index
 
     def index
       @per_page = permitted_per_page

--- a/app/controllers/organized/impound_records_controller.rb
+++ b/app/controllers/organized/impound_records_controller.rb
@@ -6,7 +6,6 @@ module Organized
     DEFAULT_DISTANCE = 1
 
     before_action :find_impound_record, except: [:index]
-    around_action :set_reading_role, only: :index
 
     def index
       @per_page = permitted_per_page

--- a/app/controllers/organized/impound_records_controller.rb
+++ b/app/controllers/organized/impound_records_controller.rb
@@ -6,6 +6,7 @@ module Organized
     DEFAULT_DISTANCE = 1
 
     before_action :find_impound_record, except: [:index]
+    around_action :set_reading_role, only: :index
 
     def index
       @per_page = permitted_per_page

--- a/app/controllers/organized/parking_notifications_controller.rb
+++ b/app/controllers/organized/parking_notifications_controller.rb
@@ -5,6 +5,7 @@ module Organized
 
     DEFAULT_PER_PAGE = 200
     before_action :ensure_access_to_parking_notifications!, only: %i[index create]
+    around_action :set_reading_role, only: :index
 
     before_action :set_failed_and_repeated_ivars
 

--- a/app/controllers/organized/registrations_controller.rb
+++ b/app/controllers/organized/registrations_controller.rb
@@ -5,6 +5,7 @@ module Organized
     SORTABLE_COLUMNS = %w[id updated_by_user_at owner_email mnfg_name frame_model cycle_type propulsion_type]
 
     skip_before_action :ensure_not_ambassador_organization!, only: [:multi_search, :multi_search_response]
+    around_action :set_reading_role, only: :multi_search_response
 
     def index
       set_period

--- a/app/controllers/stolen_bike_listings_controller.rb
+++ b/app/controllers/stolen_bike_listings_controller.rb
@@ -1,6 +1,8 @@
 class StolenBikeListingsController < ApplicationController
   include Binxtils::SortableTable
 
+  around_action :set_reading_role
+
   def index
     @render_info = calculated_render_info
     if @render_info

--- a/app/models/bike.rb
+++ b/app/models/bike.rb
@@ -72,6 +72,7 @@
 #
 # Indexes
 #
+#  index_bikes_current_listing_order         (listing_order) WHERE ((example = false) AND (user_hidden = false) AND (likely_spam = false) AND (deleted_at IS NULL))
 #  index_bikes_on_address_record_id          (address_record_id) WHERE (address_record_id IS NOT NULL)
 #  index_bikes_on_creation_organization_id   (creation_organization_id) WHERE (creation_organization_id IS NOT NULL)
 #  index_bikes_on_current_impound_record_id  (current_impound_record_id) WHERE (current_impound_record_id IS NOT NULL)

--- a/db/migrate/20260425000001_add_partial_index_for_current_bikes_listing_order.rb
+++ b/db/migrate/20260425000001_add_partial_index_for_current_bikes_listing_order.rb
@@ -1,0 +1,16 @@
+class AddPartialIndexForCurrentBikesListingOrder < ActiveRecord::Migration[8.1]
+  disable_ddl_transaction!
+
+  def up
+    add_index :bikes, :listing_order,
+      order: {listing_order: :desc},
+      where: "example = false AND user_hidden = false AND likely_spam = false AND deleted_at IS NULL",
+      name: :index_bikes_current_listing_order,
+      algorithm: :concurrently, if_not_exists: true
+  end
+
+  def down
+    remove_index :bikes, name: :index_bikes_current_listing_order,
+      algorithm: :concurrently, if_exists: true
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -6054,6 +6054,13 @@ CREATE INDEX index_bike_versions_on_tertiary_frame_color_id ON public.bike_versi
 
 
 --
+-- Name: index_bikes_current_listing_order; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_bikes_current_listing_order ON public.bikes USING btree (listing_order DESC) WHERE ((example = false) AND (user_hidden = false) AND (likely_spam = false) AND (deleted_at IS NULL));
+
+
+--
 -- Name: index_bikes_on_address_record_id; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -7525,6 +7532,7 @@ ALTER TABLE ONLY public.ambassador_task_assignments
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20260425000001'),
 ('20260424000002'),
 ('20260424000001'),
 ('20260412183446'),


### PR DESCRIPTION
Address the pghero-flagged 530ms `Bike.current` listing query. The existing `index_bikes_on_listing_order` had no filter, so Postgres walked it in order and re-checked the four boolean filters on the heap for every row — costly under OFFSET pagination.

- Add partial index `index_bikes_current_listing_order` on `bikes (listing_order DESC) WHERE example=false AND user_hidden=false AND likely_spam=false AND deleted_at IS NULL`. Created concurrently and reversible. Matches `Bike.current` exactly, so every public bike listing benefits.
- Wrap the remaining bike-search controller actions in `connected_to(role: :reading)`: `stolen_bike_listings`, `org_public/impounded_bikes`, and the index actions of `bike_versions`, `organized/graduated_notifications`, `organized/impound_records`, `organized/parking_notifications`, plus `organized/registrations#multi_search_response`.
- Skipped `organized/registrations#index` (writes via `create_export?`) and `api/v3/search#external_registries` (writes via `find_or_search_registry_for`); the other `api/v3/search` endpoints were already wrapped.

If pghero shows the query still slow after this lands, the next step is a cursor parameter on `/api/v3/search` for deep paginators — the partial index is still O(offset).
