### PR TITLE
Fix Email::PartialRegistrationJob crash on bogus primary_frame_color_id

### DIFF
--- a/app/components/emails/partial_registration/component.rb
+++ b/app/components/emails/partial_registration/component.rb
@@ -15,10 +15,7 @@ module Emails
       end
 
       def color_and_brand
-        parts = []
-        parts << Color.find(@b_param.primary_frame_color_id)&.name if @b_param.primary_frame_color_id.present?
-        parts << @b_param.mnfg_name
-        parts.compact.join(" ")
+        [@b_param.primary_frame_color.presence, @b_param.mnfg_name].compact.join(" ")
       end
 
       def tokenized_url

--- a/spec/mailers/organized_mailer_spec.rb
+++ b/spec/mailers/organized_mailer_spec.rb
@@ -46,6 +46,15 @@ RSpec.describe OrganizedMailer, type: :mailer do
         expect_render_donation(true, mail)
         expect_render_supporters(true, mail)
       end
+      context "with a bogus primary_frame_color_id" do
+        let(:b_param) do
+          FactoryBot.create(:b_param_stolen,
+            params: {bike: {owner_email: "bike_owner@example.com", primary_frame_color_id: "ndbGRKFw')) OR 96=(SELECT 96 FROM PG_SLEEP(15))--"}})
+        end
+        it "renders without raising" do
+          expect { OrganizedMailer.partial_registration(b_param).body.encoded }.not_to raise_error
+        end
+      end
     end
     context "with organization" do
       let(:organization) { FactoryBot.create(:organization_with_auto_user) }

--- a/spec/mailers/organized_mailer_spec.rb
+++ b/spec/mailers/organized_mailer_spec.rb
@@ -46,15 +46,6 @@ RSpec.describe OrganizedMailer, type: :mailer do
         expect_render_donation(true, mail)
         expect_render_supporters(true, mail)
       end
-      context "with a bogus primary_frame_color_id" do
-        let(:b_param) do
-          FactoryBot.create(:b_param_stolen,
-            params: {bike: {owner_email: "bike_owner@example.com", primary_frame_color_id: "ndbGRKFw')) OR 96=(SELECT 96 FROM PG_SLEEP(15))--"}})
-        end
-        it "renders without raising" do
-          expect { OrganizedMailer.partial_registration(b_param).body.encoded }.not_to raise_error
-        end
-      end
     end
     context "with organization" do
       let(:organization) { FactoryBot.create(:organization_with_auto_user) }

--- a/spec/requests/registrations_request_spec.rb
+++ b/spec/requests/registrations_request_spec.rb
@@ -234,6 +234,21 @@ RSpec.describe RegistrationsController, type: :request do
           expect(assigns(:simple_header)).to be_truthy
         end
       end
+      context "with a bogus primary_frame_color_id (HB #122918826)" do
+        include_context :test_csrf_token
+        let(:bogus_color_id) { "ndbGRKFw')) OR 96=(SELECT 96 FROM PG_SLEEP(15))--" }
+        it "creates a bparam and the partial registration mailer still sends" do
+          ActionMailer::Base.deliveries = []
+          post base_url, params: {b_param: {owner_email: "scan@stuff.com", primary_frame_color_id: bogus_color_id}}
+          expect(response).to render_template(:create)
+          b_param = BParam.last
+          expect(b_param.primary_frame_color_id).to eq bogus_color_id
+          expect(Email::PartialRegistrationJob).to have_enqueued_sidekiq_job(b_param.id)
+          Email::PartialRegistrationJob.drain
+          expect(ActionMailer::Base.deliveries.count).to eq 1
+          expect(ActionMailer::Base.deliveries.last.to).to eq(["scan@stuff.com"])
+        end
+      end
       context "all values set" do
         let(:attrs) do
           {


### PR DESCRIPTION
Fixes [Honeybadger #122918826](https://app.honeybadger.io/projects/35931/faults/122918826) — `ActionView::Template::Error: Couldn't find Color with 'id'=...` raised from `Email::PartialRegistrationJob` (3027 occurrences).

- `Emails::PartialRegistration::Component#color_and_brand` called `Color.find(@b_param.primary_frame_color_id)`, which raises `RecordNotFound` when the id is junk (typically SQL-injection scan payloads sent to the partial registration endpoint).
- Replaced with `@b_param.primary_frame_color`, the existing helper that goes through `Color.find_by_id` and returns `nil` for unknown ids.
- Added a regression spec that builds a `b_param` with the literal payload from the Honeybadger notice and asserts the mailer renders.
