### PR TITLE
Fix MissingTemplate crash on failed bike version update

### DIFF
--- a/app/controllers/bike_versions_controller.rb
+++ b/app/controllers/bike_versions_controller.rb
@@ -42,9 +42,8 @@ class BikeVersionsController < ApplicationController
       flash[:success] = "#{@bike.type.titleize} version updated"
       redirect_to(edit_bike_version_path(@bike_version, edit_template: params[:edit_template])) && return
     else
-      @edit_template = nil
-      flash[:error] = "Unable to update"
-      render :edit_template
+      flash[:error] = "Unable to update: #{@bike_version.errors.full_messages.to_sentence}"
+      redirect_to(edit_bike_version_path(@bike_version, edit_template: params[:edit_template])) && return
     end
   end
 

--- a/app/controllers/bike_versions_controller.rb
+++ b/app/controllers/bike_versions_controller.rb
@@ -40,11 +40,10 @@ class BikeVersionsController < ApplicationController
     end
     if @bike_version.update(permitted_params.except(:start_at, :end_at))
       flash[:success] = "#{@bike.type.titleize} version updated"
-      redirect_to(edit_bike_version_path(@bike_version, edit_template: params[:edit_template])) && return
     else
       flash[:error] = "Unable to update: #{@bike_version.errors.full_messages.to_sentence}"
-      redirect_to(edit_bike_version_path(@bike_version, edit_template: params[:edit_template])) && return
     end
+    redirect_to(edit_bike_version_path(@bike_version, edit_template: params[:edit_template]))
   end
 
   def destroy

--- a/spec/requests/bike_versions_request_spec.rb
+++ b/spec/requests/bike_versions_request_spec.rb
@@ -171,6 +171,17 @@ RSpec.describe BikeVersionsController, type: :request do
       expect(bike_version.start_at.to_i).to be_within(1).of 1524938400
       expect(bike_version.end_at.to_i).to be_within(1).of 1632852000
     end
+    context "invalid params" do
+      it "redirects to edit with the error" do
+        patch "#{base_url}/#{bike_version.id}", params: {
+          edit_template: "bike_details",
+          bike_version: valid_update_params.merge(name: "")
+        }
+        expect(flash[:error]).to match("Unable to update")
+        expect(response).to redirect_to("/bike_versions/#{bike_version.id}/edit/bike_details")
+        expect(bike_version.reload.name).to_not eq ""
+      end
+    end
     context "update visibility" do
       it "updates visibility" do
         expect(bike_version.reload.visibility).to eq "visible_not_related"


### PR DESCRIPTION
`BikeVersionsController#update` rendered `:edit_template` when a version update failed validation, but no such template exists — the edit views live in the separate `BikeVersions::EditsController` (`render :"/bikes_edit/..."`). Every failed update therefore returned a 500 (`ActionView::MissingTemplate`) instead of showing the user an error.

- Failed updates now redirect back to the edit page with the validation messages in `flash[:error]`, matching the success branch's redirect.
- Added a request spec covering an invalid update (blank `name`).
