### PR TITLE
UI::Button: drop underline on hover; tighten PeriodSelect on mobile

### DIFF
--- a/app/assets/tailwind/application.css
+++ b/app/assets/tailwind/application.css
@@ -163,6 +163,11 @@
   @apply tw:antialiased tw:font-sans tw:text-gray-900 tw:dark:text-gray-400;
 }
 
+/* Unlayered so it wins over the size utilities (`tw:px-2.5`) injected by UI::Button */
+.period-select-standard {
+  @apply tw:px-1.5 tw:sm:px-2.5;
+}
+
 @layer base {
   button:not(:disabled),
   [role="button"]:not(:disabled),

--- a/app/components/ui/button/component.rb
+++ b/app/components/ui/button/component.rb
@@ -31,7 +31,7 @@ module UI
         classes = [BASE_CLASSES, COLORS[color], html_class]
         unless color == :link
           classes << SIZES[size]
-          classes << "tw:focus:outline-none tw:focus:ring-3 tw:font-medium"
+          classes << "tw:focus:outline-none tw:focus:ring-3 tw:font-medium tw:no-underline"
         end
         classes << ACTIVE_COLORS[color] if active
         classes.compact.join(" ")

--- a/app/components/ui/period_select/component.html.erb
+++ b/app/components/ui/period_select/component.html.erb
@@ -26,7 +26,7 @@
       text: translation(".custom"),
       size: :sm,
       active: @period == "custom",
-      html_class: "tw:px-1.5! tw:sm:px-2.5!",
+      html_class: "period-select-standard",
       data: {period: "custom", action: "click->collapse#toggle"}
     ) %>
   </div>

--- a/app/components/ui/period_select/component.html.erb
+++ b/app/components/ui/period_select/component.html.erb
@@ -1,7 +1,7 @@
 <div data-controller="collapse ui--period-select">
   <div
     id="timeSelectionBtnGroup"
-    class="text-right tw:flex tw:flex-wrap tw:justify-end tw:gap-2 <%= "custom-period-selected" if @period == "custom" %>"
+    class="text-right tw:flex tw:flex-wrap tw:justify-end tw:gap-1 tw:sm:gap-2 <%= "custom-period-selected" if @period == "custom" %>"
     role="group"
   >
     <% if @prepend_text.present? %>
@@ -26,6 +26,7 @@
       text: translation(".custom"),
       size: :sm,
       active: @period == "custom",
+      html_class: "tw:px-1.5! tw:sm:px-2.5!",
       data: {period: "custom", action: "click->collapse#toggle"}
     ) %>
   </div>

--- a/app/components/ui/period_select/component.rb
+++ b/app/components/ui/period_select/component.rb
@@ -33,7 +33,7 @@ module UI
           href: period_url(period_key),
           size: :sm,
           active: @period == period_key,
-          class: "period-select-standard tw:px-1.5! tw:sm:px-2.5!",
+          class: "period-select-standard",
           data: {period: period_key, turbo_action: "advance"}
         )
       end

--- a/app/components/ui/period_select/component.rb
+++ b/app/components/ui/period_select/component.rb
@@ -33,7 +33,7 @@ module UI
           href: period_url(period_key),
           size: :sm,
           active: @period == period_key,
-          class: "period-select-standard",
+          class: "period-select-standard tw:px-1.5! tw:sm:px-2.5!",
           data: {period: period_key, turbo_action: "advance"}
         )
       end


### PR DESCRIPTION
Two small UI component fixes:

- `UI::Button` non-link variants now include `tw:no-underline`, which keeps `UI::ButtonLink` (renders `<a>`) from picking up the legacy `a:hover { text-decoration: underline }` rule in `admin.scss`. Visible on admin period-select buttons.
- `UI::PeriodSelect` tightens gap and per-button padding on mobile so the seven period buttons fit on one line at 375px instead of wrapping `custom`. The container drops to `tw:gap-1` below `sm`, and `.period-select-standard` (now applied to the custom button too) is defined unlayered in `tailwind/application.css` so its `tw:px-1.5 tw:sm:px-2.5` wins over the `tw:px-2.5` that `UI::Button::SIZES[:sm]` injects from `@layer utilities`.
