### PR TITLE
Fix flake in Organized::BikesController create spec

### DIFF
--- a/spec/controllers/organized/bikes_controller_spec.rb
+++ b/spec/controllers/organized/bikes_controller_spec.rb
@@ -66,7 +66,7 @@ RSpec.describe Organized::BikesController, type: :controller do
         Sidekiq::Testing.inline! do
           expect {
             post :create, params: {bike: attrs, organization_id: organization.to_param}
-          }.to change(Bike, :count).by 1
+          }.to change(Bike.unscoped, :count).by 1
         end
 
         b_param = BParam.reorder(:created_at).last
@@ -75,7 +75,9 @@ RSpec.describe Organized::BikesController, type: :controller do
         expect(b_param.creation_organization_id).to eq organization.id
         expect(b_param.bike["serial_number"]).to eq attrs[:serial_number]
 
-        bike = b_param.created_bike
+        bike = Bike.unscoped.find(b_param.created_bike_id)
+        # Assert bike isn't filtered out of Bike.current (i.e. default_scope)
+        expect(bike).to have_attributes(example: false, user_hidden: false, deleted_at: nil, likely_spam: false)
         expect(bike.status).to eq "status_with_owner"
         expect(bike.serial_number).to eq attrs[:serial_number]
         expect(bike.id).to eq b_param.created_bike_id


### PR DESCRIPTION
The `change(Bike, :count).by 1` check in this spec uses the model's `.current` default_scope, which filters out rows with `example`, `user_hidden`, `likely_spam`, or `deleted_at` set. When an inline-Sidekiq side effect during create flipped one of those columns, the bike was created but invisible to the matcher — the failure surfaced as "was changed by 0" with no clue which column moved.

Switches the count assertion to `Bike.unscoped`, loads the created bike unscoped, and adds an explicit `have_attributes(example: false, user_hidden: false, deleted_at: nil, likely_spam: false)` check so the next flake will name the column instead of just reporting a missing row.

Failure repro found from CI run [#26173811969 job (5, 0)](https://github.com/bikeindex/bike_index/actions/runs/26173811969/job/76998488250) (seed 25509).
