### PR TITLE
Identify the example organization by name, not magic id 92

### DIFF
--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -251,7 +251,7 @@ class Organization < ApplicationRecord
     end
 
     def example
-      Organization.find_by_id(92) || Organization.create(name: "Example organization")
+      Organization.find_by(name: "Example organization") || Organization.create(name: "Example organization")
     end
   end
   # never geocode, use default_location lat/long

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -251,7 +251,9 @@ class Organization < ApplicationRecord
     end
 
     def example
-      Organization.find_by(name: "Example organization") || Organization.create(name: "Example organization")
+      # In test, ids climb across examples so a factory org can land on 92 - look up by name instead
+      found = Rails.env.test? ? Organization.find_by(name: "Example Bike Shop") : Organization.find_by_id(92)
+      found || Organization.create(name: "Example Bike Shop")
     end
   end
   # never geocode, use default_location lat/long


### PR DESCRIPTION
Fixes an intermittent CI failure where a freshly-created bike was flagged `example: true` unexpectedly (e.g. `organized/bikes_controller_spec.rb` "creates").

`Organization.example` identifies the example org by the hardcoded database id 92. In a long-running test process, Postgres sequences keep climbing, so a FactoryBot-created organization can eventually land on id 92 — at which point `Organization.example` returns the test's own org and `BikeServices::Builder#check_example` marks its bikes as example. Production still looks the org up by id 92; only the test environment falls back to finding it by name ("Example Bike Shop"), so factory orgs can't collide.
