### PR TITLE
Re-record geocoder cassettes

### DIFF
--- a/spec/services/geocode_helper_spec.rb
+++ b/spec/services/geocode_helper_spec.rb
@@ -117,8 +117,8 @@ RSpec.describe GeocodeHelper do
       context "another IP address" do
         let(:address) { "50.211.197.209" }
         let(:target_address_hash) do
-          target_assignable_hash.merge(latitude: 37.7506, longitude: -122.4121, city: "San Francisco",
-            formatted_address: "San Francisco, CA, US")
+          target_assignable_hash.merge(latitude: 37.3209, longitude: -121.9126, city: "San Jose",
+            formatted_address: "San Jose, CA, US")
         end
         it "finds the address" do
           VCR.use_cassette("geohelper-ip_address2", vcr_config) do

--- a/spec/vcr_cassettes/geohelper-boundingbox.yml
+++ b/spec/vcr_cassettes/geohelper-boundingbox.yml
@@ -21,87 +21,6 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       Date:
-      - Thu, 05 Feb 2026 17:43:57 GMT
-      Pragma:
-      - no-cache
-      Expires:
-      - Fri, 01 Jan 1990 00:00:00 GMT
-      Cache-Control:
-      - no-cache, must-revalidate
-      Access-Control-Allow-Origin:
-      - "*"
-      X-Goog-Maps-Metro-Area:
-      - San Francisco, CA
-      Content-Security-Policy-Report-Only:
-      - script-src 'none'; form-action 'none'; frame-src 'none'; report-uri https://csp.withgoogle.com/csp/scaffolding/msaifdggmnwc:213:0
-      Cross-Origin-Opener-Policy-Report-Only:
-      - same-origin; report-to=msaifdggmnwc:213:0
-      Report-To:
-      - '{"group":"msaifdggmnwc:213:0","max_age":2592000,"endpoints":[{"url":"https://csp.withgoogle.com/csp/report-to/scaffolding/msaifdggmnwc:213:0"}],}'
-      Server:
-      - mafe
-      Content-Length:
-      - '2186'
-      X-Xss-Protection:
-      - '0'
-      X-Frame-Options:
-      - SAMEORIGIN
-      Server-Timing:
-      - gfet4t7; dur=50
-      Alt-Svc:
-      - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
-    body:
-      encoding: UTF-8
-      string: "{\n   \"results\" : \n   [\n      {\n         \"address_components\"
-        : \n         [\n            {\n               \"long_name\" : \"San Francisco\",\n
-        \              \"short_name\" : \"SF\",\n               \"types\" : \n               [\n
-        \                 \"locality\",\n                  \"political\"\n               ]\n
-        \           },\n            {\n               \"long_name\" : \"San Francisco
-        County\",\n               \"short_name\" : \"San Francisco County\",\n               \"types\"
-        : \n               [\n                  \"administrative_area_level_2\",\n
-        \                 \"political\"\n               ]\n            },\n            {\n
-        \              \"long_name\" : \"California\",\n               \"short_name\"
-        : \"CA\",\n               \"types\" : \n               [\n                  \"administrative_area_level_1\",\n
-        \                 \"political\"\n               ]\n            },\n            {\n
-        \              \"long_name\" : \"United States\",\n               \"short_name\"
-        : \"US\",\n               \"types\" : \n               [\n                  \"country\",\n
-        \                 \"political\"\n               ]\n            }\n         ],\n
-        \        \"formatted_address\" : \"San Francisco, CA, USA\",\n         \"geometry\"
-        : \n         {\n            \"bounds\" : \n            {\n               \"northeast\"
-        : \n               {\n                  \"lat\" : 37.929824,\n                  \"lng\"
-        : -122.28178\n               },\n               \"southwest\" : \n               {\n
-        \                 \"lat\" : 37.6398299,\n                  \"lng\" : -123.1328145\n
-        \              }\n            },\n            \"location\" : \n            {\n
-        \              \"lat\" : 37.7749295,\n               \"lng\" : -122.4194155\n
-        \           },\n            \"location_type\" : \"APPROXIMATE\",\n            \"viewport\"
-        : \n            {\n               \"northeast\" : \n               {\n                  \"lat\"
-        : 37.812,\n                  \"lng\" : -122.3482\n               },\n               \"southwest\"
-        : \n               {\n                  \"lat\" : 37.70339999999999,\n                  \"lng\"
-        : -122.527\n               }\n            }\n         },\n         \"place_id\"
-        : \"ChIJIQBpAG2ahYAR_6128GcTUEo\",\n         \"types\" : \n         [\n            \"locality\",\n
-        \           \"political\"\n         ]\n      }\n   ],\n   \"status\" : \"OK\"\n}"
-  recorded_at: Thu, 05 Feb 2026 17:43:57 GMT
-- request:
-    method: get
-    uri: https://maps.googleapis.com/maps/api/geocode/json?address=San%20Francisco,%20CA&key=<GOOGLE_GEOCODER>&language=en&sensor=false
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      User-Agent:
-      - Ruby
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Content-Type:
-      - application/json; charset=UTF-8
-      Date:
       - Thu, 21 May 2026 17:08:04 GMT
       Pragma:
       - no-cache
@@ -162,4 +81,85 @@ http_interactions:
         : \"ChIJIQBpAG2ahYAR_6128GcTUEo\",\n         \"types\" : \n         [\n            \"locality\",\n
         \           \"political\"\n         ]\n      }\n   ],\n   \"status\" : \"OK\"\n}"
   recorded_at: Thu, 21 May 2026 17:08:04 GMT
+- request:
+    method: get
+    uri: https://maps.googleapis.com/maps/api/geocode/json?address=San%20Francisco,%20CA&key=<GOOGLE_GEOCODER>&language=en&sensor=false
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Fri, 05 Jun 2026 17:59:29 GMT
+      Pragma:
+      - no-cache
+      Expires:
+      - Fri, 01 Jan 1990 00:00:00 GMT
+      Cache-Control:
+      - no-cache, must-revalidate
+      Access-Control-Allow-Origin:
+      - "*"
+      X-Goog-Maps-Metro-Area:
+      - San Francisco, CA
+      Content-Security-Policy-Report-Only:
+      - script-src 'none'; form-action 'none'; frame-src 'none'; report-uri https://csp.withgoogle.com/csp/scaffolding/msaifdggmnwc:257:0
+      Cross-Origin-Opener-Policy-Report-Only:
+      - same-origin; report-to=msaifdggmnwc:257:0
+      Report-To:
+      - '{"group":"msaifdggmnwc:257:0","max_age":2592000,"endpoints":[{"url":"https://csp.withgoogle.com/csp/report-to/scaffolding/msaifdggmnwc:257:0"}],}'
+      Server:
+      - mafe
+      Content-Length:
+      - '2186'
+      X-Xss-Protection:
+      - '0'
+      X-Frame-Options:
+      - SAMEORIGIN
+      Server-Timing:
+      - gfet4t7; dur=82
+      Alt-Svc:
+      - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
+    body:
+      encoding: UTF-8
+      string: "{\n   \"results\" : \n   [\n      {\n         \"address_components\"
+        : \n         [\n            {\n               \"long_name\" : \"San Francisco\",\n
+        \              \"short_name\" : \"SF\",\n               \"types\" : \n               [\n
+        \                 \"locality\",\n                  \"political\"\n               ]\n
+        \           },\n            {\n               \"long_name\" : \"San Francisco
+        County\",\n               \"short_name\" : \"San Francisco County\",\n               \"types\"
+        : \n               [\n                  \"administrative_area_level_2\",\n
+        \                 \"political\"\n               ]\n            },\n            {\n
+        \              \"long_name\" : \"California\",\n               \"short_name\"
+        : \"CA\",\n               \"types\" : \n               [\n                  \"administrative_area_level_1\",\n
+        \                 \"political\"\n               ]\n            },\n            {\n
+        \              \"long_name\" : \"United States\",\n               \"short_name\"
+        : \"US\",\n               \"types\" : \n               [\n                  \"country\",\n
+        \                 \"political\"\n               ]\n            }\n         ],\n
+        \        \"formatted_address\" : \"San Francisco, CA, USA\",\n         \"geometry\"
+        : \n         {\n            \"bounds\" : \n            {\n               \"northeast\"
+        : \n               {\n                  \"lat\" : 37.929824,\n                  \"lng\"
+        : -122.28178\n               },\n               \"southwest\" : \n               {\n
+        \                 \"lat\" : 37.6398299,\n                  \"lng\" : -123.1328145\n
+        \              }\n            },\n            \"location\" : \n            {\n
+        \              \"lat\" : 37.7749295,\n               \"lng\" : -122.4194155\n
+        \           },\n            \"location_type\" : \"APPROXIMATE\",\n            \"viewport\"
+        : \n            {\n               \"northeast\" : \n               {\n                  \"lat\"
+        : 37.812,\n                  \"lng\" : -122.3482\n               },\n               \"southwest\"
+        : \n               {\n                  \"lat\" : 37.70339999999999,\n                  \"lng\"
+        : -122.527\n               }\n            }\n         },\n         \"place_id\"
+        : \"ChIJIQBpAG2ahYAR_6128GcTUEo\",\n         \"types\" : \n         [\n            \"locality\",\n
+        \           \"political\"\n         ]\n      }\n   ],\n   \"status\" : \"OK\"\n}"
+  recorded_at: Fri, 05 Jun 2026 17:59:29 GMT
 recorded_with: VCR 6.4.0

--- a/spec/vcr_cassettes/geohelper-coordinates-US.yml
+++ b/spec/vcr_cassettes/geohelper-coordinates-US.yml
@@ -21,7 +21,7 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       Date:
-      - Thu, 05 Feb 2026 17:43:57 GMT
+      - Fri, 05 Jun 2026 17:59:29 GMT
       Pragma:
       - no-cache
       Expires:
@@ -31,11 +31,11 @@ http_interactions:
       Access-Control-Allow-Origin:
       - "*"
       Content-Security-Policy-Report-Only:
-      - script-src 'none'; form-action 'none'; frame-src 'none'; report-uri https://csp.withgoogle.com/csp/scaffolding/msaifdggmnwc:213:0
+      - script-src 'none'; form-action 'none'; frame-src 'none'; report-uri https://csp.withgoogle.com/csp/scaffolding/msaifdggmnwc:257:0
       Cross-Origin-Opener-Policy-Report-Only:
-      - same-origin; report-to=msaifdggmnwc:213:0
+      - same-origin; report-to=msaifdggmnwc:257:0
       Report-To:
-      - '{"group":"msaifdggmnwc:213:0","max_age":2592000,"endpoints":[{"url":"https://csp.withgoogle.com/csp/report-to/scaffolding/msaifdggmnwc:213:0"}],}'
+      - '{"group":"msaifdggmnwc:257:0","max_age":2592000,"endpoints":[{"url":"https://csp.withgoogle.com/csp/report-to/scaffolding/msaifdggmnwc:257:0"}],}'
       Server:
       - mafe
       Content-Length:
@@ -45,7 +45,7 @@ http_interactions:
       X-Frame-Options:
       - SAMEORIGIN
       Server-Timing:
-      - gfet4t7; dur=33
+      - gfet4t7; dur=49
       Alt-Svc:
       - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
     body:
@@ -69,5 +69,5 @@ http_interactions:
         \              }\n            }\n         },\n         \"place_id\" : \"ChIJCzYy5IS16lQRQrfeQ5K5Oxw\",\n
         \        \"types\" : \n         [\n            \"country\",\n            \"political\"\n
         \        ]\n      }\n   ],\n   \"status\" : \"OK\"\n}"
-  recorded_at: Thu, 05 Feb 2026 17:43:57 GMT
-recorded_with: VCR 6.3.1
+  recorded_at: Fri, 05 Jun 2026 17:59:29 GMT
+recorded_with: VCR 6.4.0

--- a/spec/vcr_cassettes/geohelper-coordinates.yml
+++ b/spec/vcr_cassettes/geohelper-coordinates.yml
@@ -21,7 +21,7 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       Date:
-      - Thu, 05 Feb 2026 17:43:57 GMT
+      - Fri, 05 Jun 2026 17:59:28 GMT
       Pragma:
       - no-cache
       Expires:
@@ -33,11 +33,11 @@ http_interactions:
       X-Goog-Maps-Metro-Area:
       - Chicago, IL
       Content-Security-Policy-Report-Only:
-      - script-src 'none'; form-action 'none'; frame-src 'none'; report-uri https://csp.withgoogle.com/csp/scaffolding/msaifdggmnwc:213:0
+      - script-src 'none'; form-action 'none'; frame-src 'none'; report-uri https://csp.withgoogle.com/csp/scaffolding/msaifdggmnwc:257:0
       Cross-Origin-Opener-Policy-Report-Only:
-      - same-origin; report-to=msaifdggmnwc:213:0
+      - same-origin; report-to=msaifdggmnwc:257:0
       Report-To:
-      - '{"group":"msaifdggmnwc:213:0","max_age":2592000,"endpoints":[{"url":"https://csp.withgoogle.com/csp/report-to/scaffolding/msaifdggmnwc:213:0"}],}'
+      - '{"group":"msaifdggmnwc:257:0","max_age":2592000,"endpoints":[{"url":"https://csp.withgoogle.com/csp/report-to/scaffolding/msaifdggmnwc:257:0"}],}'
       Server:
       - mafe
       Content-Length:
@@ -47,7 +47,7 @@ http_interactions:
       X-Frame-Options:
       - SAMEORIGIN
       Server-Timing:
-      - gfet4t7; dur=246
+      - gfet4t7; dur=127
       Alt-Svc:
       - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
     body:
@@ -90,9 +90,9 @@ http_interactions:
         : -87.7170058302915\n               }\n            }\n         },\n         \"navigation_points\"
         : \n         [\n            {\n               \"location\" : \n               {\n
         \                 \"latitude\" : 41.9200585,\n                  \"longitude\"
-        : -87.71565509999999\n               }\n            }\n         ],\n         \"place_id\"
+        : -87.71565510000001\n               }\n            }\n         ],\n         \"place_id\"
         : \"Ei4zNTUwIFcgU2hha2VzcGVhcmUgQXZlLCBDaGljYWdvLCBJTCA2MDY0NywgVVNBIjESLwoUChIJm9ZhPWvND4gRlgAk98FUWaEQ3hsqFAoSCXfgB2pmzQ-IEaIyran4cOEx\",\n
         \        \"types\" : \n         [\n            \"street_address\"\n         ]\n
         \     }\n   ],\n   \"status\" : \"OK\"\n}"
-  recorded_at: Thu, 05 Feb 2026 17:43:57 GMT
-recorded_with: VCR 6.3.1
+  recorded_at: Fri, 05 Jun 2026 17:59:28 GMT
+recorded_with: VCR 6.4.0

--- a/spec/vcr_cassettes/geohelper-formatted_address_hash.yml
+++ b/spec/vcr_cassettes/geohelper-formatted_address_hash.yml
@@ -21,7 +21,7 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       Date:
-      - Thu, 05 Feb 2026 17:43:56 GMT
+      - Fri, 05 Jun 2026 17:59:29 GMT
       Pragma:
       - no-cache
       Expires:
@@ -33,11 +33,11 @@ http_interactions:
       X-Goog-Maps-Metro-Area:
       - San Francisco, CA
       Content-Security-Policy-Report-Only:
-      - script-src 'none'; form-action 'none'; frame-src 'none'; report-uri https://csp.withgoogle.com/csp/scaffolding/msaifdggmnwc:213:0
+      - script-src 'none'; form-action 'none'; frame-src 'none'; report-uri https://csp.withgoogle.com/csp/scaffolding/msaifdggmnwc:257:0
       Cross-Origin-Opener-Policy-Report-Only:
-      - same-origin; report-to=msaifdggmnwc:213:0
+      - same-origin; report-to=msaifdggmnwc:257:0
       Report-To:
-      - '{"group":"msaifdggmnwc:213:0","max_age":2592000,"endpoints":[{"url":"https://csp.withgoogle.com/csp/report-to/scaffolding/msaifdggmnwc:213:0"}],}'
+      - '{"group":"msaifdggmnwc:257:0","max_age":2592000,"endpoints":[{"url":"https://csp.withgoogle.com/csp/report-to/scaffolding/msaifdggmnwc:257:0"}],}'
       Server:
       - mafe
       Content-Length:
@@ -47,7 +47,7 @@ http_interactions:
       X-Frame-Options:
       - SAMEORIGIN
       Server-Timing:
-      - gfet4t7; dur=112
+      - gfet4t7; dur=102
       Alt-Svc:
       - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
     body:
@@ -95,5 +95,5 @@ http_interactions:
         \           }\n         ],\n         \"place_id\" : \"ChIJhZ74MY-AhYARscx5mk67G-w\",\n
         \        \"types\" : \n         [\n            \"premise\",\n            \"street_address\"\n
         \        ]\n      }\n   ],\n   \"status\" : \"OK\"\n}"
-  recorded_at: Thu, 05 Feb 2026 17:43:56 GMT
-recorded_with: VCR 6.3.1
+  recorded_at: Fri, 05 Jun 2026 17:59:29 GMT
+recorded_with: VCR 6.4.0

--- a/spec/vcr_cassettes/geohelper-ip_address.yml
+++ b/spec/vcr_cassettes/geohelper-ip_address.yml
@@ -19,15 +19,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 05 Feb 2026 17:43:56 GMT
+      - Fri, 05 Jun 2026 17:59:29 GMT
       Content-Type:
       - text/plain; charset=ISO-8859-1
       Content-Length:
       - '37'
       Connection:
       - keep-alive
-      Cf-Ray:
-      - 9c943682dff9b1ae-SJC
       Access-Control-Allow-Origin:
       - "*"
       Cache-Control:
@@ -40,10 +38,12 @@ http_interactions:
       - max-age=31536000; includeSubDomains; preload
       Server:
       - cloudflare
+      Cf-Ray:
+      - a0711249fe36327e-SJC
       Alt-Svc:
       - h3=":443"; ma=86400
     body:
       encoding: UTF-8
       string: US,CA,Brentwood,37.928500,-121.688100
-  recorded_at: Thu, 05 Feb 2026 17:43:56 GMT
-recorded_with: VCR 6.3.1
+  recorded_at: Fri, 05 Jun 2026 17:59:29 GMT
+recorded_with: VCR 6.4.0

--- a/spec/vcr_cassettes/geohelper-ip_address2.yml
+++ b/spec/vcr_cassettes/geohelper-ip_address2.yml
@@ -19,15 +19,13 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 05 Feb 2026 17:43:56 GMT
+      - Fri, 05 Jun 2026 17:59:29 GMT
       Content-Type:
       - text/plain; charset=ISO-8859-1
       Content-Length:
-      - '41'
+      - '36'
       Connection:
       - keep-alive
-      Cf-Ray:
-      - 9c9436839ab4c8de-SJC
       Access-Control-Allow-Origin:
       - "*"
       Cache-Control:
@@ -40,10 +38,12 @@ http_interactions:
       - max-age=31536000; includeSubDomains; preload
       Server:
       - cloudflare
+      Cf-Ray:
+      - a071124a984bc79e-SJC
       Alt-Svc:
       - h3=":443"; ma=86400
     body:
       encoding: UTF-8
-      string: US,CA,San Francisco,37.750600,-122.412100
-  recorded_at: Thu, 05 Feb 2026 17:43:56 GMT
-recorded_with: VCR 6.3.1
+      string: US,CA,San Jose,37.320900,-121.912600
+  recorded_at: Fri, 05 Jun 2026 17:59:29 GMT
+recorded_with: VCR 6.4.0

--- a/spec/vcr_cassettes/geohelper-us.yml
+++ b/spec/vcr_cassettes/geohelper-us.yml
@@ -21,7 +21,7 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       Date:
-      - Thu, 05 Feb 2026 17:43:56 GMT
+      - Fri, 05 Jun 2026 17:59:29 GMT
       Pragma:
       - no-cache
       Expires:
@@ -31,11 +31,11 @@ http_interactions:
       Access-Control-Allow-Origin:
       - "*"
       Content-Security-Policy-Report-Only:
-      - script-src 'none'; form-action 'none'; frame-src 'none'; report-uri https://csp.withgoogle.com/csp/scaffolding/msaifdggmnwc:213:0
+      - script-src 'none'; form-action 'none'; frame-src 'none'; report-uri https://csp.withgoogle.com/csp/scaffolding/msaifdggmnwc:257:0
       Cross-Origin-Opener-Policy-Report-Only:
-      - same-origin; report-to=msaifdggmnwc:213:0
+      - same-origin; report-to=msaifdggmnwc:257:0
       Report-To:
-      - '{"group":"msaifdggmnwc:213:0","max_age":2592000,"endpoints":[{"url":"https://csp.withgoogle.com/csp/report-to/scaffolding/msaifdggmnwc:213:0"}],}'
+      - '{"group":"msaifdggmnwc:257:0","max_age":2592000,"endpoints":[{"url":"https://csp.withgoogle.com/csp/report-to/scaffolding/msaifdggmnwc:257:0"}],}'
       Server:
       - mafe
       Content-Length:
@@ -45,7 +45,7 @@ http_interactions:
       X-Frame-Options:
       - SAMEORIGIN
       Server-Timing:
-      - gfet4t7; dur=52
+      - gfet4t7; dur=45
       Alt-Svc:
       - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
     body:
@@ -69,5 +69,5 @@ http_interactions:
         \              }\n            }\n         },\n         \"place_id\" : \"ChIJCzYy5IS16lQRQrfeQ5K5Oxw\",\n
         \        \"types\" : \n         [\n            \"country\",\n            \"political\"\n
         \        ]\n      }\n   ],\n   \"status\" : \"OK\"\n}"
-  recorded_at: Thu, 05 Feb 2026 17:43:56 GMT
-recorded_with: VCR 6.3.1
+  recorded_at: Fri, 05 Jun 2026 17:59:29 GMT
+recorded_with: VCR 6.4.0

--- a/spec/vcr_cassettes/geohelper-zipcode.yml
+++ b/spec/vcr_cassettes/geohelper-zipcode.yml
@@ -21,7 +21,7 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       Date:
-      - Thu, 05 Feb 2026 17:43:56 GMT
+      - Fri, 05 Jun 2026 17:59:29 GMT
       Pragma:
       - no-cache
       Expires:
@@ -33,11 +33,11 @@ http_interactions:
       X-Goog-Maps-Metro-Area:
       - Chicago, IL
       Content-Security-Policy-Report-Only:
-      - script-src 'none'; form-action 'none'; frame-src 'none'; report-uri https://csp.withgoogle.com/csp/scaffolding/msaifdggmnwc:213:0
+      - script-src 'none'; form-action 'none'; frame-src 'none'; report-uri https://csp.withgoogle.com/csp/scaffolding/msaifdggmnwc:257:0
       Cross-Origin-Opener-Policy-Report-Only:
-      - same-origin; report-to=msaifdggmnwc:213:0
+      - same-origin; report-to=msaifdggmnwc:257:0
       Report-To:
-      - '{"group":"msaifdggmnwc:213:0","max_age":2592000,"endpoints":[{"url":"https://csp.withgoogle.com/csp/report-to/scaffolding/msaifdggmnwc:213:0"}],}'
+      - '{"group":"msaifdggmnwc:257:0","max_age":2592000,"endpoints":[{"url":"https://csp.withgoogle.com/csp/report-to/scaffolding/msaifdggmnwc:257:0"}],}'
       Server:
       - mafe
       Content-Length:
@@ -47,7 +47,7 @@ http_interactions:
       X-Frame-Options:
       - SAMEORIGIN
       Server-Timing:
-      - gfet4t7; dur=185
+      - gfet4t7; dur=102
       Alt-Svc:
       - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
     body:
@@ -83,5 +83,5 @@ http_interactions:
         \           }\n         },\n         \"partial_match\" : true,\n         \"place_id\"
         : \"ChIJ3fO3tQjND4gR1psfMQ0T28k\",\n         \"types\" : \n         [\n            \"postal_code\"\n
         \        ]\n      }\n   ],\n   \"status\" : \"OK\"\n}"
-  recorded_at: Thu, 05 Feb 2026 17:43:56 GMT
-recorded_with: VCR 6.3.1
+  recorded_at: Fri, 05 Jun 2026 17:59:29 GMT
+recorded_with: VCR 6.4.0


### PR DESCRIPTION
Re-records the GeocodeHelper VCR cassettes against the current geocoder responses.

- Refreshed all eight `geohelper-*` cassettes so the geocoding specs run against up-to-date provider data.
- Updated the `address_hash_for` IP expectation: `50.211.197.209` now geolocates to San Jose (37.3209, -121.9126) rather than San Francisco.
