### PR TITLE
Fix Rack::Timeout in /api/v3/search: memoize image_url in BikeV2Serializer

### DIFF
--- a/app/serializers/bike_v2_serializer.rb
+++ b/app/serializers/bike_v2_serializer.rb
@@ -71,7 +71,7 @@ class BikeV2Serializer < ApplicationSerializer
   end
 
   def large_img
-    object.image_url(:large).presence || object.stock_photo_url
+    image_url.presence || object.stock_photo_url
   end
 
   def url
@@ -79,7 +79,7 @@ class BikeV2Serializer < ApplicationSerializer
   end
 
   def is_stock_img
-    object.image_url.blank? && object.stock_photo_url.present?
+    image_url.blank? && object.stock_photo_url.present?
   end
 
   def stolen_location
@@ -101,6 +101,12 @@ class BikeV2Serializer < ApplicationSerializer
   end
 
   private
+
+  # Memoized — Bike#image_url issues a public_images SQL query per call.
+  def image_url
+    return @image_url if defined?(@image_url)
+    @image_url = object.image_url(:large)
+  end
 
   def current_stolen_record
     object.current_stolen_record

--- a/spec/serializers/bike_v2_serializer_spec.rb
+++ b/spec/serializers/bike_v2_serializer_spec.rb
@@ -41,6 +41,15 @@ RSpec.describe BikeV2Serializer do
       expect(serializer.as_json(root: false)).to eq target
     end
 
+    # Regression: each Bike#image_url issues a public_images SQL query, and
+    # the serializer used to invoke it twice per bike — at per_page=100 on
+    # /api/v3/search that blew Rack::Timeout.
+    it "calls Bike#image_url once per serialization" do
+      bike.reload
+      expect(bike).to receive(:image_url).once.and_call_original
+      serializer.as_json(root: false)
+    end
+
     context "stolen bike" do
       let(:bike) { FactoryBot.create(:stolen_bike_in_nyc, :with_ownership) }
       let(:target_stolen) do


### PR DESCRIPTION
Fixes [Honeybadger fault 130726718](https://app.honeybadger.io/projects/35931/faults/130726718) — `Rack::Timeout::RequestTimeoutException` on `/api/v3/search`. Same endpoint as #3595, different bottleneck.

- #3595 stopped the per-call S3 HEAD inside `Bike#image_url`, but `BikeV2Serializer` still invokes `object.image_url` twice per bike (`large_img` + `is_stock_img`), and each call issues a `public_images.limit(1).first` SQL query — at `per_page=100` that is 200 DB queries per response.
- Wrap the call in a private memoized `image_url` helper used by both attributes. `Bike#image_url`'s blank-check path is size-independent, so semantics are unchanged.
- Regression spec asserts `Bike#image_url` is invoked at most once per serialization.
