### PR TITLE
Rename org--multi-serial-search Stimulus controller to org--multi-search

### DIFF
--- a/app/javascript/controllers/org/multi_search_controller.js
+++ b/app/javascript/controllers/org/multi_search_controller.js
@@ -2,7 +2,7 @@ import { Controller } from '@hotwired/stimulus'
 
 /* global Turbo, requestAnimationFrame */
 
-// Connects to data-controller='org--multi-serial-search'
+// Connects to data-controller='org--multi-search'
 export default class extends Controller {
   static targets = ['textarea', 'button', 'serialChips', 'results', 'searchAll']
   static values = { url: String, emptyClass: String, successClass: String, grayClass: String, errorClass: String, errorTooltip: String, spinner: String }

--- a/app/views/organized/registrations/multi_search.html.erb
+++ b/app/views/organized/registrations/multi_search.html.erb
@@ -10,29 +10,29 @@
 <% end %>
 
 <div
-  data-controller="org--multi-serial-search org--registration-search org--registration-search-column-toggle"
-  data-org--multi-serial-search-url-value="<%= multi_search_response_organization_registrations_path(organization_id: current_organization.to_param) %>"
-  data-org--multi-serial-search-empty-class-value="<%= UI::Badge::Component.badge_classes(color: :empty, size: :md) %>"
-  data-org--multi-serial-search-success-class-value="<%= UI::Badge::Component.badge_classes(color: :success, size: :md) %>"
-  data-org--multi-serial-search-gray-class-value="<%= UI::Badge::Component.badge_classes(color: :gray, size: :md) %>"
-  data-org--multi-serial-search-error-class-value="<%= UI::Badge::Component.badge_classes(color: :error, size: :md, cursor: "tw:cursor-help") %>"
-  data-org--multi-serial-search-error-tooltip-value="<%= ERB::Util.html_escape(error_tooltip_template.to_str) %>"
-  data-org--multi-serial-search-spinner-value="<%= ERB::Util.html_escape(render(UI::LoadingSpinner::Component.new(size: :sm)).to_str) %>"
+  data-controller="org--multi-search org--registration-search org--registration-search-column-toggle"
+  data-org--multi-search-url-value="<%= multi_search_response_organization_registrations_path(organization_id: current_organization.to_param) %>"
+  data-org--multi-search-empty-class-value="<%= UI::Badge::Component.badge_classes(color: :empty, size: :md) %>"
+  data-org--multi-search-success-class-value="<%= UI::Badge::Component.badge_classes(color: :success, size: :md) %>"
+  data-org--multi-search-gray-class-value="<%= UI::Badge::Component.badge_classes(color: :gray, size: :md) %>"
+  data-org--multi-search-error-class-value="<%= UI::Badge::Component.badge_classes(color: :error, size: :md, cursor: "tw:cursor-help") %>"
+  data-org--multi-search-error-tooltip-value="<%= ERB::Util.html_escape(error_tooltip_template.to_str) %>"
+  data-org--multi-search-spinner-value="<%= ERB::Util.html_escape(render(UI::LoadingSpinner::Component.new(size: :sm)).to_str) %>"
   data-org--registration-search-column-toggle-default-columns-value="<%= settings.initially_checked_columns.to_json %>"
 >
   <div class="tw:mx-auto tw:mb-6 tw:max-w-2xl">
     <h3 class="uncap tw:mb-4">Multiple Serial Search</h3>
 
-    <form data-action="submit->org--multi-serial-search#submit">
+    <form data-action="submit->org--multi-search#submit">
       <%= text_area_tag :serials, nil,
         placeholder: "Enter multiple serial numbers, separated by commas or new lines",
         class: "twinput tw:w-full tw:font-mono tw:h-32 tw:resize-none",
-        data: {"org--multi-serial-search-target": "textarea"} %>
+        data: {"org--multi-search-target": "textarea"} %>
 
       <div class="tw:mt-2 tw:flex tw:items-center tw:justify-between tw:gap-3">
         <label class="tw:mb-0! tw:flex tw:cursor-pointer tw:items-center tw:gap-2">
           <%= check_box_tag :search_all, "1", false,
-            data: {"org--multi-serial-search-target": "searchAll"} %>
+            data: {"org--multi-search-target": "searchAll"} %>
 
           <span>
             Search all bikes (not just <%= current_organization.short_name %>)
@@ -44,18 +44,18 @@
           color: :primary,
           size: :lg,
           kind: :submit,
-          data: {"org--multi-serial-search-target": "button"}
+          data: {"org--multi-search-target": "button"}
         ) %>
       </div>
     </form>
   </div>
 
   <div
-    data-org--multi-serial-search-target="serialChips"
+    data-org--multi-search-target="serialChips"
     class="tw:mb-4 tw:flex tw:flex-wrap tw:gap-3"
   ></div>
 
   <%= render settings %>
 
-  <div id="multi_serial_results" data-org--multi-serial-search-target="results"></div>
+  <div id="multi_serial_results" data-org--multi-search-target="results"></div>
 </div>

--- a/spec/integration/organized/registrations_search_spec.rb
+++ b/spec/integration/organized/registrations_search_spec.rb
@@ -321,7 +321,7 @@ RSpec.describe "Organized registrations search", :js, type: :system do
       visit multi_serial_path
 
       expect(page).to have_content(/multiple serial search/i)
-      expect(page).to have_css("[data-controller~='org--multi-serial-search']", wait: 5)
+      expect(page).to have_css("[data-controller~='org--multi-search']", wait: 5)
 
       find("textarea#serials").set("SERIAL111, SERIAL222, NONEXISTENT")
       click_button "Search serials"


### PR DESCRIPTION
Renames the `org--multi-serial-search` Stimulus controller to `org--multi-search` (file, `data-controller` attribute, targets, values, actions, and the spec selector).