### PR TITLE
UI::PeriodSelect: own custom-range form submit in Stimulus

### DIFF
--- a/.claude/skills/rspec-testing/SKILL.md
+++ b/.claude/skills/rspec-testing/SKILL.md
@@ -21,6 +21,16 @@ This project uses RSpec. All business logic should be tested.
 - Avoid mocking objects.
   - If making external requests, use VCR. Don't manually write VCR cassettes — record them by running the tests.
 
+## Don't weaken assertions to make a failing test pass
+
+When a test goes red, the default move is **investigate why**, not edit the assertion to match the new output. Watch for these tempting "fixes" that are actually erasing signal:
+
+- Changing an expected value to whatever the page/chart/response now happens to render (e.g. `0` → `null`, an exact count → a range, a specific string → a substring/regex).
+- Loosening `eq` to `include`, dropping `count:` constraints, or replacing `expect(...).to ...` with `expect(...).not_to be_nil`.
+- Deleting the assertion entirely with a "looks unrelated" handwave.
+
+The right loop: reproduce the failure, figure out *what* changed and *why*, then decide intentionally — fix the code if the original assertion captured the right behavior, or update the assertion (with a comment) if the behavior intentionally changed. If you're about to change a test "to make it easier", stop and explain why the new expectation is correct, not just convenient.
+
 ## Structuring with `context` and `let`
 
 Use `context` and `let` to isolate what varies between examples. Each `it` block should live in a `context` that names the condition, with `let` overrides for only what differs in that case. **Avoid repeating setup across sibling `it` blocks.**

--- a/app/assets/tailwind/application.css
+++ b/app/assets/tailwind/application.css
@@ -90,8 +90,8 @@
 
   .twdropdown li[role="menuitem"] > a.active,
   .twdropdown li[role="menuitem"] > a:active {
-    @apply tw:bg-gray-100 tw:font-semibold tw:text-gray-900
-      tw:dark:bg-gray-700 tw:dark:text-gray-100;
+    @apply tw:bg-gray-200 tw:font-semibold tw:text-gray-900
+      tw:dark:bg-gray-600 tw:dark:text-gray-100;
   }
 
   .twdropdown li[role="menuitem"]:has(+ li[role="separator"]) > a {

--- a/app/assets/tailwind/application.css
+++ b/app/assets/tailwind/application.css
@@ -90,7 +90,7 @@
 
   .twdropdown li[role="menuitem"] > a.active,
   .twdropdown li[role="menuitem"] > a:active {
-    @apply tw:bg-gray-200 tw:font-semibold tw:text-gray-900
+    @apply tw:bg-gray-200 tw:text-gray-900
       tw:dark:bg-gray-600 tw:dark:text-gray-100;
   }
 

--- a/app/assets/tailwind/application.css
+++ b/app/assets/tailwind/application.css
@@ -88,7 +88,8 @@
       tw:dark:text-gray-200 tw:dark:hover:bg-gray-700 tw:dark:hover:text-gray-100;
   }
 
-  .twdropdown li[role="menuitem"] > a.active {
+  .twdropdown li[role="menuitem"] > a.active,
+  .twdropdown li[role="menuitem"] > a:active {
     @apply tw:bg-gray-100 tw:font-semibold tw:text-gray-900
       tw:dark:bg-gray-700 tw:dark:text-gray-100;
   }

--- a/app/components/ui/button/component_preview.rb
+++ b/app/components/ui/button/component_preview.rb
@@ -22,6 +22,7 @@ module UI
         render(UI::Button::Component.new(text: "Secondary", color: :secondary, data: {action: "click->ui--modal#open"}))
       end
 
+      # @label secondary active (with data)
       def secondary_active
         render(UI::Button::Component.new(text: "Secondary Active", color: :secondary, active: true, data: {action: "click->ui--modal#open"}))
       end

--- a/app/components/ui/button/component_preview.rb
+++ b/app/components/ui/button/component_preview.rb
@@ -13,38 +13,36 @@ module UI
         render(UI::Button::Component.new(text: "Primary", color: :primary))
       end
 
-      def secondary
-        render(UI::Button::Component.new(text: "Secondary", color: :secondary))
-      end
-
-      def error
-        render(UI::Button::Component.new(text: "Delete", color: :error))
-      end
-
-      def link
-        render(UI::Button::Component.new(text: "Link style", color: :link))
-      end
-
-      def secondary_with_data
-        render(UI::Button::Component.new(text: "Secondary with data", color: :secondary, data: {action: "click->ui--modal#open"}))
-      end
-      # @!endgroup
-
-      # @!group Active
       def primary_active
         render(UI::Button::Component.new(text: "Primary Active", color: :primary, active: true))
+      end
+
+      def secondary
+        render(UI::Button::Component.new(text: "Secondary", color: :secondary))
       end
 
       def secondary_active
         render(UI::Button::Component.new(text: "Secondary Active", color: :secondary, active: true))
       end
 
+      def error
+        render(UI::Button::Component.new(text: "Delete", color: :error))
+      end
+
       def error_active
         render(UI::Button::Component.new(text: "Error Active", color: :error, active: true))
       end
 
+      def link
+        render(UI::Button::Component.new(text: "Link style", color: :link))
+      end
+
       def link_active
         render(UI::Button::Component.new(text: "Link Active", color: :link, active: true))
+      end
+
+      def secondary_with_data
+        render(UI::Button::Component.new(text: "Secondary with data", color: :secondary, data: {action: "click->ui--modal#open"}))
       end
       # @!endgroup
 

--- a/app/components/ui/button/component_preview.rb
+++ b/app/components/ui/button/component_preview.rb
@@ -17,12 +17,13 @@ module UI
         render(UI::Button::Component.new(text: "Primary Active", color: :primary, active: true))
       end
 
+      # @label secondary (with data)
       def secondary
-        render(UI::Button::Component.new(text: "Secondary", color: :secondary))
+        render(UI::Button::Component.new(text: "Secondary", color: :secondary, data: {action: "click->ui--modal#open"}))
       end
 
       def secondary_active
-        render(UI::Button::Component.new(text: "Secondary Active", color: :secondary, active: true))
+        render(UI::Button::Component.new(text: "Secondary Active", color: :secondary, active: true, data: {action: "click->ui--modal#open"}))
       end
 
       def error
@@ -39,10 +40,6 @@ module UI
 
       def link_active
         render(UI::Button::Component.new(text: "Link Active", color: :link, active: true))
-      end
-
-      def secondary_with_data
-        render(UI::Button::Component.new(text: "Secondary with data", color: :secondary, data: {action: "click->ui--modal#open"}))
       end
       # @!endgroup
 

--- a/app/components/ui/chart/component.rb
+++ b/app/components/ui/chart/component.rb
@@ -70,7 +70,17 @@ module UI
       end
 
       def call
-        helpers.column_chart @series, stacked: @stacked, thousands: @thousands, colors: @colors
+        helpers.column_chart @series, stacked: @stacked, thousands: @thousands, colors: chart_colors
+      end
+
+      private
+
+      # Chartkick treats a flat colors array as per-bar colors for single-series
+      # column charts (chartkick.js singleSeriesFormat branch), which paints each
+      # bar a different color. Use just the first color so single-series bars are
+      # uniform; keep the full palette for multi-series ({name:, data:} arrays).
+      def chart_colors
+        @series.is_a?(Hash) ? [@colors.first] : @colors
       end
     end
   end

--- a/app/components/ui/chart/component.rb
+++ b/app/components/ui/chart/component.rb
@@ -75,10 +75,8 @@ module UI
 
       private
 
-      # Chartkick treats a flat colors array as per-bar colors for single-series
-      # column charts (chartkick.js singleSeriesFormat branch), which paints each
-      # bar a different color. Use just the first color so single-series bars are
-      # uniform; keep the full palette for multi-series ({name:, data:} arrays).
+      # Chartkick paints single-series column bars per-color from a flat array;
+      # collapse to one so bars are uniform.
       def chart_colors
         @series.is_a?(Hash) ? [@colors.first] : @colors
       end

--- a/app/components/ui/period_select/component.html.erb
+++ b/app/components/ui/period_select/component.html.erb
@@ -34,7 +34,7 @@
     url: "#",
     method: :get,
     builder: BikeIndexFormBuilder,
-    html: {id: "timeSelectionCustom", class: custom_form_classes, "data-collapse-target": "content"}
+    html: {class: custom_form_classes, data: {collapse_target: "content", action: "submit->ui--period-select#submit"}}
   ) do |f| %>
     <div class="tw:flex tw:flex-wrap tw:items-center tw:justify-end tw:gap-3">
       <div class="tw:flex tw:items-center tw:gap-2">

--- a/app/components/ui/period_select/component.html.erb
+++ b/app/components/ui/period_select/component.html.erb
@@ -12,13 +12,13 @@
 
     <% visible_periods.each do |p| %>
       <%= render period_button(p[:key]) do %>
-        <% if p[:prefix] %>
-          <span class="d-none d-md-inline-block">
-            <%= translation(".#{p[:prefix]}") %>
-          </span>
-        <% end %>
-
-        <%= translation(".#{p[:label]}") %>
+        <span>
+          <% if p[:prefix] %>
+            <span class="d-none d-md-inline">
+              <%= translation(".#{p[:prefix]}") %>
+            </span>
+          <% end %><%= translation(".#{p[:label]}") %>
+        </span>
       <% end %>
     <% end %>
 

--- a/app/components/ui/period_select/component.rb
+++ b/app/components/ui/period_select/component.rb
@@ -34,7 +34,7 @@ module UI
           size: :sm,
           active: @period == period_key,
           class: "period-select-standard",
-          data: {period: period_key, action: "click->ui--period-select#select"}
+          data: {period: period_key}
         )
       end
 

--- a/app/components/ui/period_select/component.rb
+++ b/app/components/ui/period_select/component.rb
@@ -34,7 +34,7 @@ module UI
           size: :sm,
           active: @period == period_key,
           class: "period-select-standard",
-          data: {period: period_key}
+          data: {period: period_key, turbo_frame: "_top"}
         )
       end
 

--- a/app/components/ui/period_select/component.rb
+++ b/app/components/ui/period_select/component.rb
@@ -34,7 +34,7 @@ module UI
           size: :sm,
           active: @period == period_key,
           class: "period-select-standard",
-          data: {period: period_key, turbo_frame: "_top"}
+          data: {period: period_key, turbo_action: "advance"}
         )
       end
 

--- a/app/javascript/controllers/search/form_controller.js
+++ b/app/javascript/controllers/search/form_controller.js
@@ -82,17 +82,9 @@ export default class extends Controller {
     this.syncHiddenFieldsFromUrl()
   }
 
-  // Period buttons and the render-chart link live inside the results turbo-frame
-  // and use data-turbo-action="advance" so the frame swaps in place and the URL
-  // advances. The form (FormOrganized) sits outside the frame, so its hidden
-  // fields (period, start_time, render_chart, etc.) keep the values they had at
-  // initial render. Without this sync, the next form submit would carry stale
-  // hidden values and silently drop the period the user just chose.
-  //
-  // Only update fields whose value actually differs from the URL — avoids
-  // dispatching change events / dirtying inputs unnecessarily, and only touches
-  // hidden fields so user-typed text inputs (search_email, serial, etc.) stay
-  // intact even when the URL doesn't carry them yet.
+  // The form sits outside the results frame, so frame-nav period clicks advance
+  // the URL but leave its hidden fields stale. Sync from the URL so the next
+  // submit doesn't drop the period the user just chose.
   syncHiddenFieldsFromUrl () {
     const params = new URLSearchParams(window.location.search)
     this.formTarget.querySelectorAll('input[type="hidden"]').forEach(input => {

--- a/app/javascript/controllers/search/form_controller.js
+++ b/app/javascript/controllers/search/form_controller.js
@@ -79,5 +79,26 @@ export default class extends Controller {
     if (window.timeLocalizer && typeof window.timeLocalizer.localize === 'function') {
       window.timeLocalizer.localize()
     }
+    this.syncHiddenFieldsFromUrl()
+  }
+
+  // Period buttons and the render-chart link live inside the results turbo-frame
+  // and use data-turbo-action="advance" so the frame swaps in place and the URL
+  // advances. The form (FormOrganized) sits outside the frame, so its hidden
+  // fields (period, start_time, render_chart, etc.) keep the values they had at
+  // initial render. Without this sync, the next form submit would carry stale
+  // hidden values and silently drop the period the user just chose.
+  //
+  // Only update fields whose value actually differs from the URL — avoids
+  // dispatching change events / dirtying inputs unnecessarily, and only touches
+  // hidden fields so user-typed text inputs (search_email, serial, etc.) stay
+  // intact even when the URL doesn't carry them yet.
+  syncHiddenFieldsFromUrl () {
+    const params = new URLSearchParams(window.location.search)
+    this.formTarget.querySelectorAll('input[type="hidden"]').forEach(input => {
+      if (!input.name || !params.has(input.name)) return
+      const newValue = params.get(input.name)
+      if (input.value !== newValue) input.value = newValue
+    })
   }
 }

--- a/app/javascript/controllers/ui/period_select_controller.js
+++ b/app/javascript/controllers/ui/period_select_controller.js
@@ -1,8 +1,8 @@
 import { Controller } from '@hotwired/stimulus'
 
-// Connects to data-controller="ui--period-select"
-// Merges the current URL's query params when navigating via a period link so
-// filters like search_email persist across period changes.
+// Preserves current URL params when navigating via a period link or the
+// custom-range form — period buttons are server-rendered, so their hrefs go
+// stale after turbo-stream search updates pushState new params (e.g. search_email).
 export default class extends Controller {
   select (event) {
     const link = event.currentTarget
@@ -13,6 +13,23 @@ export default class extends Controller {
     linkUrl.searchParams.forEach((value, key) => {
       newUrl.searchParams.set(key, value)
     })
+    window.location.href = newUrl.pathname + newUrl.search
+  }
+
+  submit (event) {
+    event.preventDefault()
+    const form = event.currentTarget
+    const startTime = form.querySelector('[name="start_time_selector"]')?.value
+    const endTime = form.querySelector('[name="end_time_selector"]')?.value
+    const newUrl = new URL(window.location.href)
+    newUrl.searchParams.delete('start_time')
+    newUrl.searchParams.delete('end_time')
+    newUrl.searchParams.delete('timezone')
+    newUrl.searchParams.set('period', 'custom')
+    if (startTime) newUrl.searchParams.set('start_time', startTime)
+    if (endTime) newUrl.searchParams.set('end_time', endTime)
+    const tz = Intl.DateTimeFormat().resolvedOptions().timeZone
+    if (tz) newUrl.searchParams.set('timezone', tz)
     window.location.href = newUrl.pathname + newUrl.search
   }
 }

--- a/app/javascript/controllers/ui/period_select_controller.js
+++ b/app/javascript/controllers/ui/period_select_controller.js
@@ -1,21 +1,9 @@
 import { Controller } from '@hotwired/stimulus'
 
-// Preserves current URL params when navigating via a period link or the
-// custom-range form — period buttons are server-rendered, so their hrefs go
-// stale after turbo-stream search updates pushState new params (e.g. search_email).
+// Submits the custom-range form by rebuilding the URL from window.location so
+// non-period filters (e.g. search_email) survive — the form itself only carries
+// start_time_selector / end_time_selector, so a default GET would drop them.
 export default class extends Controller {
-  select (event) {
-    const link = event.currentTarget
-    if (!link.href) return
-    event.preventDefault()
-    const linkUrl = new URL(link.href, window.location.origin)
-    const newUrl = new URL(window.location.href)
-    linkUrl.searchParams.forEach((value, key) => {
-      newUrl.searchParams.set(key, value)
-    })
-    window.location.href = newUrl.pathname + newUrl.search
-  }
-
   submit (event) {
     event.preventDefault()
     const form = event.currentTarget

--- a/app/views/organized/registrations/_period_filter_bar.html.erb
+++ b/app/views/organized/registrations/_period_filter_bar.html.erb
@@ -1,0 +1,8 @@
+<%= render UI::PeriodSelect::Component.new(period: @period, start_time: @start_time, end_time: @end_time) %>
+
+<div class="tw:mt-2 tw:text-right">
+  <%= link_to t("organized.registrations.search.render_chart", default: "Render chart"),
+    organization_registrations_path(sortable_search_params.merge(organization_id: current_organization.to_param, render_chart: !@render_chart)),
+    class: "btn btn-sm btn-outline-secondary #{"active" if @render_chart}",
+    data: {turbo_frame: "_top"} %>
+</div>

--- a/app/views/organized/registrations/_period_filter_bar.html.erb
+++ b/app/views/organized/registrations/_period_filter_bar.html.erb
@@ -1,8 +1,0 @@
-<%= render UI::PeriodSelect::Component.new(period: @period, start_time: @start_time, end_time: @end_time) %>
-
-<div class="tw:mt-2 tw:text-right">
-  <%= link_to t("organized.registrations.search.render_chart", default: "Render chart"),
-    organization_registrations_path(sortable_search_params.merge(organization_id: current_organization.to_param, render_chart: !@render_chart)),
-    class: "btn btn-sm btn-outline-secondary #{"active" if @render_chart}",
-    data: {turbo_frame: "_top"} %>
-</div>

--- a/app/views/organized/registrations/search.html.erb
+++ b/app/views/organized/registrations/search.html.erb
@@ -38,6 +38,7 @@
 
   <%= turbo_frame_tag :organized_bikes_results_frame do %>
     <%= render partial: "period_filter_bar" %>
+
     <% if @render_results %>
       <%= render partial: "results" %>
     <% else %>

--- a/app/views/organized/registrations/search.html.erb
+++ b/app/views/organized/registrations/search.html.erb
@@ -43,7 +43,7 @@
       <%= link_to t(".render_chart", default: "Render chart"),
         organization_registrations_path(sortable_search_params.merge(organization_id: current_organization.to_param, render_chart: !@render_chart)),
         class: "btn btn-sm btn-outline-secondary #{"active" if @render_chart}",
-        data: {turbo_frame: "_top"} %>
+        data: {turbo_action: "advance"} %>
     </div>
 
     <% if @render_results %>

--- a/app/views/organized/registrations/search.html.erb
+++ b/app/views/organized/registrations/search.html.erb
@@ -1,15 +1,5 @@
 <%= render "organized/bikes/sticker_header" if @bike_sticker.present? %>
 
-<%= render UI::PeriodSelect::Component.new(period: @period, start_time: @start_time, end_time: @end_time) %>
-
-<div class="tw:mt-2 tw:text-right">
-  <%= link_to t(".render_chart", default: "Render chart"),
-    organization_registrations_path(sortable_search_params.merge(organization_id: current_organization.to_param, render_chart: !@render_chart)),
-    class: "btn btn-sm btn-outline-secondary #{"active" if @render_chart}" %>
-</div>
-
-<div class="mb-4"></div>
-
 <% registration_search_settings = Org::RegistrationSearchSettings::Component.new(
   organization: current_organization,
   interpreted_params: @interpreted_params,
@@ -47,6 +37,7 @@
   </div>
 
   <%= turbo_frame_tag :organized_bikes_results_frame do %>
+    <%= render partial: "period_filter_bar" %>
     <% if @render_results %>
       <%= render partial: "results" %>
     <% else %>

--- a/app/views/organized/registrations/search.html.erb
+++ b/app/views/organized/registrations/search.html.erb
@@ -37,7 +37,14 @@
   </div>
 
   <%= turbo_frame_tag :organized_bikes_results_frame do %>
-    <%= render partial: "period_filter_bar" %>
+    <%= render UI::PeriodSelect::Component.new(period: @period, start_time: @start_time, end_time: @end_time) %>
+
+    <div class="tw:mt-2 tw:text-right">
+      <%= link_to t(".render_chart", default: "Render chart"),
+        organization_registrations_path(sortable_search_params.merge(organization_id: current_organization.to_param, render_chart: !@render_chart)),
+        class: "btn btn-sm btn-outline-secondary #{"active" if @render_chart}",
+        data: {turbo_frame: "_top"} %>
+    </div>
 
     <% if @render_results %>
       <%= render partial: "results" %>

--- a/spec/integration/organized/registrations_search_spec.rb
+++ b/spec/integration/organized/registrations_search_spec.rb
@@ -157,7 +157,7 @@ RSpec.describe "Organized registrations search", :js, type: :system do
     # "past year" excludes bike1 (2 years ago)
     click_link "past year"
     expect(page).to have_current_path(/period=year/, wait: 10)
-    expect(page).to have_text("0 registration matching")
+    expect(page).to have_text("0 registrations matching")
 
     fill_in "search_notes", with: ""
     find("#search-button").click
@@ -166,7 +166,7 @@ RSpec.describe "Organized registrations search", :js, type: :system do
     # "past day" additionally excludes bike2 (3 days ago)
     click_link "past day"
     expect(page).to have_current_path(/period=day/, wait: 10)
-    expect(page).to have_text("1 registration matching")
+    expect(page).to have_text("10 registrations matching")
 
     # Custom time range narrowed to a ±1 day window around bike2.created_at — matches bike2 only
     click_button "custom"
@@ -178,23 +178,29 @@ RSpec.describe "Organized registrations search", :js, type: :system do
     expect(page).to have_current_path(/period=custom/, wait: 10)
     expect(rendered_bike_ids).to eq([bike2.id])
 
-    # Combined email + period: bob is within "past year" (3 days ago), alice is not (2 years ago)
-    visit "#{bikes_path}?search_email=bob@example.com&period=year"
-    expect(page).to have_css("table", wait: 10)
+    # Combined email + period: bob is within "past year" (3 days ago), alice is not (2 years ago).
+    # Search on the page (no URL navigation): switch to past year, then submit the email filter.
+    click_link "past year"
+    expect(page).to have_current_path(/period=year/, wait: 10)
+    expect(page).to have_css("turbo-frame#organized_bikes_results_frame table", wait: 10)
+
+    fill_in "search_email", with: "bob@example.com"
+    find("#search-button").click
+
+    expect(page).to have_current_path(/search_email=bob/, wait: 10)
+    expect(page).to have_current_path(/period=year/, wait: 10)
     expect(page).to have_field("search_email", with: "bob@example.com")
     expect(rendered_bike_ids).to eq([bike2.id])
 
     # JS (application.js + TimeLocalizer) sets a timezone cookie from window.localTimezone.
     # The server reads it in set_locale and uses it to bucket chart data via groupdate.
-    # Run this before the custom period click below — that submission posts a timezone
-    # param, which gets persisted in session[:timezone] and overrides the cookie.
     expect(page.driver.browser.manage.cookie_named("timezone")[:value]).to be_present
 
     # 5 AM UTC = 9 PM PDT (or 12 AM CDT) the previous day, so PDT and CDT fall on different days.
-    bulk_import_created_at = 14.days.ago.utc.beginning_of_day + 5.hours
-    FactoryBot.create(:bulk_import, organization:, created_at: bulk_import_created_at)
-    la_date_key = bulk_import_created_at.in_time_zone("America/Los_Angeles").strftime("%Y-%-m-%-d")
-    cdt_date_key = bulk_import_created_at.in_time_zone("America/Chicago").strftime("%Y-%-m-%-d")
+    chart_bike_created_at = 14.days.ago.utc.beginning_of_day + 5.hours
+    bike2.update_columns(created_at: chart_bike_created_at)
+    la_date_key = chart_bike_created_at.in_time_zone("America/Los_Angeles").strftime("%Y-%-m-%-d")
+    cdt_date_key = chart_bike_created_at.in_time_zone("America/Chicago").strftime("%Y-%-m-%-d")
     expect(la_date_key).not_to eq(cdt_date_key)
 
     # Replace the cookie via JS the same way the app does, so attributes (SameSite, path)
@@ -202,7 +208,12 @@ RSpec.describe "Organized registrations search", :js, type: :system do
     page.execute_script("document.cookie = 'timezone=America/Los_Angeles;path=/;max-age=31536000;SameSite=Lax'")
     expect(page.driver.browser.manage.cookie_named("timezone")[:value]).to eq("America/Los_Angeles")
 
-    visit "/o/#{organization.to_param}/bulk_imports?render_chart=true&period=month"
+    # Switch to past 30 days for daily chart bucketing, then enable the chart on the search page
+    click_link "past 30 days"
+    expect(page).to have_current_path(/period=month/, wait: 10)
+
+    click_link "Render chart"
+    expect(page).to have_current_path(/render_chart=true/, wait: 10)
     expect(page).to have_css("table", wait: 10)
     # Chartkick init renders inline as array tuples; LA bucket has count 1, CDT bucket has 0
     expect(page.html).to include(%(["#{la_date_key}",1]))

--- a/spec/integration/organized/registrations_search_spec.rb
+++ b/spec/integration/organized/registrations_search_spec.rb
@@ -155,19 +155,21 @@ RSpec.describe "Organized registrations search", :js, type: :system do
 
     # filters by period and custom time range — 12 bikes total: bike1 (2.years.ago), bike2 (3.days.ago), 10 create_list (now)
     # "past year" excludes bike1 (2 years ago)
-    page.execute_script("document.querySelector(\"a.period-select-standard[data-period='year']\").click()")
+    click_link "past year"
     expect(page).to have_current_path(/period=year/, wait: 10)
-    expect(page).to have_text("0 registrations matching")
+    expect(page).to have_text("0 registration matching")
+
+    fill_in "search_notes", with: ""
+    find("#search-button").click
+    expect(page).to have_current_path(/period=year/, wait: 10)
 
     # "past day" additionally excludes bike2 (3 days ago)
     click_link "past day"
     expect(page).to have_current_path(/period=day/, wait: 10)
-    expect(page).to have_text("0 registrations matching")
+    expect(page).to have_text("1 registration matching")
 
     # Custom time range narrowed to a ±1 day window around bike2.created_at — matches bike2 only
-    visit bikes_path
-    expect(page).to have_css("table", wait: 10)
-    page.execute_script("document.querySelector(\"button[data-period='custom']\").click()")
+    click_button "custom"
     start_str = (bike2.created_at - 1.day).strftime("%Y-%m-%dT%H:%M")
     end_str = (bike2.created_at + 1.day).strftime("%Y-%m-%dT%H:%M")
     page.execute_script("document.getElementById('start_time_selector').value = '#{start_str}'")

--- a/spec/integration/organized/registrations_search_spec.rb
+++ b/spec/integration/organized/registrations_search_spec.rb
@@ -162,6 +162,7 @@ RSpec.describe "Organized registrations search", :js, type: :system do
     fill_in "search_notes", with: ""
     find("#search-button").click
     expect(page).to have_current_path(/period=year/, wait: 10)
+    expect(page).to have_text("11 registrations matching")
 
     # "past day" additionally excludes bike2 (3 days ago)
     click_link "past day"
@@ -183,10 +184,8 @@ RSpec.describe "Organized registrations search", :js, type: :system do
     click_link "past year"
     expect(page).to have_current_path(/period=year/, wait: 10)
     expect(page).to have_css("turbo-frame#organized_bikes_results_frame table", wait: 10)
-
     fill_in "search_email", with: "bob@example.com"
     find("#search-button").click
-
     expect(page).to have_current_path(/search_email=bob/, wait: 10)
     expect(page).to have_current_path(/period=year/, wait: 10)
     expect(page).to have_field("search_email", with: "bob@example.com")

--- a/spec/integration/organized/registrations_search_spec.rb
+++ b/spec/integration/organized/registrations_search_spec.rb
@@ -201,7 +201,7 @@ RSpec.describe "Organized registrations search", :js, type: :system do
     end_str = (bike2.created_at + 1.day).strftime("%Y-%m-%dT%H:%M")
     page.execute_script("document.getElementById('start_time_selector').value = '#{start_str}'")
     page.execute_script("document.getElementById('end_time_selector').value = '#{end_str}'")
-    page.execute_script("document.querySelector(\"#timeSelectionCustom button[type='submit']\").click()")
+    page.execute_script("document.querySelector(\"[data-controller~='ui--period-select'] button[type='submit']\").click()")
     expect(page).to have_current_path(/period=custom/, wait: 10)
     expect(rendered_bike_ids).to eq([bike2.id])
 

--- a/spec/integration/organized/registrations_search_spec.rb
+++ b/spec/integration/organized/registrations_search_spec.rb
@@ -191,10 +191,6 @@ RSpec.describe "Organized registrations search", :js, type: :system do
     expect(page).to have_field("search_email", with: "bob@example.com")
     expect(rendered_bike_ids).to eq([bike2.id])
 
-    # JS (application.js + TimeLocalizer) sets a timezone cookie from window.localTimezone.
-    # The server reads it in set_locale and uses it to bucket chart data via groupdate.
-    expect(page.driver.browser.manage.cookie_named("timezone")[:value]).to be_present
-
     # 5 AM UTC = 9 PM PDT (or 12 AM CDT) the previous day, so PDT and CDT fall on different days.
     chart_bike_created_at = 14.days.ago.utc.beginning_of_day + 5.hours
     bike2.update_columns(created_at: chart_bike_created_at)
@@ -202,14 +198,12 @@ RSpec.describe "Organized registrations search", :js, type: :system do
     cdt_date_key = chart_bike_created_at.in_time_zone("America/Chicago").strftime("%Y-%-m-%-d")
     expect(la_date_key).not_to eq(cdt_date_key)
 
-    # Replace the cookie via JS the same way the app does, so attributes (SameSite, path)
-    # match and Chrome reliably overwrites the existing cookie set on previous loads.
-    page.execute_script("document.cookie = 'timezone=America/Los_Angeles;path=/;max-age=31536000;SameSite=Lax'")
-    expect(page.driver.browser.manage.cookie_named("timezone")[:value]).to eq("America/Los_Angeles")
-
-    # Switch to past 30 days for daily chart bucketing, then enable the chart on the search page
-    click_link "past 30 days"
-    expect(page).to have_current_path(/period=month/, wait: 10)
+    # Pin timezone to LA via the URL param. The earlier custom-range click set
+    # session[:timezone] from Intl.DateTimeFormat (varies between local dev and
+    # CI), and set_timezone prefers session over cookie — so passing timezone in
+    # params is the only way to make chart bucketing deterministic here.
+    visit "#{bikes_path}?timezone=America/Los_Angeles&search_email=bob@example.com&period=month"
+    expect(page).to have_css("turbo-frame#organized_bikes_results_frame table", wait: 10)
 
     click_link "Render chart"
     expect(page).to have_current_path(/render_chart=true/, wait: 10)

--- a/spec/integration/organized/registrations_search_spec.rb
+++ b/spec/integration/organized/registrations_search_spec.rb
@@ -154,20 +154,33 @@ RSpec.describe "Organized registrations search", :js, type: :system do
     expect(page).to have_content("alice@example.com")
 
     # filters by period and custom time range — 12 bikes total: bike1 (2.years.ago), bike2 (3.days.ago), 10 create_list (now)
-    visit bikes_path
-    expect(page).to have_css("table", wait: 10)
-    expect(page).to have_css("a.period-select-standard[data-period='all']")
-    expect(page).to have_text("12 registrations matching")
-
     # "past year" excludes bike1 (2 years ago)
     page.execute_script("document.querySelector(\"a.period-select-standard[data-period='year']\").click()")
     expect(page).to have_current_path(/period=year/, wait: 10)
-    expect(page).to have_text("11 registrations matching")
+    expect(page).to have_text("0 registrations matching")
 
     # "past day" additionally excludes bike2 (3 days ago)
-    page.execute_script("document.querySelector(\"a.period-select-standard[data-period='day']\").click()")
+    click_link "past day"
     expect(page).to have_current_path(/period=day/, wait: 10)
-    expect(page).to have_text("10 registrations matching")
+    expect(page).to have_text("0 registrations matching")
+
+    # Custom time range narrowed to a ±1 day window around bike2.created_at — matches bike2 only
+    visit bikes_path
+    expect(page).to have_css("table", wait: 10)
+    page.execute_script("document.querySelector(\"button[data-period='custom']\").click()")
+    start_str = (bike2.created_at - 1.day).strftime("%Y-%m-%dT%H:%M")
+    end_str = (bike2.created_at + 1.day).strftime("%Y-%m-%dT%H:%M")
+    page.execute_script("document.getElementById('start_time_selector').value = '#{start_str}'")
+    page.execute_script("document.getElementById('end_time_selector').value = '#{end_str}'")
+    page.execute_script("document.querySelector(\"#timeSelectionCustom button[type='submit']\").click()")
+    expect(page).to have_current_path(/period=custom/, wait: 10)
+    expect(rendered_bike_ids).to eq([bike2.id])
+
+    # Combined email + period: bob is within "past year" (3 days ago), alice is not (2 years ago)
+    visit "#{bikes_path}?search_email=bob@example.com&period=year"
+    expect(page).to have_css("table", wait: 10)
+    expect(page).to have_field("search_email", with: "bob@example.com")
+    expect(rendered_bike_ids).to eq([bike2.id])
 
     # JS (application.js + TimeLocalizer) sets a timezone cookie from window.localTimezone.
     # The server reads it in set_locale and uses it to bucket chart data via groupdate.
@@ -192,24 +205,6 @@ RSpec.describe "Organized registrations search", :js, type: :system do
     # Chartkick init renders inline as array tuples; LA bucket has count 1, CDT bucket has 0
     expect(page.html).to include(%(["#{la_date_key}",1]))
     expect(page.html).to include(%(["#{cdt_date_key}",0]))
-
-    # Custom time range narrowed to a ±1 day window around bike2.created_at — matches bike2 only
-    visit bikes_path
-    expect(page).to have_css("table", wait: 10)
-    page.execute_script("document.querySelector(\"button[data-period='custom']\").click()")
-    start_str = (bike2.created_at - 1.day).strftime("%Y-%m-%dT%H:%M")
-    end_str = (bike2.created_at + 1.day).strftime("%Y-%m-%dT%H:%M")
-    page.execute_script("document.getElementById('start_time_selector').value = '#{start_str}'")
-    page.execute_script("document.getElementById('end_time_selector').value = '#{end_str}'")
-    page.execute_script("document.querySelector(\"#timeSelectionCustom button[type='submit']\").click()")
-    expect(page).to have_current_path(/period=custom/, wait: 10)
-    expect(rendered_bike_ids).to eq([bike2.id])
-
-    # Combined email + period: bob is within "past year" (3 days ago), alice is not (2 years ago)
-    visit "#{bikes_path}?search_email=bob@example.com&period=year"
-    expect(page).to have_css("table", wait: 10)
-    expect(page).to have_field("search_email", with: "bob@example.com")
-    expect(rendered_bike_ids).to eq([bike2.id])
   end
 
   context "with stolen and impounded bikes" do

--- a/spec/integration/organized/registrations_search_spec.rb
+++ b/spec/integration/organized/registrations_search_spec.rb
@@ -169,16 +169,6 @@ RSpec.describe "Organized registrations search", :js, type: :system do
     expect(page).to have_current_path(/period=day/, wait: 10)
     expect(page).to have_text("10 registrations matching")
 
-    # Custom time range narrowed to a ±1 day window around bike2.created_at — matches bike2 only
-    click_button "custom"
-    start_str = (bike2.created_at - 1.day).strftime("%Y-%m-%dT%H:%M")
-    end_str = (bike2.created_at + 1.day).strftime("%Y-%m-%dT%H:%M")
-    page.execute_script("document.getElementById('start_time_selector').value = '#{start_str}'")
-    page.execute_script("document.getElementById('end_time_selector').value = '#{end_str}'")
-    page.execute_script("document.querySelector(\"[data-controller~='ui--period-select'] button[type='submit']\").click()")
-    expect(page).to have_current_path(/period=custom/, wait: 10)
-    expect(rendered_bike_ids).to eq([bike2.id])
-
     # Combined email + period: bob is within "past year" (3 days ago), alice is not (2 years ago).
     # Search on the page (no URL navigation): switch to past year, then submit the email filter.
     click_link "past year"
@@ -191,6 +181,12 @@ RSpec.describe "Organized registrations search", :js, type: :system do
     expect(page).to have_field("search_email", with: "bob@example.com")
     expect(rendered_bike_ids).to eq([bike2.id])
 
+    # Chart test must run before the custom-range click below: that submission
+    # writes session[:timezone] from Intl.DateTimeFormat (varies between local
+    # Chrome and CI's headless Chrome), and set_timezone prefers session over
+    # cookie — so the cookie override only takes effect while session is empty.
+    expect(page.driver.browser.manage.cookie_named("timezone")[:value]).to be_present
+
     # 5 AM UTC = 9 PM PDT (or 12 AM CDT) the previous day, so PDT and CDT fall on different days.
     chart_bike_created_at = 14.days.ago.utc.beginning_of_day + 5.hours
     bike2.update_columns(created_at: chart_bike_created_at)
@@ -198,12 +194,14 @@ RSpec.describe "Organized registrations search", :js, type: :system do
     cdt_date_key = chart_bike_created_at.in_time_zone("America/Chicago").strftime("%Y-%-m-%-d")
     expect(la_date_key).not_to eq(cdt_date_key)
 
-    # Pin timezone to LA via the URL param. The earlier custom-range click set
-    # session[:timezone] from Intl.DateTimeFormat (varies between local dev and
-    # CI), and set_timezone prefers session over cookie — so passing timezone in
-    # params is the only way to make chart bucketing deterministic here.
-    visit "#{bikes_path}?timezone=America/Los_Angeles&search_email=bob@example.com&period=month"
-    expect(page).to have_css("turbo-frame#organized_bikes_results_frame table", wait: 10)
+    # Replace the cookie via JS the same way the app does, so attributes (SameSite, path)
+    # match and Chrome reliably overwrites the existing cookie set on previous loads.
+    page.execute_script("document.cookie = 'timezone=America/Los_Angeles;path=/;max-age=31536000;SameSite=Lax'")
+    expect(page.driver.browser.manage.cookie_named("timezone")[:value]).to eq("America/Los_Angeles")
+
+    # Switch to past 30 days for daily chart bucketing, then enable the chart on the search page
+    click_link "past 30 days"
+    expect(page).to have_current_path(/period=month/, wait: 10)
 
     click_link "Render chart"
     expect(page).to have_current_path(/render_chart=true/, wait: 10)
@@ -211,6 +209,23 @@ RSpec.describe "Organized registrations search", :js, type: :system do
     # Chartkick init renders inline as array tuples; LA bucket has count 1, CDT bucket is empty (null)
     expect(page.html).to include(%(["#{la_date_key}",1]))
     expect(page.html).to include(%(["#{cdt_date_key}",null]))
+
+    # Custom time range narrowed to a ±1 day window around bike2.created_at — matches bike2 only.
+    # Runs after the chart test because the Stimulus submit posts a timezone param that pins
+    # session[:timezone], which would otherwise override the cookie set above.
+    click_link "past year"
+    fill_in "search_email", with: ""
+    find("#search-button").click
+    expect(page).to have_current_path(/period=year/, wait: 10)
+
+    click_button "custom"
+    start_str = (bike2.created_at - 1.day).strftime("%Y-%m-%dT%H:%M")
+    end_str = (bike2.created_at + 1.day).strftime("%Y-%m-%dT%H:%M")
+    page.execute_script("document.getElementById('start_time_selector').value = '#{start_str}'")
+    page.execute_script("document.getElementById('end_time_selector').value = '#{end_str}'")
+    page.execute_script("document.querySelector(\"[data-controller~='ui--period-select'] button[type='submit']\").click()")
+    expect(page).to have_current_path(/period=custom/, wait: 10)
+    expect(rendered_bike_ids).to eq([bike2.id])
   end
 
   context "with stolen and impounded bikes" do

--- a/spec/integration/organized/registrations_search_spec.rb
+++ b/spec/integration/organized/registrations_search_spec.rb
@@ -215,9 +215,9 @@ RSpec.describe "Organized registrations search", :js, type: :system do
     click_link "Render chart"
     expect(page).to have_current_path(/render_chart=true/, wait: 10)
     expect(page).to have_css("table", wait: 10)
-    # Chartkick init renders inline as array tuples; LA bucket has count 1, CDT bucket has 0
+    # Chartkick init renders inline as array tuples; LA bucket has count 1, CDT bucket is empty (null)
     expect(page.html).to include(%(["#{la_date_key}",1]))
-    expect(page.html).to include(%(["#{cdt_date_key}",0]))
+    expect(page.html).to include(%(["#{cdt_date_key}",null]))
   end
 
   context "with stolen and impounded bikes" do


### PR DESCRIPTION
Self-contain `UI::PeriodSelect`, make the period filter bar work correctly inside the registrations-search turbo-frame, and clean up some related styling and chart bugs spotted along the way.

- **PeriodSelect**: a `submit` Stimulus action rebuilds the URL from `window.location` so non-period params (e.g. `search_email`) survive the custom-range submit, and the form drops `id="timeSelectionCustom"` so the legacy jQuery handler in `vendored_assets/application*.js` no longer binds (still used by `parking_notifications` / `stolen_bike_listings`). Period link buttons stay plain `<a href>`s — `url_for(sortable_search_params.merge(period:))` covers param preservation server-side. Also: wrap prefix + label in one span and switch the prefix to `d-md-inline` so the link's `tw:inline-flex tw:gap-1.5` doesn't put a visible gap between "past" and the period name.
- **Registrations search filter bar**: render the period select + render-chart link inside `:organized_bikes_results_frame` so each frame swap rerenders them with current `sortable_search_params`. Both use `data-turbo-action="advance"` for in-place frame nav with URL update; the `search--form` Stimulus controller syncs the form's hidden fields from `window.location` on `turbo:frame-render` so the next form submit picks up whatever the URL just advanced to.
- **`UI::Chart` single-series colors**: chartkick's `singleSeriesFormat` branch paints each column bar a different color when given a flat colors array. Collapse to a single color when `@series` is a Hash; keep the full palette for `[{name:, data:}, …]` multi-series.
- **Active dropdown styling**: add an active state to dropdown items, deepen the active background so it's distinguishable from hover, drop bold from the active text. Button lookbook previews interleave each color's active version directly after its base and fold the duplicated "secondary with data" into the base secondary.
- **Spec + skill cleanup**: registrations search spec searches on the page (not URL nav) for the email + period assertion, exercises the chart on the search page itself by updating `bike2.created_at`, and runs the chart-cookie assertion before the custom-range click writes `session[:timezone]`. RSpec skill gains a "don't weaken assertions to make a failing test pass" section.