### PR TITLE
Handle concurrent ModelAudit creation race in FindOrCreateModelAuditJob

### DIFF
--- a/app/jobs/find_or_create_model_audit_job.rb
+++ b/app/jobs/find_or_create_model_audit_job.rb
@@ -68,5 +68,10 @@ class FindOrCreateModelAuditJob < ApplicationJob
       frame_model: frame_model,
       propulsion_type: propulsion_type,
       cycle_type: cycle_type)
+  rescue ActiveRecord::RecordInvalid => e
+    # A concurrent job may have created the matching ModelAudit between find_for and create!
+    raise e unless e.record.errors.of_kind?(:frame_model, :taken)
+
+    ModelAudit.find_for(bike)
   end
 end

--- a/spec/jobs/find_or_create_model_audit_job_spec.rb
+++ b/spec/jobs/find_or_create_model_audit_job_spec.rb
@@ -188,6 +188,20 @@ RSpec.describe FindOrCreateModelAuditJob, type: :job do
         end
       end
     end
+    context "concurrent job created a matching model_audit" do
+      let!(:model_audit) { FactoryBot.create(:model_audit, manufacturer: manufacturer, frame_model: frame_model1) }
+      it "uses the existing model_audit rather than raising" do
+        Sidekiq::Job.clear_all
+        # Simulate find_for returning blank, then a concurrent job creating the matching model_audit
+        # before this job reaches ModelAudit.create!
+        allow(ModelAudit).to receive(:find_for).and_return(nil, model_audit)
+        expect {
+          instance.perform(bike1.id)
+        }.to change(ModelAudit, :count).by 0
+        expect(bike1.reload.model_audit_id).to eq model_audit.id
+        expect(UpdateModelAuditJob.jobs.map { |j| j["args"] }.flatten).to eq([model_audit.id])
+      end
+    end
     context "not matching model_audit" do
       let(:model_audit) { FactoryBot.create(:model_audit) }
       # This test replicates what would happen if a user updated a bike and it no longer matched the vehicle


### PR DESCRIPTION
Fixes Honeybadger fault [#123478542](https://app.honeybadger.io/projects/35931/faults/123478542) — `ActiveRecord::RecordInvalid: Validation failed: Frame model has already been taken` (1,159 occurrences).

Concurrent `FindOrCreateModelAuditJob`s for bikes sharing a model could both pass `ModelAudit.find_for` and then race on `ModelAudit.create!`; since uniqueness is enforced only by validation (no DB unique index), the loser raised `RecordInvalid`. The job now rescues that specific taken-`frame_model` error and falls back to `find_for`, linking the bike to the audit the other job created so it still gets assigned and `UpdateModelAuditJob` is enqueued.
