### PR TITLE
Throttle search data endpoints under the API limit

### DIFF
--- a/app/javascript/controllers/search/kind_select_fields_controller.js
+++ b/app/javascript/controllers/search/kind_select_fields_controller.js
@@ -111,17 +111,11 @@ export default class extends Controller {
   }
 
   setKindCounts () {
+    // console.log('setting kind counts')
+
     const queryString = this.searchQuery
     if (this.doNotFetchCounts(queryString)) {
       return this.resetKindCounts()
-    }
-
-    // Skip if the rendered counts already reflect this query - eg Turbo
-    // reconnecting the controller against a cached snapshot whose counts are
-    // already filled in. The marker lives on the element so it rides along in the
-    // cached DOM; resetKindCounts clears it whenever the counts are blanked.
-    if (this.element.dataset.countsQuery === queryString) {
-      return this.setResetFieldListeners()
     }
 
     fetch(`${this.apiCountUrlValue}?${queryString}`, {
@@ -129,10 +123,7 @@ export default class extends Controller {
       headers: { 'Content-Type': 'application/json' }
     })
       .then(response => response.json())
-      .then(data => {
-        this.element.dataset.countsQuery = queryString
-        this.insertTabCounts(data)
-      })
+      .then(data => { this.insertTabCounts(data) })
 
     this.setResetFieldListeners()
   }
@@ -154,9 +145,7 @@ export default class extends Controller {
   }
 
   resetKindCounts () {
-    // Counts are being blanked, so drop the dedupe marker - the next fetch for
-    // this query must run again rather than being skipped as already-rendered.
-    delete this.element.dataset.countsQuery
+    // console.log('resetting counts')
 
     // dataCountTargets looks like: ['non', 'stolen', 'proximity', 'for_sale']
     const dataCountTargets = [...this.element.querySelectorAll('[data-count-target]')]

--- a/app/javascript/controllers/search/kind_select_fields_controller.js
+++ b/app/javascript/controllers/search/kind_select_fields_controller.js
@@ -111,11 +111,17 @@ export default class extends Controller {
   }
 
   setKindCounts () {
-    // console.log('setting kind counts')
-
     const queryString = this.searchQuery
     if (this.doNotFetchCounts(queryString)) {
       return this.resetKindCounts()
+    }
+
+    // Skip if the rendered counts already reflect this query - eg Turbo
+    // reconnecting the controller against a cached snapshot whose counts are
+    // already filled in. The marker lives on the element so it rides along in the
+    // cached DOM; resetKindCounts clears it whenever the counts are blanked.
+    if (this.element.dataset.countsQuery === queryString) {
+      return this.setResetFieldListeners()
     }
 
     fetch(`${this.apiCountUrlValue}?${queryString}`, {
@@ -123,7 +129,10 @@ export default class extends Controller {
       headers: { 'Content-Type': 'application/json' }
     })
       .then(response => response.json())
-      .then(data => { this.insertTabCounts(data) })
+      .then(data => {
+        this.element.dataset.countsQuery = queryString
+        this.insertTabCounts(data)
+      })
 
     this.setResetFieldListeners()
   }
@@ -145,7 +154,9 @@ export default class extends Controller {
   }
 
   resetKindCounts () {
-    // console.log('resetting counts')
+    // Counts are being blanked, so drop the dedupe marker - the next fetch for
+    // this query must run again rather than being skipped as already-rendered.
+    delete this.element.dataset.countsQuery
 
     // dataCountTargets looks like: ['non', 'stolen', 'proximity', 'for_sale']
     const dataCountTargets = [...this.element.querySelectorAll('[data-count-target]')]

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -17,18 +17,24 @@ class Rack::Attack
   SKIP_THROTTLE_PREFIXES = %w[/api /oauth /assets].freeze
   API_PATH_PREFIXES = %w[/api /oauth].freeze
 
+  # Search autocomplete and kind-count endpoints are XHR/data calls fired
+  # repeatedly during normal searching (per-keystroke autocomplete, kind counts) -
+  # not page navigations. Throttle them like the API (generous per-IP budget)
+  # rather than against the strict per-page limit, which active searching trips.
+  SEARCH_DATA_PREFIXES = %w[/search/combobox /search/marketplace/counts].freeze
+
   cache.store = ActiveSupport::Cache::RedisCacheStore.new(
     url: Bikeindex::Application.config.redis_rack_attack_url
   )
 
-  # API and OAuth: 150 per 30 seconds per IP
+  # API, OAuth, and search data (autocomplete/counts): 150 per 30 seconds per IP
   throttle("api/ip", limit: API_MAX_REQUESTS, period: 30.seconds) do |request|
-    request.ip if request.path.start_with?(*API_PATH_PREFIXES)
+    request.ip if request.path.start_with?(*API_PATH_PREFIXES, *SEARCH_DATA_PREFIXES)
   end
 
-  # Global rate limit per IP (non-API, non-OAuth, non-assets)
+  # Global rate limit per IP (non-API, non-OAuth, non-assets, non-search-data)
   throttle("requests/ip", limit: MAX_REQUESTS_PER_TWENTY, period: 20.seconds) do |request|
-    request.ip unless request.path.start_with?(*SKIP_THROTTLE_PREFIXES)
+    request.ip unless request.path.start_with?(*SKIP_THROTTLE_PREFIXES, *SEARCH_DATA_PREFIXES)
   end
 
   # Sign-in: 10 per minute per IP

--- a/spec/requests/search/combobox_request_spec.rb
+++ b/spec/requests/search/combobox_request_spec.rb
@@ -82,4 +82,20 @@ RSpec.describe Search::ComboboxController, type: :request do
       end
     end
   end
+
+  describe "rack_attack" do
+    include_context :rack_attack
+
+    # The per-keystroke autocomplete is the heaviest search endpoint, so it rides
+    # the generous API limit rather than the strict per-page request limit, which
+    # active typing would otherwise trip.
+    it "throttles at the API limit, not the lower per-page limit" do
+      expect(Rack::Attack::API_MAX_REQUESTS).to be > Rack::Attack::MAX_REQUESTS_PER_TWENTY
+      throttled = rack_attack_throttled_response(limit: Rack::Attack::API_MAX_REQUESTS) do
+        get "/search/combobox/options", params: {q: "x", for_id: "test"}, as: :turbo_stream
+        response
+      end
+      expect(throttled).to have_http_status(:too_many_requests)
+    end
+  end
 end

--- a/spec/requests/search/marketplace_request_spec.rb
+++ b/spec/requests/search/marketplace_request_spec.rb
@@ -190,6 +190,21 @@ RSpec.describe Search::MarketplaceController, type: :request do
         expect(json_result).to match_hash_indifferently({for_sale: 1, for_sale_proximity: 0})
       end
 
+      describe "rack_attack" do
+        include_context :rack_attack
+
+        # Counts is an XHR data endpoint fired on every search, so it rides the
+        # generous API limit rather than the strict per-page request limit.
+        it "throttles at the API limit, not the lower per-page limit" do
+          expect(Rack::Attack::API_MAX_REQUESTS).to be > Rack::Attack::MAX_REQUESTS_PER_TWENTY
+          throttled = rack_attack_throttled_response(limit: Rack::Attack::API_MAX_REQUESTS) do
+            get "#{base_url}/counts"
+            response
+          end
+          expect(throttled).to have_http_status(:too_many_requests)
+        end
+      end
+
       context "with listings" do
         let(:target_result) { {for_sale: 2, for_sale_proximity: 1} }
         include_context :geocoder_real


### PR DESCRIPTION
Active searching tripped Rack::Attack's strict per-page limit (30 req/20s) because the search autocomplete and kind-count endpoints live under `/search`, not `/api` — per-keystroke autocomplete alone could exhaust it. Route `/search/combobox` and `/search/marketplace/counts` through the generous API throttle (150/30s) and out of the per-page limit, with request specs covering both.

Extracted from #3633 where it was discovered