### PR TITLE
Fix Doorkeeper cookie access to use AUTH_COOKIE_KEY

### DIFF
--- a/config/initializers/doorkeeper.rb
+++ b/config/initializers/doorkeeper.rb
@@ -22,7 +22,7 @@ Doorkeeper.configure do
 
   # This block is be called to check whether the resource owner is authenticated or not.
   resource_owner_authenticator do |request_envi|
-    user = User.from_auth(cookies.signed[:auth])
+    user = User.from_auth(cookies.signed[ControllerHelpers::AUTH_COOKIE_KEY])
     if user.present? && user.confirmed?
       user # Return user immediately, if user is confirmed
     else


### PR DESCRIPTION
- In production environment cookie[:auth] is the right key
- but in development this key is mismatched and should use the dev key w/ the port number 

See:> app/controllers/concerns/controller_helpers.rb:10:  AUTH_COOKIE_KEY = Rails.env.development? ? :"auth_#{ENV.fetch("DEV_PORT", 3042)}" : :auth
- now Doorkeeper uses the right key from ControllerHelpers `AUTH_COOKIE_KEY`