### PR TITLE
Skill: integration-testing

### DIFF
--- a/.claude/skills/integration-testing/SKILL.md
+++ b/.claude/skills/integration-testing/SKILL.md
@@ -1,0 +1,154 @@
+---
+name: integration-testing
+description: >-
+  Bike Index conventions for browser specs (`type: :system, :js`)
+  — every example pays a Selenium boot cost, so bias hard toward fewer,
+  denser examples that walk through state via clicks, prefer
+  named-element matchers over CSS selectors or `execute_script`, and
+  combine same-setup work into one `it` even when scenarios feel
+  independent. **Consult this skill any time you create or modify a
+  `:js, type: :system` spec** — that includes everything under
+  `spec/integration/` AND component system specs at
+  `spec/components/**/*_system_spec.rb`; the rules apply equally to
+  both. Read alongside the `rspec-testing` skill for the project's
+  general `context`/`let` style.
+---
+
+# Integration testing in Bike Index
+
+Browser specs (`type: :system, :js`) live in two places: feature flows under `spec/integration/` and component-level interaction specs at `spec/components/**/*_system_spec.rb`. Both run full Chrome sessions via Capybara/Selenium and pay a real Selenium boot cost per example, so the same conventions apply to both: optimize for fewer, denser examples and high-level Capybara helpers.
+
+The general `context`/`let` style and "what to test" rules are in the [`rspec-testing`](../rspec-testing/SKILL.md) skill — the rules below extend it for the system-spec case.
+
+## One `it` per setup; many assertions per `it`
+
+Unit specs prefer one assertion per example. **Integration specs prefer the opposite**: when several assertions share the same fixture and the same initial `visit`, fold them into one example that walks through state transitions (click → assert → click → assert).
+
+Use `context` only when the *setup* differs — a different `let!`, a different page, a different feature flag. Don't split a single user flow across sibling `it` blocks just because each step has its own assertion.
+
+**Combine same-setup work, even when scenarios feel independent.** Before writing a new `describe`/`context`/`it`, read the existing file and find an example whose fixtures and initial `visit` match what you need — then append your clicks/assertions to it. It's tempting to leave a separate `it` for things that feel like different concerns ("button-state test", "filter-persistence test", "URL-param test", "mobile-layout test"). Don't. A long, sectioned-with-comments example pays one Selenium boot; four short examples pay four. Failure attribution is fine — the failed line number tells you exactly which phase broke. Only add a new block when the setup genuinely differs.
+
+### Good
+
+```ruby
+it "filters listings, persists filters across pagination, and clears them" do
+  expect(page).to have_css("[data-test-id^='vehicle-thumbnail-linkspan-']", count: 12)
+
+  fill_in "Manufacturer", with: "Yuba"
+  click_button "Search"
+
+  expect(page).to have_css("[data-test-id^='vehicle-thumbnail-linkspan-']", count: 8)
+  expect(find_field("Manufacturer").value).to eq "Yuba"
+
+  click_link "Next"
+
+  expect(page).to have_current_path(/page=2/)
+  expect(find_field("Manufacturer").value).to eq "Yuba"
+
+  click_link "Clear filters"
+
+  expect(find_field("Manufacturer").value).to be_blank
+  expect(page).to have_css("[data-test-id^='vehicle-thumbnail-linkspan-']", count: 12)
+end
+```
+
+### Bad
+
+```ruby
+# Three browser sessions for what's effectively one user flow.
+it "filters listings by manufacturer" do
+  fill_in "Manufacturer", with: "Yuba"
+  click_button "Search"
+  expect(page).to have_css("[data-test-id^='vehicle-thumbnail-linkspan-']", count: 8)
+end
+
+it "persists filters across pagination" do
+  fill_in "Manufacturer", with: "Yuba"
+  click_button "Search"
+  click_link "Next"
+  expect(find_field("Manufacturer").value).to eq "Yuba"
+end
+
+it "clears filters when Clear is clicked" do
+  fill_in "Manufacturer", with: "Yuba"
+  click_button "Search"
+  click_link "Clear filters"
+  expect(find_field("Manufacturer").value).to be_blank
+end
+```
+
+## Carry state forward, don't reset between phases
+
+You know what state the page is in after each click — write the next assertion against that state. Don't click a "Reset" / "Clear" between phases just to get a clean slate; resets cost a click (often two — clear, then re-establish), obscure what's actually happening, and tempt you to think of each phase as an isolated scenario rather than as one continuous user flow.
+
+If a carried-over state makes the next assertion awkward, that's information: usually you can reorder or rephrase phases so the previous phase's end state is exactly what the next phase needs to start from. Treat the example as a flow with state advancing through it, not a sequence of independent scenarios each demanding a pristine baseline.
+
+`visit page.current_url` is a reload, not a reset — use it specifically to verify URL persistence across a fresh page load. Otherwise, prefer letting state flow.
+
+## Navigate by clicking, not re-visiting
+
+After the initial `visit` in `before`, prefer **clicking** to get to the next state. Re-visiting bypasses the very thing system specs exist to verify (client-side state, JS handlers, history, ARIA wiring).
+
+Re-visit only when you specifically want to verify **URL persistence / reload behavior** — and make that intent explicit (`visit page.current_url` with a comment, or a context named "after reload").
+
+```ruby
+# Good — drive the flow with clicks
+visit "/search/marketplace"
+fill_in "Manufacturer", with: "Yuba"
+click_button "Search"
+
+# Good — explicit reload to verify URL persistence
+visit page.current_url
+
+# Bad — re-rendering that should have been a click/form submit
+visit "/search/marketplace?manufacturer=Yuba"
+```
+
+## Prefer named matchers over CSS selectors and JS
+
+Capybara's high-level helpers find elements by visible role + text. They are more readable, more accessible (they only see what a real user can interact with), and less brittle than scraping selectors. Reach for low-level tools only when the high-level ones can't express what you need.
+
+Order of preference:
+
+1. **Named-element helpers**: `click_button("Search")`, `click_link("Next")`, `find_button(...)`, `have_button(...)`, `fill_in("Manufacturer", with: ...)`.
+2. **Role-scoped Capybara finders**: `find(:button, "...")`, `within(:section, "Filters") { ... }`.
+3. **ARIA / data attributes** when there is no visible text: `find('[aria-label="..."]')`, `find('[data-test-id="..."]')`.
+4. **CSS selectors** as a last resort.
+5. **`page.execute_script`** only when the browser fundamentally cannot otherwise do what the test needs (synthesizing custom events, scrolling for IntersectionObserver, etc.).
+
+If a button has no visible text (icon-only, etc.), add an `aria-label` to the component rather than scraping a selector in the test.
+
+### Good
+
+```ruby
+click_button("Search")
+expect(find_button("Sort")["aria-pressed"]).to eq "true"
+expect(page).to have_link("Next")
+```
+
+### Bad
+
+```ruby
+find('[data-action="click->search#submit"]').click
+expect(page).to have_css('button[aria-pressed="true"]')
+page.execute_script("document.querySelector('.search-btn').click()")
+```
+
+## ActionCable broadcasts: do the real thing
+
+The test cable adapter is `:async`, so broadcasts in the test process do round-trip to the browser. **Don't synthesize `turbo:morph-element` events with `execute_script` to fake an ActionCable refresh** — call the real broadcaster (`Component.broadcast_replace_to`, `broadcast_refresh_later_to`, etc.) and let Capybara's wait do the synchronization.
+
+The pattern is: prepare the data the broadcast will render → call the real broadcaster → assert on an unambiguous post-morph element with a `wait:` (e.g. `expect(page).to have_css(some_new_selector, wait: 5)`). The trailing wait is the synchronization barrier — the test proceeds only once the morph has actually rendered.
+
+## Build Tailwind before running system specs
+
+CI builds `app/assets/builds/tailwind.css` automatically; your local sandbox does not. Without it, Tailwind utility classes (most importantly `tw:hidden` → `display: none`) silently don't apply, and assertions like `expect(tooltip).not_to be_visible` fail in confusing ways that look like flakes but aren't.
+
+**Before running any `:js, type: :system` spec locally, run `bin/rails tailwindcss:build`** (or have `bin/dev` running, which watches and rebuilds). If a system spec is failing on visibility/styling assertions, check `app/assets/builds/tailwind.css` exists and is recent before assuming the test or component is broken.
+
+See the [`frontend-conventions`](../frontend-conventions/SKILL.md) skill for the `tw:` prefix and other styling rules.
+
+## Other conventions
+
+- Always include `:js, type: :system`.
+- Define a few small DSL-style helpers in the file (`def listing_for(item)`, `def thumbnail_selector(...)`) when they make assertions readable. Don't reach for `page.execute_script` to replace what a helper method could do in Ruby.

--- a/spec/integration/marketplace_infinite_scroll_spec.rb
+++ b/spec/integration/marketplace_infinite_scroll_spec.rb
@@ -25,13 +25,6 @@ RSpec.describe "Marketplace infinite scroll", :js, type: :system do
     Autocomplete::Loader.load_all(%w[Manufacturer])
   end
 
-  def click_last_bike_and_go_back
-    all("[data-test-id^='vehicle-thumbnail-linkspan-'] a").last.click
-    expect(page).to have_css("h1.bike-title", wait: 10)
-    page.go_back
-    expect(page).to have_css("[data-test-id^='vehicle-thumbnail-linkspan-']", wait: 10)
-  end
-
   def scroll_to_lazy_load
     # Scroll the lazy-loading frame into view
     page.execute_script(<<~JS)
@@ -73,7 +66,7 @@ RSpec.describe "Marketplace infinite scroll", :js, type: :system do
     # Change the search filters By adding a max price and submit via pressing enter
     # and verify that infinite scroll still works
     fill_in "price_max_amount", with: "1300"
-    find("#price_max_amount").send_keys(:return)
+    find_field("price_max_amount").send_keys(:return)
     # Wait for filtered results to load
     expect(page).to have_css("[data-test-id^='vehicle-thumbnail-linkspan-']", wait: 10, count: 12)
     # Verify lazy frame exists

--- a/spec/integration/marketplace_infinite_scroll_spec.rb
+++ b/spec/integration/marketplace_infinite_scroll_spec.rb
@@ -38,38 +38,42 @@ RSpec.describe "Marketplace infinite scroll", :js, type: :system do
     sleep 1
   end
 
-  def bike_show_links
-    page.all(:link, href: %r{/bikes/\d+\z})
-  end
-
   it "automatically loads the next page when scrolling to bottom", :flaky do
     expect(manufacturer1.reload.id).to eq 1003 # sanity check - otherwise the search won't work
     expect(manufacturer2.reload.id).to eq 764 # sanity check - otherwise the search won't work
     visit marketplace_url
 
     # Wait for the initial results to load
-    expect(page).to have_link(href: %r{/bikes/\d+\z}, count: 12, wait: 10)
+    expect(page).to have_css("[data-test-id^='vehicle-thumbnail-linkspan-']", wait: 10, count: 12)
     expect(page).to be_axe_clean.skipping(*SKIPPABLE_AXE_RULES)
-    initial_bikes = bike_show_links.map { |a| a[:href][%r{/bikes/(\d+)}, 1] }
+    # Get the initial bike IDs visible on page 1
+    initial_bikes = page.all("[data-test-id^='vehicle-thumbnail-linkspan-']").map do |el|
+      el["data-test-id"].split("-").last
+    end
+    expect(initial_bikes.count).to eq(12)
     # Verify the lazy-loading frame for page 2 exists
     expect(page).to have_css("turbo-frame#page_2[loading='lazy']", visible: :all)
     scroll_to_lazy_load
     # Wait for page 2 to load (3 more items should appear)
-    expect(page).to have_link(href: %r{/bikes/\d+\z}, minimum: 13, wait: 10)
+    expect(page).to have_css("[data-test-id^='vehicle-thumbnail-linkspan-']", wait: 10, minimum: 13)
+    # Get all bike IDs now visible
+    all_bikes = page.all("[data-test-id^='vehicle-thumbnail-linkspan-']").map do |el|
+      el["data-test-id"].split("-").last
+    end
     # Verify that we have more bikes than initially
-    expect(bike_show_links.count).to be > initial_bikes.count
+    expect(all_bikes.count).to be > initial_bikes.count
 
     # Change the search filters By adding a max price and submit via pressing enter
     # and verify that infinite scroll still works
     fill_in "price_max_amount", with: "1300"
     find_field("price_max_amount").send_keys(:return)
     # Wait for filtered results to load
-    expect(page).to have_link(href: %r{/bikes/\d+\z}, count: 12, wait: 10)
+    expect(page).to have_css("[data-test-id^='vehicle-thumbnail-linkspan-']", wait: 10, count: 12)
     # Verify lazy frame exists
     expect(page).to have_css("turbo-frame#page_2[loading='lazy']", visible: :all)
     scroll_to_lazy_load
     # Should load more results
-    expect(page).to have_link(href: %r{/bikes/\d+\z}, count: 14, wait: 10)
+    expect(page).to have_css("[data-test-id^='vehicle-thumbnail-linkspan-']", wait: 10, count: 14)
 
     # And then search "Yuba" without price filter
     # Which will return 8 bikes - so the page won't have the ability to scroll. Verify that it works correctly
@@ -81,7 +85,7 @@ RSpec.describe "Marketplace infinite scroll", :js, type: :system do
     find(".select2-search__field").send_keys(:enter)
     page.send_keys :return
     # Should load new results
-    expect(page).to have_link(href: %r{/bikes/\d+\z}, count: 8, wait: 10)
+    expect(page).to have_css("[data-test-id^='vehicle-thumbnail-linkspan-']", wait: 10, count: 8)
     # Should NOT have a lazy-loading frame for page 2
     expect(page).not_to have_css("turbo-frame#page_2")
   end

--- a/spec/integration/marketplace_infinite_scroll_spec.rb
+++ b/spec/integration/marketplace_infinite_scroll_spec.rb
@@ -38,42 +38,38 @@ RSpec.describe "Marketplace infinite scroll", :js, type: :system do
     sleep 1
   end
 
+  def bike_show_links
+    page.all(:link, href: %r{/bikes/\d+\z})
+  end
+
   it "automatically loads the next page when scrolling to bottom", :flaky do
     expect(manufacturer1.reload.id).to eq 1003 # sanity check - otherwise the search won't work
     expect(manufacturer2.reload.id).to eq 764 # sanity check - otherwise the search won't work
     visit marketplace_url
 
     # Wait for the initial results to load
-    expect(page).to have_css("[data-test-id^='vehicle-thumbnail-linkspan-']", wait: 10, count: 12)
+    expect(page).to have_link(href: %r{/bikes/\d+\z}, count: 12, wait: 10)
     expect(page).to be_axe_clean.skipping(*SKIPPABLE_AXE_RULES)
-    # Get the initial bike IDs visible on page 1
-    initial_bikes = page.all("[data-test-id^='vehicle-thumbnail-linkspan-']").map do |el|
-      el["data-test-id"].split("-").last
-    end
-    expect(initial_bikes.count).to eq(12)
+    initial_bikes = bike_show_links.map { |a| a[:href][%r{/bikes/(\d+)}, 1] }
     # Verify the lazy-loading frame for page 2 exists
     expect(page).to have_css("turbo-frame#page_2[loading='lazy']", visible: :all)
     scroll_to_lazy_load
     # Wait for page 2 to load (3 more items should appear)
-    expect(page).to have_css("[data-test-id^='vehicle-thumbnail-linkspan-']", wait: 10, minimum: 13)
-    # Get all bike IDs now visible
-    all_bikes = page.all("[data-test-id^='vehicle-thumbnail-linkspan-']").map do |el|
-      el["data-test-id"].split("-").last
-    end
+    expect(page).to have_link(href: %r{/bikes/\d+\z}, minimum: 13, wait: 10)
     # Verify that we have more bikes than initially
-    expect(all_bikes.count).to be > initial_bikes.count
+    expect(bike_show_links.count).to be > initial_bikes.count
 
     # Change the search filters By adding a max price and submit via pressing enter
     # and verify that infinite scroll still works
     fill_in "price_max_amount", with: "1300"
     find_field("price_max_amount").send_keys(:return)
     # Wait for filtered results to load
-    expect(page).to have_css("[data-test-id^='vehicle-thumbnail-linkspan-']", wait: 10, count: 12)
+    expect(page).to have_link(href: %r{/bikes/\d+\z}, count: 12, wait: 10)
     # Verify lazy frame exists
     expect(page).to have_css("turbo-frame#page_2[loading='lazy']", visible: :all)
     scroll_to_lazy_load
     # Should load more results
-    expect(page).to have_css("[data-test-id^='vehicle-thumbnail-linkspan-']", wait: 10, count: 14)
+    expect(page).to have_link(href: %r{/bikes/\d+\z}, count: 14, wait: 10)
 
     # And then search "Yuba" without price filter
     # Which will return 8 bikes - so the page won't have the ability to scroll. Verify that it works correctly
@@ -85,7 +81,7 @@ RSpec.describe "Marketplace infinite scroll", :js, type: :system do
     find(".select2-search__field").send_keys(:enter)
     page.send_keys :return
     # Should load new results
-    expect(page).to have_css("[data-test-id^='vehicle-thumbnail-linkspan-']", wait: 10, count: 8)
+    expect(page).to have_link(href: %r{/bikes/\d+\z}, count: 8, wait: 10)
     # Should NOT have a lazy-loading frame for page 2
     expect(page).not_to have_css("turbo-frame#page_2")
   end

--- a/spec/integration/organized/registrations_search_spec.rb
+++ b/spec/integration/organized/registrations_search_spec.rb
@@ -83,7 +83,7 @@ RSpec.describe "Organized registrations search", :js, type: :system do
     expect(page).to have_css("table", wait: 10)
 
     fill_in "search_email", with: "alice@example.com"
-    find("#search_email").send_keys(:return)
+    find_field("search_email").send_keys(:return)
 
     expect(page).to have_current_path(/search_email=alice/, wait: 10)
     expect(page).to have_css("tbody tr", count: 1)

--- a/spec/integration/search_registrations_spec.rb
+++ b/spec/integration/search_registrations_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe "Bike search", :js, type: :system do
     expect(page).to have_css(".bike-box-item", wait: 10)
 
     # Select "All registrations" stolenness
-    find("label[for='stolenness_all']").click
+    choose("stolenness_all", allow_label_click: true, visible: :all)
 
     # Search for Blue via the Select2 combobox
     find(".select2-container").click
@@ -61,9 +61,9 @@ RSpec.describe "Bike search", :js, type: :system do
     click_first_bike_and_go_back
 
     # Switch to proximity search for NYC
-    find("label[for='stolenness_proximity']").click
-    find("#distance").set("200")
-    find("#location").set("New York, NY")
+    choose("stolenness_proximity", allow_label_click: true, visible: :all)
+    fill_in "distance", with: "200"
+    fill_in "location", with: "New York, NY"
     find("#search-button").click
 
     # Only the blue NYC bike (proximity + color filter still active)


### PR DESCRIPTION
Adds an `integration-testing` skill covering Bike Index conventions for `:js, type: :system` specs (`spec/integration/` and `spec/components/**/*_system_spec.rb`).

Adapted from [MayIsBikeMonth/may_is_bike_month#124](https://github.com/MayIsBikeMonth/may_is_bike_month/pull/124) with project-specific tweaks: examples use marketplace search/filter flows, the Tailwind section references the `tw:` prefix and links to `frontend-conventions`, and the cable-adapter wording matches our `:async` test config.
