### PR TITLE
Disable Rack::Timeout state-change logger

### DIFF
--- a/config/initializers/rack_timeout.rb
+++ b/config/initializers/rack_timeout.rb
@@ -2,4 +2,9 @@ if Rails.env.production?
   Rails.application.config.middleware.insert_after(
     ActionDispatch::RequestId, Rack::Timeout, service_timeout: 30, wait_timeout: 10
   )
+  # The gem's base.rb auto-inits a state-change observer that writes two plain
+  # "source=rack-timeout ..." INFO lines per request to Rails.logger, which
+  # would pollute the Lograge JSON stream. Honeybadger captures the actual
+  # timeout exceptions independently, so the observer is pure noise here.
+  Rack::Timeout::Logger.disable
 end


### PR DESCRIPTION
Follow-up to #3585. The gem's `base.rb` unconditionally calls `Rack::Timeout::Logger.init`, which registers a state-change observer that writes two plain-text `source=rack-timeout id=… state=…` INFO lines through `Rails.logger` on every request (`ready` and `completed` transitions). At ~850k requests/day that's ~1.7M plain-text lines polluting the Lograge JSON stream.