### PR TITLE
Fix address fields overflow on org manage page below lg

### DIFF
--- a/app/views/organized/manages/_location_fields.html.haml
+++ b/app/views/organized/manages/_location_fields.html.haml
@@ -14,8 +14,9 @@
   .form-group.row
     %label.org-form-label
       = f.label :street, t(".address")
-    = f.fields_for :address_record do |address_form|
-      = render(Org::LocationAddressFields::Component.new(form_builder: address_form))
+    .col-sm-8
+      = f.fields_for :address_record do |address_form|
+        = render(Org::LocationAddressFields::Component.new(form_builder: address_form))
 
 
 - else


### PR DESCRIPTION
The `Org::LocationAddressFields` component renders a nested `.row.countrystatezip` with Bootstrap's -15px negative margins, but on the org manage page (`initial_location_form: true`) it was rendered as a direct sibling of `.org-form-label` with no `.col-sm-*` wrapper to absorb those margins. Below `lg` the overflow became visible. Wrapping the component in `.col-sm-8` (the standard pair with `.org-form-label`'s `.col-sm-4`) fixes the layout.
