### PR TITLE
Assert text_part body in mailer "renders email" specs

### DIFF
--- a/spec/mailers/admin_mailer_spec.rb
+++ b/spec/mailers/admin_mailer_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe AdminMailer, type: :mailer do
       expect(mail.reply_to).to eq([feedback.email])
       expect(mail.tag).to eq("admin")
       expect(mail.body.encoded).to match "supported by"
+      expect(Premailer::Rails::Hook.perform(mail).text_part.body.to_s).to include(feedback.body).and include("supported by")
     end
   end
 
@@ -93,6 +94,7 @@ RSpec.describe AdminMailer, type: :mailer do
       expect(@mail.to).to eq(["contact@bikeindex.org"])
       expect(@mail.subject).to match("doesn't have any admins")
       expect(@mail.tag).to eq("admin")
+      expect(Premailer::Rails::Hook.perform(@mail).text_part.body.to_s).to include("There are no admins in").and include(@organization.name)
     end
   end
 
@@ -106,6 +108,7 @@ RSpec.describe AdminMailer, type: :mailer do
       expect(@mail.subject[/blocked/i].present?).to be_truthy
       expect(@mail.body.encoded).to match(@stolen_notification.message)
       expect(@mail.tag).to eq("admin")
+      expect(Premailer::Rails::Hook.perform(@mail).text_part.body.to_s).to include(@stolen_notification.message)
     end
   end
 
@@ -117,6 +120,7 @@ RSpec.describe AdminMailer, type: :mailer do
       expect(mail.subject[/blocked/i].present?).to be_truthy
       expect(mail.body.encoded).to match(marketplace_message.body)
       expect(mail.tag).to eq("admin")
+      expect(Premailer::Rails::Hook.perform(mail).text_part.body.to_s).to include(marketplace_message.body)
     end
   end
 
@@ -130,6 +134,7 @@ RSpec.describe AdminMailer, type: :mailer do
         expect(mail.subject).to match("RECOVERED Promoted Alert: #{theft_alert.id}")
         expect(mail.body.encoded).to include("RECOVERED")
         expect(mail.tag).to eq("admin")
+        expect(Premailer::Rails::Hook.perform(mail).text_part.body.to_s).to include("RECOVERED").and include("Promoted Alert")
       end
     end
   end

--- a/spec/mailers/admin_mailer_spec.rb
+++ b/spec/mailers/admin_mailer_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe AdminMailer, type: :mailer do
       expect(mail.reply_to).to eq([feedback.email])
       expect(mail.tag).to eq("admin")
       expect(mail.body.encoded).to match "supported by"
-      expect(Premailer::Rails::Hook.perform(mail).text_part.body.to_s).to include(feedback.body).and include("supported by")
+      expect(mail.deliver_now.text_part.body.to_s).to include(feedback.body).and include("supported by")
     end
   end
 
@@ -94,7 +94,7 @@ RSpec.describe AdminMailer, type: :mailer do
       expect(@mail.to).to eq(["contact@bikeindex.org"])
       expect(@mail.subject).to match("doesn't have any admins")
       expect(@mail.tag).to eq("admin")
-      expect(Premailer::Rails::Hook.perform(@mail).text_part.body.to_s).to include("There are no admins in").and include(@organization.name)
+      expect(@mail.deliver_now.text_part.body.to_s).to include("There are no admins in").and include(@organization.name)
     end
   end
 
@@ -108,7 +108,7 @@ RSpec.describe AdminMailer, type: :mailer do
       expect(@mail.subject[/blocked/i].present?).to be_truthy
       expect(@mail.body.encoded).to match(@stolen_notification.message)
       expect(@mail.tag).to eq("admin")
-      expect(Premailer::Rails::Hook.perform(@mail).text_part.body.to_s).to include(@stolen_notification.message)
+      expect(@mail.deliver_now.text_part.body.to_s).to include(@stolen_notification.message)
     end
   end
 
@@ -120,7 +120,7 @@ RSpec.describe AdminMailer, type: :mailer do
       expect(mail.subject[/blocked/i].present?).to be_truthy
       expect(mail.body.encoded).to match(marketplace_message.body)
       expect(mail.tag).to eq("admin")
-      expect(Premailer::Rails::Hook.perform(mail).text_part.body.to_s).to include(marketplace_message.body)
+      expect(mail.deliver_now.text_part.body.to_s).to include(marketplace_message.body)
     end
   end
 
@@ -134,7 +134,7 @@ RSpec.describe AdminMailer, type: :mailer do
         expect(mail.subject).to match("RECOVERED Promoted Alert: #{theft_alert.id}")
         expect(mail.body.encoded).to include("RECOVERED")
         expect(mail.tag).to eq("admin")
-        expect(Premailer::Rails::Hook.perform(mail).text_part.body.to_s).to include("RECOVERED").and include("Promoted Alert")
+        expect(mail.deliver_now.text_part.body.to_s).to include("RECOVERED").and include("Promoted Alert")
       end
     end
   end

--- a/spec/mailers/customer_mailer_spec.rb
+++ b/spec/mailers/customer_mailer_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe CustomerMailer, type: :mailer do
       expect(mail.to).to eq([user.email])
       expect(mail.tag).to eq "welcome_email"
       expect(mail.body.encoded).to match(/supported by/i)
+      expect(Premailer::Rails::Hook.perform(mail).text_part.body.to_s).to include("Welcome to Bike Index").and match(/supported by/i)
     end
   end
 
@@ -21,6 +22,7 @@ RSpec.describe CustomerMailer, type: :mailer do
       expect(mail.to).to eq([user.email])
       expect(mail.from).to eq(["contact@bikeindex.org"])
       expect(mail.tag).to eq "confirmation_email"
+      expect(Premailer::Rails::Hook.perform(mail).text_part.body.to_s).to include("Please confirm your email address").and include("Verify email")
     end
     context "partner signup" do
       let(:user) { FactoryBot.create(:user_bikehub_signup) }
@@ -31,6 +33,7 @@ RSpec.describe CustomerMailer, type: :mailer do
         expect(mail.to).to eq([user.email])
         expect(mail.from).to eq(["contact@bikeindex.org"])
         expect(mail.tag).to eq "confirmation_email"
+        expect(Premailer::Rails::Hook.perform(mail).text_part.body.to_s).to include("Please confirm your email address").and include("Verify email")
       end
     end
   end
@@ -45,6 +48,7 @@ RSpec.describe CustomerMailer, type: :mailer do
       # And just to be sure, test the route a little more
       expect(mail.body.encoded).to match(/users\/update_password_form_with_reset_token\?token=#{user.token_for_password_reset}/)
       expect(mail.tag).to eq "password_reset_email"
+      expect(Premailer::Rails::Hook.perform(mail).text_part.body.to_s).to include(user.token_for_password_reset).and include("Reset password")
     end
   end
 
@@ -56,6 +60,7 @@ RSpec.describe CustomerMailer, type: :mailer do
       expect(mail.from).to eq(["contact@bikeindex.org"])
       expect(mail.body.encoded).to match(user.magic_link_token)
       expect(mail.tag).to eq "magic_login_link_email"
+      expect(Premailer::Rails::Hook.perform(mail).text_part.body.to_s).to include(user.magic_link_token).and include("Sign in")
     end
   end
 
@@ -66,6 +71,7 @@ RSpec.describe CustomerMailer, type: :mailer do
       expect(mail.subject).to match(/confirm/i)
       expect(mail.from).to eq(["contact@bikeindex.org"])
       expect(mail.tag).to eq "additional_email_confirmation"
+      expect(Premailer::Rails::Hook.perform(mail).text_part.body.to_s).to include(user_email.email).and include("Verify email")
     end
   end
 
@@ -79,6 +85,7 @@ RSpec.describe CustomerMailer, type: :mailer do
         expect(mail.from).to eq(["contact@bikeindex.org"])
         expect(mail.body.encoded).to match "donation of"
         expect(mail.tag).to eq "invoice_email"
+        expect(Premailer::Rails::Hook.perform(mail).text_part.body.to_s).to include("donation of")
       end
     end
     context "payment" do
@@ -90,6 +97,7 @@ RSpec.describe CustomerMailer, type: :mailer do
         expect(mail.from).to eq(["contact@bikeindex.org"])
         expect(mail.body.encoded).to_not match "donation of"
         expect(mail.tag).to eq "invoice_email"
+        expect(Premailer::Rails::Hook.perform(mail).text_part.body.to_s).to include("payment of").and include("Thank you so much")
       end
     end
   end
@@ -116,6 +124,7 @@ RSpec.describe CustomerMailer, type: :mailer do
       expect(mail.to).to eq([customer_contact.user_email])
       expect(mail.subject).to eq "CUSTOM CUSTOMER contact Title"
       expect(mail.from).to eq(["contact@bikeindex.org"])
+      expect(Premailer::Rails::Hook.perform(mail).text_part.body.to_s).to include("spreading the word about").and include("bikeindex")
     end
   end
 
@@ -131,6 +140,7 @@ RSpec.describe CustomerMailer, type: :mailer do
       expect(mail.subject).to eq "Your tall bike (multiple frames fused together) has been marked recovered!"
       expect(mail.from).to eq(["bryan@bikeindex.org"])
       expect(mail.body.encoded).to match recovered_description
+      expect(Premailer::Rails::Hook.perform(mail).text_part.body.to_s).to include(recovered_description).and include("was marked")
     end
   end
 
@@ -152,6 +162,7 @@ RSpec.describe CustomerMailer, type: :mailer do
       expect(mail.body.encoded).to match("some message")
       expect(mail.reply_to).to eq(["something@stuff.com"])
       expect(mail.from).to eq(["contact@bikeindex.org"])
+      expect(Premailer::Rails::Hook.perform(mail).text_part.body.to_s).to include("some message")
     end
   end
 
@@ -166,6 +177,7 @@ RSpec.describe CustomerMailer, type: :mailer do
       expect(mail.from.first).to eq("bryan@bikeindex.org")
       expect(mail.body.encoded).to match(stolen_notification.message)
       expect(mail.body.encoded).to match(stolen_notification.reference_url)
+      expect(Premailer::Rails::Hook.perform(mail).text_part.body.to_s).to include(stolen_notification.message).and include(stolen_notification.reference_url)
       expect(mail.reply_to).to eq(["party@example.com"])
       expect(mail.cc).to eq(["bryan@bikeindex.org", "gavin@bikeindex.org"])
       stolen_notification.reload
@@ -187,6 +199,7 @@ RSpec.describe CustomerMailer, type: :mailer do
       expect(mail.from.count).to eq(1)
       expect(mail.from.first).to eq("gavin@bikeindex.org")
       expect(mail.body.encoded).to_not match "vendor terms"
+      expect(Premailer::Rails::Hook.perform(mail).text_part.body.to_s).to include("Gavin Hoover and the Bike Index Team").and include("updated our privacy policy")
     end
   end
 

--- a/spec/mailers/customer_mailer_spec.rb
+++ b/spec/mailers/customer_mailer_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe CustomerMailer, type: :mailer do
       expect(mail.to).to eq([user.email])
       expect(mail.tag).to eq "welcome_email"
       expect(mail.body.encoded).to match(/supported by/i)
-      expect(Premailer::Rails::Hook.perform(mail).text_part.body.to_s).to include("Welcome to Bike Index").and match(/supported by/i)
+      expect(mail.deliver_now.text_part.body.to_s).to include("Welcome to Bike Index").and match(/supported by/i)
     end
   end
 
@@ -22,7 +22,7 @@ RSpec.describe CustomerMailer, type: :mailer do
       expect(mail.to).to eq([user.email])
       expect(mail.from).to eq(["contact@bikeindex.org"])
       expect(mail.tag).to eq "confirmation_email"
-      expect(Premailer::Rails::Hook.perform(mail).text_part.body.to_s).to include("Please confirm your email address").and include("Verify email")
+      expect(mail.deliver_now.text_part.body.to_s).to include("Please confirm your email address").and include("Verify email")
     end
     context "partner signup" do
       let(:user) { FactoryBot.create(:user_bikehub_signup) }
@@ -33,7 +33,7 @@ RSpec.describe CustomerMailer, type: :mailer do
         expect(mail.to).to eq([user.email])
         expect(mail.from).to eq(["contact@bikeindex.org"])
         expect(mail.tag).to eq "confirmation_email"
-        expect(Premailer::Rails::Hook.perform(mail).text_part.body.to_s).to include("Please confirm your email address").and include("Verify email")
+        expect(mail.deliver_now.text_part.body.to_s).to include("Please confirm your email address").and include("Verify email")
       end
     end
   end
@@ -48,7 +48,7 @@ RSpec.describe CustomerMailer, type: :mailer do
       # And just to be sure, test the route a little more
       expect(mail.body.encoded).to match(/users\/update_password_form_with_reset_token\?token=#{user.token_for_password_reset}/)
       expect(mail.tag).to eq "password_reset_email"
-      expect(Premailer::Rails::Hook.perform(mail).text_part.body.to_s).to include(user.token_for_password_reset).and include("Reset password")
+      expect(mail.deliver_now.text_part.body.to_s).to include(user.token_for_password_reset).and include("Reset password")
     end
   end
 
@@ -60,7 +60,7 @@ RSpec.describe CustomerMailer, type: :mailer do
       expect(mail.from).to eq(["contact@bikeindex.org"])
       expect(mail.body.encoded).to match(user.magic_link_token)
       expect(mail.tag).to eq "magic_login_link_email"
-      expect(Premailer::Rails::Hook.perform(mail).text_part.body.to_s).to include(user.magic_link_token).and include("Sign in")
+      expect(mail.deliver_now.text_part.body.to_s).to include(user.magic_link_token).and include("Sign in")
     end
   end
 
@@ -71,7 +71,7 @@ RSpec.describe CustomerMailer, type: :mailer do
       expect(mail.subject).to match(/confirm/i)
       expect(mail.from).to eq(["contact@bikeindex.org"])
       expect(mail.tag).to eq "additional_email_confirmation"
-      expect(Premailer::Rails::Hook.perform(mail).text_part.body.to_s).to include(user_email.email).and include("Verify email")
+      expect(mail.deliver_now.text_part.body.to_s).to include(user_email.email).and include("Verify email")
     end
   end
 
@@ -85,7 +85,7 @@ RSpec.describe CustomerMailer, type: :mailer do
         expect(mail.from).to eq(["contact@bikeindex.org"])
         expect(mail.body.encoded).to match "donation of"
         expect(mail.tag).to eq "invoice_email"
-        expect(Premailer::Rails::Hook.perform(mail).text_part.body.to_s).to include("donation of")
+        expect(mail.deliver_now.text_part.body.to_s).to include("donation of")
       end
     end
     context "payment" do
@@ -97,7 +97,7 @@ RSpec.describe CustomerMailer, type: :mailer do
         expect(mail.from).to eq(["contact@bikeindex.org"])
         expect(mail.body.encoded).to_not match "donation of"
         expect(mail.tag).to eq "invoice_email"
-        expect(Premailer::Rails::Hook.perform(mail).text_part.body.to_s).to include("payment of").and include("Thank you so much")
+        expect(mail.deliver_now.text_part.body.to_s).to include("payment of").and include("Thank you so much")
       end
     end
   end
@@ -124,7 +124,7 @@ RSpec.describe CustomerMailer, type: :mailer do
       expect(mail.to).to eq([customer_contact.user_email])
       expect(mail.subject).to eq "CUSTOM CUSTOMER contact Title"
       expect(mail.from).to eq(["contact@bikeindex.org"])
-      expect(Premailer::Rails::Hook.perform(mail).text_part.body.to_s).to include("spreading the word about").and include("bikeindex")
+      expect(mail.deliver_now.text_part.body.to_s).to include("spreading the word about").and include("bikeindex")
     end
   end
 
@@ -140,7 +140,7 @@ RSpec.describe CustomerMailer, type: :mailer do
       expect(mail.subject).to eq "Your tall bike (multiple frames fused together) has been marked recovered!"
       expect(mail.from).to eq(["bryan@bikeindex.org"])
       expect(mail.body.encoded).to match recovered_description
-      expect(Premailer::Rails::Hook.perform(mail).text_part.body.to_s).to include(recovered_description).and include("was marked")
+      expect(mail.deliver_now.text_part.body.to_s).to include(recovered_description).and include("was marked")
     end
   end
 
@@ -162,7 +162,7 @@ RSpec.describe CustomerMailer, type: :mailer do
       expect(mail.body.encoded).to match("some message")
       expect(mail.reply_to).to eq(["something@stuff.com"])
       expect(mail.from).to eq(["contact@bikeindex.org"])
-      expect(Premailer::Rails::Hook.perform(mail).text_part.body.to_s).to include("some message")
+      expect(mail.deliver_now.text_part.body.to_s).to include("some message")
     end
   end
 
@@ -177,7 +177,7 @@ RSpec.describe CustomerMailer, type: :mailer do
       expect(mail.from.first).to eq("bryan@bikeindex.org")
       expect(mail.body.encoded).to match(stolen_notification.message)
       expect(mail.body.encoded).to match(stolen_notification.reference_url)
-      expect(Premailer::Rails::Hook.perform(mail).text_part.body.to_s).to include(stolen_notification.message).and include(stolen_notification.reference_url)
+      expect(mail.deliver_now.text_part.body.to_s).to include(stolen_notification.message).and include(stolen_notification.reference_url)
       expect(mail.reply_to).to eq(["party@example.com"])
       expect(mail.cc).to eq(["bryan@bikeindex.org", "gavin@bikeindex.org"])
       stolen_notification.reload
@@ -199,7 +199,7 @@ RSpec.describe CustomerMailer, type: :mailer do
       expect(mail.from.count).to eq(1)
       expect(mail.from.first).to eq("gavin@bikeindex.org")
       expect(mail.body.encoded).to_not match "vendor terms"
-      expect(Premailer::Rails::Hook.perform(mail).text_part.body.to_s).to include("Gavin Hoover and the Bike Index Team").and include("updated our privacy policy")
+      expect(mail.deliver_now.text_part.body.to_s).to include("Gavin Hoover and the Bike Index Team").and include("updated our privacy policy")
     end
   end
 

--- a/spec/mailers/donation_mailer_spec.rb
+++ b/spec/mailers/donation_mailer_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe DonationMailer, type: :mailer do
       expect(mail.body.encoded).to match(/gavin/i)
       expect(mail.tag).to eq "donation"
       expect(mail.body.encoded).to_not match(/supported by/i)
-      expect(Premailer::Rails::Hook.perform(mail).text_part.body.to_s).to include("recently donated to Bike Index").and match(/gavin/i)
+      expect(mail.deliver_now.text_part.body.to_s).to include("recently donated to Bike Index").and match(/gavin/i)
     end
   end
 
@@ -23,7 +23,7 @@ RSpec.describe DonationMailer, type: :mailer do
           expect(mail.subject).to eq("Thank you for donating to Bike Index")
           expect(mail.to).to eq([payment.email])
           expect(mail.tag).to eq "donation"
-          expect(Premailer::Rails::Hook.perform(mail).text_part.body.to_s).to include("Gavin Hoover").and include("BikeIndex.org")
+          expect(mail.deliver_now.text_part.body.to_s).to include("Gavin Hoover").and include("BikeIndex.org")
         end
       end
     end

--- a/spec/mailers/donation_mailer_spec.rb
+++ b/spec/mailers/donation_mailer_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe DonationMailer, type: :mailer do
       expect(mail.body.encoded).to match(/gavin/i)
       expect(mail.tag).to eq "donation"
       expect(mail.body.encoded).to_not match(/supported by/i)
+      expect(Premailer::Rails::Hook.perform(mail).text_part.body.to_s).to include("recently donated to Bike Index").and match(/gavin/i)
     end
   end
 
@@ -22,6 +23,7 @@ RSpec.describe DonationMailer, type: :mailer do
           expect(mail.subject).to eq("Thank you for donating to Bike Index")
           expect(mail.to).to eq([payment.email])
           expect(mail.tag).to eq "donation"
+          expect(Premailer::Rails::Hook.perform(mail).text_part.body.to_s).to include("Gavin Hoover").and include("BikeIndex.org")
         end
       end
     end

--- a/spec/mailers/organized_mailer_spec.rb
+++ b/spec/mailers/organized_mailer_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe OrganizedMailer, type: :mailer do
         expect(mail.tag).to eq "partial_registration"
         expect_render_donation(true, mail)
         expect_render_supporters(true, mail)
-        expect(Premailer::Rails::Hook.perform(mail).text_part.body.to_s).to include("Almost Done").and include("Finish it")
+        expect(mail.deliver_now.text_part.body.to_s).to include("Almost Done").and include("Finish it")
       end
     end
     context "with organization" do
@@ -64,7 +64,7 @@ RSpec.describe OrganizedMailer, type: :mailer do
           expect(mail.tag).to eq "partial_registration"
           expect_render_donation(true, mail)
           expect_render_supporters(true, mail)
-          expect(Premailer::Rails::Hook.perform(mail).text_part.body.to_s).to include("HEADERXSNIPPET").and include("Almost Done")
+          expect(mail.deliver_now.text_part.body.to_s).to include("HEADERXSNIPPET").and include("Almost Done")
         end
         context "with partial snippet and paid invoice" do
           let!(:partial_mail_snippet) do
@@ -88,7 +88,7 @@ RSpec.describe OrganizedMailer, type: :mailer do
             expect(mail.tag).to eq "partial_registration"
             expect_render_donation(false, mail)
             expect_render_supporters(false, mail)
-            expect(Premailer::Rails::Hook.perform(mail).text_part.body.to_s).to include("HEADERXSNIPPET").and include("PARTIALYXSNIPPET")
+            expect(mail.deliver_now.text_part.body.to_s).to include("HEADERXSNIPPET").and include("PARTIALYXSNIPPET")
           end
         end
       end
@@ -104,7 +104,7 @@ RSpec.describe OrganizedMailer, type: :mailer do
         expect(mail.tag).to eq "finished_registration"
         expect_render_donation(true, mail)
         expect_render_supporters(true, mail)
-        expect(Premailer::Rails::Hook.perform(mail).text_part.body.to_s).to include("Confirm this").and include("Protect your bike")
+        expect(mail.deliver_now.text_part.body.to_s).to include("Confirm this").and include("Protect your bike")
       end
     end
     context "existing bike and ownership passed" do
@@ -120,7 +120,7 @@ RSpec.describe OrganizedMailer, type: :mailer do
           expect(mail.tag).to eq "finished_registration"
           expect_render_donation(true, mail)
           expect_render_supporters(true, mail)
-          expect(Premailer::Rails::Hook.perform(mail).text_part.body.to_s).to include("Confirm this").and include("Protect your bike")
+          expect(mail.deliver_now.text_part.body.to_s).to include("Confirm this").and include("Protect your bike")
         end
       end
       context "claimed registration (e.g. self_made)" do
@@ -134,7 +134,7 @@ RSpec.describe OrganizedMailer, type: :mailer do
           expect(mail.tag).to eq "finished_registration"
           expect_render_donation(true, mail)
           expect_render_supporters(true, mail)
-          expect(Premailer::Rails::Hook.perform(mail).text_part.body.to_s).to include("Protect your bike")
+          expect(mail.deliver_now.text_part.body.to_s).to include("Protect your bike")
         end
       end
       context "pos registration" do
@@ -151,7 +151,7 @@ RSpec.describe OrganizedMailer, type: :mailer do
           expect(mail.tag).to eq "finished_registration_pos"
           expect_render_donation(true, mail)
           expect_render_supporters(false, mail)
-          expect(Premailer::Rails::Hook.perform(mail).text_part.body.to_s).to include("Confirm this").and include(bike.creation_organization.name)
+          expect(mail.deliver_now.text_part.body.to_s).to include("Confirm this").and include(bike.creation_organization.name)
           # But for a transferred registration, it does different
           ownership2 = FactoryBot.create(:ownership, bike: bike)
           expect(bike.reload.current_ownership.id).to eq ownership2.id
@@ -183,7 +183,7 @@ RSpec.describe OrganizedMailer, type: :mailer do
           expect(mail.tag).to eq "finished_registration"
           expect_render_donation(true, mail)
           expect_render_supporters(false, mail)
-          expect(Premailer::Rails::Hook.perform(mail).text_part.body.to_s).to include(bike.creation_organization.name).and include("Protect your bike")
+          expect(mail.deliver_now.text_part.body.to_s).to include(bike.creation_organization.name).and include("Protect your bike")
           # Transferred registration
           BikeServices::Updator.new(user: user, bike: bike, permitted_params: {bike: {owner_email: "new@bikes.com"}}.as_json).update_available_attributes
           CallbackJob::AfterBikeSaveJob.new.perform(bike.id, true, true)
@@ -218,7 +218,7 @@ RSpec.describe OrganizedMailer, type: :mailer do
           expect(mail.tag).to eq "finished_registration"
           expect_render_donation(true, mail)
           expect_render_supporters(true, mail)
-          expect(Premailer::Rails::Hook.perform(mail).text_part.body.to_s).to include(bike.creation_organization.name).and include("Protect your bike")
+          expect(mail.deliver_now.text_part.body.to_s).to include(bike.creation_organization.name).and include("Protect your bike")
         end
         context "Bike shop" do
           let(:organization) { FactoryBot.create(:organization, :with_auto_user, kind: "bike_shop") }
@@ -242,7 +242,7 @@ RSpec.describe OrganizedMailer, type: :mailer do
           expect(mail.tag).to eq "finished_registration"
           expect_render_donation(true, mail)
           expect_render_supporters(true, mail)
-          expect(Premailer::Rails::Hook.perform(mail).text_part.body.to_s).to include(bike.current_stolen_record.find_or_create_recovery_link_token)
+          expect(mail.deliver_now.text_part.body.to_s).to include(bike.current_stolen_record.find_or_create_recovery_link_token)
         end
       end
     end
@@ -274,7 +274,7 @@ RSpec.describe OrganizedMailer, type: :mailer do
           expect(mail.body.encoded).to match security_mail_snippet.body
           expect(mail.reply_to).to eq([organization.auto_user.email])
           expect(mail.tag).to eq "finished_registration"
-          expect(Premailer::Rails::Hook.perform(mail).text_part.body.to_s).to include("WELCOMEXSNIPPET").and include("SECURITYXSNIPPET")
+          expect(mail.deliver_now.text_part.body.to_s).to include("WELCOMEXSNIPPET").and include("SECURITYXSNIPPET")
         end
       end
       context "new stolen registration" do
@@ -307,7 +307,7 @@ RSpec.describe OrganizedMailer, type: :mailer do
           expect(mail.subject).to eq("Confirm your Bike Index registration")
           expect(mail.reply_to).to eq(["contact@bikeindex.org"])
           expect(mail.tag).to eq "finished_registration"
-          expect(Premailer::Rails::Hook.perform(mail).text_part.body.to_s).to include("Confirm this").and include("Protect your bike")
+          expect(mail.deliver_now.text_part.body.to_s).to include("Confirm this").and include("Protect your bike")
         end
       end
     end
@@ -322,7 +322,7 @@ RSpec.describe OrganizedMailer, type: :mailer do
       expect(mail.subject).to eq("Join #{organization.short_name} on Bike Index")
       expect(mail.reply_to).to eq([organization.auto_user.email])
       expect(mail.tag).to eq "organization_invitation"
-      expect(Premailer::Rails::Hook.perform(mail).text_part.body.to_s).to include("HEADERXSNIPPET").and include("Join #{organization.short_name}")
+      expect(mail.deliver_now.text_part.body.to_s).to include("HEADERXSNIPPET").and include("Join #{organization.short_name}")
     end
   end
 
@@ -339,7 +339,7 @@ RSpec.describe OrganizedMailer, type: :mailer do
       expect(mail.body.encoded).to match target_retrieval_link_url
       expect(mail.reply_to).to eq([parking_notification.reply_to_email])
       expect(mail.tag).to eq "parking_notification"
-      expect(Premailer::Rails::Hook.perform(mail).text_part.body.to_s).to include("parked incorrectly").and include("It is located at:")
+      expect(mail.deliver_now.text_part.body.to_s).to include("parked incorrectly").and include("It is located at:")
     end
     context "parking_notification kind: other_notification" do
       let(:parking_notification) { FactoryBot.create(:parking_notification_organized, organization: organization, kind: :other_parking_notification) }
@@ -351,7 +351,7 @@ RSpec.describe OrganizedMailer, type: :mailer do
         expect(mail.body.encoded).to_not match target_retrieval_link_url
         expect(mail.reply_to).to eq([parking_notification.reply_to_email])
         expect(mail.tag).to eq "parking_notification"
-        expect(Premailer::Rails::Hook.perform(mail).text_part.body.to_s).to include("This is for your").and include("It is located at:")
+        expect(mail.deliver_now.text_part.body.to_s).to include("This is for your").and include("It is located at:")
       end
     end
     context "impound" do
@@ -362,7 +362,7 @@ RSpec.describe OrganizedMailer, type: :mailer do
         expect(mail.body.encoded).to match "map" # includes location
         expect(mail.body.encoded).to_not match "I picked up my"
         expect(mail.reply_to).to eq([parking_notification.reply_to_email])
-        expect(Premailer::Rails::Hook.perform(mail).text_part.body.to_s).to include("was impounded").and include("It was located at:")
+        expect(mail.deliver_now.text_part.body.to_s).to include("was impounded").and include("It was located at:")
       end
       context "impound_configuration email" do
         let!(:impound_configuration) { FactoryBot.create(:impound_configuration, email: "example@email.com", organization: organization) }
@@ -371,7 +371,7 @@ RSpec.describe OrganizedMailer, type: :mailer do
           expect(mail.body.encoded).to match header_mail_snippet.body
           expect(mail.body.encoded).to match "map" # includes location
           expect(mail.reply_to).to eq(["example@email.com"])
-          expect(Premailer::Rails::Hook.perform(mail).text_part.body.to_s).to include("was impounded").and include("It was located at:")
+          expect(mail.deliver_now.text_part.body.to_s).to include("was impounded").and include("It was located at:")
         end
       end
       context "with impound_record location" do
@@ -391,7 +391,7 @@ RSpec.describe OrganizedMailer, type: :mailer do
           expect(mail.body.encoded).to match "1300 W 14th Pl"
           expect(mail.body.encoded).to match "Chicago"
           expect(mail.body.encoded).to match "IL 60608"
-          expect(Premailer::Rails::Hook.perform(mail).text_part.body.to_s).to include("Main Impound Lot").and include("1300 W 14th Pl")
+          expect(mail.deliver_now.text_part.body.to_s).to include("Main Impound Lot").and include("1300 W 14th Pl")
         end
       end
     end
@@ -410,7 +410,7 @@ RSpec.describe OrganizedMailer, type: :mailer do
       expect(mail.to).to eq([graduated_notification.email])
       expect(mail.reply_to).to eq([organization.auto_user.email])
       expect(mail.subject).to eq graduated_notification.subject
-      expect(Premailer::Rails::Hook.perform(mail).text_part.body.to_s).to include("HEADERXSNIPPET").and include(target_remaining_link_url)
+      expect(mail.deliver_now.text_part.body.to_s).to include("HEADERXSNIPPET").and include(target_remaining_link_url)
     end
     context "with graduated_notification snippet" do
       let(:variable_snippet_kind) { "graduated_notification" }
@@ -423,7 +423,7 @@ RSpec.describe OrganizedMailer, type: :mailer do
         expect(mail.reply_to).to eq([organization.auto_user.email])
         expect(mail.subject).to eq graduated_notification.subject
         expect(mail.tag).to eq "graduated_notification"
-        expect(Premailer::Rails::Hook.perform(mail).text_part.body.to_s).to include("HEADERXSNIPPET").and include(variable_snippet.body.gsub(/<\/?p>/, ""))
+        expect(mail.deliver_now.text_part.body.to_s).to include("HEADERXSNIPPET").and include(variable_snippet.body.gsub(/<\/?p>/, ""))
       end
     end
   end
@@ -450,7 +450,7 @@ RSpec.describe OrganizedMailer, type: :mailer do
       # It removes the auto_user from the bcc
       expect(mail.bcc).to eq([recipient.email])
       expect(mail.subject).to eq hot_sheet.subject
-      expect(Premailer::Rails::Hook.perform(mail).text_part.body.to_s).to include("HEADERXSNIPPET").and include(hot_sheet.subject)
+      expect(mail.deliver_now.text_part.body.to_s).to include("HEADERXSNIPPET").and include(hot_sheet.subject)
       # expect the bike to have a thumb_path
       bike.reload
       expect(bike.thumb_path).to be_present

--- a/spec/mailers/organized_mailer_spec.rb
+++ b/spec/mailers/organized_mailer_spec.rb
@@ -45,6 +45,7 @@ RSpec.describe OrganizedMailer, type: :mailer do
         expect(mail.tag).to eq "partial_registration"
         expect_render_donation(true, mail)
         expect_render_supporters(true, mail)
+        expect(Premailer::Rails::Hook.perform(mail).text_part.body.to_s).to include("Almost Done").and include("Finish it")
       end
     end
     context "with organization" do
@@ -63,6 +64,7 @@ RSpec.describe OrganizedMailer, type: :mailer do
           expect(mail.tag).to eq "partial_registration"
           expect_render_donation(true, mail)
           expect_render_supporters(true, mail)
+          expect(Premailer::Rails::Hook.perform(mail).text_part.body.to_s).to include("HEADERXSNIPPET").and include("Almost Done")
         end
         context "with partial snippet and paid invoice" do
           let!(:partial_mail_snippet) do
@@ -86,6 +88,7 @@ RSpec.describe OrganizedMailer, type: :mailer do
             expect(mail.tag).to eq "partial_registration"
             expect_render_donation(false, mail)
             expect_render_supporters(false, mail)
+            expect(Premailer::Rails::Hook.perform(mail).text_part.body.to_s).to include("HEADERXSNIPPET").and include("PARTIALYXSNIPPET")
           end
         end
       end
@@ -101,6 +104,7 @@ RSpec.describe OrganizedMailer, type: :mailer do
         expect(mail.tag).to eq "finished_registration"
         expect_render_donation(true, mail)
         expect_render_supporters(true, mail)
+        expect(Premailer::Rails::Hook.perform(mail).text_part.body.to_s).to include("Confirm this").and include("Protect your bike")
       end
     end
     context "existing bike and ownership passed" do
@@ -116,6 +120,7 @@ RSpec.describe OrganizedMailer, type: :mailer do
           expect(mail.tag).to eq "finished_registration"
           expect_render_donation(true, mail)
           expect_render_supporters(true, mail)
+          expect(Premailer::Rails::Hook.perform(mail).text_part.body.to_s).to include("Confirm this").and include("Protect your bike")
         end
       end
       context "claimed registration (e.g. self_made)" do
@@ -129,6 +134,7 @@ RSpec.describe OrganizedMailer, type: :mailer do
           expect(mail.tag).to eq "finished_registration"
           expect_render_donation(true, mail)
           expect_render_supporters(true, mail)
+          expect(Premailer::Rails::Hook.perform(mail).text_part.body.to_s).to include("Protect your bike")
         end
       end
       context "pos registration" do
@@ -145,6 +151,7 @@ RSpec.describe OrganizedMailer, type: :mailer do
           expect(mail.tag).to eq "finished_registration_pos"
           expect_render_donation(true, mail)
           expect_render_supporters(false, mail)
+          expect(Premailer::Rails::Hook.perform(mail).text_part.body.to_s).to include("Confirm this").and include(bike.creation_organization.name)
           # But for a transferred registration, it does different
           ownership2 = FactoryBot.create(:ownership, bike: bike)
           expect(bike.reload.current_ownership.id).to eq ownership2.id
@@ -176,6 +183,7 @@ RSpec.describe OrganizedMailer, type: :mailer do
           expect(mail.tag).to eq "finished_registration"
           expect_render_donation(true, mail)
           expect_render_supporters(false, mail)
+          expect(Premailer::Rails::Hook.perform(mail).text_part.body.to_s).to include(bike.creation_organization.name).and include("Protect your bike")
           # Transferred registration
           BikeServices::Updator.new(user: user, bike: bike, permitted_params: {bike: {owner_email: "new@bikes.com"}}.as_json).update_available_attributes
           CallbackJob::AfterBikeSaveJob.new.perform(bike.id, true, true)
@@ -210,6 +218,7 @@ RSpec.describe OrganizedMailer, type: :mailer do
           expect(mail.tag).to eq "finished_registration"
           expect_render_donation(true, mail)
           expect_render_supporters(true, mail)
+          expect(Premailer::Rails::Hook.perform(mail).text_part.body.to_s).to include(bike.creation_organization.name).and include("Protect your bike")
         end
         context "Bike shop" do
           let(:organization) { FactoryBot.create(:organization, :with_auto_user, kind: "bike_shop") }
@@ -233,6 +242,7 @@ RSpec.describe OrganizedMailer, type: :mailer do
           expect(mail.tag).to eq "finished_registration"
           expect_render_donation(true, mail)
           expect_render_supporters(true, mail)
+          expect(Premailer::Rails::Hook.perform(mail).text_part.body.to_s).to include(bike.current_stolen_record.find_or_create_recovery_link_token)
         end
       end
     end
@@ -264,6 +274,7 @@ RSpec.describe OrganizedMailer, type: :mailer do
           expect(mail.body.encoded).to match security_mail_snippet.body
           expect(mail.reply_to).to eq([organization.auto_user.email])
           expect(mail.tag).to eq "finished_registration"
+          expect(Premailer::Rails::Hook.perform(mail).text_part.body.to_s).to include("WELCOMEXSNIPPET").and include("SECURITYXSNIPPET")
         end
       end
       context "new stolen registration" do
@@ -296,6 +307,7 @@ RSpec.describe OrganizedMailer, type: :mailer do
           expect(mail.subject).to eq("Confirm your Bike Index registration")
           expect(mail.reply_to).to eq(["contact@bikeindex.org"])
           expect(mail.tag).to eq "finished_registration"
+          expect(Premailer::Rails::Hook.perform(mail).text_part.body.to_s).to include("Confirm this").and include("Protect your bike")
         end
       end
     end
@@ -310,6 +322,7 @@ RSpec.describe OrganizedMailer, type: :mailer do
       expect(mail.subject).to eq("Join #{organization.short_name} on Bike Index")
       expect(mail.reply_to).to eq([organization.auto_user.email])
       expect(mail.tag).to eq "organization_invitation"
+      expect(Premailer::Rails::Hook.perform(mail).text_part.body.to_s).to include("HEADERXSNIPPET").and include("Join #{organization.short_name}")
     end
   end
 
@@ -326,6 +339,7 @@ RSpec.describe OrganizedMailer, type: :mailer do
       expect(mail.body.encoded).to match target_retrieval_link_url
       expect(mail.reply_to).to eq([parking_notification.reply_to_email])
       expect(mail.tag).to eq "parking_notification"
+      expect(Premailer::Rails::Hook.perform(mail).text_part.body.to_s).to include("parked incorrectly").and include("It is located at:")
     end
     context "parking_notification kind: other_notification" do
       let(:parking_notification) { FactoryBot.create(:parking_notification_organized, organization: organization, kind: :other_parking_notification) }
@@ -337,6 +351,7 @@ RSpec.describe OrganizedMailer, type: :mailer do
         expect(mail.body.encoded).to_not match target_retrieval_link_url
         expect(mail.reply_to).to eq([parking_notification.reply_to_email])
         expect(mail.tag).to eq "parking_notification"
+        expect(Premailer::Rails::Hook.perform(mail).text_part.body.to_s).to include("This is for your").and include("It is located at:")
       end
     end
     context "impound" do
@@ -347,6 +362,7 @@ RSpec.describe OrganizedMailer, type: :mailer do
         expect(mail.body.encoded).to match "map" # includes location
         expect(mail.body.encoded).to_not match "I picked up my"
         expect(mail.reply_to).to eq([parking_notification.reply_to_email])
+        expect(Premailer::Rails::Hook.perform(mail).text_part.body.to_s).to include("was impounded").and include("It was located at:")
       end
       context "impound_configuration email" do
         let!(:impound_configuration) { FactoryBot.create(:impound_configuration, email: "example@email.com", organization: organization) }
@@ -355,6 +371,7 @@ RSpec.describe OrganizedMailer, type: :mailer do
           expect(mail.body.encoded).to match header_mail_snippet.body
           expect(mail.body.encoded).to match "map" # includes location
           expect(mail.reply_to).to eq(["example@email.com"])
+          expect(Premailer::Rails::Hook.perform(mail).text_part.body.to_s).to include("was impounded").and include("It was located at:")
         end
       end
       context "with impound_record location" do
@@ -374,6 +391,7 @@ RSpec.describe OrganizedMailer, type: :mailer do
           expect(mail.body.encoded).to match "1300 W 14th Pl"
           expect(mail.body.encoded).to match "Chicago"
           expect(mail.body.encoded).to match "IL 60608"
+          expect(Premailer::Rails::Hook.perform(mail).text_part.body.to_s).to include("Main Impound Lot").and include("1300 W 14th Pl")
         end
       end
     end
@@ -392,6 +410,7 @@ RSpec.describe OrganizedMailer, type: :mailer do
       expect(mail.to).to eq([graduated_notification.email])
       expect(mail.reply_to).to eq([organization.auto_user.email])
       expect(mail.subject).to eq graduated_notification.subject
+      expect(Premailer::Rails::Hook.perform(mail).text_part.body.to_s).to include("HEADERXSNIPPET").and include(target_remaining_link_url)
     end
     context "with graduated_notification snippet" do
       let(:variable_snippet_kind) { "graduated_notification" }
@@ -404,6 +423,7 @@ RSpec.describe OrganizedMailer, type: :mailer do
         expect(mail.reply_to).to eq([organization.auto_user.email])
         expect(mail.subject).to eq graduated_notification.subject
         expect(mail.tag).to eq "graduated_notification"
+        expect(Premailer::Rails::Hook.perform(mail).text_part.body.to_s).to include("HEADERXSNIPPET").and include(variable_snippet.body.gsub(/<\/?p>/, ""))
       end
     end
   end
@@ -430,6 +450,7 @@ RSpec.describe OrganizedMailer, type: :mailer do
       # It removes the auto_user from the bcc
       expect(mail.bcc).to eq([recipient.email])
       expect(mail.subject).to eq hot_sheet.subject
+      expect(Premailer::Rails::Hook.perform(mail).text_part.body.to_s).to include("HEADERXSNIPPET").and include(hot_sheet.subject)
       # expect the bike to have a thumb_path
       bike.reload
       expect(bike.thumb_path).to be_present


### PR DESCRIPTION
Add `text_part.body.to_s` assertions to every "renders email" example across the four mailer specs (admin, customer, donation, organized) so the suite fails loudly if premailer ever stops generating a text part or strips something important. Each new assertion checks one or two distinguishing phrases — reusing content already matched in `body.encoded` where possible (feedback body, stolen-notification message, recovery tokens, mail-snippet bodies) and template phrases otherwise ("Welcome to Bike Index", "Protect your bike", "It is located at:", etc.).

Premailer-rails generates the text part via a delivery interceptor, so `mail.text_part` is nil for a built-but-undelivered mail. The new assertions chain through `mail.deliver_now`, which runs the interceptor and returns the mutated message; in test env this just appends to `ActionMailer::Base.deliveries` (cleared between examples).
