### PR TITLE
Track bike_possibly_found email delivery via Notification

### DIFF
--- a/app/jobs/email/bike_possibly_found_notification_job.rb
+++ b/app/jobs/email/bike_possibly_found_notification_job.rb
@@ -16,7 +16,14 @@ module Email
 
       email = CustomerMailer.bike_possibly_found_email(contact)
       contact.email = email
-      email.deliver_now if contact.save
+      return unless contact.save
+
+      notification = contact.notification || Notification.create(notifiable: contact,
+        user_id: contact.user_id,
+        bike_id: contact.bike_id,
+        kind: contact.kind)
+
+      notification.track_email_delivery { email.deliver_now }
     end
   end
 end

--- a/spec/jobs/email/bike_possibly_found_notification_job_spec.rb
+++ b/spec/jobs/email/bike_possibly_found_notification_job_spec.rb
@@ -16,10 +16,19 @@ RSpec.describe Email::BikePossiblyFoundNotificationJob, type: :job do
     expect(bike.serial_normalized).to eq(match.serial_normalized)
     expect(bike.owner_email).to_not eq(match.owner_email)
 
-    described_class.new.perform(bike.id, match.class, match.id)
+    expect {
+      described_class.new.perform(bike.id, match.class, match.id)
+    }.to change(Notification, :count).by(1)
 
     expect(ActionMailer::Base.deliveries.length).to eq(1)
     expect(CustomerMailer).to have_received(:bike_possibly_found_email).once
+
+    notification = Notification.last
+    expect(notification.kind).to eq "bike_possibly_found"
+    expect(notification.bike_id).to eq bike.id
+    expect(notification.notifiable_type).to eq "CustomerContact"
+    expect(notification.delivery_status).to eq "delivery_success"
+    expect(notification.message_id).to be_present
   end
 
   it "skips the bike if it's its own match" do


### PR DESCRIPTION
Wraps the `bike_possibly_found_email` send in `Notification#track_email_delivery`, so possibly-found alerts get the same delivery tracking (message_id, delivery_status, user_email error bookkeeping) as the other Email jobs.

- Find-or-create a `Notification` on the saved `CustomerContact` and deliver inside `track_email_delivery`, matching the pattern in `CustomerContactNotificationCreateJob` and the other `Email::*Job`s.
- Spec now asserts the notification is created with `delivery_status: "delivery_success"` and a populated `message_id`.
