### PR TITLE
Add capybara-lockstep to reduce flaky :js specs

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -170,6 +170,7 @@ group :test do
   gem "webmock" # mocking for VCR
   gem "rspec-retry", require: false # Retry flaky test failures on CI
   gem "capybara" # For view components
+  gem "capybara-lockstep" # Sync Capybara with in-flight JS/AJAX to reduce flaky :js specs
   gem "selenium-webdriver" # For capybara
   gem "chunky_png" # used to test that generated images match their targets
   gem "axe-core-rspec" # Accessibility testing

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -175,6 +175,9 @@ GEM
       rack-test (>= 0.6.3)
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
+    capybara-lockstep (2.3.1)
+      activesupport (>= 7.0)
+      capybara (>= 3.0)
     carrierwave (3.1.2)
       activemodel (>= 6.0.0)
       activesupport (>= 6.0.0)
@@ -933,6 +936,7 @@ DEPENDENCIES
   brakeman
   bullet
   capybara
+  capybara-lockstep
   carrierwave (~> 3.1)
   carrierwave_backgrounder!
   chartkick

--- a/app/javascript/controllers/search/form_controller.js
+++ b/app/javascript/controllers/search/form_controller.js
@@ -35,11 +35,19 @@ export default class extends Controller {
 
   // if the frame was loaded without results, submit the form
   submitIfEmptyResults = () => {
+    // connect() and the turbo:load listener can both fire before the first
+    // auto-submit's frame renders. Without this guard the second call submits
+    // again, and once the first render flips data-turbo-action to 'advance' the
+    // duplicate submit pushes a history entry - so the back button no longer
+    // leaves the search page. Skip while an auto-submit is already in flight.
+    if (this.autoSubmitting) return
     if (!this.frameElement?.querySelector('#loadedWithoutResults')) return
+    this.autoSubmitting = true
     // Use replace for the initial auto-submit so it doesn't add a duplicate history entry
     this.formTarget.setAttribute('data-turbo-action', 'replace')
     this.frameElement.addEventListener('turbo:frame-render', () => {
       this.formTarget.setAttribute('data-turbo-action', 'advance')
+      this.autoSubmitting = false
     }, { once: true })
     this.formTarget.requestSubmit()
   }

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -2,6 +2,7 @@
 
 <html lang="<%= I18n.locale %>">
   <head>
+    <%= capybara_lockstep if defined?(Capybara::Lockstep) %>
     <%= render(PageBlock::HeaderTags::Component.new(**header_tags_component_options)) %>
 
     <%# TODO: Cache this ^ %>

--- a/app/views/layouts/component_preview.html.erb
+++ b/app/views/layouts/component_preview.html.erb
@@ -2,8 +2,6 @@
 
 <html>
   <head>
-    <%= capybara_lockstep if defined?(Capybara::Lockstep) %>
-
     <title>Bike Index Component Preview</title>
 
     <link

--- a/app/views/layouts/component_preview.html.erb
+++ b/app/views/layouts/component_preview.html.erb
@@ -2,6 +2,8 @@
 
 <html>
   <head>
+    <%= capybara_lockstep if defined?(Capybara::Lockstep) %>
+
     <title>Bike Index Component Preview</title>
 
     <link

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -4,6 +4,10 @@ Rails.application.configure do
   # While tests run files are not watched, reloading is not necessary.
   config.enable_reloading = false
 
+  # capybara-lockstep: let the browser-side helper know when the server is still
+  # processing a request, so :js specs wait for in-flight work before proceeding.
+  config.middleware.insert_before 0, Capybara::Lockstep::Middleware if defined?(Capybara::Lockstep::Middleware)
+
   # Don't log things in test
   config.active_record.verbose_query_logs = false
   config.active_record.query_log_tags_enabled = false

--- a/spec/integration/claim_registration_signup_spec.rb
+++ b/spec/integration/claim_registration_signup_spec.rb
@@ -82,7 +82,9 @@ RSpec.describe "Claim registration signup", :js, type: :system do
     expect(page).to have_link("sign up", wait: 5)
     click_link "sign up"
 
-    expect(find_field("Email").value).to eq claimer_email
+    # Retrying matcher (not find_field(...).value, which reads once) so the
+    # assertion waits for the signup page to finish loading after the click.
+    expect(page).to have_field("Email", with: claimer_email)
     fill_in "Name", with: "New Claimer"
     fill_in "Password", with: "testthisthing7$"
     check "user_terms_of_service"

--- a/spec/integration/marketplace_infinite_scroll_spec.rb
+++ b/spec/integration/marketplace_infinite_scroll_spec.rb
@@ -26,19 +26,19 @@ RSpec.describe "Marketplace infinite scroll", :js, type: :system do
   end
 
   def scroll_to_lazy_load
-    # Scroll the lazy-loading frame into view
+    # Scroll the lazy-loading frame into view to trigger its IntersectionObserver.
+    # Use an instant scroll (not "smooth") so the observer fires deterministically
+    # in headless Chrome; capybara-lockstep then holds the next assertion until the
+    # frame's in-flight fetch completes, so no manual sleep is needed.
     page.execute_script(<<~JS)
       const lazyFrame = document.querySelector('turbo-frame#page_2[loading="lazy"]');
       if (lazyFrame) {
-        lazyFrame.scrollIntoView({ behavior: 'smooth', block: 'end' });
+        lazyFrame.scrollIntoView({ block: "end" });
       }
     JS
-
-    # Wait a moment for the scroll and IntersectionObserver to trigger
-    sleep 1
   end
 
-  it "automatically loads the next page when scrolling to bottom", :flaky do
+  it "automatically loads the next page when scrolling to bottom" do
     expect(manufacturer1.reload.id).to eq 1003 # sanity check - otherwise the search won't work
     expect(manufacturer2.reload.id).to eq 764 # sanity check - otherwise the search won't work
     visit marketplace_url

--- a/spec/integration/organized/graduated_notifications_search_spec.rb
+++ b/spec/integration/organized/graduated_notifications_search_spec.rb
@@ -72,9 +72,7 @@ RSpec.describe "Organized graduated notifications search", :js, type: :system do
     expect(page).to have_css("turbo-frame#graduated_notifications_results_frame", wait: 10)
 
     page.go_back
-    # Wait for the form controller's auto-submit to settle the URL before
-    # interacting — without this, fill_in can race the in-flight replace and
-    # the click submits an unfilled form.
+    # Back navigation restores the default (unfiltered) search
     expect(page).to have_current_path(/stolenness=all/, wait: 10)
     expect(page).not_to have_current_path(/query_items/)
     expect(page).to have_css("turbo-frame#graduated_notifications_results_frame table.ui-table", wait: 10)

--- a/spec/integration/organized/impound_records_spec.rb
+++ b/spec/integration/organized/impound_records_spec.rb
@@ -132,9 +132,7 @@ RSpec.describe "Organized impound records index", :js, type: :system do
     end
     page.go_back
 
-    # Wait for the back-nav frame restoration to complete before opening the
-    # multi-update panel — otherwise the visibility toggle can run before the
-    # restored rows arrive and miss them.
+    # Back navigation restores the unfiltered listing (all 4 rows)
     expect(page).to have_css("turbo-frame#impound_records_results_frame table tbody tr", count: 4, wait: 10)
 
     # Cells are hidden until the user opts into multi-update.

--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -2,9 +2,12 @@
 
 require "capybara/rails"
 require "capybara/rspec"
+require "capybara-lockstep"
 
 Capybara.register_driver :chrome_headless do |app|
-  options = Selenium::WebDriver::Chrome::Options.new
+  # unhandled_prompt_behavior: "ignore" keeps capybara-lockstep from stalling on
+  # a JS dialog (alert/confirm/prompt) that a spec hasn't explicitly accepted.
+  options = Selenium::WebDriver::Chrome::Options.new(unhandled_prompt_behavior: "ignore")
   options.add_argument("--headless")
   options.add_argument("--window-size=1920,1080")
   Capybara::Selenium::Driver.new(app, browser: :chrome, options: options)


### PR DESCRIPTION
Adds [capybara-lockstep](https://github.com/makandra/capybara-lockstep) to synchronize Capybara with in-flight JavaScript/AJAX, so `:js` specs wait for the browser to go idle and flake less.

- Add the gem to the `:test` group, require it, and set `unhandled_prompt_behavior: "ignore"` on the Chrome driver so an unexpected JS dialog can't stall lockstep.
- Insert the lockstep middleware in the test environment.
- Render the `capybara_lockstep` helper in the `application` and `component_preview` layouts, guarded by `defined?` so it emits nothing outside the test env.
