### PR TITLE
Organized specs: navigate via org menu after sign-in

### DIFF
--- a/app/javascript/controllers/search/form_controller.js
+++ b/app/javascript/controllers/search/form_controller.js
@@ -26,33 +26,26 @@ export default class extends Controller {
     const noJsElement = this.element.querySelector('#search_no_js')
     if (noJsElement) noJsElement.remove()
 
-    this.submitIfEmptyResults()
+    // if the frame was loaded without results, submit the form
+    if (this.frameElement?.querySelector('#loadedWithoutResults')) {
+      // Use replace for the initial auto-submit so it doesn't add a duplicate history entry
+      this.formTarget.setAttribute('data-turbo-action', 'replace')
+      this.frameElement.addEventListener('turbo:frame-render', () => {
+        this.formTarget.setAttribute('data-turbo-action', 'advance')
+      }, { once: true })
+      this.formTarget.requestSubmit()
+    }
+
     this.setupFormFieldListeners()
 
     // Add timeLocalizer and watch for turbo-frame renders
     if (!window.timeLocalizer) window.timeLocalizer = new TimeLocalizer()
     document.addEventListener('turbo:frame-render', this.handleFrameRender)
-    // Re-check after Turbo navigations: on back/forward, connect() can fire
-    // before the frame element is parsed, leaving #loadedWithoutResults in
-    // place with no auto-submit.
-    document.addEventListener('turbo:load', this.submitIfEmptyResults)
-  }
-
-  // if the frame was loaded without results, submit the form
-  submitIfEmptyResults = () => {
-    if (!this.frameElement?.querySelector('#loadedWithoutResults')) return
-    // Use replace for the initial auto-submit so it doesn't add a duplicate history entry
-    this.formTarget.setAttribute('data-turbo-action', 'replace')
-    this.frameElement.addEventListener('turbo:frame-render', () => {
-      this.formTarget.setAttribute('data-turbo-action', 'advance')
-    }, { once: true })
-    this.formTarget.requestSubmit()
   }
 
   disconnect () {
     // Clean up event listener when controller disconnects
     document.removeEventListener('turbo:frame-render', this.frameRenderHandler)
-    document.removeEventListener('turbo:load', this.submitIfEmptyResults)
   }
 
   setupFormFieldListeners () {

--- a/app/javascript/controllers/search/form_controller.js
+++ b/app/javascript/controllers/search/form_controller.js
@@ -26,26 +26,33 @@ export default class extends Controller {
     const noJsElement = this.element.querySelector('#search_no_js')
     if (noJsElement) noJsElement.remove()
 
-    // if the frame was loaded without results, submit the form
-    if (this.frameElement?.querySelector('#loadedWithoutResults')) {
-      // Use replace for the initial auto-submit so it doesn't add a duplicate history entry
-      this.formTarget.setAttribute('data-turbo-action', 'replace')
-      this.frameElement.addEventListener('turbo:frame-render', () => {
-        this.formTarget.setAttribute('data-turbo-action', 'advance')
-      }, { once: true })
-      this.formTarget.requestSubmit()
-    }
-
+    this.submitIfEmptyResults()
     this.setupFormFieldListeners()
 
     // Add timeLocalizer and watch for turbo-frame renders
     if (!window.timeLocalizer) window.timeLocalizer = new TimeLocalizer()
     document.addEventListener('turbo:frame-render', this.handleFrameRender)
+    // Re-check after Turbo navigations: on back/forward, connect() can fire
+    // before the frame element is parsed, leaving #loadedWithoutResults in
+    // place with no auto-submit.
+    document.addEventListener('turbo:load', this.submitIfEmptyResults)
+  }
+
+  // if the frame was loaded without results, submit the form
+  submitIfEmptyResults = () => {
+    if (!this.frameElement?.querySelector('#loadedWithoutResults')) return
+    // Use replace for the initial auto-submit so it doesn't add a duplicate history entry
+    this.formTarget.setAttribute('data-turbo-action', 'replace')
+    this.frameElement.addEventListener('turbo:frame-render', () => {
+      this.formTarget.setAttribute('data-turbo-action', 'advance')
+    }, { once: true })
+    this.formTarget.requestSubmit()
   }
 
   disconnect () {
     // Clean up event listener when controller disconnects
     document.removeEventListener('turbo:frame-render', this.frameRenderHandler)
+    document.removeEventListener('turbo:load', this.submitIfEmptyResults)
   }
 
   setupFormFieldListeners () {

--- a/spec/integration/organized/parking_notifications_spec.rb
+++ b/spec/integration/organized/parking_notifications_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe "Organized parking notifications", :js, type: :system do
     click_button "Log in"
     find(".alert-success .close").click
     find("#passive_organization_submenu").click
-    click_link "Parking notifications"
+    within(".current-organization-submenu") { click_link "Parking notifications" }
     expect(page).to have_current_path(/\A#{Regexp.escape(base_url)}(\?|\z)/, wait: 10)
   end
 

--- a/spec/integration/organized/parking_notifications_spec.rb
+++ b/spec/integration/organized/parking_notifications_spec.rb
@@ -13,10 +13,15 @@ RSpec.describe "Organized parking notifications", :js, type: :system do
   let!(:retrieved) { FactoryBot.create(:parking_notification_organized, :retrieved, organization:, user:) }
 
   before do
+    # Force desktop viewport — Chrome's --window-size flag is ignored in headless
+    # mode, and the organized-left-menu is `display: none` below the md breakpoint.
+    page.current_window.resize_to(1920, 1080)
     visit new_session_path
     fill_in "Email", with: user.email
     fill_in "Password", with: "testthisthing7$"
     click_button "Log in"
+    click_link "Parking notifications"
+    expect(page).to have_current_path(/\A#{Regexp.escape(base_url)}(\?|\z)/, wait: 10)
   end
 
   def click_filter(text)
@@ -29,7 +34,6 @@ RSpec.describe "Organized parking notifications", :js, type: :system do
   def row_for(notification) = "tr[data-recordid='#{notification.id}']"
 
   it "filters notifications through the dropdown menus and toggles them off when re-clicked" do
-    visit base_url
     # Default view (status=current) loads three current notifications via JSON.
     expect(page).to have_css(row_for(registered), wait: 20)
     expect(page).to have_css(row_for(unregistered))

--- a/spec/integration/organized/parking_notifications_spec.rb
+++ b/spec/integration/organized/parking_notifications_spec.rb
@@ -13,13 +13,12 @@ RSpec.describe "Organized parking notifications", :js, type: :system do
   let!(:retrieved) { FactoryBot.create(:parking_notification_organized, :retrieved, organization:, user:) }
 
   before do
-    # Force desktop viewport — Chrome's --window-size flag is ignored in headless
-    # mode, and the organized-left-menu is `display: none` below the md breakpoint.
-    page.current_window.resize_to(1920, 1080)
     visit new_session_path
     fill_in "Email", with: user.email
     fill_in "Password", with: "testthisthing7$"
     click_button "Log in"
+    find(".alert-success .close").click
+    find("#passive_organization_submenu").click
     click_link "Parking notifications"
     expect(page).to have_current_path(/\A#{Regexp.escape(base_url)}(\?|\z)/, wait: 10)
   end

--- a/spec/integration/organized/parking_notifications_spec.rb
+++ b/spec/integration/organized/parking_notifications_spec.rb
@@ -13,6 +13,10 @@ RSpec.describe "Organized parking notifications", :js, type: :system do
   let!(:retrieved) { FactoryBot.create(:parking_notification_organized, :retrieved, organization:, user:) }
 
   before do
+    # Pin below the md breakpoint (768px) so the sidebar is hidden and the
+    # mobile org dropdown is the only menu path. Chrome's --window-size flag
+    # is unreliable in headless mode, so resize explicitly.
+    page.current_window.resize_to(720, 2000)
     visit new_session_path
     fill_in "Email", with: user.email
     fill_in "Password", with: "testthisthing7$"

--- a/spec/integration/organized/registrations_search_spec.rb
+++ b/spec/integration/organized/registrations_search_spec.rb
@@ -15,13 +15,12 @@ RSpec.describe "Organized registrations search", :js, type: :system do
     # Ensure gear types exist so bike show page doesn't write during readonly mode
     RearGearType.fixed
     FrontGearType.fixed
-    # Force desktop viewport — Chrome's --window-size flag is ignored in headless
-    # mode, and the organized-left-menu is `display: none` below the md breakpoint.
-    page.current_window.resize_to(1920, 1080)
     visit new_session_path
     fill_in "Email", with: user.email
     fill_in "Password", with: "testthisthing7$"
     click_button "Log in"
+    find(".alert-success .close").click
+    find("#passive_organization_submenu").click
     click_link "#{organization.short_name} Bikes"
     expect(page).to have_current_path(/\A#{Regexp.escape(bikes_path)}(\?|\z)/, wait: 10)
   end
@@ -323,6 +322,7 @@ RSpec.describe "Organized registrations search", :js, type: :system do
     end
 
     it "searches multiple serials, shows results, and caches rows by updated_at" do
+      find("#passive_organization_submenu").click
       click_link "Multi search"
       expect(page).to have_current_path(/\A#{Regexp.escape(multi_serial_path)}(\?|\z)/, wait: 10)
 

--- a/spec/integration/organized/registrations_search_spec.rb
+++ b/spec/integration/organized/registrations_search_spec.rb
@@ -15,6 +15,10 @@ RSpec.describe "Organized registrations search", :js, type: :system do
     # Ensure gear types exist so bike show page doesn't write during readonly mode
     RearGearType.fixed
     FrontGearType.fixed
+    # Pin below the md breakpoint (768px) so the sidebar is hidden and the
+    # mobile org dropdown is the only menu path. Chrome's --window-size flag
+    # is unreliable in headless mode, so resize explicitly.
+    page.current_window.resize_to(720, 2000)
     visit new_session_path
     fill_in "Email", with: user.email
     fill_in "Password", with: "testthisthing7$"

--- a/spec/integration/organized/registrations_search_spec.rb
+++ b/spec/integration/organized/registrations_search_spec.rb
@@ -15,10 +15,15 @@ RSpec.describe "Organized registrations search", :js, type: :system do
     # Ensure gear types exist so bike show page doesn't write during readonly mode
     RearGearType.fixed
     FrontGearType.fixed
+    # Force desktop viewport — Chrome's --window-size flag is ignored in headless
+    # mode, and the organized-left-menu is `display: none` below the md breakpoint.
+    page.current_window.resize_to(1920, 1080)
     visit new_session_path
     fill_in "Email", with: user.email
     fill_in "Password", with: "testthisthing7$"
     click_button "Log in"
+    click_link "#{organization.short_name} Bikes"
+    expect(page).to have_current_path(/\A#{Regexp.escape(bikes_path)}(\?|\z)/, wait: 10)
   end
 
   def settings_selector
@@ -318,7 +323,8 @@ RSpec.describe "Organized registrations search", :js, type: :system do
     end
 
     it "searches multiple serials, shows results, and caches rows by updated_at" do
-      visit multi_serial_path
+      click_link "Multi search"
+      expect(page).to have_current_path(/\A#{Regexp.escape(multi_serial_path)}(\?|\z)/, wait: 10)
 
       expect(page).to have_content(/multiple serial search/i)
       expect(page).to have_css("[data-controller~='org--multi-search']", wait: 5)

--- a/spec/integration/organized/registrations_search_spec.rb
+++ b/spec/integration/organized/registrations_search_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe "Organized registrations search", :js, type: :system do
     click_button "Log in"
     find(".alert-success .close").click
     find("#passive_organization_submenu").click
-    click_link "#{organization.short_name} Bikes"
+    within(".current-organization-submenu") { click_link "#{organization.short_name} Bikes" }
     expect(page).to have_current_path(/\A#{Regexp.escape(bikes_path)}(\?|\z)/, wait: 10)
   end
 
@@ -323,7 +323,7 @@ RSpec.describe "Organized registrations search", :js, type: :system do
 
     it "searches multiple serials, shows results, and caches rows by updated_at" do
       find("#passive_organization_submenu").click
-      click_link "Multi search"
+      within(".current-organization-submenu") { click_link "Multi search" }
       expect(page).to have_current_path(/\A#{Regexp.escape(multi_serial_path)}(\?|\z)/, wait: 10)
 
       expect(page).to have_content(/multiple serial search/i)

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -42,7 +42,7 @@ require "capybara/rspec"
 Capybara.register_driver :chrome_headless do |app|
   options = Selenium::WebDriver::Chrome::Options.new
   options.add_argument("--headless")
-  options.add_argument("--window-size=1920,1080")
+  options.add_argument("--window-size=720,2000")
   Capybara::Selenium::Driver.new(app, browser: :chrome, options: options)
 end
 # Configure Capybara
@@ -97,6 +97,11 @@ RSpec.configure do |config|
   config.include HtmlContentHelpers, type: :component
   config.before(:each, :browser, type: :system) { driven_by(:selenium) }
   config.before(:each, :js, type: :system) { driven_by(:selenium_chrome_headless) }
+  # Chrome's --window-size argument is unreliable in headless mode; resize
+  # explicitly so the viewport matches across local and CI. 720px is below
+  # the md breakpoint (768px) so the org sidebar stays hidden and specs
+  # interact with the mobile dropdown.
+  config.before(:each, type: :system) { page.current_window.resize_to(720, 2000) }
 end
 
 require "vcr"

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -42,7 +42,7 @@ require "capybara/rspec"
 Capybara.register_driver :chrome_headless do |app|
   options = Selenium::WebDriver::Chrome::Options.new
   options.add_argument("--headless")
-  options.add_argument("--window-size=720,2000")
+  options.add_argument("--window-size=1920,1080")
   Capybara::Selenium::Driver.new(app, browser: :chrome, options: options)
 end
 # Configure Capybara
@@ -97,11 +97,6 @@ RSpec.configure do |config|
   config.include HtmlContentHelpers, type: :component
   config.before(:each, :browser, type: :system) { driven_by(:selenium) }
   config.before(:each, :js, type: :system) { driven_by(:selenium_chrome_headless) }
-  # Chrome's --window-size argument is unreliable in headless mode; resize
-  # explicitly so the viewport matches across local and CI. 720px is below
-  # the md breakpoint (768px) so the org sidebar stays hidden and specs
-  # interact with the mobile dropdown.
-  config.before(:each, type: :system) { page.current_window.resize_to(720, 2000) }
 end
 
 require "vcr"


### PR DESCRIPTION
Update the two `spec/integration/organized/*_spec.rb` files so each one navigates to its starting page by clicking the relevant link in the mobile org dropdown after sign-in (`#passive_organization_submenu` in the top header → "Parking notifications" / "{org} Bikes" / "Multi search"). Dismiss the post-login success flash first so it doesn't intercept the dropdown click.

Also fixes a bug in `search--form`: on Turbo back/forward navigation, `connect()` can fire before the turbo-frame is parsed, so the `#loadedWithoutResults` auto-submit check silently no-ops and the user lands on the empty initial state instead of their search results. Re-running the check on `turbo:load` recovers in that case (idempotent once results load). Affects the org registrations search and the public bike search.
