### PR TITLE
Document headless GitHub re-login in upload-image skill

### DIFF
--- a/.claude/skills/github-upload-image-to-pr/SKILL.md
+++ b/.claude/skills/github-upload-image-to-pr/SKILL.md
@@ -40,7 +40,23 @@ cp /path/to/CleanShot*keyword*.png /tmp/screenshot.png
 
 Use `ToolSearch` with a query like `"browser navigate upload"` to confirm `mcp__playwright__*` tools are registered.
 
-Playwright MCP attaches to or spawns a browser with a fresh profile, so **the user will need to sign into github.com the first time** in the spawned window. The session then persists across reuse.
+Playwright MCP reuses a persistent profile (`--user-data-dir`), so the github.com session persists across reuse once signed in.
+
+**Logging into GitHub when the MCP runs headless.** The MCP is configured with `--headless` (no visible window) so it never steals focus. The login cookie still lives in the persistent `--user-data-dir` profile and works headless — but you can't *type* credentials into a window that doesn't exist. When GitHub logs the user out (expired session, or first-ever use), re-login by temporarily running headed:
+
+```bash
+# 1. Remove the --headless flag for one session
+claude mcp remove playwright -s user
+claude mcp add playwright -s user -- npx -y @playwright/mcp@latest \
+  --user-data-dir="$HOME/.cache/ms-playwright/mcp-chrome-shared"
+# 2. Restart Claude Code, sign into github.com in the visible window (handles 2FA)
+# 3. Re-add --headless once the cookie is saved to the profile:
+claude mcp remove playwright -s user
+claude mcp add playwright -s user -- npx -y @playwright/mcp@latest \
+  --user-data-dir="$HOME/.cache/ms-playwright/mcp-chrome-shared" --headless
+```
+
+If you hit a 404 / login screen mid-task and the MCP is headless, stop and tell the user to do the headed re-login above rather than trying to drive the login form blind.
 
 ### If Playwright MCP is not installed
 
@@ -165,7 +181,7 @@ Reload the page in the Playwright browser and take a screenshot to confirm the i
 
 | Issue | Solution |
 |-------|----------|
-| Not logged in | SSO screen may appear — take snapshot, find "Continue" button, click it |
+| Not logged in | SSO screen may appear — take snapshot, find "Continue" button, click it. Full GitHub login can't be done headless — see "Logging into GitHub when the MCP runs headless" in Step 2 |
 | File path with special characters (e.g., Unicode narrow spaces from CleanShot) | Copy file to `/tmp/` with a simple name: `cp /path/CleanShot*keyword*.png /tmp/screenshot.png` |
 | File upload fails | Ensure the file path is absolute |
 | Textarea doesn't contain URLs yet | Wait 3–5 seconds after upload before running JS eval; retry once if needed |


### PR DESCRIPTION
The Playwright MCP now runs `--headless` so it no longer steals focus when capturing screenshots.

- Document in the `github-upload-image-to-pr` skill how to re-authenticate to github.com while headless — the login cookie persists in the `--user-data-dir` profile, but a fresh sign-in needs a temporary headed run.
- Note in the troubleshooting table that a mid-task login screen means stopping for a headed re-login rather than driving the form blind.

(The `--headless` MCP flag itself lives in global `~/.claude.json`, outside this repo; this PR only carries the skill documentation.)
