### PR TITLE
Fix flake in graduated notifications search spec

### DIFF
--- a/spec/integration/organized/graduated_notifications_search_spec.rb
+++ b/spec/integration/organized/graduated_notifications_search_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe "Organized graduated notifications search", :js, type: :system do
     visit graduated_notifications_path
     # Results load via turbo auto-submit
     expect(page).to have_css("turbo-frame#graduated_notifications_results_frame table.ui-table", wait: 10)
-    expect(page).to have_css("tbody tr", count: 2)
+    expect(page).to have_css("tbody tr", count: 2, wait: 10)
     expect(page).to have_css(".select2-container", count: 1, wait: 10)
 
     # search_no_js should NOT be in the URL (removed by JS controller)
@@ -40,7 +40,7 @@ RSpec.describe "Organized graduated notifications search", :js, type: :system do
     within("tbody tr", text: "alice@example.com") { click_link "🔎" }
 
     expect(page).to have_current_path(/search_email=alice/, wait: 10)
-    expect(page).to have_css("tbody tr", count: 1)
+    expect(page).to have_css("tbody tr", count: 1, wait: 10)
     expect(page).to have_field("search_email", with: "alice@example.com")
     expect(page).to have_css(".select2-container", count: 1, wait: 10)
     expect(page).to have_content("alice@example.com")
@@ -49,7 +49,7 @@ RSpec.describe "Organized graduated notifications search", :js, type: :system do
     # Back navigation restores the unfiltered listing
     page.go_back
     expect(page).to have_css("turbo-frame#graduated_notifications_results_frame table.ui-table", wait: 10)
-    expect(page).to have_css("tbody tr", count: 2)
+    expect(page).to have_css("tbody tr", count: 2, wait: 10)
     expect(page).to have_field("search_email", with: "")
     expect(page).not_to have_current_path(/search_email=alice/)
     # select2 combobox search: type a query, pick the autocomplete option, submit
@@ -67,14 +67,14 @@ RSpec.describe "Organized graduated notifications search", :js, type: :system do
     page.go_back
     expect(page).not_to have_current_path(/query_items/, wait: 10)
     expect(page).to have_css("turbo-frame#graduated_notifications_results_frame table.ui-table", wait: 10)
-    expect(page).to have_css("tbody tr", count: 2)
+    expect(page).to have_css("tbody tr", count: 2, wait: 10)
 
     # Form submit + direct back-nav: regression guard for turbo-cache spinner state
     fill_in "search_email", with: "alice@example.com"
     find("#search-button").click
 
     expect(page).to have_current_path(/search_email=alice/, wait: 10)
-    expect(page).to have_css("tbody tr", count: 1)
+    expect(page).to have_css("tbody tr", count: 1, wait: 10)
     expect(page).to have_content("alice@example.com")
     expect(page).not_to have_content("bob@example.com")
     # turbo-frame survives the turbo_stream response (catches replace-vs-update regression)
@@ -83,7 +83,7 @@ RSpec.describe "Organized graduated notifications search", :js, type: :system do
     page.go_back
     expect(page).not_to have_current_path(/search_email=alice/, wait: 10)
     expect(page).to have_css("turbo-frame#graduated_notifications_results_frame table.ui-table", wait: 10)
-    expect(page).to have_css("tbody tr", count: 2)
+    expect(page).to have_css("tbody tr", count: 2, wait: 10)
     expect(page).to have_field("search_email", with: "")
 
     # Re-apply alice filter for click-row/back-nav steps
@@ -91,7 +91,7 @@ RSpec.describe "Organized graduated notifications search", :js, type: :system do
     find("#search-button").click
 
     expect(page).to have_current_path(/search_email=alice/, wait: 10)
-    expect(page).to have_css("tbody tr", count: 1)
+    expect(page).to have_css("tbody tr", count: 1, wait: 10)
 
     within("tbody tr") { first("a.preciseTime").click }
 
@@ -104,7 +104,7 @@ RSpec.describe "Organized graduated notifications search", :js, type: :system do
     page.go_back
     expect(page).to have_current_path(/search_email=alice/, wait: 10)
     expect(page).to have_css("turbo-frame#graduated_notifications_results_frame table.ui-table", wait: 10)
-    expect(page).to have_css("tbody tr", count: 1)
+    expect(page).to have_css("tbody tr", count: 1, wait: 10)
     expect(page).to have_field("search_email", with: "alice@example.com")
     expect(page).to have_content("alice@example.com")
     expect(page).not_to have_content("bob@example.com")
@@ -119,7 +119,7 @@ RSpec.describe "Organized graduated notifications search", :js, type: :system do
     page.go_back
     expect(page).to have_current_path(/search_email=alice/, wait: 10)
     expect(page).to have_css("turbo-frame#graduated_notifications_results_frame table.ui-table", wait: 10)
-    expect(page).to have_css("tbody tr", count: 1)
+    expect(page).to have_css("tbody tr", count: 1, wait: 10)
     expect(page).to have_field("search_email", with: "alice@example.com")
     expect(page).to have_content("alice@example.com")
     expect(page).not_to have_content("bob@example.com")
@@ -139,7 +139,7 @@ RSpec.describe "Organized graduated notifications search", :js, type: :system do
 
     expect(page).to have_current_path(/search_status=marked_remaining/, wait: 10)
     expect(page).to have_button(text: /marked not graduated/i)
-    expect(page).to have_css("tbody tr", count: 1)
+    expect(page).to have_css("tbody tr", count: 1, wait: 10)
     expect(page).to have_content("carol@example.com")
     expect(page).not_to have_content("alice@example.com")
     expect(page).not_to have_content("bob@example.com")
@@ -149,7 +149,7 @@ RSpec.describe "Organized graduated notifications search", :js, type: :system do
     expect(page).to have_current_path(/search_status=marked_remaining/, wait: 10)
     expect(page).to have_css("turbo-frame#graduated_notifications_results_frame table.ui-table", wait: 10)
     expect(page).to have_button(text: /marked not graduated/i)
-    expect(page).to have_css("tbody tr", count: 1)
+    expect(page).to have_css("tbody tr", count: 1, wait: 10)
     expect(page).to have_content("carol@example.com")
     expect(page).not_to have_content("alice@example.com")
     expect(page).not_to have_content("bob@example.com")


### PR DESCRIPTION
`tbody tr` row-count assertions in `graduated_notifications_search_spec.rb` had no explicit `wait:`, so they fired against Capybara's default ~2s window. After `page.go_back` and form submits, the turbo-frame's `table.ui-table` check could match while rows were still mid-replace, leaving 0 rows when 2 were expected. This was the failure in [CI run 26239960033](https://github.com/bikeindex/bike_index/actions/runs/26239960033/job/77223332105) at line 86.

Adds `wait: 10` to every `have_css("tbody tr", count: N)` assertion in the spec, matching the pattern already in place on line 131 (which got this treatment for the same reason).
