### PR TITLE
Drop 61 unused indexes (primary + replica)

### DIFF
--- a/app/models/address_record.rb
+++ b/app/models/address_record.rb
@@ -24,11 +24,10 @@
 #
 # Indexes
 #
-#  index_address_records_on_bike_id           (bike_id) WHERE (bike_id IS NOT NULL)
-#  index_address_records_on_country_id        (country_id)
-#  index_address_records_on_organization_id   (organization_id) WHERE (organization_id IS NOT NULL)
-#  index_address_records_on_region_record_id  (region_record_id)
-#  index_address_records_on_user_id           (user_id) WHERE (user_id IS NOT NULL)
+#  index_address_records_on_bike_id          (bike_id) WHERE (bike_id IS NOT NULL)
+#  index_address_records_on_country_id       (country_id)
+#  index_address_records_on_organization_id  (organization_id) WHERE (organization_id IS NOT NULL)
+#  index_address_records_on_user_id          (user_id) WHERE (user_id IS NOT NULL)
 #
 class AddressRecord < ApplicationRecord
   include Geocodeable

--- a/app/models/ambassador.rb
+++ b/app/models/ambassador.rb
@@ -56,7 +56,6 @@
 # Indexes
 #
 #  index_users_on_address_record_id         (address_record_id)
-#  index_users_on_auth_token                (auth_token)
 #  index_users_on_email                     (email) WHERE (deleted_at IS NULL)
 #  index_users_on_email_trgm                (email) WHERE (deleted_at IS NULL) USING gin
 #  index_users_on_token_for_password_reset  (token_for_password_reset)

--- a/app/models/ambassador_task_assignment.rb
+++ b/app/models/ambassador_task_assignment.rb
@@ -12,8 +12,7 @@
 #
 # Indexes
 #
-#  index_ambassador_task_assignments_on_ambassador_task_id  (ambassador_task_id)
-#  unique_assignment_to_ambassador                          (user_id,ambassador_task_id) UNIQUE
+#  unique_assignment_to_ambassador  (user_id,ambassador_task_id) UNIQUE
 #
 # Foreign Keys
 #

--- a/app/models/bike.rb
+++ b/app/models/bike.rb
@@ -74,9 +74,7 @@
 # Indexes
 #
 #  index_bikes_current_listing_order               (listing_order) WHERE ((example = false) AND (user_hidden = false) AND (likely_spam = false) AND (deleted_at IS NULL))
-#  index_bikes_on_address_record_id                (address_record_id) WHERE (address_record_id IS NOT NULL)
 #  index_bikes_on_creation_organization_id         (creation_organization_id) WHERE (creation_organization_id IS NOT NULL)
-#  index_bikes_on_current_impound_record_id        (current_impound_record_id) WHERE (current_impound_record_id IS NOT NULL)
 #  index_bikes_on_current_ownership_id             (current_ownership_id)
 #  index_bikes_on_current_stolen_record_id         (current_stolen_record_id) WHERE (current_stolen_record_id IS NOT NULL)
 #  index_bikes_on_deleted_at                       (deleted_at) WHERE (deleted_at IS NOT NULL)
@@ -88,7 +86,6 @@
 #  index_bikes_on_manufacturer_id                  (manufacturer_id)
 #  index_bikes_on_model_audit_id                   (model_audit_id) WHERE (model_audit_id IS NOT NULL)
 #  index_bikes_on_owner_email_trgm                 (owner_email) USING gin
-#  index_bikes_on_paint_id                         (paint_id) WHERE (paint_id IS NOT NULL)
 #  index_bikes_on_primary_activity_id              (primary_activity_id) WHERE (primary_activity_id IS NOT NULL)
 #  index_bikes_on_primary_frame_color_id           (primary_frame_color_id)
 #  index_bikes_on_search_vector                    (search_vector) USING gin

--- a/app/models/bike_organization.rb
+++ b/app/models/bike_organization.rb
@@ -14,7 +14,6 @@
 # Indexes
 #
 #  index_bike_organizations_on_bike_id          (bike_id)
-#  index_bike_organizations_on_deleted_at       (deleted_at)
 #  index_bike_organizations_on_organization_id  (organization_id)
 #
 class BikeOrganization < ApplicationRecord

--- a/app/models/bike_organization_note.rb
+++ b/app/models/bike_organization_note.rb
@@ -16,8 +16,6 @@
 # Indexes
 #
 #  index_bike_organization_notes_on_bike_id_and_organization_id  (bike_id,organization_id) UNIQUE
-#  index_bike_organization_notes_on_organization_id              (organization_id)
-#  index_bike_organization_notes_on_user_id                      (user_id)
 #
 class BikeOrganizationNote < ApplicationRecord
   has_paper_trail only: %i[bike_id body]

--- a/app/models/bike_sticker.rb
+++ b/app/models/bike_sticker.rb
@@ -23,9 +23,8 @@
 #
 # Indexes
 #
-#  index_bike_stickers_on_bike_id                    (bike_id)
-#  index_bike_stickers_on_bike_sticker_batch_id      (bike_sticker_batch_id)
-#  index_bike_stickers_on_secondary_organization_id  (secondary_organization_id)
+#  index_bike_stickers_on_bike_id                (bike_id)
+#  index_bike_stickers_on_bike_sticker_batch_id  (bike_sticker_batch_id)
 #
 class BikeSticker < ApplicationRecord
   KIND_ENUM = {sticker: 0, spokecard: 1}.freeze

--- a/app/models/bike_sticker_batch.rb
+++ b/app/models/bike_sticker_batch.rb
@@ -12,11 +12,6 @@
 #  organization_id    :integer
 #  user_id            :integer
 #
-# Indexes
-#
-#  index_bike_sticker_batches_on_organization_id  (organization_id)
-#  index_bike_sticker_batches_on_user_id          (user_id)
-#
 class BikeStickerBatch < ApplicationRecord
   belongs_to :user # Creator of the batch
   belongs_to :organization

--- a/app/models/bike_version.rb
+++ b/app/models/bike_version.rb
@@ -49,18 +49,10 @@
 #
 # Indexes
 #
-#  index_bike_versions_on_bike_id                   (bike_id)
-#  index_bike_versions_on_front_gear_type_id        (front_gear_type_id)
-#  index_bike_versions_on_front_wheel_size_id       (front_wheel_size_id)
-#  index_bike_versions_on_manufacturer_id           (manufacturer_id)
-#  index_bike_versions_on_owner_id                  (owner_id)
-#  index_bike_versions_on_paint_id                  (paint_id)
-#  index_bike_versions_on_primary_activity_id       (primary_activity_id)
-#  index_bike_versions_on_primary_frame_color_id    (primary_frame_color_id)
-#  index_bike_versions_on_rear_gear_type_id         (rear_gear_type_id)
-#  index_bike_versions_on_rear_wheel_size_id        (rear_wheel_size_id)
-#  index_bike_versions_on_secondary_frame_color_id  (secondary_frame_color_id)
-#  index_bike_versions_on_tertiary_frame_color_id   (tertiary_frame_color_id)
+#  index_bike_versions_on_bike_id              (bike_id)
+#  index_bike_versions_on_manufacturer_id      (manufacturer_id)
+#  index_bike_versions_on_owner_id             (owner_id)
+#  index_bike_versions_on_primary_activity_id  (primary_activity_id)
 #
 class BikeVersion < ApplicationRecord
   include BikeSearchable

--- a/app/models/email_domain.rb
+++ b/app/models/email_domain.rb
@@ -18,7 +18,6 @@
 #
 # Indexes
 #
-#  index_email_domains_on_creator_id     (creator_id)
 #  index_email_domains_on_domain_trgm    (domain) USING gin
 #  index_email_domains_on_domain_unique  (domain) UNIQUE WHERE (deleted_at IS NULL)
 #

--- a/app/models/export.rb
+++ b/app/models/export.rb
@@ -19,7 +19,6 @@
 # Indexes
 #
 #  index_exports_on_organization_id  (organization_id)
-#  index_exports_on_user_id          (user_id)
 #
 class Export < ApplicationRecord
   PROGRESS_ENUM = {

--- a/app/models/external_registry_credential.rb
+++ b/app/models/external_registry_credential.rb
@@ -13,10 +13,6 @@
 #  updated_at              :datetime         not null
 #  app_id                  :string
 #
-# Indexes
-#
-#  index_external_registry_credentials_on_type  (type)
-#
 class ExternalRegistryCredential < ApplicationRecord
   validates :type, uniqueness: true
   validates :app_id, uniqueness: {scope: :type}

--- a/app/models/external_registry_credential/project529_credential.rb
+++ b/app/models/external_registry_credential/project529_credential.rb
@@ -13,10 +13,6 @@
 #  updated_at              :datetime         not null
 #  app_id                  :string
 #
-# Indexes
-#
-#  index_external_registry_credentials_on_type  (type)
-#
 class ExternalRegistryCredential
   class Project529Credential < ExternalRegistryCredential
     validates :app_id, :refresh_token, presence: true

--- a/app/models/external_registry_credential/stop_heling_credential.rb
+++ b/app/models/external_registry_credential/stop_heling_credential.rb
@@ -13,10 +13,6 @@
 #  updated_at              :datetime         not null
 #  app_id                  :string
 #
-# Indexes
-#
-#  index_external_registry_credentials_on_type  (type)
-#
 class ExternalRegistryCredential
   class StopHelingCredential < ExternalRegistryCredential
     validates :app_id, :access_token, presence: true

--- a/app/models/graduated_notification.rb
+++ b/app/models/graduated_notification.rb
@@ -24,8 +24,6 @@
 # Indexes
 #
 #  index_graduated_notifications_on_bike_id                  (bike_id)
-#  index_graduated_notifications_on_bike_organization_id     (bike_organization_id)
-#  index_graduated_notifications_on_marked_remaining_by_id   (marked_remaining_by_id)
 #  index_graduated_notifications_on_organization_id          (organization_id)
 #  index_graduated_notifications_on_primary_bike_id          (primary_bike_id)
 #  index_graduated_notifications_on_primary_notification_id  (primary_notification_id)

--- a/app/models/impound_configuration.rb
+++ b/app/models/impound_configuration.rb
@@ -14,10 +14,6 @@
 #  updated_at              :datetime         not null
 #  organization_id         :bigint
 #
-# Indexes
-#
-#  index_impound_configurations_on_organization_id  (organization_id)
-#
 class ImpoundConfiguration < ApplicationRecord
   belongs_to :organization
   has_many :impound_records, through: :organization

--- a/app/models/impound_record_update.rb
+++ b/app/models/impound_record_update.rb
@@ -19,8 +19,6 @@
 #
 #  index_impound_record_updates_on_impound_claim_id   (impound_claim_id)
 #  index_impound_record_updates_on_impound_record_id  (impound_record_id)
-#  index_impound_record_updates_on_location_id        (location_id)
-#  index_impound_record_updates_on_user_id            (user_id)
 #
 class ImpoundRecordUpdate < ApplicationRecord
   # These statuses are used by impound_records!

--- a/app/models/mail_snippet.rb
+++ b/app/models/mail_snippet.rb
@@ -13,11 +13,6 @@
 #  doorkeeper_app_id :bigint
 #  organization_id   :integer
 #
-# Indexes
-#
-#  index_mail_snippets_on_doorkeeper_app_id  (doorkeeper_app_id)
-#  index_mail_snippets_on_organization_id    (organization_id)
-#
 class MailSnippet < ApplicationRecord
   has_paper_trail only: %i[body is_enabled kind subject]
 

--- a/app/models/marketplace_listing.rb
+++ b/app/models/marketplace_listing.rb
@@ -28,7 +28,6 @@
 #  index_marketplace_listings_on_address_record_id  (address_record_id)
 #  index_marketplace_listings_on_buyer_id           (buyer_id)
 #  index_marketplace_listings_on_item               (item_type,item_id)
-#  index_marketplace_listings_on_sale_id            (sale_id)
 #  index_marketplace_listings_on_seller_id          (seller_id)
 #
 class MarketplaceListing < ApplicationRecord

--- a/app/models/membership.rb
+++ b/app/models/membership.rb
@@ -15,8 +15,7 @@
 #
 # Indexes
 #
-#  index_memberships_on_creator_id  (creator_id)
-#  index_memberships_on_user_id     (user_id)
+#  index_memberships_on_user_id  (user_id)
 #
 class Membership < ApplicationRecord
   include ActivePeriodable

--- a/app/models/model_attestation.rb
+++ b/app/models/model_attestation.rb
@@ -18,9 +18,7 @@
 #
 # Indexes
 #
-#  index_model_attestations_on_model_audit_id   (model_audit_id)
 #  index_model_attestations_on_organization_id  (organization_id)
-#  index_model_attestations_on_user_id          (user_id)
 #
 class ModelAttestation < ApplicationRecord
   # NOTE: This hash is ordered by the importance of the kind

--- a/app/models/organization_manufacturer.rb
+++ b/app/models/organization_manufacturer.rb
@@ -12,7 +12,6 @@
 #
 # Indexes
 #
-#  index_organization_manufacturers_on_manufacturer_id  (manufacturer_id)
 #  index_organization_manufacturers_on_organization_id  (organization_id)
 #
 class OrganizationManufacturer < ApplicationRecord

--- a/app/models/organization_stolen_message.rb
+++ b/app/models/organization_stolen_message.rb
@@ -20,7 +20,6 @@
 # Indexes
 #
 #  index_organization_stolen_messages_on_organization_id  (organization_id)
-#  index_organization_stolen_messages_on_updator_id       (updator_id)
 #
 class OrganizationStolenMessage < ApplicationRecord
   include SearchRadiusMetricable

--- a/app/models/ownership.rb
+++ b/app/models/ownership.rb
@@ -40,7 +40,6 @@
 #  index_ownerships_on_bulk_import_id     (bulk_import_id)
 #  index_ownerships_on_creator_id         (creator_id)
 #  index_ownerships_on_doorkeeper_app_id  (doorkeeper_app_id)
-#  index_ownerships_on_impound_record_id  (impound_record_id)
 #  index_ownerships_on_organization_id    (organization_id)
 #  index_ownerships_on_sale_id            (sale_id)
 #  index_ownerships_on_user_id            (user_id)

--- a/app/models/parking_notification.rb
+++ b/app/models/parking_notification.rb
@@ -41,12 +41,9 @@
 # Indexes
 #
 #  index_parking_notifications_on_bike_id            (bike_id)
-#  index_parking_notifications_on_country_id         (country_id)
 #  index_parking_notifications_on_impound_record_id  (impound_record_id)
 #  index_parking_notifications_on_initial_record_id  (initial_record_id)
 #  index_parking_notifications_on_organization_id    (organization_id)
-#  index_parking_notifications_on_region_record_id   (region_record_id)
-#  index_parking_notifications_on_retrieved_by_id    (retrieved_by_id)
 #  index_parking_notifications_on_user_id            (user_id)
 #
 class ParkingNotification < ActiveRecord::Base

--- a/app/models/sale.rb
+++ b/app/models/sale.rb
@@ -19,13 +19,6 @@
 #  ownership_id           :bigint
 #  seller_id              :bigint
 #
-# Indexes
-#
-#  index_sales_on_item                    (item_type,item_id)
-#  index_sales_on_marketplace_message_id  (marketplace_message_id)
-#  index_sales_on_ownership_id            (ownership_id)
-#  index_sales_on_seller_id               (seller_id)
-#
 class Sale < ApplicationRecord
   include Amountable
   include Currencyable

--- a/app/models/social_account.rb
+++ b/app/models/social_account.rb
@@ -31,10 +31,7 @@
 #
 # Indexes
 #
-#  index_social_accounts_on_country_id              (country_id)
-#  index_social_accounts_on_latitude_and_longitude  (latitude,longitude)
-#  index_social_accounts_on_screen_name             (screen_name)
-#  index_social_accounts_on_state_id                (state_id)
+#  index_social_accounts_on_screen_name  (screen_name)
 #
 class SocialAccount < ApplicationRecord
   include GeocodeableLegacy

--- a/app/models/state.rb
+++ b/app/models/state.rb
@@ -10,10 +10,6 @@
 #  updated_at   :datetime         not null
 #  country_id   :integer
 #
-# Indexes
-#
-#  index_states_on_country_id  (country_id)
-#
 class State < ApplicationRecord
   belongs_to :country
   has_many :locations

--- a/app/models/stolen_bike_listing.rb
+++ b/app/models/stolen_bike_listing.rb
@@ -29,15 +29,6 @@
 #  secondary_frame_color_id :bigint
 #  tertiary_frame_color_id  :bigint
 #
-# Indexes
-#
-#  index_stolen_bike_listings_on_bike_id                   (bike_id)
-#  index_stolen_bike_listings_on_initial_listing_id        (initial_listing_id)
-#  index_stolen_bike_listings_on_manufacturer_id           (manufacturer_id)
-#  index_stolen_bike_listings_on_primary_frame_color_id    (primary_frame_color_id)
-#  index_stolen_bike_listings_on_secondary_frame_color_id  (secondary_frame_color_id)
-#  index_stolen_bike_listings_on_tertiary_frame_color_id   (tertiary_frame_color_id)
-#
 
 # Initially created for mexican stolen bike ring
 class StolenBikeListing < ActiveRecord::Base

--- a/app/models/stolen_notification.rb
+++ b/app/models/stolen_notification.rb
@@ -17,10 +17,6 @@
 #  receiver_id       :integer
 #  sender_id         :integer
 #
-# Indexes
-#
-#  index_stolen_notifications_on_doorkeeper_app_id  (doorkeeper_app_id)
-#
 class StolenNotification < ApplicationRecord
   KIND_ENUM = {
     stolen_permitted: 0,

--- a/app/models/stolen_record.rb
+++ b/app/models/stolen_record.rb
@@ -50,10 +50,8 @@
 #
 # Indexes
 #
-#  index_stolen_records_on_bike_id                         (bike_id)
-#  index_stolen_records_on_latitude_and_longitude          (latitude,longitude)
-#  index_stolen_records_on_organization_stolen_message_id  (organization_stolen_message_id)
-#  index_stolen_records_on_recovering_user_id              (recovering_user_id)
+#  index_stolen_records_on_bike_id                 (bike_id)
+#  index_stolen_records_on_latitude_and_longitude  (latitude,longitude)
 #
 class StolenRecord < ApplicationRecord
   include ActiveModel::Dirty

--- a/app/models/strava_integration.rb
+++ b/app/models/strava_integration.rb
@@ -23,8 +23,7 @@
 #
 # Indexes
 #
-#  index_strava_integrations_on_deleted_at  (deleted_at)
-#  index_strava_integrations_on_user_id     (user_id) UNIQUE WHERE (deleted_at IS NULL)
+#  index_strava_integrations_on_user_id  (user_id) UNIQUE WHERE (deleted_at IS NULL)
 #
 class StravaIntegration < ApplicationRecord
   STATUS_ENUM = {pending: 0, syncing: 1, synced: 2, error: 3}.freeze

--- a/app/models/stripe_subscription.rb
+++ b/app/models/stripe_subscription.rb
@@ -17,9 +17,8 @@
 #
 # Indexes
 #
-#  index_stripe_subscriptions_on_membership_id           (membership_id)
-#  index_stripe_subscriptions_on_stripe_price_stripe_id  (stripe_price_stripe_id)
-#  index_stripe_subscriptions_on_user_id                 (user_id)
+#  index_stripe_subscriptions_on_membership_id  (membership_id)
+#  index_stripe_subscriptions_on_user_id        (user_id)
 #
 class StripeSubscription < ApplicationRecord
   include ActivePeriodable

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -56,7 +56,6 @@
 # Indexes
 #
 #  index_users_on_address_record_id         (address_record_id)
-#  index_users_on_auth_token                (auth_token)
 #  index_users_on_email                     (email) WHERE (deleted_at IS NULL)
 #  index_users_on_email_trgm                (email) WHERE (deleted_at IS NULL) USING gin
 #  index_users_on_token_for_password_reset  (token_for_password_reset)

--- a/app/models/user_alert.rb
+++ b/app/models/user_alert.rb
@@ -18,11 +18,10 @@
 #
 # Indexes
 #
-#  index_user_alerts_on_bike_id          (bike_id)
-#  index_user_alerts_on_organization_id  (organization_id)
-#  index_user_alerts_on_theft_alert_id   (theft_alert_id)
-#  index_user_alerts_on_user_id          (user_id)
-#  index_user_alerts_on_user_phone_id    (user_phone_id)
+#  index_user_alerts_on_bike_id         (bike_id)
+#  index_user_alerts_on_theft_alert_id  (theft_alert_id)
+#  index_user_alerts_on_user_id         (user_id)
+#  index_user_alerts_on_user_phone_id   (user_phone_id)
 #
 class UserAlert < ApplicationRecord
   KIND_ENUM = {

--- a/app/models/user_ban.rb
+++ b/app/models/user_ban.rb
@@ -14,8 +14,7 @@
 #
 # Indexes
 #
-#  index_user_bans_on_creator_id  (creator_id)
-#  index_user_bans_on_user_id     (user_id)
+#  index_user_bans_on_user_id  (user_id)
 #
 class UserBan < ApplicationRecord
   REASON_ENUM = {

--- a/db/migrate/20260514085900_remove_unused_indexes.rb
+++ b/db/migrate/20260514085900_remove_unused_indexes.rb
@@ -1,0 +1,67 @@
+class RemoveUnusedIndexes < ActiveRecord::Migration[8.1]
+  disable_ddl_transaction!
+
+  def change
+    remove_index :users, :auth_token, name: :index_users_on_auth_token, algorithm: :concurrently
+    remove_index :bikes, :address_record_id, name: :index_bikes_on_address_record_id, where: "address_record_id IS NOT NULL", algorithm: :concurrently
+    remove_index :bike_organizations, :deleted_at, name: :index_bike_organizations_on_deleted_at, algorithm: :concurrently
+    remove_index :ownerships, :impound_record_id, name: :index_ownerships_on_impound_record_id, algorithm: :concurrently
+    remove_index :address_records, :region_record_id, name: :index_address_records_on_region_record_id, algorithm: :concurrently
+    remove_index :bike_stickers, :secondary_organization_id, name: :index_bike_stickers_on_secondary_organization_id, algorithm: :concurrently
+    remove_index :bikes, :paint_id, name: :index_bikes_on_paint_id, where: "paint_id IS NOT NULL", algorithm: :concurrently
+    remove_index :stolen_records, :organization_stolen_message_id, name: :index_stolen_records_on_organization_stolen_message_id, algorithm: :concurrently
+    remove_index :stolen_records, :recovering_user_id, name: :index_stolen_records_on_recovering_user_id, algorithm: :concurrently
+    remove_index :user_alerts, :organization_id, name: :index_user_alerts_on_organization_id, algorithm: :concurrently
+    remove_index :graduated_notifications, :bike_organization_id, name: :index_graduated_notifications_on_bike_organization_id, algorithm: :concurrently
+    remove_index :bikes, :current_impound_record_id, name: :index_bikes_on_current_impound_record_id, algorithm: :concurrently
+    remove_index :email_domains, :creator_id, name: :index_email_domains_on_creator_id, algorithm: :concurrently
+    remove_index :stolen_notifications, :doorkeeper_app_id, name: :index_stolen_notifications_on_doorkeeper_app_id, algorithm: :concurrently
+    remove_index :graduated_notifications, :marked_remaining_by_id, name: :index_graduated_notifications_on_marked_remaining_by_id, algorithm: :concurrently
+    remove_index :parking_notifications, :region_record_id, name: :index_parking_notifications_on_region_record_id, algorithm: :concurrently
+    remove_index :parking_notifications, :country_id, name: :index_parking_notifications_on_country_id, algorithm: :concurrently
+    remove_index :parking_notifications, :retrieved_by_id, name: :index_parking_notifications_on_retrieved_by_id, algorithm: :concurrently
+    remove_index :impound_record_updates, :user_id, name: :index_impound_record_updates_on_user_id, algorithm: :concurrently
+    remove_index :stripe_subscriptions, :stripe_price_stripe_id, name: :index_stripe_subscriptions_on_stripe_price_stripe_id, algorithm: :concurrently
+    remove_index :impound_record_updates, :location_id, name: :index_impound_record_updates_on_location_id, algorithm: :concurrently
+    remove_index :exports, :user_id, name: :index_exports_on_user_id, algorithm: :concurrently
+    remove_index :ambassador_task_assignments, :ambassador_task_id, name: :index_ambassador_task_assignments_on_ambassador_task_id, algorithm: :concurrently
+    remove_index :bike_organization_notes, :organization_id, name: :index_bike_organization_notes_on_organization_id, algorithm: :concurrently
+    remove_index :bike_organization_notes, :user_id, name: :index_bike_organization_notes_on_user_id, algorithm: :concurrently
+    remove_index :bike_sticker_batches, :organization_id, name: :index_bike_sticker_batches_on_organization_id, algorithm: :concurrently
+    remove_index :bike_sticker_batches, :user_id, name: :index_bike_sticker_batches_on_user_id, algorithm: :concurrently
+    remove_index :bike_versions, :front_gear_type_id, name: :index_bike_versions_on_front_gear_type_id, algorithm: :concurrently
+    remove_index :bike_versions, :front_wheel_size_id, name: :index_bike_versions_on_front_wheel_size_id, algorithm: :concurrently
+    remove_index :bike_versions, :paint_id, name: :index_bike_versions_on_paint_id, algorithm: :concurrently
+    remove_index :bike_versions, :primary_frame_color_id, name: :index_bike_versions_on_primary_frame_color_id, algorithm: :concurrently
+    remove_index :bike_versions, :rear_gear_type_id, name: :index_bike_versions_on_rear_gear_type_id, algorithm: :concurrently
+    remove_index :bike_versions, :rear_wheel_size_id, name: :index_bike_versions_on_rear_wheel_size_id, algorithm: :concurrently
+    remove_index :bike_versions, :secondary_frame_color_id, name: :index_bike_versions_on_secondary_frame_color_id, algorithm: :concurrently
+    remove_index :bike_versions, :tertiary_frame_color_id, name: :index_bike_versions_on_tertiary_frame_color_id, algorithm: :concurrently
+    remove_index :external_registry_credentials, :type, name: :index_external_registry_credentials_on_type, algorithm: :concurrently
+    remove_index :impound_configurations, :organization_id, name: :index_impound_configurations_on_organization_id, algorithm: :concurrently
+    remove_index :mail_snippets, :doorkeeper_app_id, name: :index_mail_snippets_on_doorkeeper_app_id, algorithm: :concurrently
+    remove_index :mail_snippets, :organization_id, name: :index_mail_snippets_on_organization_id, algorithm: :concurrently
+    remove_index :marketplace_listings, :sale_id, name: :index_marketplace_listings_on_sale_id, algorithm: :concurrently
+    remove_index :memberships, :creator_id, name: :index_memberships_on_creator_id, algorithm: :concurrently
+    remove_index :model_attestations, :model_audit_id, name: :index_model_attestations_on_model_audit_id, algorithm: :concurrently
+    remove_index :model_attestations, :user_id, name: :index_model_attestations_on_user_id, algorithm: :concurrently
+    remove_index :organization_manufacturers, :manufacturer_id, name: :index_organization_manufacturers_on_manufacturer_id, algorithm: :concurrently
+    remove_index :organization_stolen_messages, :updator_id, name: :index_organization_stolen_messages_on_updator_id, algorithm: :concurrently
+    remove_index :sales, [:item_type, :item_id], name: :index_sales_on_item, algorithm: :concurrently
+    remove_index :sales, :marketplace_message_id, name: :index_sales_on_marketplace_message_id, algorithm: :concurrently
+    remove_index :sales, :ownership_id, name: :index_sales_on_ownership_id, algorithm: :concurrently
+    remove_index :sales, :seller_id, name: :index_sales_on_seller_id, algorithm: :concurrently
+    remove_index :social_accounts, :country_id, name: :index_social_accounts_on_country_id, algorithm: :concurrently
+    remove_index :social_accounts, [:latitude, :longitude], name: :index_social_accounts_on_latitude_and_longitude, algorithm: :concurrently
+    remove_index :social_accounts, :state_id, name: :index_social_accounts_on_state_id, algorithm: :concurrently
+    remove_index :states, :country_id, name: :index_states_on_country_id, algorithm: :concurrently
+    remove_index :stolen_bike_listings, :bike_id, name: :index_stolen_bike_listings_on_bike_id, algorithm: :concurrently
+    remove_index :stolen_bike_listings, :initial_listing_id, name: :index_stolen_bike_listings_on_initial_listing_id, algorithm: :concurrently
+    remove_index :stolen_bike_listings, :manufacturer_id, name: :index_stolen_bike_listings_on_manufacturer_id, algorithm: :concurrently
+    remove_index :stolen_bike_listings, :primary_frame_color_id, name: :index_stolen_bike_listings_on_primary_frame_color_id, algorithm: :concurrently
+    remove_index :stolen_bike_listings, :secondary_frame_color_id, name: :index_stolen_bike_listings_on_secondary_frame_color_id, algorithm: :concurrently
+    remove_index :stolen_bike_listings, :tertiary_frame_color_id, name: :index_stolen_bike_listings_on_tertiary_frame_color_id, algorithm: :concurrently
+    remove_index :strava_integrations, :deleted_at, name: :index_strava_integrations_on_deleted_at, algorithm: :concurrently
+    remove_index :user_bans, :creator_id, name: :index_user_bans_on_creator_id, algorithm: :concurrently
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -5813,13 +5813,6 @@ CREATE INDEX index_address_records_on_organization_id ON public.address_records 
 
 
 --
--- Name: index_address_records_on_region_record_id; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX index_address_records_on_region_record_id ON public.address_records USING btree (region_record_id);
-
-
---
 -- Name: index_address_records_on_user_id; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -5831,13 +5824,6 @@ CREATE INDEX index_address_records_on_user_id ON public.address_records USING bt
 --
 
 CREATE INDEX index_alert_images_on_stolen_record_id ON public.alert_images USING btree (stolen_record_id);
-
-
---
--- Name: index_ambassador_task_assignments_on_ambassador_task_id; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX index_ambassador_task_assignments_on_ambassador_task_id ON public.ambassador_task_assignments USING btree (ambassador_task_id);
 
 
 --
@@ -5883,20 +5869,6 @@ CREATE UNIQUE INDEX index_bike_organization_notes_on_bike_id_and_organization_id
 
 
 --
--- Name: index_bike_organization_notes_on_organization_id; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX index_bike_organization_notes_on_organization_id ON public.bike_organization_notes USING btree (organization_id);
-
-
---
--- Name: index_bike_organization_notes_on_user_id; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX index_bike_organization_notes_on_user_id ON public.bike_organization_notes USING btree (user_id);
-
-
---
 -- Name: index_bike_organizations_on_bike_id; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -5904,31 +5876,10 @@ CREATE INDEX index_bike_organizations_on_bike_id ON public.bike_organizations US
 
 
 --
--- Name: index_bike_organizations_on_deleted_at; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX index_bike_organizations_on_deleted_at ON public.bike_organizations USING btree (deleted_at);
-
-
---
 -- Name: index_bike_organizations_on_organization_id; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX index_bike_organizations_on_organization_id ON public.bike_organizations USING btree (organization_id);
-
-
---
--- Name: index_bike_sticker_batches_on_organization_id; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX index_bike_sticker_batches_on_organization_id ON public.bike_sticker_batches USING btree (organization_id);
-
-
---
--- Name: index_bike_sticker_batches_on_user_id; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX index_bike_sticker_batches_on_user_id ON public.bike_sticker_batches USING btree (user_id);
 
 
 --
@@ -5988,31 +5939,10 @@ CREATE INDEX index_bike_stickers_on_bike_sticker_batch_id ON public.bike_sticker
 
 
 --
--- Name: index_bike_stickers_on_secondary_organization_id; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX index_bike_stickers_on_secondary_organization_id ON public.bike_stickers USING btree (secondary_organization_id);
-
-
---
 -- Name: index_bike_versions_on_bike_id; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX index_bike_versions_on_bike_id ON public.bike_versions USING btree (bike_id);
-
-
---
--- Name: index_bike_versions_on_front_gear_type_id; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX index_bike_versions_on_front_gear_type_id ON public.bike_versions USING btree (front_gear_type_id);
-
-
---
--- Name: index_bike_versions_on_front_wheel_size_id; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX index_bike_versions_on_front_wheel_size_id ON public.bike_versions USING btree (front_wheel_size_id);
 
 
 --
@@ -6030,52 +5960,10 @@ CREATE INDEX index_bike_versions_on_owner_id ON public.bike_versions USING btree
 
 
 --
--- Name: index_bike_versions_on_paint_id; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX index_bike_versions_on_paint_id ON public.bike_versions USING btree (paint_id);
-
-
---
 -- Name: index_bike_versions_on_primary_activity_id; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX index_bike_versions_on_primary_activity_id ON public.bike_versions USING btree (primary_activity_id);
-
-
---
--- Name: index_bike_versions_on_primary_frame_color_id; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX index_bike_versions_on_primary_frame_color_id ON public.bike_versions USING btree (primary_frame_color_id);
-
-
---
--- Name: index_bike_versions_on_rear_gear_type_id; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX index_bike_versions_on_rear_gear_type_id ON public.bike_versions USING btree (rear_gear_type_id);
-
-
---
--- Name: index_bike_versions_on_rear_wheel_size_id; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX index_bike_versions_on_rear_wheel_size_id ON public.bike_versions USING btree (rear_wheel_size_id);
-
-
---
--- Name: index_bike_versions_on_secondary_frame_color_id; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX index_bike_versions_on_secondary_frame_color_id ON public.bike_versions USING btree (secondary_frame_color_id);
-
-
---
--- Name: index_bike_versions_on_tertiary_frame_color_id; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX index_bike_versions_on_tertiary_frame_color_id ON public.bike_versions USING btree (tertiary_frame_color_id);
 
 
 --
@@ -6086,24 +5974,10 @@ CREATE INDEX index_bikes_current_listing_order ON public.bikes USING btree (list
 
 
 --
--- Name: index_bikes_on_address_record_id; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX index_bikes_on_address_record_id ON public.bikes USING btree (address_record_id) WHERE (address_record_id IS NOT NULL);
-
-
---
 -- Name: index_bikes_on_creation_organization_id; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX index_bikes_on_creation_organization_id ON public.bikes USING btree (creation_organization_id) WHERE (creation_organization_id IS NOT NULL);
-
-
---
--- Name: index_bikes_on_current_impound_record_id; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX index_bikes_on_current_impound_record_id ON public.bikes USING btree (current_impound_record_id) WHERE (current_impound_record_id IS NOT NULL);
 
 
 --
@@ -6181,13 +6055,6 @@ CREATE INDEX index_bikes_on_model_audit_id ON public.bikes USING btree (model_au
 --
 
 CREATE INDEX index_bikes_on_owner_email_trgm ON public.bikes USING gin (owner_email public.gin_trgm_ops);
-
-
---
--- Name: index_bikes_on_paint_id; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX index_bikes_on_paint_id ON public.bikes USING btree (paint_id) WHERE (paint_id IS NOT NULL);
 
 
 --
@@ -6296,13 +6163,6 @@ CREATE INDEX index_email_bans_on_user_id ON public.email_bans USING btree (user_
 
 
 --
--- Name: index_email_domains_on_creator_id; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX index_email_domains_on_creator_id ON public.email_domains USING btree (creator_id);
-
-
---
 -- Name: index_email_domains_on_domain_trgm; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -6331,13 +6191,6 @@ CREATE INDEX index_exports_on_organization_id ON public.exports USING btree (org
 
 
 --
--- Name: index_exports_on_user_id; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX index_exports_on_user_id ON public.exports USING btree (user_id);
-
-
---
 -- Name: index_external_registry_bikes_on_country_id; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -6363,13 +6216,6 @@ CREATE INDEX index_external_registry_bikes_on_serial_normalized ON public.extern
 --
 
 CREATE INDEX index_external_registry_bikes_on_type ON public.external_registry_bikes USING btree (type);
-
-
---
--- Name: index_external_registry_credentials_on_type; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX index_external_registry_credentials_on_type ON public.external_registry_credentials USING btree (type);
 
 
 --
@@ -6405,20 +6251,6 @@ CREATE UNIQUE INDEX index_flipper_gates_on_feature_key_and_key_and_value ON publ
 --
 
 CREATE INDEX index_graduated_notifications_on_bike_id ON public.graduated_notifications USING btree (bike_id);
-
-
---
--- Name: index_graduated_notifications_on_bike_organization_id; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX index_graduated_notifications_on_bike_organization_id ON public.graduated_notifications USING btree (bike_organization_id);
-
-
---
--- Name: index_graduated_notifications_on_marked_remaining_by_id; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX index_graduated_notifications_on_marked_remaining_by_id ON public.graduated_notifications USING btree (marked_remaining_by_id);
 
 
 --
@@ -6506,13 +6338,6 @@ CREATE INDEX index_impound_claims_on_user_id ON public.impound_claims USING btre
 
 
 --
--- Name: index_impound_configurations_on_organization_id; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX index_impound_configurations_on_organization_id ON public.impound_configurations USING btree (organization_id);
-
-
---
 -- Name: index_impound_record_updates_on_impound_claim_id; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -6524,20 +6349,6 @@ CREATE INDEX index_impound_record_updates_on_impound_claim_id ON public.impound_
 --
 
 CREATE INDEX index_impound_record_updates_on_impound_record_id ON public.impound_record_updates USING btree (impound_record_id);
-
-
---
--- Name: index_impound_record_updates_on_location_id; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX index_impound_record_updates_on_location_id ON public.impound_record_updates USING btree (location_id);
-
-
---
--- Name: index_impound_record_updates_on_user_id; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX index_impound_record_updates_on_user_id ON public.impound_record_updates USING btree (user_id);
 
 
 --
@@ -6632,20 +6443,6 @@ CREATE INDEX index_locks_on_user_id ON public.locks USING btree (user_id);
 
 
 --
--- Name: index_mail_snippets_on_doorkeeper_app_id; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX index_mail_snippets_on_doorkeeper_app_id ON public.mail_snippets USING btree (doorkeeper_app_id);
-
-
---
--- Name: index_mail_snippets_on_organization_id; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX index_mail_snippets_on_organization_id ON public.mail_snippets USING btree (organization_id);
-
-
---
 -- Name: index_mailchimp_data_on_user_id; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -6671,13 +6468,6 @@ CREATE INDEX index_marketplace_listings_on_buyer_id ON public.marketplace_listin
 --
 
 CREATE INDEX index_marketplace_listings_on_item ON public.marketplace_listings USING btree (item_type, item_id);
-
-
---
--- Name: index_marketplace_listings_on_sale_id; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX index_marketplace_listings_on_sale_id ON public.marketplace_listings USING btree (sale_id);
 
 
 --
@@ -6716,13 +6506,6 @@ CREATE INDEX index_marketplace_messages_on_sender_id ON public.marketplace_messa
 
 
 --
--- Name: index_memberships_on_creator_id; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX index_memberships_on_creator_id ON public.memberships USING btree (creator_id);
-
-
---
 -- Name: index_memberships_on_user_id; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -6730,24 +6513,10 @@ CREATE INDEX index_memberships_on_user_id ON public.memberships USING btree (use
 
 
 --
--- Name: index_model_attestations_on_model_audit_id; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX index_model_attestations_on_model_audit_id ON public.model_attestations USING btree (model_audit_id);
-
-
---
 -- Name: index_model_attestations_on_organization_id; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX index_model_attestations_on_organization_id ON public.model_attestations USING btree (organization_id);
-
-
---
--- Name: index_model_attestations_on_user_id; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX index_model_attestations_on_user_id ON public.model_attestations USING btree (user_id);
 
 
 --
@@ -6849,13 +6618,6 @@ CREATE UNIQUE INDEX index_oauth_applications_on_uid ON public.oauth_applications
 
 
 --
--- Name: index_organization_manufacturers_on_manufacturer_id; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX index_organization_manufacturers_on_manufacturer_id ON public.organization_manufacturers USING btree (manufacturer_id);
-
-
---
 -- Name: index_organization_manufacturers_on_organization_id; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -6902,13 +6664,6 @@ CREATE INDEX index_organization_roles_on_user_id ON public.organization_roles US
 --
 
 CREATE INDEX index_organization_stolen_messages_on_organization_id ON public.organization_stolen_messages USING btree (organization_id);
-
-
---
--- Name: index_organization_stolen_messages_on_updator_id; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX index_organization_stolen_messages_on_updator_id ON public.organization_stolen_messages USING btree (updator_id);
 
 
 --
@@ -6975,13 +6730,6 @@ CREATE INDEX index_ownerships_on_doorkeeper_app_id ON public.ownerships USING bt
 
 
 --
--- Name: index_ownerships_on_impound_record_id; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX index_ownerships_on_impound_record_id ON public.ownerships USING btree (impound_record_id);
-
-
---
 -- Name: index_ownerships_on_organization_id; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -7010,13 +6758,6 @@ CREATE INDEX index_parking_notifications_on_bike_id ON public.parking_notificati
 
 
 --
--- Name: index_parking_notifications_on_country_id; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX index_parking_notifications_on_country_id ON public.parking_notifications USING btree (country_id);
-
-
---
 -- Name: index_parking_notifications_on_impound_record_id; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -7035,20 +6776,6 @@ CREATE INDEX index_parking_notifications_on_initial_record_id ON public.parking_
 --
 
 CREATE INDEX index_parking_notifications_on_organization_id ON public.parking_notifications USING btree (organization_id);
-
-
---
--- Name: index_parking_notifications_on_region_record_id; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX index_parking_notifications_on_region_record_id ON public.parking_notifications USING btree (region_record_id);
-
-
---
--- Name: index_parking_notifications_on_retrieved_by_id; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX index_parking_notifications_on_retrieved_by_id ON public.parking_notifications USING btree (retrieved_by_id);
 
 
 --
@@ -7108,59 +6835,10 @@ CREATE INDEX index_recovery_displays_on_stolen_record_id ON public.recovery_disp
 
 
 --
--- Name: index_sales_on_item; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX index_sales_on_item ON public.sales USING btree (item_type, item_id);
-
-
---
--- Name: index_sales_on_marketplace_message_id; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX index_sales_on_marketplace_message_id ON public.sales USING btree (marketplace_message_id);
-
-
---
--- Name: index_sales_on_ownership_id; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX index_sales_on_ownership_id ON public.sales USING btree (ownership_id);
-
-
---
--- Name: index_sales_on_seller_id; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX index_sales_on_seller_id ON public.sales USING btree (seller_id);
-
-
---
--- Name: index_social_accounts_on_country_id; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX index_social_accounts_on_country_id ON public.social_accounts USING btree (country_id);
-
-
---
--- Name: index_social_accounts_on_latitude_and_longitude; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX index_social_accounts_on_latitude_and_longitude ON public.social_accounts USING btree (latitude, longitude);
-
-
---
 -- Name: index_social_accounts_on_screen_name; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX index_social_accounts_on_screen_name ON public.social_accounts USING btree (screen_name);
-
-
---
--- Name: index_social_accounts_on_state_id; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX index_social_accounts_on_state_id ON public.social_accounts USING btree (state_id);
 
 
 --
@@ -7185,62 +6863,6 @@ CREATE INDEX index_social_posts_on_stolen_record_id ON public.social_posts USING
 
 
 --
--- Name: index_states_on_country_id; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX index_states_on_country_id ON public.states USING btree (country_id);
-
-
---
--- Name: index_stolen_bike_listings_on_bike_id; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX index_stolen_bike_listings_on_bike_id ON public.stolen_bike_listings USING btree (bike_id);
-
-
---
--- Name: index_stolen_bike_listings_on_initial_listing_id; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX index_stolen_bike_listings_on_initial_listing_id ON public.stolen_bike_listings USING btree (initial_listing_id);
-
-
---
--- Name: index_stolen_bike_listings_on_manufacturer_id; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX index_stolen_bike_listings_on_manufacturer_id ON public.stolen_bike_listings USING btree (manufacturer_id);
-
-
---
--- Name: index_stolen_bike_listings_on_primary_frame_color_id; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX index_stolen_bike_listings_on_primary_frame_color_id ON public.stolen_bike_listings USING btree (primary_frame_color_id);
-
-
---
--- Name: index_stolen_bike_listings_on_secondary_frame_color_id; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX index_stolen_bike_listings_on_secondary_frame_color_id ON public.stolen_bike_listings USING btree (secondary_frame_color_id);
-
-
---
--- Name: index_stolen_bike_listings_on_tertiary_frame_color_id; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX index_stolen_bike_listings_on_tertiary_frame_color_id ON public.stolen_bike_listings USING btree (tertiary_frame_color_id);
-
-
---
--- Name: index_stolen_notifications_on_doorkeeper_app_id; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX index_stolen_notifications_on_doorkeeper_app_id ON public.stolen_notifications USING btree (doorkeeper_app_id);
-
-
---
 -- Name: index_stolen_records_on_bike_id; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -7252,20 +6874,6 @@ CREATE INDEX index_stolen_records_on_bike_id ON public.stolen_records USING btre
 --
 
 CREATE INDEX index_stolen_records_on_latitude_and_longitude ON public.stolen_records USING btree (latitude, longitude);
-
-
---
--- Name: index_stolen_records_on_organization_stolen_message_id; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX index_stolen_records_on_organization_stolen_message_id ON public.stolen_records USING btree (organization_stolen_message_id);
-
-
---
--- Name: index_stolen_records_on_recovering_user_id; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX index_stolen_records_on_recovering_user_id ON public.stolen_records USING btree (recovering_user_id);
 
 
 --
@@ -7290,13 +6898,6 @@ CREATE UNIQUE INDEX index_strava_gears_on_strava_integration_id_and_strava_id ON
 
 
 --
--- Name: index_strava_integrations_on_deleted_at; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX index_strava_integrations_on_deleted_at ON public.strava_integrations USING btree (deleted_at);
-
-
---
 -- Name: index_strava_integrations_on_user_id; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -7308,13 +6909,6 @@ CREATE UNIQUE INDEX index_strava_integrations_on_user_id ON public.strava_integr
 --
 
 CREATE INDEX index_stripe_subscriptions_on_membership_id ON public.stripe_subscriptions USING btree (membership_id);
-
-
---
--- Name: index_stripe_subscriptions_on_stripe_price_stripe_id; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX index_stripe_subscriptions_on_stripe_price_stripe_id ON public.stripe_subscriptions USING btree (stripe_price_stripe_id);
 
 
 --
@@ -7374,13 +6968,6 @@ CREATE INDEX index_user_alerts_on_bike_id ON public.user_alerts USING btree (bik
 
 
 --
--- Name: index_user_alerts_on_organization_id; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX index_user_alerts_on_organization_id ON public.user_alerts USING btree (organization_id);
-
-
---
 -- Name: index_user_alerts_on_theft_alert_id; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -7399,13 +6986,6 @@ CREATE INDEX index_user_alerts_on_user_id ON public.user_alerts USING btree (use
 --
 
 CREATE INDEX index_user_alerts_on_user_phone_id ON public.user_alerts USING btree (user_phone_id);
-
-
---
--- Name: index_user_bans_on_creator_id; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX index_user_bans_on_creator_id ON public.user_bans USING btree (creator_id);
 
 
 --
@@ -7455,13 +7035,6 @@ CREATE INDEX index_user_registration_organizations_on_user_id ON public.user_reg
 --
 
 CREATE INDEX index_users_on_address_record_id ON public.users USING btree (address_record_id);
-
-
---
--- Name: index_users_on_auth_token; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX index_users_on_auth_token ON public.users USING btree (auth_token);
 
 
 --
@@ -7592,6 +7165,7 @@ ALTER TABLE ONLY public.ambassador_task_assignments
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20260514085900'),
 ('20260430122735'),
 ('20260428142526'),
 ('20260428000001'),


### PR DESCRIPTION
Drop btree indexes that pghero reports as unused on **both** the primary and replica, reclaiming ~1.1 GB and reducing per-row write overhead. Migration uses `DROP INDEX CONCURRENTLY` so it is safe under live writes.

- 824 MB from `index_users_on_auth_token` alone — the only lookup is `User.from_auth` (`where(id:, auth_token:)`), which Postgres plans via `users_pkey` and verifies `auth_token` from the heap; the secondary index is never the better plan.
- 60.9 MB from `index_bikes_on_address_record_id` — column is write-only in practice (no `Bike.where(address_record_id: …)` and no reverse `has_many` pointing at it; the bike↔address_record reverse lookup goes through `address_records.bike_id` instead).
- Remaining 59 indexes are mostly small unused FK/secondary indexes across `bike_versions`, `stolen_bike_listings`, `sales`, `social_accounts`, `parking_notifications`, etc.
- Held back two primary-unused indexes that the replica still uses: `index_bikes_on_serial_normalized_no_space_trgm` (serial search) and `index_bikes_on_primary_activity_id`.
