### PR TITLE
Skill docs: screenshots-in-comment + default org slug

### DIFF
--- a/.claude/skills/frontend-screenshots/SKILL.md
+++ b/.claude/skills/frontend-screenshots/SKILL.md
@@ -36,6 +36,8 @@ Pick the user the caller specified, or default to `user@bikeindex.org` (lowest p
 
 If a URL redirects to `/session/new` or `/session/magic_link`, drive the form via Playwright — don't ask the user to sign in manually.
 
+**Picking an org slug.** When the URL is org-scoped (`/o/<slug>/...`) and the caller didn't specify a slug, default to `hogwarts`
+
 **Verify identity before capturing.** The dev DB can contain real-looking data (see `feedback_no_programmatic_auth_for_screenshots.md`). Check:
 
 ```js

--- a/.claude/skills/pr/SKILL.md
+++ b/.claude/skills/pr/SKILL.md
@@ -71,7 +71,7 @@ Only continue past this step when there's a real reason to capture. Otherwise re
 - New PR + `FRONTEND=false` → done.
 - New PR + `FRONTEND=true` → continue; capture every affected page.
 - Existing PR + `FRONTEND=false` → done.
-- Existing PR + `FRONTEND=true` → continue only if the captures in the existing body are stale: a commit since the last capture touched a page already screenshotted, or a new affected page now appears in the diff. Limit step 5 to those pages. If nothing has moved, done.
+- Existing PR + `FRONTEND=true` → continue only if the captures in the existing screenshots comment are stale: a commit since the last capture touched a page already screenshotted, or a new affected page now appears in the diff. Limit step 5 to those pages. If nothing has moved, done.
 
 From the changed files, infer the affected routes. Heuristics:
 - A view at `app/views/bikes/show.html.erb` → `/bikes/:id` (pick a representative id from the dev db, e.g. `Bike.last.id`)
@@ -100,14 +100,25 @@ Skip per-page only when the URL didn't exist on `main` (a brand-new route or pag
 
 Re-invoke `frontend-screenshots` with the same `(url-path, page-slug)` pairs and tell it to capture against `main` (its step 6 — git checkout dance, captures into `...-main-...` filenames, returns to the original branch). Then re-invoke `github-upload-image-to-pr` for those PNGs.
 
-### 7. Append the Screenshots section to the PR body
+### 7. Post the Screenshots section as the first PR comment
 
-Append this to the existing body and `gh pr edit <num> --body-file <tmp-body-file>` again. **Headers are always `| Desktop | Mobile |`** — that stays the same regardless of whether there's a main comparison. The main shots and branch shots stack as additional rows, with a small indicator row between them when both are present.
+Post the screenshots as a **PR comment**, not in the PR body. This keeps the description tight and skimmable — reviewers see the human-written summary first, with screenshots one scroll down. It also avoids re-editing the body (and its notification noise) every time screenshots are recaptured.
+
+On a fresh PR, this comment is naturally the first one. On an update, find the existing screenshots comment (the one authored by you whose body starts with `## Screenshots`) and edit it in place rather than posting a new one:
+
+```bash
+SCREENSHOT_COMMENT_ID=$(gh api repos/{owner}/{repo}/issues/{PR_NUMBER}/comments \
+  --jq '.[] | select(.body | startswith("## Screenshots")) | .id' | head -1)
+```
+
+- If `$SCREENSHOT_COMMENT_ID` is empty: `gh pr comment <num> --body-file <tmp-comment-file>`.
+- Otherwise: `gh api -X PATCH repos/{owner}/{repo}/issues/comments/$SCREENSHOT_COMMENT_ID -f body=@<tmp-comment-file>`.
+
+**Headers are always `| Desktop | Mobile |`** — that stays the same regardless of whether there's a main comparison. The main shots and branch shots stack as additional rows, with a small indicator row between them when both are present.
 
 Default (with main comparison):
 
 ```markdown
-
 ## Screenshots
 
 ### <url-path>
@@ -134,7 +145,7 @@ Rules:
 - **Headers are always `| Desktop | Mobile |`** — never `| main | this branch |` or any per-PR variation. Reviewers should see the same column meaning across every PR.
 - Use `<img src=... width=...>` rather than `![]()` so the widths render predictably in GitHub's table cells. ~500 for desktop, ~250 for mobile fits a side-by-side cell layout cleanly.
 
-When updating an existing body, replace the existing `### <url-path>` block for any page you recaptured; leave other pages' blocks alone.
+When updating an existing screenshots comment, replace the existing `### <url-path>` block for any page you recaptured; leave other pages' blocks alone.
 
 Return the PR URL.
 


### PR DESCRIPTION
Two unrelated skill doc tweaks bundled on this branch:

- `pr` skill: post the `## Screenshots` section as a PR comment rather than appending it to the description, so the body stays focused on the human-written summary. Re-runs locate the existing screenshots comment via the issues-comments API and PATCH it in place.
- `frontend-screenshots` skill: note that org-scoped URLs (`/o/<slug>/...`) default to the `hogwarts` slug when the caller doesn't specify one.
