### PR TITLE
Rename org search "Search owner email" label to include name

### DIFF
--- a/app/components/search/form_organized/component.en.yml
+++ b/app/components/search/form_organized/component.en.yml
@@ -8,5 +8,5 @@ en:
           numbers, located under the bottom bracket.
         search_for_serial_number: Search for serial number
         search_notes: Search notes
-        search_owner_email: Search owner email
+        search_owner_email: Search owner email and name
         submit: submit

--- a/app/components/search/form_organized/component.en.yml
+++ b/app/components/search/form_organized/component.en.yml
@@ -8,5 +8,5 @@ en:
           numbers, located under the bottom bracket.
         search_for_serial_number: Search for serial number
         search_notes: Search notes
-        search_owner_email: Search owner email and name
+        search_owner_email_and_name: Search owner email and name
         submit: submit

--- a/app/components/search/form_organized/component.html.erb
+++ b/app/components/search/form_organized/component.html.erb
@@ -19,12 +19,12 @@
 
         <div class="tw:mt-2 tw:flex tw:flex-col tw:gap-2 tw:lg:flex-row">
           <%= label_tag :search_email,
-          translation(".search_owner_email"),
+          translation(".search_owner_email_and_name"),
           class: "twlabel tw:sr-only" %>
 
           <%= text_field_tag :search_email,
           params[:search_email],
-          placeholder: translation(".search_owner_email"),
+          placeholder: translation(".search_owner_email_and_name"),
           class: "twinput tw:flex-1 fieldResetsCounts" %>
 
           <% if render_serial_field? %>

--- a/config/locales/.translation_io
+++ b/config/locales/.translation_io
@@ -5,4 +5,4 @@
 # ignore the conflicts and "sync" again, it will fix this file for you.
 
 ---
-timestamp: 1779206773
+timestamp: 1779314182

--- a/config/locales/translation.es.yml
+++ b/config/locales/translation.es.yml
@@ -4434,9 +4434,9 @@ es:
       form_organized:
         doesnt_look_like_serial:
         search_for_serial_number:
-        search_owner_email:
         submit:
         search_notes:
+        search_owner_email_and_name:
     search_results:
       bike_box:
         location:

--- a/config/locales/translation.it.yml
+++ b/config/locales/translation.it.yml
@@ -4516,9 +4516,9 @@ it:
       form_organized:
         doesnt_look_like_serial:
         search_for_serial_number:
-        search_owner_email:
         submit:
         search_notes:
+        search_owner_email_and_name:
     search_results:
       bike_box:
         location: Luogo

--- a/config/locales/translation.nb.yml
+++ b/config/locales/translation.nb.yml
@@ -5619,9 +5619,9 @@ nb:
         doesnt_look_like_serial: Dette ser ikke ut som et serienummer. Serienumre
           er vanligvis 6+ bokstaver og tall, plassert under kranklageret.
         search_for_serial_number: Søk etter serienummer
-        search_owner_email: Søk etter eierens e-postadresse
         submit: sende inn
         search_notes: Søk i notater
+        search_owner_email_and_name: Søk eierens e-postadresse og navn
     search_results:
       bike_box:
         location: plassering

--- a/config/locales/translation.nl.yml
+++ b/config/locales/translation.nl.yml
@@ -5767,9 +5767,9 @@ nl:
         doesnt_look_like_serial: Dit lijkt geen serienummer. Serienummers bestaan
           meestal uit 6 of meer letters en cijfers en bevinden zich onder de trapas.
         search_for_serial_number: Zoek naar framenummer
-        search_owner_email: Zoek eigenaar e-mail
         submit: Voorleggen
         search_notes: Zoeknotities
+        search_owner_email_and_name: Zoek eigenaar e-mail
     search_results:
       bike_box:
         location: Plaats


### PR DESCRIPTION
The organized bike search input filters on both `bikes.owner_email` and `ownerships.owner_name` via `BikeServices::OrganizedSearch.email_and_name`, but the label/placeholder only mentioned email. Updates the English translation to "Search owner email and name" so the UI matches what the search actually does.
