### PR TITLE
API v3 /me: add short_name and logo_url to memberships

### DIFF
--- a/.claude/skills/rspec-testing/SKILL.md
+++ b/.claude/skills/rspec-testing/SKILL.md
@@ -35,6 +35,39 @@ When a test goes red, the correct move is **investigate why**, not edit the asse
 
 The right loop: reproduce the failure, figure out *what* changed and *why*, then decide intentionally — fix the code if the original assertion captured the right behavior, or update the assertion (with a comment) if the behavior intentionally changed. If you're about to change a test "to make it easier", stop and explain why the new expectation is correct, not just convenient.
 
+## Match a target attributes hash, not one attribute at a time
+
+When you're checking several fields on the same object or response, build one expected-attributes hash and assert against it in a single matcher. Don't write a chain of one-attribute-per-line `expect`s.
+
+- Object (ActiveRecord, plain Ruby): `expect(record).to have_attributes(target_attributes)`
+- Hash (JSON response, parsed body): `expect(hash).to eq(target.as_json)` for full match, or `expect(hash).to include(target_attributes)` for partial.
+
+This collapses what would be 4 brittle assertions into 1, makes the *contract* visible at a glance, and gives a single readable diff when something changes. It also avoids the trap of weak per-field assertions like `expect(x).to be_present` or `expect(url).not_to include("blank.png")` standing in for "the right value" — match the value directly.
+
+### Good
+
+```ruby
+target_attributes = {kind: "found", impounded_description: "Some description"}
+expect(impound_record).to have_attributes(target_attributes)
+
+expect(json_result["memberships"]).to eq([target_membership.as_json])
+```
+
+### Bad
+
+```ruby
+expect(impound_record.kind).to eq("found")
+expect(impound_record.impounded_description).to be_present
+expect(impound_record.impounded_description).to eq("Some description")
+
+logo_url = json_result["memberships"].first["organization_logo_url"]
+expect(logo_url).to be_present
+expect(logo_url).not_to include("blank.png")
+expect(logo_url).to eq(organization.avatar_url)
+```
+
+The bad version spreads one logical assertion across many lines, mixes weak presence checks with the real expected value, and produces noisier failure output.
+
 ## Structuring with `context` and `let`
 
 Use `context` and `let` to isolate what varies between examples. Each `it` block should live in a `context` that names the condition, with `let` overrides for only what differs in that case. **Avoid repeating setup across sibling `it` blocks.**

--- a/app/controllers/api/v3/me.rb
+++ b/app/controllers/api/v3/me.rb
@@ -28,9 +28,11 @@ module API
           def serialized_membership(membership)
             {
               organization_name: membership.organization.name,
+              organization_short_name: membership.organization.short_name,
               organization_slug: membership.organization.slug,
               organization_id: membership.organization_id,
               organization_access_token: membership.organization.access_token,
+              organization_logo_url: membership.organization.avatar_url,
               user_is_organization_admin: membership.role == "admin"
             }
           end

--- a/app/controllers/api/v3/me.rb
+++ b/app/controllers/api/v3/me.rb
@@ -32,7 +32,7 @@ module API
               organization_slug: membership.organization.slug,
               organization_id: membership.organization_id,
               organization_access_token: membership.organization.access_token,
-              organization_logo_url: membership.organization.avatar_url,
+              organization_logo_url: (membership.organization.avatar_url if membership.organization.avatar?),
               user_is_organization_admin: membership.role == "admin"
             }
           end

--- a/spec/requests/api/v3/me_request_spec.rb
+++ b/spec/requests/api/v3/me_request_spec.rb
@@ -24,9 +24,11 @@ RSpec.describe "Me API V3", type: :request do
       let(:target_membership) do
         {
           organization_name: organization_role.organization.name,
+          organization_short_name: organization_role.organization.short_name,
           organization_slug: organization_role.organization.slug,
           organization_id: organization_role.organization_id,
           organization_access_token: organization_role.organization.access_token,
+          organization_logo_url: organization_role.organization.avatar_url,
           user_is_organization_admin: false
         }
       end

--- a/spec/requests/api/v3/me_request_spec.rb
+++ b/spec/requests/api/v3/me_request_spec.rb
@@ -28,13 +28,14 @@ RSpec.describe "Me API V3", type: :request do
           organization_slug: organization_role.organization.slug,
           organization_id: organization_role.organization_id,
           organization_access_token: organization_role.organization.access_token,
-          organization_logo_url: organization_role.organization.avatar_url,
+          organization_logo_url: nil,
           user_is_organization_admin: false
         }
       end
       it "responds with all available attributes with full scoped token" do
         user.reload
         expect(user.secondary_emails).to eq(["d@f.co"])
+        expect(organization_role.organization.avatar?).to be_falsey
         get "/api/v3/me", params: {access_token: token.token}, headers: {format: :json}
         expect(response.headers["Access-Control-Allow-Origin"]).to eq("*")
         expect(json_result["user"]["name"]).to eq(user.name)
@@ -45,6 +46,19 @@ RSpec.describe "Me API V3", type: :request do
         expect(json_result["memberships"].is_a?(Array)).to be_truthy
         expect(json_result["memberships"]).to eq([target_membership.as_json])
         expect(response.response_code).to eq(200)
+      end
+
+      context "organization with uploaded avatar" do
+        let(:avatar) { Rack::Test::UploadedFile.new(File.open(Rails.root.join("spec/fixtures/bike.jpg"))) }
+        before { organization_role.organization.update!(avatar: avatar) }
+        it "returns the avatar URL as organization_logo_url" do
+          get "/api/v3/me", params: {access_token: token.token}, headers: {format: :json}
+          expect(response.response_code).to eq(200)
+          logo_url = json_result["memberships"].first["organization_logo_url"]
+          expect(logo_url).to be_present
+          expect(logo_url).not_to include("blank.png")
+          expect(logo_url).to eq(organization_role.organization.reload.avatar_url)
+        end
       end
     end
 

--- a/spec/requests/api/v3/me_request_spec.rb
+++ b/spec/requests/api/v3/me_request_spec.rb
@@ -54,10 +54,8 @@ RSpec.describe "Me API V3", type: :request do
         it "returns the avatar URL as organization_logo_url" do
           get "/api/v3/me", params: {access_token: token.token}, headers: {format: :json}
           expect(response.response_code).to eq(200)
-          logo_url = json_result["memberships"].first["organization_logo_url"]
-          expect(logo_url).to be_present
-          expect(logo_url).not_to include("blank.png")
-          expect(logo_url).to eq(organization_role.organization.reload.avatar_url)
+          expect(organization_role.organization.reload).to have_attributes(avatar?: true)
+          expect(json_result["memberships"]).to eq([target_membership.merge(organization_logo_url: organization_role.organization.avatar_url).as_json])
         end
       end
     end


### PR DESCRIPTION
Adds two new fields to each entry in the `memberships` array returned by `GET /api/v3/me`:

- `organization_short_name` — the org's short name
- `organization_logo_url` — the org's avatar URL, or `nil` when no logo has been uploaded (avoids returning the `blank.png` default)
