### PR TITLE
Rename Stimulus controller to table-multi-checkbox

### DIFF
--- a/app/javascript/controllers/table_multi_checkbox_controller.js
+++ b/app/javascript/controllers/table_multi_checkbox_controller.js
@@ -1,6 +1,6 @@
 import { Controller } from '@hotwired/stimulus'
 
-// Connects to data-controller="table-multi-select"
+// Connects to data-controller="table-multi-checkbox"
 export default class extends Controller {
   static targets = ['checkbox']
 

--- a/app/javascript/controllers/table_multi_select_controller.js
+++ b/app/javascript/controllers/table_multi_select_controller.js
@@ -1,6 +1,6 @@
 import { Controller } from '@hotwired/stimulus'
 
-// Connects to data-controller="table-multi-delete"
+// Connects to data-controller="table-multi-select"
 export default class extends Controller {
   static targets = ['checkbox']
 

--- a/app/views/admin/bikes/_table.html.erb
+++ b/app/views/admin/bikes/_table.html.erb
@@ -29,7 +29,7 @@
   <style>.ui-table thead {display: none !important;}</style>
 <% end %>
 
-<%= form_tag get_destroy_admin_bike_path(id: "multi_delete"), method: :get, data: {controller: "table-multi-select"} do %>
+<%= form_tag get_destroy_admin_bike_path(id: "multi_delete"), method: :get, data: {controller: "table-multi-checkbox"} do %>
   <div class="display-multi-check mb-3 text-center">
     <%= submit_tag 'Delete selected', class: 'btn btn-outline-danger' %>
   </div>
@@ -39,8 +39,8 @@
     data-update-cached-sortable-links-base-url-value="<%= url_for(sortable_search_params) %>"
   >
     <%= render(UI::Table::Component.new(records: bikes, cache_key: "admin-bikes-v2", render_sortable:, classes: show_serial ? "show-admin-bike-table-serial-cell" : nil)) do |table| %>
-      <% table.column(label: button_tag(check_mark, type: "button", class: "twlink tw:bg-transparent tw:border-0 tw:p-0 tw:cursor-pointer", data: {action: "click->table-multi-select#toggleAll"}), classes: "display-multi-check tw:w-8", header_classes: "display-multi-check tw:w-8") do |bike| %>
-        <%= check_box_tag "bikes_selected[#{bike.id}]", bike.id, false, data: {"table-multi-select-target" => "checkbox"} %>
+      <% table.column(label: button_tag(check_mark, type: "button", class: "twlink tw:bg-transparent tw:border-0 tw:p-0 tw:cursor-pointer", data: {action: "click->table-multi-checkbox#toggleAll"}), classes: "display-multi-check tw:w-8", header_classes: "display-multi-check tw:w-8") do |bike| %>
+        <%= check_box_tag "bikes_selected[#{bike.id}]", bike.id, false, data: {"table-multi-checkbox-target" => "checkbox"} %>
       <% end %>
 
       <% table.column(sortable: "id", label: "Added", lower_right: ->(bike) { content_tag(:span, bike.id, class: "only-dev-visible") }) do |bike| %>

--- a/app/views/admin/bikes/_table.html.erb
+++ b/app/views/admin/bikes/_table.html.erb
@@ -29,7 +29,7 @@
   <style>.ui-table thead {display: none !important;}</style>
 <% end %>
 
-<%= form_tag get_destroy_admin_bike_path(id: "multi_delete"), method: :get, data: {controller: "table-multi-delete"} do %>
+<%= form_tag get_destroy_admin_bike_path(id: "multi_delete"), method: :get, data: {controller: "table-multi-select"} do %>
   <div class="display-multi-check mb-3 text-center">
     <%= submit_tag 'Delete selected', class: 'btn btn-outline-danger' %>
   </div>
@@ -39,8 +39,8 @@
     data-update-cached-sortable-links-base-url-value="<%= url_for(sortable_search_params) %>"
   >
     <%= render(UI::Table::Component.new(records: bikes, cache_key: "admin-bikes-v2", render_sortable:, classes: show_serial ? "show-admin-bike-table-serial-cell" : nil)) do |table| %>
-      <% table.column(label: button_tag(check_mark, type: "button", class: "twlink tw:bg-transparent tw:border-0 tw:p-0 tw:cursor-pointer", data: {action: "click->table-multi-delete#toggleAll"}), classes: "display-multi-check tw:w-8", header_classes: "display-multi-check tw:w-8") do |bike| %>
-        <%= check_box_tag "bikes_selected[#{bike.id}]", bike.id, false, data: {"table-multi-delete-target" => "checkbox"} %>
+      <% table.column(label: button_tag(check_mark, type: "button", class: "twlink tw:bg-transparent tw:border-0 tw:p-0 tw:cursor-pointer", data: {action: "click->table-multi-select#toggleAll"}), classes: "display-multi-check tw:w-8", header_classes: "display-multi-check tw:w-8") do |bike| %>
+        <%= check_box_tag "bikes_selected[#{bike.id}]", bike.id, false, data: {"table-multi-select-target" => "checkbox"} %>
       <% end %>
 
       <% table.column(sortable: "id", label: "Added", lower_right: ->(bike) { content_tag(:span, bike.id, class: "only-dev-visible") }) do |bike| %>

--- a/app/views/admin/bikes/missing_manufacturer.html.haml
+++ b/app/views/admin/bikes/missing_manufacturer.html.haml
@@ -43,7 +43,7 @@
 
 = render_admin_pagination_with_count(collection: @bikes)
 
-= form_tag update_manufacturers_admin_bikes_path, data: {controller: "table-multi-delete"} do
+= form_tag update_manufacturers_admin_bikes_path, data: {controller: "table-multi-select"} do
   .row
     .col-md-4
       .fancy-select.unfancy
@@ -55,7 +55,7 @@
     %table.table.table-striped.table-bordered.table-sm
       %thead.thead-light
         %th.table-checkbox-select
-          %button{ type: "button", class: "twlink tw:bg-transparent tw:border-0 tw:p-0 tw:cursor-pointer", data: { action: "click->table-multi-delete#toggleAll" } }
+          %button{ type: "button", class: "twlink tw:bg-transparent tw:border-0 tw:p-0 tw:cursor-pointer", data: { action: "click->table-multi-select#toggleAll" } }
             = check_mark
         %th
           Date indexed
@@ -70,7 +70,7 @@
         - @bikes.each do |bike|
           %tr
             %td.table-checkbox-select
-              = check_box_tag "bikes_selected[#{bike.id}]", bike.id, false, data: { "table-multi-delete-target" => "checkbox" }
+              = check_box_tag "bikes_selected[#{bike.id}]", bike.id, false, data: { "table-multi-select-target" => "checkbox" }
             %td
               .less-strong-hold
                 %a.localizeTime{ href: edit_admin_bike_url(bike) }

--- a/app/views/admin/bikes/missing_manufacturer.html.haml
+++ b/app/views/admin/bikes/missing_manufacturer.html.haml
@@ -43,7 +43,7 @@
 
 = render_admin_pagination_with_count(collection: @bikes)
 
-= form_tag update_manufacturers_admin_bikes_path, data: {controller: "table-multi-select"} do
+= form_tag update_manufacturers_admin_bikes_path, data: {controller: "table-multi-checkbox"} do
   .row
     .col-md-4
       .fancy-select.unfancy
@@ -55,7 +55,7 @@
     %table.table.table-striped.table-bordered.table-sm
       %thead.thead-light
         %th.table-checkbox-select
-          %button{ type: "button", class: "twlink tw:bg-transparent tw:border-0 tw:p-0 tw:cursor-pointer", data: { action: "click->table-multi-select#toggleAll" } }
+          %button{ type: "button", class: "twlink tw:bg-transparent tw:border-0 tw:p-0 tw:cursor-pointer", data: { action: "click->table-multi-checkbox#toggleAll" } }
             = check_mark
         %th
           Date indexed
@@ -70,7 +70,7 @@
         - @bikes.each do |bike|
           %tr
             %td.table-checkbox-select
-              = check_box_tag "bikes_selected[#{bike.id}]", bike.id, false, data: { "table-multi-select-target" => "checkbox" }
+              = check_box_tag "bikes_selected[#{bike.id}]", bike.id, false, data: { "table-multi-checkbox-target" => "checkbox" }
             %td
               .less-strong-hold
                 %a.localizeTime{ href: edit_admin_bike_url(bike) }

--- a/app/views/admin/stolen_bikes/_table.html.erb
+++ b/app/views/admin/stolen_bikes/_table.html.erb
@@ -7,7 +7,7 @@
         <button
           type="button"
           class="twlink tw:cursor-pointer tw:border-0 tw:bg-transparent tw:p-0"
-          data-action="click->table-multi-select#toggleAll"
+          data-action="click->table-multi-checkbox#toggleAll"
         >
           <%= check_mark %>
         </button>
@@ -33,7 +33,7 @@
 
         <tr>
           <td class="display-multi-check table-checkbox-select">
-            <%= check_box_tag "sr_selected[#{stolen_record.id}]", stolen_record.id, false, data: {"table-multi-select-target" => "checkbox"} %>
+            <%= check_box_tag "sr_selected[#{stolen_record.id}]", stolen_record.id, false, data: {"table-multi-checkbox-target" => "checkbox"} %>
           </td>
 
           <td>

--- a/app/views/admin/stolen_bikes/_table.html.erb
+++ b/app/views/admin/stolen_bikes/_table.html.erb
@@ -7,7 +7,7 @@
         <button
           type="button"
           class="twlink tw:cursor-pointer tw:border-0 tw:bg-transparent tw:p-0"
-          data-action="click->table-multi-delete#toggleAll"
+          data-action="click->table-multi-select#toggleAll"
         >
           <%= check_mark %>
         </button>
@@ -33,7 +33,7 @@
 
         <tr>
           <td class="display-multi-check table-checkbox-select">
-            <%= check_box_tag "sr_selected[#{stolen_record.id}]", stolen_record.id, false, data: {"table-multi-delete-target" => "checkbox"} %>
+            <%= check_box_tag "sr_selected[#{stolen_record.id}]", stolen_record.id, false, data: {"table-multi-select-target" => "checkbox"} %>
           </td>
 
           <td>

--- a/app/views/admin/stolen_bikes/index.html.erb
+++ b/app/views/admin/stolen_bikes/index.html.erb
@@ -70,7 +70,7 @@
     </p>
   <% end %>
 
-  <%= form_tag approve_admin_stolen_bike_path(id: "multi_approve"), method: :post, data: {controller: "table-multi-select"} do %>
+  <%= form_tag approve_admin_stolen_bike_path(id: "multi_approve"), method: :post, data: {controller: "table-multi-checkbox"} do %>
     <%= render partial: "table", locals: {render_sortable: true} %>
 
     <div class="mb-3 text-center">

--- a/app/views/admin/stolen_bikes/index.html.erb
+++ b/app/views/admin/stolen_bikes/index.html.erb
@@ -70,7 +70,7 @@
     </p>
   <% end %>
 
-  <%= form_tag approve_admin_stolen_bike_path(id: "multi_approve"), method: :post, data: {controller: "table-multi-delete"} do %>
+  <%= form_tag approve_admin_stolen_bike_path(id: "multi_approve"), method: :post, data: {controller: "table-multi-select"} do %>
     <%= render partial: "table", locals: {render_sortable: true} %>
 
     <div class="mb-3 text-center">


### PR DESCRIPTION
Rename the Stimulus controller previously named `table-multi-delete` to `table-multi-checkbox`. It powers more than deletion — admin bikes deletion, stolen-bike approval, and missing-manufacturer updates all use it for bulk row selection via header checkboxes — so the new name reflects what the controller actually wires up.

- Renamed `app/javascript/controllers/table_multi_delete_controller.js` → `table_multi_checkbox_controller.js`
- Updated `data-controller`, `data-action`, and `data-*-target` references across the four admin views that use it
