### PR TITLE
rspec-testing skill: always fix failing tests

### DIFF
--- a/.claude/skills/rspec-testing/SKILL.md
+++ b/.claude/skills/rspec-testing/SKILL.md
@@ -21,6 +21,10 @@ This project uses RSpec. All business logic should be tested.
 - Avoid mocking objects.
   - If making external requests, use VCR. Don't manually write VCR cassettes — record them by running the tests.
 
+## Always fix failing tests
+
+Fix every failing test, even ones that were already failing on `main`. Confirming a failure pre-dates your branch (via `git stash` or checking out `main`) explains *what* broke — not whether you fix it. You fix it.
+
 ## Structuring with `context` and `let`
 
 Use `context` and `let` to isolate what varies between examples. Each `it` block should live in a `context` that names the condition, with `let` overrides for only what differs in that case. **Avoid repeating setup across sibling `it` blocks.**


### PR DESCRIPTION
Adds a short "Always fix failing tests" section to the rspec-testing skill — never excuse a red test as pre-existing on `main`. Reproducing on `main` (via `git stash` or checkout) explains *what* broke, not whether you fix it.

Validated against three skill-creator eval prompts (model spec, refactor, request spec); the with-skill outputs received "Looks great" / "good" qualitative review; the structural shared-`let` pattern remains the load-bearing thing the skill teaches. The eval prompts and iteration-1 workspace aren't included here — they were development artifacts; preserved in the branch's reflog if needed.
