### PR TITLE
Email components: use image_tag with alt text

### DIFF
--- a/app/components/emails/hot_sheet/component.html.erb
+++ b/app/components/emails/hot_sheet/component.html.erb
@@ -81,7 +81,7 @@
 
           <td class="image-holder bike-display-wrapper-cell <%= 'placeholder' if thumb_placeholder?(bike) %>">
             <a href="<%= bike_link(bike) %>">
-              <img src="<%= thumb_url(bike) %>">
+              <%= image_tag thumb_url(bike), alt: bike.title_string %>
             </a>
           </td>
         </tr>

--- a/app/components/emails/parking_notification/component.html.erb
+++ b/app/components/emails/parking_notification/component.html.erb
@@ -48,7 +48,7 @@
   <em><%= @parking_notification.formatted_address_string %></em>
 </p>
 
-<img class="geolocated-message-map" src="<%= map_url %>">
+<%= image_tag map_url, class: "geolocated-message-map", alt: "Map showing #{@parking_notification.formatted_address_string}" %>
 
 <% if show_pickup_link? %>
   <div class="mark-retrieved-box">


### PR DESCRIPTION
Fixes herb-lint warnings (`erb-prefer-image-tag-helper` and `html-img-require-alt`) in two email component templates.

- `parking_notification`: replace raw `<img>` with `image_tag map_url, ..., alt: "Map showing <address>"`.
- `hot_sheet`: replace raw `<img>` with `image_tag thumb_url(bike), alt: bike.title_string`.
