### PR TITLE
Wrap legacy styles in @layer legacy in revised.scss

### DIFF
--- a/app/assets/stylesheets/revised.scss
+++ b/app/assets/stylesheets/revised.scss
@@ -1,6 +1,13 @@
 // Wrap all Bootstrap / legacy styles in @layer legacy so Tailwind's @layer
 // components / utilities (declared in app/assets/tailwind/application.css)
 // can override them by simple cascade order, without needing !important.
+//
+// The layer order must be declared identically here and in
+// app/assets/tailwind/application.css — CSS fixes a layer's position the
+// first time it is named, so whichever stylesheet the browser parses first
+// would otherwise decide the order.
+@layer theme, base, legacy, components, utilities;
+
 @layer legacy {
 
 @import 'legacy_includes/select2';

--- a/app/assets/stylesheets/revised.scss
+++ b/app/assets/stylesheets/revised.scss
@@ -1,3 +1,8 @@
+// Wrap all Bootstrap / legacy styles in @layer legacy so Tailwind's @layer
+// components / utilities (declared in app/assets/tailwind/application.css)
+// can override them by simple cascade order, without needing !important.
+@layer legacy {
+
 @import 'legacy_includes/select2';
 @import 'legacy_includes/selectize.bootstrap3';
 
@@ -406,3 +411,5 @@ $dev-color: #9400d3;
     }
   }
 }
+
+} // end @layer legacy


### PR DESCRIPTION
Wraps all Bootstrap / legacy styles in `revised.scss` in an `@layer legacy` block so Tailwind's `@layer components`/`utilities` can override them by simple cascade order, without needing `!important`. Also declares the full layer order (`@layer theme, base, legacy, components, utilities;`) at the top of `revised.scss` — matching `app/assets/tailwind/application.css` — so the order is deterministic regardless of which stylesheet the browser parses first.
