### PR TITLE
Retry StolenBike::AfterStolenRecordSaveJob on transient image-fetch failures

### DIFF
--- a/app/jobs/stolen_bike/after_stolen_record_save_job.rb
+++ b/app/jobs/stolen_bike/after_stolen_record_save_job.rb
@@ -1,6 +1,8 @@
 module StolenBike
   class AfterStolenRecordSaveJob < ApplicationJob
-    sidekiq_options retry: false
+    # Retries because Images::StolenProcessor fetches remote images and can
+    # hit transient Net::ReadTimeout. The rest of the job is idempotent.
+    sidekiq_options retry: 3
 
     def perform(stolen_record_id, force_regenerate_images = false, public_image_id = nil)
       stolen_record = StolenRecord.unscoped.find_by_id(stolen_record_id)


### PR DESCRIPTION
`StolenBike::AfterStolenRecordSaveJob` fetches a remote image through `URI.parse(image.url).open` in `PublicImage#open_file`. Two open Honeybadger faults are transient failures from that single call site: [`Net::ReadTimeout` #130707247](https://app.honeybadger.io/projects/35931/faults/130707247) and [`OpenURI::HTTPError: 520 <none>` #125292832](https://app.honeybadger.io/projects/35931/faults/125292832) (Cloudflare upstream). With `retry: false`, a single blip permanently failed the job.

Switches the job to `retry: 3`. The rest of the job is idempotent (touches `theft_alerts`, attaches `organization_stolen_message` only when blank, `find_or_create_recovery_link_token`, image regeneration guarded by `force_regenerate` / `images_attached_id` equality), so allowing sidekiq's default exponential backoff covers these transient errors without side effects.
