### PR TITLE
Prefer PR comments over the description for uploaded screenshots

### DIFF
--- a/.claude/skills/github-upload-image-to-pr/SKILL.md
+++ b/.claude/skills/github-upload-image-to-pr/SKILL.md
@@ -132,25 +132,34 @@ Use the **standard textarea selector** from step 6, then assign `ta.value = ""`:
 
 ## Step 8: Embed images in the PR
 
-In both options below, substitute whichever form (markdown `![](...)` or HTML `<img ...>`) GitHub returned in step 6 — preserve it verbatim instead of rewrapping.
+Substitute whichever form (markdown `![](...)` or HTML `<img ...>`) GitHub returned in step 6 — preserve it verbatim instead of rewrapping.
 
-**Option A — Update PR description** (append images to existing body):
+**Post as a comment** (the default). A comment keeps the description tight and skimmable, and avoids re-editing the body (and its notification noise) on every recapture.
+
+If a screenshots comment already exists (one authored by you whose body starts with `## Screenshots`), edit it in place instead of posting a new one:
+```bash
+SCREENSHOT_COMMENT_ID=$(gh api repos/{owner}/{repo}/issues/{PR_NUMBER}/comments \
+  --jq '.[] | select(.body | startswith("## Screenshots")) | .id' | head -1)
+```
+
+Write the comment body to a temp file:
+```
+## Screenshots
+
+<image markup from step 6>
+```
+
+- If `$SCREENSHOT_COMMENT_ID` is empty: `gh pr comment {PR_NUMBER} --body-file <tmp-comment-file>`.
+- Otherwise: `gh api -X PATCH repos/{owner}/{repo}/issues/comments/$SCREENSHOT_COMMENT_ID -f body=@<tmp-comment-file>`.
+
+Only edit the PR description instead when the user explicitly asks for it:
 ```bash
 EXISTING_BODY=$(gh pr view {PR_NUMBER} --json body -q .body)
 
 gh pr edit {PR_NUMBER} --body "$(printf '%s\n\n## Screenshots\n\n%s' "$EXISTING_BODY" "<image markup from step 6>")"
 ```
 
-If `$EXISTING_BODY` already contains a `## Screenshots` heading (e.g., on re-runs), this will create a duplicate section. Check first with `grep -q "^## Screenshots" <<< "$EXISTING_BODY"` and either replace the existing section or post as a comment (Option B) instead.
-
-**Option B — Post as a new comment**:
-```bash
-gh pr comment {PR_NUMBER} --body "## Screenshots
-
-<image markup from step 6>"
-```
-
-Use Option A by default unless the user explicitly asks for a comment, or if the PR description is already long and a comment would be cleaner.
+If `$EXISTING_BODY` already contains a `## Screenshots` heading (e.g., on re-runs), this will create a duplicate section. Check first with `grep -q "^## Screenshots" <<< "$EXISTING_BODY"` and either replace the existing section or post as a comment instead.
 
 ## Step 9: Verify the result
 

--- a/spec/integration/organized/impound_records_spec.rb
+++ b/spec/integration/organized/impound_records_spec.rb
@@ -36,17 +36,9 @@ RSpec.describe "Organized impound records index", :js, type: :system do
     find("input[type=checkbox][name='ids[#{impound_record.id}]']", visible: :all)
   end
 
-  # Headless Chrome on CI sometimes loses the click on these freshly-enabled
-  # checkboxes (set/check/native.click all flaked), so set the property
-  # directly (and fire change, as a real click would). The form posts the
-  # value regardless of how the box got checked.
   def check_for_update(impound_record)
     expect(checkbox_for(impound_record)).not_to be_disabled
-    page.execute_script(<<~JS)
-      const el = document.getElementById('ids_#{impound_record.id}')
-      el.checked = true
-      el.dispatchEvent(new Event('change', {bubbles: true}))
-    JS
+    check "ids[#{impound_record.id}]"
     expect(checkbox_for(impound_record)).to be_checked
   end
 


### PR DESCRIPTION
Make posting a `## Screenshots` comment the default in the `github-upload-image-to-pr` skill, reusing an existing screenshots comment in place when one already exists. Editing the PR description is now only done when the user explicitly asks, removing the prior default that appended screenshots to the body.
