### PR TITLE
Fix flaky combobox component system spec

### DIFF
--- a/spec/components/form/combobox/component_system_spec.rb
+++ b/spec/components/form/combobox/component_system_spec.rb
@@ -6,7 +6,9 @@ RSpec.describe Form::Combobox::Component, :js, type: :system do
   it "opens, filters, selects, and closes" do
     visit "/rails/view_components/form/combobox/component/default"
 
-    expect(page).to have_css('[aria-expanded="false"]')
+    # `aria-expanded` is set by the combobox Stimulus controller on connect, not
+    # in the server-rendered HTML -- wait out the first JS connect on slow CI.
+    expect(page).to have_css('[aria-expanded="false"]', wait: 10)
     expect(page).to be_axe_clean.skipping(*SKIPPABLE_AXE_RULES)
 
     # Opens the listbox on click


### PR DESCRIPTION
Fixes a flaky failure in the combobox component system spec ([CI run](https://github.com/bikeindex/bike_index/actions/runs/26596598347/job/78369065265?pr=3621)).

- The first `aria-expanded="false"` assertion was really waiting for the hotwire_combobox Stimulus controller to connect — the attribute is set on `connect`, not in the server-rendered HTML — and that occasionally exceeded Capybara's default 2s wait on a loaded CI runner.
- Added an explicit `wait: 10` to that assertion as a synchronization barrier, with a comment explaining why.
