### PR TITLE
Ask user to start bin/dev; warn against ENV partial-mock in specs

### DIFF
--- a/.claude/skills/frontend-screenshots/SKILL.md
+++ b/.claude/skills/frontend-screenshots/SKILL.md
@@ -24,7 +24,7 @@ Drive Playwright MCP to capture viewport screenshots of pages served by `bin/dev
 ## Preflight
 
 - `eval "$(ruby bin/env --export)"` so `$BASE_URL` is set.
-- `curl -fs "$BASE_URL/" >/dev/null` — if not up, start `bin/dev` yourself in the background (`run_in_background: true`) from the workspace directory and wait for `$BASE_URL/` to become reachable before continuing. `bin/env` resolves `$DEV_PORT`/`$BASE_URL` from the workspace ID, so the bin/dev you start binds to the same port and DB the user expects.
+- `curl -fs "$BASE_URL/" >/dev/null` — if it isn't, **stop and ask the user to start it**. `bin/env` resolves `$DEV_PORT`/`$BASE_URL` from the workspace ID, so the bin/dev the user starts will bind to the same port and DB this skill expects.
 - If `mcp__playwright__*` tools aren't registered, tell the user to run `claude mcp add playwright -- npx -y @playwright/mcp@latest` and restart.
 
 ## Sign in (with the PII gate)

--- a/.claude/skills/rspec-testing/SKILL.md
+++ b/.claude/skills/rspec-testing/SKILL.md
@@ -39,6 +39,25 @@ let!(:bike_transferred) do
 end
 ```
 
+## Stubbing ENV
+
+Never partial-mock `ENV` with `allow(ENV).to receive(:[]).and_call_original` — it makes every subsequent `ENV[...]` lookup go through RSpec's message router, which is slow and easy to break by forgetting a `.with(...)` branch.
+
+Use `stub_const` against a merged hash instead:
+
+### Good
+
+```ruby
+stub_const("ENV", ENV.to_hash.merge("STRIPE_SECRET_KEY" => "sk_test_123"))
+```
+
+### Bad
+
+```ruby
+allow(ENV).to receive(:[]).and_call_original
+allow(ENV).to receive(:[]).with("STRIPE_SECRET_KEY").and_return("sk_test_123")
+```
+
 ## Always fix failing tests
 
 Fix every failing test, even ones that were already failing on `main`. Confirming a failure pre-dates your branch (via `git stash` or checking out `main`) explains *what* broke — not whether you fix it. You fix it.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,7 +28,7 @@ Uses RSpec. All business logic should be tested. The `rspec-testing` skill cover
 
 Uses Stimulus.js for JavaScript and Tailwind CSS for styling. SCSS and CoffeeScript files exist but are deprecated. The `bin/dev` command handles Tailwind and JS builds. The `frontend-conventions` skill covers project-specific class prefixes (`tw:`, `twinput`, `twlabel`, `twlink`), the `number_display` helper, and ViewComponent rules.
 
-Check whether the dev server is up: `curl -fs "$BASE_URL/" >/dev/null`. If it isn't, **start `bin/dev` yourself in the background** so Tailwind and JS asset watchers are running before any frontend work.
+Check whether the dev server is up: `curl -fs "$BASE_URL/" >/dev/null`. If it isn't, **stop and ask the user to start it** so Tailwind and JS asset watchers are running before any frontend work.
 
 ## Pull requests
 


### PR DESCRIPTION
Tightens two skill rules and updates `AGENTS.md` to match.

- `frontend-screenshots` skill + `AGENTS.md`: when the dev server isn't up, stop and ask the user to start `bin/dev` rather than backgrounding it ourselves.
- `rspec-testing` skill: new "Stubbing ENV" section warning against `allow(ENV).to receive(:[]).and_call_original` and pointing at `stub_const("ENV", ENV.to_hash.merge(...))` instead.
