### PR TITLE
PaymentsController#create: rescue Stripe::InvalidRequestError

### DIFF
--- a/app/controllers/payments_controller.rb
+++ b/app/controllers/payments_controller.rb
@@ -26,6 +26,9 @@ class PaymentsController < ApplicationController
     @payment.stripe_checkout_session
 
     redirect_to @payment.stripe_checkout_session.url, allow_other_host: true
+  rescue Stripe::InvalidRequestError => e
+    flash[:notice] = "Unable to process payment: #{e.message}"
+    redirect_back(fallback_location: new_payment_path)
   end
 
   private

--- a/spec/requests/payments_request_spec.rb
+++ b/spec/requests/payments_request_spec.rb
@@ -179,6 +179,19 @@ RSpec.describe PaymentsController, type: :request do
       end
     end
 
+    context "with amount below stripe minimum" do
+      it "redirects back with the stripe error message" do
+        VCR.use_cassette("payments_controller-below-stripe-minimum", match_requests_on: [:method], re_record_interval:) do
+          post base_url, params: {
+            is_arbitrary: false,
+            payment: {amount_cents: 1, currency: "USD", kind: "donation"}
+          }
+        end
+        expect(response).to redirect_to(new_payment_path)
+        expect(flash[:notice]).to match(/unable to process payment/i)
+      end
+    end
+
     context "with user" do
       include_context :request_spec_logged_in_as_user
       it "makes a onetime payment with current user" do

--- a/spec/vcr_cassettes/payments_controller-below-stripe-minimum.yml
+++ b/spec/vcr_cassettes/payments_controller-below-stripe-minimum.yml
@@ -1,0 +1,91 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/checkout/sessions
+    body:
+      encoding: UTF-8
+      string: submit_type=donate&line_items[0][price_data][unit_amount]=1&line_items[0][price_data][currency]=USD&line_items[0][price_data][product_data][name]=Donation&line_items[0][price_data][product_data][images][0]=https%3A%2F%2Ffiles.bikeindex.org%2Fuploads%2FPu%2F151203%2Freg_hance.jpg&line_items[0][quantity]=1&mode=payment&success_url=http%3A%2F%2Ftest.host%2Fpayments%2Fsuccess%3Fsession_id%3D%7BCHECKOUT_SESSION_ID%7D&cancel_url=http%3A%2F%2Ftest.host%2Fpayments%2Fnew
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/13.4.1
+      Idempotency-Key:
+      - 9cd1debd-0f5e-4759-a37a-fdbd250ea32f
+      Stripe-Version:
+      - 2025-01-27.acacia
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 400
+      message: Bad Request
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Tue, 28 Apr 2026 15:32:21 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '379'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=rt7f3NaRRjEvZ-f7Gkff6305Gq_GOR5m6TOCNO47ZY_iJWix4iWOZ-gigiSOrCgRskfObuB9tAo0rXGL
+      Idempotency-Key:
+      - 9cd1debd-0f5e-4759-a37a-fdbd250ea32f
+      Original-Request:
+      - req_c2PSUJCFgRm2an
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=rt7f3NaRRjEvZ-f7Gkff6305Gq_GOR5m6TOCNO47ZY_iJWix4iWOZ-gigiSOrCgRskfObuB9tAo0rXGL&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=rt7f3NaRRjEvZ-f7Gkff6305Gq_GOR5m6TOCNO47ZY_iJWix4iWOZ-gigiSOrCgRskfObuB9tAo0rXGL&t=1"
+      Request-Id:
+      - req_c2PSUJCFgRm2an
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - 2025-01-27.acacia
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |
+        {
+          "error": {
+            "code": "amount_too_small",
+            "doc_url": "https://stripe.com/docs/error-codes/amount-too-small",
+            "message": "The Checkout Session's total amount due must add up to at least $0.50 usd",
+            "request_log_url": "https://dashboard.stripe.com/acct_2Ksnm0T0GBfX0vyPUIxE/test/workbench/logs?object=req_c2PSUJCFgRm2an",
+            "type": "invalid_request_error"
+          }
+        }
+  recorded_at: Tue, 28 Apr 2026 15:32:21 GMT
+recorded_with: VCR 6.4.0

--- a/spec/vcr_cassettes/payments_controller-donation-customer.yml
+++ b/spec/vcr_cassettes/payments_controller-donation-customer.yml
@@ -294,9 +294,9 @@ http_interactions:
       User-Agent:
       - Stripe/v1 RubyBindings/13.4.1
       X-Stripe-Client-Telemetry:
-      - '{"last_request_metrics":{"request_id":"req_IKAqOsl6Cv1SIT","request_duration_ms":454}}'
+      - '{"last_request_metrics":{"request_id":"req_jPzFuFS4XJOX7a","request_duration_ms":407}}'
       Idempotency-Key:
-      - 2fb12b58-bc81-4ef4-9b36-4f7809253e24
+      - bcef9016-0b22-4487-b29e-3a2155be9c72
       Stripe-Version:
       - 2025-01-27.acacia
       Content-Type:
@@ -313,11 +313,11 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Fri, 03 Apr 2026 13:12:53 GMT
+      - Tue, 28 Apr 2026 15:33:00 GMT
       Content-Type:
       - application/json
       Content-Length:
-      - '3906'
+      - '3996'
       Connection:
       - keep-alive
       Access-Control-Allow-Credentials:
@@ -336,13 +336,17 @@ http_interactions:
       Content-Security-Policy:
       - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
         img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
-        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=WTQQIC7f6vIyzn7htHAPST8rxzNrQDi0jfT0af-AWX9NIR9d9lajbxNZveeLW3huoyik9FNHc_9WBScd
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=VbHfLfgJs-T4GfT80dTlB33bw66-rIWseBvuW75wij_E0g_bbqIvJe5XmYchFKzSvKpRZa0s7tBqNeO3
       Idempotency-Key:
-      - 2fb12b58-bc81-4ef4-9b36-4f7809253e24
+      - bcef9016-0b22-4487-b29e-3a2155be9c72
       Original-Request:
-      - req_8fckReS621fkw2
+      - req_ubn3p9z9i7PSb7
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=VbHfLfgJs-T4GfT80dTlB33bw66-rIWseBvuW75wij_E0g_bbqIvJe5XmYchFKzSvKpRZa0s7tBqNeO3&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=VbHfLfgJs-T4GfT80dTlB33bw66-rIWseBvuW75wij_E0g_bbqIvJe5XmYchFKzSvKpRZa0s7tBqNeO3&t=1"
       Request-Id:
-      - req_8fckReS621fkw2
+      - req_ubn3p9z9i7PSb7
       Stripe-Should-Retry:
       - 'false'
       Stripe-Version:
@@ -361,7 +365,7 @@ http_interactions:
       encoding: UTF-8
       string: |-
         {
-          "id": "cs_test_a101zGo58F9HbqA6MZu0chU0gfiAD1Kyd1ebwruohgLowUwmSn8PxC6BJZ",
+          "id": "cs_test_a1YGb5WONjfWDLIo5y0GDgTQ4fBSCFj2axWt3SztB19q9voPB5gygJfuZK",
           "object": "checkout.session",
           "adaptive_pricing": {
             "enabled": true
@@ -399,7 +403,7 @@ http_interactions:
           },
           "consent": null,
           "consent_collection": null,
-          "created": 1775221973,
+          "created": 1777390380,
           "currency": "usd",
           "currency_conversion": null,
           "custom_fields": [],
@@ -424,7 +428,7 @@ http_interactions:
           },
           "customer_email": null,
           "discounts": [],
-          "expires_at": 1775308372,
+          "expires_at": 1777476780,
           "integration_identifier": null,
           "invoice": null,
           "invoice_creation": {
@@ -441,6 +445,9 @@ http_interactions:
           },
           "livemode": false,
           "locale": null,
+          "managed_payments": {
+            "enabled": false
+          },
           "metadata": {},
           "mode": "payment",
           "origin_context": null,
@@ -488,8 +495,8 @@ http_interactions:
             "amount_tax": 0
           },
           "ui_mode": "hosted",
-          "url": "https://checkout.stripe.com/c/pay/cs_test_a101zGo58F9HbqA6MZu0chU0gfiAD1Kyd1ebwruohgLowUwmSn8PxC6BJZ#fidnandhYHdWcXxpYCc%2FJ2FgY2RwaXEnKSdkdWxOYHwnPyd1blpxYHZxWl9PQWxNZ19JVkdmZFFcbzV2N0RtMmhLYCcpJ2N3amhWYHdzYHcnP3F3cGApJ2dkZm5id2pwa2FGamlqdyc%2FJyZjY2NjY2MnKSdpZHxqcHFRfHVgJz8ndmxrYmlgWmxxYGgnKSdga2RnaWBVaWRmYG1qaWFgd3YnP3F3cGB4JSUl",
+          "url": "https://checkout.stripe.com/c/pay/cs_test_a1YGb5WONjfWDLIo5y0GDgTQ4fBSCFj2axWt3SztB19q9voPB5gygJfuZK#fidnandhYHdWcXxpYCc%2FJ2FgY2RwaXEnKSdicGRmZGhqaWBTZHdsZGtxJz8nZmprcXdqaScpJ2R1bE5gfCc%2FJ3VuWnFgdnFaX09BbE1nX0lWR2ZkUVxvNXY3RG0yaEtgJyknY3dqaFZgd3Ngdyc%2FcXdwYCknZ2RmbmJ3anBrYUZqaWp3Jz8nJmNjY2NjYycpJ2lkfGpwcVF8dWAnPyd2bGtiaWBabHFgaCcpJ2BrZGdpYFVpZGZgbWppYWB3dic%2FcXdwYHgl",
           "wallet_options": null
         }
-  recorded_at: Fri, 03 Apr 2026 13:12:53 GMT
+  recorded_at: Tue, 28 Apr 2026 15:33:00 GMT
 recorded_with: VCR 6.4.0

--- a/spec/vcr_cassettes/payments_controller-donation.yml
+++ b/spec/vcr_cassettes/payments_controller-donation.yml
@@ -174,14 +174,12 @@ http_interactions:
     uri: https://api.stripe.com/v1/checkout/sessions
     body:
       encoding: UTF-8
-      string: submit_type=donate&line_items[0][price_data][unit_amount]=4000&line_items[0][price_data][currency]=MXN&line_items[0][price_data][product_data][name]=Donation&line_items[0][price_data][product_data][images][0]=https%3A%2F%2Ffiles.bikeindex.org%2Fuploads%2FPu%2F151203%2Freg_hance.jpg&line_items[0][quantity]=1&mode=payment&success_url=http%3A%2F%2Ftest.host%2Fpayments%2Fsuccess%3Fsession_id%3D%7BCHECKOUT_SESSION_ID%7D&cancel_url=http%3A%2F%2Ftest.host%2Fpayments%2Fnew&customer_email=user217s%40bikeindex.org
+      string: submit_type=donate&line_items[0][price_data][unit_amount]=4000&line_items[0][price_data][currency]=MXN&line_items[0][price_data][product_data][name]=Donation&line_items[0][price_data][product_data][images][0]=https%3A%2F%2Ffiles.bikeindex.org%2Fuploads%2FPu%2F151203%2Freg_hance.jpg&line_items[0][quantity]=1&mode=payment&success_url=http%3A%2F%2Ftest.host%2Fpayments%2Fsuccess%3Fsession_id%3D%7BCHECKOUT_SESSION_ID%7D&cancel_url=http%3A%2F%2Ftest.host%2Fpayments%2Fnew&customer_email=user1s%40bikeindex.org
     headers:
       User-Agent:
       - Stripe/v1 RubyBindings/13.4.1
-      X-Stripe-Client-Telemetry:
-      - '{"last_request_metrics":{"request_id":"req_8Gwd22WHoAgKEi","request_duration_ms":4}}'
       Idempotency-Key:
-      - 7e0ed23d-0ffb-46ac-9fb6-5a874ef1bf83
+      - 24c42470-fb51-48f0-ae33-084ce7f9b0c3
       Stripe-Version:
       - 2025-01-27.acacia
       Content-Type:
@@ -198,11 +196,11 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Fri, 03 Apr 2026 13:12:52 GMT
+      - Tue, 28 Apr 2026 15:32:59 GMT
       Content-Type:
       - application/json
       Content-Length:
-      - '3781'
+      - '3867'
       Connection:
       - keep-alive
       Access-Control-Allow-Credentials:
@@ -221,13 +219,17 @@ http_interactions:
       Content-Security-Policy:
       - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
         img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
-        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=WTQQIC7f6vIyzn7htHAPST8rxzNrQDi0jfT0af-AWX9NIR9d9lajbxNZveeLW3huoyik9FNHc_9WBScd
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=VbHfLfgJs-T4GfT80dTlB33bw66-rIWseBvuW75wij_E0g_bbqIvJe5XmYchFKzSvKpRZa0s7tBqNeO3
       Idempotency-Key:
-      - 7e0ed23d-0ffb-46ac-9fb6-5a874ef1bf83
+      - 24c42470-fb51-48f0-ae33-084ce7f9b0c3
       Original-Request:
-      - req_IKAqOsl6Cv1SIT
+      - req_jPzFuFS4XJOX7a
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=VbHfLfgJs-T4GfT80dTlB33bw66-rIWseBvuW75wij_E0g_bbqIvJe5XmYchFKzSvKpRZa0s7tBqNeO3&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=VbHfLfgJs-T4GfT80dTlB33bw66-rIWseBvuW75wij_E0g_bbqIvJe5XmYchFKzSvKpRZa0s7tBqNeO3&t=1"
       Request-Id:
-      - req_IKAqOsl6Cv1SIT
+      - req_jPzFuFS4XJOX7a
       Stripe-Should-Retry:
       - 'false'
       Stripe-Version:
@@ -246,7 +248,7 @@ http_interactions:
       encoding: UTF-8
       string: |-
         {
-          "id": "cs_test_a1blNKj6QLWRvs2v32j6KKI6sv0t4eQIAokkH8psSXjos8qZICtDy3IN7m",
+          "id": "cs_test_a1H7PTIC4OBWv900WO9g8o76NJknBh02dWQwfFiG9UohfrZxwWTbvwhkQd",
           "object": "checkout.session",
           "adaptive_pricing": {
             "enabled": true
@@ -284,7 +286,7 @@ http_interactions:
           },
           "consent": null,
           "consent_collection": null,
-          "created": 1775221972,
+          "created": 1777390379,
           "currency": "mxn",
           "currency_conversion": null,
           "custom_fields": [],
@@ -300,16 +302,16 @@ http_interactions:
           "customer_details": {
             "address": null,
             "business_name": null,
-            "email": "user217s@bikeindex.org",
+            "email": "user1s@bikeindex.org",
             "individual_name": null,
             "name": null,
             "phone": null,
             "tax_exempt": "none",
             "tax_ids": null
           },
-          "customer_email": "user217s@bikeindex.org",
+          "customer_email": "user1s@bikeindex.org",
           "discounts": [],
-          "expires_at": 1775308372,
+          "expires_at": 1777476779,
           "integration_identifier": null,
           "invoice": null,
           "invoice_creation": {
@@ -326,6 +328,9 @@ http_interactions:
           },
           "livemode": false,
           "locale": null,
+          "managed_payments": {
+            "enabled": false
+          },
           "metadata": {},
           "mode": "payment",
           "origin_context": null,
@@ -366,8 +371,8 @@ http_interactions:
             "amount_tax": 0
           },
           "ui_mode": "hosted",
-          "url": "https://checkout.stripe.com/c/pay/cs_test_a1blNKj6QLWRvs2v32j6KKI6sv0t4eQIAokkH8psSXjos8qZICtDy3IN7m#fidnandhYHdWcXxpYCc%2FJ2FgY2RwaXEnKSdkdWxOYHwnPyd1blpxYHZxWl9PQWxNZ19JVkdmZFFcbzV2N0RtMmhLYCcpJ2N3amhWYHdzYHcnP3F3cGApJ2dkZm5id2pwa2FGamlqdyc%2FJyZjY2NjY2MnKSdpZHxqcHFRfHVgJz8ndmxrYmlgWmxxYGgnKSdga2RnaWBVaWRmYG1qaWFgd3YnP3F3cGB4JSUl",
+          "url": "https://checkout.stripe.com/c/pay/cs_test_a1H7PTIC4OBWv900WO9g8o76NJknBh02dWQwfFiG9UohfrZxwWTbvwhkQd#fidnandhYHdWcXxpYCc%2FJ2FgY2RwaXEnKSdicGRmZGhqaWBTZHdsZGtxJz8nZmprcXdqaScpJ2R1bE5gfCc%2FJ3VuWnFgdnFaX09BbE1nX0lWR2ZkUVxvNXY3RG0yaEtgJyknY3dqaFZgd3Ngdyc%2FcXdwYCknZ2RmbmJ3anBrYUZqaWp3Jz8nJmNjY2NjYycpJ2lkfGpwcVF8dWAnPyd2bGtiaWBabHFgaCcpJ2BrZGdpYFVpZGZgbWppYWB3dic%2FcXdwYHgl",
           "wallet_options": null
         }
-  recorded_at: Fri, 03 Apr 2026 13:12:52 GMT
+  recorded_at: Tue, 28 Apr 2026 15:32:59 GMT
 recorded_with: VCR 6.4.0

--- a/spec/vcr_cassettes/payments_controller-onetime-nouser.yml
+++ b/spec/vcr_cassettes/payments_controller-onetime-nouser.yml
@@ -9,10 +9,8 @@ http_interactions:
     headers:
       User-Agent:
       - Stripe/v1 RubyBindings/13.4.1
-      X-Stripe-Client-Telemetry:
-      - '{"last_request_metrics":{"request_id":"req_o23tZZDW8OKFvb","request_duration_ms":266}}'
       Idempotency-Key:
-      - 71b9d350-3ffe-4c32-be2f-d130ddd5b807
+      - 6b01dcc1-8492-4a72-8a36-8d2b6ba17778
       Stripe-Version:
       - 2025-01-27.acacia
       Content-Type:
@@ -29,11 +27,11 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Tue, 24 Feb 2026 18:23:04 GMT
+      - Tue, 28 Apr 2026 15:32:59 GMT
       Content-Type:
       - application/json
       Content-Length:
-      - '3449'
+      - '3573'
       Connection:
       - keep-alive
       Access-Control-Allow-Credentials:
@@ -52,13 +50,17 @@ http_interactions:
       Content-Security-Policy:
       - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
         img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
-        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=1BhH5EIvs7_cxwG8cRQTppPStQrNq6ApY3ZoMf2IIf8CHze3Vpyl1V66vf6sNxrVitHPvKTSaQPfUy2e
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=aTjASQ5rN63L65omajFv6M2qyGhtkKopwLc0phq2r39EQddFwhP1ytKmzCeR0wlwmy4DilAUj85EVGrP
       Idempotency-Key:
-      - 71b9d350-3ffe-4c32-be2f-d130ddd5b807
+      - 6b01dcc1-8492-4a72-8a36-8d2b6ba17778
       Original-Request:
-      - req_8Gwd22WHoAgKEi
+      - req_wbOb1o6EJnJjsC
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=aTjASQ5rN63L65omajFv6M2qyGhtkKopwLc0phq2r39EQddFwhP1ytKmzCeR0wlwmy4DilAUj85EVGrP&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=aTjASQ5rN63L65omajFv6M2qyGhtkKopwLc0phq2r39EQddFwhP1ytKmzCeR0wlwmy4DilAUj85EVGrP&t=1"
       Request-Id:
-      - req_8Gwd22WHoAgKEi
+      - req_wbOb1o6EJnJjsC
       Stripe-Should-Retry:
       - 'false'
       Stripe-Version:
@@ -70,14 +72,14 @@ http_interactions:
       X-Stripe-Routing-Context-Priority-Tier:
       - api-testmode
       X-Wc:
-      - ABGHIJ
+      - 3c3
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains; preload
     body:
       encoding: UTF-8
       string: |-
         {
-          "id": "cs_test_a14GYV7WoMSZ6WkizcBUySkq0J2ePYmGFpfahXMzYFm73LSJBAndXKQkXe",
+          "id": "cs_test_a1yxkCSwichSFf34QyYfdd40nd2pm4VxjXFdTNlrHM0qL5RF7ccIZZtnEV",
           "object": "checkout.session",
           "adaptive_pricing": {
             "enabled": true
@@ -111,7 +113,7 @@ http_interactions:
           "collected_information": null,
           "consent": null,
           "consent_collection": null,
-          "created": 1771957384,
+          "created": 1777390379,
           "currency": "usd",
           "currency_conversion": null,
           "custom_fields": [],
@@ -127,7 +129,8 @@ http_interactions:
           "customer_details": null,
           "customer_email": null,
           "discounts": [],
-          "expires_at": 1772043784,
+          "expires_at": 1777476779,
+          "integration_identifier": null,
           "invoice": null,
           "invoice_creation": {
             "enabled": false,
@@ -143,6 +146,9 @@ http_interactions:
           },
           "livemode": false,
           "locale": null,
+          "managed_payments": {
+            "enabled": false
+          },
           "metadata": {},
           "mode": "payment",
           "origin_context": null,
@@ -184,8 +190,8 @@ http_interactions:
             "amount_tax": 0
           },
           "ui_mode": "hosted",
-          "url": "https://checkout.stripe.com/c/pay/cs_test_a14GYV7WoMSZ6WkizcBUySkq0J2ePYmGFpfahXMzYFm73LSJBAndXKQkXe#fidnandhYHdWcXxpYCc%2FJ2FgY2RwaXEnKSdkdWxOYHwnPyd1blpxYHZxWl9PQWxNZ19JVkdmZFFcbzV2N0RtMmhLYCcpJ2N3amhWYHdzYHcnP3F3cGApJ2dkZm5id2pwa2FGamlqdyc%2FJyZjY2NjY2MnKSdpZHxqcHFRfHVgJz8ndmxrYmlgWmxxYGgnKSdga2RnaWBVaWRmYG1qaWFgd3YnP3F3cGB4JSUl",
+          "url": "https://checkout.stripe.com/c/pay/cs_test_a1yxkCSwichSFf34QyYfdd40nd2pm4VxjXFdTNlrHM0qL5RF7ccIZZtnEV#fidnandhYHdWcXxpYCc%2FJ2FgY2RwaXEnKSdicGRmZGhqaWBTZHdsZGtxJz8nZmprcXdqaScpJ2R1bE5gfCc%2FJ3VuWnFgdnFaX09BbE1nX0lWR2ZkUVxvNXY3RG0yaEtgJyknY3dqaFZgd3Ngdyc%2FcXdwYCknZ2RmbmJ3anBrYUZqaWp3Jz8nJmNjY2NjYycpJ2lkfGpwcVF8dWAnPyd2bGtiaWBabHFgaCcpJ2BrZGdpYFVpZGZgbWppYWB3dic%2FcXdwYHgl",
           "wallet_options": null
         }
-  recorded_at: Tue, 24 Feb 2026 18:23:04 GMT
-recorded_with: VCR 6.3.1
+  recorded_at: Tue, 28 Apr 2026 15:32:59 GMT
+recorded_with: VCR 6.4.0


### PR DESCRIPTION
Stripe rejects sub-minimum amounts (e.g. `amount_cents=1`) with `Stripe::InvalidRequestError`, which `PaymentsController#create` was letting bubble up as a 500. Production logs showed ~2k of these in 36 hours, all from one scanner IP fuzzing `/payments`, but a real user with an off-by-cents amount would see the same 500.

- Rescue `Stripe::InvalidRequestError` in `create`, set `flash[:notice]` with the Stripe message, and redirect back — same shape as the existing invalid-amount path.
- Request spec covers a `1`-cent USD donation, with a fresh VCR cassette of Stripe's real rejection.
