### PR TITLE
Fix Rack::Timeout in /api/v3/search: avoid S3 HEAD per bike in image_url

### DIFF
--- a/app/models/concerns/bike_attributable.rb
+++ b/app/models/concerns/bike_attributable.rb
@@ -209,6 +209,7 @@ module BikeAttributable
     return nil if image_col&.path.blank? && !REMOTE_IMAGE_FALLBACK_URLS
 
     image_url = image_col&.send(:url, size)
+    # image_col.blank? and image_url.present? indicates it's a remote file in local development
     if REMOTE_IMAGE_FALLBACK_URLS && image_col.blank? && image_url.present?
       # Create a image_url using the aws path
       "https://files.bikeindex.org" + image_url.gsub(ENV["BASE_URL"], "")

--- a/app/models/concerns/bike_attributable.rb
+++ b/app/models/concerns/bike_attributable.rb
@@ -205,10 +205,10 @@ module BikeAttributable
     end
 
     image_col = public_images.limit(1).first&.image
-    return nil if image_col.blank? && !REMOTE_IMAGE_FALLBACK_URLS
+    # NOTE: avoid image_col.blank? — on Fog storage it issues an S3 HEAD per call (timed out the API search).
+    return nil if image_col&.path.blank? && !REMOTE_IMAGE_FALLBACK_URLS
 
     image_url = image_col&.send(:url, size)
-    # image_col.blank? and image_url.present? indicates it's a remote file in local development
     if REMOTE_IMAGE_FALLBACK_URLS && image_col.blank? && image_url.present?
       # Create a image_url using the aws path
       "https://files.bikeindex.org" + image_url.gsub(ENV["BASE_URL"], "")

--- a/spec/models/bike_spec.rb
+++ b/spec/models/bike_spec.rb
@@ -1705,6 +1705,14 @@ RSpec.describe Bike, type: :model do
         expect(bike.image_url).to eq public_image.image_url
         expect(bike.image_url(:medium)).to eq public_image.image_url(:medium)
       end
+      # On Fog storage, CarrierWave's Uploader#blank? issues an S3 HEAD per call
+      # (via Fog::File#exists? → directory.files.head). image_url is invoked twice
+      # per bike in BikeV2Serializer (is_stock_img + large_img); on a 100-row API
+      # search page that's >=200 sequential HEADs and triggered Rack::Timeout.
+      it "does not call blank? on the uploader" do
+        expect_any_instance_of(ImageUploader).not_to receive(:blank?)
+        bike.reload.image_url
+      end
       it "with REMOTE_IMAGE_FALLBACK_URLS true return URL" do
         stub_const("BikeAttributable::REMOTE_IMAGE_FALLBACK_URLS", true)
         expect(Bike::REMOTE_IMAGE_FALLBACK_URLS).to be_truthy


### PR DESCRIPTION
Fixes `Rack::Timeout::RequestTimeoutException` on `/api/v3/search` ([Honeybadger fault 130724182](https://app.honeybadger.io/projects/35931/faults/130724182)).

`BikeAttributable#image_url` checked `image_col.blank?` on the CarrierWave uploader. In production (`:fog` storage) that resolves through `CarrierWave::Uploader::Proxy#blank?` → `Fog::File#empty?` → `Fog::File#exists?` → `directory.files.head(path)`, i.e. one S3 HEAD per call. `BikeV2Serializer` invokes `image_url` twice per bike (`is_stock_img` + `large_img`), so a 100-row API search page issued 200+ sequential HEADs and blew the 30s Rack timeout.

- Replace the check with `image_col&.path.blank?`, which reads the stored S3 key from the model column with no HTTP.
- Add a regression spec asserting `image_url` never calls `blank?` on the uploader (verified by reverting the fix — the spec fails pointing at the offending line).
