### PR TITLE
Harden registration and search params against malformed input

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -150,7 +150,7 @@ GEM
     bcrypt (3.1.13)
     benchmark (0.5.0)
     bigdecimal (4.1.1)
-    binxtils (0.4.1)
+    binxtils (0.4.2)
       functionable
       loofah
       rails

--- a/app/controllers/concerns/controller_helpers.rb
+++ b/app/controllers/concerns/controller_helpers.rb
@@ -426,13 +426,13 @@ module ControllerHelpers
   end
 
   def permitted_per_page(default: 25, max: 100)
-    per_page = params[:per_page]&.to_i
-    per_page = (per_page.present? && per_page > 0) ? per_page : default
+    per_page = params[:per_page].to_s.to_i
+    per_page = (per_page > 0) ? per_page : default
     per_page.clamp(1, max)
   end
 
   def permitted_page(max: nil)
-    page = params[:page]&.to_i || 1
+    page = params[:page].to_s.to_i
     page = 1 if page < 1
     max.present? ? page.clamp(1, max) : page
   end

--- a/app/models/b_param.rb
+++ b/app/models/b_param.rb
@@ -629,6 +629,7 @@ class BParam < ApplicationRecord
 
   def assign_bike_val(key, val)
     ensure_valid_params
+    val = val.delete("\u0000") if val.is_a?(String)
     self.params["bike"][key] = val
   end
 

--- a/app/models/b_param.rb
+++ b/app/models/b_param.rb
@@ -630,7 +630,7 @@ class BParam < ApplicationRecord
   def assign_bike_val(key, val)
     ensure_valid_params
     val = Binxtils::InputNormalizer.string(val) if val.is_a?(String)
-    self.params["bike"][key] = val
+    self.params["bike"][key] = val if val.present?
   end
 
   def clean_key_value(key, value)

--- a/app/models/b_param.rb
+++ b/app/models/b_param.rb
@@ -629,7 +629,7 @@ class BParam < ApplicationRecord
 
   def assign_bike_val(key, val)
     ensure_valid_params
-    val = val.delete("\u0000") if val.is_a?(String)
+    val = Binxtils::InputNormalizer.string(val) if val.is_a?(String)
     self.params["bike"][key] = val
   end
 

--- a/app/models/blog.rb
+++ b/app/models/blog.rb
@@ -73,7 +73,8 @@ class Blog < ApplicationRecord
     end
 
     def friendly_find(str)
-      return nil unless str.present?
+      str = Binxtils::InputNormalizer.string(str) if str.is_a?(String)
+      return nil if str.blank?
       return find_by_id(str) if integer_slug?(str)
 
       slug = slugify_title(str)

--- a/app/models/color.rb
+++ b/app/models/color.rb
@@ -44,9 +44,11 @@ class Color < ApplicationRecord
 
   def self.friendly_find(n)
     # Use the FriendlyNameFindable version, then the first part of the string (for slug), then grasp at straws
+    n = normalize_friendly_str(n)
+    return nil if n.blank?
     super ||
-      where("lower(name) ILIKE ?", "#{n.to_s.downcase.strip}%").first ||
-      where("lower(name) ILIKE ?", "%#{n.to_s.downcase.strip}%").first
+      where("lower(name) ILIKE ?", "#{n.to_s.downcase}%").first ||
+      where("lower(name) ILIKE ?", "%#{n.to_s.downcase}%").first
   end
 
   def autocomplete_hash

--- a/app/models/concerns/enumable.rb
+++ b/app/models/concerns/enumable.rb
@@ -50,7 +50,7 @@ module Enumable
       end
       slug = (slugs & [str]).first
       slug ||= names_and_secondary_names.detect { |names| names.include?(str) }&.first
-      if slug.blank? && str[/\(/].present?
+      if slug.blank? && str.is_a?(String) && str[/\(/].present?
         str = str.split("(").first.strip
         slug = names_and_secondary_names.detect { |names| names.include?(str) }&.first
       end

--- a/app/models/concerns/friendly_name_findable.rb
+++ b/app/models/concerns/friendly_name_findable.rb
@@ -3,12 +3,11 @@ module FriendlyNameFindable
 
   module ClassMethods
     def friendly_find(str)
+      str = normalize_friendly_str(str)
       return nil if str.blank?
-
-      strip_if_str!(str)
       return where(id: str).first if integer_string?(str)
 
-      where("lower(name) = ?", str.downcase.strip).first
+      where("lower(name) = ?", str.downcase).first
     end
 
     def friendly_find!(str)
@@ -23,10 +22,8 @@ module FriendlyNameFindable
       str.is_a?(Integer) || str.match(/\A\d+\z/).present?
     end
 
-    def strip_if_str!(str)
-      return unless str.is_a?(String) && !str.frozen?
-      str.delete!("\u0000")
-      str.strip!
+    def normalize_friendly_str(str)
+      str.is_a?(String) ? Binxtils::InputNormalizer.string(str) : str
     end
   end
 end

--- a/app/models/concerns/friendly_slug_findable.rb
+++ b/app/models/concerns/friendly_slug_findable.rb
@@ -4,12 +4,11 @@ module FriendlySlugFindable
 
   module ClassMethods
     def friendly_find(str)
+      str = normalize_friendly_str(str)
       return nil if str.blank?
-
-      str.strip! if str.is_a?(String)
       return where(id: str).first if integer_string?(str)
 
-      find_by_slug(Slugifyer.slugify(str)) || where("lower(name) = ?", str.downcase.strip).first
+      find_by_slug(Slugifyer.slugify(str)) || where("lower(name) = ?", str.downcase).first
     end
 
     def friendly_find_id(str)

--- a/app/models/country.rb
+++ b/app/models/country.rb
@@ -29,7 +29,7 @@ class Country < ApplicationRecord
     end
 
     def friendly_find(name_or_iso)
-      name_or_iso = name_or_iso&.to_s&.strip&.downcase
+      name_or_iso = normalize_friendly_str(name_or_iso)&.downcase
       return if name_or_iso.blank?
       return where(id: name_or_iso).first if integer_string?(name_or_iso)
       return united_states if %w[us usa].include?(name_or_iso)

--- a/app/models/country.rb
+++ b/app/models/country.rb
@@ -29,6 +29,7 @@ class Country < ApplicationRecord
     end
 
     def friendly_find(name_or_iso)
+      return name_or_iso if name_or_iso.is_a?(Country)
       name_or_iso = normalize_friendly_str(name_or_iso)&.downcase
       return if name_or_iso.blank?
       return where(id: name_or_iso).first if integer_string?(name_or_iso)

--- a/app/models/manufacturer.rb
+++ b/app/models/manufacturer.rb
@@ -61,6 +61,7 @@ class Manufacturer < ApplicationRecord
     end
 
     def friendly_find(n)
+      n = Binxtils::InputNormalizer.string(n) if n.is_a?(String)
       return nil if n.blank?
 
       if n.is_a?(Integer) || n.match(/\A\d+\z/).present?

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -203,7 +203,8 @@ class Organization < ApplicationRecord
     def friendly_find(n)
       return nil unless n.present?
       return n if n.is_a?(Organization)
-      n = n.delete("\u0000").strip if n.is_a?(String)
+      n = Binxtils::InputNormalizer.string(n) if n.is_a?(String)
+      return nil if n.blank?
       return find_by_id(n) if integer_string?(n)
 
       slug = Slugifyer.slugify(n)

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -203,6 +203,7 @@ class Organization < ApplicationRecord
     def friendly_find(n)
       return nil unless n.present?
       return n if n.is_a?(Organization)
+      n = n.delete("\u0000").strip if n.is_a?(String)
       return find_by_id(n) if integer_string?(n)
 
       slug = Slugifyer.slugify(n)

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -201,9 +201,8 @@ class Organization < ApplicationRecord
     end
 
     def friendly_find(n)
-      return nil unless n.present?
       return n if n.is_a?(Organization)
-      n = Binxtils::InputNormalizer.string(n) if n.is_a?(String)
+      n = normalize_friendly_str(n)
       return nil if n.blank?
       return find_by_id(n) if integer_string?(n)
 

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -212,9 +212,10 @@ class Organization < ApplicationRecord
     end
 
     def admin_text_search(n)
-      return nil unless n.present?
+      n = normalize_friendly_str(n)
+      return nil if n.blank?
 
-      str = "%#{n.strip}%"
+      str = "%#{n}%"
       match_cols = %w[organizations.name organizations.short_name organizations.ascend_name locations.name address_records.city]
       left_outer_joins(:locations, :location_address_records)
         .distinct

--- a/app/models/primary_activity.rb
+++ b/app/models/primary_activity.rb
@@ -63,9 +63,9 @@ class PrimaryActivity < ApplicationRecord
 
     # This returns just the id if it's
     def friendly_find_id_and_family_ids(str)
+      str = normalize_friendly_str(str)
       return [] if str.blank?
 
-      strip_if_str!(str)
       if integer_string?(str)
         ids = ids_matching_family_id(str)
         ids = by_priority.where(id: str).pluck(:id) if ids.none?
@@ -89,9 +89,8 @@ class PrimaryActivity < ApplicationRecord
     end
 
     def friendly_find_with_select(str, select_attrs: [:id])
+      str = normalize_friendly_str(str)
       return nil if str.blank?
-
-      strip_if_str!(str)
       return by_priority.where(id: str).select(*select_attrs).first if integer_string?(str)
 
       # Special short slugs

--- a/app/models/state.rb
+++ b/app/models/state.rb
@@ -26,14 +26,16 @@ class State < ApplicationRecord
 
   class << self
     def friendly_find(str, country_id: nil)
-      return nil unless str.present?
+      str = Binxtils::InputNormalizer.string(str) if str.is_a?(String)
+      return nil if str.blank?
 
       matches = country_id.present? ? where(country_id:) : all
-      matches.fuzzy_abbr_find(str) || matches.where("lower(name) = ?", str.downcase.strip).first
+      matches.fuzzy_abbr_find(str) || matches.where("lower(name) = ?", str.downcase).first
     end
 
     def fuzzy_abbr_find(str)
-      str && where("lower(abbreviation) = ?", str.downcase.strip).first
+      str = Binxtils::InputNormalizer.string(str) if str.is_a?(String)
+      str.present? && where("lower(abbreviation) = ?", str.downcase).first
     end
 
     def valid_names

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -175,6 +175,7 @@ class User < ApplicationRecord
     end
 
     def username_friendly_find(str)
+      str = Binxtils::InputNormalizer.string(str) if str.is_a?(String)
       return if str.blank?
 
       if str.is_a?(Integer) || str.match(/\A\d+\z/).present?
@@ -185,6 +186,7 @@ class User < ApplicationRecord
     end
 
     def friendly_find(str)
+      str = Binxtils::InputNormalizer.string(str) if str.is_a?(String)
       username_friendly_find(str) || fuzzy_email_find(str)
     end
 

--- a/app/services/log_searcher/parser.rb
+++ b/app/services/log_searcher/parser.rb
@@ -64,8 +64,14 @@ module LogSearcher
         stolenness: stolenness_for(endpoint, opts),
         serial_normalized: SerialNormalizer.normalized_and_corrected(query_items["serial"]),
         includes_query: includes_query?(query_items),
-        page: [nil, "1", "undefined"].include?(query_items["page"]) ? nil : query_items["page"].to_i
+        page: page_for(query_items["page"])
       }
+    end
+
+    def page_for(value)
+      return nil if [nil, "1", "undefined"].include?(value)
+      return nil unless value.is_a?(String) || value.is_a?(Numeric)
+      value.to_i
     end
 
     #
@@ -136,6 +142,6 @@ module LogSearcher
       end
     end
 
-    conceal :includes_query?, :parse_endpoint, :organization_from_params, :parse_request_time, :scrub_null_bytes, :stolenness_for
+    conceal :includes_query?, :parse_endpoint, :organization_from_params, :page_for, :parse_request_time, :scrub_null_bytes, :stolenness_for
   end
 end

--- a/app/services/log_searcher/parser.rb
+++ b/app/services/log_searcher/parser.rb
@@ -68,15 +68,15 @@ module LogSearcher
       }
     end
 
+    #
+    # private below here
+    #
+
     def page_for(value)
       return nil if [nil, "1", "undefined"].include?(value)
       return nil unless value.is_a?(String) || value.is_a?(Numeric)
       value.to_i
     end
-
-    #
-    # private below here
-    #
 
     def includes_query?(query_items)
       query_items.except(*NON_QUERY_ITEMS).present?

--- a/spec/models/b_param_spec.rb
+++ b/spec/models/b_param_spec.rb
@@ -514,6 +514,17 @@ RSpec.describe BParam, type: :model do
     end
   end
 
+  describe "string assignments scrub null bytes" do
+    it "saves without raising when input contains a null byte" do
+      b_param = BParam.new
+      b_param.owner_email = "1\u0000foo@example.com"
+      b_param.cycle_type = "tall\u0000-bike"
+      expect(b_param.bike["owner_email"]).to eq "1foo@example.com"
+      expect(b_param.bike["cycle_type"]).to eq "tall-bike"
+      expect { b_param.save! }.not_to raise_error
+    end
+  end
+
   describe "display_email?" do
     context "owner_email present" do
       it "is false" do

--- a/spec/models/cycle_type_spec.rb
+++ b/spec/models/cycle_type_spec.rb
@@ -34,6 +34,12 @@ RSpec.describe CycleType, type: :model do
         expect(finder.short_name).to eq "Cargo Bike"
       end
     end
+    context "numeric string with no matching slug id" do
+      it "returns nil rather than raising" do
+        expect(CycleType.find_sym("19039792")).to be_nil
+        expect(CycleType.friendly_find("19039792")).to be_nil
+      end
+    end
     context "EPAMD" do
       let(:cycle_type) { CycleType.new("personal-mobility") }
 

--- a/spec/models/organization_spec.rb
+++ b/spec/models/organization_spec.rb
@@ -263,6 +263,10 @@ RSpec.describe Organization, type: :model do
       expect(Organization.friendly_find("bikeeastbay")).to eq organization3
       expect(Organization.friendly_find(organization)).to eq organization
     end
+    it "scrubs null bytes rather than raising" do
+      expect(Organization.friendly_find("1\u0000xxx")).to be_nil
+      expect(Organization.friendly_find("#{organization.id}\u0000")).to eq organization
+    end
   end
 
   describe "#nearby_organizations" do

--- a/spec/requests/search/marketplace_request_spec.rb
+++ b/spec/requests/search/marketplace_request_spec.rb
@@ -10,6 +10,11 @@ RSpec.describe Search::MarketplaceController, type: :request do
     expect(search_marketplace_path).to eq base_url
   end
 
+  it "renders without erroring when page is hash-injected" do
+    get "#{base_url}?search_no_js=true&page%5B%24eq%5D=2"
+    expect(response).to have_http_status(:success)
+  end
+
   context "with listings" do
     let(:seller) { FactoryBot.create(:user, :with_address_record, address_in: :davis) }
     let(:item) { FactoryBot.create(:bike, :with_primary_activity, cycle_type: "personal-mobility", propulsion_type: "throttle") }

--- a/spec/services/log_searcher/parser_spec.rb
+++ b/spec/services/log_searcher/parser_spec.rb
@@ -61,6 +61,14 @@ RSpec.describe LogSearcher::Parser do
           end
         end
 
+        context "with hash-injected page param" do
+          let(:log_line) { 'I, [2026-04-27T12:06:53.334338 #277631]  INFO -- : [989d075e-a235-40ed-a408-6919a54c1b4d] {"method":"GET","path":"/search/marketplace","format":"html","controller":"Search::MarketplaceController","action":"index","status":500,"allocations":5792,"duration":12.78,"view":0.0,"db":5.01,"remote_ip":"193.233.112.165","u_id":null,"params":{"button":"","currency":"$","distance":"100","location":"you","marketplace_scope":"for_sale","page":{"$eq":"2"},"price_max_amount":"","price_min_amount":"","primary_activity":"","search_result_view":"thumbnail"},"@timestamp":"2026-04-27T12:06:53.334Z","@version":"1","message":"[500] GET /search/marketplace (Search::MarketplaceController#index)"}' }
+          it "stores nil page rather than raising" do
+            parsed = described_class.parse_log_line(log_line)
+            expect(parsed[:page]).to be_nil
+          end
+        end
+
         context "count" do
           let(:log_line) { 'I, [2025-06-19T22:42:11.977671 #476516]  INFO -- : [29e848c7-c6ac-4a7d-bc3a-34bbf44dc8ce] {"method":"GET","path":"/search/marketplace/counts","format":"*/*","controller":"Search::MarketplaceController","action":"counts","status":200,"allocations":8787,"duration":50.22,"view":0.33,"db":12.42,"remote_ip":"198.27.190.253","u_id":69,"params":{"query_items":["m_244"],"distance":"50","location":"Chicago, IL","marketplace_scope":"for_sale_proximity","marketplace":{}},"@timestamp":"2025-06-19T22:42:12.090Z","@version":"1","message":"[200] GET /search/marketplace/counts (Search::MarketplaceController#counts)"}' }
           let(:target) do

--- a/spec/vcr_cassettes/StripeSubscription-create_for-invalid_user_id.yml
+++ b/spec/vcr_cassettes/StripeSubscription-create_for-invalid_user_id.yml
@@ -10,9 +10,9 @@ http_interactions:
       User-Agent:
       - Stripe/v1 RubyBindings/13.4.1
       X-Stripe-Client-Telemetry:
-      - '{"last_request_metrics":{"request_id":"req_aaeNVI4ddFAfVV","request_duration_ms":0}}'
+      - '{"last_request_metrics":{"request_id":"req_MfVth8xGxigJEM","request_duration_ms":0}}'
       Idempotency-Key:
-      - 392f35ee-7131-4a72-b105-27f98021d8a4
+      - 4acadfaf-aa07-4a9c-ac26-50daa2308598
       Stripe-Version:
       - 2025-01-27.acacia
       Content-Type:
@@ -29,7 +29,7 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Fri, 13 Feb 2026 19:11:31 GMT
+      - Tue, 28 Apr 2026 00:20:48 GMT
       Content-Type:
       - application/json
       Content-Length:
@@ -52,13 +52,17 @@ http_interactions:
       Content-Security-Policy:
       - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
         img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
-        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=_wllP6bfFHtUWoDjJf0bpG2tfeIXjIfxIyUs1EU8_fn7t6cAhU6kvXB6PuTWTU377nIVf-Q9Iz_tejyS
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=WbwGuuQv-cO0ZaZfJzeqR34qifTlJCJMAiYVm1lf3Xbrjfy0AJIRsX-bwpL9NwIvxCqxxCDm3pwab-sN
       Idempotency-Key:
-      - 392f35ee-7131-4a72-b105-27f98021d8a4
+      - 4acadfaf-aa07-4a9c-ac26-50daa2308598
       Original-Request:
-      - req_6M8FUWYhXs0Zcz
+      - req_Hpdosal17KOssR
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=WbwGuuQv-cO0ZaZfJzeqR34qifTlJCJMAiYVm1lf3Xbrjfy0AJIRsX-bwpL9NwIvxCqxxCDm3pwab-sN&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=WbwGuuQv-cO0ZaZfJzeqR34qifTlJCJMAiYVm1lf3Xbrjfy0AJIRsX-bwpL9NwIvxCqxxCDm3pwab-sN&t=1"
       Request-Id:
-      - req_6M8FUWYhXs0Zcz
+      - req_Hpdosal17KOssR
       Stripe-Version:
       - 2025-01-27.acacia
       Vary:
@@ -68,7 +72,7 @@ http_interactions:
       X-Stripe-Routing-Context-Priority-Tier:
       - api-testmode
       X-Wc:
-      - ABGHIJ
+      - 3c3
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
     body:
@@ -80,22 +84,22 @@ http_interactions:
             "doc_url": "https://stripe.com/docs/error-codes/resource-missing",
             "message": "No such customer: 'cus_xxxx'",
             "param": "customer",
-            "request_log_url": "https://dashboard.stripe.com/acct_2Ksnm0T0GBfX0vyPUIxE/test/workbench/logs?object=req_6M8FUWYhXs0Zcz",
+            "request_log_url": "https://dashboard.stripe.com/acct_2Ksnm0T0GBfX0vyPUIxE/test/workbench/logs?object=req_Hpdosal17KOssR",
             "type": "invalid_request_error"
           }
         }
-  recorded_at: Fri, 13 Feb 2026 19:11:31 GMT
+  recorded_at: Tue, 28 Apr 2026 00:20:48 GMT
 - request:
     method: post
     uri: https://api.stripe.com/v1/checkout/sessions
     body:
       encoding: UTF-8
-      string: success_url=http%3A%2F%2Ftest.host%2Fmembership%2Fsuccess%3Fsession_id%3D%7BCHECKOUT_SESSION_ID%7D&cancel_url=http%3A%2F%2Ftest.host%2Fmembership%2Fnew&mode=subscription&line_items[0][quantity]=1&line_items[0][price]=price_0Qs5rim0T0GBfX0vE7Q7cyoG&customer_email=user53s%40bikeindex.org
+      string: success_url=http%3A%2F%2Ftest.host%2Fmembership%2Fsuccess%3Fsession_id%3D%7BCHECKOUT_SESSION_ID%7D&cancel_url=http%3A%2F%2Ftest.host%2Fmembership%2Fnew&mode=subscription&line_items[0][quantity]=1&line_items[0][price]=price_0Qs5rim0T0GBfX0vE7Q7cyoG&customer_email=user1679s%40bikeindex.org
     headers:
       User-Agent:
       - Stripe/v1 RubyBindings/13.4.1
       Idempotency-Key:
-      - 50644a62-bbc4-476a-9d86-f540453f634e
+      - 480279ce-f8fc-4cbc-ba8d-16e778b84b7e
       Stripe-Version:
       - 2025-01-27.acacia
       Content-Type:
@@ -112,11 +116,11 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Fri, 13 Feb 2026 19:11:31 GMT
+      - Tue, 28 Apr 2026 00:20:48 GMT
       Content-Type:
       - application/json
       Content-Length:
-      - '3644'
+      - '3776'
       Connection:
       - keep-alive
       Access-Control-Allow-Credentials:
@@ -135,13 +139,17 @@ http_interactions:
       Content-Security-Policy:
       - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
         img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
-        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=_wllP6bfFHtUWoDjJf0bpG2tfeIXjIfxIyUs1EU8_fn7t6cAhU6kvXB6PuTWTU377nIVf-Q9Iz_tejyS
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=WbwGuuQv-cO0ZaZfJzeqR34qifTlJCJMAiYVm1lf3Xbrjfy0AJIRsX-bwpL9NwIvxCqxxCDm3pwab-sN
       Idempotency-Key:
-      - 50644a62-bbc4-476a-9d86-f540453f634e
+      - 480279ce-f8fc-4cbc-ba8d-16e778b84b7e
       Original-Request:
-      - req_0cdBCPy77KJkZB
+      - req_7zUWXwHGGdMLbt
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=WbwGuuQv-cO0ZaZfJzeqR34qifTlJCJMAiYVm1lf3Xbrjfy0AJIRsX-bwpL9NwIvxCqxxCDm3pwab-sN&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=WbwGuuQv-cO0ZaZfJzeqR34qifTlJCJMAiYVm1lf3Xbrjfy0AJIRsX-bwpL9NwIvxCqxxCDm3pwab-sN&t=1"
       Request-Id:
-      - req_0cdBCPy77KJkZB
+      - req_7zUWXwHGGdMLbt
       Stripe-Should-Retry:
       - 'false'
       Stripe-Version:
@@ -153,14 +161,14 @@ http_interactions:
       X-Stripe-Routing-Context-Priority-Tier:
       - api-testmode
       X-Wc:
-      - ABGHIJ
+      - 3c3
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
     body:
       encoding: UTF-8
       string: |-
         {
-          "id": "cs_test_a1I1vOQaOr8w6Oey8PorTbbULg8IpikMRyKAYo80Lf7bmGTUzcbFgz4hZW",
+          "id": "cs_test_a1mQFKniDllWidhN4Rj8MtJt3LrQ1hVidhHSHShuXr2SMUTpYvWhZ6dejP",
           "object": "checkout.session",
           "adaptive_pricing": {
             "enabled": true
@@ -184,7 +192,7 @@ http_interactions:
             "font_family": "default",
             "icon": {
               "type": "url",
-              "url": "https://d1wqzb5bdbcre6.cloudfront.net/b4482d0007d24b441c7905466ea522c2ee3dcc6a8eff7f58350343a828cf242e/68747470733a2f2f73332e616d617a6f6e6177732e636f6d2f7374726970652d75706c6f6164732f616363745f324b736e6d3054304742665830767950554978456d65726368616e742d69636f6e2d3436393534342d42696b65496e6465784c6f676f2e706e67/6d65726368616e745f69643d616363745f324b736e6d30543047426658307679505549784526636c69656e743d5041594d454e545f50414745"
+              "url": "https://stripe-camo.global.ssl.fastly.net/b4482d0007d24b441c7905466ea522c2ee3dcc6a8eff7f58350343a828cf242e/68747470733a2f2f73332e616d617a6f6e6177732e636f6d2f7374726970652d75706c6f6164732f616363745f324b736e6d3054304742665830767950554978456d65726368616e742d69636f6e2d3436393534342d42696b65496e6465784c6f676f2e706e67/6d65726368616e745f69643d616363745f324b736e6d30543047426658307679505549784526636c69656e743d5041594d454e545f50414745"
             },
             "logo": null
           },
@@ -198,7 +206,7 @@ http_interactions:
           },
           "consent": null,
           "consent_collection": null,
-          "created": 1771009891,
+          "created": 1777335648,
           "currency": "usd",
           "currency_conversion": null,
           "custom_fields": [],
@@ -214,20 +222,24 @@ http_interactions:
           "customer_details": {
             "address": null,
             "business_name": null,
-            "email": "user53s@bikeindex.org",
+            "email": "user1679s@bikeindex.org",
             "individual_name": null,
             "name": null,
             "phone": null,
             "tax_exempt": "none",
             "tax_ids": null
           },
-          "customer_email": "user53s@bikeindex.org",
+          "customer_email": "user1679s@bikeindex.org",
           "discounts": [],
-          "expires_at": 1771096291,
+          "expires_at": 1777422048,
+          "integration_identifier": null,
           "invoice": null,
           "invoice_creation": null,
           "livemode": false,
           "locale": null,
+          "managed_payments": {
+            "enabled": false
+          },
           "metadata": {},
           "mode": "subscription",
           "origin_context": null,
@@ -275,8 +287,8 @@ http_interactions:
             "amount_tax": 0
           },
           "ui_mode": "hosted",
-          "url": "https://checkout.stripe.com/c/pay/cs_test_a1I1vOQaOr8w6Oey8PorTbbULg8IpikMRyKAYo80Lf7bmGTUzcbFgz4hZW#fidnandhYHdWcXxpYCc%2FJ2FgY2RwaXEnKSdkdWxOYHwnPyd1blpxYHZxWl9PQWxNZ19JVkdmZFFcbzV2N0RtMmhLYCcpJ2N3amhWYHdzYHcnP3F3cGApJ2dkZm5id2pwa2FGamlqdyc%2FJyZjY2NjY2MnKSdpZHxqcHFRfHVgJz8ndmxrYmlgWmxxYGgnKSdga2RnaWBVaWRmYG1qaWFgd3YnP3F3cGB4JSUl",
+          "url": "https://checkout.stripe.com/c/pay/cs_test_a1mQFKniDllWidhN4Rj8MtJt3LrQ1hVidhHSHShuXr2SMUTpYvWhZ6dejP#fidnandhYHdWcXxpYCc%2FJ2FgY2RwaXEnKSdicGRmZGhqaWBTZHdsZGtxJz8nZmprcXdqaScpJ2R1bE5gfCc%2FJ3VuWnFgdnFaX09BbE1nX0lWR2ZkUVxvNXY3RG0yaEtgJyknY3dqaFZgd3Ngdyc%2FcXdwYCknZ2RmbmJ3anBrYUZqaWp3Jz8nJmNjY2NjYycpJ2lkfGpwcVF8dWAnPyd2bGtiaWBabHFgaCcpJ2BrZGdpYFVpZGZgbWppYWB3dic%2FcXdwYHgl",
           "wallet_options": null
         }
-  recorded_at: Fri, 13 Feb 2026 19:11:31 GMT
-recorded_with: VCR 6.3.1
+  recorded_at: Tue, 28 Apr 2026 00:20:49 GMT
+recorded_with: VCR 6.4.0

--- a/spec/vcr_cassettes/StripeSubscription-create_for-success.yml
+++ b/spec/vcr_cassettes/StripeSubscription-create_for-success.yml
@@ -5,12 +5,14 @@ http_interactions:
     uri: https://api.stripe.com/v1/checkout/sessions
     body:
       encoding: UTF-8
-      string: success_url=http%3A%2F%2Ftest.host%2Fmembership%2Fsuccess%3Fsession_id%3D%7BCHECKOUT_SESSION_ID%7D&cancel_url=http%3A%2F%2Ftest.host%2Fmembership%2Fnew&mode=subscription&line_items[0][quantity]=1&line_items[0][price]=price_0Qs5rim0T0GBfX0vE7Q7cyoG&customer_email=user51s%40bikeindex.org
+      string: success_url=http%3A%2F%2Ftest.host%2Fmembership%2Fsuccess%3Fsession_id%3D%7BCHECKOUT_SESSION_ID%7D&cancel_url=http%3A%2F%2Ftest.host%2Fmembership%2Fnew&mode=subscription&line_items[0][quantity]=1&line_items[0][price]=price_0Qs5rim0T0GBfX0vE7Q7cyoG&customer_email=user1677s%40bikeindex.org
     headers:
       User-Agent:
       - Stripe/v1 RubyBindings/13.4.1
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_6F5fpz6Ihgs46l","request_duration_ms":1}}'
       Idempotency-Key:
-      - 830e328e-9197-476b-b39e-c981afa1055e
+      - '02472972-e5e5-4489-ab9d-5295900ce97f'
       Stripe-Version:
       - 2025-01-27.acacia
       Content-Type:
@@ -27,11 +29,11 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Fri, 13 Feb 2026 19:11:31 GMT
+      - Tue, 28 Apr 2026 00:20:48 GMT
       Content-Type:
       - application/json
       Content-Length:
-      - '3648'
+      - '3776'
       Connection:
       - keep-alive
       Access-Control-Allow-Credentials:
@@ -50,13 +52,17 @@ http_interactions:
       Content-Security-Policy:
       - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
         img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
-        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=r0MHs3xYLEtcp66z5qiUFfO3z7T23FEjk9XzisFI6apXphWXyU2Du05sZVM4_YqpZIw-kXtTMVIWlJsu
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=2EgX3QsnqsA07w1cVbtpxpsAyHXvheI20S8WEqke_hBiw683RyLrl6edTH35AOzI3FsMWGS0s8e8fqI3
       Idempotency-Key:
-      - 830e328e-9197-476b-b39e-c981afa1055e
+      - '02472972-e5e5-4489-ab9d-5295900ce97f'
       Original-Request:
-      - req_aaeNVI4ddFAfVV
+      - req_MfVth8xGxigJEM
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=2EgX3QsnqsA07w1cVbtpxpsAyHXvheI20S8WEqke_hBiw683RyLrl6edTH35AOzI3FsMWGS0s8e8fqI3&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=2EgX3QsnqsA07w1cVbtpxpsAyHXvheI20S8WEqke_hBiw683RyLrl6edTH35AOzI3FsMWGS0s8e8fqI3&t=1"
       Request-Id:
-      - req_aaeNVI4ddFAfVV
+      - req_MfVth8xGxigJEM
       Stripe-Should-Retry:
       - 'false'
       Stripe-Version:
@@ -68,14 +74,14 @@ http_interactions:
       X-Stripe-Routing-Context-Priority-Tier:
       - api-testmode
       X-Wc:
-      - ABGHIJ
+      - 3c3
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
     body:
       encoding: UTF-8
       string: |-
         {
-          "id": "cs_test_a1W3bVDkQ0hGdGBNz03EKBd0z4Y46ReDmZ5OHBliHjz4i5Y6TscPnwuKob",
+          "id": "cs_test_a1kR92giRfpMYQ3z9348aS7QstqQxMWPAxfk559oG7M9szEu6MrOYS6qIG",
           "object": "checkout.session",
           "adaptive_pricing": {
             "enabled": true
@@ -113,7 +119,7 @@ http_interactions:
           },
           "consent": null,
           "consent_collection": null,
-          "created": 1771009891,
+          "created": 1777335648,
           "currency": "usd",
           "currency_conversion": null,
           "custom_fields": [],
@@ -129,20 +135,24 @@ http_interactions:
           "customer_details": {
             "address": null,
             "business_name": null,
-            "email": "user51s@bikeindex.org",
+            "email": "user1677s@bikeindex.org",
             "individual_name": null,
             "name": null,
             "phone": null,
             "tax_exempt": "none",
             "tax_ids": null
           },
-          "customer_email": "user51s@bikeindex.org",
+          "customer_email": "user1677s@bikeindex.org",
           "discounts": [],
-          "expires_at": 1771096290,
+          "expires_at": 1777422048,
+          "integration_identifier": null,
           "invoice": null,
           "invoice_creation": null,
           "livemode": false,
           "locale": null,
+          "managed_payments": {
+            "enabled": false
+          },
           "metadata": {},
           "mode": "subscription",
           "origin_context": null,
@@ -190,8 +200,8 @@ http_interactions:
             "amount_tax": 0
           },
           "ui_mode": "hosted",
-          "url": "https://checkout.stripe.com/c/pay/cs_test_a1W3bVDkQ0hGdGBNz03EKBd0z4Y46ReDmZ5OHBliHjz4i5Y6TscPnwuKob#fidnandhYHdWcXxpYCc%2FJ2FgY2RwaXEnKSdkdWxOYHwnPyd1blpxYHZxWl9PQWxNZ19JVkdmZFFcbzV2N0RtMmhLYCcpJ2N3amhWYHdzYHcnP3F3cGApJ2dkZm5id2pwa2FGamlqdyc%2FJyZjY2NjY2MnKSdpZHxqcHFRfHVgJz8ndmxrYmlgWmxxYGgnKSdga2RnaWBVaWRmYG1qaWFgd3YnP3F3cGB4JSUl",
+          "url": "https://checkout.stripe.com/c/pay/cs_test_a1kR92giRfpMYQ3z9348aS7QstqQxMWPAxfk559oG7M9szEu6MrOYS6qIG#fidnandhYHdWcXxpYCc%2FJ2FgY2RwaXEnKSdicGRmZGhqaWBTZHdsZGtxJz8nZmprcXdqaScpJ2R1bE5gfCc%2FJ3VuWnFgdnFaX09BbE1nX0lWR2ZkUVxvNXY3RG0yaEtgJyknY3dqaFZgd3Ngdyc%2FcXdwYCknZ2RmbmJ3anBrYUZqaWp3Jz8nJmNjY2NjYycpJ2lkfGpwcVF8dWAnPyd2bGtiaWBabHFgaCcpJ2BrZGdpYFVpZGZgbWppYWB3dic%2FcXdwYHgl",
           "wallet_options": null
         }
-  recorded_at: Fri, 13 Feb 2026 19:11:31 GMT
-recorded_with: VCR 6.3.1
+  recorded_at: Tue, 28 Apr 2026 00:20:48 GMT
+recorded_with: VCR 6.4.0


### PR DESCRIPTION
Four Honeybadger faults from bot-style injection in user input, plus a sweep of related normalization across `friendly_find` lookups.

## Honeybadger faults fixed

- [`page[$eq]=2`](https://app.honeybadger.io/projects/35931/faults/123690260) coerced `params[:page]` to a Hash, crashing `permitted_page`/`permitted_per_page` (500) and `LogSearcher::Parser.parse_log_line` while ingesting the resulting log line. Helpers use `.to_s.to_i`; parser uses a new `page_for(value)` returning nil for non-string/numeric.
- [Numeric `cycle_type`](https://app.honeybadger.io/projects/35931/faults/129918710) (e.g. `19039792`) reached `Enumable.find_sym`'s paren-name fallback as an Integer, raising `TypeError` on `str[/\(/]`. Guarded with `str.is_a?(String)`.
- [Null-byte `owner_email`](https://app.honeybadger.io/projects/35931/faults/123023251) reached Postgres via `BParam.save`.
- [Null-byte `organization_id`](https://app.honeybadger.io/projects/35931/faults/129918588) reached Postgres via `Organization.friendly_find`.

## Normalization

Bumps `binxtils` to 0.4.2, which adds null-byte stripping to `Binxtils::InputNormalizer.string`. That helper now drives input scrubbing across the codebase: