### PR TITLE
Fix AfterBikeSaveJob spec flake: extract excluded-org-ids constant

### DIFF
--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -67,6 +67,8 @@ class Organization < ApplicationRecord
     bike_depot: 9
   }.freeze
 
+  USER_REGISTRATION_ALL_BIKES_EXCLUDED_IDS = [36, 1].freeze # SBR and BikeIndex
+
   POS_KIND_ENUM = {
     no_pos: 0,
     other_pos: 1,
@@ -328,7 +330,7 @@ class Organization < ApplicationRecord
   # For now - just using paid
   def user_registration_all_bikes?
     paid? && !official_manufacturer? &&
-      [36, 1].exclude?(id) # Exclude SBR and BikeIndex
+      USER_REGISTRATION_ALL_BIKES_EXCLUDED_IDS.exclude?(id)
   end
 
   def paid_money?

--- a/spec/jobs/callback_job/after_bike_save_job_spec.rb
+++ b/spec/jobs/callback_job/after_bike_save_job_spec.rb
@@ -166,6 +166,7 @@ RSpec.describe CallbackJob::AfterBikeSaveJob, type: :job do
         let(:organization) { FactoryBot.create(:organization_with_organization_features) }
         let!(:bike2) { FactoryBot.create(:bike, :with_ownership_claimed, user: user, creation_registration_info: registration_info) }
         let(:registration_info) { default_location_registration_address.merge(phone: "1112223333", student_id: "ffffff") }
+        before { stub_const("Organization::USER_REGISTRATION_ALL_BIKES_EXCLUDED_IDS", []) }
         it "creates with all_bikes" do
           expect(bike.bike_organizations.pluck(:organization_id)).to eq([organization.id])
           expect(bike.ownerships.pluck(:id)).to eq([ownership.id])


### PR DESCRIPTION
`Organization#user_registration_all_bikes?` returns false when an org's id is 1 or 36 (BikeIndex and SBR). In [CI run 26237768935](https://github.com/bikeindex/bike_index/actions/runs/26237768935/job/77215603219) the factory-created `organization_with_organization_features` happened to auto-increment to id 36, flipping `all_bikes` to false and failing the `"creates with all_bikes"` assertion at `spec/jobs/callback_job/after_bike_save_job_spec.rb:182`.

- Extracts the magic ids into `Organization::USER_REGISTRATION_ALL_BIKES_EXCLUDED_IDS`.
- `stub_const`s it to `[]` in the affected spec context so the expectation is independent of the factory's id sequence.
