### PR TITLE
API V3 Me: include organization menu in serialized membership

### DIFF
--- a/app/controllers/api/v3/me.rb
+++ b/app/controllers/api/v3/me.rb
@@ -33,7 +33,8 @@ module API
               organization_id: membership.organization_id,
               organization_access_token: membership.organization.access_token,
               organization_logo_url: (membership.organization.avatar_url if membership.organization.avatar?),
-              user_is_organization_admin: membership.role == "admin"
+              user_is_organization_admin: membership.role == "admin",
+              menu: OrganizedServices::UserMenuItems.for(organization: membership.organization, current_user:)
             }
           end
 

--- a/spec/requests/api/v3/me_request_spec.rb
+++ b/spec/requests/api/v3/me_request_spec.rb
@@ -29,7 +29,8 @@ RSpec.describe "Me API V3", type: :request do
           organization_id: organization_role.organization_id,
           organization_access_token: organization_role.organization.access_token,
           organization_logo_url: nil,
-          user_is_organization_admin: false
+          user_is_organization_admin: false,
+          menu: OrganizedServices::UserMenuItems.for(organization: organization_role.organization, current_user: user)
         }
       end
       it "responds with all available attributes with full scoped token" do

--- a/spec/requests/api/v3/me_request_spec.rb
+++ b/spec/requests/api/v3/me_request_spec.rb
@@ -21,16 +21,30 @@ RSpec.describe "Me API V3", type: :request do
       let(:scopes) { all_scopes }
       let!(:secondary_email) { FactoryBot.create(:user_email, user: user, email: "d@f.co") }
       let!(:organization_role) { FactoryBot.create(:organization_role_claimed, user: user) }
+      let(:organization) { organization_role.organization }
+      let(:target_menu) do
+        [
+          {type: "link", label: "#{organization.short_name} Bikes",
+           path: "/o/#{organization.slug}/registrations",
+           secondary: false, active: "on_registrations_index"},
+          {type: "disabled", label: "Incomplete registrations", secondary: true},
+          {type: "link", label: "Add a bike",
+           path: "/o/#{organization.slug}/bikes/new",
+           secondary: false, active: "on_bikes_new"},
+          {type: "divider"},
+          {type: "disabled", label: "Registration stickers", secondary: false}
+        ]
+      end
       let(:target_membership) do
         {
-          organization_name: organization_role.organization.name,
-          organization_short_name: organization_role.organization.short_name,
-          organization_slug: organization_role.organization.slug,
-          organization_id: organization_role.organization_id,
-          organization_access_token: organization_role.organization.access_token,
+          organization_name: organization.name,
+          organization_short_name: organization.short_name,
+          organization_slug: organization.slug,
+          organization_id: organization.id,
+          organization_access_token: organization.access_token,
           organization_logo_url: nil,
           user_is_organization_admin: false,
-          menu: OrganizedServices::UserMenuItems.for(organization: organization_role.organization, current_user: user)
+          menu: target_menu
         }
       end
       it "responds with all available attributes with full scoped token" do


### PR DESCRIPTION
Adds a `menu` array to each membership in `GET /api/v3/me`, sourced from `OrganizedServices::UserMenuItems.for(organization:, current_user:)` so API consumers get the same per-user, per-org menu the web UI renders.

- `serialized_membership` now includes `menu:` alongside the existing organization fields.
- Spec asserts the membership payload matches `UserMenuItems.for(...)` for the user/org under test.
