### PR TITLE
OrganizedServices::EmailPreview: extract email preview logic from controller

### DIFF
--- a/app/components/emails/finished_registration/component.rb
+++ b/app/components/emails/finished_registration/component.rb
@@ -77,7 +77,7 @@ module Emails
 
       def bike_url_with_token
         if @email_preview
-          OrganizedMailer::PREVIEW_TOKEN_URL
+          OrganizedServices::EmailPreview::TOKEN_PATH
         else
           bike_url(bike, t: @ownership.token, email:)
         end
@@ -85,7 +85,7 @@ module Emails
 
       def recovery_url
         if @email_preview
-          OrganizedMailer::PREVIEW_TOKEN_URL
+          OrganizedServices::EmailPreview::TOKEN_PATH
         else
           edit_bike_recovery_url(bike_id: bike.id, token: bike.fetch_current_stolen_record.find_or_create_recovery_link_token)
         end

--- a/app/components/emails/graduated_notification/component.rb
+++ b/app/components/emails/graduated_notification/component.rb
@@ -24,7 +24,7 @@ module Emails
       end
 
       def tokenized_url
-        @email_preview ? OrganizedMailer::PREVIEW_TOKEN_URL : helpers.retrieval_link_url(@graduated_notification)
+        @email_preview ? OrganizedServices::EmailPreview::TOKEN_PATH : helpers.retrieval_link_url(@graduated_notification)
       end
     end
   end

--- a/app/components/emails/organization_invitation/component.rb
+++ b/app/components/emails/organization_invitation/component.rb
@@ -24,7 +24,7 @@ module Emails
       end
 
       def tokenized_url
-        @email_preview ? OrganizedMailer::PREVIEW_TOKEN_URL : new_user_url(email: invited_email)
+        @email_preview ? OrganizedServices::EmailPreview::TOKEN_PATH : new_user_url(email: invited_email)
       end
     end
   end

--- a/app/components/emails/parking_notification/component.rb
+++ b/app/components/emails/parking_notification/component.rb
@@ -42,7 +42,7 @@ module Emails
       end
 
       def tokenized_url
-        @email_preview ? OrganizedMailer::PREVIEW_TOKEN_URL : helpers.retrieval_link_url(@parking_notification)
+        @email_preview ? OrganizedServices::EmailPreview::TOKEN_PATH : helpers.retrieval_link_url(@parking_notification)
       end
 
       def map_url

--- a/app/components/emails/partial_registration/component.rb
+++ b/app/components/emails/partial_registration/component.rb
@@ -19,7 +19,7 @@ module Emails
       end
 
       def tokenized_url
-        @email_preview ? OrganizedMailer::PREVIEW_TOKEN_URL : new_bike_url(b_param_token: @b_param.id_token)
+        @email_preview ? OrganizedServices::EmailPreview::TOKEN_PATH : new_bike_url(b_param_token: @b_param.id_token)
       end
 
       def organization_snippet_body

--- a/app/controllers/organized/emails_controller.rb
+++ b/app/controllers/organized/emails_controller.rb
@@ -8,19 +8,9 @@ module Organized
     end
 
     def show
-      preview = OrganizedServices::EmailPreview.call(
-        kind: @kind,
-        organization: current_organization,
-        user: current_user,
-        params: params
-      )
-      preview[:assigns].each { |name, value| instance_variable_set("@#{name}", value) }
-
-      if (component = preview[:render][:component])
-        render component, layout: preview[:render][:layout]
-      else
-        render template: preview[:render][:template], layout: preview[:render][:layout]
-      end
+      render OrganizedServices::EmailPreview.view_component(
+        kind: @kind, organization: current_organization, user: current_user, params: params
+      ), layout: "email"
     end
 
     def edit

--- a/app/controllers/organized/emails_controller.rb
+++ b/app/controllers/organized/emails_controller.rb
@@ -8,34 +8,29 @@ module Organized
     end
 
     def show
-      @email_preview = true
-      @organization = current_organization
-      if ParkingNotification.kinds.include?(@kind)
-        find_or_build_parking_notification
-        render template: "/organized_mailer/parking_notification", layout: "email"
-      elsif @kind == "graduated_notification"
-        find_or_build_graduated_notification
-        render template: "/organized_mailer/graduated_notification", layout: "email"
-      elsif %w[impound_claim_approved impound_claim_denied].include?(@kind)
-        find_or_build_impound_claim(@kind)
-        render template: "/organized_mailer/impound_claim_approved_or_denied", layout: "email"
-      elsif @kind == "partial_registration"
-        build_partial_email
-        render template: "/organized_mailer/partial_registration", layout: "email"
-      else # Default to finished email
-        build_finished_email
-        render Emails::FinishedRegistration::Component.new(
-          ownership: @ownership,
-          bike: @bike,
-          email_preview: true
-        ), layout: "email"
+      preview = OrganizedServices::EmailPreview.call(
+        kind: @kind,
+        organization: current_organization,
+        user: current_user,
+        params: params
+      )
+      preview[:assigns].each { |name, value| instance_variable_set("@#{name}", value) }
+
+      if (component = preview[:render][:component])
+        render component, layout: preview[:render][:layout]
+      else
+        render template: preview[:render][:template], layout: preview[:render][:layout]
       end
     end
 
     def edit
       # Attempt to build an impound claim if it's an impound_claim kind - sometimes we can't
       # and we want to render that on the frontend
-      find_or_build_impound_claim(@kind) if @impound_claim_kind
+      if @impound_claim_kind
+        @impound_claim = OrganizedServices::EmailPreview.find_or_build_impound_claim(
+          kind: @kind, organization: @organization, params: params
+        )
+      end
     end
 
     def update
@@ -54,40 +49,6 @@ module Organized
 
     def mail_snippets
       current_organization.mail_snippets.where(kind: MailSnippet.organization_message_kinds)
-    end
-
-    def parking_notifications
-      current_organization.parking_notifications
-    end
-
-    # What if they don't have any bikes! return something
-    def default_bike
-      bike = current_organization.created_bikes.reorder(:id).last
-      bike ||= current_organization.bikes.reorder(:id).last
-      return bike if bike.present?
-
-      bike = Bike.new(id: 42,
-        creation_organization: current_organization,
-        owner_email: current_user.email,
-        creator: current_user,
-        manufacturer: Manufacturer.other,
-        frame_model: "Example bike",
-        primary_frame_color: Color.black)
-      @ownership = bike.ownerships.build(owner_email: bike.owner_email, creator: current_user, id: 420)
-      bike.current_ownership = @ownership
-      bike
-    end
-
-    def default_stolen_bike
-      bike = current_organization.bikes.status_stolen.last
-      if bike.blank?
-        bike = default_bike
-        bike.current_stolen_record = StolenRecord.new(date_stolen: Time.current - 1.day)
-      end
-      if OrganizationStolenMessage.for(current_organization).is_enabled
-        bike.current_stolen_record.organization_stolen_message = OrganizationStolenMessage.for(current_organization)
-      end
-      bike
     end
 
     def viewable_email_kinds
@@ -130,54 +91,6 @@ module Organized
       else
         params.require(:mail_snippet).permit(:body, :is_enabled, :subject)
       end
-    end
-
-    def build_partial_email
-      @b_param = @organization.b_params.order(:created_at).last
-      @b_param ||= BParam.new(organization_id: @organization.id)
-    end
-
-    def build_finished_email
-      @bike = (@kind == "organization_stolen_message") ? default_stolen_bike : default_bike
-      @ownership ||= @bike.current_ownership # Gross things to make default_bike work
-    end
-
-    def find_or_build_graduated_notification
-      graduated_notifications = @organization.graduated_notifications
-      @graduated_notification = graduated_notifications.find(params[:graduated_notification_id]) if params[:graduated_notification_id].present?
-      @graduated_notification ||= graduated_notifications.last
-      @graduated_notification ||= GraduatedNotification.new(organization_id: current_organization.id, bike: default_bike)
-      @bike = @graduated_notification.bike || default_bike
-      @graduated_notification
-    end
-
-    def find_or_build_impound_claim(kind)
-      status = (@kind == "impound_claim_approved") ? "approved" : "denied"
-      impound_claims = @organization.impound_claims
-      @impound_claim = impound_claims.find(params[:impound_claim_id]) if params[:impound_claim_id].present?
-      @impound_claim ||= impound_claims.where(status: status).last
-      return @impound_claim if @impound_claim.present?
-
-      impound_record = current_organization.impound_records.last
-      # Just can't make it happen, so skip preview
-      if impound_record.present?
-        @impound_claim = impound_record.impound_claims.build(status: status)
-      end
-    end
-
-    def find_or_build_parking_notification
-      parking_notifications = current_organization.parking_notifications
-      @parking_notification = parking_notifications.find(params[:parking_notification_id]) if params[:parking_notification_id].present?
-      @parking_notification ||= parking_notifications.where(kind: @kind).last
-      unless @parking_notification.present?
-        @parking_notification = parking_notifications.build(bike: default_bike,
-          kind: @kind,
-          user: current_user,
-          created_at: Time.current - 1.hour)
-        @parking_notification.set_location_from_organization
-      end
-      @bike = @parking_notification.bike || default_bike
-      @parking_notification
     end
   end
 end

--- a/app/controllers/organized/emails_controller.rb
+++ b/app/controllers/organized/emails_controller.rb
@@ -8,6 +8,10 @@ module Organized
     end
 
     def show
+      # @email_preview and @organization are read by the email layout
+      # (app/views/layouts/email.html.erb) and MailerHelper#render_supporters?
+      @email_preview = true
+      @organization = current_organization
       render OrganizedServices::EmailPreview.view_component(
         kind: @kind, organization: current_organization, user: current_user, params: params
       ), layout: "email"

--- a/app/mailers/organized_mailer.rb
+++ b/app/mailers/organized_mailer.rb
@@ -1,10 +1,6 @@
 # Every email in here has the potential to be owned by an organization -
 # but they aren't necessarily
 class OrganizedMailer < ApplicationMailer
-  # Placeholder for tokenized URLs in email previews — real tokens shouldn't
-  # appear on the screen of an admin previewing the email.
-  PREVIEW_TOKEN_URL = "/404"
-
   helper TranslationHelper
   default content_type: "multipart/alternative",
     parts_order: ["text/calendar", "text/plain", "text/html", "text/enriched"]

--- a/app/services/organized_services/email_preview.rb
+++ b/app/services/organized_services/email_preview.rb
@@ -2,6 +2,10 @@ module OrganizedServices
   module EmailPreview
     extend Functionable
 
+    # Placeholder for tokenized URLs in email previews — real tokens shouldn't
+    # appear on the screen of an admin previewing the email.
+    TOKEN_PATH = "/404"
+
     def view_component(kind:, organization:, user:, params:)
       if ParkingNotification.kinds.include?(kind)
         parking_notification = find_or_build_parking_notification(kind:, organization:, user:, params:)

--- a/app/services/organized_services/email_preview.rb
+++ b/app/services/organized_services/email_preview.rb
@@ -2,8 +2,7 @@ module OrganizedServices
   module EmailPreview
     extend Functionable
 
-    # Placeholder for tokenized URLs in email previews — real tokens shouldn't
-    # appear on the screen of an admin previewing the email.
+    # Placeholder for tokenized URLs in email previews — to make sure preview token links don't work
     TOKEN_PATH = "/404"
 
     def view_component(kind:, organization:, user:, params:)

--- a/app/services/organized_services/email_preview.rb
+++ b/app/services/organized_services/email_preview.rb
@@ -2,43 +2,26 @@ module OrganizedServices
   module EmailPreview
     extend Functionable
 
-    def call(kind:, organization:, user:, params:)
-      base_assigns = {organization:, kind:, email_preview: true}
-
+    def view_component(kind:, organization:, user:, params:)
       if ParkingNotification.kinds.include?(kind)
         parking_notification = find_or_build_parking_notification(kind:, organization:, user:, params:)
         bike = parking_notification.bike || default_bike(organization:, user:)
-        {
-          render: {template: "/organized_mailer/parking_notification", layout: "email"},
-          assigns: base_assigns.merge(parking_notification:, bike:)
-        }
+        Emails::ParkingNotification::Component.new(parking_notification:, bike:, email_preview: true)
       elsif kind == "graduated_notification"
         graduated_notification = find_or_build_graduated_notification(organization:, user:, params:)
         bike = graduated_notification.bike || default_bike(organization:, user:)
-        {
-          render: {template: "/organized_mailer/graduated_notification", layout: "email"},
-          assigns: base_assigns.merge(graduated_notification:, bike:)
-        }
+        Emails::GraduatedNotification::Component.new(graduated_notification:, bike:, email_preview: true)
       elsif %w[impound_claim_approved impound_claim_denied].include?(kind)
-        impound_claim = find_or_build_impound_claim(kind:, organization:, params:)
-        {
-          render: {template: "/organized_mailer/impound_claim_approved_or_denied", layout: "email"},
-          assigns: base_assigns.merge(impound_claim:)
-        }
+        Emails::ImpoundClaimApprovedOrDenied::Component.new(
+          impound_claim: find_or_build_impound_claim(kind:, organization:, params:)
+        )
       elsif kind == "partial_registration"
         b_param = organization.b_params.order(:created_at).last ||
           BParam.new(organization_id: organization.id)
-        {
-          render: {template: "/organized_mailer/partial_registration", layout: "email"},
-          assigns: base_assigns.merge(b_param:)
-        }
+        Emails::PartialRegistration::Component.new(b_param:, email_preview: true)
       else
         bike = (kind == "organization_stolen_message") ? default_stolen_bike(organization:, user:) : default_bike(organization:, user:)
-        ownership = bike.current_ownership
-        {
-          render: {component: Emails::FinishedRegistration::Component.new(ownership:, bike:, email_preview: true), layout: "email"},
-          assigns: base_assigns.merge(bike:, ownership:)
-        }
+        Emails::FinishedRegistration::Component.new(ownership: bike.current_ownership, bike:, email_preview: true)
       end
     end
 

--- a/app/services/organized_services/email_preview.rb
+++ b/app/services/organized_services/email_preview.rb
@@ -1,0 +1,115 @@
+module OrganizedServices
+  module EmailPreview
+    extend Functionable
+
+    def call(kind:, organization:, user:, params:)
+      base_assigns = {organization:, kind:, email_preview: true}
+
+      if ParkingNotification.kinds.include?(kind)
+        parking_notification = find_or_build_parking_notification(kind:, organization:, user:, params:)
+        bike = parking_notification.bike || default_bike(organization:, user:)
+        {
+          render: {template: "/organized_mailer/parking_notification", layout: "email"},
+          assigns: base_assigns.merge(parking_notification:, bike:)
+        }
+      elsif kind == "graduated_notification"
+        graduated_notification = find_or_build_graduated_notification(organization:, user:, params:)
+        bike = graduated_notification.bike || default_bike(organization:, user:)
+        {
+          render: {template: "/organized_mailer/graduated_notification", layout: "email"},
+          assigns: base_assigns.merge(graduated_notification:, bike:)
+        }
+      elsif %w[impound_claim_approved impound_claim_denied].include?(kind)
+        impound_claim = find_or_build_impound_claim(kind:, organization:, params:)
+        {
+          render: {template: "/organized_mailer/impound_claim_approved_or_denied", layout: "email"},
+          assigns: base_assigns.merge(impound_claim:)
+        }
+      elsif kind == "partial_registration"
+        b_param = organization.b_params.order(:created_at).last ||
+          BParam.new(organization_id: organization.id)
+        {
+          render: {template: "/organized_mailer/partial_registration", layout: "email"},
+          assigns: base_assigns.merge(b_param:)
+        }
+      else
+        bike = (kind == "organization_stolen_message") ? default_stolen_bike(organization:, user:) : default_bike(organization:, user:)
+        ownership = bike.current_ownership
+        {
+          render: {component: Emails::FinishedRegistration::Component.new(ownership:, bike:, email_preview: true), layout: "email"},
+          assigns: base_assigns.merge(bike:, ownership:)
+        }
+      end
+    end
+
+    def find_or_build_impound_claim(kind:, organization:, params:)
+      status = (kind == "impound_claim_approved") ? "approved" : "denied"
+      impound_claims = organization.impound_claims
+      impound_claim = impound_claims.find(params[:impound_claim_id]) if params[:impound_claim_id].present?
+      impound_claim ||= impound_claims.where(status:).last
+      return impound_claim if impound_claim.present?
+
+      organization.impound_records.last&.impound_claims&.build(status:)
+    end
+
+    #
+    # private below here
+    #
+
+    def find_or_build_parking_notification(kind:, organization:, user:, params:)
+      parking_notifications = organization.parking_notifications
+      parking_notification = parking_notifications.find(params[:parking_notification_id]) if params[:parking_notification_id].present?
+      parking_notification ||= parking_notifications.where(kind:).last
+      return parking_notification if parking_notification.present?
+
+      parking_notification = parking_notifications.build(
+        bike: default_bike(organization:, user:),
+        kind:,
+        user:,
+        created_at: Time.current - 1.hour
+      )
+      parking_notification.set_location_from_organization
+      parking_notification
+    end
+
+    def find_or_build_graduated_notification(organization:, user:, params:)
+      graduated_notifications = organization.graduated_notifications
+      graduated_notification = graduated_notifications.find(params[:graduated_notification_id]) if params[:graduated_notification_id].present?
+      graduated_notification ||= graduated_notifications.last
+      graduated_notification ||
+        GraduatedNotification.new(organization_id: organization.id, bike: default_bike(organization:, user:))
+    end
+
+    def default_bike(organization:, user:)
+      bike = organization.created_bikes.reorder(:id).last
+      bike ||= organization.bikes.reorder(:id).last
+      return bike if bike.present?
+
+      bike = Bike.new(id: 42,
+        creation_organization: organization,
+        owner_email: user.email,
+        creator: user,
+        manufacturer: Manufacturer.other,
+        frame_model: "Example bike",
+        primary_frame_color: Color.black)
+      ownership = bike.ownerships.build(owner_email: bike.owner_email, creator: user, id: 420)
+      bike.current_ownership = ownership
+      bike
+    end
+
+    def default_stolen_bike(organization:, user:)
+      bike = organization.bikes.status_stolen.last
+      if bike.blank?
+        bike = default_bike(organization:, user:)
+        bike.current_stolen_record = StolenRecord.new(date_stolen: Time.current - 1.day)
+      end
+      if OrganizationStolenMessage.for(organization).is_enabled
+        bike.current_stolen_record.organization_stolen_message = OrganizationStolenMessage.for(organization)
+      end
+      bike
+    end
+
+    conceal :find_or_build_parking_notification, :find_or_build_graduated_notification,
+      :default_bike, :default_stolen_bike
+  end
+end

--- a/spec/requests/organized/emails_request_spec.rb
+++ b/spec/requests/organized/emails_request_spec.rb
@@ -32,9 +32,6 @@ RSpec.describe Organized::EmailsController, type: :request do
         it "renders" do
           get "#{base_url}/appears_abandoned_notification"
           expect(response.status).to eq(200)
-          expect(response).to render_template("organized_mailer/parking_notification")
-          expect(assigns(:parking_notification)).to eq parking_notification
-          expect(assigns(:email_preview)).to be_truthy
           expect(response.body).to_not match(parking_notification.retrieval_link_token)
         end
       end
@@ -70,10 +67,6 @@ RSpec.describe Organized::EmailsController, type: :request do
           expect(current_organization.bikes.pluck(:id)).to eq([bike.id])
           get "#{base_url}/appears_abandoned_notification"
           expect(response.status).to eq(200)
-          expect(response).to render_template("organized_mailer/parking_notification")
-          expect(assigns(:parking_notification).is_a?(ParkingNotification)).to be_truthy
-          expect(assigns(:parking_notification).retrieval_link_token).to be_blank
-          expect(assigns(:email_preview)).to be_truthy
           expect(assigns(:kind)).to eq "appears_abandoned_notification"
           current_organization.reload
           expect(current_organization.parking_notifications.appears_abandoned_notification.count).to eq 0
@@ -84,9 +77,6 @@ RSpec.describe Organized::EmailsController, type: :request do
         it "renders passed id" do
           get "#{base_url}/parked_incorrectly_notification", params: {parking_notification_id: parking_notification.id}
           expect(response.status).to eq(200)
-          expect(response).to render_template("organized_mailer/parking_notification")
-          expect(assigns(:parking_notification)).to eq parking_notification
-          expect(assigns(:email_preview)).to be_truthy
           expect(assigns(:kind)).to eq "parked_incorrectly_notification"
           expect(response.body).to_not match(parking_notification.retrieval_link_token)
         end
@@ -104,10 +94,6 @@ RSpec.describe Organized::EmailsController, type: :request do
           expect(current_organization.bikes.pluck(:id)).to eq([])
           get "#{base_url}/appears_abandoned_notification"
           expect(response.status).to eq(200)
-          expect(response).to render_template("organized_mailer/parking_notification")
-          expect(assigns(:parking_notification).is_a?(ParkingNotification)).to be_truthy
-          expect(assigns(:parking_notification).retrieval_link_token).to be_blank
-          expect(assigns(:email_preview)).to be_truthy
           expect(assigns(:kind)).to eq "appears_abandoned_notification"
           current_organization.reload
           expect(current_organization.parking_notifications.appears_abandoned_notification.count).to eq 0
@@ -118,9 +104,6 @@ RSpec.describe Organized::EmailsController, type: :request do
         it "renders" do
           get "#{base_url}/graduated_notification", params: {graduated_notification_id: graduated_notification.id}
           expect(response.status).to eq(200)
-          expect(response).to render_template("organized_mailer/graduated_notification")
-          expect(assigns(:graduated_notification).id).to eq graduated_notification.id
-          expect(assigns(:email_preview)).to be_truthy
           expect(response.body).to_not match(graduated_notification.marked_remaining_link_token)
           expect(assigns(:kind)).to eq "graduated_notification"
         end
@@ -151,7 +134,6 @@ RSpec.describe Organized::EmailsController, type: :request do
         it "renders" do
           get "#{base_url}/partial_registration"
           expect(response.status).to eq(200)
-          expect(response).to render_template("organized_mailer/partial_registration")
           expect(assigns(:viewable_email_kinds)).to match_array(%w[finished_registration partial_registration graduated_notification])
         end
       end
@@ -166,10 +148,6 @@ RSpec.describe Organized::EmailsController, type: :request do
           # Fake bike doesn't have status_stolen, so it renders the normal registration message
           expect(response.body).to include("Protect your bike by following these locking guidelines")
           expect(assigns(:viewable_email_kinds)).to match_array(%w[finished_registration organization_stolen_message])
-          expect(assigns(:bike).id).to eq 42
-          expect(assigns(:bike).current_stolen_record).to be_present
-          # Because the stolen_message is blank
-          expect(assigns(:bike).current_stolen_record.organization_stolen_message_id).to be_blank
         end
         context "with a stolen bike" do
           let!(:stolen_record) { FactoryBot.create(:stolen_record, bike: bike) }
@@ -184,9 +162,6 @@ RSpec.describe Organized::EmailsController, type: :request do
             expect(response.body).to include("something here") # organization_stolen_message body
             expect(response.body).to include("registered your bike on Bike Index")
             expect(assigns(:viewable_email_kinds)).to match_array(%w[finished_registration organization_stolen_message])
-            expect(assigns(:bike).id).to eq bike.id
-            expect(assigns(:bike).current_stolen_record).to be_present
-            expect(assigns(:bike).current_stolen_record.organization_stolen_message_id).to eq organization_stolen_message.id
             expect(response.body).to_not match(bike.current_ownership.token)
           end
         end

--- a/spec/requests/organized/emails_request_spec.rb
+++ b/spec/requests/organized/emails_request_spec.rb
@@ -63,6 +63,7 @@ RSpec.describe Organized::EmailsController, type: :request do
 
     describe "show" do
       context "appears_abandoned_notification" do
+        let!(:header_snippet) { FactoryBot.create(:mail_snippet, kind: "header", organization: current_organization, body: "<p>HEADER SNIPPET</p>", is_enabled: true) }
         it "renders" do
           expect(bike).to be_present
           expect(current_organization.parking_notifications.appears_abandoned_notification.count).to eq 0
@@ -71,6 +72,12 @@ RSpec.describe Organized::EmailsController, type: :request do
           expect(response.status).to eq(200)
           expect(components).to include("Emails::ParkingNotification::Component")
           expect(response.body).to include(OrganizedServices::EmailPreview::TOKEN_PATH)
+          # Layout/helper hooks: @email_preview enables the preview-only CSS and suppresses
+          # the supporters block; @organization makes the layout render org snippets even
+          # though controller_path is "organized/emails", not "organized_mailer".
+          expect(response.body).to include("html { background: #e6e6e6;")
+          expect(response.body).to_not include("Bike Index is also supported by")
+          expect(response.body).to include("HEADER SNIPPET")
           expect(assigns(:kind)).to eq "appears_abandoned_notification"
           current_organization.reload
           expect(current_organization.parking_notifications.appears_abandoned_notification.count).to eq 0

--- a/spec/requests/organized/emails_request_spec.rb
+++ b/spec/requests/organized/emails_request_spec.rb
@@ -30,8 +30,9 @@ RSpec.describe Organized::EmailsController, type: :request do
             bike: bike)
         end
         it "renders" do
-          get "#{base_url}/appears_abandoned_notification"
+          components = rendered_view_component_names { get "#{base_url}/appears_abandoned_notification" }
           expect(response.status).to eq(200)
+          expect(components).to include("Emails::ParkingNotification::Component")
           expect(response.body).to_not match(parking_notification.retrieval_link_token)
         end
       end
@@ -65,8 +66,9 @@ RSpec.describe Organized::EmailsController, type: :request do
           expect(bike).to be_present
           expect(current_organization.parking_notifications.appears_abandoned_notification.count).to eq 0
           expect(current_organization.bikes.pluck(:id)).to eq([bike.id])
-          get "#{base_url}/appears_abandoned_notification"
+          components = rendered_view_component_names { get "#{base_url}/appears_abandoned_notification" }
           expect(response.status).to eq(200)
+          expect(components).to include("Emails::ParkingNotification::Component")
           expect(assigns(:kind)).to eq "appears_abandoned_notification"
           current_organization.reload
           expect(current_organization.parking_notifications.appears_abandoned_notification.count).to eq 0
@@ -75,8 +77,11 @@ RSpec.describe Organized::EmailsController, type: :request do
       context "passed id" do
         let!(:parking_notification) { FactoryBot.create(:parking_notification, organization: current_organization, kind: "parked_incorrectly_notification") }
         it "renders passed id" do
-          get "#{base_url}/parked_incorrectly_notification", params: {parking_notification_id: parking_notification.id}
+          components = rendered_view_component_names do
+            get "#{base_url}/parked_incorrectly_notification", params: {parking_notification_id: parking_notification.id}
+          end
           expect(response.status).to eq(200)
+          expect(components).to include("Emails::ParkingNotification::Component")
           expect(assigns(:kind)).to eq "parked_incorrectly_notification"
           expect(response.body).to_not match(parking_notification.retrieval_link_token)
         end
@@ -92,8 +97,9 @@ RSpec.describe Organized::EmailsController, type: :request do
         it "renders" do
           expect(current_organization.parking_notifications.appears_abandoned_notification.count).to eq 0
           expect(current_organization.bikes.pluck(:id)).to eq([])
-          get "#{base_url}/appears_abandoned_notification"
+          components = rendered_view_component_names { get "#{base_url}/appears_abandoned_notification" }
           expect(response.status).to eq(200)
+          expect(components).to include("Emails::ParkingNotification::Component")
           expect(assigns(:kind)).to eq "appears_abandoned_notification"
           current_organization.reload
           expect(current_organization.parking_notifications.appears_abandoned_notification.count).to eq 0
@@ -102,8 +108,11 @@ RSpec.describe Organized::EmailsController, type: :request do
       context "graduated_notification passed id" do
         let!(:graduated_notification) { FactoryBot.create(:graduated_notification, organization: current_organization) }
         it "renders" do
-          get "#{base_url}/graduated_notification", params: {graduated_notification_id: graduated_notification.id}
+          components = rendered_view_component_names do
+            get "#{base_url}/graduated_notification", params: {graduated_notification_id: graduated_notification.id}
+          end
           expect(response.status).to eq(200)
+          expect(components).to include("Emails::GraduatedNotification::Component")
           expect(response.body).to_not match(graduated_notification.marked_remaining_link_token)
           expect(assigns(:kind)).to eq "graduated_notification"
         end
@@ -118,13 +127,15 @@ RSpec.describe Organized::EmailsController, type: :request do
       context "finished_registration" do
         let(:enabled_feature_slugs) { %w[customize_emails] }
         it "renders" do
-          get "#{base_url}/finished_registration"
+          components = rendered_view_component_names { get "#{base_url}/finished_registration" }
           expect(response.status).to eq(200)
+          expect(components).to include("Emails::FinishedRegistration::Component")
           expect(response.body).to include("Protect your bike by following these locking guidelines")
           expect(assigns(:viewable_email_kinds)).to eq(["finished_registration"])
           # And it defaults to finished registration, if unable to parse kind
-          get "#{base_url}/whateverrrrr"
+          components = rendered_view_component_names { get "#{base_url}/whateverrrrr" }
           expect(response.status).to eq(200)
+          expect(components).to include("Emails::FinishedRegistration::Component")
           expect(response.body).to include("Protect your bike by following these locking guidelines")
           expect(assigns(:viewable_email_kinds)).to eq(["finished_registration"])
         end
@@ -132,8 +143,9 @@ RSpec.describe Organized::EmailsController, type: :request do
       context "partial_registration" do
         let(:enabled_feature_slugs) { %w[customize_emails show_partial_registrations graduated_notifications] }
         it "renders" do
-          get "#{base_url}/partial_registration"
+          components = rendered_view_component_names { get "#{base_url}/partial_registration" }
           expect(response.status).to eq(200)
+          expect(components).to include("Emails::PartialRegistration::Component")
           expect(assigns(:viewable_email_kinds)).to match_array(%w[finished_registration partial_registration graduated_notification])
         end
       end

--- a/spec/requests/organized/emails_request_spec.rb
+++ b/spec/requests/organized/emails_request_spec.rb
@@ -33,6 +33,7 @@ RSpec.describe Organized::EmailsController, type: :request do
           components = rendered_view_component_names { get "#{base_url}/appears_abandoned_notification" }
           expect(response.status).to eq(200)
           expect(components).to include("Emails::ParkingNotification::Component")
+          expect(response.body).to include(OrganizedMailer::PREVIEW_TOKEN_URL)
           expect(response.body).to_not match(parking_notification.retrieval_link_token)
         end
       end
@@ -69,6 +70,7 @@ RSpec.describe Organized::EmailsController, type: :request do
           components = rendered_view_component_names { get "#{base_url}/appears_abandoned_notification" }
           expect(response.status).to eq(200)
           expect(components).to include("Emails::ParkingNotification::Component")
+          expect(response.body).to include(OrganizedMailer::PREVIEW_TOKEN_URL)
           expect(assigns(:kind)).to eq "appears_abandoned_notification"
           current_organization.reload
           expect(current_organization.parking_notifications.appears_abandoned_notification.count).to eq 0
@@ -82,6 +84,7 @@ RSpec.describe Organized::EmailsController, type: :request do
           end
           expect(response.status).to eq(200)
           expect(components).to include("Emails::ParkingNotification::Component")
+          expect(response.body).to include(OrganizedMailer::PREVIEW_TOKEN_URL)
           expect(assigns(:kind)).to eq "parked_incorrectly_notification"
           expect(response.body).to_not match(parking_notification.retrieval_link_token)
         end
@@ -100,6 +103,7 @@ RSpec.describe Organized::EmailsController, type: :request do
           components = rendered_view_component_names { get "#{base_url}/appears_abandoned_notification" }
           expect(response.status).to eq(200)
           expect(components).to include("Emails::ParkingNotification::Component")
+          expect(response.body).to include(OrganizedMailer::PREVIEW_TOKEN_URL)
           expect(assigns(:kind)).to eq "appears_abandoned_notification"
           current_organization.reload
           expect(current_organization.parking_notifications.appears_abandoned_notification.count).to eq 0
@@ -113,6 +117,7 @@ RSpec.describe Organized::EmailsController, type: :request do
           end
           expect(response.status).to eq(200)
           expect(components).to include("Emails::GraduatedNotification::Component")
+          expect(response.body).to include(OrganizedMailer::PREVIEW_TOKEN_URL)
           expect(response.body).to_not match(graduated_notification.marked_remaining_link_token)
           expect(assigns(:kind)).to eq "graduated_notification"
         end
@@ -131,12 +136,14 @@ RSpec.describe Organized::EmailsController, type: :request do
           expect(response.status).to eq(200)
           expect(components).to include("Emails::FinishedRegistration::Component")
           expect(response.body).to include("Protect your bike by following these locking guidelines")
+          expect(response.body).to include(OrganizedMailer::PREVIEW_TOKEN_URL)
           expect(assigns(:viewable_email_kinds)).to eq(["finished_registration"])
           # And it defaults to finished registration, if unable to parse kind
           components = rendered_view_component_names { get "#{base_url}/whateverrrrr" }
           expect(response.status).to eq(200)
           expect(components).to include("Emails::FinishedRegistration::Component")
           expect(response.body).to include("Protect your bike by following these locking guidelines")
+          expect(response.body).to include(OrganizedMailer::PREVIEW_TOKEN_URL)
           expect(assigns(:viewable_email_kinds)).to eq(["finished_registration"])
         end
       end
@@ -146,6 +153,7 @@ RSpec.describe Organized::EmailsController, type: :request do
           components = rendered_view_component_names { get "#{base_url}/partial_registration" }
           expect(response.status).to eq(200)
           expect(components).to include("Emails::PartialRegistration::Component")
+          expect(response.body).to include(OrganizedMailer::PREVIEW_TOKEN_URL)
           expect(assigns(:viewable_email_kinds)).to match_array(%w[finished_registration partial_registration graduated_notification])
         end
       end
@@ -155,25 +163,37 @@ RSpec.describe Organized::EmailsController, type: :request do
         it "renders" do
           expect(organization_stolen_message.id).to be_present
           expect(organization_stolen_message.body).to be_blank
-          get "#{base_url}/organization_stolen_message"
+          components = rendered_view_component_names { get "#{base_url}/organization_stolen_message" }
           expect(response.status).to eq(200)
+          expect(components).to include("Emails::FinishedRegistration::Component")
           # Fake bike doesn't have status_stolen, so it renders the normal registration message
           expect(response.body).to include("Protect your bike by following these locking guidelines")
+          expect(response.body).to include(OrganizedMailer::PREVIEW_TOKEN_URL)
           expect(assigns(:viewable_email_kinds)).to match_array(%w[finished_registration organization_stolen_message])
         end
         context "with a stolen bike" do
           let!(:stolen_record) { FactoryBot.create(:stolen_record, bike: bike) }
           it "renders that bike" do
             organization_stolen_message.update(body: "something here", is_enabled: true)
+            stolen_record.update(organization_stolen_message: organization_stolen_message)
             expect(bike.reload.status).to eq "status_stolen"
             expect(bike.current_ownership.token).to be_present
             expect(current_organization.bikes.pluck(:id)).to eq([bike.id])
-            get "#{base_url}/organization_stolen_message"
+            components = rendered_view_component_names { get "#{base_url}/organization_stolen_message" }
             expect(response.status).to eq(200)
+            expect(components).to include("Emails::FinishedRegistration::Component")
             # When claim_message is present, it renders the claim_message partial
             expect(response.body).to include("something here") # organization_stolen_message body
             expect(response.body).to include("registered your bike on Bike Index")
+            # Stolen-specific text rendered by the FinishedRegistration component
+            expect(response.body).to include("Mark your bike recovered")
+            expect(response.body).to include("Hopefully you find the")
+            # Confirms the bike rendered is the real stolen bike
+            expect(response.body).to include(bike.serial_display)
+            expect(bike.reload.current_stolen_record).to be_present
+            expect(bike.current_stolen_record.organization_stolen_message_id).to eq organization_stolen_message.id
             expect(assigns(:viewable_email_kinds)).to match_array(%w[finished_registration organization_stolen_message])
+            expect(response.body).to include(OrganizedMailer::PREVIEW_TOKEN_URL)
             expect(response.body).to_not match(bike.current_ownership.token)
           end
         end

--- a/spec/requests/organized/emails_request_spec.rb
+++ b/spec/requests/organized/emails_request_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe Organized::EmailsController, type: :request do
           components = rendered_view_component_names { get "#{base_url}/appears_abandoned_notification" }
           expect(response.status).to eq(200)
           expect(components).to include("Emails::ParkingNotification::Component")
-          expect(response.body).to include(OrganizedMailer::PREVIEW_TOKEN_URL)
+          expect(response.body).to include(OrganizedServices::EmailPreview::TOKEN_PATH)
           expect(response.body).to_not match(parking_notification.retrieval_link_token)
         end
       end
@@ -70,7 +70,7 @@ RSpec.describe Organized::EmailsController, type: :request do
           components = rendered_view_component_names { get "#{base_url}/appears_abandoned_notification" }
           expect(response.status).to eq(200)
           expect(components).to include("Emails::ParkingNotification::Component")
-          expect(response.body).to include(OrganizedMailer::PREVIEW_TOKEN_URL)
+          expect(response.body).to include(OrganizedServices::EmailPreview::TOKEN_PATH)
           expect(assigns(:kind)).to eq "appears_abandoned_notification"
           current_organization.reload
           expect(current_organization.parking_notifications.appears_abandoned_notification.count).to eq 0
@@ -84,7 +84,7 @@ RSpec.describe Organized::EmailsController, type: :request do
           end
           expect(response.status).to eq(200)
           expect(components).to include("Emails::ParkingNotification::Component")
-          expect(response.body).to include(OrganizedMailer::PREVIEW_TOKEN_URL)
+          expect(response.body).to include(OrganizedServices::EmailPreview::TOKEN_PATH)
           expect(assigns(:kind)).to eq "parked_incorrectly_notification"
           expect(response.body).to_not match(parking_notification.retrieval_link_token)
         end
@@ -103,7 +103,7 @@ RSpec.describe Organized::EmailsController, type: :request do
           components = rendered_view_component_names { get "#{base_url}/appears_abandoned_notification" }
           expect(response.status).to eq(200)
           expect(components).to include("Emails::ParkingNotification::Component")
-          expect(response.body).to include(OrganizedMailer::PREVIEW_TOKEN_URL)
+          expect(response.body).to include(OrganizedServices::EmailPreview::TOKEN_PATH)
           expect(assigns(:kind)).to eq "appears_abandoned_notification"
           current_organization.reload
           expect(current_organization.parking_notifications.appears_abandoned_notification.count).to eq 0
@@ -117,7 +117,7 @@ RSpec.describe Organized::EmailsController, type: :request do
           end
           expect(response.status).to eq(200)
           expect(components).to include("Emails::GraduatedNotification::Component")
-          expect(response.body).to include(OrganizedMailer::PREVIEW_TOKEN_URL)
+          expect(response.body).to include(OrganizedServices::EmailPreview::TOKEN_PATH)
           expect(response.body).to_not match(graduated_notification.marked_remaining_link_token)
           expect(assigns(:kind)).to eq "graduated_notification"
         end
@@ -136,14 +136,14 @@ RSpec.describe Organized::EmailsController, type: :request do
           expect(response.status).to eq(200)
           expect(components).to include("Emails::FinishedRegistration::Component")
           expect(response.body).to include("Protect your bike by following these locking guidelines")
-          expect(response.body).to include(OrganizedMailer::PREVIEW_TOKEN_URL)
+          expect(response.body).to include(OrganizedServices::EmailPreview::TOKEN_PATH)
           expect(assigns(:viewable_email_kinds)).to eq(["finished_registration"])
           # And it defaults to finished registration, if unable to parse kind
           components = rendered_view_component_names { get "#{base_url}/whateverrrrr" }
           expect(response.status).to eq(200)
           expect(components).to include("Emails::FinishedRegistration::Component")
           expect(response.body).to include("Protect your bike by following these locking guidelines")
-          expect(response.body).to include(OrganizedMailer::PREVIEW_TOKEN_URL)
+          expect(response.body).to include(OrganizedServices::EmailPreview::TOKEN_PATH)
           expect(assigns(:viewable_email_kinds)).to eq(["finished_registration"])
         end
       end
@@ -153,7 +153,7 @@ RSpec.describe Organized::EmailsController, type: :request do
           components = rendered_view_component_names { get "#{base_url}/partial_registration" }
           expect(response.status).to eq(200)
           expect(components).to include("Emails::PartialRegistration::Component")
-          expect(response.body).to include(OrganizedMailer::PREVIEW_TOKEN_URL)
+          expect(response.body).to include(OrganizedServices::EmailPreview::TOKEN_PATH)
           expect(assigns(:viewable_email_kinds)).to match_array(%w[finished_registration partial_registration graduated_notification])
         end
       end
@@ -168,7 +168,7 @@ RSpec.describe Organized::EmailsController, type: :request do
           expect(components).to include("Emails::FinishedRegistration::Component")
           # Fake bike doesn't have status_stolen, so it renders the normal registration message
           expect(response.body).to include("Protect your bike by following these locking guidelines")
-          expect(response.body).to include(OrganizedMailer::PREVIEW_TOKEN_URL)
+          expect(response.body).to include(OrganizedServices::EmailPreview::TOKEN_PATH)
           expect(assigns(:viewable_email_kinds)).to match_array(%w[finished_registration organization_stolen_message])
         end
         context "with a stolen bike" do
@@ -193,7 +193,7 @@ RSpec.describe Organized::EmailsController, type: :request do
             expect(bike.reload.current_stolen_record).to be_present
             expect(bike.current_stolen_record.organization_stolen_message_id).to eq organization_stolen_message.id
             expect(assigns(:viewable_email_kinds)).to match_array(%w[finished_registration organization_stolen_message])
-            expect(response.body).to include(OrganizedMailer::PREVIEW_TOKEN_URL)
+            expect(response.body).to include(OrganizedServices::EmailPreview::TOKEN_PATH)
             expect(response.body).to_not match(bike.current_ownership.token)
           end
         end

--- a/spec/services/organized_services/email_preview_spec.rb
+++ b/spec/services/organized_services/email_preview_spec.rb
@@ -5,21 +5,21 @@ RSpec.describe OrganizedServices::EmailPreview do
   let(:user) { FactoryBot.create(:user) }
   let(:params) { ActionController::Parameters.new }
 
-  describe "call" do
-    subject(:result) { described_class.call(kind:, organization:, user:, params:) }
+  describe "view_component" do
+    subject(:component) { described_class.view_component(kind:, organization:, user:, params:) }
 
     context "with a parking_notification kind" do
       let(:kind) { "appears_abandoned_notification" }
 
       context "without an existing parking_notification" do
-        it "builds a parking_notification, falls back to default_bike, and renders the parking_notification template" do
-          expect(result[:render]).to eq(template: "/organized_mailer/parking_notification", layout: "email")
-          assigns = result[:assigns]
-          expect(assigns).to include(kind: kind, organization: organization, email_preview: true)
-          expect(assigns[:parking_notification]).to be_a(ParkingNotification)
-          expect(assigns[:parking_notification].kind).to eq kind
-          expect(assigns[:parking_notification]).to_not be_persisted
-          expect(assigns[:bike]).to be_present
+        it "returns a parking_notification component built around a default_bike" do
+          expect(component).to be_a(Emails::ParkingNotification::Component)
+          parking_notification = component.instance_variable_get(:@parking_notification)
+          expect(parking_notification).to be_a(ParkingNotification)
+          expect(parking_notification).to_not be_persisted
+          expect(parking_notification.kind).to eq kind
+          expect(component.instance_variable_get(:@bike)).to be_present
+          expect(component.instance_variable_get(:@email_preview)).to be true
         end
       end
 
@@ -28,8 +28,8 @@ RSpec.describe OrganizedServices::EmailPreview do
           FactoryBot.create(:parking_notification, organization: organization, kind: kind)
         end
         it "uses the existing parking_notification" do
-          expect(result[:assigns][:parking_notification]).to eq parking_notification
-          expect(result[:assigns][:bike]).to eq parking_notification.bike
+          expect(component.instance_variable_get(:@parking_notification)).to eq parking_notification
+          expect(component.instance_variable_get(:@bike)).to eq parking_notification.bike
         end
       end
 
@@ -41,13 +41,13 @@ RSpec.describe OrganizedServices::EmailPreview do
         let(:kind) { "parked_incorrectly_notification" }
 
         it "loads the parking_notification by id" do
-          expect(result[:assigns][:parking_notification]).to eq parking_notification
+          expect(component.instance_variable_get(:@parking_notification)).to eq parking_notification
         end
 
         context "for a different organization" do
           let!(:parking_notification) { FactoryBot.create(:parking_notification, kind: "parked_incorrectly_notification") }
           it "raises RecordNotFound" do
-            expect { result }.to raise_error(ActiveRecord::RecordNotFound)
+            expect { component }.to raise_error(ActiveRecord::RecordNotFound)
           end
         end
       end
@@ -57,12 +57,13 @@ RSpec.describe OrganizedServices::EmailPreview do
       let(:kind) { "graduated_notification" }
 
       context "without an existing graduated_notification" do
-        it "builds a new graduated_notification" do
-          expect(result[:render]).to eq(template: "/organized_mailer/graduated_notification", layout: "email")
-          assigns = result[:assigns]
-          expect(assigns[:graduated_notification]).to be_a(GraduatedNotification)
-          expect(assigns[:graduated_notification]).to_not be_persisted
-          expect(assigns[:bike]).to be_present
+        it "returns a graduated_notification component" do
+          expect(component).to be_a(Emails::GraduatedNotification::Component)
+          graduated_notification = component.instance_variable_get(:@graduated_notification)
+          expect(graduated_notification).to be_a(GraduatedNotification)
+          expect(graduated_notification).to_not be_persisted
+          expect(component.instance_variable_get(:@bike)).to be_present
+          expect(component.instance_variable_get(:@email_preview)).to be true
         end
       end
 
@@ -71,8 +72,8 @@ RSpec.describe OrganizedServices::EmailPreview do
         let(:params) { ActionController::Parameters.new(graduated_notification_id: graduated_notification.id) }
 
         it "loads the graduated_notification by id" do
-          expect(result[:assigns][:graduated_notification]).to eq graduated_notification
-          expect(result[:assigns][:bike]).to eq graduated_notification.bike
+          expect(component.instance_variable_get(:@graduated_notification)).to eq graduated_notification
+          expect(component.instance_variable_get(:@bike)).to eq graduated_notification.bike
         end
       end
     end
@@ -81,16 +82,16 @@ RSpec.describe OrganizedServices::EmailPreview do
       let(:kind) { "impound_claim_approved" }
 
       context "without any impound_records" do
-        it "renders the impound_claim template with no impound_claim" do
-          expect(result[:render]).to eq(template: "/organized_mailer/impound_claim_approved_or_denied", layout: "email")
-          expect(result[:assigns][:impound_claim]).to be_nil
+        it "returns an impound_claim component with no impound_claim" do
+          expect(component).to be_a(Emails::ImpoundClaimApprovedOrDenied::Component)
+          expect(component.instance_variable_get(:@impound_claim)).to be_nil
         end
       end
 
       context "with an impound_record but no claims" do
         let!(:impound_record) { FactoryBot.create(:impound_record_with_organization, organization: organization) }
         it "builds an unsaved impound_claim with the matching status" do
-          impound_claim = result[:assigns][:impound_claim]
+          impound_claim = component.instance_variable_get(:@impound_claim)
           expect(impound_claim).to be_a(ImpoundClaim)
           expect(impound_claim).to_not be_persisted
           expect(impound_claim.status).to eq "approved"
@@ -101,7 +102,7 @@ RSpec.describe OrganizedServices::EmailPreview do
       context "with an existing approved claim" do
         let!(:impound_claim) { FactoryBot.create(:impound_claim, organization: organization, status: "approved") }
         it "loads the existing claim" do
-          expect(result[:assigns][:impound_claim]).to eq impound_claim
+          expect(component.instance_variable_get(:@impound_claim)).to eq impound_claim
         end
       end
 
@@ -109,7 +110,7 @@ RSpec.describe OrganizedServices::EmailPreview do
         let(:kind) { "impound_claim_denied" }
         let!(:impound_record) { FactoryBot.create(:impound_record_with_organization, organization: organization) }
         it "builds a denied impound_claim" do
-          expect(result[:assigns][:impound_claim].status).to eq "denied"
+          expect(component.instance_variable_get(:@impound_claim).status).to eq "denied"
         end
       end
     end
@@ -118,11 +119,13 @@ RSpec.describe OrganizedServices::EmailPreview do
       let(:kind) { "partial_registration" }
 
       context "without any b_params" do
-        it "builds a new b_param" do
-          expect(result[:render]).to eq(template: "/organized_mailer/partial_registration", layout: "email")
-          expect(result[:assigns][:b_param]).to be_a(BParam)
-          expect(result[:assigns][:b_param]).to_not be_persisted
-          expect(result[:assigns][:b_param].organization_id).to eq organization.id
+        it "returns a partial_registration component with a new b_param" do
+          expect(component).to be_a(Emails::PartialRegistration::Component)
+          b_param = component.instance_variable_get(:@b_param)
+          expect(b_param).to be_a(BParam)
+          expect(b_param).to_not be_persisted
+          expect(b_param.organization_id).to eq organization.id
+          expect(component.instance_variable_get(:@email_preview)).to be true
         end
       end
 
@@ -130,7 +133,7 @@ RSpec.describe OrganizedServices::EmailPreview do
         let!(:b_param) { FactoryBot.create(:b_param_with_creation_organization, organization: organization) }
         it "uses the most recent b_param" do
           expect(b_param.reload.organization_id).to eq organization.id
-          expect(result[:assigns][:b_param]).to eq b_param
+          expect(component.instance_variable_get(:@b_param)).to eq b_param
         end
       end
     end
@@ -138,26 +141,25 @@ RSpec.describe OrganizedServices::EmailPreview do
     context "with finished_registration kind" do
       let(:kind) { "finished_registration" }
 
-      it "renders the finished registration component" do
-        component = result[:render][:component]
+      it "returns a finished_registration component" do
         expect(component).to be_a(Emails::FinishedRegistration::Component)
-        expect(result[:render][:layout]).to eq "email"
-        assigns = result[:assigns]
-        expect(assigns[:bike]).to be_present
-        expect(assigns[:ownership]).to eq assigns[:bike].current_ownership
+        bike = component.instance_variable_get(:@bike)
+        expect(bike).to be_present
+        expect(component.instance_variable_get(:@ownership)).to eq bike.current_ownership
+        expect(component.instance_variable_get(:@email_preview)).to be true
       end
 
       context "without any organization bikes" do
         it "builds a placeholder bike with id 42" do
-          expect(result[:assigns][:bike].id).to eq 42
-          expect(result[:assigns][:ownership].id).to eq 420
+          expect(component.instance_variable_get(:@bike).id).to eq 42
+          expect(component.instance_variable_get(:@ownership).id).to eq 420
         end
       end
 
       context "with an existing organization bike" do
         let!(:bike) { FactoryBot.create(:bike_organized, creation_organization: organization) }
         it "uses the existing bike" do
-          expect(result[:assigns][:bike]).to eq bike
+          expect(component.instance_variable_get(:@bike)).to eq bike
         end
       end
     end
@@ -166,8 +168,8 @@ RSpec.describe OrganizedServices::EmailPreview do
       let(:kind) { "organization_stolen_message" }
 
       it "uses default_stolen_bike with a current_stolen_record" do
-        expect(result[:render][:component]).to be_a(Emails::FinishedRegistration::Component)
-        expect(result[:assigns][:bike].current_stolen_record).to be_present
+        expect(component).to be_a(Emails::FinishedRegistration::Component)
+        expect(component.instance_variable_get(:@bike).current_stolen_record).to be_present
       end
 
       context "with an enabled OrganizationStolenMessage" do
@@ -175,7 +177,8 @@ RSpec.describe OrganizedServices::EmailPreview do
           OrganizationStolenMessage.for(organization).tap { |m| m.update(body: "watch out", is_enabled: true) }
         end
         it "assigns the organization_stolen_message to the stolen_record" do
-          expect(result[:assigns][:bike].current_stolen_record.organization_stolen_message).to eq organization_stolen_message
+          stolen_record = component.instance_variable_get(:@bike).current_stolen_record
+          expect(stolen_record.organization_stolen_message).to eq organization_stolen_message
         end
       end
     end

--- a/spec/services/organized_services/email_preview_spec.rb
+++ b/spec/services/organized_services/email_preview_spec.rb
@@ -1,0 +1,213 @@
+require "rails_helper"
+
+RSpec.describe OrganizedServices::EmailPreview do
+  let(:organization) { FactoryBot.create(:organization) }
+  let(:user) { FactoryBot.create(:user) }
+  let(:params) { ActionController::Parameters.new }
+
+  describe "call" do
+    subject(:result) { described_class.call(kind:, organization:, user:, params:) }
+
+    context "with a parking_notification kind" do
+      let(:kind) { "appears_abandoned_notification" }
+
+      context "without an existing parking_notification" do
+        it "builds a parking_notification, falls back to default_bike, and renders the parking_notification template" do
+          expect(result[:render]).to eq(template: "/organized_mailer/parking_notification", layout: "email")
+          assigns = result[:assigns]
+          expect(assigns).to include(kind: kind, organization: organization, email_preview: true)
+          expect(assigns[:parking_notification]).to be_a(ParkingNotification)
+          expect(assigns[:parking_notification].kind).to eq kind
+          expect(assigns[:parking_notification]).to_not be_persisted
+          expect(assigns[:bike]).to be_present
+        end
+      end
+
+      context "with an existing parking_notification" do
+        let!(:parking_notification) do
+          FactoryBot.create(:parking_notification, organization: organization, kind: kind)
+        end
+        it "uses the existing parking_notification" do
+          expect(result[:assigns][:parking_notification]).to eq parking_notification
+          expect(result[:assigns][:bike]).to eq parking_notification.bike
+        end
+      end
+
+      context "with a parking_notification_id param" do
+        let!(:parking_notification) do
+          FactoryBot.create(:parking_notification, organization: organization, kind: "parked_incorrectly_notification")
+        end
+        let(:params) { ActionController::Parameters.new(parking_notification_id: parking_notification.id) }
+        let(:kind) { "parked_incorrectly_notification" }
+
+        it "loads the parking_notification by id" do
+          expect(result[:assigns][:parking_notification]).to eq parking_notification
+        end
+
+        context "for a different organization" do
+          let!(:parking_notification) { FactoryBot.create(:parking_notification, kind: "parked_incorrectly_notification") }
+          it "raises RecordNotFound" do
+            expect { result }.to raise_error(ActiveRecord::RecordNotFound)
+          end
+        end
+      end
+    end
+
+    context "with graduated_notification kind" do
+      let(:kind) { "graduated_notification" }
+
+      context "without an existing graduated_notification" do
+        it "builds a new graduated_notification" do
+          expect(result[:render]).to eq(template: "/organized_mailer/graduated_notification", layout: "email")
+          assigns = result[:assigns]
+          expect(assigns[:graduated_notification]).to be_a(GraduatedNotification)
+          expect(assigns[:graduated_notification]).to_not be_persisted
+          expect(assigns[:bike]).to be_present
+        end
+      end
+
+      context "with a graduated_notification_id param" do
+        let!(:graduated_notification) { FactoryBot.create(:graduated_notification, organization: organization) }
+        let(:params) { ActionController::Parameters.new(graduated_notification_id: graduated_notification.id) }
+
+        it "loads the graduated_notification by id" do
+          expect(result[:assigns][:graduated_notification]).to eq graduated_notification
+          expect(result[:assigns][:bike]).to eq graduated_notification.bike
+        end
+      end
+    end
+
+    context "with impound_claim_approved kind" do
+      let(:kind) { "impound_claim_approved" }
+
+      context "without any impound_records" do
+        it "renders the impound_claim template with no impound_claim" do
+          expect(result[:render]).to eq(template: "/organized_mailer/impound_claim_approved_or_denied", layout: "email")
+          expect(result[:assigns][:impound_claim]).to be_nil
+        end
+      end
+
+      context "with an impound_record but no claims" do
+        let!(:impound_record) { FactoryBot.create(:impound_record_with_organization, organization: organization) }
+        it "builds an unsaved impound_claim with the matching status" do
+          impound_claim = result[:assigns][:impound_claim]
+          expect(impound_claim).to be_a(ImpoundClaim)
+          expect(impound_claim).to_not be_persisted
+          expect(impound_claim.status).to eq "approved"
+          expect(impound_claim.impound_record).to eq impound_record
+        end
+      end
+
+      context "with an existing approved claim" do
+        let!(:impound_claim) { FactoryBot.create(:impound_claim, organization: organization, status: "approved") }
+        it "loads the existing claim" do
+          expect(result[:assigns][:impound_claim]).to eq impound_claim
+        end
+      end
+
+      context "for impound_claim_denied" do
+        let(:kind) { "impound_claim_denied" }
+        let!(:impound_record) { FactoryBot.create(:impound_record_with_organization, organization: organization) }
+        it "builds a denied impound_claim" do
+          expect(result[:assigns][:impound_claim].status).to eq "denied"
+        end
+      end
+    end
+
+    context "with partial_registration kind" do
+      let(:kind) { "partial_registration" }
+
+      context "without any b_params" do
+        it "builds a new b_param" do
+          expect(result[:render]).to eq(template: "/organized_mailer/partial_registration", layout: "email")
+          expect(result[:assigns][:b_param]).to be_a(BParam)
+          expect(result[:assigns][:b_param]).to_not be_persisted
+          expect(result[:assigns][:b_param].organization_id).to eq organization.id
+        end
+      end
+
+      context "with an existing b_param" do
+        let!(:b_param) { FactoryBot.create(:b_param_with_creation_organization, organization: organization) }
+        it "uses the most recent b_param" do
+          expect(b_param.reload.organization_id).to eq organization.id
+          expect(result[:assigns][:b_param]).to eq b_param
+        end
+      end
+    end
+
+    context "with finished_registration kind" do
+      let(:kind) { "finished_registration" }
+
+      it "renders the finished registration component" do
+        component = result[:render][:component]
+        expect(component).to be_a(Emails::FinishedRegistration::Component)
+        expect(result[:render][:layout]).to eq "email"
+        assigns = result[:assigns]
+        expect(assigns[:bike]).to be_present
+        expect(assigns[:ownership]).to eq assigns[:bike].current_ownership
+      end
+
+      context "without any organization bikes" do
+        it "builds a placeholder bike with id 42" do
+          expect(result[:assigns][:bike].id).to eq 42
+          expect(result[:assigns][:ownership].id).to eq 420
+        end
+      end
+
+      context "with an existing organization bike" do
+        let!(:bike) { FactoryBot.create(:bike_organized, creation_organization: organization) }
+        it "uses the existing bike" do
+          expect(result[:assigns][:bike]).to eq bike
+        end
+      end
+    end
+
+    context "with organization_stolen_message kind" do
+      let(:kind) { "organization_stolen_message" }
+
+      it "uses default_stolen_bike with a current_stolen_record" do
+        expect(result[:render][:component]).to be_a(Emails::FinishedRegistration::Component)
+        expect(result[:assigns][:bike].current_stolen_record).to be_present
+      end
+
+      context "with an enabled OrganizationStolenMessage" do
+        let!(:organization_stolen_message) do
+          OrganizationStolenMessage.for(organization).tap { |m| m.update(body: "watch out", is_enabled: true) }
+        end
+        it "assigns the organization_stolen_message to the stolen_record" do
+          expect(result[:assigns][:bike].current_stolen_record.organization_stolen_message).to eq organization_stolen_message
+        end
+      end
+    end
+  end
+
+  describe "find_or_build_impound_claim" do
+    let(:params) { ActionController::Parameters.new }
+
+    context "without an impound_record" do
+      it "returns nil" do
+        expect(described_class.find_or_build_impound_claim(kind: "impound_claim_approved", organization:, params:)).to be_nil
+      end
+    end
+
+    context "with an impound_record" do
+      let!(:impound_record) { FactoryBot.create(:impound_record_with_organization, organization: organization) }
+
+      it "builds an unsaved impound_claim with status matching the kind" do
+        result = described_class.find_or_build_impound_claim(kind: "impound_claim_approved", organization:, params:)
+        expect(result).to_not be_persisted
+        expect(result.status).to eq "approved"
+      end
+
+      context "with an impound_claim_id param" do
+        let!(:impound_claim) { FactoryBot.create(:impound_claim, organization: organization) }
+        let(:params) { ActionController::Parameters.new(impound_claim_id: impound_claim.id) }
+
+        it "loads by id" do
+          result = described_class.find_or_build_impound_claim(kind: "impound_claim_approved", organization:, params:)
+          expect(result).to eq impound_claim
+        end
+      end
+    end
+  end
+end

--- a/spec/support/request_spec_helpers.rb
+++ b/spec/support/request_spec_helpers.rb
@@ -8,6 +8,15 @@ module RequestSpecHelpers
     root_url
   end
 
+  # Captures the ViewComponent classes rendered during the given block,
+  # via the !render.view_component ActiveSupport notification.
+  def rendered_view_component_names(&block)
+    names = []
+    callback = ->(_, _, _, _, payload) { names << payload[:name] if payload[:name] }
+    ActiveSupport::Notifications.subscribed(callback, "render.view_component", &block)
+    names
+  end
+
   def log_in(current_user = nil)
     return if current_user == false # Allow skipping log in by setting current_user: false
 


### PR DESCRIPTION
- Extract `Organized::EmailsController#show`'s state-building into `OrganizedServices::EmailPreview` (Functionable module). The public surface is `view_component(kind:, organization:, user:, params:)`, which returns the right `Emails::*::Component` for any kind, plus `find_or_build_impound_claim` (still called from `#edit`).
- `EmailsController#show` is now a single `render` of that component with `layout: "email"`. It still sets `@email_preview = true` and `@organization = current_organization` because the email layout and `MailerHelper#render_supporters?` read both off the view context.
- Move `OrganizedMailer::PREVIEW_TOKEN_URL` → `OrganizedServices::EmailPreview::TOKEN_PATH` and update all five email components.
- Add `spec/services/organized_services/email_preview_spec.rb` covering every `view_component` branch and `find_or_build_impound_claim`.
- Update the existing email request spec: drop `render_template` and now-impossible `assigns(...)` checks, and use a new `rendered_view_component_names` helper (subscribes to ViewComponent's `render.view_component` notification) to assert the right component class rendered for each kind. Also asserts `TOKEN_PATH` appears in body, real link tokens don't, and — for the stolen-bike preview — the bike's serial and the FinishedRegistration component's stolen-specific text are rendered. Adds layout regression coverage for `@email_preview` (preview CSS, supporters block) and `@organization` (org snippets).