### PR TITLE
Raise puma NOFILE; 406 on organized registrations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -78,6 +78,7 @@ vendor/strava_search/storybook-static/
 
 # Ignore local Claude Code settings
 .claude/settings.local.json
+.claude/scheduled_tasks.lock
 
 # Ignore Playwright MCP session cache (snapshots, console logs)
 .playwright-mcp/

--- a/app/controllers/organized/registrations_controller.rb
+++ b/app/controllers/organized/registrations_controller.rb
@@ -8,6 +8,7 @@ module Organized
     around_action :set_reading_role, only: :multi_search_response
 
     def index
+      return head(:not_acceptable) unless request.format.html? || request.format.turbo_stream?
       set_period
       @bike_sticker = BikeSticker.lookup_with_fallback(params[:bike_sticker], organization_id: current_organization.id) if params[:bike_sticker].present?
 

--- a/config/initializers/carrierwave.rb
+++ b/config/initializers/carrierwave.rb
@@ -50,7 +50,6 @@ CarrierWave.configure do |config|
       path_style: true
     }
     config.fog_directory = ENV["S3_BUCKET"]
-    config.fog_public = true
     config.fog_attributes = {"Cache-Control" => "max-age=315576000"}
   end
 end

--- a/config/initializers/carrierwave.rb
+++ b/config/initializers/carrierwave.rb
@@ -50,6 +50,7 @@ CarrierWave.configure do |config|
       path_style: true
     }
     config.fog_directory = ENV["S3_BUCKET"]
+    config.fog_public = true
     config.fog_attributes = {"Cache-Control" => "max-age=315576000"}
   end
 end

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -1,3 +1,7 @@
+# Raise from the systemd default of 1024; insufficient for our DB pool + Redis clients + Excon sockets under load
+soft, hard = Process.getrlimit(:NOFILE)
+Process.setrlimit(:NOFILE, [65536, hard].min, hard) if soft < 65536
+
 # Puma can serve each request in a thread from an internal thread pool.
 # The `threads` method setting takes two numbers: a minimum and maximum.
 # Any libraries that use thread pools should be configured to match

--- a/spec/requests/organized/registrations_request_spec.rb
+++ b/spec/requests/organized/registrations_request_spec.rb
@@ -239,6 +239,12 @@ RSpec.describe Organized::RegistrationsController, type: :request do
         expect(assigns(:bikes).pluck(:id)).to eq([])
       end
     end
+    context "unsupported format" do
+      it "returns 406 for json" do
+        get "#{base_url}.json", params: {period: "custom", start_time: "2025-04-01", end_time: "2026-04-30", per_page: "1"}
+        expect(response.status).to eq(406)
+      end
+    end
   end
 
   describe "multi_search" do


### PR DESCRIPTION
Three small fixes bundled together:

- **406 on `organized/registrations#index` for non-HTML formats** — JSON requests to `/o/:org/registrations.json` were raising `ActionView::MissingTemplate` ([Honeybadger #130382932](https://app.honeybadger.io/projects/35931/faults/130382932)) because `respond_to` only handles HTML/turbo_stream and there is no `search.json` template. Return `head(:not_acceptable)` for anything other than HTML or turbo_stream.
- **Raise puma `NOFILE` to 65536** — puma workers were inheriting systemd's default `LimitNOFILE=1024`, insufficient for our DB pool + Redis clients + Excon sockets under bot load; triggered an `Errno::EMFILE` storm on `BikesController#show` on 2026-05-11. Set via `Process.setrlimit` in `config/puma.rb` so workers fork with the higher limit.
- **Gitignore `.claude/scheduled_tasks.lock`** — local-only lock file.
