### PR TITLE
Replace letter_opener with letter_opener_web

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -130,7 +130,7 @@ group :development do
   # gem "faraday-request_response_logger", github: "pramod-sharma/faraday-request_response_logger"
   gem "guard", require: false
   gem "guard-rspec", require: false
-  gem "letter_opener"
+  gem "letter_opener_web"
   gem "rerun" # restart sidekiq processes in development on app change
   gem "hotwire-livereload", "~> 1.4.1" # See #2759 for reasoning on version
   gem "terminal-notifier"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -464,6 +464,11 @@ GEM
       addressable (~> 2.8)
     letter_opener (1.10.0)
       launchy (>= 2.2, < 4)
+    letter_opener_web (3.0.0)
+      actionmailer (>= 6.1)
+      letter_opener (~> 1.9)
+      railties (>= 6.1)
+      rexml
     lint_roller (1.1.0)
     listen (3.10.0)
       logger
@@ -978,7 +983,7 @@ DEPENDENCIES
   inline_svg
   knapsack_pro
   kramdown
-  letter_opener
+  letter_opener_web
   lograge
   logstash-event
   lookbook

--- a/README.markdown
+++ b/README.markdown
@@ -48,7 +48,9 @@ Follow [the Getting Started guide](docs/getting-started.markdown) for a complete
 | [letter_opener][]     | `bin/rake dev:letter_opener`  | disabled |
 | logging with lograge  | `bin/rake dev:lograge`        | enabled  |
 
-[letter_opener]: https://github.com/ryanb/letter_opener
+When letter_opener is enabled, sent emails are viewable at [localhost:3042/letter_opener](http://localhost:3042/letter_opener).
+
+[letter_opener]: https://github.com/fgrehm/letter_opener_web
 
 ## Localization
 

--- a/README.markdown
+++ b/README.markdown
@@ -45,12 +45,11 @@ Follow [the Getting Started guide](docs/getting-started.markdown) for a complete
 | Toggle in development | command                       | default  |
 | ---------             | -------                       | -------  |
 | Caching               | `bundle exec rails dev:cache` | disabled |
-| [letter_opener][]     | `bin/rake dev:letter_opener`  | disabled |
 | logging with lograge  | `bin/rake dev:lograge`        | enabled  |
 
-When letter_opener is enabled, sent emails are viewable at [localhost:3042/letter_opener](http://localhost:3042/letter_opener).
+Sent emails are captured by [letter_opener_web][] and viewable at [localhost:3042/letter_opener](http://localhost:3042/letter_opener).
 
-[letter_opener]: https://github.com/fgrehm/letter_opener_web
+[letter_opener_web]: https://github.com/fgrehm/letter_opener_web
 
 ## Localization
 

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -43,7 +43,7 @@ Rails.application.configure do
   routes.default_url_options = config.action_mailer.default_url_options
   if Rails.root.join("tmp", "enable-letter_opener.txt").exist?
     config.action_mailer.perform_deliveries = true
-    config.action_mailer.delivery_method = :letter_opener
+    config.action_mailer.delivery_method = :letter_opener_web
   else
     config.action_mailer.perform_deliveries = false
     config.action_mailer.delivery_method = :smtp

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -41,13 +41,8 @@ Rails.application.configure do
   config.action_mailer.raise_delivery_errors = true
   config.action_mailer.default_url_options = {host: "localhost", port: ENV.fetch("DEV_PORT", 3042).to_i}
   routes.default_url_options = config.action_mailer.default_url_options
-  if Rails.root.join("tmp", "enable-letter_opener.txt").exist?
-    config.action_mailer.perform_deliveries = true
-    config.action_mailer.delivery_method = :letter_opener_web
-  else
-    config.action_mailer.perform_deliveries = false
-    config.action_mailer.delivery_method = :smtp
-  end
+  config.action_mailer.perform_deliveries = true
+  config.action_mailer.delivery_method = :letter_opener_web
 
   # Print deprecation notices to the Rails logger.
   config.active_support.deprecation = :log

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -374,6 +374,8 @@ Rails.application.routes.draw do
 
   mount Lookbook::Engine, at: "/lookbook"
 
+  mount LetterOpenerWeb::Engine, at: "/letter_opener" if Rails.env.development?
+
   get "/400", to: "errors#bad_request", via: :all
   get "/401", to: "errors#unauthorized", via: :all
   get "/404", to: "errors#not_found", via: :all

--- a/lib/tasks/dev_configuration.rake
+++ b/lib/tasks/dev_configuration.rake
@@ -50,7 +50,7 @@ end
 namespace :dev do
   # desc "Toggle caching" - already a rake action, no need to add our own
 
-  desc "Toggle letter_opener gem, which automatically opens sent emails in a browser window"
+  desc "Toggle letter_opener_web gem, which makes sent emails viewable at /letter_opener"
   task letter_opener: :environment do
     RakeDevConfiguration.toggle_letter_opener
   end

--- a/lib/tasks/dev_configuration.rake
+++ b/lib/tasks/dev_configuration.rake
@@ -5,21 +5,6 @@
 class RakeDevConfiguration
   require "fileutils"
   class << self
-    def toggle_letter_opener
-      file = "tmp/enable-letter_opener.txt"
-      FileUtils.mkdir_p("tmp")
-
-      if File.exist?(file)
-        delete_toggle_file(file)
-        puts "letter_opener is now disabled."
-      else
-        create_toggle_file(file)
-        puts "letter_opener is now enabled."
-      end
-
-      FileUtils.touch "tmp/restart.txt"
-    end
-
     def toggle_lograge
       file = "tmp/non-lograge-dev.txt"
       FileUtils.mkdir_p("tmp")
@@ -49,11 +34,6 @@ end
 
 namespace :dev do
   # desc "Toggle caching" - already a rake action, no need to add our own
-
-  desc "Toggle letter_opener_web gem, which makes sent emails viewable at /letter_opener"
-  task letter_opener: :environment do
-    RakeDevConfiguration.toggle_letter_opener
-  end
 
   desc "Toggle lograge logging in development"
   task lograge: :environment do


### PR DESCRIPTION
Replaces the `letter_opener` gem with [`letter_opener_web`](https://github.com/fgrehm/letter_opener_web), so previewed development emails are browsable at `/letter_opener` instead of auto-opening a browser tab per message.

- Swapped the gem in the `development` group and regenerated `Gemfile.lock`.
- Always captures sent emails in development via `:letter_opener_web` — dropped the `tmp/enable-letter_opener.txt` toggle and the `dev:letter_opener` rake task.
- Mounted `LetterOpenerWeb::Engine` at `/letter_opener`, guarded by `Rails.env.development?` since the gem is dev-only.
- Updated the README to document the `/letter_opener` inbox.
