### PR TITLE
Admin Strava requests: hide pie chart legend when more than 4 slices

### DIFF
--- a/app/components/admin/strava_requests_chart/component.html.erb
+++ b/app/components/admin/strava_requests_chart/component.html.erb
@@ -14,7 +14,7 @@
   <% pie_columns.each do |title, data, colors| %>
     <div>
       <h4><%= title %></h4>
-      <%= helpers.pie_chart(data, **pie_chart_opts(colors)) %>
+      <%= helpers.pie_chart(data, **pie_chart_opts(colors, data)) %>
     </div>
   <% end %>
 </div>

--- a/app/components/admin/strava_requests_chart/component.rb
+++ b/app/components/admin/strava_requests_chart/component.rb
@@ -53,8 +53,9 @@ module Admin
         end
       end
 
-      def pie_chart_opts(colors)
-        opts = {thousands: ",", library: {plugins: {legend: {position: "bottom"}}}}
+      def pie_chart_opts(colors, data)
+        legend = (data.size > 4) ? false : {position: "bottom"}
+        opts = {thousands: ",", library: {plugins: {legend:}}}
         opts[:colors] = colors if colors
         opts
       end


### PR DESCRIPTION
The admin Strava requests "By integration" pie chart legend lists every integration's email — with dozens of integrations, the legend grows tall enough to push the actual chart out of view.

- `Admin::StravaRequestsChart#pie_chart_opts` now disables the legend when a pie has more than 4 slices. Slice details remain available on hover, and the response-status / request-type pies (small enums) keep their legend.
