### PR TITLE
Clear stale Turbo [busy] on restored search frames

### DIFF
--- a/app/javascript/controllers/search/everything_combobox_controller.js
+++ b/app/javascript/controllers/search/everything_combobox_controller.js
@@ -59,6 +59,12 @@ export default class extends Controller {
       attributeFilter: ['hidden', 'data-hw-combobox-expanded-value'],
       subtree: true
     })
+
+    // Let the search form know its query fields are ready: the non-JS `query`
+    // field is gone and query_items[] is populated. Its empty-results
+    // auto-submit waits for this so a restored page submits query_items[]
+    // instead of the stale `query` field (which made the URL drop the items).
+    document.dispatchEvent(new CustomEvent('search--combobox:connected'))
   }
 
   disconnect () {

--- a/app/javascript/controllers/search/form_controller.js
+++ b/app/javascript/controllers/search/form_controller.js
@@ -33,6 +33,10 @@ export default class extends Controller {
     // is rendering, so reloadFrameFromUrl can stay out of its way. Cleared on any
     // render below so the flag can never stick on.
     document.addEventListener('turbo:visit', this.markTurboVisit)
+    // The combobox swaps its non-JS query field for query_items[] on connect,
+    // and it connects after this controller. Retry the auto-submit once it's
+    // ready, otherwise a restored page submits the empty `query` field instead.
+    document.addEventListener('search--combobox:connected', this.submitIfEmptyResults)
     // Same-document back/forward (a filter link advanced the URL without a
     // full page load) leaves the results frame's src stale. Re-point it at the
     // restored URL so the frame matches the address bar.
@@ -49,6 +53,11 @@ export default class extends Controller {
     // against a duplicate requestSubmit, which Turbo aborts (uncaught AbortError).
     if (this.autoSubmitPending) return
     if (!this.frameElement?.querySelector('#loadedWithoutResults')) return
+    // Wait until the combobox has removed its non-JS `query` field (it fires
+    // search--combobox:connected when done). Submitting first serializes the
+    // empty `query` field instead of query_items[], so the URL drops the
+    // selected items and stops matching the form.
+    if (this.element.querySelector('[data-search--everything-combobox-target="nonjsfields"]')) return
     this.autoSubmitPending = true
     // Use replace for the initial auto-submit so it doesn't add a duplicate history entry
     this.formTarget.setAttribute('data-turbo-action', 'replace')
@@ -76,6 +85,7 @@ export default class extends Controller {
     document.removeEventListener('turbo:frame-render', this.handleFrameRender)
     document.removeEventListener('turbo:load', this.handleTurboLoad)
     document.removeEventListener('turbo:visit', this.markTurboVisit)
+    document.removeEventListener('search--combobox:connected', this.submitIfEmptyResults)
     window.removeEventListener('popstate', this.reloadFrameFromUrl)
   }
 

--- a/app/javascript/controllers/search/form_controller.js
+++ b/app/javascript/controllers/search/form_controller.js
@@ -18,6 +18,7 @@ export default class extends Controller {
     const noJsElement = this.element.querySelector('#search_no_js')
     if (noJsElement) noJsElement.remove()
 
+    this.clearStaleFrameBusy()
     this.submitIfEmptyResults()
 
     // Add timeLocalizer and watch for turbo-frame renders
@@ -25,8 +26,9 @@ export default class extends Controller {
     document.addEventListener('turbo:frame-render', this.handleFrameRender)
     // Re-check after Turbo navigations: on back/forward, connect() can fire
     // before the frame element is parsed, leaving #loadedWithoutResults in
-    // place with no auto-submit.
-    document.addEventListener('turbo:load', this.submitIfEmptyResults)
+    // place with no auto-submit. Clear stale [busy] before the empty-results
+    // check so it can re-run the auto-submit if needed.
+    document.addEventListener('turbo:load', this.handleTurboLoad)
     // Same-document back/forward (a filter link advanced the URL without a
     // full page load) leaves the results frame's src stale. Re-point it at the
     // restored URL so the frame matches the address bar.
@@ -54,8 +56,25 @@ export default class extends Controller {
 
   disconnect () {
     document.removeEventListener('turbo:frame-render', this.handleFrameRender)
-    document.removeEventListener('turbo:load', this.submitIfEmptyResults)
+    document.removeEventListener('turbo:load', this.handleTurboLoad)
     window.removeEventListener('popstate', this.reloadFrameFromUrl)
+  }
+
+  handleTurboLoad = () => {
+    this.clearStaleFrameBusy()
+    this.submitIfEmptyResults()
+  }
+
+  // Turbo's [busy]/[aria-busy] loading state is transient, but a back/forward
+  // snapshot can be cached mid-search and restored with busy stuck on - which
+  // leaves the results frame hidden under the loading overlay forever. A real
+  // search is a frame navigation (never fires turbo:load), so on load/connect
+  // any busy on a [complete] frame is stale and safe to clear.
+  clearStaleFrameBusy () {
+    const frame = this.frameElement
+    if (!frame?.hasAttribute('complete')) return
+    frame.removeAttribute('busy')
+    frame.removeAttribute('aria-busy')
   }
 
   handleFrameRender = () => {

--- a/app/javascript/controllers/search/form_controller.js
+++ b/app/javascript/controllers/search/form_controller.js
@@ -29,26 +29,44 @@ export default class extends Controller {
     // place with no auto-submit. Clear stale [busy] before the empty-results
     // check so it can re-run the auto-submit if needed.
     document.addEventListener('turbo:load', this.handleTurboLoad)
+    // Track whether a cross-document Turbo visit (eg a back/forward restoration)
+    // is rendering, so reloadFrameFromUrl can stay out of its way. Cleared on any
+    // render below so the flag can never stick on.
+    document.addEventListener('turbo:visit', this.markTurboVisit)
     // Same-document back/forward (a filter link advanced the URL without a
     // full page load) leaves the results frame's src stale. Re-point it at the
     // restored URL so the frame matches the address bar.
     window.addEventListener('popstate', this.reloadFrameFromUrl)
   }
 
+  markTurboVisit = () => { this.turboVisitInProgress = true }
+
   // if the frame was loaded without results, submit the form
   submitIfEmptyResults = () => {
+    // connect() and the turbo:load listener both call this, and on a
+    // back/forward restoration both fire before the auto-submit re-renders the
+    // frame - so #loadedWithoutResults is still present on the second call. Guard
+    // against a duplicate requestSubmit, which Turbo aborts (uncaught AbortError).
+    if (this.autoSubmitPending) return
     if (!this.frameElement?.querySelector('#loadedWithoutResults')) return
+    this.autoSubmitPending = true
     // Use replace for the initial auto-submit so it doesn't add a duplicate history entry
     this.formTarget.setAttribute('data-turbo-action', 'replace')
     this.frameElement.addEventListener('turbo:frame-render', () => {
       this.formTarget.setAttribute('data-turbo-action', 'advance')
+      this.autoSubmitPending = false
     }, { once: true })
     this.formTarget.requestSubmit()
   }
 
-  // Only fires for same-document history navigation; cross-document back/forward
-  // re-renders the page and submitIfEmptyResults handles it instead.
+  // Re-point the results frame at the restored URL after same-document history
+  // navigation (a filter link advanced the URL without a full page load),
+  // leaving the frame's src stale. A cross-document restoration instead starts a
+  // Turbo visit that re-renders the whole page (and the turbo:load handler
+  // re-runs the auto-submit), so re-pointing here would start a frame fetch the
+  // body swap immediately aborts (uncaught AbortError) - skip it in that case.
   reloadFrameFromUrl = () => {
+    if (this.turboVisitInProgress) return
     if (this.frameElement?.getAttribute('src')) {
       this.frameElement.setAttribute('src', window.location.href)
     }
@@ -57,10 +75,12 @@ export default class extends Controller {
   disconnect () {
     document.removeEventListener('turbo:frame-render', this.handleFrameRender)
     document.removeEventListener('turbo:load', this.handleTurboLoad)
+    document.removeEventListener('turbo:visit', this.markTurboVisit)
     window.removeEventListener('popstate', this.reloadFrameFromUrl)
   }
 
   handleTurboLoad = () => {
+    this.turboVisitInProgress = false
     this.clearStaleFrameBusy()
     this.submitIfEmptyResults()
   }
@@ -78,6 +98,7 @@ export default class extends Controller {
   }
 
   handleFrameRender = () => {
+    this.turboVisitInProgress = false
     // Run the time localization command on frame render
     if (window.timeLocalizer && typeof window.timeLocalizer.localize === 'function') {
       window.timeLocalizer.localize()

--- a/app/javascript/controllers/search/form_controller.js
+++ b/app/javascript/controllers/search/form_controller.js
@@ -18,16 +18,13 @@ export default class extends Controller {
     const noJsElement = this.element.querySelector('#search_no_js')
     if (noJsElement) noJsElement.remove()
 
-    this.clearStaleFrameBusy()
-    this.submitIfEmptyResults()
+    this.refreshResults()
 
     // Add timeLocalizer and watch for turbo-frame renders
     if (!window.timeLocalizer) window.timeLocalizer = new TimeLocalizer()
     document.addEventListener('turbo:frame-render', this.handleFrameRender)
-    // Re-check after Turbo navigations: on back/forward, connect() can fire
-    // before the frame element is parsed, leaving #loadedWithoutResults in
-    // place with no auto-submit. Clear stale [busy] before the empty-results
-    // check so it can re-run the auto-submit if needed.
+    // Re-run refreshResults after Turbo navigations: on back/forward, connect()
+    // can fire before the frame is parsed, leaving the auto-submit un-run.
     document.addEventListener('turbo:load', this.handleTurboLoad)
     // Track whether a cross-document Turbo visit (eg a back/forward restoration)
     // is rendering, so reloadFrameFromUrl can stay out of its way. Cleared on any
@@ -93,6 +90,12 @@ export default class extends Controller {
 
   handleTurboLoad = () => {
     this.turboVisitInProgress = false
+    this.refreshResults()
+  }
+
+  // Clear any stale loading state, then auto-submit if the loaded/restored frame
+  // has no results yet. Runs on initial connect and after every Turbo page load.
+  refreshResults () {
     this.clearStaleFrameBusy()
     this.submitIfEmptyResults()
   }

--- a/spec/integration/organized/registrations_search_spec.rb
+++ b/spec/integration/organized/registrations_search_spec.rb
@@ -191,6 +191,9 @@ RSpec.describe "Organized registrations search", :js, type: :system do
     expect(page).to have_current_path(/search_email=bob/, wait: 10)
     expect(page).to have_current_path(/period=year/, wait: 10)
     expect(page).to have_field("search_email", with: "bob@example.com")
+    # Wait for the results frame to settle before reading hrefs, otherwise
+    # rendered_bike_ids can read a row that's being replaced mid-render
+    expect(page).to have_css("tbody tr", count: 1, wait: 10)
     expect(rendered_bike_ids).to eq([bike2.id])
 
     # Chart test must run before the custom-range click below: that submission
@@ -240,6 +243,9 @@ RSpec.describe "Organized registrations search", :js, type: :system do
     page.execute_script("document.getElementById('end_time_selector').value = '#{end_str}'")
     page.execute_script("document.querySelector(\"[data-controller~='ui--period-select'] button[type='submit']\").click()")
     expect(page).to have_current_path(/period=custom/, wait: 10)
+    # Wait for the results frame to settle before reading hrefs, otherwise
+    # rendered_bike_ids can read a row that's being replaced mid-render
+    expect(page).to have_css("tbody tr", count: 1, wait: 10)
     expect(rendered_bike_ids).to eq([bike2.id])
   end
 

--- a/spec/integration/search_registrations_spec.rb
+++ b/spec/integration/search_registrations_spec.rb
@@ -107,13 +107,16 @@ RSpec.describe "Bike search", :js, type: :system do
     expect(page).to have_css(".bike-box-item", wait: 10)
   end
 
-  it "auto-submits only once when going back to a re-fetched search page" do
+  it "keeps back/forward navigation in sync without double-submitting" do
+    # Two searches in a row, then back to the first - the user's repro. connect()
+    # and the turbo:load handler both run the empty-results auto-submit on that
+    # back; it must fire at most once - without the guard the duplicate
+    # requestSubmit is aborted by Turbo (the uncaught AbortError in the console).
     visit "/"
     visit "/search/registrations"
     expect(page).to have_css(".bike-box-item", wait: 10)
     choose("stolenness_all", allow_label_click: true, visible: :all)
 
-    # Two searches in a row, then back to the first - the user's repro.
     find(".hw-combobox__input").set("Red")
     expect(page).to have_css(".hw-combobox__option", text: "that are", wait: 5)
     find(".hw-combobox__option", text: "Red", match: :first).click
@@ -127,23 +130,19 @@ RSpec.describe "Bike search", :js, type: :system do
     find("#search-button").click
     expect(page).to have_css(".bike-box-item", count: 2, wait: 10)
 
-    # On back, connect() and the turbo:load handler both run the empty-results
-    # auto-submit. Whether the restoration re-fetches (auto-submit runs) or
-    # restores a cached snapshot (no auto-submit) varies, but it must never fire
-    # the auto-submit twice: without the guard the duplicate requestSubmit is
-    # aborted by Turbo (the uncaught AbortError in the console).
     page.execute_script("window.__submitStarts = 0; document.addEventListener('turbo:submit-start', () => { window.__submitStarts += 1 })")
     page.go_back
     expect(page).to have_css(".bike-box-item", count: 2, wait: 10)
     expect(page.evaluate_script("window.__submitStarts")).to be <= 1
-  end
 
-  it "keeps the URL and combobox in sync going forward after back" do
+    # Now a fresh search, then back and forward. Forward must restore the selected
+    # query_items[] in the URL: the auto-submit waits for the combobox to swap its
+    # non-JS query field for query_items[]; otherwise it submits the empty `query`
+    # field and the URL drops the items, no longer matching the form.
     visit "/"
     visit "/search/registrations"
     expect(page).to have_css(".bike-box-item", wait: 10)
     choose("stolenness_all", allow_label_click: true, visible: :all)
-
     find(".hw-combobox__input").set("Blue")
     expect(page).to have_css(".hw-combobox__option", text: "Blue", wait: 5)
     find(".hw-combobox__option", text: "Blue", match: :first).click
@@ -153,11 +152,6 @@ RSpec.describe "Bike search", :js, type: :system do
 
     page.go_back
     expect(page).to have_css(".bike-box-item", wait: 10)
-
-    # Forward must restore the selected query_items[] in the URL. The auto-submit
-    # has to wait for the combobox to swap its non-JS query field for
-    # query_items[]; otherwise it submits the empty `query` field and the URL
-    # drops the items, no longer matching the form.
     page.go_forward
     expect(page).to have_css(".bike-box-item", wait: 10)
     expect(page).to have_current_path(/query_items/, wait: 10)

--- a/spec/integration/search_registrations_spec.rb
+++ b/spec/integration/search_registrations_spec.rb
@@ -59,15 +59,6 @@ RSpec.describe "Bike search", :js, type: :system do
 
     click_first_bike_and_go_back
 
-    # Going back again lands on the initial search page. Its results must
-    # reload rather than restoring a Turbo snapshot whose frame is stuck in the
-    # [busy] loading state (results hidden under the spinner overlay) - the
-    # "everything fails after going back from a search" regression.
-    page.go_back
-    expect(page).to have_css(".bike-box-item", wait: 10)
-    page.go_forward
-    expect(page).to have_css(".bike-box-item", count: 2, wait: 10)
-
     # Switch to proximity search for NYC
     choose("stolenness_proximity", allow_label_click: true, visible: :all)
     fill_in "distance", with: "200"
@@ -88,5 +79,31 @@ RSpec.describe "Bike search", :js, type: :system do
     expect(page).to have_css(".bike-box-item", count: 2, wait: 10)
 
     click_first_bike_and_go_back
+  end
+
+  it "reloads results when going back to the initial search page" do
+    visit "/"
+    visit "/search/registrations"
+    expect(page).to have_css(".bike-box-item", wait: 10)
+
+    # Search Blue, then view a result
+    choose("stolenness_all", allow_label_click: true, visible: :all)
+    find(".hw-combobox__input").set("Blue")
+    expect(page).to have_css(".hw-combobox__option", text: "that are", wait: 5)
+    find(".hw-combobox__option", text: "Blue", match: :first).click
+    find("#search-button").click
+    expect(page).to have_css(".bike-box-item", count: 2, wait: 10)
+
+    first(".bike-box-item .title-link a").click
+    expect(page).to have_css("h1.bike-title", wait: 10)
+
+    # Back to the Blue results, then back again to the initial search page. Its
+    # results must reload rather than restoring a Turbo snapshot whose frame is
+    # stuck in the [busy] loading state (results hidden under the spinner
+    # overlay) - the "everything fails after going back from a search" bug.
+    page.go_back
+    expect(page).to have_css(".bike-box-item", wait: 10)
+    page.go_back
+    expect(page).to have_css(".bike-box-item", wait: 10)
   end
 end

--- a/spec/integration/search_registrations_spec.rb
+++ b/spec/integration/search_registrations_spec.rb
@@ -59,6 +59,15 @@ RSpec.describe "Bike search", :js, type: :system do
 
     click_first_bike_and_go_back
 
+    # Going back again lands on the initial search page. Its results must
+    # reload rather than restoring a Turbo snapshot whose frame is stuck in the
+    # [busy] loading state (results hidden under the spinner overlay) - the
+    # "everything fails after going back from a search" regression.
+    page.go_back
+    expect(page).to have_css(".bike-box-item", wait: 10)
+    page.go_forward
+    expect(page).to have_css(".bike-box-item", count: 2, wait: 10)
+
     # Switch to proximity search for NYC
     choose("stolenness_proximity", allow_label_click: true, visible: :all)
     fill_in "distance", with: "200"

--- a/spec/integration/search_registrations_spec.rb
+++ b/spec/integration/search_registrations_spec.rb
@@ -28,6 +28,13 @@ RSpec.describe "Bike search", :js, type: :system do
     expect(page).to have_css(".bike-box-item", wait: 10)
   end
 
+  def search_color_and_submit(color)
+    find(".hw-combobox__input").set(color)
+    expect(page).to have_css(".hw-combobox__option", text: "that are", wait: 5)
+    find(".hw-combobox__option", text: color, match: :first).click
+    find("#search-button").click
+  end
+
   it "filters by color and location" do
     # Visit a different page first to establish history, then navigate to search
     visit "/"
@@ -42,16 +49,9 @@ RSpec.describe "Bike search", :js, type: :system do
     page.go_forward
     expect(page).to have_css(".bike-box-item", wait: 10)
 
-    # Select "All registrations" stolenness
+    # Select "All registrations" stolenness, then search Blue via the combobox
     choose("stolenness_all", allow_label_click: true, visible: :all)
-
-    # Search for Blue via the combobox
-    find(".hw-combobox__input").set("Blue")
-    expect(page).to have_css(".hw-combobox__option", text: "that are", wait: 5)
-    find(".hw-combobox__option", text: "Blue", match: :first).click
-
-    # Submit search
-    find("#search-button").click
+    search_color_and_submit("Blue")
 
     expect(page).to have_css(".bike-box-item", count: 2, wait: 10)
     expect(page).to have_content("Blue")
@@ -86,23 +86,16 @@ RSpec.describe "Bike search", :js, type: :system do
     visit "/search/registrations"
     expect(page).to have_css(".bike-box-item", wait: 10)
 
-    # Search Blue, then view a result
+    # Search Blue, view a result, then return to the Blue results
     choose("stolenness_all", allow_label_click: true, visible: :all)
-    find(".hw-combobox__input").set("Blue")
-    expect(page).to have_css(".hw-combobox__option", text: "that are", wait: 5)
-    find(".hw-combobox__option", text: "Blue", match: :first).click
-    find("#search-button").click
+    search_color_and_submit("Blue")
     expect(page).to have_css(".bike-box-item", count: 2, wait: 10)
+    click_first_bike_and_go_back
 
-    first(".bike-box-item .title-link a").click
-    expect(page).to have_css("h1.bike-title", wait: 10)
-
-    # Back to the Blue results, then back again to the initial search page. Its
-    # results must reload rather than restoring a Turbo snapshot whose frame is
-    # stuck in the [busy] loading state (results hidden under the spinner
-    # overlay) - the "everything fails after going back from a search" bug.
-    page.go_back
-    expect(page).to have_css(".bike-box-item", wait: 10)
+    # Back again to the initial search page. Its results must reload rather than
+    # restoring a Turbo snapshot whose frame is stuck in the [busy] loading state
+    # (results hidden under the spinner overlay) - the "everything fails after
+    # going back from a search" bug.
     page.go_back
     expect(page).to have_css(".bike-box-item", wait: 10)
   end
@@ -117,17 +110,11 @@ RSpec.describe "Bike search", :js, type: :system do
     expect(page).to have_css(".bike-box-item", wait: 10)
     choose("stolenness_all", allow_label_click: true, visible: :all)
 
-    find(".hw-combobox__input").set("Red")
-    expect(page).to have_css(".hw-combobox__option", text: "that are", wait: 5)
-    find(".hw-combobox__option", text: "Red", match: :first).click
-    find("#search-button").click
+    search_color_and_submit("Red")
     expect(page).to have_css(".bike-box-item", count: 2, wait: 10)
 
     find(".hw-combobox__chip__remover").click
-    find(".hw-combobox__input").set("Blue")
-    expect(page).to have_css(".hw-combobox__option", text: "that are", wait: 5)
-    find(".hw-combobox__option", text: "Blue", match: :first).click
-    find("#search-button").click
+    search_color_and_submit("Blue")
     expect(page).to have_css(".bike-box-item", count: 2, wait: 10)
 
     page.execute_script("window.__submitStarts = 0; document.addEventListener('turbo:submit-start', () => { window.__submitStarts += 1 })")
@@ -143,10 +130,7 @@ RSpec.describe "Bike search", :js, type: :system do
     visit "/search/registrations"
     expect(page).to have_css(".bike-box-item", wait: 10)
     choose("stolenness_all", allow_label_click: true, visible: :all)
-    find(".hw-combobox__input").set("Blue")
-    expect(page).to have_css(".hw-combobox__option", text: "Blue", wait: 5)
-    find(".hw-combobox__option", text: "Blue", match: :first).click
-    find("#search-button").click
+    search_color_and_submit("Blue")
     expect(page).to have_css(".bike-box-item", count: 2, wait: 10)
     expect(page).to have_current_path(/query_items/, wait: 10)
 

--- a/spec/integration/search_registrations_spec.rb
+++ b/spec/integration/search_registrations_spec.rb
@@ -106,4 +106,35 @@ RSpec.describe "Bike search", :js, type: :system do
     page.go_back
     expect(page).to have_css(".bike-box-item", wait: 10)
   end
+
+  it "auto-submits only once when going back to a re-fetched search page" do
+    visit "/"
+    visit "/search/registrations"
+    expect(page).to have_css(".bike-box-item", wait: 10)
+    choose("stolenness_all", allow_label_click: true, visible: :all)
+
+    # Two searches in a row, then back to the first - the user's repro.
+    find(".hw-combobox__input").set("Red")
+    expect(page).to have_css(".hw-combobox__option", text: "that are", wait: 5)
+    find(".hw-combobox__option", text: "Red", match: :first).click
+    find("#search-button").click
+    expect(page).to have_css(".bike-box-item", count: 2, wait: 10)
+
+    find(".hw-combobox__chip__remover").click
+    find(".hw-combobox__input").set("Blue")
+    expect(page).to have_css(".hw-combobox__option", text: "that are", wait: 5)
+    find(".hw-combobox__option", text: "Blue", match: :first).click
+    find("#search-button").click
+    expect(page).to have_css(".bike-box-item", count: 2, wait: 10)
+
+    # On back, connect() and the turbo:load handler both run the empty-results
+    # auto-submit. Whether the restoration re-fetches (auto-submit runs) or
+    # restores a cached snapshot (no auto-submit) varies, but it must never fire
+    # the auto-submit twice: without the guard the duplicate requestSubmit is
+    # aborted by Turbo (the uncaught AbortError in the console).
+    page.execute_script("window.__submitStarts = 0; document.addEventListener('turbo:submit-start', () => { window.__submitStarts += 1 })")
+    page.go_back
+    expect(page).to have_css(".bike-box-item", count: 2, wait: 10)
+    expect(page.evaluate_script("window.__submitStarts")).to be <= 1
+  end
 end

--- a/spec/integration/search_registrations_spec.rb
+++ b/spec/integration/search_registrations_spec.rb
@@ -137,4 +137,29 @@ RSpec.describe "Bike search", :js, type: :system do
     expect(page).to have_css(".bike-box-item", count: 2, wait: 10)
     expect(page.evaluate_script("window.__submitStarts")).to be <= 1
   end
+
+  it "keeps the URL and combobox in sync going forward after back" do
+    visit "/"
+    visit "/search/registrations"
+    expect(page).to have_css(".bike-box-item", wait: 10)
+    choose("stolenness_all", allow_label_click: true, visible: :all)
+
+    find(".hw-combobox__input").set("Blue")
+    expect(page).to have_css(".hw-combobox__option", text: "Blue", wait: 5)
+    find(".hw-combobox__option", text: "Blue", match: :first).click
+    find("#search-button").click
+    expect(page).to have_css(".bike-box-item", count: 2, wait: 10)
+    expect(page).to have_current_path(/query_items/, wait: 10)
+
+    page.go_back
+    expect(page).to have_css(".bike-box-item", wait: 10)
+
+    # Forward must restore the selected query_items[] in the URL. The auto-submit
+    # has to wait for the combobox to swap its non-JS query field for
+    # query_items[]; otherwise it submits the empty `query` field and the URL
+    # drops the items, no longer matching the form.
+    page.go_forward
+    expect(page).to have_css(".bike-box-item", wait: 10)
+    expect(page).to have_current_path(/query_items/, wait: 10)
+  end
 end


### PR DESCRIPTION
Fixes search back-navigation breaking after the `[busy]` loading-state change (#3622). Going back to a search page after viewing a result restored a Turbo page-cache snapshot captured mid-fetch with `busy=true` baked in; nothing cleared it on restoration, so the results frame stayed hidden under the loading overlay forever ("everything fails after going back from a search").