### PR TITLE
Add trigram index on bikes.serial_normalized_no_space

### DIFF
--- a/app/models/bike.rb
+++ b/app/models/bike.rb
@@ -72,28 +72,29 @@
 #
 # Indexes
 #
-#  index_bikes_current_listing_order         (listing_order) WHERE ((example = false) AND (user_hidden = false) AND (likely_spam = false) AND (deleted_at IS NULL))
-#  index_bikes_on_address_record_id          (address_record_id) WHERE (address_record_id IS NOT NULL)
-#  index_bikes_on_creation_organization_id   (creation_organization_id) WHERE (creation_organization_id IS NOT NULL)
-#  index_bikes_on_current_impound_record_id  (current_impound_record_id) WHERE (current_impound_record_id IS NOT NULL)
-#  index_bikes_on_current_ownership_id       (current_ownership_id)
-#  index_bikes_on_current_stolen_record_id   (current_stolen_record_id) WHERE (current_stolen_record_id IS NOT NULL)
-#  index_bikes_on_deleted_at                 (deleted_at) WHERE (deleted_at IS NOT NULL)
-#  index_bikes_on_example                    (example) WHERE (example IS NOT NULL)
-#  index_bikes_on_latitude_and_longitude     (latitude,longitude)
-#  index_bikes_on_listing_order              (listing_order)
-#  index_bikes_on_lower_frame_model          ("left"(lower(frame_model), 255))
-#  index_bikes_on_lower_mnfg_name            (lower((mnfg_name)::text))
-#  index_bikes_on_manufacturer_id            (manufacturer_id)
-#  index_bikes_on_model_audit_id             (model_audit_id) WHERE (model_audit_id IS NOT NULL)
-#  index_bikes_on_owner_email_trgm           (owner_email) USING gin
-#  index_bikes_on_paint_id                   (paint_id) WHERE (paint_id IS NOT NULL)
-#  index_bikes_on_primary_activity_id        (primary_activity_id) WHERE (primary_activity_id IS NOT NULL)
-#  index_bikes_on_primary_frame_color_id     (primary_frame_color_id)
-#  index_bikes_on_secondary_frame_color_id   (secondary_frame_color_id) WHERE (secondary_frame_color_id IS NOT NULL)
-#  index_bikes_on_status                     (status)
-#  index_bikes_on_tertiary_frame_color_id    (tertiary_frame_color_id) WHERE (tertiary_frame_color_id IS NOT NULL)
-#  index_bikes_on_user_hidden                (user_hidden) WHERE (user_hidden IS NOT NULL)
+#  index_bikes_current_listing_order               (listing_order) WHERE ((example = false) AND (user_hidden = false) AND (likely_spam = false) AND (deleted_at IS NULL))
+#  index_bikes_on_address_record_id                (address_record_id) WHERE (address_record_id IS NOT NULL)
+#  index_bikes_on_creation_organization_id         (creation_organization_id) WHERE (creation_organization_id IS NOT NULL)
+#  index_bikes_on_current_impound_record_id        (current_impound_record_id) WHERE (current_impound_record_id IS NOT NULL)
+#  index_bikes_on_current_ownership_id             (current_ownership_id)
+#  index_bikes_on_current_stolen_record_id         (current_stolen_record_id) WHERE (current_stolen_record_id IS NOT NULL)
+#  index_bikes_on_deleted_at                       (deleted_at) WHERE (deleted_at IS NOT NULL)
+#  index_bikes_on_example                          (example) WHERE (example IS NOT NULL)
+#  index_bikes_on_latitude_and_longitude           (latitude,longitude)
+#  index_bikes_on_listing_order                    (listing_order)
+#  index_bikes_on_lower_frame_model                ("left"(lower(frame_model), 255))
+#  index_bikes_on_lower_mnfg_name                  (lower((mnfg_name)::text))
+#  index_bikes_on_manufacturer_id                  (manufacturer_id)
+#  index_bikes_on_model_audit_id                   (model_audit_id) WHERE (model_audit_id IS NOT NULL)
+#  index_bikes_on_owner_email_trgm                 (owner_email) USING gin
+#  index_bikes_on_paint_id                         (paint_id) WHERE (paint_id IS NOT NULL)
+#  index_bikes_on_primary_activity_id              (primary_activity_id) WHERE (primary_activity_id IS NOT NULL)
+#  index_bikes_on_primary_frame_color_id           (primary_frame_color_id)
+#  index_bikes_on_secondary_frame_color_id         (secondary_frame_color_id) WHERE (secondary_frame_color_id IS NOT NULL)
+#  index_bikes_on_serial_normalized_no_space_trgm  (serial_normalized_no_space) WHERE ((example = false) AND (user_hidden = false) AND (likely_spam = false) AND (deleted_at IS NULL)) USING gin
+#  index_bikes_on_status                           (status)
+#  index_bikes_on_tertiary_frame_color_id          (tertiary_frame_color_id) WHERE (tertiary_frame_color_id IS NOT NULL)
+#  index_bikes_on_user_hidden                      (user_hidden) WHERE (user_hidden IS NOT NULL)
 #
 class Bike < ApplicationRecord
   include ActiveModel::Dirty

--- a/db/migrate/20260428000001_add_trigram_index_to_bikes_serial_normalized_no_space.rb
+++ b/db/migrate/20260428000001_add_trigram_index_to_bikes_serial_normalized_no_space.rb
@@ -1,0 +1,16 @@
+class AddTrigramIndexToBikesSerialNormalizedNoSpace < ActiveRecord::Migration[8.1]
+  disable_ddl_transaction!
+
+  def up
+    add_index :bikes, :serial_normalized_no_space,
+      using: :gin, opclass: :gin_trgm_ops,
+      where: "example = false AND user_hidden = false AND likely_spam = false AND deleted_at IS NULL",
+      name: :index_bikes_on_serial_normalized_no_space_trgm,
+      algorithm: :concurrently, if_not_exists: true
+  end
+
+  def down
+    remove_index :bikes, name: :index_bikes_on_serial_normalized_no_space_trgm,
+      algorithm: :concurrently, if_exists: true
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -6194,6 +6194,13 @@ CREATE INDEX index_bikes_on_secondary_frame_color_id ON public.bikes USING btree
 
 
 --
+-- Name: index_bikes_on_serial_normalized_no_space_trgm; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_bikes_on_serial_normalized_no_space_trgm ON public.bikes USING gin (serial_normalized_no_space public.gin_trgm_ops) WHERE ((example = false) AND (user_hidden = false) AND (likely_spam = false) AND (deleted_at IS NULL));
+
+
+--
 -- Name: index_bikes_on_status; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -7546,6 +7553,7 @@ ALTER TABLE ONLY public.ambassador_task_assignments
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20260428000001'),
 ('20260425103043'),
 ('20260425000001'),
 ('20260424000002'),


### PR DESCRIPTION
pghero flagged serial-search queries against `bikes` as the top slow queries on the primary replica (~24 minutes total over the window, led by a 10-min/16% `LEVENSHTEIN(serial_normalized_no_space, ?) < 3` scan). `bikes` had no index on `serial_normalized` or `serial_normalized_no_space`, so every serial search fell back to a sequential scan of the whole table.

- Adds `index_bikes_on_serial_normalized_no_space_trgm` — a partial GIN trigram index (`gin_trgm_ops`) on `serial_normalized_no_space`, with the same `example=false AND user_hidden=false AND likely_spam=false AND deleted_at IS NULL` filter as `index_bikes_current_listing_order` so the planner can combine them.
- Index-only; no query changes. This directly accelerates the `LIKE '%serial%'` path used by `search_serials_containing` (`/api/v3/search/serials_containing` + the registrations search fallback frame).
