### PR TITLE
Skip capybara-lockstep during axe audits to fix flaky ScriptTimeoutError

### DIFF
--- a/spec/components/form/combobox/component_system_spec.rb
+++ b/spec/components/form/combobox/component_system_spec.rb
@@ -9,14 +9,14 @@ RSpec.describe Form::Combobox::Component, :js, type: :system do
     # `aria-expanded` is set by the combobox Stimulus controller on connect, not
     # in the server-rendered HTML -- wait out the first JS connect on slow CI.
     expect(page).to have_css('[aria-expanded="false"]', wait: 10)
-    expect(page).to be_axe_clean.skipping(*SKIPPABLE_AXE_RULES)
+    expect_axe_clean
 
     # Opens the listbox on click
     find_field("Manufacturer").click
 
     expect(page).to have_css('[aria-expanded="true"]')
     expect(page).to have_css('[role="option"]', count: 6)
-    expect(page).to be_axe_clean.skipping(*SKIPPABLE_AXE_RULES)
+    expect_axe_clean
 
     # Filters the options as you type
     fill_in "Manufacturer", with: "an"

--- a/spec/components/form/legacy_form_well/address_record/component_system_spec.rb
+++ b/spec/components/form/legacy_form_well/address_record/component_system_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Form::LegacyFormWell::AddressRecord::Component, :js, type: :syste
     visit(preview_path)
 
     expect(page).to have_content "Street address"
-    expect(page).to be_axe_clean.skipping(*SKIPPABLE_AXE_RULES, "select-name")
+    expect_axe_clean("select-name")
     expect(page).to have_select(
       "user[address_record_attributes][country_id]", selected: "United States"
     )
@@ -43,7 +43,7 @@ RSpec.describe Form::LegacyFormWell::AddressRecord::Component, :js, type: :syste
       Country.canada
       visit(preview_path)
 
-      expect(page).to be_axe_clean.skipping(*SKIPPABLE_AXE_RULES, "select-name")
+      expect_axe_clean("select-name")
       expect(page).to have_select(
         "impound_record[address_record_attributes][country_id]", selected: "United States"
       )

--- a/spec/components/form/legacy_form_well/address_record_with_default/component_system_spec.rb
+++ b/spec/components/form/legacy_form_well/address_record_with_default/component_system_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe Form::LegacyFormWell::AddressRecordWithDefault::Component, :js, t
 
       visit(preview_path)
       expect(page).to have_text("Use account address")
-      expect(page).to be_axe_clean.skipping(*SKIPPABLE_AXE_RULES, "link-in-text-block")
+      expect_axe_clean("link-in-text-block")
       expect(page).to have_checked_field("bike[current_marketplace_listing_attributes][address_record_attributes][user_account_address]")
 
       expect(page).to_not have_field("bike[current_marketplace_listing_attributes][address_record_attributes][postal_code]", visible: true)

--- a/spec/components/form/radio_button_group/component_system_spec.rb
+++ b/spec/components/form/radio_button_group/component_system_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Form::RadioButtonGroup::Component, :js, type: :system do
       expect(page).to have_content "Active"
       expect(page).to have_content "Inactive"
       expect(page).to have_css "input[name='search_status'][value=''][checked]", visible: :all
-      expect(page).to be_axe_clean.skipping(*SKIPPABLE_AXE_RULES)
+      expect_axe_clean
 
       find("label", text: "Active").click
       expect(page).to have_css "input[name='search_status'][value='active']:checked", visible: :all

--- a/spec/components/messages/thread_show/component_system_spec.rb
+++ b/spec/components/messages/thread_show/component_system_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Messages::ThreadShow::Component, :js, type: :system do
     visit(preview_path)
 
     expect(page).to have_content "When are you available"
-    expect(page).to be_axe_clean.skipping(*SKIPPABLE_AXE_RULES)
+    expect_axe_clean
 
     expect(page).to have_content("Me (")
   end
@@ -23,7 +23,7 @@ RSpec.describe Messages::ThreadShow::Component, :js, type: :system do
       visit(preview_path)
 
       expect(page).to have_content "When are you available"
-      expect(page).to be_axe_clean.skipping(*SKIPPABLE_AXE_RULES)
+      expect_axe_clean
       expect(page).to have_content("to me")
     end
   end

--- a/spec/components/messages/threads_index/component_system_spec.rb
+++ b/spec/components/messages/threads_index/component_system_spec.rb
@@ -13,6 +13,6 @@ RSpec.describe Messages::ThreadsIndex::Component, :js, type: :system do
     visit(preview_path)
 
     expect(page).to have_content "John Smith"
-    expect(page).to be_axe_clean.skipping(*SKIPPABLE_AXE_RULES)
+    expect_axe_clean
   end
 end

--- a/spec/components/org/registration_search/component_system_spec.rb
+++ b/spec/components/org/registration_search/component_system_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe Org::RegistrationSearch::Component, :js, type: :system do
   end
 
   it "toggles settings panel visibility" do
-    expect(page).to be_axe_clean.skipping(*SKIPPABLE_AXE_RULES)
+    expect_axe_clean
     settings_selector = "[data-org--registration-search-target='settings']"
     expect(page).not_to have_css(settings_selector, visible: true, wait: 2)
 

--- a/spec/components/page_block/choose_membership/component_system_spec.rb
+++ b/spec/components/page_block/choose_membership/component_system_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe PageBlock::ChooseMembership::Component, :js, type: :system do
     visit(preview_path)
 
     expect(page).to have_content(/\$4.99\s+per\s+month/)
-    expect(page).to be_axe_clean.skipping(*SKIPPABLE_AXE_RULES)
+    expect_axe_clean
 
     # Click yearly toggle
     choose "Yearly"

--- a/spec/components/search/form/component_system_spec.rb
+++ b/spec/components/search/form/component_system_spec.rb
@@ -74,7 +74,7 @@ RSpec.describe Search::Form::Component, :js, type: :system do
 
     it "submits after selecting a color" do
       expect(combobox_values).to eq([])
-      expect(page).to be_axe_clean.skipping(*SKIPPABLE_AXE_RULES)
+      expect_axe_clean
       expect(page_text(page.text)).to_not match("miles of")
 
       find("label", text: "Stolen in search area").click

--- a/spec/components/search/form_organized/component_system_spec.rb
+++ b/spec/components/search/form_organized/component_system_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Search::FormOrganized::Component, :js, type: :system do
       visit(preview_path)
 
       expect(page).to have_css("form#Search_Form")
-      expect(page).to be_axe_clean.skipping(*SKIPPABLE_AXE_RULES)
+      expect_axe_clean
       expect(page).to have_field("search_email")
       expect(page).to have_field("serial")
     end

--- a/spec/components/search/result_view_select/component_system_spec.rb
+++ b/spec/components/search/result_view_select/component_system_spec.rb
@@ -9,6 +9,6 @@ RSpec.describe Search::ResultViewSelect::Component, :js, type: :system do
     visit(preview_path)
 
     expect(page).to have_css "ul"
-    expect(page).to be_axe_clean.skipping(*SKIPPABLE_AXE_RULES)
+    expect_axe_clean
   end
 end

--- a/spec/components/search_results/bike_box/component_system_spec.rb
+++ b/spec/components/search_results/bike_box/component_system_spec.rb
@@ -9,6 +9,6 @@ RSpec.describe SearchResults::BikeBox::Component, :js, type: :system do
     visit(preview_path)
 
     expect(page).to have_content "XXX999 999XXXX"
-    expect(page).to be_axe_clean.skipping(*SKIPPABLE_AXE_RULES)
+    expect_axe_clean
   end
 end

--- a/spec/components/search_results/vehicle_thumbnail/component_system_spec.rb
+++ b/spec/components/search_results/vehicle_thumbnail/component_system_spec.rb
@@ -9,6 +9,6 @@ RSpec.describe SearchResults::VehicleThumbnail::Component, :js, type: :system do
     visit(preview_path)
 
     expect(page).to have_content "Humble Frameworks"
-    expect(page).to be_axe_clean.skipping(*SKIPPABLE_AXE_RULES)
+    expect_axe_clean
   end
 end

--- a/spec/components/ui/alert/component_system_spec.rb
+++ b/spec/components/ui/alert/component_system_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe UI::Alert::Component, :js, type: :system do
       visit(preview_path)
 
       expect(page).to have_content "Dismissable error"
-      expect(page).to be_axe_clean.skipping(*SKIPPABLE_AXE_RULES)
+      expect_axe_clean
 
       find('button[aria-label="Close"]').click
 

--- a/spec/components/ui/badge/component_system_spec.rb
+++ b/spec/components/ui/badge/component_system_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe UI::Badge::Component, :js, type: :system do
     tooltip = find("[role='tooltip']", visible: :all)
     expect(tooltip.text(:all)).to eq "Notice"
     expect(tooltip).not_to be_visible
-    expect(page).to be_axe_clean.skipping(*SKIPPABLE_AXE_RULES)
+    expect_axe_clean
 
     trigger = find("[aria-describedby='#{tooltip[:id]}']")
     expect(trigger).to have_text "N"

--- a/spec/components/ui/chart/component_system_spec.rb
+++ b/spec/components/ui/chart/component_system_spec.rb
@@ -7,6 +7,6 @@ RSpec.describe UI::Chart::Component, :js, type: :system do
     visit("/rails/view_components/ui/chart/component/bikes_by_status")
 
     expect(page).to have_css("[id^='chart-']")
-    expect(page).to be_axe_clean.skipping(*SKIPPABLE_AXE_RULES)
+    expect_axe_clean
   end
 end

--- a/spec/components/ui/definition_list/container/component_system_spec.rb
+++ b/spec/components/ui/definition_list/container/component_system_spec.rb
@@ -9,6 +9,6 @@ RSpec.describe UI::DefinitionList::Container::Component, :js, type: :system do
     visit(preview_path)
 
     expect(page).to have_content "Manufacturer"
-    expect(page).to be_axe_clean.skipping(*SKIPPABLE_AXE_RULES)
+    expect_axe_clean
   end
 end

--- a/spec/components/ui/dropdown/component_system_spec.rb
+++ b/spec/components/ui/dropdown/component_system_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe UI::Dropdown::Component, :js, type: :system do
       visit "/rails/view_components/ui/dropdown/component/default"
 
       expect(page).to have_css('[aria-expanded="false"]')
-      expect(page).to be_axe_clean.skipping(*SKIPPABLE_AXE_RULES)
+      expect_axe_clean
 
       click_button("Menu ▾")
 
@@ -17,7 +17,7 @@ RSpec.describe UI::Dropdown::Component, :js, type: :system do
       expect(page).to have_text("Settings")
       expect(page).to have_text("Logout")
       expect(page).to have_css('li[role="menuitem"]:nth-child(2) + li[role="separator"] + li[role="menuitem"]')
-      expect(page).to be_axe_clean.skipping(*SKIPPABLE_AXE_RULES)
+      expect_axe_clean
 
       send_keys(:escape)
 
@@ -38,7 +38,7 @@ RSpec.describe UI::Dropdown::Component, :js, type: :system do
       visit "/rails/view_components/ui/dropdown/component/custom_button"
 
       expect(page).to have_css('[aria-expanded="false"]')
-      expect(page).to be_axe_clean.skipping(*SKIPPABLE_AXE_RULES)
+      expect_axe_clean
 
       click_button("seth herr ▾")
 
@@ -46,7 +46,7 @@ RSpec.describe UI::Dropdown::Component, :js, type: :system do
       expect(page).to have_text("Last synced: 2 minutes ago")
       expect(page).to have_text("Settings")
       expect(page).to have_text("Sync")
-      expect(page).to be_axe_clean.skipping(*SKIPPABLE_AXE_RULES)
+      expect_axe_clean
 
       send_keys(:escape)
 

--- a/spec/components/ui/modal/component_system_spec.rb
+++ b/spec/components/ui/modal/component_system_spec.rb
@@ -6,12 +6,12 @@ RSpec.describe UI::Modal::Component, :js, type: :system do
   it "opens and closes modal" do
     visit("/rails/view_components/ui/modal/component/default")
 
-    expect(page).to be_axe_clean.skipping(*SKIPPABLE_AXE_RULES)
+    expect_axe_clean
 
     click_button "Open Settings"
 
     expect(page).to have_text("Modal body content")
-    expect(page).to be_axe_clean.skipping(*SKIPPABLE_AXE_RULES)
+    expect_axe_clean
 
     find('button[aria-label="Close"]').click
 

--- a/spec/components/ui/table/component_system_spec.rb
+++ b/spec/components/ui/table/component_system_spec.rb
@@ -7,6 +7,6 @@ RSpec.describe UI::Table::Component, :js, type: :system do
     visit("/rails/view_components/ui/table/component/sortable_with_cache")
 
     expect(page).to have_css("table")
-    expect(page).to be_axe_clean.skipping(*SKIPPABLE_AXE_RULES)
+    expect_axe_clean
   end
 end

--- a/spec/components/ui/time_localizer/component_system_spec.rb
+++ b/spec/components/ui/time_localizer/component_system_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe "time_localizer.js", :js, type: :system do
     tz_str = Binxtils::TimeZoneParser.parse(time_zone).now.strftime("%Z")
 
     expect(page).to have_content("Current time: #{current_time}", wait: 5)
-    expect(page).to be_axe_clean.skipping(*SKIPPABLE_AXE_RULES)
+    expect_axe_clean
     expect(page).to have_content("Yesterday: #{yesterday}")
     expect(page).to have_content("Tomorrow: #{tomorrow}")
     expect(page).to have_content("One week ago: #{one_week_ago}")

--- a/spec/components/ui/tooltip/component_system_spec.rb
+++ b/spec/components/ui/tooltip/component_system_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe UI::Tooltip::Component, :js, type: :system do
     tooltips = all("[role='tooltip']", visible: :all)
     expect(tooltips.size).to be >= 2
     expect(tooltips.map { |t| t[:id] }.uniq.size).to eq tooltips.size
-    expect(page).to be_axe_clean.skipping(*SKIPPABLE_AXE_RULES)
+    expect_axe_clean
 
     tooltip = tooltips.first
     trigger = find("[aria-describedby='#{tooltip[:id]}']")
@@ -105,6 +105,6 @@ RSpec.describe UI::Tooltip::Component, :js, type: :system do
     visit "#{preview_url}?_display=#{CGI.escape({theme: "dark"}.to_json)}"
 
     expect(page).to have_css("[role='tooltip']", visible: :all)
-    expect(page).to be_axe_clean.skipping(*SKIPPABLE_AXE_RULES)
+    expect_axe_clean
   end
 end

--- a/spec/integration/marketplace_infinite_scroll_spec.rb
+++ b/spec/integration/marketplace_infinite_scroll_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe "Marketplace infinite scroll", :js, type: :system do
 
     # Wait for the initial results to load
     expect(page).to have_css("[data-test-id^='vehicle-thumbnail-linkspan-']", wait: 10, count: 12)
-    expect(page).to be_axe_clean.skipping(*SKIPPABLE_AXE_RULES)
+    expect_axe_clean
     # Get the initial bike IDs visible on page 1
     initial_bikes = page.all("[data-test-id^='vehicle-thumbnail-linkspan-']").map do |el|
       el["data-test-id"].split("-").last

--- a/spec/integration/organized/registrations_search_spec.rb
+++ b/spec/integration/organized/registrations_search_spec.rb
@@ -61,7 +61,7 @@ RSpec.describe "Organized registrations search", :js, type: :system do
     # Results load via turbo auto-submit (search--form controller)
     expect(page).to have_css("turbo-frame#organized_bikes_results_frame table", wait: 10)
     expect(page).to have_css("tbody tr", minimum: 2)
-    expect(page).to be_axe_clean.skipping(*SKIPPABLE_AXE_RULES, "select-name")
+    expect_axe_clean("select-name")
 
     # search_no_js should NOT be in the URL (removed by JS controller)
     expect(page).not_to have_current_path(/search_no_js/)

--- a/spec/integration/search_registrations_spec.rb
+++ b/spec/integration/search_registrations_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe "Bike search", :js, type: :system do
     visit "/search/registrations"
 
     expect(page).to have_css(".bike-box-item", wait: 10)
-    expect(page).to be_axe_clean.skipping(*SKIPPABLE_AXE_RULES)
+    expect_axe_clean
 
     # Initial load doesn't add a duplicate history entry, so back button returns to previous page
     page.go_back

--- a/spec/integration/strava_search_spec.rb
+++ b/spec/integration/strava_search_spec.rb
@@ -27,6 +27,12 @@ RSpec.describe "Strava search", :js, type: :system do
     # Verify the React app has mounted and rendered content into #root
     expect(page).to have_css("#root *", wait: 10)
     expect(page).to have_title("Strava search")
-    expect(page).to be_axe_clean.skipping(*SKIPPABLE_AXE_RULES)
+
+    # capybara-lockstep's page instrumentation intermittently hangs axe-core's
+    # execute_async_script, surfacing as a flaky ScriptTimeoutError. Skip lockstep
+    # while the accessibility audit runs (other :js specs keep it enabled).
+    Capybara::Lockstep.with_mode(:off) do
+      expect(page).to be_axe_clean.skipping(*SKIPPABLE_AXE_RULES)
+    end
   end
 end

--- a/spec/integration/strava_search_spec.rb
+++ b/spec/integration/strava_search_spec.rb
@@ -27,12 +27,6 @@ RSpec.describe "Strava search", :js, type: :system do
     # Verify the React app has mounted and rendered content into #root
     expect(page).to have_css("#root *", wait: 10)
     expect(page).to have_title("Strava search")
-
-    # capybara-lockstep's page instrumentation intermittently hangs axe-core's
-    # execute_async_script, surfacing as a flaky ScriptTimeoutError. Skip lockstep
-    # while the accessibility audit runs (other :js specs keep it enabled).
-    Capybara::Lockstep.with_mode(:off) do
-      expect(page).to be_axe_clean.skipping(*SKIPPABLE_AXE_RULES)
-    end
+    expect_axe_clean
   end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -43,8 +43,6 @@ require "view_component/test_helpers"
 require "view_component/system_test_helpers"
 require "axe-rspec"
 
-SKIPPABLE_AXE_RULES = %w[aria-allowed-role color-contrast heading-order html-has-lang landmark-one-main landmark-unique page-has-heading-one region]
-
 ActiveRecord::Migration.maintain_test_schema!
 
 # Requires supporting ruby files with custom matchers and macros, etc,

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -84,7 +84,14 @@ RSpec.configure do |config|
   config.include Capybara::RSpecMatchers, type: :component
   config.include HtmlContentHelpers, type: :component
   config.before(:each, :browser, type: :system) { driven_by(:selenium) }
-  config.before(:each, :js, type: :system) { driven_by(:selenium_chrome_headless) }
+  config.before(:each, :js, type: :system) do
+    driven_by(:selenium_chrome_headless)
+    # `be_axe_clean` runs axe-core through Selenium's execute_async_script, which
+    # is bound by the WebDriver script timeout (30s by default). Analyzing a heavy
+    # page (e.g. the strava_search SPA) on a loaded CI runner can exceed that and
+    # surface as a flaky ScriptTimeoutError, so give axe extra headroom.
+    Capybara.current_session.driver.browser.manage.timeouts.script_timeout = 90
+  end
 end
 
 require "vcr"

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -84,14 +84,7 @@ RSpec.configure do |config|
   config.include Capybara::RSpecMatchers, type: :component
   config.include HtmlContentHelpers, type: :component
   config.before(:each, :browser, type: :system) { driven_by(:selenium) }
-  config.before(:each, :js, type: :system) do
-    driven_by(:selenium_chrome_headless)
-    # `be_axe_clean` runs axe-core through Selenium's execute_async_script, which
-    # is bound by the WebDriver script timeout (30s by default). Analyzing a heavy
-    # page (e.g. the strava_search SPA) on a loaded CI runner can exceed that and
-    # surface as a flaky ScriptTimeoutError, so give axe extra headroom.
-    Capybara.current_session.driver.browser.manage.timeouts.script_timeout = 90
-  end
+  config.before(:each, :js, type: :system) { driven_by(:selenium_chrome_headless) }
 end
 
 require "vcr"

--- a/spec/support/axe.rb
+++ b/spec/support/axe.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+# Shared helper for axe-core accessibility audits in :js system specs.
+#
+# capybara-lockstep's page instrumentation intermittently leaves axe-core's
+# execute_async_script callback pending, surfacing as a flaky
+# Selenium::WebDriver::Error::ScriptTimeoutError. Disable lockstep just for the
+# audit; the rest of the example keeps it enabled.
+module AxeAuditHelpers
+  SKIPPABLE_AXE_RULES = %w[aria-allowed-role color-contrast heading-order html-has-lang landmark-one-main landmark-unique page-has-heading-one region]
+
+  def expect_axe_clean(*extra_skipped_rules)
+    Capybara::Lockstep.with_mode(:off) do
+      expect(page).to be_axe_clean.skipping(*SKIPPABLE_AXE_RULES, *extra_skipped_rules)
+    end
+  end
+end
+
+RSpec.configure do |config|
+  config.include AxeAuditHelpers, type: :system
+end


### PR DESCRIPTION
Fixes flaky `Selenium::WebDriver::Error::ScriptTimeoutError` failures in the `:js` accessibility specs (`strava_search`, `ui/chart`, `ui/alert`, `ui/dropdown`, `ui/table`, `messages/thread_show`, …). `be_axe_clean` runs axe-core through Selenium's `execute_async_script`; capybara-lockstep's page instrumentation (added in #3628) can leave that callback pending until the WebDriver script timeout fires — a hang, not slowness, so raising the timeout doesn't help.

- Add an `expect_axe_clean` helper in `spec/support/axe.rb` that runs the audit inside `Capybara::Lockstep.with_mode(:off)` and folds in `SKIPPABLE_AXE_RULES` (moved here from `rails_helper`).
- Convert all 34 `be_axe_clean` call sites to the helper; pass extra rules as args, e.g. `expect_axe_clean("select-name")`.
- Lockstep stays enabled for the rest of every example, so specs that depend on it (e.g. `marketplace_infinite_scroll`) are unaffected.
