### PR TITLE
Use MultiJson.adapter= instead of deprecated MultiJson.engine=

### DIFF
--- a/config/initializers/oj.rb
+++ b/config/initializers/oj.rb
@@ -7,4 +7,4 @@ Oj::Rails.optimize
 Oj.default_options = Oj.default_options.merge(mode: :compat)
 
 # Not sure why it's not using this by default!
-MultiJson.engine = :oj
+MultiJson.adapter = :oj


### PR DESCRIPTION
`multi_json` 1.20 deprecated `MultiJson.engine=` in favor of `MultiJson.adapter=`. Updates the Oj initializer to use the supported setter and silence the warning.
