### PR TITLE
Admin oauth/applications: add name/client ID search

### DIFF
--- a/.claude/skills/pr/SKILL.md
+++ b/.claude/skills/pr/SKILL.md
@@ -80,7 +80,9 @@ From the changed files, infer the affected routes. Heuristics:
 - Admin views → `/admin/...`
 - If unclear, ask the user which URLs to capture before proceeding. Do not guess blindly — 1–3 well-chosen URLs beats 10 random ones.
 
-If `bin/dev` isn't already up (`curl -fs "$BASE_URL/" >/dev/null` fails), start it in the background — Tailwind and JS need to compile before screenshots will render correctly. Then poll the same `curl` until it succeeds.
+**Never start or stop `bin/dev` for the user.** The dev server is the user's process — it owns their database connection (which in Conductor workspaces depends on `CONDUCTOR_WORKSPACE_NAME` being set in the launching shell, something agent shells don't inherit), holds their authenticated session, and may be mid-debug. Starting your own copy can land you on a different DB; stopping theirs interrupts work.
+
+Check whether the dev server is up: `curl -fs "$BASE_URL/" >/dev/null`. If it isn't, **stop and ask the user to start it** (`bin/dev` from their own terminal), then resume once they confirm. Do not background-launch it yourself, even temporarily.
 
 ### 5. Capture screenshots
 

--- a/.claude/skills/pr/SKILL.md
+++ b/.claude/skills/pr/SKILL.md
@@ -80,7 +80,7 @@ From the changed files, infer the affected routes. Heuristics:
 - Admin views → `/admin/...`
 - If unclear, ask the user which URLs to capture before proceeding. Do not guess blindly — 1–3 well-chosen URLs beats 10 random ones.
 
-**Never start or stop `bin/dev` for the user.** The dev server is the user's process — it owns their database connection (which in Conductor workspaces depends on `CONDUCTOR_WORKSPACE_NAME` being set in the launching shell, something agent shells don't inherit), holds their authenticated session, and may be mid-debug. Starting your own copy can land you on a different DB; stopping theirs interrupts work.
+**Never start or stop `bin/dev` for the user.** The dev server is the user's process. Starting your own copy can land you on a different DB; stopping theirs interrupts work.
 
 Check whether the dev server is up: `curl -fs "$BASE_URL/" >/dev/null`. If it isn't, **stop and ask the user to start it** (`bin/dev` from their own terminal), then resume once they confirm. Do not background-launch it yourself, even temporarily.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,9 +4,7 @@ Bike Index is a Rails webapp
 
 # Development
 
-Start the dev server with `bin/dev`
-
-This will start a dev server at [http://localhost:3042](http://localhost:3042) (or the configured `DEV_PORT` or `CONDUCTOR_PORT`)
+Run `eval "$(ruby bin/env --export)"` once so `$DEV_PORT` (and `$BASE_URL`, `$REDIS_URL`) are set with the right CONDUCTOR_PORT fallback.
 
 ## Code style
 
@@ -29,6 +27,8 @@ Uses RSpec. All business logic should be tested. The `rspec-testing` skill cover
 ## Frontend Development
 
 Uses Stimulus.js for JavaScript and Tailwind CSS for styling. SCSS and CoffeeScript files exist but are deprecated. The `bin/dev` command handles Tailwind and JS builds. The `frontend-conventions` skill covers project-specific class prefixes (`tw:`, `twinput`, `twlabel`, `twlink`), the `number_display` helper, and ViewComponent rules.
+
+Check whether the dev server is up: `curl -fs "$BASE_URL/" >/dev/null`. If it isn't, **stop and ask the user to start it**
 
 ## Pull requests
 

--- a/app/controllers/oauth/applications_controller.rb
+++ b/app/controllers/oauth/applications_controller.rb
@@ -67,6 +67,11 @@ module Oauth
         doorkeeper_apps = doorkeeper_apps.where(owner_id: user_subject&.id || params[:user_id])
       end
 
+      if params[:search_query].present?
+        str = "%#{params[:search_query].strip}%"
+        doorkeeper_apps = doorkeeper_apps.where("oauth_applications.name ILIKE :str OR oauth_applications.uid ILIKE :str", str:)
+      end
+
       @time_range_column = sort_column if %w[updated_at].include?(sort_column)
       @time_range_column ||= "created_at"
       doorkeeper_apps.where(@time_range_column => @time_range)

--- a/app/views/doorkeeper/applications/admin_index.html.erb
+++ b/app/views/doorkeeper/applications/admin_index.html.erb
@@ -1,1 +1,18 @@
-<%= render(Admin::IndexSkeleton::Component.new(chart_collection: @render_chart && @matching_applications)) %>
+<% admin_search_form = capture do %>
+  <%= form_tag oauth_applications_path, method: :get do %>
+    <%= hidden_field_tag :search_all, true %>
+    <%= render partial: "/shared/hidden_search_fields" %>
+
+    <div class="mt-4 mb-4 d-flex justify-content-md-end flex-wrap">
+      <div class="align-self-end mt-2 mr-2">
+        <%= text_field_tag :search_query, params[:search_query], placeholder: "Name/Client ID", class: "form-control" %>
+      </div>
+
+      <div class="mt-2 mr-2">
+        <%= submit_tag "Search", name: "search", class: "btn btn-primary" %>
+      </div>
+    </div>
+  <% end %>
+<% end %>
+
+<%= render(Admin::IndexSkeleton::Component.new(admin_search_form:, chart_collection: @render_chart && @matching_applications)) %>

--- a/app/views/doorkeeper/applications/show.html.erb
+++ b/app/views/doorkeeper/applications/show.html.erb
@@ -22,13 +22,17 @@
       Application Id:
     </h4>
 
-    <p class="tw:overflow-x-auto tw:whitespace-nowrap"><code id="application_id"><%= @application.uid %></code></p>
+    <p class="tw:overflow-x-auto tw:whitespace-nowrap">
+      <code id="application_id"><%= @application.uid %></code>
+    </p>
 
     <h4 class="mb-1 uncap" style="font-size: 18px;">
       Secret:
     </h4>
 
-    <p class="tw:overflow-x-auto tw:whitespace-nowrap"><code id="secret"><%= @application.secret %></code></p>
+    <p class="tw:overflow-x-auto tw:whitespace-nowrap">
+      <code id="secret"><%= @application.secret %></code>
+    </p>
 
     <h4 class="mb-1 uncap" style="font-size: 18px;">
       Bikes registered

--- a/app/views/doorkeeper/applications/show.html.erb
+++ b/app/views/doorkeeper/applications/show.html.erb
@@ -22,13 +22,13 @@
       Application Id:
     </h4>
 
-    <p><code id="application_id"><%= @application.uid %></code></p>
+    <p class="tw:overflow-x-auto tw:whitespace-nowrap"><code id="application_id"><%= @application.uid %></code></p>
 
     <h4 class="mb-1 uncap" style="font-size: 18px;">
       Secret:
     </h4>
 
-    <p><code id="secret"><%= @application.secret %></code></p>
+    <p class="tw:overflow-x-auto tw:whitespace-nowrap"><code id="secret"><%= @application.secret %></code></p>
 
     <h4 class="mb-1 uncap" style="font-size: 18px;">
       Bikes registered

--- a/spec/requests/oauth/applications_request_spec.rb
+++ b/spec/requests/oauth/applications_request_spec.rb
@@ -44,6 +44,12 @@ RSpec.describe Oauth::ApplicationsController, type: :request do
           expect(response).to render_template(:admin_index)
           expect(assigns(:applications)).to be_nil
           expect(assigns(:collection).pluck(:id)).to match_array([doorkeeper_app2.id])
+
+          get "#{base_url}?search_all=true&search_query=MyApp"
+          expect(assigns(:collection).pluck(:id)).to match_array([doorkeeper_app2.id])
+
+          get "#{base_url}?search_all=true&search_query=#{doorkeeper_app.uid}"
+          expect(assigns(:collection).pluck(:id)).to match_array([doorkeeper_app.id])
         end
       end
     end


### PR DESCRIPTION
Adds a Name/Client ID search box to the admin OAuth applications listing (`/oauth/applications?search_all=true`), and makes the application id and secret on the show page horizontally scrollable so they no longer overflow on narrow viewports.

- Controller filters `admin_oauth_applications` by `params[:search_query]` against `name` and `uid` (case-insensitive).
- Admin index view renders a search form using the standard hidden-fields partial, mirroring the admin organizations pattern.
- Show view: app id/secret `<p>` wrappers get `tw:overflow-x-auto tw:whitespace-nowrap` so the strings stay on one line and scroll on mobile.
- Request spec extended to cover both name and uid matches.
