### PR TITLE
Stop double-sending organization role invitation emails

### DIFF
--- a/app/jobs/users/process_organization_role_job.rb
+++ b/app/jobs/users/process_organization_role_job.rb
@@ -29,7 +29,7 @@ module Users
       user_id ||= User.fuzzy_confirmed_or_unconfirmed_email_find(organization_role.invited_email)&.id
       return false unless user_id.present?
 
-      organization_role.update(user_id: user_id)
+      organization_role.update(user_id:, skip_processing: true)
       organization_role.reload
       User.find_by_id(user_id)&.update(updated_at: Time.current)
     end
@@ -54,7 +54,7 @@ module Users
       user.save!
       user.confirm(user.confirmation_token)
       # We don't want to send users emails in this situation.
-      organization_role.update(user_id: user.id, email_invitation_sent_at: Time.current)
+      organization_role.update(user_id: user.id, email_invitation_sent_at: Time.current, skip_processing: true)
       organization_role.reload
     end
 

--- a/app/jobs/users/process_organization_role_job.rb
+++ b/app/jobs/users/process_organization_role_job.rb
@@ -11,7 +11,12 @@ module Users
 
       auto_generate_user_for_organization(organization_role)
       if organization_role.send_invitation_email?
-        OrganizedMailer.organization_invitation(organization_role).deliver_now
+        notification = organization_role.notifications.where(kind: "organization_invitation").first ||
+          Notification.create(kind: "organization_invitation", notifiable: organization_role,
+            user_id: organization_role.user_id, message_channel_target: organization_role.invited_email)
+        notification.track_email_delivery do
+          OrganizedMailer.organization_invitation(organization_role).deliver_now
+        end
         organization_role.update(email_invitation_sent_at: Time.current, skip_processing: true)
       end
 

--- a/app/models/organization_role.rb
+++ b/app/models/organization_role.rb
@@ -36,6 +36,7 @@ class OrganizationRole < ApplicationRecord
   belongs_to :user
   belongs_to :organization
   belongs_to :sender, class_name: "User"
+  has_many :notifications, as: :notifiable
 
   validates_presence_of :role, :organization_id, :invited_email
 

--- a/config/notification_kinds_enums.yml
+++ b/config/notification_kinds_enums.yml
@@ -30,3 +30,4 @@
 :marketplace_message_blocked: 32
 :newsletter: 31
 :graduated_notification: 33
+:organization_invitation: 34

--- a/spec/jobs/users/process_organization_role_job_spec.rb
+++ b/spec/jobs/users/process_organization_role_job_spec.rb
@@ -141,6 +141,23 @@ RSpec.describe Users::ProcessOrganizationRoleJob, type: :job do
           expect(user.organization_roles.count).to eq 1
         end
       end
+
+      context "user with email exists but is not yet assigned" do
+        let!(:user) { FactoryBot.create(:user_confirmed, email: "existing@example.com") }
+        let(:organization_role) { FactoryBot.create(:organization_role, invited_email: "existing@example.com", user: nil) }
+        it "sends one email and does not enqueue a duplicate processing job" do
+          Sidekiq::Job.clear_all
+          expect(organization_role.user).to be_blank
+          # assigning the user must not re-enqueue ProcessOrganizationRoleJob (which would race and double-send)
+          expect {
+            instance.perform(organization_role.id)
+          }.to_not change(described_class.jobs, :count)
+          organization_role.reload
+          expect(organization_role.user).to eq user
+          expect(organization_role.email_invitation_sent_at).to be_present
+          expect(ActionMailer::Base.deliveries.count).to eq 1
+        end
+      end
     end
   end
 end

--- a/spec/jobs/users/process_organization_role_job_spec.rb
+++ b/spec/jobs/users/process_organization_role_job_spec.rb
@@ -113,16 +113,20 @@ RSpec.describe Users::ProcessOrganizationRoleJob, type: :job do
 
     context "email not sent" do
       let(:organization_role) { FactoryBot.create(:organization_role) }
-      it "sends the email" do
+      it "sends the email and records a notification" do
         expect(organization_role.claimed?).to be_falsey
         expect(organization_role.email_invitation_sent_at).to be_blank
         expect {
-          instance.perform(organization_role.id)
-        }.to_not change(User, :count)
+          expect { instance.perform(organization_role.id) }.to_not change(User, :count)
+        }.to change(Notification, :count).by(1)
         organization_role.reload
         expect(organization_role.claimed?).to be_falsey
         expect(organization_role.email_invitation_sent_at).to be_present
         expect(ActionMailer::Base.deliveries.empty?).to be_falsey
+        notification = organization_role.notifications.first
+        expect(notification.kind).to eq "organization_invitation"
+        expect(notification.message_channel_target).to eq organization_role.invited_email
+        expect(notification.delivery_success?).to be_truthy
       end
       context "user with email exists" do
         let!(:user) { FactoryBot.build(:user_confirmed, email: organization_role.invited_email) }
@@ -156,6 +160,7 @@ RSpec.describe Users::ProcessOrganizationRoleJob, type: :job do
           expect(organization_role.user).to eq user
           expect(organization_role.email_invitation_sent_at).to be_present
           expect(ActionMailer::Base.deliveries.count).to eq 1
+          expect(organization_role.notifications.pluck(:kind)).to eq(["organization_invitation"])
         end
       end
     end


### PR DESCRIPTION
Organization role invitation emails could be sent twice. When an invite's email matched an existing user not yet in the org, `assign_organization_role_user` updated `user_id` without `skip_processing: true`, so the model's `after_commit` callback enqueued a second `ProcessOrganizationRoleJob`. Because the `email_invitation_sent_at` guard is only set *after* the email is sent, the duplicate job could race past it and send the invitation again.

- Pass `skip_processing: true` on the `user_id` assignment update (and the passwordless-user update, for consistency) so no redundant job is enqueued.
- Record a `Notification` (new `organization_invitation` kind) when sending the invitation, wrapping delivery in `track_email_delivery` like every other email — find-or-create on the `organization_role` keeps it idempotent.
- Add regression specs: one email sent, zero duplicate jobs enqueued, and a notification recorded.
