### PR TITLE
Fix flaky rack_attack and organized registrations search specs

### DIFF
--- a/spec/integration/organized/registrations_search_spec.rb
+++ b/spec/integration/organized/registrations_search_spec.rb
@@ -24,6 +24,9 @@ RSpec.describe "Organized registrations search", :js, type: :system do
     fill_in "Password", with: "testthisthing7$"
     click_button "Log in"
     find(".alert-success .close").click
+    # Wait for the flash to finish dismissing -- otherwise it overlaps and
+    # intercepts the click on the nav link below
+    expect(page).to have_no_css(".alert-success")
     find("#passive_organization_submenu").click
     within(".current-organization-submenu") { click_link "#{organization.short_name} Bikes" }
     expect(page).to have_current_path(/\A#{Regexp.escape(bikes_path)}(\?|\z)/, wait: 10)

--- a/spec/requests/api/v3/search_request_spec.rb
+++ b/spec/requests/api/v3/search_request_spec.rb
@@ -195,14 +195,13 @@ RSpec.describe "Search API V3", type: :request do
 
     it "throttles after exceeding the API limit, returns JSON" do
       expect(Rack::Attack::API_MAX_REQUESTS).to eq 15
-      # Send 2x the limit so throttling is guaranteed even if a
-      # period boundary resets the counter mid-test.
-      (Rack::Attack::API_MAX_REQUESTS * 2).times do
+      throttled = rack_attack_throttled_response(limit: Rack::Attack::API_MAX_REQUESTS) do
         get "/api/v3/search", params: {stolenness: "non", format: :json}
+        response
       end
-      expect(response).to have_http_status(:too_many_requests)
-      expect(response.content_type).to include("application/json")
-      expect(JSON.parse(response.body)).to eq("error" => "Too Many Requests")
+      expect(throttled).to have_http_status(:too_many_requests)
+      expect(throttled.content_type).to include("application/json")
+      expect(JSON.parse(throttled.body)).to eq("error" => "Too Many Requests")
     end
   end
 

--- a/spec/requests/my_accounts_request_spec.rb
+++ b/spec/requests/my_accounts_request_spec.rb
@@ -752,12 +752,11 @@ RSpec.describe MyAccountsController, type: :request do
     include_context :rack_attack
 
     it "returns 429 after exceeding the limit" do
-      5.times do
+      throttled = rack_attack_throttled_response(limit: 5) do
         patch base_url, params: {user: {password: "newpass123"}}
-        expect(response.status).to_not eq 429
+        response
       end
-      patch base_url, params: {user: {password: "newpass123"}}
-      expect(response).to have_http_status(:too_many_requests)
+      expect(throttled).to have_http_status(:too_many_requests)
     end
   end
 end

--- a/spec/requests/sessions_request_spec.rb
+++ b/spec/requests/sessions_request_spec.rb
@@ -113,25 +113,23 @@ RSpec.describe SessionsController, type: :request do
       include_context :rack_attack
 
       it "returns 429 after exceeding IP limit" do
-        users = Array.new(10) { FactoryBot.create(:user_confirmed, password:, password_confirmation: password) }
-        users.each do |sign_in_user|
+        # A fresh user per request keeps each email under the per-email
+        # throttle, so only the per-IP throttle (retry-after 60) can trip.
+        throttled = rack_attack_throttled_response(limit: 10) do
+          sign_in_user = FactoryBot.create(:user_confirmed, password:, password_confirmation: password)
           post "/session", params: {session: {email: sign_in_user.email, password:}}
-          expect(response.status).to_not eq 429
+          response
         end
-        post "/session", params: {session: {email: user.email, password:}}
-        expect(response).to have_http_status(:too_many_requests)
-        expect(response.headers["retry-after"]).to eq "60"
-        expect(response.body).to eq "Too Many Requests"
+        expect(throttled.headers["retry-after"]).to eq "60"
+        expect(throttled.body).to eq "Too Many Requests"
       end
 
       it "returns 429 after exceeding per-email limit" do
-        5.times do
+        throttled = rack_attack_throttled_response(limit: 5) do
           post "/session", params: {session: {email: user.email, password:}}
-          expect(response.status).to_not eq 429
+          response
         end
-        post "/session", params: {session: {email: user.email, password:}}
-        expect(response).to have_http_status(:too_many_requests)
-        expect(response.headers["retry-after"]).to eq "20"
+        expect(throttled.headers["retry-after"]).to eq "20"
       end
     end
   end
@@ -140,12 +138,11 @@ RSpec.describe SessionsController, type: :request do
     include_context :rack_attack
 
     it "returns 429 after exceeding the limit" do
-      5.times do
+      throttled = rack_attack_throttled_response(limit: 5) do
         post "/session/create_magic_link"
-        expect(response.status).to_not eq 429
+        response
       end
-      post "/session/create_magic_link"
-      expect(response).to have_http_status(:too_many_requests)
+      expect(throttled).to have_http_status(:too_many_requests)
     end
   end
 end

--- a/spec/requests/user_emails_request_spec.rb
+++ b/spec/requests/user_emails_request_spec.rb
@@ -42,12 +42,11 @@ RSpec.describe UserEmailsController, type: :request do
     include_context :rack_attack
 
     it "returns 429 after exceeding the limit" do
-      5.times do
+      throttled = rack_attack_throttled_response(limit: 5) do
         post "#{base_url}/123/resend_confirmation"
-        expect(response.status).to_not eq 429
+        response
       end
-      post "#{base_url}/123/resend_confirmation"
-      expect(response).to have_http_status(:too_many_requests)
+      expect(throttled).to have_http_status(:too_many_requests)
     end
   end
 

--- a/spec/requests/users_request_spec.rb
+++ b/spec/requests/users_request_spec.rb
@@ -160,12 +160,11 @@ RSpec.describe UsersController, type: :request do
     include_context :rack_attack
 
     it "returns 429 after exceeding the limit" do
-      5.times do
+      throttled = rack_attack_throttled_response(limit: 5) do
         post "#{base_url}/resend_confirmation_email", params: {email: "a@b.com"}
-        expect(response.status).to_not eq 429
+        response
       end
-      post "#{base_url}/resend_confirmation_email", params: {email: "a@b.com"}
-      expect(response).to have_http_status(:too_many_requests)
+      expect(throttled).to have_http_status(:too_many_requests)
     end
   end
 
@@ -173,12 +172,11 @@ RSpec.describe UsersController, type: :request do
     include_context :rack_attack
 
     it "returns 429 after exceeding the limit" do
-      5.times do
+      throttled = rack_attack_throttled_response(limit: 5) do
         post "#{base_url}/send_password_reset_email", params: {email: "a@b.com"}
-        expect(response.status).to_not eq 429
+        response
       end
-      post "#{base_url}/send_password_reset_email", params: {email: "a@b.com"}
-      expect(response).to have_http_status(:too_many_requests)
+      expect(throttled).to have_http_status(:too_many_requests)
     end
   end
 

--- a/spec/support/rack_attack.rb
+++ b/spec/support/rack_attack.rb
@@ -14,4 +14,24 @@ RSpec.shared_context :rack_attack do
     Rack::Attack.enabled = false
     Rack::Attack.cache.store.clear
   end
+
+  # Rack::Attack throttles use fixed wall-clock windows -- the cache key is
+  # floor(Time.now / period) -- so a window boundary can roll over mid-example
+  # and reset the counter. Firing 2 * limit + 1 requests guarantees that, even
+  # if one rollover splits them across two windows, one window still exceeds
+  # `limit` (the larger half is always >= limit + 1). The whole batch runs in
+  # well under a throttle period, so at most one rollover can happen. This
+  # makes a 429 deterministic without freezing time.
+  #
+  # The block makes one request and returns its response; the first throttled
+  # response is returned for further assertions (retry-after, body, etc).
+  def rack_attack_throttled_response(limit:)
+    responses = Array.new(2 * limit + 1) { yield }
+    # The first `limit` requests can never be throttled: each request's
+    # window count is at most its index, so index <= limit stays <= limit.
+    expect(responses.first(limit).map(&:status)).to all(be < 429)
+    throttled = responses.find { |response| response.status == 429 }
+    expect(throttled).to be_present
+    throttled
+  end
 end


### PR DESCRIPTION
Fixes flaky CI failures in several specs.

**rack_attack throttle tests** — Rack::Attack throttles use fixed wall-clock windows (the cache key is `floor(Time.now / period)`), so a window boundary can roll over mid-example and reset the counter — a test that fired exactly `limit + 1` requests expecting the last one to trip the throttle would intermittently get a non-429 response.

- Adds a `rack_attack_throttled_response` helper to the `:rack_attack` shared context that fires `2 * limit + 1` requests, so one window always exceeds the limit even with a rollover — making the 429 deterministic without freezing time.
- Converts every spec with this flake to the helper: the three sessions specs (`create_magic_link`, per-IP, per-email), `resend_confirmation_email` and `send_password_reset_email` (users), `resend_confirmation` (user_emails), `update` (my_accounts), and the API search throttle.
- The sessions per-IP test now creates a fresh user per request so only the per-IP throttle can trip; the API search spec previously fired 2x the limit but asserted the *last* response was a 429, which still flaked if a rollover landed in the final gap.

**Organized registrations search spec** — the `before` block clicks the flash's `.close` button, but the dismissal is animated, so the `.alert-success` flash could still overlap the nav link when the next click fired (`ElementClickInterceptedError`). Now waits for the flash to fully dismiss first.
