### PR TITLE
Replace admin fancy-selects with Form::Combobox

### DIFF
--- a/app/views/admin/bike_stickers/new.html.haml
+++ b/app/views/admin/bike_stickers/new.html.haml
@@ -55,9 +55,8 @@
 
   .row.mt-4
     .col-md-6.col-lg-3
-      .form-group.fancy-select.unfancy
-        = f.label :organization_id
-        = f.collection_select(:organization_id, @organizations, :id, :name, {prompt: "Choose organization"}, {class: "form-control", required: true})
+      .form-group
+        = render Form::Combobox::Component.new(name: :organization_id, form: f, label: BikeStickerBatch.human_attribute_name(:organization_id), placeholder: "Choose organization", required: true, include_blank: true, options: @organizations.pluck(:name, :id))
     .col-md-6.col-lg-9
       .form-group
         = f.label :notes, "Notes"

--- a/app/views/admin/bike_stickers/reassign.html.haml
+++ b/app/views/admin/bike_stickers/reassign.html.haml
@@ -28,10 +28,9 @@
           .row.mt-4
             - if @bike_sticker1.present?
               .col-12
-                .form-group.fancy-select.unfancy
-                  - opt_vals = BikeStickerBatch.includes(:organization).order(id: :desc).map { |b| ["##{b.id} - #{b.organization&.short_name} - #{b.notes}", b.id]  }
-                  = label_tag :search_bike_sticker_batch_id, "Sticker Batch"
-                  = select_tag :search_bike_sticker_batch_id, options_for_select(opt_vals, selected: @bike_sticker_batch&.id), placeholder: "Select batch", class: 'form-control', include_blank: true
+                .form-group
+                  - opt_vals = BikeStickerBatch.includes(:organization).order(id: :desc).map { |b| ["##{b.id} - #{b.organization&.short_name} - #{b.notes}", b.id] }
+                  = render Form::Combobox::Component.new(name: :search_bike_sticker_batch_id, label: "Sticker Batch", placeholder: "Select batch", value: @bike_sticker_batch&.id, include_blank: true, options: opt_vals)
             .col-sm-6
               .form-group
                 = label_tag :search_sticker1, "Starting Sticker code"
@@ -41,10 +40,9 @@
                 = label_tag :search_sticker2, "Ending Sticker code"
                 = text_field_tag :search_sticker2, params[:search_sticker2], class: "form-control"
             .col-12
-              .form-group.fancy-select.unfancy
-                = label_tag :organization, "Organization to assign stickers to"
+              .form-group
                 - org_opt_vals = Organization.approved.name_ordered.pluck(:name, :id)
-                = select_tag(:organization_id, options_for_select(org_opt_vals, selected: current_organization&.id), include_blank: true, placeholder: "Select organization", class: 'form-control')
+                = render Form::Combobox::Component.new(name: :organization_id, label: "Organization to assign stickers to", placeholder: "Select organization", value: current_organization&.id, include_blank: true, options: org_opt_vals)
           .form-group.mt-2
             = submit_tag 'Select', name: 'select', class: 'btn btn-primary ml-2'
 

--- a/app/views/admin/bikes/edit.html.haml
+++ b/app/views/admin/bikes/edit.html.haml
@@ -16,7 +16,8 @@
   .row
     .col-md-4.col-lg-3
       .form-group
-        = render Form::Combobox::Component.new(name: :cycle_type, form: f, label: "Cycle type", required: true, options: CycleType.select_options)
+        -# cycle_type is an integer-backed enum: pass enum *labels* as option values and an explicit value: to override hotwire_combobox's enum branch (which would emit cycle_type_before_type_cast)
+        = render Form::Combobox::Component.new(name: :cycle_type, form: f, value: @bike.cycle_type, label: "Cycle type", required: true, options: CycleType.select_options)
     .col-6.col-md-4.col-lg-5
       .form-group
         = f.label :serial_number

--- a/app/views/admin/bikes/edit.html.haml
+++ b/app/views/admin/bikes/edit.html.haml
@@ -15,9 +15,8 @@
 
   .row
     .col-md-4.col-lg-3
-      .form-group.fancy-select.unfancy
-        = f.label :cycle_type, "Cycle type"
-        = select(:bike, :cycle_type, CycleType.select_options, { required: true })
+      .form-group
+        = render Form::Combobox::Component.new(name: :cycle_type, form: f, label: "Cycle type", required: true, options: CycleType.select_options)
     .col-6.col-md-4.col-lg-5
       .form-group
         = f.label :serial_number
@@ -31,12 +30,12 @@
         = f.label :made_without_serial
   .row
     .col-6.col-md-4.col-lg-3
-      .form-group.fancy-select.unfancy
-        = f.label :manufacturer_id do
+      .form-group
+        - manufacturer_label = capture do
           Manufacturer
           %em.small
             = link_to "mfg bikes", admin_bikes_path(search_manufacturer: @bike.mnfg_name), class: "less-strong"
-        = collection_select(:bike, :manufacturer_id, Manufacturer.frame_makers, :id, :name, {}, { required: true, class: "form-control" })
+        = render Form::Combobox::Component.new(name: :manufacturer_id, form: f, label: manufacturer_label, required: true, options: Manufacturer.frame_makers.pluck(:name, :id))
     .col-6.col-md-4.col-lg-3
       .form-group
         = f.label :manufacturer_other do
@@ -52,9 +51,8 @@
         = f.label :year
         = f.text_field :year, class: "form-control"
     .col-6.col-md-4.col-lg-3
-      .form-group.fancy-select.unfancy
-        = f.label :primary_frame_color_id
-        = collection_select(:bike, :primary_frame_color_id, Color.all, :id, :name, { prompt: "Choose color" }, { required: true, class: "form-control" })
+      .form-group
+        = render Form::Combobox::Component.new(name: :primary_frame_color_id, form: f, label: Bike.human_attribute_name(:primary_frame_color_id), placeholder: "Choose color", required: true, include_blank: true, options: Color.all.pluck(:name, :id))
     .col-md-4.col-lg-3
       .form-group
         = f.label :frame_model
@@ -79,9 +77,8 @@
         = f.email_field :owner_email, required: true, class: "form-control"
     - if @organizations.present?
       .col-md-4.col-lg-3
-        .form-group.fancy-select.unfancy
-          = f.label :creation_organization_id
-          = f.collection_select(:creation_organization_id, @organizations, :id, :name, { prompt: "Choose organization" }, { class: "form-control" })
+        .form-group
+          = render Form::Combobox::Component.new(name: :creation_organization_id, form: f, label: Bike.human_attribute_name(:creation_organization_id), placeholder: "Choose organization", include_blank: true, options: @organizations.pluck(:name, :id))
       .col-md-4.col-lg-3
         .form-group.fancy-select.unfancy
           = f.label :bike_organization_ids, 'Current orgs'
@@ -99,15 +96,13 @@
       .row.mt-4
         .col-md-4
           .row
-            #stolen-bike-location.form-group.fancy-select.unfancy.col-6
+            #stolen-bike-location.form-group.col-6
               #country_select_container
-                = label :country, "Country"
-                = s.select(:country_id, Country.select_options, prompt: "Choose country")
+                = render Form::Combobox::Component.new(name: :country_id, form: s, label: "Country", placeholder: "Choose country", include_blank: true, options: Country.select_options)
                 %p.d-none
                   = Country.united_states_id
-            .form-group.fancy-select.unfancy.col-6
-              = s.label :state, "State"
-              = s.collection_select(:state_id, State.united_states, :id, :name, include_blank: true, prompt: "State")
+            .form-group.col-6
+              = render Form::Combobox::Component.new(name: :state_id, form: s, label: "State", placeholder: "State", include_blank: true, options: State.united_states.pluck(:name, :id))
           .form-group
             = label :street, "Intersection or address"
             = s.text_field :street, placeholder: "Intersection or address", class: "form-control"

--- a/app/views/admin/bikes/missing_manufacturer.html.haml
+++ b/app/views/admin/bikes/missing_manufacturer.html.haml
@@ -46,8 +46,7 @@
 = form_tag update_manufacturers_admin_bikes_path, data: {controller: "table-multi-checkbox"} do
   .row
     .col-md-4
-      .fancy-select.unfancy
-        = select_tag :manufacturer_id, options_from_collection_for_select(Manufacturer.frame_makers, :id, :name), prompt: "Choose manufacturer"
+      = render Form::Combobox::Component.new(name: :manufacturer_id, label: Manufacturer.model_name.human, placeholder: "Choose manufacturer", include_blank: true, options: Manufacturer.frame_makers.pluck(:name, :id))
     .col-md-2
       = submit_tag 'Update selected', class: 'btn btn-primary'
 

--- a/app/views/admin/bulk_imports/new.html.haml
+++ b/app/views/admin/bulk_imports/new.html.haml
@@ -7,9 +7,8 @@
     = form_for [:admin, @bulk_import] do |f|
       = render(Alerts::ObjectErrors::Component.new(object: @bulk_import))
 
-      .form-group.fancy-select.unfancy
-        = f.label :organization_id
-        = f.collection_select(:organization_id, Organization.all, :id, :name, { prompt: "Choose organization", required: true }, class: "form-control")
+      .form-group
+        = render Form::Combobox::Component.new(name: :organization_id, form: f, label: BulkImport.human_attribute_name(:organization_id), placeholder: "Choose organization", required: true, include_blank: true, options: Organization.all.pluck(:name, :id))
       .form-group
         .input-group
           .custom-file

--- a/app/views/admin/organization_roles/_form.html.haml
+++ b/app/views/admin/organization_roles/_form.html.haml
@@ -9,9 +9,8 @@
     = form_for [:admin, @organization_role] do |f|
       = render(Alerts::ObjectErrors::Component.new(object: @organization_role))
 
-      .form-group.fancy-select.unfancy
-        = f.label :organization
-        = collection_select :organization_role, :organization_id, @organizations, :id, :name, { include_blank: "Please select an organization" }, required: true,  class: "form-control"
+      .form-group
+        = render Form::Combobox::Component.new(name: :organization_id, form: f, label: OrganizationRole.human_attribute_name(:organization), placeholder: "Please select an organization", required: true, include_blank: true, options: @organizations.pluck(:name, :id))
 
       .form-group
         = f.label :invited_email

--- a/app/views/admin/organizations/_form.html.haml
+++ b/app/views/admin/organizations/_form.html.haml
@@ -93,14 +93,13 @@
       = f.label :direct_unclaimed_notifications do
         Send emails directly to unclaimed bike owners
         %small.less-strong don't require org to forward
-    .form-group.fancy-select.unfancy.no-restore-on-backspace
-      = f.label :parent_organization_id do
+    .form-group
+      - parent_org_label = capture do
         Parent organization
         %small.less-strong
           %strong.text-danger (probably) do not add parents!
           Parents must be part of the same organization
-
-      = f.collection_select(:parent_organization_id, Organization.with_enabled_feature_slugs("child_organizations"), :id, :name, {prompt: "Choose organization", required: false}, class: "form-control")
+      = render Form::Combobox::Component.new(name: :parent_organization_id, form: f, label: parent_org_label, placeholder: "Choose organization", include_blank: true, options: Organization.with_enabled_feature_slugs("child_organizations").pluck(:name, :id))
       %small
         %strong Use the "regional" feature instead.
         %em To add regional organizations rather than child/parent relationships, enable it through a paid invoice for the organization. All organizations with a location in the same area will automatically be associated.
@@ -123,11 +122,11 @@
     - if @organization.id.present?
       - emails = @organization.users.pluck(:email)
       - emails << ENV['AUTO_ORG_MEMBER'] unless emails.any?
-      .form-group.fancy-select.unfancy
-        = f.label :embedable_user_email do
+      .form-group
+        - embedable_label = capture do
           Auto user email
           %small.less-strong embed registration email
-        = f.select :embedable_user_email, emails, {prompt: "Select email", selected: @embedable_email}, class: "form-control"
+        = render Form::Combobox::Component.new(name: :embedable_user_email, form: f, label: embedable_label, placeholder: "Select email", value: @embedable_email, include_blank: true, options: emails)
         %small.less-strong
           - if @organization.organization_roles.count == 0
             You can use #{ENV['AUTO_ORG_MEMBER']} if
@@ -141,9 +140,8 @@
             if checked, we will start email their customers theft surveys
 
     - if @organization.official_manufacturer?
-      .form-group.fancy-select.unfancy
-        = f.label :manufacturer
-        = collection_select(:organization, :manufacturer_id, Manufacturer.frame_makers, :id, :name, {}, {required: true, class: "form-control"})
+      .form-group
+        = render Form::Combobox::Component.new(name: :manufacturer_id, form: f, label: Organization.human_attribute_name(:manufacturer), required: true, options: Manufacturer.frame_makers.pluck(:name, :id))
         %small
           %strong This organization has <code>Official manufacturer organization</code> enabled.
           Select a manufacturer to give them manufacturer access.

--- a/app/views/admin/payments/edit.html.haml
+++ b/app/views/admin/payments/edit.html.haml
@@ -24,9 +24,8 @@
 
         .row
           .col-lg-6
-            .form-group.fancy-select.unfancy
-              = f.label :organization_id
-              = collection_select(:payment, :organization_id, Organization.approved, :id, :name, prompt: "Choose organization")
+            .form-group
+              = render Form::Combobox::Component.new(name: :organization_id, form: f, label: Payment.human_attribute_name(:organization_id), placeholder: "Choose organization", include_blank: true, options: Organization.approved.pluck(:name, :id))
           .col-lg-6
             .form-group
               = f.label :invoice_id, "Invoice #"

--- a/app/views/admin/payments/new.html.haml
+++ b/app/views/admin/payments/new.html.haml
@@ -7,7 +7,8 @@
   .row
     .col-md-6
       .form-group
-        = render Form::Combobox::Component.new(name: :payment_method, form: f, label: Payment.human_attribute_name(:payment_method), options: Payment.admin_creatable_payment_methods.map { |m| [m.humanize, m] })
+        -# payment_method is an integer-backed enum: pass enum *labels* as option values and an explicit value: to override hotwire_combobox's enum branch (which would emit payment_method_before_type_cast)
+        = render Form::Combobox::Component.new(name: :payment_method, form: f, value: @payment.payment_method, label: Payment.human_attribute_name(:payment_method), options: Payment.admin_creatable_payment_methods.map { |m| [m.humanize, m] })
     .col-md-6
       .form-group
         - f.object.created_at = Binxtils::TimeParser.round(f.object.created_at || Time.current)

--- a/app/views/admin/payments/new.html.haml
+++ b/app/views/admin/payments/new.html.haml
@@ -6,9 +6,8 @@
 
   .row
     .col-md-6
-      .form-group.fancy-select.unfancy
-        = f.label :payment_method
-        = f.select :payment_method, Payment.admin_creatable_payment_methods.map { |m| [m.humanize, m] }, {}, class: "form-control"
+      .form-group
+        = render Form::Combobox::Component.new(name: :payment_method, form: f, label: Payment.human_attribute_name(:payment_method), options: Payment.admin_creatable_payment_methods.map { |m| [m.humanize, m] })
     .col-md-6
       .form-group
         - f.object.created_at = Binxtils::TimeParser.round(f.object.created_at || Time.current)
@@ -26,12 +25,10 @@
         = f.label :email, "Email of user who created payment"
         = f.email_field :email, class: "form-control"
     .col-md-6
-      - organizations = Organization.all
-      .form-group.fancy-select.unfancy
-        = f.label :organization_id, class: "control-label"
-        = collection_select(:payment, :organization_id, organizations, :id, :name, {include_blank: true, prompt: "Choose organization"})
+      .form-group
+        = render Form::Combobox::Component.new(name: :organization_id, form: f, label: Payment.human_attribute_name(:organization_id), placeholder: "Choose organization", include_blank: true, options: Organization.all.pluck(:name, :id))
     .col-md-6
-      .form-group.fancy-select.unfancy
+      .form-group
         = f.label :referral_source, class: "control-label"
         = f.text_field :referral_source, class: "form-control"
     .col-md-6.mt-4

--- a/app/views/admin/social_posts/new.html.haml
+++ b/app/views/admin/social_posts/new.html.haml
@@ -17,12 +17,12 @@
       .card-body
         .row
           .col-md-6
-            .form-group.fancy-select.unfancy
-              = f.label :social_account_id do
+            .form-group
+              - account_label = capture do
                 Account
                 %small.less-strong
                   will send the original post
-              = f.collection_select(:social_account_id, SocialAccount.all, :id, :screen_name, { prompt: "Choose  " }, { class: "form-control" })
+              = render Form::Combobox::Component.new(name: :social_account_id, form: f, label: account_label, placeholder: "Choose  ", include_blank: true, options: SocialAccount.all.pluck(:screen_name, :id))
               .form-group.avatar-upload
                 = f.label :image, 'Post photo', class: 'control-label'
                 .avatar-img


### PR DESCRIPTION
Converts the remaining single-value `fancy-select` dropdowns across `admin/` views to render `Form::Combobox::Component` (introduced in #3570), so admin selects use the new hotwire_combobox-based control instead of selectize.

- 10 admin views updated: payments, bulk imports, organization roles, organizations form, bike sticker batches (new/reassign), bikes edit (cycle type, manufacturer, color, creation org, stolen-record country/state), missing-manufacturer, social posts.
- Drops the `.fancy-select.unfancy` wrapper class on a `referral_source` text_field in `admin/payments/new` (was misapplied — not a select).
- Multi-select / grouped fancy-selects (`news/edit` content tags, `bikes/edit` bike_organization_ids, `organizations/index` features-and-settings) are deferred — hotwire_combobox multiselect needs a `multiselect_chip_src` endpoint that doesn't exist yet.
- Shared `bikes_edit/bike_fields/_primary_activity` partial untouched (used by user-facing edit too).
