### PR TITLE
Allow REDIS_RACK_ATTACK_URL to use a separate Redis instance for Rack::Attack

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -24,12 +24,14 @@ module Bikeindex
   class Application < Rails::Application
     config.redis_default_url = ENV["REDIS_URL"]
     config.redis_cache_url = ENV.fetch("REDIS_CACHE_URL", config.redis_default_url)
-    # Separate Redis database for Rack::Attack to avoid key collisions with app cache.
-    # Note: eviction still operates server-wide, not per database.
-    config.redis_rack_attack_url = if config.redis_cache_url.match?(%r{/\d+\z})
-      config.redis_cache_url.sub(%r{/(\d+)\z}) { "/#{$1.to_i + 1}" }
-    else
-      "#{config.redis_cache_url}/1"
+    # Prefer a separate Redis instance for Rack::Attack so cache eviction can't
+    # drop rate-limit keys. Falls back to the next database on the cache Redis.
+    config.redis_rack_attack_url = ENV.fetch("REDIS_RACK_ATTACK_URL") do
+      if config.redis_cache_url.match?(%r{/\d+\z})
+        config.redis_cache_url.sub(%r{/(\d+)\z}) { "/#{$1.to_i + 1}" }
+      else
+        "#{config.redis_cache_url}/1"
+      end
     end
 
     config.load_defaults 8.0


### PR DESCRIPTION
Allow `REDIS_RACK_ATTACK_URL` to point Rack::Attack at its own Redis instance, so cache eviction on the main Redis can't drop rate-limit keys. When unset, falls back to the previous behavior (next database on the cache Redis).