### PR TITLE
Fix time issue in graduated_notification owner-change spec

### DIFF
--- a/spec/models/graduated_notification_spec.rb
+++ b/spec/models/graduated_notification_spec.rb
@@ -669,9 +669,7 @@ RSpec.describe GraduatedNotification, type: :model do
         expect(graduated_notification.reload.user_id).to be_blank
         expect(graduated_notification.email).to_not eq user2.email
 
-        # Post-integration created_at — set in the future so email_success? takes the notifications branch
-        graduated_notification2 = GraduatedNotification.create(bike: bike, organization: organization,
-          created_at: GraduatedNotification::PRE_NOTIFICATION_INTEGRATION + 1.second)
+        graduated_notification2 = GraduatedNotification.create(bike: bike, organization: organization)
         expect(graduated_notification2).to be_valid
         allow(graduated_notification2).to receive(:processable?) { true }
         expect(graduated_notification2.user_id).to eq user2.id


### PR DESCRIPTION
Fixes a time-bomb in the `GraduatedNotification` owner-change spec.

#3548 added `PRE_NOTIFICATION_INTEGRATION` - and had to set the spec to run in the future, because it used the current time. Now the time is passed and it can be switched to testing the functionality using realistic times.