### PR TITLE
Remove example Claude skills

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,11 +1,3 @@
 {
-  "extraKnownMarketplaces": {
-    "anthropic-agent-skills": {
-      "source": { "source": "github", "repo": "anthropics/skills" }
-    }
-  },
-  "enabledPlugins": {
-    "example-skills@anthropic-agent-skills": true
-  },
   "enabledMcpjsonServers": ["playwright"]
 }


### PR DESCRIPTION
Because they were using up the available context and causing other skills to be dropped.

> 16 descriptions dropped (full descriptions kept for most-used skills) (1.8%/1% of context)