### PR TITLE
Fix collapsed whitespace in RadioButtonGroup toggle labels

### DIFF
--- a/app/components/form/radio_button_group/component.rb
+++ b/app/components/form/radio_button_group/component.rb
@@ -49,7 +49,7 @@ module Form
             class: "tw:sr-only",
             form: @form,
             data: @data) +
-            option[:label].html_safe
+            tag.span(option[:label].html_safe)
         end
       end
     end

--- a/app/components/form/radio_button_group/component_preview.rb
+++ b/app/components/form/radio_button_group/component_preview.rb
@@ -15,6 +15,17 @@ module Form
         ))
       end
 
+      def with_html_labels
+        render(Form::RadioButtonGroup::Component.new(
+          name: :search_status,
+          entries: [
+            {value: "", label: "All"},
+            {value: "not_impounded", label: "only <strong>not</strong> impounded"},
+            {value: "impounded", label: "only <strong>impounded</strong>"}
+          ]
+        ))
+      end
+
       def with_selection
         render(Form::RadioButtonGroup::Component.new(
           name: :search_filter,

--- a/spec/components/form/radio_button_group/component_system_spec.rb
+++ b/spec/components/form/radio_button_group/component_system_spec.rb
@@ -24,6 +24,17 @@ RSpec.describe Form::RadioButtonGroup::Component, :js, type: :system do
     end
   end
 
+  context "with_html_labels" do
+    it "keeps spaces around inline markup" do
+      visit("#{base_path}with_html_labels")
+
+      # The label is inline-flex, so each text run/element is a separate flex
+      # item — without a wrapper the whitespace between them gets collapsed.
+      expect(find("label", text: "only not impounded")).to be_present
+      expect(find("label", text: "only impounded")).to be_present
+    end
+  end
+
   context "with_selection" do
     it "renders with pre-selected value" do
       visit("#{base_path}with_selection")


### PR DESCRIPTION
The org registration search status/sticker/address toggle buttons stopped showing spaces between words (e.g. `only not impounded` rendered as `onlynotimpounded`).

- `Form::RadioButtonGroup::Component` labels are `inline-flex`, so each text run and inline element (`<strong>`) became a separate flex item and the whitespace between them was stripped — wrap the label content in a `span` so it is a single flex item.
- Add a `with_html_labels` component preview and a spec asserting spaces around inline markup are preserved (existing previews only used single-word labels).
