### PR TITLE
Workspace teardown kills bin/dev; drop "w" prefix on WORKSPACE_ID

### DIFF
--- a/bin/env
+++ b/bin/env
@@ -8,7 +8,7 @@
 workspace_file = File.expand_path("../.workspace_id", __dir__)
 if File.exist?(workspace_file)
   workspace_int = File.read(workspace_file).strip
-  ENV["WORKSPACE_ID"] ||= "w#{workspace_int}"
+  ENV["WORKSPACE_ID"] ||= workspace_int
   ENV["DEV_PORT"] ||= workspace_int
 end
 

--- a/bin/workspace_setup
+++ b/bin/workspace_setup
@@ -31,7 +31,7 @@ def psql(database, query)
 end
 
 if File.exist?(WORKSPACE_FILE)
-  puts "workspace ID already set: w#{File.read(WORKSPACE_FILE).strip}"
+  puts "workspace ID already set: #{File.read(WORKSPACE_FILE).strip}"
 else
   unless system("psql", "-d", "postgres", "-tAXc", "SELECT 1 FROM pg_database WHERE datname = '#{WORKSPACE_DB}'", out: File::NULL)
     abort "Could not query Postgres. Is it running?"
@@ -41,14 +41,16 @@ else
     system("createdb", WORKSPACE_DB) || abort("Failed to create database #{WORKSPACE_DB}")
   end
 
-  psql(WORKSPACE_DB, "CREATE TABLE IF NOT EXISTS workspace_ids (id INTEGER PRIMARY KEY)")
+  if psql(WORKSPACE_DB, "SELECT 1 FROM pg_tables WHERE tablename = 'workspace_ids'").empty?
+    psql(WORKSPACE_DB, "CREATE TABLE workspace_ids (id INTEGER PRIMARY KEY)")
+  end
   taken = psql(WORKSPACE_DB, "SELECT id FROM workspace_ids").split("\n").map(&:to_i)
   next_id = 3072
   next_id += 1 while taken.include?(next_id)
 
   psql(WORKSPACE_DB, "INSERT INTO workspace_ids (id) VALUES (#{next_id})")
   File.write(WORKSPACE_FILE, next_id.to_s)
-  puts "workspace ID set to w#{next_id}"
+  puts "workspace ID set to #{next_id}"
 end
 
 system(File.expand_path("setup", __dir__), *setup_args) || abort("bin/setup failed")

--- a/bin/workspace_teardown
+++ b/bin/workspace_teardown
@@ -1,52 +1,70 @@
-#!/bin/sh
-#/ Usage: bin/workspace_teardown
-#/
-#/ Clean up workspace-specific resources for this checkout: drops the
-#/ workspace-specific dev/test databases, removes the row from the
-#/ dev_workspaces.workspace_ids table, and deletes .workspace_id.
+#!/usr/bin/env ruby
+# frozen_string_literal: true
 
-set -e
-cd $(dirname "$0")/..
+# Clean up workspace-specific resources for this checkout: stops bin/dev,
+# drops the workspace-specific dev/test databases, removes the row from
+# the dev_workspaces.workspace_ids table, and deletes .workspace_id.
 
-if [ -z "$WORKSPACE_ID" ] && [ -f .workspace_id ]; then
-  WORKSPACE_ID="w$(cat .workspace_id)"
-fi
+require "fileutils"
 
-if [ -z "$WORKSPACE_ID" ]; then
-  echo "WORKSPACE_ID not set and .workspace_id missing, skipping teardown."
+APP_ROOT = File.expand_path("..", __dir__)
+WORKSPACE_FILE = File.join(APP_ROOT, ".workspace_id")
+WORKSPACE_DB = "dev_workspaces"
+
+Dir.chdir(APP_ROOT)
+
+workspace_id = ENV["WORKSPACE_ID"]
+if (workspace_id.nil? || workspace_id.empty?) && File.exist?(WORKSPACE_FILE)
+  workspace_id = File.read(WORKSPACE_FILE).strip
+end
+
+if workspace_id.nil? || workspace_id.empty?
+  puts "WORKSPACE_ID not set and .workspace_id missing, skipping teardown."
   exit 0
-fi
+end
 
-echo "Tearing down workspace: $WORKSPACE_ID"
+puts "Tearing down workspace: #{workspace_id}"
 
-# Drop workspace-specific development databases
-for db in "bikeindex_development_${WORKSPACE_ID}" \
-          "bikeindex_analytics_development_${WORKSPACE_ID}"; do
-  echo "Dropping database: $db"
-  dropdb --if-exists "$db" 2>/dev/null || true
-done
+# Stop bin/dev for this workspace (kill the foreman process group on DEV_PORT)
+if workspace_id.match?(/\A\d+\z/)
+  listener_pid = IO.popen(["lsof", "-ti", "tcp:#{workspace_id}", "-sTCP:LISTEN"], err: File::NULL, &:read).split.first
+  if listener_pid
+    pgid = IO.popen(["ps", "-o", "pgid=", "-p", listener_pid], err: File::NULL, &:read).strip
+    unless pgid.empty?
+      puts "Stopping bin/dev (port #{workspace_id}, pgid #{pgid})"
+      begin
+        Process.kill("TERM", -pgid.to_i)
+      rescue Errno::ESRCH, Errno::EPERM
+      end
+    end
+  end
+end
 
-# Drop workspace-specific test databases
-for db in "bikeindex_test_${WORKSPACE_ID}" \
-          "bikeindex_test_${WORKSPACE_ID}_replica" \
-          "bikeindex_analytics_test_${WORKSPACE_ID}"; do
-  echo "Dropping database: $db"
-  dropdb --if-exists "$db" 2>/dev/null || true
-done
+def dropdb(name, announce: true)
+  puts "Dropping database: #{name}" if announce
+  system("dropdb", "--if-exists", name, out: File::NULL, err: File::NULL)
+end
 
-# Also drop parallel test databases (TEST_ENV_NUMBER suffixed)
-for i in $(seq 1 8); do
-  for db in "bikeindex_test_${WORKSPACE_ID}${i}" \
-            "bikeindex_test_${WORKSPACE_ID}_replica${i}" \
-            "bikeindex_analytics_test_${WORKSPACE_ID}${i}"; do
-    dropdb --if-exists "$db" 2>/dev/null || true
-  done
-done
+%W[
+  bikeindex_development_#{workspace_id}
+  bikeindex_analytics_development_#{workspace_id}
+  bikeindex_test_#{workspace_id}
+  bikeindex_test_#{workspace_id}_replica
+  bikeindex_analytics_test_#{workspace_id}
+].each { |db| dropdb(db) }
 
-workspace_int="${WORKSPACE_ID#w}"
-echo "Removing workspace_ids row: $workspace_int"
-psql -d dev_workspaces -tAXc "DELETE FROM workspace_ids WHERE id = ${workspace_int}" 2>/dev/null || true
+# Parallel test databases (TEST_ENV_NUMBER suffixed)
+(1..8).each do |i|
+  %W[
+    bikeindex_test_#{workspace_id}#{i}
+    bikeindex_test_#{workspace_id}_replica#{i}
+    bikeindex_analytics_test_#{workspace_id}#{i}
+  ].each { |db| dropdb(db, announce: false) }
+end
 
-rm -f .workspace_id
+puts "Removing workspace_ids row: #{workspace_id}"
+system("psql", "-d", WORKSPACE_DB, "-tAXc", "DELETE FROM workspace_ids WHERE id = #{workspace_id}", out: File::NULL, err: File::NULL)
 
-echo "Workspace teardown complete!"
+FileUtils.rm_f(WORKSPACE_FILE)
+
+puts "Workspace teardown complete!"


### PR DESCRIPTION
A few workspace-script improvements following up on #3521:

- `bin/workspace_teardown` rewritten in Ruby to match `bin/workspace_setup`. Before dropping databases it now also stops `bin/dev` for the workspace by finding the listener on `DEV_PORT` and `SIGTERM`-ing its process group (foreman + puma + watchers). Skipped silently when nothing is bound.
- `WORKSPACE_ID` is now the bare integer (e.g. `3072`) instead of `w3072`. Database names become `bikeindex_development_3072`; `config/database.yml` and `config/cable.yml` pick this up automatically. Existing checkouts should `bin/workspace_teardown` *before* pulling so they can drop the old `_w####` databases.
- `bin/workspace_setup` checks `pg_tables` before creating `workspace_ids` so it stops emitting `NOTICE: relation "workspace_ids" already exists, skipping` on repeat runs.
