### PR TITLE
Use Turbo [busy] frame attribute for search loading state

### DIFF
--- a/app/assets/stylesheets/revised/sections/bike_search_form.scss
+++ b/app/assets/stylesheets/revised/sections/bike_search_form.scss
@@ -222,34 +222,3 @@
     text-align: left;
   }
 }
-
-// Turbo sets [busy] on the results frame during requests. Dim the existing
-// results and overlay a spinner; min-height gives the spinner a place to land
-// on the initial auto-submit when the frame is still empty.
-.search-results-frame-wrapper {
-  position: relative;
-
-  > turbo-frame[busy] {
-    opacity: 0.5;
-    pointer-events: none;
-    transition: opacity 0.15s;
-  }
-
-  > .search-loading-overlay {
-    display: none;
-    position: absolute;
-    top: 0;
-    left: 0;
-    right: 0;
-    pointer-events: none;
-    z-index: 10;
-  }
-
-  &:has(> turbo-frame[busy]) {
-    min-height: 12rem;
-
-    > .search-loading-overlay {
-      display: block;
-    }
-  }
-}

--- a/app/assets/stylesheets/revised/sections/bike_search_form.scss
+++ b/app/assets/stylesheets/revised/sections/bike_search_form.scss
@@ -222,3 +222,34 @@
     text-align: left;
   }
 }
+
+// Turbo sets [busy] on the results frame during requests. Dim the existing
+// results and overlay a spinner; min-height gives the spinner a place to land
+// on the initial auto-submit when the frame is still empty.
+.search-results-frame-wrapper {
+  position: relative;
+
+  > turbo-frame[busy] {
+    opacity: 0.5;
+    pointer-events: none;
+    transition: opacity 0.15s;
+  }
+
+  > .search-loading-overlay {
+    display: none;
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    pointer-events: none;
+    z-index: 10;
+  }
+
+  &:has(> turbo-frame[busy]) {
+    min-height: 12rem;
+
+    > .search-loading-overlay {
+      display: block;
+    }
+  }
+}

--- a/app/assets/tailwind/application.css
+++ b/app/assets/tailwind/application.css
@@ -144,6 +144,25 @@
   .ui-table-bordered thead tr th:last-child {
     @apply tw:ui-table-bordered-th-last;
   }
+
+  /* Turbo sets [busy] on the results frame during requests. Hide the existing
+     results and overlay a spinner; min-height gives the spinner a place to
+     land on the initial auto-submit when the frame is still empty. */
+  .search-results-frame-wrapper {
+    @apply tw:relative;
+  }
+  .search-results-frame-wrapper > turbo-frame[busy] {
+    @apply tw:opacity-0 tw:pointer-events-none;
+  }
+  .search-results-frame-wrapper > .search-loading-overlay {
+    @apply tw:hidden tw:absolute tw:top-0 tw:left-0 tw:right-0 tw:pointer-events-none tw:z-10;
+  }
+  .search-results-frame-wrapper:has(> turbo-frame[busy]) {
+    @apply tw:min-h-48;
+  }
+  .search-results-frame-wrapper:has(> turbo-frame[busy]) > .search-loading-overlay {
+    @apply tw:block;
+  }
 }
 
 /* Create utility classes for the sides of the table so that it can be applied in JS when columns are hidden */

--- a/app/assets/tailwind/application.css
+++ b/app/assets/tailwind/application.css
@@ -155,7 +155,7 @@
     @apply tw:opacity-0 tw:pointer-events-none;
   }
   .search-results-frame-wrapper > .search-loading-overlay {
-    @apply tw:hidden tw:absolute tw:top-0 tw:left-0 tw:right-0 tw:pointer-events-none tw:z-10;
+    @apply tw:hidden tw:absolute tw:top-0 tw:left-0 tw:right-0 tw:pointer-events-none tw:z-1;
   }
   .search-results-frame-wrapper:has(> turbo-frame[busy]) {
     @apply tw:min-h-48;

--- a/app/components/search/form/component.html.erb
+++ b/app/components/search/form/component.html.erb
@@ -83,8 +83,7 @@
 
       <div class="tw:w-20">
         <%= button_tag(type: translation(".submit"),
-            class: "twbtn-blue tw:w-full tw:h-full tw:disabled:cursor-wait",
-            "data-search--form-target" => "button") do %>
+            class: "twbtn-blue tw:w-full tw:h-full tw:disabled:cursor-wait") do %>
           <%= helpers.inline_svg_tag "icons/searcher.svg",
             id: "search-button",
             class: "tw:text-white",

--- a/app/components/search/form_organized/component.html.erb
+++ b/app/components/search/form_organized/component.html.erb
@@ -57,8 +57,7 @@
 
       <div class="tw:w-20">
         <%= button_tag(type: translation(".submit"),
-          class: "twbtn-blue tw:w-full tw:h-full#{" tw:disabled:cursor-wait" if turbo?}",
-          data: turbo? ? {"search--form-target" => "button"} : {}) do %>
+          class: "twbtn-blue tw:w-full tw:h-full#{" tw:disabled:cursor-wait" if turbo?}") do %>
           <%= helpers.inline_svg_tag "icons/searcher.svg",
           id: "search-button",
           class: "tw:text-white",

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,10 +1,10 @@
 class ApplicationController < ActionController::Base
   include ControllerHelpers
   include Binxtils::SetPeriod
-
-  self.default_earliest_time = Time.at(1134972000).freeze # Earliest bike created at
   include Turbo::Redirection
   include Pagy::Method
+
+  self.default_earliest_time = Time.at(1134972000).freeze # Earliest bike created at
 
   protect_from_forgery
 

--- a/app/controllers/search/registrations_controller.rb
+++ b/app/controllers/search/registrations_controller.rb
@@ -48,7 +48,6 @@ module Search
 
       @page = permitted_page(max: MAX_INDEX_PAGE)
       @search_kind = :registration
-      @result_view = params[:search_result_view] || :bike_boxes
       @result_view = SearchResults::Container::Component.permitted_result_view(params[:search_result_view])
     end
 

--- a/app/javascript/controllers/search/form_controller.js
+++ b/app/javascript/controllers/search/form_controller.js
@@ -5,20 +5,12 @@ import TimeLocalizer from '@bikeindex/time-localizer'
 
 // Connects to data-controller='search--form'
 export default class extends Controller {
-  static targets = ['form', 'button']
-  static values = { spinnerId: { type: String, default: 'hiddenLoadingSpinner' } }
+  static targets = ['form']
 
   get frameElement () {
     const turboFrameId = this.formTarget.getAttribute('data-turbo-frame')
 
     return (document.getElementById(turboFrameId))
-  }
-
-  initialize () {
-    // every time the form submits, show the loading spinner
-    this.formTarget.addEventListener('turbo:submit-start', this.showLoadingSpinnerAndDisableButton.bind(this))
-    // re-enable the button when submission completes or fails
-    this.formTarget.addEventListener('turbo:submit-end', this.resetButton.bind(this))
   }
 
   connect () {
@@ -27,7 +19,6 @@ export default class extends Controller {
     if (noJsElement) noJsElement.remove()
 
     this.submitIfEmptyResults()
-    this.setupFormFieldListeners()
 
     // Add timeLocalizer and watch for turbo-frame renders
     if (!window.timeLocalizer) window.timeLocalizer = new TimeLocalizer()
@@ -62,36 +53,9 @@ export default class extends Controller {
   }
 
   disconnect () {
-    // Clean up event listener when controller disconnects
     document.removeEventListener('turbo:frame-render', this.handleFrameRender)
     document.removeEventListener('turbo:load', this.submitIfEmptyResults)
     window.removeEventListener('popstate', this.reloadFrameFromUrl)
-  }
-
-  setupFormFieldListeners () {
-    // Find all input, select, and textarea elements within the form
-    const formFields = this.formTarget.querySelectorAll('input, select, textarea')
-
-    // Add change event listeners to all form fields
-    formFields.forEach(field => {
-      // TODO: This doesn't catch changes to the query_items field
-      field.addEventListener('change', this.resetButton.bind(this))
-    })
-  }
-
-  showLoadingSpinnerAndDisableButton () {
-    // Disable the submit button
-    if (this.hasButtonTarget) { this.buttonTarget.disabled = true }
-
-    if (!this.frameElement) return
-
-    const spinnerWrapper = document.getElementById(this.spinnerIdValue)
-    // IDK if this should clone instead of just use innerHTML - this seems much simpler
-    this.frameElement.innerHTML = spinnerWrapper.innerHTML
-  }
-
-  resetButton () {
-    if (this.hasButtonTarget) { this.buttonTarget.disabled = false }
   }
 
   handleFrameRender = () => {

--- a/app/views/organized/graduated_notifications/index.html.erb
+++ b/app/views/organized/graduated_notifications/index.html.erb
@@ -44,25 +44,27 @@
   )) %>
 </div>
 
-<%= turbo_frame_tag :graduated_notifications_results_frame do %>
-  <div class="tw:mt-4">
-    <%= render UI::PeriodSelect::Component.new(period: @period, start_time: @start_time, end_time: @end_time) %>
-  </div>
+<div class="search-results-frame-wrapper">
+  <%= turbo_frame_tag :graduated_notifications_results_frame do %>
+    <div class="tw:mt-4">
+      <%= render UI::PeriodSelect::Component.new(period: @period, start_time: @start_time, end_time: @end_time) %>
+    </div>
 
-  <div class="tw:mt-2 tw:text-right">
-    <%= link_to "Render chart",
-      organization_graduated_notifications_path(sortable_search_params.merge(organization_id: current_organization.to_param, render_chart: !@render_chart)),
-      class: "btn btn-sm btn-outline-secondary #{"active" if @render_chart}",
-      data: {turbo_action: "advance"} %>
-  </div>
+    <div class="tw:mt-2 tw:text-right">
+      <%= link_to "Render chart",
+        organization_graduated_notifications_path(sortable_search_params.merge(organization_id: current_organization.to_param, render_chart: !@render_chart)),
+        class: "btn btn-sm btn-outline-secondary #{"active" if @render_chart}",
+        data: {turbo_action: "advance"} %>
+    </div>
 
-  <% if @render_results %>
-    <%= render partial: "results" %>
-  <% else %>
-    <span id="loadedWithoutResults" class="tw:hidden"></span>
+    <% if @render_results %>
+      <%= render partial: "results" %>
+    <% else %>
+      <span id="loadedWithoutResults" class="tw:hidden"></span>
+    <% end %>
   <% end %>
-<% end %>
 
-<div id="hiddenLoadingSpinner" class="tw:hidden">
-  <%= render UI::LoadingSpinner::Component.new(text: "Loading results...") %>
+  <div class="search-loading-overlay">
+    <%= render UI::LoadingSpinner::Component.new(text: "Loading results...") %>
+  </div>
 </div>

--- a/app/views/organized/impound_records/index.html.erb
+++ b/app/views/organized/impound_records/index.html.erb
@@ -41,25 +41,27 @@
   <% end %>
 </div>
 
-<%= turbo_frame_tag :impound_records_results_frame do %>
-  <div class="tw:mt-4">
-    <%= render UI::PeriodSelect::Component.new(period: @period, start_time: @start_time, end_time: @end_time) %>
-  </div>
+<div class="search-results-frame-wrapper">
+  <%= turbo_frame_tag :impound_records_results_frame do %>
+    <div class="tw:mt-4">
+      <%= render UI::PeriodSelect::Component.new(period: @period, start_time: @start_time, end_time: @end_time) %>
+    </div>
 
-  <div class="text-right mb-2 mt-4">
-    <%= link_to t(".render_chart"),
-      organization_impound_records_path(sortable_search_params.merge(organization_id: current_organization.to_param, render_chart: !@render_chart)),
-      class: "btn btn-sm less-strong btn-outline-secondary #{"active" if @render_chart}",
-      data: {turbo_action: "advance"} %>
-  </div>
+    <div class="text-right mb-2 mt-4">
+      <%= link_to t(".render_chart"),
+        organization_impound_records_path(sortable_search_params.merge(organization_id: current_organization.to_param, render_chart: !@render_chart)),
+        class: "btn btn-sm less-strong btn-outline-secondary #{"active" if @render_chart}",
+        data: {turbo_action: "advance"} %>
+    </div>
 
-  <% if @render_results %>
-    <%= render partial: "results" %>
-  <% else %>
-    <span id="loadedWithoutResults" class="tw:hidden"></span>
+    <% if @render_results %>
+      <%= render partial: "results" %>
+    <% else %>
+      <span id="loadedWithoutResults" class="tw:hidden"></span>
+    <% end %>
   <% end %>
-<% end %>
 
-<div id="hiddenLoadingSpinner" class="tw:hidden">
-  <%= render UI::LoadingSpinner::Component.new(text: "Loading results...") %>
+  <div class="search-loading-overlay">
+    <%= render UI::LoadingSpinner::Component.new(text: "Loading results...") %>
+  </div>
 </div>

--- a/app/views/organized/registrations/search.html.erb
+++ b/app/views/organized/registrations/search.html.erb
@@ -36,24 +36,26 @@
     <% end %>
   </div>
 
-  <%= turbo_frame_tag :organized_bikes_results_frame do %>
-    <%= render UI::PeriodSelect::Component.new(period: @period, start_time: @start_time, end_time: @end_time) %>
+  <div class="search-results-frame-wrapper">
+    <%= turbo_frame_tag :organized_bikes_results_frame do %>
+      <%= render UI::PeriodSelect::Component.new(period: @period, start_time: @start_time, end_time: @end_time) %>
 
-    <div class="tw:mt-2 tw:text-right">
-      <%= link_to t(".render_chart", default: "Render chart"),
-        organization_registrations_path(sortable_search_params.merge(organization_id: current_organization.to_param, render_chart: !@render_chart)),
-        class: "btn btn-sm btn-outline-secondary #{"active" if @render_chart}",
-        data: {turbo_action: "advance"} %>
-    </div>
+      <div class="tw:mt-2 tw:text-right">
+        <%= link_to t(".render_chart", default: "Render chart"),
+          organization_registrations_path(sortable_search_params.merge(organization_id: current_organization.to_param, render_chart: !@render_chart)),
+          class: "btn btn-sm btn-outline-secondary #{"active" if @render_chart}",
+          data: {turbo_action: "advance"} %>
+      </div>
 
-    <% if @render_results %>
-      <%= render partial: "results" %>
-    <% else %>
-      <span id="loadedWithoutResults" class="tw:hidden"></span>
+      <% if @render_results %>
+        <%= render partial: "results" %>
+      <% else %>
+        <span id="loadedWithoutResults" class="tw:hidden"></span>
+      <% end %>
     <% end %>
-  <% end %>
-</div>
 
-<div id="hiddenLoadingSpinner" class="tw:hidden">
-  <%= render UI::LoadingSpinner::Component.new(text: "Loading results...") %>
+    <div class="search-loading-overlay">
+      <%= render UI::LoadingSpinner::Component.new(text: "Loading results...") %>
+    </div>
+  </div>
 </div>

--- a/app/views/search/marketplace/index.html.erb
+++ b/app/views/search/marketplace/index.html.erb
@@ -7,16 +7,18 @@
     price_max_amount: @price_max_amount, result_view: @result_view, search_obj_name: @search_obj_name) %>
 </div>
 
-<%= turbo_frame_tag :marketplace_results_frame do %>
-  <% if @render_results %>
-    <%= turbo_frame_tag "page_#{@pagy.page}" do %>
-      <%= render partial: "marketplace_results" %>
+<div class="search-results-frame-wrapper">
+  <%= turbo_frame_tag :marketplace_results_frame do %>
+    <% if @render_results %>
+      <%= turbo_frame_tag "page_#{@pagy.page}" do %>
+        <%= render partial: "marketplace_results" %>
+      <% end %>
+    <% else %>
+      <span id="loadedWithoutResults" class="tw:hidden"></span>
     <% end %>
-  <% else %>
-    <span id="loadedWithoutResults" class="tw:hidden"></span>
   <% end %>
-<% end %>
 
-<div id="hiddenLoadingSpinner" class="tw:hidden">
-  <%= render UI::LoadingSpinner::Component.new(text: t(".loading_results")) %>
+  <div class="search-loading-overlay">
+    <%= render UI::LoadingSpinner::Component.new(text: t(".loading_results")) %>
+  </div>
 </div>

--- a/app/views/search/registrations/index.html.erb
+++ b/app/views/search/registrations/index.html.erb
@@ -7,14 +7,16 @@
     target_frame: :search_registrations_results_frame, interpreted_params: @interpreted_params, result_view: @result_view) %>
 </div>
 
-<%= turbo_frame_tag :search_registrations_results_frame do %>
-  <% if @render_results %>
-    <%= render partial: "results" %>
-  <% else %>
-    <span id="loadedWithoutResults" class="tw:hidden"></span>
+<div class="search-results-frame-wrapper">
+  <%= turbo_frame_tag :search_registrations_results_frame do %>
+    <% if @render_results %>
+      <%= render partial: "results" %>
+    <% else %>
+      <span id="loadedWithoutResults" class="tw:hidden"></span>
+    <% end %>
   <% end %>
-<% end %>
 
-<div id="hiddenLoadingSpinner" class="tw:hidden">
-  <%= render UI::LoadingSpinner::Component.new(text: t(".loading_results")) %>
+  <div class="search-loading-overlay">
+    <%= render UI::LoadingSpinner::Component.new(text: t(".loading_results")) %>
+  </div>
 </div>


### PR DESCRIPTION
Drive the search results loading state through Turbo's built-in `[busy]` / `aria-busy` attribute on the `<turbo-frame>` instead of swapping the frame's innerHTML for a spinner. Previous results now dim and stay in place under an overlaid spinner, and Turbo's auto-disable on the submit button replaces the manual `button` target + `submit-start`/`submit-end` plumbing.

- `app/javascript/controllers/search/form_controller.js`: drop `initialize`, `showLoadingSpinnerAndDisableButton`, `resetButton`, `setupFormFieldListeners`, the `spinnerId` value, and the `button` target — along with the TODO admitting the combobox field wasn't wired up.
- Form components: remove `data-search--form-target="button"` from `Search::Form` and `Search::FormOrganized`.
- 5 index views (`search/registrations`, `search/marketplace`, `organized/registrations/search`, `organized/impound_records`, `organized/graduated_notifications`): wrap `<turbo-frame>` + spinner in a `search-results-frame-wrapper`; the old hidden `#hiddenLoadingSpinner` div becomes a `search-loading-overlay` sibling.
- `revised/sections/bike_search_form.scss`: dim `turbo-frame[busy]`, reveal the overlay via `:has(> turbo-frame[busy])`, and apply `min-height` so the spinner lands somewhere on the initial empty-frame auto-submit.
- `Search::RegistrationsController#set_interpreted_params`: drop a dead `@result_view` assignment that set the invalid `:bike_boxes` (plural) symbol before being immediately overwritten via `permitted_result_view`.

The `search_no_js` progressive-enhancement signal is intentionally kept.
