### PR TITLE
Flaky fix - Dismiss flash in graduated notifications search spec

### DIFF
--- a/spec/integration/organized/graduated_notifications_search_spec.rb
+++ b/spec/integration/organized/graduated_notifications_search_spec.rb
@@ -27,6 +27,11 @@ RSpec.describe "Organized graduated notifications search", :js, type: :system do
     fill_in "Email", with: user.email
     fill_in "Password", with: "testthisthing7$"
     click_button "Log in"
+    # Dismiss the post-login flash and wait for it to clear, so the next
+    # navigation isn't racing the redirect. The Bootstrap fade-out can exceed
+    # Capybara's default 2s wait on slow CI runners.
+    find(".alert-success .close").click
+    expect(page).to have_no_css(".alert-success", wait: 10)
   end
 
   it "searches by email via turbo, then opens the notification" do


### PR DESCRIPTION
`graduated_notifications_search_spec.rb` flaked in [CI run 26490900877](https://github.com/bikeindex/bike_index/actions/runs/26490900877/job/78008260227) on the first `have_css` assertion after `visit graduated_notifications_path` (line 35) — the auto-submit-loaded `table.ui-table` didn't appear within the 10s wait.

Applies the same fix #3547 used in `registrations_search_spec.rb`: after `click_button "Log in"`, click `.alert-success .close` and wait for the flash to clear, so the next navigation isn't racing the post-login redirect on slow CI runners.
