### PR TITLE
Add rack-timeout: bound per-request wall-clock at 30s in production

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,6 +17,7 @@ gem "rails"
 
 # Things to improve/extend Rails
 gem "puma" # App server
+gem "rack-timeout", require: "rack/timeout/base" # Bound per-request wall-clock time so one slow request can't hold a Puma worker
 gem "bcrypt" # encryption
 gem "bootsnap" # Faster bootup
 gem "pg" # Postgres

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -631,6 +631,7 @@ GEM
       rack (>= 3.0.0)
     rack-test (2.2.0)
       rack (>= 1.3)
+    rack-timeout (0.7.0)
     rack-utf8_sanitizer (1.11.1)
       rack (>= 1.0, < 4.0)
     rackup (2.3.1)
@@ -1001,6 +1002,7 @@ DEPENDENCIES
   puma
   rack-attack
   rack-mini-profiler
+  rack-timeout
   rack-utf8_sanitizer
   rails
   rails-controller-testing

--- a/config/initializers/rack_timeout.rb
+++ b/config/initializers/rack_timeout.rb
@@ -1,0 +1,5 @@
+if Rails.env.production?
+  Rails.application.config.middleware.insert_before(
+    Rack::Runtime, Rack::Timeout, service_timeout: 30, wait_timeout: 10
+  )
+end

--- a/config/initializers/rack_timeout.rb
+++ b/config/initializers/rack_timeout.rb
@@ -1,5 +1,5 @@
 if Rails.env.production?
-  Rails.application.config.middleware.insert_before(
-    Rack::Runtime, Rack::Timeout, service_timeout: 30, wait_timeout: 10
+  Rails.application.config.middleware.insert_after(
+    ActionDispatch::RequestId, Rack::Timeout, service_timeout: 30, wait_timeout: 10
   )
 end


### PR DESCRIPTION
On 2026-05-20 13:05–13:08 PDT one user fired five expensive `Organized::RegistrationsController#index` requests in three minutes; each held a Puma worker for 22–139s. Worker-pool exhaustion cascaded into nginx returning 503 for unrelated traffic in the same window (four `/bikes/<id>` requests stalled at 57–58s as bystanders). The 60s replica `statement_timeout` from #3473 didn't catch it — the slow request had `db=47s, view=92s`, so SQL stayed under the cap and rendering was the bottleneck.

Adds `rack-timeout` with two ceilings:

- **`service_timeout: 30`** — raises `Rack::Timeout::RequestTimeoutError` after 30s in Rails, freeing the worker. In the 45h of production log preceding the incident, **9 of 1,618,998 requests** would have crossed the threshold; **8 of the 9 sit inside this single 3-minute window**. Steady-state cost is effectively zero, blast-radius cap is meaningful.
- **`wait_timeout: 10`** — drops requests that have been queued >10s before reaching Rails (uses nginx's `X-Request-Start` header). Avoids spending a worker on a request the user has likely already abandoned.

Honeybadger captures `Rack::Timeout::RequestTimeoutError` automatically as a new fault class, so no extra wiring; the existing #3473 fault (67 `ActiveRecord::QueryCanceled` catches between 2026-04-28 and 2026-05-07) is the precedent that this approach surfaces cleanly.

Doesn't address the root cause of the 139s render — that's the controller's chart code and is a separate, bigger fix.
