### PR TITLE
Org multi search: add 'search all bikes' toggle, redact non-org data

### DIFF
--- a/app/components/org/registration_search/component.en.yml
+++ b/app/components/org/registration_search/component.en.yml
@@ -11,7 +11,7 @@ en:
         color: Color
         e_vehicle_propulsion: E-vehicle (propulsion)
         e_vehicles_for_audit: 'E-Vehicles for audit:'
-        hidden_not_registered: "hidden, not registered with %{org_name}"
+        hidden_not_registered: hidden, not registered with %{org_name}
         impound_id: Impound ID
         impounded: Impounded
         link: Link

--- a/app/components/org/registration_search/component.en.yml
+++ b/app/components/org/registration_search/component.en.yml
@@ -11,7 +11,7 @@ en:
         color: Color
         e_vehicle_propulsion: E-vehicle (propulsion)
         e_vehicles_for_audit: 'E-Vehicles for audit:'
-        email_hidden: email hidden
+        hidden_not_registered: "hidden, not registered with %{org_name}"
         impound_id: Impound ID
         impounded: Impounded
         link: Link

--- a/app/components/org/registration_search/component.en.yml
+++ b/app/components/org/registration_search/component.en.yml
@@ -11,6 +11,7 @@ en:
         color: Color
         e_vehicle_propulsion: E-vehicle (propulsion)
         e_vehicles_for_audit: 'E-Vehicles for audit:'
+        email_hidden: email hidden
         hidden_not_registered: hidden, not registered with %{org_name}
         impound_id: Impound ID
         impounded: Impounded

--- a/app/components/org/registration_search/component.html.erb
+++ b/app/components/org/registration_search/component.html.erb
@@ -49,7 +49,6 @@
 
   <% organization = @organization %>
   <% bike_sticker = @bike_sticker %>
-  <% bike_in_org = method(:bike_in_org?) %>
 
   <%= tag.div(data: table_wrapper_data_attributes) do %>
     <%= render(UI::Table::Component.new(records: @bikes, cache_key: "org-#{@organization.id}-bikes_3", render_sortable: true)) do |table| %>
@@ -132,7 +131,7 @@
       <% end %>
 
       <% table.column(label: translation(".owner_name"), classes: "hideableColumn owner_name_cell") do |bike| %>
-        <% if bike_in_org.(bike) %>
+        <% if bike.organized?(organization) %>
           <% if bike.owner_name.present? %>
             <em><%= bike.owner_name %></em>
           <% end %>
@@ -147,7 +146,7 @@
 
       <% if organization.enabled?("registration_notes") %>
         <% table.column(label: translation(".notes"), classes: "hideableColumn notes_cell tw:leading-none") do |bike| %>
-          <% if bike_in_org.(bike) %>
+          <% if bike.organized?(organization) %>
             <small>
               <%= BikeOrganizationNote.find_by(bike_id: bike.id, organization_id: organization.id)&.body %>
             </small>
@@ -161,7 +160,7 @@
         <% next if reg_field == "extra_registration_number" %>
 
         <% table.column(label: column_renames[:"#{reg_field}_cell"], classes: "hideableColumn #{reg_field}_cell") do |bike| %>
-          <% if bike_in_org.(bike) %>
+          <% if bike.organized?(organization) %>
             <% bike_attr = OrganizationFeature.reg_field_to_bike_attrs(reg_field) %>
             <% if bike_attr == "address" %>
               <% if bike.valid_mailing_address? %>
@@ -183,7 +182,7 @@
       <% end %>
 
       <% table.column(label: translation(".secondary_number"), classes: "hideableColumn extra_registration_number_cell") do |bike| %>
-        <% if bike_in_org.(bike) %>
+        <% if bike.organized?(organization) %>
           <%= bike.extra_registration_number %>
         <% else %>
           <%= hidden_html %>
@@ -192,7 +191,7 @@
 
       <% if organization.enabled?("impound_bikes") %>
         <% table.column(label: translation(".impound_id"), classes: "hideableColumn impound_id_cell") do |bike| %>
-          <% if bike_in_org.(bike) %>
+          <% if bike.organized?(organization) %>
             <% if bike.status_impounded? && bike.current_impound_record.present? %>
               <%= number_display(bike.current_impound_record.id) %>
             <% end %>
@@ -201,7 +200,7 @@
           <% end %>
         <% end %>
         <% table.column(label: translation(".impounded"), classes: "hideableColumn impounded_cell") do |bike| %>
-          <% if bike_in_org.(bike) %>
+          <% if bike.organized?(organization) %>
             <% if bike.status_impounded? && bike.current_impound_record&.created_at&.present? %>
               <small class="localizeTime">
                 <%= l bike.current_impound_record.created_at, format: :convert_time %>
@@ -215,7 +214,7 @@
 
       <% if @organization.enabled?("avery_export") %>
         <% table.column(label: translation(".avery"), classes: "hideableColumn avery_cell") do |bike| %>
-          <% if bike_in_org.(bike) %>
+          <% if bike.organized?(organization) %>
             <%= check_mark if bike.avery_exportable? %>
           <% else %>
             <%= hidden_html %>
@@ -225,7 +224,7 @@
 
       <% if organization.enabled?("bike_stickers") %>
         <% table.column(label: translation(".sticker"), classes: "hideableColumn sticker_cell tw:pt-0", header_classes: "tw:pt-1") do |bike| %>
-          <% if bike_in_org.(bike) %>
+          <% if bike.organized?(organization) %>
             <% bike.bike_stickers.each_with_index do |bs, index| %>
               <% if bs.organization.present? && bs.organization_id == organization.id %>
                 <%= link_to bs.pretty_code, edit_organization_sticker_path(id: bs.code, organization_id: bs.organization&.to_param), class: "tw:text-xs tw:block tw:mt-1", data: {turbo_frame: "_top"} %>
@@ -240,7 +239,7 @@
           <% end %>
         <% end %>
         <% table.column(label: translation(".assign_bike_sticker"), classes: "assign_bike_sticker_cell tw:hidden") do |bike| %>
-          <% if bike_in_org.(bike) %>
+          <% if bike.organized?(organization) %>
             <small>
               <a data-bike-id="<%= bike.id %>">
                 <%= t("components.org.registration_search.link_sticker") %>

--- a/app/components/org/registration_search/component.html.erb
+++ b/app/components/org/registration_search/component.html.erb
@@ -51,7 +51,10 @@
   <% bike_sticker = @bike_sticker %>
 
   <%= tag.div(data: table_wrapper_data_attributes) do %>
-    <%= render(UI::Table::Component.new(records: @bikes, cache_key: "org-#{@organization.id}-bikes_3", render_sortable: true)) do |table| %>
+    <%= render(UI::Table::Component.new(records: @bikes, cache_key: "org-#{@organization.id}-bikes_4", render_sortable: true)) do |table| %>
+
+      <% hidden_html = hidden_not_registered_tag %>
+
       <% table.column(label: translation(".url"), classes: "hideableColumn url_cell") do |bike| %>
         <code class="tw:p-0 tw:text-xs!" style="word-break: normal">
           <%= bike.html_url %>
@@ -109,20 +112,20 @@
         </span>
       <% end %>
 
-      <% hidden_html = hidden_not_registered_tag %>
-
-      <% table.column(sortable: "owner_email", label: translation(".sent_to"), classes: "hideableColumn owner_email_cell") do |bike| %>
-        <% if bike.email_visible_for?(organization) %>
+      <% table.column(sortable: "owner_email", label: translation(".sent_to"), classes: "hideableColumn owner_email_cell tw:leading-none") do |bike| %>
+        <% if !bike.organized?(organization) %>
+          <%= hidden_html %>
+        <% elsif bike.email_visible_for?(organization) %>
           <%= bike.owner_email %>
           <small>
             <%= link_to "\u{1F50E}", organization_registrations_path(organization_id: organization.to_param, search_email: bike.owner_email), class: "display-sortable-link", data: {turbo_frame: "_top"} %>
           </small>
         <% else %>
-          <%= hidden_html %>
+          <em class="tw:text-gray-400"><%= translation(".email_hidden") %></em>
         <% end %>
       <% end %>
 
-      <% table.column(label: translation(".source"), classes: "hideableColumn creation_description_cell") do |bike| %>
+      <% table.column(label: translation(".source"), classes: "hideableColumn creation_description_cell tw:leading-none") do |bike| %>
         <% if bike.creation_description %>
           <small class="tw:text-gray-400">
             <%= helpers.origin_display(bike.creation_description) %>
@@ -130,7 +133,7 @@
         <% end %>
       <% end %>
 
-      <% table.column(label: translation(".owner_name"), classes: "hideableColumn owner_name_cell") do |bike| %>
+      <% table.column(label: translation(".owner_name"), classes: "hideableColumn owner_name_cell tw:leading-none") do |bike| %>
         <% if bike.organized?(organization) %>
           <% if bike.owner_name.present? %>
             <em><%= bike.owner_name %></em>
@@ -146,20 +149,16 @@
 
       <% if organization.enabled?("registration_notes") %>
         <% table.column(label: translation(".notes"), classes: "hideableColumn notes_cell tw:leading-none") do |bike| %>
-          <% if bike.organized?(organization) %>
-            <small>
-              <%= BikeOrganizationNote.find_by(bike_id: bike.id, organization_id: organization.id)&.body %>
-            </small>
-          <% else %>
-            <%= hidden_html %>
-          <% end %>
+          <small>
+            <%= BikeOrganizationNote.find_by(bike_id: bike.id, organization_id: organization.id)&.body %>
+          </small>
         <% end %>
       <% end %>
 
       <% additional_registration_fields.each do |reg_field| %>
         <% next if reg_field == "extra_registration_number" %>
 
-        <% table.column(label: column_renames[:"#{reg_field}_cell"], classes: "hideableColumn #{reg_field}_cell") do |bike| %>
+        <% table.column(label: column_renames[:"#{reg_field}_cell"], classes: "hideableColumn #{reg_field}_cell tw:leading-none") do |bike| %>
           <% if bike.organized?(organization) %>
             <% bike_attr = OrganizationFeature.reg_field_to_bike_attrs(reg_field) %>
             <% if bike_attr == "address" %>
@@ -182,15 +181,11 @@
       <% end %>
 
       <% table.column(label: translation(".secondary_number"), classes: "hideableColumn extra_registration_number_cell") do |bike| %>
-        <% if bike.organized?(organization) %>
-          <%= bike.extra_registration_number %>
-        <% else %>
-          <%= hidden_html %>
-        <% end %>
+        <%= bike.extra_registration_number %>
       <% end %>
 
       <% if organization.enabled?("impound_bikes") %>
-        <% table.column(label: translation(".impound_id"), classes: "hideableColumn impound_id_cell") do |bike| %>
+        <% table.column(label: translation(".impound_id"), classes: "hideableColumn impound_id_cell tw:leading-none") do |bike| %>
           <% if bike.organized?(organization) %>
             <% if bike.status_impounded? && bike.current_impound_record.present? %>
               <%= number_display(bike.current_impound_record.id) %>
@@ -199,7 +194,7 @@
             <%= hidden_html %>
           <% end %>
         <% end %>
-        <% table.column(label: translation(".impounded"), classes: "hideableColumn impounded_cell") do |bike| %>
+        <% table.column(label: translation(".impounded"), classes: "hideableColumn impounded_cell tw:leading-none") do |bike| %>
           <% if bike.organized?(organization) %>
             <% if bike.status_impounded? && bike.current_impound_record&.created_at&.present? %>
               <small class="localizeTime">
@@ -214,40 +209,28 @@
 
       <% if @organization.enabled?("avery_export") %>
         <% table.column(label: translation(".avery"), classes: "hideableColumn avery_cell") do |bike| %>
-          <% if bike.organized?(organization) %>
-            <%= check_mark if bike.avery_exportable? %>
-          <% else %>
-            <%= hidden_html %>
-          <% end %>
+          <% check_mark if bike.organized?(organization) && bike.avery_exportable? %>
         <% end %>
       <% end %>
 
       <% if organization.enabled?("bike_stickers") %>
         <% table.column(label: translation(".sticker"), classes: "hideableColumn sticker_cell tw:pt-0", header_classes: "tw:pt-1") do |bike| %>
-          <% if bike.organized?(organization) %>
-            <% bike.bike_stickers.each_with_index do |bs, index| %>
-              <% if bs.organization.present? && bs.organization_id == organization.id %>
-                <%= link_to bs.pretty_code, edit_organization_sticker_path(id: bs.code, organization_id: bs.organization&.to_param), class: "tw:text-xs tw:block tw:mt-1", data: {turbo_frame: "_top"} %>
-              <% else %>
-                <small class="tw:mt-1 tw:block tw:text-xs">
-                  <%= bs.pretty_code %>
-                </small>
-              <% end %>
+          <% bike.bike_stickers.each_with_index do |bs, index| %>
+            <% if bs.organization.present? && bs.organization_id == organization.id %>
+              <%= link_to bs.pretty_code, edit_organization_sticker_path(id: bs.code, organization_id: bs.organization&.to_param), class: "tw:text-xs tw:block tw:mt-1", data: {turbo_frame: "_top"} %>
+            <% else %>
+              <small class="tw:mt-1 tw:block tw:text-xs">
+                <%= bs.pretty_code %>
+              </small>
             <% end %>
-          <% else %>
-            <%= hidden_html %>
           <% end %>
         <% end %>
         <% table.column(label: translation(".assign_bike_sticker"), classes: "assign_bike_sticker_cell tw:hidden") do |bike| %>
-          <% if bike.organized?(organization) %>
-            <small>
-              <a data-bike-id="<%= bike.id %>">
-                <%= t("components.org.registration_search.link_sticker") %>
-              </a>
-            </small>
-          <% else %>
-            <%= hidden_html %>
-          <% end %>
+          <small>
+            <a data-bike-id="<%= bike.id %>">
+              <%= t("components.org.registration_search.link_sticker") %>
+            </a>
+          </small>
         <% end %>
       <% end %>
     <% end %>

--- a/app/components/org/registration_search/component.html.erb
+++ b/app/components/org/registration_search/component.html.erb
@@ -52,7 +52,6 @@
 
   <%= tag.div(data: table_wrapper_data_attributes) do %>
     <%= render(UI::Table::Component.new(records: @bikes, cache_key: "org-#{@organization.id}-bikes_4", render_sortable: true)) do |table| %>
-
       <% hidden_html = hidden_not_registered_tag %>
 
       <% table.column(label: translation(".url"), classes: "hideableColumn url_cell") do |bike| %>

--- a/app/components/org/registration_search/component.html.erb
+++ b/app/components/org/registration_search/component.html.erb
@@ -109,7 +109,7 @@
         </span>
       <% end %>
 
-      <% hidden_html = tag.small(translation(".hidden_not_registered", org_name: organization.short_name), class: "less-strong") %>
+      <% hidden_html = hidden_not_registered_tag %>
 
       <% table.column(sortable: "owner_email", label: translation(".sent_to"), classes: "hideableColumn owner_email_cell") do |bike| %>
         <% if bike.email_visible_for?(organization) %>

--- a/app/components/org/registration_search/component.html.erb
+++ b/app/components/org/registration_search/component.html.erb
@@ -49,6 +49,7 @@
 
   <% organization = @organization %>
   <% bike_sticker = @bike_sticker %>
+  <% bike_in_org = method(:bike_in_org?) %>
 
   <%= tag.div(data: table_wrapper_data_attributes) do %>
     <%= render(UI::Table::Component.new(records: @bikes, cache_key: "org-#{@organization.id}-bikes_3", render_sortable: true)) do |table| %>
@@ -109,6 +110,8 @@
         </span>
       <% end %>
 
+      <% hidden_html = tag.small(translation(".hidden_not_registered", org_name: organization.short_name), class: "less-strong") %>
+
       <% table.column(sortable: "owner_email", label: translation(".sent_to"), classes: "hideableColumn owner_email_cell") do |bike| %>
         <% if bike.email_visible_for?(organization) %>
           <%= bike.owner_email %>
@@ -116,7 +119,7 @@
             <%= link_to "\u{1F50E}", organization_registrations_path(organization_id: organization.to_param, search_email: bike.owner_email), class: "display-sortable-link", data: {turbo_frame: "_top"} %>
           </small>
         <% else %>
-          <em class="tw:text-gray-400"><%= translation(".email_hidden") %></em>
+          <%= hidden_html %>
         <% end %>
       <% end %>
 
@@ -129,8 +132,12 @@
       <% end %>
 
       <% table.column(label: translation(".owner_name"), classes: "hideableColumn owner_name_cell") do |bike| %>
-        <% if bike.owner_name.present? %>
-          <em><%= bike.owner_name %></em>
+        <% if bike_in_org.(bike) %>
+          <% if bike.owner_name.present? %>
+            <em><%= bike.owner_name %></em>
+          <% end %>
+        <% else %>
+          <%= hidden_html %>
         <% end %>
       <% end %>
 
@@ -140,9 +147,13 @@
 
       <% if organization.enabled?("registration_notes") %>
         <% table.column(label: translation(".notes"), classes: "hideableColumn notes_cell tw:leading-none") do |bike| %>
-          <small>
-            <%= BikeOrganizationNote.find_by(bike_id: bike.id, organization_id: organization.id)&.body %>
-          </small>
+          <% if bike_in_org.(bike) %>
+            <small>
+              <%= BikeOrganizationNote.find_by(bike_id: bike.id, organization_id: organization.id)&.body %>
+            </small>
+          <% else %>
+            <%= hidden_html %>
+          <% end %>
         <% end %>
       <% end %>
 
@@ -150,67 +161,94 @@
         <% next if reg_field == "extra_registration_number" %>
 
         <% table.column(label: column_renames[:"#{reg_field}_cell"], classes: "hideableColumn #{reg_field}_cell") do |bike| %>
-          <% bike_attr = OrganizationFeature.reg_field_to_bike_attrs(reg_field) %>
-
-          <% if bike_attr == "address" %>
-            <% if bike.valid_mailing_address? %>
-              <small>
-                <%= render UI::AddressDisplay::Component.new(address_record: BikeServices::CalculateLocation.registration_address_record(bike), visible_attribute: :street) %>
-              </small>
+          <% if bike_in_org.(bike) %>
+            <% bike_attr = OrganizationFeature.reg_field_to_bike_attrs(reg_field) %>
+            <% if bike_attr == "address" %>
+              <% if bike.valid_mailing_address? %>
+                <small>
+                  <%= render UI::AddressDisplay::Component.new(address_record: BikeServices::CalculateLocation.registration_address_record(bike), visible_attribute: :street) %>
+                </small>
+              <% end %>
+            <% elsif bike_attr == "organization_affiliation" %>
+              <%= bike.organization_affiliation(organization)&.humanize %>
+            <% elsif bike_attr == "student_id" %>
+              <%= bike.student_id(organization)&.humanize %>
+            <% else %>
+              <%= bike.send(bike_attr) %>
             <% end %>
-          <% elsif bike_attr == "organization_affiliation" %>
-            <%= bike.organization_affiliation(organization)&.humanize %>
-          <% elsif bike_attr == "student_id" %>
-            <%= bike.student_id(organization)&.humanize %>
           <% else %>
-            <%= bike.send(bike_attr) %>
+            <%= hidden_html %>
           <% end %>
         <% end %>
       <% end %>
 
       <% table.column(label: translation(".secondary_number"), classes: "hideableColumn extra_registration_number_cell") do |bike| %>
-        <%= bike.extra_registration_number %>
+        <% if bike_in_org.(bike) %>
+          <%= bike.extra_registration_number %>
+        <% else %>
+          <%= hidden_html %>
+        <% end %>
       <% end %>
 
       <% if organization.enabled?("impound_bikes") %>
         <% table.column(label: translation(".impound_id"), classes: "hideableColumn impound_id_cell") do |bike| %>
-          <% if bike.status_impounded? && bike.current_impound_record.present? %>
-            <%= number_display(bike.current_impound_record.id) %>
+          <% if bike_in_org.(bike) %>
+            <% if bike.status_impounded? && bike.current_impound_record.present? %>
+              <%= number_display(bike.current_impound_record.id) %>
+            <% end %>
+          <% else %>
+            <%= hidden_html %>
           <% end %>
         <% end %>
         <% table.column(label: translation(".impounded"), classes: "hideableColumn impounded_cell") do |bike| %>
-          <% if bike.status_impounded? && bike.current_impound_record&.created_at&.present? %>
-            <small class="localizeTime">
-              <%= l bike.current_impound_record.created_at, format: :convert_time %>
-            </small>
+          <% if bike_in_org.(bike) %>
+            <% if bike.status_impounded? && bike.current_impound_record&.created_at&.present? %>
+              <small class="localizeTime">
+                <%= l bike.current_impound_record.created_at, format: :convert_time %>
+              </small>
+            <% end %>
+          <% else %>
+            <%= hidden_html %>
           <% end %>
         <% end %>
       <% end %>
 
       <% if @organization.enabled?("avery_export") %>
         <% table.column(label: translation(".avery"), classes: "hideableColumn avery_cell") do |bike| %>
-          <%= check_mark if bike.avery_exportable? %>
+          <% if bike_in_org.(bike) %>
+            <%= check_mark if bike.avery_exportable? %>
+          <% else %>
+            <%= hidden_html %>
+          <% end %>
         <% end %>
       <% end %>
 
       <% if organization.enabled?("bike_stickers") %>
         <% table.column(label: translation(".sticker"), classes: "hideableColumn sticker_cell tw:pt-0", header_classes: "tw:pt-1") do |bike| %>
-          <% bike.bike_stickers.each_with_index do |bs, index| %>
-            <% if bs.organization.present? && bs.organization_id == organization.id %>
-              <%= link_to bs.pretty_code, edit_organization_sticker_path(id: bs.code, organization_id: bs.organization&.to_param), class: "tw:text-xs tw:block tw:mt-1", data: {turbo_frame: "_top"} %>
-            <% else %>
-              <small class="tw:mt-1 tw:block tw:text-xs">
-                <%= bs.pretty_code %>
-              </small>
+          <% if bike_in_org.(bike) %>
+            <% bike.bike_stickers.each_with_index do |bs, index| %>
+              <% if bs.organization.present? && bs.organization_id == organization.id %>
+                <%= link_to bs.pretty_code, edit_organization_sticker_path(id: bs.code, organization_id: bs.organization&.to_param), class: "tw:text-xs tw:block tw:mt-1", data: {turbo_frame: "_top"} %>
+              <% else %>
+                <small class="tw:mt-1 tw:block tw:text-xs">
+                  <%= bs.pretty_code %>
+                </small>
+              <% end %>
             <% end %>
+          <% else %>
+            <%= hidden_html %>
           <% end %>
         <% end %>
         <% table.column(label: translation(".assign_bike_sticker"), classes: "assign_bike_sticker_cell tw:hidden") do |bike| %>
-          <small>
-            <a data-bike-id="<%= bike.id %>">
-              <%= t("components.org.registration_search.link_sticker") %>
-            </a>
-          </small>
+          <% if bike_in_org.(bike) %>
+            <small>
+              <a data-bike-id="<%= bike.id %>">
+                <%= t("components.org.registration_search.link_sticker") %>
+              </a>
+            </small>
+          <% else %>
+            <%= hidden_html %>
+          <% end %>
         <% end %>
       <% end %>
     <% end %>

--- a/app/components/org/registration_search/component.rb
+++ b/app/components/org/registration_search/component.rb
@@ -70,6 +70,12 @@ module Org
         @search_query_present || @params[:search_stickers].present? || @params[:search_address].present? || @model_audit.present?
       end
 
+      def bike_in_org?(bike)
+        @bike_in_org ||= {}
+        return @bike_in_org[bike.id] if @bike_in_org.key?(bike.id)
+        @bike_in_org[bike.id] = bike.organized?(@organization)
+      end
+
       def component_wrapper_data_attributes
         return {} if @skip_settings
         {controller: "org--registration-search org--registration-search-column-toggle",

--- a/app/components/org/registration_search/component.rb
+++ b/app/components/org/registration_search/component.rb
@@ -70,12 +70,6 @@ module Org
         @search_query_present || @params[:search_stickers].present? || @params[:search_address].present? || @model_audit.present?
       end
 
-      def bike_in_org?(bike)
-        @bike_in_org ||= {}
-        return @bike_in_org[bike.id] if @bike_in_org.key?(bike.id)
-        @bike_in_org[bike.id] = bike.organized?(@organization)
-      end
-
       def component_wrapper_data_attributes
         return {} if @skip_settings
         {controller: "org--registration-search org--registration-search-column-toggle",

--- a/app/components/org/registration_search/component.rb
+++ b/app/components/org/registration_search/component.rb
@@ -71,9 +71,9 @@ module Org
       end
 
       def hidden_not_registered_tag
-        @hidden_not_registered_tag ||= tag.small(
+        @hidden_not_registered_tag ||= tag.em(
           translation(".hidden_not_registered", org_name: @organization.short_name),
-          class: "less-strong"
+          class: "less-strong tw:leading-snug tw:text-xs"
         )
       end
 

--- a/app/components/org/registration_search/component.rb
+++ b/app/components/org/registration_search/component.rb
@@ -70,6 +70,13 @@ module Org
         @search_query_present || @params[:search_stickers].present? || @params[:search_address].present? || @model_audit.present?
       end
 
+      def hidden_not_registered_tag
+        @hidden_not_registered_tag ||= tag.small(
+          translation(".hidden_not_registered", org_name: @organization.short_name),
+          class: "less-strong"
+        )
+      end
+
       def component_wrapper_data_attributes
         return {} if @skip_settings
         {controller: "org--registration-search org--registration-search-column-toggle",

--- a/app/controllers/organized/registrations_controller.rb
+++ b/app/controllers/organized/registrations_controller.rb
@@ -51,11 +51,13 @@ module Organized
       @chip_id = params[:chip_id].to_s.strip.presence
       return head(:bad_request) unless @serial.present?
 
+      @search_all = Binxtils::InputNormalizer.boolean(params[:search_all])
       @interpreted_params = BikeSearchable.searchable_interpreted_params({serial: @serial, stolenness: "all"}, ip: forwarded_ip_address)
-      bikes = current_organization.bikes.search(@interpreted_params)
+      search_scope = @search_all ? Bike : current_organization.bikes
+      bikes = search_scope.search(@interpreted_params)
       @per_page = 10
       @pagy, @bikes = pagy(:countish, bikes.reorder("bikes.id desc"), limit: @per_page, page: permitted_page)
-      @close_serials = current_organization.bikes.search_close_serials(@interpreted_params).limit(25) if @bikes.none?
+      @close_serials = search_scope.search_close_serials(@interpreted_params).limit(25) if @bikes.none?
     end
 
     private

--- a/app/javascript/controllers/org/multi_serial_search_controller.js
+++ b/app/javascript/controllers/org/multi_serial_search_controller.js
@@ -27,12 +27,6 @@ export default class extends Controller {
     this.search(serials)
   }
 
-  searchAllToggled () {
-    const serials = this.parseSerials(this.textareaTarget.value)
-    if (!serials.length) return
-    this.search(serials)
-  }
-
   get searchAll () {
     return this.hasSearchAllTarget && this.searchAllTarget.checked
   }

--- a/app/javascript/controllers/org/multi_serial_search_controller.js
+++ b/app/javascript/controllers/org/multi_serial_search_controller.js
@@ -4,12 +4,16 @@ import { Controller } from '@hotwired/stimulus'
 
 // Connects to data-controller='org--multi-serial-search'
 export default class extends Controller {
-  static targets = ['textarea', 'button', 'serialChips', 'results']
+  static targets = ['textarea', 'button', 'serialChips', 'results', 'searchAll']
   static values = { url: String, emptyClass: String, successClass: String, grayClass: String, errorClass: String, errorTooltip: String, spinner: String }
 
   connect () {
     if (this.searching) return
-    const serialsParam = new URL(window.location).searchParams.get('serials')
+    const params = new URL(window.location).searchParams
+    if (this.hasSearchAllTarget && params.get('search_all') === '1') {
+      this.searchAllTarget.checked = true
+    }
+    const serialsParam = params.get('serials')
     if (serialsParam) {
       this.textareaTarget.value = serialsParam
       this.search(this.parseSerials(serialsParam))
@@ -23,6 +27,16 @@ export default class extends Controller {
     this.search(serials)
   }
 
+  searchAllToggled () {
+    const serials = this.parseSerials(this.textareaTarget.value)
+    if (!serials.length) return
+    this.search(serials)
+  }
+
+  get searchAll () {
+    return this.hasSearchAllTarget && this.searchAllTarget.checked
+  }
+
   parseSerials (text) {
     return [...new Set(
       text.split(/[,\n]/).map(s => s.trim()).filter(s => s)
@@ -33,6 +47,11 @@ export default class extends Controller {
     this.searching = true
     const url = new URL(window.location.pathname, window.location.origin)
     url.searchParams.set('serials', serials.join(','))
+    if (this.searchAll) {
+      url.searchParams.set('search_all', '1')
+    } else {
+      url.searchParams.delete('search_all')
+    }
     window.history.pushState({}, '', url)
 
     this.resultsTarget.innerHTML = ''
@@ -87,6 +106,7 @@ export default class extends Controller {
     const url = new URL(this.urlValue, window.location.origin)
     url.searchParams.set('serial', serial)
     url.searchParams.set('chip_id', `chip_${index}`)
+    if (this.searchAll) url.searchParams.set('search_all', '1')
 
     try {
       const response = await fetch(url, {

--- a/app/views/organized/registrations/multi_search.html.erb
+++ b/app/views/organized/registrations/multi_search.html.erb
@@ -29,7 +29,19 @@
         class: "twinput tw:w-full tw:font-mono tw:h-32 tw:resize-none",
         data: {"org--multi-serial-search-target": "textarea"} %>
 
-      <div class="tw:mt-2 tw:flex tw:justify-end">
+      <div class="tw:mt-2 tw:flex tw:items-center tw:justify-between tw:gap-3">
+        <label class="tw:mb-0! tw:flex tw:cursor-pointer tw:items-center tw:gap-2">
+          <%= check_box_tag :search_all, "1", false,
+            data: {
+              "org--multi-serial-search-target": "searchAll",
+              action: "change->org--multi-serial-search#searchAllToggled"
+            } %>
+
+          <span>
+            Search all bikes (not just <%= current_organization.short_name %>)
+          </span>
+        </label>
+
         <%= render UI::Button::Component.new(
           text: "Search serials",
           color: :primary,

--- a/app/views/organized/registrations/multi_search.html.erb
+++ b/app/views/organized/registrations/multi_search.html.erb
@@ -32,10 +32,7 @@
       <div class="tw:mt-2 tw:flex tw:items-center tw:justify-between tw:gap-3">
         <label class="tw:mb-0! tw:flex tw:cursor-pointer tw:items-center tw:gap-2">
           <%= check_box_tag :search_all, "1", false,
-            data: {
-              "org--multi-serial-search-target": "searchAll",
-              action: "change->org--multi-serial-search#searchAllToggled"
-            } %>
+            data: {"org--multi-serial-search-target": "searchAll"} %>
 
           <span>
             Search all bikes (not just <%= current_organization.short_name %>)

--- a/config/locales/.translation_io
+++ b/config/locales/.translation_io
@@ -5,4 +5,4 @@
 # ignore the conflicts and "sync" again, it will fix this file for you.
 
 ---
-timestamp: 1778187787
+timestamp: 1778347784

--- a/config/locales/translation.es.yml
+++ b/config/locales/translation.es.yml
@@ -4699,7 +4699,7 @@ es:
         color:
         e_vehicle_propulsion:
         e_vehicles_for_audit:
-        hidden_not_registered:
+        email_hidden:
         impound_id:
         impounded:
         link:
@@ -4728,6 +4728,7 @@ es:
         vehicle:
         vehicle_type:
         view_matching_any_audit:
+        hidden_not_registered:
       registration_search_settings:
         address:
         all:

--- a/config/locales/translation.es.yml
+++ b/config/locales/translation.es.yml
@@ -4699,7 +4699,7 @@ es:
         color:
         e_vehicle_propulsion:
         e_vehicles_for_audit:
-        email_hidden:
+        hidden_not_registered:
         impound_id:
         impounded:
         link:

--- a/config/locales/translation.it.yml
+++ b/config/locales/translation.it.yml
@@ -4781,7 +4781,7 @@ it:
         color: Colore
         e_vehicle_propulsion:
         e_vehicles_for_audit:
-        hidden_not_registered:
+        email_hidden:
         impound_id:
         impounded:
         link: Collegamento
@@ -4810,6 +4810,7 @@ it:
         vehicle:
         vehicle_type:
         view_matching_any_audit:
+        hidden_not_registered:
       registration_search_settings:
         address:
         all: Tutti

--- a/config/locales/translation.it.yml
+++ b/config/locales/translation.it.yml
@@ -4781,7 +4781,7 @@ it:
         color: Colore
         e_vehicle_propulsion:
         e_vehicles_for_audit:
-        email_hidden:
+        hidden_not_registered:
         impound_id:
         impounded:
         link: Collegamento

--- a/config/locales/translation.nb.yml
+++ b/config/locales/translation.nb.yml
@@ -5921,7 +5921,7 @@ nb:
         color: Farge
         e_vehicle_propulsion: Elbil (fremdrift)
         e_vehicles_for_audit: 'Elbiler for revisjon:'
-        hidden_not_registered: "skjult, ikke registrert hos %{org_name}"
+        email_hidden: e-post skjult
         impound_id: Beslags-ID
         impounded: Beslaglagt
         link: Link
@@ -5950,6 +5950,7 @@ nb:
         vehicle: registrering
         vehicle_type: Bil type
         view_matching_any_audit: visning som samsvarer med enhver revisjon
+        hidden_not_registered: skjult, ikke registrert hos %{org_name}
       registration_search_settings:
         address: 'Adresse:'
         all: Alle

--- a/config/locales/translation.nb.yml
+++ b/config/locales/translation.nb.yml
@@ -5921,7 +5921,7 @@ nb:
         color: Farge
         e_vehicle_propulsion: Elbil (fremdrift)
         e_vehicles_for_audit: 'Elbiler for revisjon:'
-        email_hidden: e-post skjult
+        hidden_not_registered: "skjult, ikke registrert hos %{org_name}"
         impound_id: Beslags-ID
         impounded: Beslaglagt
         link: Link

--- a/config/locales/translation.nl.yml
+++ b/config/locales/translation.nl.yml
@@ -6077,7 +6077,7 @@ nl:
         color: Kleur
         e_vehicle_propulsion: Elektrisch voertuig (aandrijving)
         e_vehicles_for_audit: 'Elektrische voertuigen voor audit:'
-        email_hidden: email verborgen
+        hidden_not_registered: "verborgen, niet geregistreerd bij %{org_name}"
         impound_id: Inbeslagname-ID
         impounded: In beslag genomen bij
         link: Link

--- a/config/locales/translation.nl.yml
+++ b/config/locales/translation.nl.yml
@@ -6077,7 +6077,7 @@ nl:
         color: Kleur
         e_vehicle_propulsion: Elektrisch voertuig (aandrijving)
         e_vehicles_for_audit: 'Elektrische voertuigen voor audit:'
-        hidden_not_registered: "verborgen, niet geregistreerd bij %{org_name}"
+        email_hidden: email verborgen
         impound_id: Inbeslagname-ID
         impounded: In beslag genomen bij
         link: Link
@@ -6106,6 +6106,7 @@ nl:
         vehicle: Registratie
         vehicle_type: 'Voertuigtype:'
         view_matching_any_audit: weergave die overeenkomt met elke audit
+        hidden_not_registered: verborgen, niet geregistreerd bij %{org_name}
       registration_search_settings:
         address: 'Adres:'
         all: Alle

--- a/spec/components/org/registration_search/component_spec.rb
+++ b/spec/components/org/registration_search/component_spec.rb
@@ -144,18 +144,18 @@ RSpec.describe Org::RegistrationSearch::Component, type: :component do
         phone: "555-555-1212")
     end
 
-    it "redacts private and org-specific fields with the same hidden message" do
+    it "redacts private fields and leaves non-private columns visible" do
       expect(component).to have_css("tbody tr", count: 1)
       expect(component).to have_text(bike.mnfg_name)
+      # Private contact info is redacted with the shared hidden marker
       expect(component).not_to have_text("stranger@example.com")
-      expect(component).not_to have_text("SECRET-EXTRA")
       expect(component).not_to have_text("555-555-1212")
       hidden_text = "hidden, not registered with #{organization.short_name}"
-      expect(component).to have_css(".owner_email_cell small.less-strong", text: hidden_text)
-      expect(component).to have_css(".owner_name_cell small.less-strong", text: hidden_text)
-      expect(component).to have_css(".extra_registration_number_cell small.less-strong", text: hidden_text)
-      expect(component).to have_css(".reg_phone_cell small.less-strong", text: hidden_text)
-      expect(component).to have_css(".sticker_cell small.less-strong", text: hidden_text)
+      expect(component).to have_css(".owner_email_cell em.less-strong", text: hidden_text)
+      expect(component).to have_css(".owner_name_cell em.less-strong", text: hidden_text)
+      expect(component).to have_css(".reg_phone_cell em.less-strong", text: hidden_text)
+      # Non-private columns are visible
+      expect(component).to have_text("SECRET-EXTRA")
     end
   end
 end

--- a/spec/components/org/registration_search/component_spec.rb
+++ b/spec/components/org/registration_search/component_spec.rb
@@ -132,4 +132,30 @@ RSpec.describe Org::RegistrationSearch::Component, type: :component do
       expect(component).to have_link(text: /Create export/, visible: :all)
     end
   end
+
+  context "when bike does not belong to the organization" do
+    let(:enabled_feature_slugs) { %w[bike_search reg_phone bike_stickers] }
+    let(:other_org) { FactoryBot.create(:organization) }
+    let(:bike) do
+      FactoryBot.create(:bike_organized,
+        creation_organization: other_org,
+        owner_email: "stranger@example.com",
+        extra_registration_number: "SECRET-EXTRA",
+        phone: "555-555-1212")
+    end
+
+    it "redacts private and org-specific fields with the same hidden message" do
+      expect(component).to have_css("tbody tr", count: 1)
+      expect(component).to have_text(bike.mnfg_name)
+      expect(component).not_to have_text("stranger@example.com")
+      expect(component).not_to have_text("SECRET-EXTRA")
+      expect(component).not_to have_text("555-555-1212")
+      hidden_text = "hidden, not registered with #{organization.short_name}"
+      expect(component).to have_css(".owner_email_cell small.less-strong", text: hidden_text)
+      expect(component).to have_css(".owner_name_cell small.less-strong", text: hidden_text)
+      expect(component).to have_css(".extra_registration_number_cell small.less-strong", text: hidden_text)
+      expect(component).to have_css(".reg_phone_cell small.less-strong", text: hidden_text)
+      expect(component).to have_css(".sticker_cell small.less-strong", text: hidden_text)
+    end
+  end
 end

--- a/spec/integration/organized/registrations_search_spec.rb
+++ b/spec/integration/organized/registrations_search_spec.rb
@@ -304,11 +304,20 @@ RSpec.describe "Organized registrations search", :js, type: :system do
   context "multi serial search" do
     let(:multi_serial_path) { "/o/#{organization.to_param}/registrations/multi_search" }
 
-    let!(:bike_a) { FactoryBot.create(:bike_organized, serial_number: "SERIAL111", creation_organization: organization) }
+    let!(:bike_a) { FactoryBot.create(:bike_organized, serial_number: "SERIAL111", owner_email: "owner-alpha@example.com", creation_organization: organization) }
     let!(:bike_b) { FactoryBot.create(:bike_organized, serial_number: "SERIAL222", creation_organization: organization) }
     let!(:other_org_bike) { FactoryBot.create(:bike, serial_number: "SERIAL333") }
 
-    it "searches multiple serials and shows results" do
+    around do |example|
+      ActionController::Base.perform_caching = true
+      ActionController::Base.cache_store = ActiveSupport::Cache::MemoryStore.new
+      example.run
+    ensure
+      ActionController::Base.perform_caching = false
+      ActionController::Base.cache_store = :null_store
+    end
+
+    it "searches multiple serials, shows results, and caches rows by updated_at" do
       visit multi_serial_path
 
       expect(page).to have_content(/multiple serial search/i)
@@ -324,6 +333,21 @@ RSpec.describe "Organized registrations search", :js, type: :system do
       expect(page).to have_css(".multi-search-serial-result", count: 2)
       expect(page).not_to have_content("No matches found")
       expect(page).not_to have_content("SERIAL333")
+      expect(page).to have_content("owner-alpha@example.com")
+
+      # Mutate without bumping updated_at — reload should serve the cached row
+      bike_a.update_columns(owner_email: "owner-beta@example.com")
+      visit page.current_url
+
+      expect(page).to have_content("owner-alpha@example.com", wait: 10)
+      expect(page).not_to have_content("owner-beta@example.com")
+
+      # Bump updated_at to bust the per-row cache
+      bike_a.update_column(:updated_at, 1.second.from_now)
+      visit page.current_url
+
+      expect(page).to have_content("owner-beta@example.com", wait: 10)
+      expect(page).not_to have_content("owner-alpha@example.com")
     end
   end
 

--- a/spec/requests/organized/registrations_request_spec.rb
+++ b/spec/requests/organized/registrations_request_spec.rb
@@ -269,19 +269,19 @@ RSpec.describe Organized::RegistrationsController, type: :request do
     end
 
     context "with search_all" do
-      it "returns matching bikes from any organization and redacts non-org data" do
-        get "#{base_url}/multi_search_response", params: {serial: "WXYZ9999", search_all: "1"},
-          headers: {"Accept" => "text/vnd.turbo-stream.html"}
+      let(:turbo_headers) { {"Accept" => "text/vnd.turbo-stream.html"} }
+
+      it "widens results across orgs, redacting non-org data and leaving org bikes intact" do
+        # Other-org bike: returned, with private fields redacted
+        get "#{base_url}/multi_search_response", params: {serial: "WXYZ9999", search_all: "1"}, headers: turbo_headers
         expect(response.status).to eq(200)
         expect(assigns(:search_all)).to eq true
         expect(assigns(:bikes).pluck(:id)).to eq([other_bike.id])
         expect(response.body).to include("hidden, not registered with #{current_organization.short_name}")
         expect(response.body).not_to include(other_bike.owner_email)
-      end
 
-      it "renders full bike data for the org's own bikes" do
-        get "#{base_url}/multi_search_response", params: {serial: "ABCD1234", search_all: "1"},
-          headers: {"Accept" => "text/vnd.turbo-stream.html"}
+        # Own-org bike: full data renders, no redaction marker
+        get "#{base_url}/multi_search_response", params: {serial: "ABCD1234", search_all: "1"}, headers: turbo_headers
         expect(assigns(:bikes).pluck(:id)).to eq([bike.id])
         expect(response.body).to include(bike.owner_email)
         expect(response.body).not_to include("hidden, not registered")

--- a/spec/requests/organized/registrations_request_spec.rb
+++ b/spec/requests/organized/registrations_request_spec.rb
@@ -268,6 +268,22 @@ RSpec.describe Organized::RegistrationsController, type: :request do
       expect(assigns(:bikes)).to be_empty
     end
 
+    context "with search_all" do
+      it "returns matching bikes from any organization" do
+        get "#{base_url}/multi_search_response", params: {serial: "WXYZ9999", search_all: "1"},
+          headers: {"Accept" => "text/vnd.turbo-stream.html"}
+        expect(response.status).to eq(200)
+        expect(assigns(:search_all)).to eq true
+        expect(assigns(:bikes).pluck(:id)).to eq([other_bike.id])
+      end
+
+      it "does not redact bike data when bike belongs to the org" do
+        get "#{base_url}/multi_search_response", params: {serial: "ABCD1234", search_all: "1"},
+          headers: {"Accept" => "text/vnd.turbo-stream.html"}
+        expect(assigns(:bikes).pluck(:id)).to eq([bike.id])
+      end
+    end
+
     context "without serial param" do
       it "returns bad request" do
         get "#{base_url}/multi_search_response",

--- a/spec/requests/organized/registrations_request_spec.rb
+++ b/spec/requests/organized/registrations_request_spec.rb
@@ -269,18 +269,22 @@ RSpec.describe Organized::RegistrationsController, type: :request do
     end
 
     context "with search_all" do
-      it "returns matching bikes from any organization" do
+      it "returns matching bikes from any organization and redacts non-org data" do
         get "#{base_url}/multi_search_response", params: {serial: "WXYZ9999", search_all: "1"},
           headers: {"Accept" => "text/vnd.turbo-stream.html"}
         expect(response.status).to eq(200)
         expect(assigns(:search_all)).to eq true
         expect(assigns(:bikes).pluck(:id)).to eq([other_bike.id])
+        expect(response.body).to include("hidden, not registered with #{current_organization.short_name}")
+        expect(response.body).not_to include(other_bike.owner_email)
       end
 
-      it "does not redact bike data when bike belongs to the org" do
+      it "renders full bike data for the org's own bikes" do
         get "#{base_url}/multi_search_response", params: {serial: "ABCD1234", search_all: "1"},
           headers: {"Accept" => "text/vnd.turbo-stream.html"}
         expect(assigns(:bikes).pluck(:id)).to eq([bike.id])
+        expect(response.body).to include(bike.owner_email)
+        expect(response.body).not_to include("hidden, not registered")
       end
     end
 


### PR DESCRIPTION
Adds an opt-in toggle on the org multi-serial search to widen the result set beyond the current organization, and redacts private fields when a result isn't registered with the org.

- Controller: `multi_search_response` searches `Bike` (instead of `current_organization.bikes`) when `params[:search_all]` is set, for both matches and close-serial fallback.
- Multi-search form: new "Search all bikes (not just {org})" checkbox; Stimulus controller persists it to the URL and re-runs the active search when toggled.
- `Org::RegistrationSearch::Component`: gates owner email, owner name, registration notes, additional registration fields, secondary number, impound info, Avery, and stickers on a memoized `bike_in_org?(bike)`. Non-org bikes render a single shared `<small class="less-strong">hidden, not registered with {org}</small>` (locale key `hidden_not_registered`, translated for nb/nl, blanks added for es/it).
- Fixed a latent bug where `translation(".email_hidden")` resolved against `UI::Table::Component`'s scope inside the column block; the label is now captured before the table render.
