### PR TITLE
UpdateManufacturerLogoAndPriorityJob: skip non-image responses

### DIFF
--- a/app/jobs/update_manufacturer_logo_and_priority_job.rb
+++ b/app/jobs/update_manufacturer_logo_and_priority_job.rb
@@ -52,6 +52,7 @@ class UpdateManufacturerLogoAndPriorityJob < ScheduledJob
 
     status_response = Net::HTTP.get_response(URI(logo_url))
     return unless status_response.is_a?(Net::HTTPSuccess)
+    return unless status_response.content_type&.start_with?("image/")
 
     manufacturer.update!(remote_logo_url: logo_url, logo_source: "Logo.dev")
   end

--- a/spec/jobs/update_manufacturer_logo_and_priority_job_spec.rb
+++ b/spec/jobs/update_manufacturer_logo_and_priority_job_spec.rb
@@ -30,6 +30,17 @@ RSpec.describe UpdateManufacturerLogoAndPriorityJob, type: :job do
     end
   end
 
+  it "Doesn't break when logo.dev returns 200 with a non-image body" do
+    manufacturer = FactoryBot.create(:manufacturer, website: "https://example.com")
+    logo_url = described_class.logo_url(manufacturer)
+    WebMock.stub_request(:get, logo_url)
+      .to_return(status: 200, body: '{"err":"oops"}', headers: {"Content-Type" => "application/json"})
+    described_class.new.perform(manufacturer.id)
+    manufacturer.reload
+    expect(manufacturer.logo).to_not be_present
+    expect(manufacturer.logo_source).to be_nil
+  end
+
   it "Doesn't break when website has a path" do
     VCR.use_cassette("get_manufacturer_logo_worker-website-with-path", vcr_config) do
       manufacturer = FactoryBot.create(:manufacturer, website: "http://www.ternbicycles.com/us/")

--- a/spec/jobs/update_manufacturer_logo_and_priority_job_spec.rb
+++ b/spec/jobs/update_manufacturer_logo_and_priority_job_spec.rb
@@ -31,14 +31,13 @@ RSpec.describe UpdateManufacturerLogoAndPriorityJob, type: :job do
   end
 
   it "Doesn't break when logo.dev returns 200 with a non-image body" do
-    manufacturer = FactoryBot.create(:manufacturer, website: "https://example.com")
-    logo_url = described_class.logo_url(manufacturer)
-    WebMock.stub_request(:get, logo_url)
-      .to_return(status: 200, body: '{"err":"oops"}', headers: {"Content-Type" => "application/json"})
-    described_class.new.perform(manufacturer.id)
-    manufacturer.reload
-    expect(manufacturer.logo).to_not be_present
-    expect(manufacturer.logo_source).to be_nil
+    VCR.use_cassette("get_manufacturer_logo_worker-non-image", vcr_config) do
+      manufacturer = FactoryBot.create(:manufacturer, name: "Ibera", website: "http://www.ibera.info/")
+      described_class.new.perform(manufacturer.id)
+      manufacturer.reload
+      expect(manufacturer.logo).to_not be_present
+      expect(manufacturer.logo_source).to be_nil
+    end
   end
 
   it "Doesn't break when website has a path" do

--- a/spec/vcr_cassettes/get_manufacturer_logo_worker-non-image.yml
+++ b/spec/vcr_cassettes/get_manufacturer_logo_worker-non-image.yml
@@ -1,0 +1,37 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://img.logo.dev/www.ibera.info?fallback=404&size=400&token=<LOGO_API_TOKEN>
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - text/plain; charset=utf-8
+      Content-Length:
+      - '14'
+      Connection:
+      - keep-alive
+      Date:
+      - Wed, 29 Apr 2026 22:31:08 GMT
+      Cache-Control:
+      - max-age=86400, stale-while-revalidate=600
+      X-Cache:
+      - Error from cloudfront
+    body:
+      encoding: UTF-8
+      string: 'not an image!'
+  recorded_at: Wed, 29 Apr 2026 22:31:08 GMT
+recorded_with: VCR 6.3.1


### PR DESCRIPTION
Fixes [Honeybadger fault 130002422](https://app.honeybadger.io/projects/35931/faults/130002422).

`logo.dev` occasionally returns HTTP 200 with a non-image body (e.g. JSON), which then caused `manufacturer.update!(remote_logo_url:)` to fail with `ActiveRecord::RecordInvalid: Validation failed: Logo Failed to manipulate, maybe it is not an image?`.

- Check `Content-Type` starts with `image/` before assigning `remote_logo_url` in `UpdateManufacturerLogoAndPriorityJob`
- Add a spec covering the 200-with-JSON-body case
