### PR TITLE
Admin pagination: stop wrapping awkwardly between md and lg

### DIFF
--- a/app/components/admin/pagination_with_count/component.html.erb
+++ b/app/components/admin/pagination_with_count/component.html.erb
@@ -24,7 +24,7 @@
   <% end %>
 
   <% unless @skip_pagination || @pagy.blank? %>
-    <div class="tw:flex tw:flex-wrap tw:justify-end tw:gap-4 tw:lg:flex-nowrap tw:md:text-right <%= (@skip_total ? "col-12" : "col-md-7") %>">
+    <div class="tw:flex tw:flex-wrap tw:justify-end tw:gap-4 tw:md:text-right tw:lg:flex-nowrap <%= (@skip_total ? "col-12" : "col-md-7") %>">
       <%= render(UI::Pagination::Component.new(pagy: @pagy, page_params: @params)) %>
 
       <%= select_tag :per_page_select, options_for_select(per_pages.map { |i| ["#{i} / page", i] }, selected: @per_page), {id: per_page_select_id, class: "form-control d-inline-block", style: "margin-top: -6px; max-width: 8rem;"} %>

--- a/app/components/admin/pagination_with_count/component.html.erb
+++ b/app/components/admin/pagination_with_count/component.html.erb
@@ -1,7 +1,7 @@
 <div class="row tw:mt-8 tw:mb-4">
   <% unless @skip_total %>
     <div class="col-md-5">
-      <p class="pagination-number mb-0">
+      <p class="pagination-number mb-2 mb-md-0">
         <strong><%= number_with_delimiter(count) %></strong> Matching
         <%= viewing.pluralize(count) %>
 
@@ -24,7 +24,7 @@
   <% end %>
 
   <% unless @skip_pagination || @pagy.blank? %>
-    <div class="tw:flex tw:flex-wrap tw:justify-end tw:gap-4 tw:md:flex-nowrap tw:md:text-right <%= (@skip_total ? "col-12" : "col-md-7") %>">
+    <div class="tw:flex tw:flex-wrap tw:justify-end tw:gap-4 tw:lg:flex-nowrap tw:md:text-right <%= (@skip_total ? "col-12" : "col-md-7") %>">
       <%= render(UI::Pagination::Component.new(pagy: @pagy, page_params: @params)) %>
 
       <%= select_tag :per_page_select, options_for_select(per_pages.map { |i| ["#{i} / page", i] }, selected: @per_page), {id: per_page_select_id, class: "form-control d-inline-block", style: "margin-top: -6px; max-width: 8rem;"} %>

--- a/app/components/admin/pagination_with_count/component_preview.rb
+++ b/app/components/admin/pagination_with_count/component_preview.rb
@@ -14,6 +14,17 @@ module Admin
         ))
       end
 
+      def many_pages
+        pagy = Pagy::Offset.new(count: 559, page: 1, limit: 50)
+        render(Admin::PaginationWithCount::Component.new(
+          collection: collection,
+          viewing: "application",
+          pagy:,
+          per_page: 50,
+          params: {}
+        ))
+      end
+
       def with_viewing_override
         pagy = Pagy::Offset.new(count: 50, page: 1, limit: 25)
         render(Admin::PaginationWithCount::Component.new(


### PR DESCRIPTION
At admin viewports between md and lg (e.g. 818px), the per-page select sat next to the pagination nav and squeezed it, causing the next button to wrap onto its own line below the last page number.

- Bump the pagination wrapper's flex `nowrap` breakpoint from `md` to `lg`, so the select drops below the nav between 768–1023px instead of crowding it.
- Give the matching count `mb-2 mb-md-0` so it has bottom margin when stacked above the pagination on mobile, and `mb-0` when left-aligned beside it at md+.
- Add a `many_pages` Lookbook preview (559 items, 50/page) that exercises the high-page-count layout this regression hit.
