### PR TITLE
Tinted dark-mode alert bgs; consistent secondary button states

### DIFF
--- a/app/components/ui/alert/component.rb
+++ b/app/components/ui/alert/component.rb
@@ -28,13 +28,13 @@ module UI
       def color_classes
         case @kind
         when :notice
-          "#{text_color_classes} tw:bg-blue-50 tw:dark:bg-gray-800 tw:border-blue-300 tw:dark:border-blue-800"
+          "#{text_color_classes} tw:bg-blue-50 tw:dark:bg-blue-950 tw:border-blue-300 tw:dark:border-blue-800"
         when :error
-          "#{text_color_classes} tw:bg-red-50 tw:dark:bg-gray-800 tw:border-red-300 tw:dark:border-red-800"
+          "#{text_color_classes} tw:bg-red-50 tw:dark:bg-red-950 tw:border-red-300 tw:dark:border-red-800"
         when :warning
-          "#{text_color_classes} tw:bg-yellow-50 tw:dark:bg-gray-800 tw:border-yellow-300 tw:dark:border-yellow-800"
+          "#{text_color_classes} tw:bg-yellow-50 tw:dark:bg-yellow-950 tw:border-yellow-300 tw:dark:border-yellow-800"
         when :success
-          "#{text_color_classes} tw:bg-green-50 tw:dark:bg-gray-800 tw:border-green-300 tw:dark:border-green-800"
+          "#{text_color_classes} tw:bg-green-50 tw:dark:bg-green-950 tw:border-green-300 tw:dark:border-green-800"
         end
       end
 
@@ -50,13 +50,13 @@ module UI
       def dismissable_color_classes
         case @kind
         when :notice
-          "tw:bg-blue-50 tw:focus:ring-blue-400 tw:hover:bg-blue-200 tw:dark:bg-gray-800 tw:dark:hover:bg-gray-700"
+          "tw:bg-blue-50 tw:focus:ring-blue-400 tw:hover:bg-blue-200 tw:dark:bg-blue-950 tw:dark:hover:bg-blue-900"
         when :error
-          "tw:bg-red-50 tw:focus:ring-red-400 tw:hover:bg-red-200 tw:dark:bg-gray-800 tw:dark:hover:bg-gray-700"
+          "tw:bg-red-50 tw:focus:ring-red-400 tw:hover:bg-red-200 tw:dark:bg-red-950 tw:dark:hover:bg-red-900"
         when :warning
-          "tw:bg-yellow-50 tw:focus:ring-yellow-400 tw:hover:bg-yellow-200 tw:dark:bg-gray-800 tw:dark:hover:bg-gray-700"
+          "tw:bg-yellow-50 tw:focus:ring-yellow-400 tw:hover:bg-yellow-200 tw:dark:bg-yellow-950 tw:dark:hover:bg-yellow-900"
         when :success
-          "tw:bg-green-50 tw:focus:ring-green-400 tw:hover:bg-green-200 tw:dark:bg-gray-800 tw:dark:hover:bg-gray-700"
+          "tw:bg-green-50 tw:focus:ring-green-400 tw:hover:bg-green-200 tw:dark:bg-green-950 tw:dark:hover:bg-green-900"
         end
       end
     end

--- a/app/components/ui/button/component.rb
+++ b/app/components/ui/button/component.rb
@@ -13,14 +13,14 @@ module UI
 
       COLORS = {
         primary: "tw:text-white tw:bg-blue-600 tw:border tw:border-blue-600 tw:hover:bg-blue-700 tw:active:bg-blue-800 tw:focus:ring-blue-500/40 tw:dark:bg-blue-500 tw:dark:border-blue-500 tw:dark:hover:bg-blue-600 tw:dark:active:bg-blue-700",
-        secondary: "tw:text-gray-700 tw:bg-gray-50 tw:border tw:border-gray-300 tw:hover:bg-gray-100 tw:hover:border-gray-400 tw:active:bg-gray-200 tw:focus:ring-blue-500/40 tw:dark:text-gray-200 tw:dark:bg-gray-700 tw:dark:border-gray-500 tw:dark:hover:bg-gray-800 tw:dark:hover:border-gray-600 tw:dark:active:bg-gray-900",
+        secondary: "tw:text-gray-700 tw:bg-gray-50 tw:border tw:border-gray-300 tw:hover:bg-gray-200 tw:hover:border-gray-400 tw:active:bg-gray-300 tw:focus:ring-blue-500/40 tw:dark:text-gray-200 tw:dark:bg-gray-700 tw:dark:border-gray-500 tw:dark:hover:bg-gray-800 tw:dark:hover:border-gray-600 tw:dark:active:bg-gray-900",
         error: "tw:text-white tw:bg-red-600 tw:border tw:border-red-600 tw:hover:bg-red-700 tw:active:bg-red-800 tw:focus:ring-red-500/40 tw:dark:bg-red-500 tw:dark:border-red-500 tw:dark:hover:bg-red-600 tw:dark:active:bg-red-700",
         link: "tw:text-blue-600 tw:hover:text-blue-800 tw:dark:text-blue-400 tw:dark:hover:text-blue-300 tw:underline tw:active:text-blue-800 tw:active:dark:text-blue-300 tw:active:font-bold tw:p-0 tw:focus:outline-none"
       }.freeze
 
       ACTIVE_COLORS = {
         primary: "tw:ring-2 tw:ring-blue-500/40 tw:bg-blue-700 tw:dark:bg-blue-600",
-        secondary: "tw:ring-2 tw:ring-blue-500/40 tw:bg-gray-100 tw:border-gray-400 tw:dark:bg-gray-800 tw:dark:border-gray-600",
+        secondary: "tw:ring-2 tw:ring-blue-500/40 tw:bg-gray-200 tw:border-gray-400 tw:dark:bg-gray-800 tw:dark:border-gray-600",
         error: "tw:ring-2 tw:ring-red-500/40 tw:bg-red-700 tw:dark:bg-red-600",
         link: "tw:text-blue-800 tw:dark:text-blue-300 tw:font-bold"
       }.freeze

--- a/app/components/ui/button/component.rb
+++ b/app/components/ui/button/component.rb
@@ -13,14 +13,14 @@ module UI
 
       COLORS = {
         primary: "tw:text-white tw:bg-blue-600 tw:border tw:border-blue-600 tw:hover:bg-blue-700 tw:active:bg-blue-800 tw:focus:ring-blue-500/40 tw:dark:bg-blue-500 tw:dark:border-blue-500 tw:dark:hover:bg-blue-600 tw:dark:active:bg-blue-700",
-        secondary: "tw:text-gray-700 tw:bg-white tw:border tw:border-gray-300 tw:hover:bg-gray-50 tw:hover:border-gray-400 tw:active:bg-gray-100 tw:focus:ring-blue-500/40 tw:dark:text-gray-200 tw:dark:bg-gray-800 tw:dark:border-gray-600 tw:dark:hover:bg-gray-700 tw:dark:hover:border-gray-500 tw:dark:active:bg-gray-600",
+        secondary: "tw:text-gray-700 tw:bg-gray-50 tw:border tw:border-gray-300 tw:hover:bg-gray-100 tw:hover:border-gray-400 tw:active:bg-gray-200 tw:focus:ring-blue-500/40 tw:dark:text-gray-200 tw:dark:bg-gray-700 tw:dark:border-gray-500 tw:dark:hover:bg-gray-800 tw:dark:hover:border-gray-600 tw:dark:active:bg-gray-900",
         error: "tw:text-white tw:bg-red-600 tw:border tw:border-red-600 tw:hover:bg-red-700 tw:active:bg-red-800 tw:focus:ring-red-500/40 tw:dark:bg-red-500 tw:dark:border-red-500 tw:dark:hover:bg-red-600 tw:dark:active:bg-red-700",
-        link: "tw:text-blue-600 tw:hover:text-blue-800 tw:dark:text-blue-400 tw:dark:hover:text-blue-300 tw:underline tw:active:text-blue-800 tw:active:dark:text-blue-300 tw:active:font-bold tw:p-0 tw:focus:ring-1"
+        link: "tw:text-blue-600 tw:hover:text-blue-800 tw:dark:text-blue-400 tw:dark:hover:text-blue-300 tw:underline tw:active:text-blue-800 tw:active:dark:text-blue-300 tw:active:font-bold tw:p-0 tw:focus:outline-none"
       }.freeze
 
       ACTIVE_COLORS = {
         primary: "tw:ring-2 tw:ring-blue-500/40 tw:bg-blue-700 tw:dark:bg-blue-600",
-        secondary: "tw:ring-2 tw:ring-blue-500/40 tw:bg-gray-100 tw:border-gray-400 tw:dark:bg-gray-700 tw:dark:border-gray-500",
+        secondary: "tw:ring-2 tw:ring-blue-500/40 tw:bg-gray-100 tw:border-gray-400 tw:dark:bg-gray-800 tw:dark:border-gray-600",
         error: "tw:ring-2 tw:ring-red-500/40 tw:bg-red-700 tw:dark:bg-red-600",
         link: "tw:text-blue-800 tw:dark:text-blue-300 tw:font-bold"
       }.freeze

--- a/spec/components/ui/button/component_spec.rb
+++ b/spec/components/ui/button/component_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe UI::Button::Component, type: :component do
     expect(component).to have_css("button[type='button']")
     expect(component).to have_text("Click me")
     html = component.to_html
-    expect(html).to include("tw:bg-white")
+    expect(html).to include("tw:bg-gray-50")
     expect(html).to include("tw:border-gray-300")
   end
 
@@ -57,7 +57,7 @@ RSpec.describe UI::Button::Component, type: :component do
     let(:color) { :invalid }
 
     it "falls back to secondary" do
-      expect(component.to_html).to include("tw:bg-white")
+      expect(component.to_html).to include("tw:bg-gray-50")
     end
   end
 

--- a/spec/components/ui/button_link/component_spec.rb
+++ b/spec/components/ui/button_link/component_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe UI::ButtonLink::Component, type: :component do
     expect(component).to have_text("Link")
     html = component.to_html
     expect(html).to include("tw:inline-flex")
-    expect(html).to include("tw:bg-white")
+    expect(html).to include("tw:bg-gray-50")
   end
 
   context "with primary color" do


### PR DESCRIPTION
Tightens the dark-mode look of the shared `UI::Alert` and `UI::Button` components.

- `UI::Alert`: the four kinds (notice/error/warning/success) all rendered with the same `dark:bg-gray-800` background. They now use the tinted `-950` of each variant so they're visually distinguishable in dark mode; dismissable hover follows with `-900`.
- `UI::Button[:link]`: drop the focus ring so a clicked link-styled button no longer shows a 1px outline.
- `UI::Button[:secondary]`: shift the gray scale so each interaction step is numerically higher than the last (light: `gray-50` → `200` → `300`, dark: `gray-700` → `800` → `900`). This brings dark-mode behavior in line with primary/error (darken on hover/active) and lets the `active: true` prop's bg match the hover bg, so hovering an active secondary button no longer changes its color — same pattern primary and error already had.
