### PR TITLE
Reject public image uploads over 16MB

### DIFF
--- a/app/controllers/public_images_controller.rb
+++ b/app/controllers/public_images_controller.rb
@@ -10,6 +10,10 @@ class PublicImagesController < ApplicationController
   end
 
   def create
+    if request.content_length.to_i > PublicImageUploader::MAX_FILE_SIZE
+      max_size = ActiveSupport::NumberHelper.number_to_human_size(PublicImageUploader::MAX_FILE_SIZE)
+      render(json: {error: translation(:image_too_large, size: max_size)}, status: 413) && return
+    end
     @public_image = PublicImage.new(permitted_parameters)
     if params[:bike_id].present?
       @public_image.imageable = @bike

--- a/app/models/public_image.rb
+++ b/app/models/public_image.rb
@@ -77,12 +77,10 @@ class PublicImage < ApplicationRecord
       return Images::ExternalUrlStoreJob.perform_async(id)
     end
 
-    # For bikes, AfterBikeSaveJob resaves the bike in the background (resave_bike: true).
-    # Updating here too would redundantly run the location recalc synchronously, which can
-    # blow the request timeout (Rack::Timeout) when it triggers a geocode.
-    return CallbackJob::AfterBikeSaveJob.perform_async(imageable_id, false, true) if bike?
-
     imageable&.update(updated_at: Time.current)
+    return true unless bike?
+
+    CallbackJob::AfterBikeSaveJob.perform_async(imageable_id, false, true)
   end
 
   # Because the way we load the file is different if it's remote or local

--- a/app/models/public_image.rb
+++ b/app/models/public_image.rb
@@ -77,10 +77,12 @@ class PublicImage < ApplicationRecord
       return Images::ExternalUrlStoreJob.perform_async(id)
     end
 
-    imageable&.update(updated_at: Time.current)
-    return true unless bike?
+    # For bikes, AfterBikeSaveJob resaves the bike in the background (resave_bike: true).
+    # Updating here too would redundantly run the location recalc synchronously, which can
+    # blow the request timeout (Rack::Timeout) when it triggers a geocode.
+    return CallbackJob::AfterBikeSaveJob.perform_async(imageable_id, false, true) if bike?
 
-    CallbackJob::AfterBikeSaveJob.perform_async(imageable_id, false, true)
+    imageable&.update(updated_at: Time.current)
   end
 
   # Because the way we load the file is different if it's remote or local

--- a/app/uploaders/public_image_uploader.rb
+++ b/app/uploaders/public_image_uploader.rb
@@ -3,5 +3,13 @@
 # that can push large requests past the 30s Rack::Timeout. Cache locally and
 # only hit S3 for the final store + versions.
 class PublicImageUploader < ImageUploader
+  # Reject oversized uploads before any processing/storage. Shared with
+  # PublicImagesController, which rejects on Content-Length before caching.
+  MAX_FILE_SIZE = 16.megabytes
+
   cache_storage :file
+
+  def size_range
+    0..MAX_FILE_SIZE
+  end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1937,6 +1937,7 @@ en:
     public_images:
       create:
         cannot_create: Whoops! We can't let you create that image.
+        image_too_large: 'That image is too large. Please upload an image smaller than %{size}.'
       destroy:
         cannot_delete: Whoops! How'd you do that? Can't delete mail snippet images.
         image_deleted: Image was successfully deleted

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1937,7 +1937,8 @@ en:
     public_images:
       create:
         cannot_create: Whoops! We can't let you create that image.
-        image_too_large: 'That image is too large. Please upload an image smaller than %{size}.'
+        image_too_large: That image is too large. Please upload an image smaller than
+          %{size}.
       destroy:
         cannot_delete: Whoops! How'd you do that? Can't delete mail snippet images.
         image_deleted: Image was successfully deleted

--- a/spec/requests/public_images_request_spec.rb
+++ b/spec/requests/public_images_request_spec.rb
@@ -6,6 +6,18 @@ RSpec.describe PublicImagesController, type: :request do
 
   describe "create" do
     let(:current_user) { FactoryBot.create(:superuser) }
+    context "image larger than MAX_FILE_SIZE" do
+      let(:bike) { FactoryBot.create(:bike, :with_ownership_claimed) }
+      let!(:current_user) { bike.current_ownership.creator }
+      it "responds payload_too_large and does not create" do
+        stub_const("PublicImageUploader::MAX_FILE_SIZE", 1)
+        expect {
+          post base_url, params: {bike_id: bike.id, public_image: {name: "cool name"}, format: :js}
+        }.to_not change(PublicImage, :count)
+        expect(response).to have_http_status(413)
+        expect(response.parsed_body["error"]).to match(/too large/i)
+      end
+    end
     context "bike" do
       let(:bike) { FactoryBot.create(:bike, :with_ownership_claimed) }
       let!(:current_user) { bike.current_ownership.creator }


### PR DESCRIPTION
Very large image uploads (some 25–30 MB) drive `public_images#create` past the 30s `Rack::Timeout` in synchronous ImageMagick processing and the S3 upload — Honeybadger [#130787845](https://app.honeybadger.io/projects/35931/faults/130787845) (16 notices) and [#131032609](https://app.honeybadger.io/projects/35931/faults/131032609) (9 notices). This caps uploads at 16 MB so oversized files are rejected before any of that work runs.

The limit is a single `PublicImageUploader::MAX_FILE_SIZE` constant enforced in two places:

- **`PublicImageUploader#size_range`** — authoritative CarrierWave validation; rejects before caching/processing on every upload path (`save` returns false with an error).
- **`PublicImagesController#create`** — early `Content-Length` guard returns 413 before the request body is buffered.

The over-limit message is localized with a `%{size}` interpolation fed from the constant, so it stays correct if the cap changes.

Note: this is the cheap synchronous guard. Moving the image processing/versioning itself to a background job (the broader fix for these timeouts) is still a separate follow-up.
