### PR TITLE
Touch member users on org change; touch user on SuperuserAbility change

### DIFF
--- a/app/jobs/update_organization_associations_job.rb
+++ b/app/jobs/update_organization_associations_job.rb
@@ -10,6 +10,9 @@ class UpdateOrganizationAssociationsJob < ApplicationJob
 
       # Critical that locations skip_update, so we don't loop
       organization.locations.each { |l| l.update(updated_at: Time.current, skip_update: true) }
+      # Touch member users so caches keyed on user.cache_key_with_version (e.g. the
+      # organized menu) pick up org-feature changes
+      organization.users.each { |u| u.update(updated_at: Time.current, skip_update: true) }
       organization.reload # Just in case default location has changed
       organization.update(skip_update: true, updated_at: Time.current)
       add_organization_manufacturers(organization)

--- a/app/models/superuser_ability.rb
+++ b/app/models/superuser_ability.rb
@@ -40,7 +40,7 @@ class SuperuserAbility < ApplicationRecord
 
   enum :kind, KIND_ENUM
 
-  belongs_to :user
+  belongs_to :user, touch: true
 
   before_validation :set_calculated_attributes
 

--- a/spec/jobs/update_organization_associations_job_spec.rb
+++ b/spec/jobs/update_organization_associations_job_spec.rb
@@ -80,6 +80,25 @@ RSpec.describe UpdateOrganizationAssociationsJob, type: :job do
     end
   end
 
+  describe "touching member users" do
+    let(:organization) { FactoryBot.create(:organization) }
+    let!(:user1) { FactoryBot.create(:organization_user, organization:) }
+    let!(:user2) { FactoryBot.create(:organization_user, organization:) }
+    let!(:other_user) { FactoryBot.create(:user_confirmed) }
+
+    it "touches every member user (so caches keyed on user.cache_key_with_version pick up org changes)" do
+      [user1, user2, other_user].each { |u| u.update_columns(updated_at: Time.current - 1.hour) }
+
+      expect { instance.perform(organization.id) }
+        .to change { user1.reload.updated_at }
+        .and change { user2.reload.updated_at }
+
+      expect(user1.reload.updated_at).to be_within(2).of(Time.current)
+      expect(user2.reload.updated_at).to be_within(2).of(Time.current)
+      expect(other_user.reload.updated_at).to be < Time.current - 30.minutes
+    end
+  end
+
   describe "organization_manufacturers" do
     let(:manufacturer) { FactoryBot.create(:manufacturer) }
     let!(:manufacturer_organization) { FactoryBot.create(:organization_with_organization_features, manufacturer: manufacturer, enabled_feature_slugs: ["official_manufacturer"]) }

--- a/spec/models/superuser_ability_spec.rb
+++ b/spec/models/superuser_ability_spec.rb
@@ -18,6 +18,28 @@ RSpec.describe SuperuserAbility, type: :model do
     end
   end
 
+  describe "user touch" do
+    before { user.update_columns(updated_at: Time.current - 1.hour) }
+
+    it "touches the user on create so caches keyed on user.cache_key_with_version bust" do
+      expect { SuperuserAbility.create!(user: user) }
+        .to change { user.reload.updated_at }
+      expect(user.reload.updated_at).to be_within(2).of(Time.current)
+    end
+
+    it "touches the user on update and destroy" do
+      ability = SuperuserAbility.create!(user: user)
+      user.update_columns(updated_at: Time.current - 1.hour)
+
+      expect { ability.update!(controller_name: "graphs") }
+        .to change { user.reload.updated_at }
+
+      user.update_columns(updated_at: Time.current - 1.hour)
+      expect { ability.destroy }
+        .to change { user.reload.updated_at }
+    end
+  end
+
   describe "su_options" do
     let(:user1) { FactoryBot.create(:user) }
     let!(:superuser_ability1) { SuperuserAbility.create(user: user1) }

--- a/spec/support/caching_spec_helpers.rb
+++ b/spec/support/caching_spec_helpers.rb
@@ -5,10 +5,13 @@ RSpec.shared_context :caching_enabled do
     config.around(:each, :caching) do |example|
       ActionController::Base.perform_caching = true
       ActionController::Base.cache_store = cache
+      original_rails_cache = Rails.cache
+      Rails.cache = cache
       example.run
     ensure
       ActionController::Base.perform_caching = false
       ActionController::Base.cache_store = :null_store
+      Rails.cache = original_rails_cache if original_rails_cache
     end
   end
 end

--- a/spec/support/rack_attack.rb
+++ b/spec/support/rack_attack.rb
@@ -7,6 +7,7 @@ Rack::Attack.enabled = false
 
 RSpec.shared_context :rack_attack do
   around do |example|
+    Rack::Attack.cache.store.clear
     Rack::Attack.enabled = true
     example.run
   ensure


### PR DESCRIPTION
Sets up the cache-busting contract for caches keyed on `user.cache_key_with_version` (such as the organized-menu cache in #3517), plus the spec-helper changes needed to test cache behavior reliably.

- `UpdateOrganizationAssociationsJob` touches every member user when an organization changes, so org-feature changes bump `user.cache_key_with_version`.
- `SuperuserAbility.belongs_to :user, touch: true` — superuser-ability create/update/destroy now bumps the owning user.
- `:caching` spec context swaps `Rails.cache` to the per-example store (not just `ActionController::Base.cache_store`), so services that call `Rails.cache` directly are isolated per example.
- `:rack_attack` spec context clears `Rack::Attack.cache.store` before the example as well as after, so stale counters from an earlier suite don't bleed in.
- Tests assert the touch behavior on both the job and `SuperuserAbility`.

Extracted from #3517 so it can land independently of the menu-service refactor.
