### PR TITLE
Use "or name" in org search owner field label

### DIFF
--- a/app/components/search/form_organized/component.en.yml
+++ b/app/components/search/form_organized/component.en.yml
@@ -8,5 +8,5 @@ en:
           numbers, located under the bottom bracket.
         search_for_serial_number: Search for serial number
         search_notes: Search notes
-        search_owner_email_and_name: Search owner email and name
+        search_owner_email_or_name: Search owner email or name
         submit: submit

--- a/app/components/search/form_organized/component.html.erb
+++ b/app/components/search/form_organized/component.html.erb
@@ -19,12 +19,12 @@
 
         <div class="tw:mt-2 tw:flex tw:flex-col tw:gap-2 tw:lg:flex-row">
           <%= label_tag :search_email,
-          translation(".search_owner_email_and_name"),
+          translation(".search_owner_email_or_name"),
           class: "twlabel tw:sr-only" %>
 
           <%= text_field_tag :search_email,
           params[:search_email],
-          placeholder: translation(".search_owner_email_and_name"),
+          placeholder: translation(".search_owner_email_or_name"),
           class: "twinput tw:flex-1 fieldResetsCounts" %>
 
           <% if render_serial_field? %>

--- a/config/locales/.translation_io
+++ b/config/locales/.translation_io
@@ -5,4 +5,4 @@
 # ignore the conflicts and "sync" again, it will fix this file for you.
 
 ---
-timestamp: 1779314182
+timestamp: 1779322582

--- a/config/locales/translation.es.yml
+++ b/config/locales/translation.es.yml
@@ -4436,7 +4436,7 @@ es:
         search_for_serial_number:
         submit:
         search_notes:
-        search_owner_email_and_name:
+        search_owner_email_or_name:
     search_results:
       bike_box:
         location:

--- a/config/locales/translation.it.yml
+++ b/config/locales/translation.it.yml
@@ -4518,7 +4518,7 @@ it:
         search_for_serial_number:
         submit:
         search_notes:
-        search_owner_email_and_name:
+        search_owner_email_or_name:
     search_results:
       bike_box:
         location: Luogo

--- a/config/locales/translation.nb.yml
+++ b/config/locales/translation.nb.yml
@@ -5621,7 +5621,7 @@ nb:
         search_for_serial_number: Søk etter serienummer
         submit: sende inn
         search_notes: Søk i notater
-        search_owner_email_and_name: Søk eierens e-postadresse og navn
+        search_owner_email_or_name: Søk etter eierens e-postadresse eller navn
     search_results:
       bike_box:
         location: plassering

--- a/config/locales/translation.nl.yml
+++ b/config/locales/translation.nl.yml
@@ -5769,7 +5769,7 @@ nl:
         search_for_serial_number: Zoek naar framenummer
         submit: Voorleggen
         search_notes: Zoeknotities
-        search_owner_email_and_name: Zoek eigenaar e-mail
+        search_owner_email_or_name: Zoek naar het e-mailadres of de naam van de eigenaar.
     search_results:
       bike_box:
         location: Plaats


### PR DESCRIPTION
Follow-up to #3578: switches the organized bike search owner field's translation key from `search_owner_email_and_name` to `search_owner_email_or_name` ("Search owner email or name"). The search matches on either `bikes.owner_email` *or* `ownerships.owner_name`, so "or" describes the behavior more accurately than "and".

Translation YAML files (es/it/nb/nl) intentionally left out — handling separately.
