### PR TITLE
Catch middleware exceptions in API::Base via rescue_from :all

### DIFF
--- a/app/controllers/api/base.rb
+++ b/app/controllers/api/base.rb
@@ -69,6 +69,11 @@ module API
       include: [GrapeLogging::Loggers::BinxLogger.new,
         GrapeLogging::Loggers::FilterParameters.new]
     use ::APIAuthorization::OAuth2
+
+    rescue_from :all do |e|
+      API::Base.respond_to_error(e)
+    end
+
     mount API::V3::RootV3
     mount API::V2::RootV2
 


### PR DESCRIPTION
Add `rescue_from :all` to the outer `API::Base` Grape::API so exceptions raised in API-level middleware (GrapeLogging, `APIAuthorization::OAuth2`) or in route-matching for paths that never reach a mounted endpoint flow through `respond_to_error` instead of escaping to Rack's default 500.

The mounted `RootV3` / `RootV2` already have `rescue_from :all`, but anything raised before the request reaches them produced a bare 500 with no JSON body, no CORS headers, no proper 401/403/404 mapping, and no Honeybadger notify — invisible in our error pipeline. This restores that visibility and gives clients a consistent error response.
