### PR TITLE
ProcessParkingNotificationJob: redlock to prevent duplicate emails

### DIFF
--- a/app/jobs/process_parking_notification_job.rb
+++ b/app/jobs/process_parking_notification_job.rb
@@ -1,7 +1,4 @@
-# Wrapped in a redlock keyed on parking_notification_id: the email-send guard
-# (`delivery_status.blank?`) is read-then-write, so concurrent workers picking
-# up jobs queued from cascading after_commits could each pass the check and
-# deliver duplicate emails.
+# Uses redlock so concurrent workers don't both pass the delivery_status.blank? guard and double-send.
 class ProcessParkingNotificationJob < ApplicationJob
   REDLOCK_PREFIX = "ProcessParkingNotificationLock-#{Rails.env.slice(0, 3)}"
 
@@ -29,46 +26,40 @@ class ProcessParkingNotificationJob < ApplicationJob
     return unless redlock
 
     begin
-      run(parking_notification_id)
+      parking_notification = ParkingNotification.find(parking_notification_id)
+
+      if parking_notification.impound_notification? && parking_notification.impound_record_id.blank?
+        impound_record = ImpoundRecord.create!(bike_id: parking_notification.bike_id,
+          user_id: parking_notification.user_id,
+          organization_id: parking_notification.organization_id,
+          skip_update: true)
+        parking_notification.resolved_at ||= Time.current
+        parking_notification.update(impound_record_id: impound_record.id)
+        ProcessImpoundUpdatesJob.new.perform(impound_record.id)
+      end
+
+      # Update all of them!
+      parking_notification.associated_notifications.each do |pn|
+        pn.impound_record_id = impound_record.id if impound_record.present?
+        pn.update(updated_at: Time.current, skip_update: true)
+      end
+
+      # If there are any notifications from the same period, resolve them - even if they aren't associated
+      if parking_notification.reload.resolved?
+        parking_notification.notifications_from_period.active.each do |notification|
+          # Add a note about it though, to document it
+          notes = [notification.internal_notes, "resolved by parking notification ##{parking_notification.id}"]
+          notification.update(resolved_at: parking_notification.resolved_at,
+            internal_notes: notes.join(", "))
+        end
+      end
+
+      return true unless parking_notification.send_email? && parking_notification.delivery_status.blank?
+
+      OrganizedMailer.parking_notification(parking_notification).deliver_now
+      parking_notification.update_attribute :delivery_status, "email_success" # I'm not sure how to make this more representative
     ensure
       lock_manager.unlock(redlock)
     end
-  end
-
-  private
-
-  def run(parking_notification_id)
-    parking_notification = ParkingNotification.find(parking_notification_id)
-
-    if parking_notification.impound_notification? && parking_notification.impound_record_id.blank?
-      impound_record = ImpoundRecord.create!(bike_id: parking_notification.bike_id,
-        user_id: parking_notification.user_id,
-        organization_id: parking_notification.organization_id,
-        skip_update: true)
-      parking_notification.resolved_at ||= Time.current
-      parking_notification.update(impound_record_id: impound_record.id)
-      ProcessImpoundUpdatesJob.new.perform(impound_record.id)
-    end
-
-    # Update all of them!
-    parking_notification.associated_notifications.each do |pn|
-      pn.impound_record_id = impound_record.id if impound_record.present?
-      pn.update(updated_at: Time.current, skip_update: true)
-    end
-
-    # If there are any notifications from the same period, resolve them - even if they aren't associated
-    if parking_notification.reload.resolved?
-      parking_notification.notifications_from_period.active.each do |notification|
-        # Add a note about it though, to document it
-        notes = [notification.internal_notes, "resolved by parking notification ##{parking_notification.id}"]
-        notification.update(resolved_at: parking_notification.resolved_at,
-          internal_notes: notes.join(", "))
-      end
-    end
-
-    return true unless parking_notification.send_email? && parking_notification.delivery_status.blank?
-
-    OrganizedMailer.parking_notification(parking_notification).deliver_now
-    parking_notification.update_attribute :delivery_status, "email_success" # I'm not sure how to make this more representative
   end
 end

--- a/app/jobs/process_parking_notification_job.rb
+++ b/app/jobs/process_parking_notification_job.rb
@@ -1,7 +1,43 @@
+# Wrapped in a redlock keyed on parking_notification_id: the email-send guard
+# (`delivery_status.blank?`) is read-then-write, so concurrent workers picking
+# up jobs queued from cascading after_commits could each pass the check and
+# deliver duplicate emails.
 class ProcessParkingNotificationJob < ApplicationJob
+  REDLOCK_PREFIX = "ProcessParkingNotificationLock-#{Rails.env.slice(0, 3)}"
+
   sidekiq_options queue: "notify"
 
+  def self.redlock_key(parking_notification_id)
+    "#{REDLOCK_PREFIX}-#{parking_notification_id}"
+  end
+
+  def self.new_lock_manager
+    Redlock::Client.new([Bikeindex::Application.config.redis_default_url])
+  end
+
+  def self.locked_for?(parking_notification_id)
+    new_lock_manager.locked?(redlock_key(parking_notification_id))
+  end
+
+  def lock_duration_ms
+    1.minute.in_milliseconds.to_i
+  end
+
   def perform(parking_notification_id)
+    lock_manager = self.class.new_lock_manager
+    redlock = lock_manager.lock(self.class.redlock_key(parking_notification_id), lock_duration_ms)
+    return unless redlock
+
+    begin
+      run(parking_notification_id)
+    ensure
+      lock_manager.unlock(redlock)
+    end
+  end
+
+  private
+
+  def run(parking_notification_id)
     parking_notification = ParkingNotification.find(parking_notification_id)
 
     if parking_notification.impound_notification? && parking_notification.impound_record_id.blank?

--- a/app/jobs/process_parking_notification_job.rb
+++ b/app/jobs/process_parking_notification_job.rb
@@ -1,4 +1,3 @@
-# Uses redlock so concurrent workers don't both pass the delivery_status.blank? guard and double-send.
 class ProcessParkingNotificationJob < ApplicationJob
   REDLOCK_PREFIX = "ProcessParkingNotificationLock-#{Rails.env.slice(0, 3)}"
 
@@ -26,40 +25,46 @@ class ProcessParkingNotificationJob < ApplicationJob
     return unless redlock
 
     begin
-      parking_notification = ParkingNotification.find(parking_notification_id)
-
-      if parking_notification.impound_notification? && parking_notification.impound_record_id.blank?
-        impound_record = ImpoundRecord.create!(bike_id: parking_notification.bike_id,
-          user_id: parking_notification.user_id,
-          organization_id: parking_notification.organization_id,
-          skip_update: true)
-        parking_notification.resolved_at ||= Time.current
-        parking_notification.update(impound_record_id: impound_record.id)
-        ProcessImpoundUpdatesJob.new.perform(impound_record.id)
-      end
-
-      # Update all of them!
-      parking_notification.associated_notifications.each do |pn|
-        pn.impound_record_id = impound_record.id if impound_record.present?
-        pn.update(updated_at: Time.current, skip_update: true)
-      end
-
-      # If there are any notifications from the same period, resolve them - even if they aren't associated
-      if parking_notification.reload.resolved?
-        parking_notification.notifications_from_period.active.each do |notification|
-          # Add a note about it though, to document it
-          notes = [notification.internal_notes, "resolved by parking notification ##{parking_notification.id}"]
-          notification.update(resolved_at: parking_notification.resolved_at,
-            internal_notes: notes.join(", "))
-        end
-      end
-
-      return true unless parking_notification.send_email? && parking_notification.delivery_status.blank?
-
-      OrganizedMailer.parking_notification(parking_notification).deliver_now
-      parking_notification.update_attribute :delivery_status, "email_success" # I'm not sure how to make this more representative
+      run(parking_notification_id)
     ensure
       lock_manager.unlock(redlock)
     end
+  end
+
+  private
+
+  def run(parking_notification_id)
+    parking_notification = ParkingNotification.find(parking_notification_id)
+
+    if parking_notification.impound_notification? && parking_notification.impound_record_id.blank?
+      impound_record = ImpoundRecord.create!(bike_id: parking_notification.bike_id,
+        user_id: parking_notification.user_id,
+        organization_id: parking_notification.organization_id,
+        skip_update: true)
+      parking_notification.resolved_at ||= Time.current
+      parking_notification.update(impound_record_id: impound_record.id)
+      ProcessImpoundUpdatesJob.new.perform(impound_record.id)
+    end
+
+    # Update all of them!
+    parking_notification.associated_notifications.each do |pn|
+      pn.impound_record_id = impound_record.id if impound_record.present?
+      pn.update(updated_at: Time.current, skip_update: true)
+    end
+
+    # If there are any notifications from the same period, resolve them - even if they aren't associated
+    if parking_notification.reload.resolved?
+      parking_notification.notifications_from_period.active.each do |notification|
+        # Add a note about it though, to document it
+        notes = [notification.internal_notes, "resolved by parking notification ##{parking_notification.id}"]
+        notification.update(resolved_at: parking_notification.resolved_at,
+          internal_notes: notes.join(", "))
+      end
+    end
+
+    return true unless parking_notification.send_email? && parking_notification.delivery_status.blank?
+
+    OrganizedMailer.parking_notification(parking_notification).deliver_now
+    parking_notification.update_attribute :delivery_status, "email_success" # I'm not sure how to make this more representative
   end
 end

--- a/spec/jobs/process_parking_notification_job_spec.rb
+++ b/spec/jobs/process_parking_notification_job_spec.rb
@@ -206,6 +206,21 @@ RSpec.describe ProcessParkingNotificationJob, type: :job do
       end
     end
 
+    context "redlock held by another worker" do
+      before do
+        @lock_manager = described_class.new_lock_manager
+        @redlock = @lock_manager.lock(described_class.redlock_key(parking_notification.id), 5000)
+      end
+      after { @lock_manager.unlock(@redlock) }
+      it "does not send" do
+        expect(parking_notification.send_email?).to be_truthy
+        expect(described_class.locked_for?(parking_notification.id)).to be_truthy
+        instance.perform(parking_notification.id)
+        expect(ActionMailer::Base.deliveries.empty?).to be_truthy
+        expect(parking_notification.reload.delivery_status).to be_blank
+      end
+    end
+
     context "impound_notification with location" do
       let(:organization) { FactoryBot.create(:organization_with_organization_features, enabled_feature_slugs: %w[parking_notifications impound_bikes]) }
       let(:location) { FactoryBot.create(:location, :with_address_record, address_in: :chicago, organization: organization, name: "Impound Facility") }


### PR DESCRIPTION
Princeton reported every impound-notification creation sending 3–4 copies of the parking_notification email. The `delivery_status.blank?` guard at the end of `ProcessParkingNotificationJob#perform` is a read-then-write check, and concurrent workers picking up jobs queued from cascading after_commits (`parking_notification.update(impound_record_id:)`, `update_attribute :delivery_status`, the impound's own touches) could each pass it before any of them persisted `email_success`.

- Wrap `perform` in a Redlock keyed on `parking_notification_id`, matching the pattern in `UpdateModelAuditJob` and `StravaJobs::RequestRunner`.
- 1-minute lock duration. If a worker can't acquire, return silently — the holder is doing the work, and any later cascade arrives after `delivery_status` is set.
- Spec: pre-acquire the lock and assert `perform` sends nothing.
