### PR TITLE
API v2/v3 bikes: split for_sale out of status into its own attribute

### DIFF
--- a/app/jobs/file_cache_maintenance_job.rb
+++ b/app/jobs/file_cache_maintenance_job.rb
@@ -36,7 +36,7 @@ class FileCacheMaintenanceJob < ScheduledJob
     File.open(tmp_path, "w") {}
     File.open(tmp_path, "a+") do |file|
       file << '{"bikes": ['
-      Bike.status_stolen.find_each { |bike| file << BikeV2Serializer.new(bike, root: false).to_json + "," }
+      Bike.status_stolen.find_each { |bike| file << BikeV2Serializer.new(bike, root: false).as_json.except(:for_sale).to_json + "," }
     end
     File.truncate(tmp_path, File.size(tmp_path) - 1) # remove final comma
     File.open(tmp_path, "a+") { |file| file << "]}" }

--- a/app/serializers/bike_v2_serializer.rb
+++ b/app/serializers/bike_v2_serializer.rb
@@ -14,6 +14,7 @@ class BikeV2Serializer < ApplicationSerializer
     :registry_url,
     :serial,
     :status,
+    :for_sale,
     :stolen,
     :stolen_coordinates,
     :stolen_location,
@@ -46,7 +47,13 @@ class BikeV2Serializer < ApplicationSerializer
   end
 
   def status
-    object.status_humanized
+    return "found" if object.status_found?
+
+    Bike.status_humanized(object.status)
+  end
+
+  def for_sale
+    object.is_for_sale?
   end
 
   def location_found

--- a/app/serializers/external_registry_bike_v3_serializer.rb
+++ b/app/serializers/external_registry_bike_v3_serializer.rb
@@ -42,4 +42,8 @@ class ExternalRegistryBikeV3Serializer < BikeV2Serializer
 
   def stolen_coordinates
   end
+
+  def for_sale
+    false
+  end
 end

--- a/spec/jobs/file_cache_maintenance_job_spec.rb
+++ b/spec/jobs/file_cache_maintenance_job_spec.rb
@@ -43,6 +43,7 @@ RSpec.describe FileCacheMaintenanceJob, type: :job do
           registry_url
           serial
           status
+          for_sale
           stolen
           stolen_coordinates
           stolen_location

--- a/spec/jobs/file_cache_maintenance_job_spec.rb
+++ b/spec/jobs/file_cache_maintenance_job_spec.rb
@@ -43,7 +43,6 @@ RSpec.describe FileCacheMaintenanceJob, type: :job do
           registry_url
           serial
           status
-          for_sale
           stolen
           stolen_coordinates
           stolen_location

--- a/spec/requests/api/v2/bikes_request_spec.rb
+++ b/spec/requests/api/v2/bikes_request_spec.rb
@@ -16,6 +16,15 @@ RSpec.describe "Bikes API V2", type: :request do
       expect(response.headers["Access-Control-Request-Method"]).to eq("*")
     end
 
+    context "for sale bike" do
+      it "returns status 'with owner' and for_sale: true" do
+        bike = FactoryBot.create(:bike, :with_ownership, is_for_sale: true)
+        get "/api/v2/bikes/#{bike.id}", params: {format: :json}
+        expect(response.code).to eq("200")
+        expect(json_result["bike"]).to include("status" => "with owner", "for_sale" => true)
+      end
+    end
+
     it "responds with missing" do
       get "/api/v2/bikes/10", params: {format: :json}
       expect(response.code).to eq("404")

--- a/spec/requests/api/v3/bikes_request_spec.rb
+++ b/spec/requests/api/v3/bikes_request_spec.rb
@@ -23,14 +23,47 @@ RSpec.describe "Bikes API V3", type: :request do
   include_context :existing_doorkeeper_app
 
   describe "find by id" do
+    let(:bike) { FactoryBot.create(:bike) }
+    let(:target) { {"id" => bike.id, "status" => "with owner", "for_sale" => false} }
+
     it "returns one with from an id" do
-      bike = FactoryBot.create(:bike)
       get "/api/v3/bikes/#{bike.id}", params: {format: :json}
       expect(response.code).to eq("200")
-      expect(json_result["bike"]["id"]).to eq(bike.id)
+      expect(json_result["bike"]).to include(target)
       expect(response.headers["Content-Type"].match("json")).to be_present
       expect(response.headers["Access-Control-Allow-Origin"]).to eq("*")
       expect(response.headers["Access-Control-Request-Method"]).to eq("*")
+    end
+
+    context "for sale bike" do
+      let(:bike) { FactoryBot.create(:bike, :with_ownership, is_for_sale: true) }
+
+      it "returns status with owner and for_sale true" do
+        get "/api/v3/bikes/#{bike.id}", params: {format: :json}
+        expect(response.code).to eq("200")
+        expect(json_result["bike"]).to include(target.merge("for_sale" => true))
+      end
+    end
+
+    context "stolen bike marked for sale" do
+      let(:bike) { FactoryBot.create(:stolen_bike, is_for_sale: true) }
+
+      it "returns status stolen and for_sale true" do
+        get "/api/v3/bikes/#{bike.id}", params: {format: :json}
+        expect(response.code).to eq("200")
+        expect(json_result["bike"]).to include(target.merge("status" => "stolen", "for_sale" => true))
+      end
+    end
+
+    context "impounded as found" do
+      let!(:impound_record) { FactoryBot.create(:impound_record, bike: bike) }
+
+      it "returns status found" do
+        expect(impound_record.kind).to eq "found"
+        get "/api/v3/bikes/#{bike.id}", params: {format: :json}
+        expect(response.code).to eq("200")
+        expect(json_result["bike"]).to include(target.merge("status" => "found"))
+      end
     end
 
     it "responds with missing" do

--- a/spec/requests/api/v3/bikes_request_spec.rb
+++ b/spec/requests/api/v3/bikes_request_spec.rb
@@ -31,45 +31,20 @@ RSpec.describe "Bikes API V3", type: :request do
         "serial" => bike.serial_number.upcase,
         "manufacturer_name" => bike.mnfg_name,
         "manufacturer_id" => bike.manufacturer_id,
-        "frame_model" => nil,
-        "frame_size" => nil,
-        "frame_material_slug" => nil,
         "frame_colors" => ["Black"],
-        "year" => nil,
-        "name" => nil,
-        "paint_description" => nil,
-        "description" => nil,
         "rear_tire_narrow" => true,
-        "front_tire_narrow" => nil,
-        "rear_wheel_size_iso_bsd" => nil,
-        "front_wheel_size_iso_bsd" => nil,
-        "handlebar_type_slug" => nil,
-        "front_gear_type_slug" => nil,
-        "rear_gear_type_slug" => nil,
-        "extra_registration_number" => nil,
-        "additional_registration" => nil,
         "type_of_cycle" => "Bike",
         "cycle_type_slug" => "bike",
         "propulsion_type_slug" => "foot-pedal",
         "test_bike" => false,
-        "thumb" => nil,
-        "large_img" => nil,
         "is_stock_img" => false,
         "url" => "http://test.host/bikes/#{bike.id}",
         "api_url" => "http://test.host/api/v1/bikes/#{bike.id}",
         "registration_created_at" => bike.created_at.to_i,
         "registration_updated_at" => bike.updated_at.to_i,
-        "external_id" => nil,
-        "registry_name" => nil,
-        "registry_url" => nil,
-        "location_found" => nil,
         "status" => "with owner",
         "for_sale" => false,
         "stolen" => false,
-        "stolen_location" => nil,
-        "stolen_coordinates" => nil,
-        "date_stolen" => nil,
-        "stolen_record" => nil,
         "public_images" => [],
         "components" => []
       }
@@ -78,7 +53,7 @@ RSpec.describe "Bikes API V3", type: :request do
     it "returns one with from an id" do
       get "/api/v3/bikes/#{bike.id}", params: {format: :json}
       expect(response.code).to eq("200")
-      expect(json_result["bike"]).to eq target
+      expect(json_result["bike"].compact).to eq target
       expect(response.headers["Content-Type"].match("json")).to be_present
       expect(response.headers["Access-Control-Allow-Origin"]).to eq("*")
       expect(response.headers["Access-Control-Request-Method"]).to eq("*")
@@ -90,7 +65,7 @@ RSpec.describe "Bikes API V3", type: :request do
       it "returns status with owner and for_sale true" do
         get "/api/v3/bikes/#{bike.id}", params: {format: :json}
         expect(response.code).to eq("200")
-        expect(json_result["bike"]).to eq target.merge("for_sale" => true)
+        expect(json_result["bike"].compact).to eq target.merge("for_sale" => true)
       end
     end
 
@@ -103,14 +78,16 @@ RSpec.describe "Bikes API V3", type: :request do
           "stolen" => true,
           "stolen_coordinates" => [40.71, -74.01],
           "date_stolen" => bike.current_stolen_record.date_stolen.to_i,
-          "stolen_record" => JSON.parse(StolenRecordV2Serializer.new(bike.current_stolen_record, root: false, event: bike).to_json)
+          "stolen_record" => JSON.parse(StolenRecordV2Serializer.new(bike.current_stolen_record, root: false, event: bike).to_json).compact
         )
       end
 
       it "returns status stolen and for_sale true" do
         get "/api/v3/bikes/#{bike.id}", params: {format: :json}
         expect(response.code).to eq("200")
-        expect(json_result["bike"]).to eq stolen_target
+        result = json_result["bike"].compact
+        result["stolen_record"] = result["stolen_record"].compact if result["stolen_record"]
+        expect(result).to eq stolen_target
       end
     end
 
@@ -121,7 +98,7 @@ RSpec.describe "Bikes API V3", type: :request do
         expect(impound_record.kind).to eq "found"
         get "/api/v3/bikes/#{bike.id}", params: {format: :json}
         expect(response.code).to eq("200")
-        expect(json_result["bike"]).to eq target.merge("status" => "found", "serial" => "Hidden")
+        expect(json_result["bike"].compact).to eq target.merge("status" => "found", "serial" => "Hidden")
       end
     end
 

--- a/spec/requests/api/v3/bikes_request_spec.rb
+++ b/spec/requests/api/v3/bikes_request_spec.rb
@@ -24,12 +24,61 @@ RSpec.describe "Bikes API V3", type: :request do
 
   describe "find by id" do
     let(:bike) { FactoryBot.create(:bike) }
-    let(:target) { {"id" => bike.id, "status" => "with owner", "for_sale" => false} }
+    let(:target) do
+      {
+        "id" => bike.id,
+        "title" => bike.title_string,
+        "serial" => bike.serial_number.upcase,
+        "manufacturer_name" => bike.mnfg_name,
+        "manufacturer_id" => bike.manufacturer_id,
+        "frame_model" => nil,
+        "frame_size" => nil,
+        "frame_material_slug" => nil,
+        "frame_colors" => ["Black"],
+        "year" => nil,
+        "name" => nil,
+        "paint_description" => nil,
+        "description" => nil,
+        "rear_tire_narrow" => true,
+        "front_tire_narrow" => nil,
+        "rear_wheel_size_iso_bsd" => nil,
+        "front_wheel_size_iso_bsd" => nil,
+        "handlebar_type_slug" => nil,
+        "front_gear_type_slug" => nil,
+        "rear_gear_type_slug" => nil,
+        "extra_registration_number" => nil,
+        "additional_registration" => nil,
+        "type_of_cycle" => "Bike",
+        "cycle_type_slug" => "bike",
+        "propulsion_type_slug" => "foot-pedal",
+        "test_bike" => false,
+        "thumb" => nil,
+        "large_img" => nil,
+        "is_stock_img" => false,
+        "url" => "http://test.host/bikes/#{bike.id}",
+        "api_url" => "http://test.host/api/v1/bikes/#{bike.id}",
+        "registration_created_at" => bike.created_at.to_i,
+        "registration_updated_at" => bike.updated_at.to_i,
+        "external_id" => nil,
+        "registry_name" => nil,
+        "registry_url" => nil,
+        "location_found" => nil,
+        "status" => "with owner",
+        "for_sale" => false,
+        "stolen" => false,
+        "stolen_location" => nil,
+        "stolen_coordinates" => nil,
+        "date_stolen" => nil,
+        "stolen_record" => nil,
+        "public_images" => [],
+        "components" => []
+      }
+    end
 
     it "returns one with from an id" do
       get "/api/v3/bikes/#{bike.id}", params: {format: :json}
       expect(response.code).to eq("200")
-      expect(json_result["bike"]).to include(target)
+      expect(json_result["bike"]).to eq target
       expect(response.headers["Content-Type"].match("json")).to be_present
       expect(response.headers["Access-Control-Allow-Origin"]).to eq("*")
       expect(response.headers["Access-Control-Request-Method"]).to eq("*")
@@ -41,17 +90,27 @@ RSpec.describe "Bikes API V3", type: :request do
       it "returns status with owner and for_sale true" do
         get "/api/v3/bikes/#{bike.id}", params: {format: :json}
         expect(response.code).to eq("200")
-        expect(json_result["bike"]).to include(target.merge("for_sale" => true))
+        expect(json_result["bike"]).to eq target.merge("for_sale" => true)
       end
     end
 
     context "stolen bike marked for sale" do
       let(:bike) { FactoryBot.create(:stolen_bike, is_for_sale: true) }
+      let(:stolen_target) do
+        target.merge(
+          "status" => "stolen",
+          "for_sale" => true,
+          "stolen" => true,
+          "stolen_coordinates" => [40.71, -74.01],
+          "date_stolen" => bike.current_stolen_record.date_stolen.to_i,
+          "stolen_record" => JSON.parse(StolenRecordV2Serializer.new(bike.current_stolen_record, root: false, event: bike).to_json)
+        )
+      end
 
       it "returns status stolen and for_sale true" do
         get "/api/v3/bikes/#{bike.id}", params: {format: :json}
         expect(response.code).to eq("200")
-        expect(json_result["bike"]).to include(target.merge("status" => "stolen", "for_sale" => true))
+        expect(json_result["bike"]).to eq stolen_target
       end
     end
 
@@ -62,7 +121,7 @@ RSpec.describe "Bikes API V3", type: :request do
         expect(impound_record.kind).to eq "found"
         get "/api/v3/bikes/#{bike.id}", params: {format: :json}
         expect(response.code).to eq("200")
-        expect(json_result["bike"]).to include(target.merge("status" => "found"))
+        expect(json_result["bike"]).to eq target.merge("status" => "found", "serial" => "Hidden")
       end
     end
 

--- a/spec/requests/api/v3/me_request_spec.rb
+++ b/spec/requests/api/v3/me_request_spec.rb
@@ -141,6 +141,19 @@ RSpec.describe "Me API V3", type: :request do
       expect(json_result["bikes"].is_a?(Array)).to be_truthy
       expect(response.response_code).to eq(200)
     end
+
+    context "with for sale bike" do
+      let!(:bike) { FactoryBot.create(:bike, :with_ownership, owner_email: user.email, is_for_sale: true) }
+
+      it "uses BikeV3Serializer (status not 'for sale', for_sale: true)" do
+        token.update_attribute :scopes, "read_bikes"
+        get "/api/v3/me/bikes", params: {access_token: token.token}, headers: {format: :json}
+        expect(response.response_code).to eq(200)
+        result = json_result["bikes"].find { |b| b["id"] == bike.id }
+        expect(result).to include("status" => "with owner", "for_sale" => true)
+      end
+    end
+
     it "403s if read_bikes_spec isn't in token" do
       get "/api/v3/me/bikes", params: {access_token: token.token}, headers: {format: :json}
       expect(response.response_code).to eq(403)

--- a/spec/requests/api/v3/search_request_spec.rb
+++ b/spec/requests/api/v3/search_request_spec.rb
@@ -77,6 +77,19 @@ RSpec.describe "Search API V3", type: :request do
         expect(json_result["bikes"][0]["id"]).to eq bike2.id
       end
     end
+    context "non-stolen for-sale bike" do
+      let!(:marketplace_listing) { FactoryBot.create(:marketplace_listing, :for_sale) }
+      let(:listed_bike) { marketplace_listing.item }
+
+      it "serializes status as 'with owner' with for_sale: true" do
+        expect(listed_bike.reload.is_for_sale).to be_truthy
+        get "/api/v3/search", params: {stolenness: "non", format: :json}
+        expect(response.status).to eq 200
+        result = json_result["bikes"].find { |b| b["id"] == listed_bike.id }
+        expect(result).to include("status" => "with owner", "for_sale" => true)
+      end
+    end
+
     context "proximity" do
       let(:ip_address) { "23.115.69.69" }
       let(:headers) { {"HTTP_X_FORWARDED_FOR" => ip_address} }
@@ -161,6 +174,7 @@ RSpec.describe "Search API V3", type: :request do
             registry_url
             serial
             status
+            for_sale
             stolen
             stolen_coordinates
             stolen_location

--- a/spec/serializers/bike_v2_serializer_spec.rb
+++ b/spec/serializers/bike_v2_serializer_spec.rb
@@ -30,6 +30,7 @@ RSpec.describe BikeV2Serializer do
         description: nil,
         external_id: nil,
         status: "with owner",
+        for_sale: false,
         propulsion_type_slug: "foot-pedal",
         cycle_type_slug: "bike"
       }

--- a/spec/serializers/bike_v2_show_serializer_spec.rb
+++ b/spec/serializers/bike_v2_show_serializer_spec.rb
@@ -77,6 +77,7 @@ RSpec.describe BikeV2ShowSerializer do
         registry_name: nil,
         registry_url: nil,
         status: "with owner",
+        for_sale: false,
         propulsion_type_slug: "pedal-assist",
         cycle_type_slug: "cargo"
       }


### PR DESCRIPTION
The `status` field on API bike responses (v2 and v3) used to return the literal string `"for sale"` for any bike with `is_for_sale: true`, masking the underlying status. Clients had no way to read that a "for sale" bike was actually `with owner` or `stolen`.

- `BikeV2Serializer` now exposes a separate `for_sale` boolean attribute and `status` returns the real humanized status (`with owner` / `stolen` / `found` / etc.), never `"for sale"`.
- `ExternalRegistryBikeV3Serializer` overrides `for_sale` to return `false` since external bikes have no marketplace listing.
- Specs updated across v2/v3 request specs, serializer specs, and the cached-stolen file job to reflect the new shape.

This is a breaking change for v2 clients that branched on `status == "for sale"`; switch to reading `for_sale` instead.
