### PR TITLE
Perf: avoid default_includes when finding a user's address bike

### DIFF
--- a/.claude/skills/rspec-testing/SKILL.md
+++ b/.claude/skills/rspec-testing/SKILL.md
@@ -20,6 +20,24 @@ This project uses RSpec. All business logic should be tested.
 - Avoid testing private methods.
 - Avoid mocking objects.
   - If making external requests, use VCR. Don't manually write VCR cassettes — record them by running the tests.
+- Don't use `tap` to bundle factory creation with follow-up setup. Create the record in `let`/`let!`, then do the follow-up work on its own line (a separate statement, or a `before` block). One thing per line reads better and keeps the factory call clean.
+
+### Good
+
+```ruby
+let!(:bike_transferred) { FactoryBot.create(:bike, :with_ownership_claimed, user:) }
+before { BikeServices::OwnershipTransferer.find_or_create(bike_transferred, updator: user, new_owner_email: "new@example.com") }
+```
+
+### Bad
+
+```ruby
+let!(:bike_transferred) do
+  FactoryBot.create(:bike, :with_ownership_claimed, user:).tap do |bike|
+    BikeServices::OwnershipTransferer.find_or_create(bike, updator: user, new_owner_email: "new@example.com")
+  end
+end
+```
 
 ## Always fix failing tests
 

--- a/app/services/user_services/updator.rb
+++ b/app/services/user_services/updator.rb
@@ -2,7 +2,7 @@ module UserServices
   class Updator
     class << self
       def assign_address_from_bikes(user, bikes: nil, save_user: false)
-        bikes ||= user.bikes
+        bikes ||= bikes_for_user(user)
         address_bike = bikes.with_street.first || bikes.with_location.first
         return if address_bike.blank?
 
@@ -21,6 +21,16 @@ module UserServices
         }
         user.update(skip_update: true) if save_user
         user
+      end
+
+      private
+
+      # Skip user.bikes' default_includes — with_street's where.not + LIMIT 1
+      # would otherwise force a 6-table LEFT JOIN to find one row.
+      def bikes_for_user(user)
+        Bike.unscoped.without_deleted.where(example: false)
+          .joins(:current_ownership).where(ownerships: {user_id: user.id})
+          .order(:id)
       end
     end
   end

--- a/spec/services/user_services/updator_spec.rb
+++ b/spec/services/user_services/updator_spec.rb
@@ -3,6 +3,21 @@ require "rails_helper"
 RSpec.describe UserServices::Updator do
   let(:user) { FactoryBot.create(:user, :confirmed, email: "aftercreate@bikeindex.org") }
 
+  describe "bikes_for_user" do
+    let!(:bike_kept) { FactoryBot.create(:bike, :with_ownership_claimed, user:) }
+    let!(:bike_transferred) do
+      FactoryBot.create(:bike, :with_ownership_claimed, user:).tap do |bike|
+        BikeServices::OwnershipTransferer.find_or_create(bike, updator: user, new_owner_email: "newowner@example.com")
+      end
+    end
+    let!(:bike_deleted) { FactoryBot.create(:bike, :with_ownership_claimed, user:, deleted_at: Time.current) }
+
+    it "matches user.bikes" do
+      expect(user.bikes.pluck(:id)).to eq([bike_kept.id])
+      expect(described_class.send(:bikes_for_user, user).pluck(:id)).to match_array(user.bikes.pluck(:id))
+    end
+  end
+
   describe "assign_address_from_bikes", vcr: {cassette_name: :assign_address_from_bikes} do
     let!(:state) { FactoryBot.create(:state_california) }
     let!(:country) { Country.united_states }

--- a/spec/services/user_services/updator_spec.rb
+++ b/spec/services/user_services/updator_spec.rb
@@ -5,11 +5,8 @@ RSpec.describe UserServices::Updator do
 
   describe "bikes_for_user" do
     let!(:bike_kept) { FactoryBot.create(:bike, :with_ownership_claimed, user:) }
-    let!(:bike_transferred) do
-      FactoryBot.create(:bike, :with_ownership_claimed, user:).tap do |bike|
-        BikeServices::OwnershipTransferer.find_or_create(bike, updator: user, new_owner_email: "newowner@example.com")
-      end
-    end
+    let!(:bike_transferred) { FactoryBot.create(:bike, :with_ownership_claimed, user:) }
+    before { BikeServices::OwnershipTransferer.find_or_create(bike_transferred, updator: user, new_owner_email: "newowner@example.com") }
     let!(:bike_deleted) { FactoryBot.create(:bike, :with_ownership_claimed, user:, deleted_at: Time.current) }
 
     it "matches user.bikes" do

--- a/spec/services/user_services/updator_spec.rb
+++ b/spec/services/user_services/updator_spec.rb
@@ -6,8 +6,8 @@ RSpec.describe UserServices::Updator do
   describe "bikes_for_user" do
     let!(:bike_kept) { FactoryBot.create(:bike, :with_ownership_claimed, user:) }
     let!(:bike_transferred) { FactoryBot.create(:bike, :with_ownership_claimed, user:) }
-    before { BikeServices::OwnershipTransferer.find_or_create(bike_transferred, updator: user, new_owner_email: "newowner@example.com") }
     let!(:bike_deleted) { FactoryBot.create(:bike, :with_ownership_claimed, user:, deleted_at: Time.current) }
+    before { BikeServices::OwnershipTransferer.find_or_create(bike_transferred, updator: user, new_owner_email: "newowner@example.com") }
 
     it "matches user.bikes" do
       expect(user.bikes.pluck(:id)).to eq([bike_kept.id])


### PR DESCRIPTION
pghero flagged `UserServices::Updator#assign_address_from_bikes` as the top slow query in prod — averaging 1,691 ms and consuming 34% of total DB time.

Build the relation directly: `bikes INNER JOIN ownerships`, with `address_records` only joined when `with_street` filters on it.