### PR TITLE
legacy CSS fixes for UI::PeriodSelect and UI::Table

### DIFF
--- a/.claude/skills/frontend-conventions/SKILL.md
+++ b/.claude/skills/frontend-conventions/SKILL.md
@@ -42,8 +42,6 @@ When deleting an `id`/`class`, grep the repo for the name before deciding what t
 - Zero consumers: delete it, don't rename it.
 - Consumers exist: either update them, or leave the hook in place — the consumers are the *reason* it earns its spot in the markup.
 
-The wrapper is already addressable via its `data-controller` (e.g. `[data-controller~="ui--period-select"]`) if a stylesheet ever needs it. A standalone "marker class" with no consumer is just lint.
-
 ## ViewComponent rules
 
 This project uses the ViewComponent gem to render components.

--- a/.claude/skills/frontend-conventions/SKILL.md
+++ b/.claude/skills/frontend-conventions/SKILL.md
@@ -33,6 +33,17 @@ The `bin/dev` command handles building and updating Tailwind and JS.
   - "Number" includes years, counts, prices, distances, IDs — anything numeric, even when it reads like a label.
 - **Currency amounts** use `amount_display(obj)` instead of `number_display` directly. It takes an object that responds to `amount_cents`, `amount`, `currency_symbol`, and `currency_name` (e.g. a `MarketplaceListing`), and renders the symbol + `number_display(amount)` together. Don't reach for `number_to_currency` or roll your own.
 
+## No dead hooks in markup
+
+Only add an `id` or non-utility `class` when something concrete consumes it — a CSS rule, a JS/Stimulus selector, a test fixture, an accessibility attribute. Don't keep or invent "structural identifier" hooks "in case something needs them later," and don't replace a removed hook with a renamed one out of inertia.
+
+When deleting an `id`/`class`, grep the repo for the name before deciding what to do with it:
+
+- Zero consumers: delete it, don't rename it.
+- Consumers exist: either update them, or leave the hook in place — the consumers are the *reason* it earns its spot in the markup.
+
+The wrapper is already addressable via its `data-controller` (e.g. `[data-controller~="ui--period-select"]`) if a stylesheet ever needs it. A standalone "marker class" with no consumer is just lint.
+
 ## ViewComponent rules
 
 This project uses the ViewComponent gem to render components.

--- a/app/assets/stylesheets/revised/sections/_period_selection.scss
+++ b/app/assets/stylesheets/revised/sections/_period_selection.scss
@@ -16,7 +16,8 @@
   }
 }
 
-// Duplicated from period_selection in packs
+// Duplicated from period_selection in packs (used by legacy haml usages
+// of #timeSelectionBtnGroup; UI::PeriodSelect handles its own fade via Tailwind)
 #timeSelectionBtnGroup {
   .period-select-standard {
     transition: opacity 0.5s ease-in-out;

--- a/app/assets/tailwind/application.css
+++ b/app/assets/tailwind/application.css
@@ -163,11 +163,6 @@
   @apply tw:antialiased tw:font-sans tw:text-gray-900 tw:dark:text-gray-400;
 }
 
-/* Unlayered so it wins over the size utilities (`tw:px-2.5`) injected by UI::Button */
-.period-select-standard {
-  @apply tw:px-1.5 tw:sm:px-2.5;
-}
-
 @layer base {
   button:not(:disabled),
   [role="button"]:not(:disabled),

--- a/app/components/ui/period_select/component.html.erb
+++ b/app/components/ui/period_select/component.html.erb
@@ -1,9 +1,6 @@
 <div data-controller="collapse ui--period-select">
   <div
-    class="
-      period-select-btn-group text-right tw:flex tw:flex-wrap tw:justify-end
-      tw:gap-1 tw:sm:gap-2
-    "
+    class="text-right tw:flex tw:flex-wrap tw:justify-end tw:gap-1 tw:sm:gap-2"
     role="group"
   >
     <% if @prepend_text.present? %>

--- a/app/components/ui/period_select/component.html.erb
+++ b/app/components/ui/period_select/component.html.erb
@@ -1,7 +1,9 @@
 <div data-controller="collapse ui--period-select">
   <div
-    id="timeSelectionBtnGroup"
-    class="text-right tw:flex tw:flex-wrap tw:justify-end tw:gap-1 tw:sm:gap-2 <%= "custom-period-selected" if @period == "custom" %>"
+    class="
+      period-select-btn-group text-right tw:flex tw:flex-wrap tw:justify-end
+      tw:gap-1 tw:sm:gap-2
+    "
     role="group"
   >
     <% if @prepend_text.present? %>
@@ -26,7 +28,7 @@
       text: translation(".custom"),
       size: :sm,
       active: @period == "custom",
-      html_class: "period-select-standard",
+      html_class: period_button_class,
       data: {period: "custom", action: "click->collapse#toggle"}
     ) %>
   </div>

--- a/app/components/ui/period_select/component.rb
+++ b/app/components/ui/period_select/component.rb
@@ -33,9 +33,14 @@ module UI
           href: period_url(period_key),
           size: :sm,
           active: @period == period_key,
-          class: "period-select-standard",
+          class: period_button_class,
           data: {period: period_key, turbo_action: "advance"}
         )
+      end
+
+      def period_button_class
+        base = "tw:px-1.5! tw:sm:px-2.5! tw:transition-opacity tw:duration-500"
+        (@period == "custom") ? "#{base} tw:opacity-60" : base
       end
 
       def period_url(period)

--- a/app/components/ui/table/component.rb
+++ b/app/components/ui/table/component.rb
@@ -58,7 +58,7 @@ module UI
 
       def table_classes
         [
-          "ui-table tw:min-w-full tw:text-left tw:leading-tight tw:border-separate! tw:border-spacing-0",
+          "ui-table tw:min-w-full tw:text-left tw:leading-[1.25] tw:border-separate! tw:border-spacing-0",
           ("ui-table-bordered" if @bordered),
           @classes
         ].compact.join(" ")

--- a/app/components/ui/table/component.rb
+++ b/app/components/ui/table/component.rb
@@ -58,7 +58,7 @@ module UI
 
       def table_classes
         [
-          "ui-table tw:min-w-full tw:text-left tw:border-separate! tw:border-spacing-0",
+          "ui-table tw:min-w-full tw:text-left tw:leading-tight tw:border-separate! tw:border-spacing-0",
           ("ui-table-bordered" if @bordered),
           @classes
         ].compact.join(" ")


### PR DESCRIPTION
Frontend cleanup across `UI::PeriodSelect` and `UI::Table`, plus a supporting skill note.

- **`UI::PeriodSelect`** — replaces three legacy CSS hooks (the `#timeSelectionBtnGroup` ID, the `period-select-standard` class, the `custom-period-selected` modifier) with inline Tailwind utilities on the buttons: `tw:px-1.5! tw:sm:px-2.5! tw:transition-opacity tw:duration-500`, plus `tw:opacity-60` when `period == "custom"`. Behavior is unchanged — the Stimulus controller never referenced any of them. The two legacy haml usages (`stolen_bike_listings/index`, `organized/parking_notifications/index`) keep the old ID/class with Bootstrap `.btn-sm` sizing, so the `#timeSelectionBtnGroup` SCSS rule is preserved for them.
- **`UI::Table`** — adds `tw:leading-[1.25]` to the `<table>` for tighter row line-height.
- **`frontend-conventions` skill** — adds a "No dead hooks in markup" note: only add an `id`/non-utility `class` when a CSS rule, JS selector, test, or a11y attribute consumes it; grep for consumers before deciding what to do with a removed hook.
