### PR TITLE
Skills: drop redundant bin/env eval before rspec; refresh frontend-screenshots

### DIFF
--- a/.claude/skills/frontend-screenshots/SKILL.md
+++ b/.claude/skills/frontend-screenshots/SKILL.md
@@ -5,9 +5,11 @@ description: >-
   local `bin/dev` server via Playwright MCP, with a seeded-user identity gate
   that keeps PII out of uploaded images. Use whenever a task needs screenshots
   of local pages — PR documentation, bug repros, before/after comparisons
-  across branches, design review, demos — even when the user just says "grab
-  a screenshot" or "show me what this looks like" without naming Playwright.
-  Inputs: `(url-path, page-slug)` pairs. Output: local PNG paths.
+  across branches, design review, demos — including mid-interaction states
+  like an open dropdown, a modal showing, a form mid-fill, or a hover. Use it
+  even when the user just says "grab a screenshot" or "show me what this looks
+  like" without naming Playwright. Inputs: `(url-path, page-slug)` pairs,
+  optionally with per-URL interaction steps. Output: local PNG paths.
 allowed-tools: Bash, Read
 ---
 
@@ -58,6 +60,8 @@ Two viewports — resize once each, then walk every URL:
 
 **Settle before the screenshot.** Stimulus + Chartkick render after document load; either `browser_wait_for` on a known element or pause ~500ms–1s. Otherwise charts capture mid-draw.
 
+**Mid-interaction states are in scope.** When the caller asks for a dropdown open, a modal showing, a hover state, a partially-filled form, etc., drive Playwright between settle and the screenshot — `browser_click`, `browser_type`, `browser_press_key`, `browser_hover`, then wait for the UI to reach the target state (`browser_wait_for` on a marker element, or check via `browser_evaluate`) before `browser_take_screenshot`. Treat the interaction sequence as part of the page-slug — e.g. capture `combobox-open` after clicking + typing, distinct from a static `search-registrations` page-load shot. For cross-branch comparisons, run the *same* interaction sequence on each branch so the screenshots actually compare like-for-like.
+
 Sanity-check each PNG: under ~5 KB usually means the page errored. Pull `browser_console_messages` and look only for **uncaught exceptions from app code** (Stimulus registration failures, `TypeError`s in `app/javascript/**`) — Webpacker logs, asset 404s, third-party deprecation warnings are noise. To diagnose a failed capture: HTTP status via `curl -s -o /dev/null -w "%{http_code}\n" "$BASE_URL/<path>"`, response body via `curl -s "$BASE_URL/<path>" | head -200`, full backtrace via `tail -200 log/development.log`.
 
 ## Cross-branch comparison (optional)
@@ -66,7 +70,7 @@ When the caller wants before/after, repeat the capture loop against `main`.
 
 1. `git status` — abort if there are uncommitted changes.
 2. Diff `db/migrate/` between the branch and `main`; abort if it changed — a branch-only migration leaves the DB schema ahead of `main`'s code, so `main` pages can error.
-3. `BRANCH=$(git rev-parse --abbrev-ref HEAD)`, `git checkout main`, repeat capture into `...-main-...` filenames, `git checkout $BRANCH`.
+3. `BRANCH=$(git rev-parse --abbrev-ref HEAD)`, `git checkout origin/main` (detached — `git checkout main` fails if a sibling worktree holds the `main` branch; detached HEAD at `origin/main` is allowed concurrently and is the same code), navigate the browser to force Rails to reload the changed files, repeat capture into `...-main-...` filenames, then `git checkout $BRANCH`.
 
 A `Gemfile.lock` diff is **not** a reason to abort.
 

--- a/.claude/skills/sandbox-test-setup/SKILL.md
+++ b/.claude/skills/sandbox-test-setup/SKILL.md
@@ -46,10 +46,13 @@ export PATH="/Users/seth/.local/share/mise/installs/ruby/4.0.2/bin:$PATH"
 Then run specs the normal way:
 
 ```bash
-eval "$(ruby bin/env --export)"
-export RAILS_ENV=test
 bundle exec rspec spec/path/to/file_spec.rb
 ```
+
+(No need to `eval "$(ruby bin/env --export)"` first — `config/boot.rb` loads
+`bin/env` for every Ruby entry point, so `WORKSPACE_ID` / `DEV_PORT` /
+`BASE_URL` / `REDIS_URL` are already set inside the process. Only export
+them into the shell when the shell itself reads them, e.g. `curl "$BASE_URL/..."`.)
 
 If `rails_helper` aborts complaining about a pending migration, run
 `bundle exec rails db:create db:migrate` first


### PR DESCRIPTION
Two unrelated skill-doc tweaks bundled together.

- **sandbox-test-setup**: drop the `eval "$(ruby bin/env --export)"` line in front of `bundle exec rspec`. `config/boot.rb` already loads `bin/env` for every Ruby entry point, so the export is only useful when the **shell itself** consumes `$BASE_URL` / `$REDIS_URL` (curl probes, bash scripts) — not for `bundle exec` commands. Adds a parenthetical explaining when the export still matters.
- **frontend-screenshots**: pull in the latest revision from `sethherr/combobox-hotwire` — documents mid-interaction screenshot states (open dropdown, modal, hover, mid-fill form) and switches the cross-branch step to detached `origin/main` so it works alongside a sibling worktree that holds the `main` branch.
