### PR TITLE
Flaky fix - Wait for auto-submit settle in graduated notifications search

### DIFF
--- a/spec/integration/organized/graduated_notifications_search_spec.rb
+++ b/spec/integration/organized/graduated_notifications_search_spec.rb
@@ -72,9 +72,14 @@ RSpec.describe "Organized graduated notifications search", :js, type: :system do
     expect(page).to have_css("turbo-frame#graduated_notifications_results_frame", wait: 10)
 
     page.go_back
-    expect(page).not_to have_current_path(/query_items/, wait: 10)
+    # Wait for the form controller's auto-submit to settle the URL before
+    # interacting — without this, fill_in can race the in-flight replace and
+    # the click submits an unfilled form.
+    expect(page).to have_current_path(/stolenness=all/, wait: 10)
+    expect(page).not_to have_current_path(/query_items/)
     expect(page).to have_css("turbo-frame#graduated_notifications_results_frame table.ui-table", wait: 10)
     expect(page).to have_css("tbody tr", count: 2, wait: 10)
+    expect(page).to have_field("search_email", with: "")
 
     # Form submit + direct back-nav: regression guard for turbo-cache spinner state
     fill_in "search_email", with: "alice@example.com"


### PR DESCRIPTION
`graduated_notifications_search_spec.rb` flaked in [CI run 26550831666](https://github.com/bikeindex/bike_index/actions/runs/26550831666/job/78212435995) at line 83: after `page.go_back` from the `query_items` URL, `fill_in "search_email"` raced the form controller's in-flight `data-turbo-action="replace"` auto-submit (`app/javascript/controllers/search/form_controller.js:46`), so the click at line 81 submitted with an empty `search_email`.

Brings the second go-back block in line with the other two: wait for `stolenness=all` to appear in the URL (the form's hidden default, only present post-submit) and assert the `search_email` field is empty before interacting.
