### PR TITLE
API v3 organizations: add index endpoint, expose short_name

### DIFF
--- a/app/controllers/api/v3/organizations.rb
+++ b/app/controllers/api/v3/organizations.rb
@@ -25,6 +25,7 @@ module API
         }
         params do
           requires :name, type: String, desc: "The organization name"
+          optional :short_name, type: String, desc: "The organization's short name (used for the slug). Defaults to a shortened `name`."
           requires :website, type: String, desc: "The organization website", regexp: URI::DEFAULT_PARSER.make_regexp(%w[http https])
           requires :kind, type: String, desc: "The kind of organization", values: Organization.user_creatable_kinds
 
@@ -69,6 +70,21 @@ module API
 
           organization.save || error!(organization.errors.full_messages, 422)
           OrganizationSerializer.new(organization, root: "organization")
+        end
+
+        desc "List the current user's Organizations<span class='accstr'>*</span>", {
+          authorizations: {oauth2: {scope: :read_organization_membership}},
+          notes: <<-NOTES
+          **Requires** `read_organization_membership` **in the access token** you use to make the request.
+          <hr>
+          Returns every organization the access token's user is a member of.
+          NOTES
+        }
+        # GET /api/v3/organizations
+        get "/" do
+          ActiveModel::ArraySerializer.new(current_user.organizations,
+            each_serializer: OrganizationSerializer,
+            root: "organizations")
         end
       end
     end

--- a/app/serializers/organization_serializer.rb
+++ b/app/serializers/organization_serializer.rb
@@ -1,4 +1,4 @@
 class OrganizationSerializer < ApplicationSerializer
-  attributes :name, :website, :kind, :slug
+  attributes :name, :short_name, :website, :kind, :slug
   has_many :locations
 end

--- a/app/serializers/organization_serializer.rb
+++ b/app/serializers/organization_serializer.rb
@@ -1,4 +1,8 @@
 class OrganizationSerializer < ApplicationSerializer
-  attributes :name, :short_name, :website, :kind, :slug
+  attributes :name, :short_name, :website, :kind, :slug, :logo_url
   has_many :locations
+
+  def logo_url
+    object.avatar_url if object.avatar?
+  end
 end

--- a/spec/requests/api/v3/organizations_request_spec.rb
+++ b/spec/requests/api/v3/organizations_request_spec.rb
@@ -105,6 +105,7 @@ RSpec.describe "Organization API V3", type: :request do
         let(:target_response) do
           {
             name: "Geoff's Bike Shop",
+            short_name: "Geoff's Bike Shop",
             website: "https://bikes.geoffereth.com",
             kind: "bike_shop",
             slug: "geoffs-bike-shop",
@@ -122,6 +123,16 @@ RSpec.describe "Organization API V3", type: :request do
           expect(response.code).to eq("201")
           expect(json_result["organization"]).to match_hash_indifferently target_response
         end
+
+        context "with explicit short_name" do
+          let(:organization_json) { organization_attrs.merge(short_name: "Geoff's").to_json }
+          it "uses the provided short_name and slug" do
+            post url, params: organization_json, headers: json_headers
+            expect(response.code).to eq("201")
+            expect(json_result["organization"]).to match_hash_indifferently target_response.merge(short_name: "Geoff's", slug: "geoffs")
+          end
+        end
+
         describe "with no ALLOWED_WRITE_ORGANIZATIONS" do
           it "creates an organization" do
             ENV["ALLOWED_WRITE_ORGANIZATIONS"] = nil
@@ -173,6 +184,69 @@ RSpec.describe "Organization API V3", type: :request do
           expect(response).to be_created
           expect(response.code).to eq("201")
         end
+      end
+    end
+  end
+
+  describe "index" do
+    let(:token) { create_doorkeeper_token(scopes: :read_organization_membership) }
+    let(:url) { "/api/v3/organizations?access_token=#{token.token}" }
+
+    context "without access token" do
+      it "returns a 401" do
+        get "/api/v3/organizations"
+        expect(response.code).to eq("401")
+      end
+    end
+
+    context "without read_organization_membership scope" do
+      let(:token) { create_doorkeeper_token(scopes: :read_bikes) }
+      it "returns a 403" do
+        get url, headers: json_headers
+        expect(response.code).to eq("403")
+      end
+    end
+
+    context "user has no organizations" do
+      it "returns an empty array" do
+        get url, headers: json_headers
+        expect(response.code).to eq("200")
+        expect(json_result["organizations"]).to eq([])
+      end
+    end
+
+    context "user is a member of organizations" do
+      let(:organization) { FactoryBot.create(:organization, :in_chicago, name: "Geoff's Bike Shop", website: "https://bikes.geoffereth.com", kind: "bike_shop") }
+      let(:other_organization) { FactoryBot.create(:organization, name: "Other Shop", website: "https://other.example.com", kind: "bike_shop") }
+      let!(:organization_role) { FactoryBot.create(:organization_role_claimed, user: user, organization: organization) }
+      let!(:other_organization_role) { FactoryBot.create(:organization_role_claimed, user: user, organization: other_organization) }
+      let!(:not_my_organization) { FactoryBot.create(:organization) }
+      let(:location) { organization.locations.first }
+      let(:target_organization) do
+        {
+          name: "Geoff's Bike Shop",
+          short_name: "Geoff's Bike Shop",
+          website: "https://bikes.geoffereth.com",
+          kind: "bike_shop",
+          slug: "geoffs-bike-shop",
+          locations: [{
+            address: "1300 W 14th Pl, Chicago, IL 60608, United States",
+            name: location.name,
+            phone: nil,
+            street: "1300 W 14th Pl",
+            city: "Chicago",
+            state: "Illinois",
+            country: "United States",
+            zipcode: "60608"
+          }]
+        }
+      end
+
+      it "returns only the user's organizations, serialized" do
+        get url, headers: json_headers
+        expect(response.code).to eq("200")
+        expect(json_result["organizations"].pluck("slug")).to match_array([organization.slug, other_organization.slug])
+        expect(json_result["organizations"].find { |o| o["slug"] == organization.slug }).to match_hash_indifferently target_organization
       end
     end
   end

--- a/spec/requests/api/v3/organizations_request_spec.rb
+++ b/spec/requests/api/v3/organizations_request_spec.rb
@@ -109,6 +109,7 @@ RSpec.describe "Organization API V3", type: :request do
             website: "https://bikes.geoffereth.com",
             kind: "bike_shop",
             slug: "geoffs-bike-shop",
+            logo_url: nil,
             locations: [
               {address: "1111 SE Belmont Street, Portland, OR 97215, United States"}.merge(location_1),
               {address: "2222 SE Morrison Street, Portland, OR 97214, United States"}.merge(location_2)
@@ -229,6 +230,7 @@ RSpec.describe "Organization API V3", type: :request do
           website: "https://bikes.geoffereth.com",
           kind: "bike_shop",
           slug: "geoffs-bike-shop",
+          logo_url: nil,
           locations: [{
             address: "1300 W 14th Pl, Chicago, IL 60608, United States",
             name: location.name,


### PR DESCRIPTION
Adds a way for API clients to read the organizations the access token's user belongs to, and exposes `short_name` on the existing POST.

- `GET /api/v3/organizations` returns the user's claimed-role organizations serialized via `OrganizationSerializer`. Gated on `read_organization_membership`.
- `POST /api/v3/organizations` now accepts an optional `short_name`; when omitted, `Organization#set_calculated_attributes` derives it from `name` (existing behavior).
- `OrganizationSerializer` now includes `short_name` alongside `name`/`website`/`kind`/`slug`/`locations`, so POST and the new index return the same shape.
