### PR TITLE
Fix translation-sync dedup so concurrent merges don't duplicate PRs

### DIFF
--- a/bin/check_translations
+++ b/bin/check_translations
@@ -50,8 +50,11 @@ else
   if [ -n "$CI" ]; then
     output "${YELLOW}" "On CI — creating translation sync PR"
 
-    # Check for existing open translation sync PRs
-    existing_pr=$(gh pr list --head "translations-sync" --state open --json number --jq '.[0].number' 2>/dev/null || true)
+    # Check for existing open translation sync PRs.
+    # Branches are named translations-sync-<timestamp>, so we can't use
+    # `gh pr list --head` (it requires an exact branch name) — match the prefix instead.
+    existing_pr=$(gh pr list --state open --json number,headRefName \
+      --jq 'map(select(.headRefName | startswith("translations-sync")))[0].number' 2>/dev/null || true)
     if [ -n "$existing_pr" ]; then
       output "${YELLOW}" "Translation sync PR already exists: #${existing_pr} — skipping PR creation"
       exit 1


### PR DESCRIPTION
Two PRs merging to `main` close together each triggered the CI translation sync, producing duplicate sync PRs (#3648 and #3649). The dedup guard in `bin/check_translations` was meant to prevent this but was a no-op.

- The guard used `gh pr list --head "translations-sync"`, which requires an **exact** branch name — but sync branches are named `translations-sync-<timestamp>`, so it never matched an existing PR.
- Now it lists open PRs and matches the `translations-sync` branch **prefix**, so a second concurrent run finds the already-open sync PR and skips creating a duplicate.
