### PR TITLE
Consolidate search index views into Search::ResultsFrame::Component

### DIFF
--- a/app/components/search/results_frame/component.html.erb
+++ b/app/components/search/results_frame/component.html.erb
@@ -1,0 +1,15 @@
+<div class="search-results-frame-wrapper">
+  <%= helpers.turbo_frame_tag @frame_id, src: @src do %>
+    <% if @render_results %>
+      <%= content %>
+    <% else %>
+      <div hidden data-search-loading>
+        <%= render UI::LoadingSpinner::Component.new(text: @loading_text) %>
+      </div>
+    <% end %>
+  <% end %>
+
+  <div class="search-loading-overlay">
+    <%= render UI::LoadingSpinner::Component.new(text: @loading_text) %>
+  </div>
+</div>

--- a/app/components/search/results_frame/component.html.erb
+++ b/app/components/search/results_frame/component.html.erb
@@ -1,3 +1,7 @@
+<% if @disable_snapshot_cache %>
+  <% helpers.content_for(:header) { tag.meta(name: "turbo-cache-control", content: "no-cache") } %>
+<% end %>
+
 <div class="search-results-frame-wrapper">
   <%= helpers.turbo_frame_tag @frame_id, src: @src do %>
     <% if @render_results %>

--- a/app/components/search/results_frame/component.html.erb
+++ b/app/components/search/results_frame/component.html.erb
@@ -1,6 +1,4 @@
-<% if @disable_snapshot_cache %>
-  <% helpers.content_for(:header) { tag.meta(name: "turbo-cache-control", content: "no-cache") } %>
-<% end %>
+<% helpers.content_for(:header) { tag.meta(name: "turbo-cache-control", content: "no-cache") } %>
 
 <div class="search-results-frame-wrapper">
   <%= helpers.turbo_frame_tag @frame_id, src: @src do %>

--- a/app/components/search/results_frame/component.rb
+++ b/app/components/search/results_frame/component.rb
@@ -9,12 +9,19 @@ module Search
     # connects. Without JS that `src` never fires, so a hidden spinner stands in
     # for the no-JS path instead of one that can never resolve. The caller's
     # block is the frame body, rendered once the results are present.
+    #
+    # Pass `disable_snapshot_cache: true` when the page's form lives outside the
+    # frame and submits with turbo_action="advance": a restored snapshot can
+    # leave the frame's results stale against the address-bar URL, so the page
+    # opts out of Turbo's snapshot cache and back/forward re-fetch fresh.
     class Component < ApplicationComponent
-      def initialize(frame_id:, render_results:, current_path:, loading_text: "Loading results...")
+      def initialize(frame_id:, render_results:, current_path:, loading_text: "Loading results...",
+        disable_snapshot_cache: false)
         @frame_id = frame_id
         @render_results = render_results
         @src = (current_path unless render_results)
         @loading_text = loading_text
+        @disable_snapshot_cache = disable_snapshot_cache
       end
     end
   end

--- a/app/components/search/results_frame/component.rb
+++ b/app/components/search/results_frame/component.rb
@@ -10,18 +10,16 @@ module Search
     # for the no-JS path instead of one that can never resolve. The caller's
     # block is the frame body, rendered once the results are present.
     #
-    # Pass `disable_snapshot_cache: true` when the page's form lives outside the
-    # frame and submits with turbo_action="advance": a restored snapshot can
-    # leave the frame's results stale against the address-bar URL, so the page
-    # opts out of Turbo's snapshot cache and back/forward re-fetch fresh.
+    # The form lives outside the frame and submits with turbo_action="advance",
+    # so a restored snapshot can leave the frame's results stale against the
+    # address-bar URL. Every search page opts out of Turbo's snapshot cache (via
+    # the no-cache meta) so back/forward re-fetch the page and reload fresh.
     class Component < ApplicationComponent
-      def initialize(frame_id:, render_results:, current_path:, loading_text: "Loading results...",
-        disable_snapshot_cache: false)
+      def initialize(frame_id:, render_results:, current_path:, loading_text: "Loading results...")
         @frame_id = frame_id
         @render_results = render_results
         @src = (current_path unless render_results)
         @loading_text = loading_text
-        @disable_snapshot_cache = disable_snapshot_cache
       end
     end
   end

--- a/app/components/search/results_frame/component.rb
+++ b/app/components/search/results_frame/component.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module Search
+  module ResultsFrame
+    # Wraps an eager-loaded search results turbo-frame and its loading overlay.
+    #
+    # On the JS shell render (results not yet inline) the frame gets a `src` so
+    # Turbo fetches the results in a separate request the moment the frame
+    # connects. Without JS that `src` never fires, so a hidden spinner stands in
+    # for the no-JS path instead of one that can never resolve. The caller's
+    # block is the frame body, rendered once the results are present.
+    class Component < ApplicationComponent
+      def initialize(frame_id:, render_results:, current_path:, loading_text: "Loading results...")
+        @frame_id = frame_id
+        @render_results = render_results
+        @src = (current_path unless render_results)
+        @loading_text = loading_text
+      end
+    end
+  end
+end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -8,15 +8,6 @@ module ApplicationHelper
     super([key, locale: I18n.locale], options, &block)
   end
 
-  # Opt the current page out of Turbo's snapshot cache. Use on search pages
-  # whose form sits outside the results turbo-frame and submits with
-  # turbo_action="advance": a restored snapshot can leave the frame's results
-  # stale/empty against the address-bar URL, so back/forward must re-fetch the
-  # page and reload the frame fresh from the server.
-  def turbo_disable_snapshot_cache
-    content_for(:header) { tag.meta(name: "turbo-cache-control", content: "no-cache") }
-  end
-
   def notification_delivery_display(status)
     text = if status == "delivery_success"
       check_mark

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -8,6 +8,15 @@ module ApplicationHelper
     super([key, locale: I18n.locale], options, &block)
   end
 
+  # Opt the current page out of Turbo's snapshot cache. Use on search pages
+  # whose form sits outside the results turbo-frame and submits with
+  # turbo_action="advance": a restored snapshot can leave the frame's results
+  # stale/empty against the address-bar URL, so back/forward must re-fetch the
+  # page and reload the frame fresh from the server.
+  def turbo_disable_snapshot_cache
+    content_for(:header) { tag.meta(name: "turbo-cache-control", content: "no-cache") }
+  end
+
   def notification_delivery_display(status)
     text = if status == "delivery_success"
       check_mark

--- a/app/views/organized/graduated_notifications/index.html.erb
+++ b/app/views/organized/graduated_notifications/index.html.erb
@@ -1,15 +1,6 @@
 <%# TODO: add translations %>
 
-<%#
-  no-cache: the form lives outside the results frame and submits with
-  turbo_action="advance", so a restored snapshot can leave the frame's results
-  mismatched against the address-bar URL. Opt out of the snapshot cache so
-  back/forward re-fetch the page and reload the frame fresh from the server.
-%>
-
-<% content_for :header do %>
-  <meta name="turbo-cache-control" content="no-cache">
-<% end %>
+<% turbo_disable_snapshot_cache %>
 
 <div class="organized-page-header">
   <h1>Graduated notifications</h1>

--- a/app/views/organized/graduated_notifications/index.html.erb
+++ b/app/views/organized/graduated_notifications/index.html.erb
@@ -40,39 +40,18 @@
   </div>
 <% end %>
 
-<div class="search-results-frame-wrapper">
-  <%#
-    When the results aren't rendered inline (the JS shell), give the frame a src
-    so Turbo eager-loads the results in a separate request once it connects
-  %>
-
-  <%= turbo_frame_tag :graduated_notifications_results_frame,
-    src: (request.original_fullpath unless @render_results) do %>
-    <div class="tw:mt-4">
-      <%= render UI::PeriodSelect::Component.new(period: @period, start_time: @start_time, end_time: @end_time) %>
-    </div>
-
-    <div class="tw:mt-2 tw:text-right">
-      <%= link_to "Render chart",
-        organization_graduated_notifications_path(sortable_search_params.merge(organization_id: current_organization.to_param, render_chart: !@render_chart)),
-        class: "btn btn-sm btn-outline-secondary #{"active" if @render_chart}",
-        data: {turbo_action: "advance"} %>
-    </div>
-
-    <% if @render_results %>
-      <%= render partial: "results" %>
-    <% else %>
-      <%#
-        Hidden until JS reveals it - without JS the eager src never loads, so a
-        no-JS user would otherwise be stuck on a spinner that never resolves
-      %>
-      <div hidden data-search-loading>
-        <%= render UI::LoadingSpinner::Component.new(text: "Loading results...") %>
-      </div>
-    <% end %>
-  <% end %>
-
-  <div class="search-loading-overlay">
-    <%= render UI::LoadingSpinner::Component.new(text: "Loading results...") %>
+<%= render Search::ResultsFrame::Component.new(frame_id: :graduated_notifications_results_frame,
+  render_results: @render_results, current_path: request.original_fullpath) do %>
+  <div class="tw:mt-4">
+    <%= render UI::PeriodSelect::Component.new(period: @period, start_time: @start_time, end_time: @end_time) %>
   </div>
-</div>
+
+  <div class="tw:mt-2 tw:text-right">
+    <%= link_to "Render chart",
+      organization_graduated_notifications_path(sortable_search_params.merge(organization_id: current_organization.to_param, render_chart: !@render_chart)),
+      class: "btn btn-sm btn-outline-secondary #{"active" if @render_chart}",
+      data: {turbo_action: "advance"} %>
+  </div>
+
+  <%= render partial: "results" %>
+<% end %>

--- a/app/views/organized/graduated_notifications/index.html.erb
+++ b/app/views/organized/graduated_notifications/index.html.erb
@@ -39,8 +39,7 @@
 <% end %>
 
 <%= render Search::ResultsFrame::Component.new(frame_id: :graduated_notifications_results_frame,
-  render_results: @render_results, current_path: request.original_fullpath,
-  disable_snapshot_cache: true) do %>
+  render_results: @render_results, current_path: request.original_fullpath) do %>
   <div class="tw:mt-4">
     <%= render UI::PeriodSelect::Component.new(period: @period, start_time: @start_time, end_time: @end_time) %>
   </div>

--- a/app/views/organized/graduated_notifications/index.html.erb
+++ b/app/views/organized/graduated_notifications/index.html.erb
@@ -1,7 +1,5 @@
 <%# TODO: add translations %>
 
-<% turbo_disable_snapshot_cache %>
-
 <div class="organized-page-header">
   <h1>Graduated notifications</h1>
 </div>
@@ -41,7 +39,8 @@
 <% end %>
 
 <%= render Search::ResultsFrame::Component.new(frame_id: :graduated_notifications_results_frame,
-  render_results: @render_results, current_path: request.original_fullpath) do %>
+  render_results: @render_results, current_path: request.original_fullpath,
+  disable_snapshot_cache: true) do %>
   <div class="tw:mt-4">
     <%= render UI::PeriodSelect::Component.new(period: @period, start_time: @start_time, end_time: @end_time) %>
   </div>

--- a/app/views/organized/impound_records/index.html.erb
+++ b/app/views/organized/impound_records/index.html.erb
@@ -32,8 +32,7 @@
 <% end %>
 
 <%= render Search::ResultsFrame::Component.new(frame_id: :impound_records_results_frame,
-  render_results: @render_results, current_path: request.original_fullpath,
-  disable_snapshot_cache: true) do %>
+  render_results: @render_results, current_path: request.original_fullpath) do %>
   <div class="tw:mt-4">
     <%= render UI::PeriodSelect::Component.new(period: @period, start_time: @start_time, end_time: @end_time) %>
   </div>

--- a/app/views/organized/impound_records/index.html.erb
+++ b/app/views/organized/impound_records/index.html.erb
@@ -33,39 +33,18 @@
   </div>
 <% end %>
 
-<div class="search-results-frame-wrapper">
-  <%#
-    When the results aren't rendered inline (the JS shell), give the frame a src
-    so Turbo eager-loads the results in a separate request once it connects
-  %>
-
-  <%= turbo_frame_tag :impound_records_results_frame,
-    src: (request.original_fullpath unless @render_results) do %>
-    <div class="tw:mt-4">
-      <%= render UI::PeriodSelect::Component.new(period: @period, start_time: @start_time, end_time: @end_time) %>
-    </div>
-
-    <div class="text-right mb-2 mt-4">
-      <%= link_to t(".render_chart"),
-        organization_impound_records_path(sortable_search_params.merge(organization_id: current_organization.to_param, render_chart: !@render_chart)),
-        class: "btn btn-sm less-strong btn-outline-secondary #{"active" if @render_chart}",
-        data: {turbo_action: "advance"} %>
-    </div>
-
-    <% if @render_results %>
-      <%= render partial: "results" %>
-    <% else %>
-      <%#
-        Hidden until JS reveals it - without JS the eager src never loads, so a
-        no-JS user would otherwise be stuck on a spinner that never resolves
-      %>
-      <div hidden data-search-loading>
-        <%= render UI::LoadingSpinner::Component.new(text: "Loading results...") %>
-      </div>
-    <% end %>
-  <% end %>
-
-  <div class="search-loading-overlay">
-    <%= render UI::LoadingSpinner::Component.new(text: "Loading results...") %>
+<%= render Search::ResultsFrame::Component.new(frame_id: :impound_records_results_frame,
+  render_results: @render_results, current_path: request.original_fullpath) do %>
+  <div class="tw:mt-4">
+    <%= render UI::PeriodSelect::Component.new(period: @period, start_time: @start_time, end_time: @end_time) %>
   </div>
-</div>
+
+  <div class="text-right mb-2 mt-4">
+    <%= link_to t(".render_chart"),
+      organization_impound_records_path(sortable_search_params.merge(organization_id: current_organization.to_param, render_chart: !@render_chart)),
+      class: "btn btn-sm less-strong btn-outline-secondary #{"active" if @render_chart}",
+      data: {turbo_action: "advance"} %>
+  </div>
+
+  <%= render partial: "results" %>
+<% end %>

--- a/app/views/organized/impound_records/index.html.erb
+++ b/app/views/organized/impound_records/index.html.erb
@@ -1,14 +1,4 @@
-<%#
-  no-cache: the results turbo-frame loads asynchronously - eager via its src on
-  first render, then replaced by form submits and filter-link navigations.
-  Turbo's cached page snapshot would restore that frame stale/empty on back
-  navigation, so opt out of the snapshot cache to make back/forward re-fetch the
-  page and reload the frame fresh from the server.
-%>
-
-<% content_for :header do %>
-  <meta name="turbo-cache-control" content="no-cache">
-<% end %>
+<% turbo_disable_snapshot_cache %>
 
 <div class="organized-page-header mb-4">
   <h1 class="uncap"><%= t(".impound_records") %></h1>

--- a/app/views/organized/impound_records/index.html.erb
+++ b/app/views/organized/impound_records/index.html.erb
@@ -1,5 +1,3 @@
-<% turbo_disable_snapshot_cache %>
-
 <div class="organized-page-header mb-4">
   <h1 class="uncap"><%= t(".impound_records") %></h1>
 </div>
@@ -34,7 +32,8 @@
 <% end %>
 
 <%= render Search::ResultsFrame::Component.new(frame_id: :impound_records_results_frame,
-  render_results: @render_results, current_path: request.original_fullpath) do %>
+  render_results: @render_results, current_path: request.original_fullpath,
+  disable_snapshot_cache: true) do %>
   <div class="tw:mt-4">
     <%= render UI::PeriodSelect::Component.new(period: @period, start_time: @start_time, end_time: @end_time) %>
   </div>

--- a/app/views/organized/registrations/search.html.erb
+++ b/app/views/organized/registrations/search.html.erb
@@ -39,38 +39,17 @@
     </div>
   <% end %>
 
-  <div class="search-results-frame-wrapper">
-    <%#
-      When the results aren't rendered inline (the JS shell), give the frame a src
-      so Turbo eager-loads the results in a separate request once it connects
-    %>
+  <%= render Search::ResultsFrame::Component.new(frame_id: :organized_bikes_results_frame,
+    render_results: @render_results, current_path: request.original_fullpath) do %>
+    <%= render UI::PeriodSelect::Component.new(period: @period, start_time: @start_time, end_time: @end_time) %>
 
-    <%= turbo_frame_tag :organized_bikes_results_frame,
-      src: (request.original_fullpath unless @render_results) do %>
-      <%= render UI::PeriodSelect::Component.new(period: @period, start_time: @start_time, end_time: @end_time) %>
-
-      <div class="tw:mt-2 tw:text-right">
-        <%= link_to t(".render_chart", default: "Render chart"),
-          organization_registrations_path(sortable_search_params.merge(organization_id: current_organization.to_param, render_chart: !@render_chart)),
-          class: "btn btn-sm btn-outline-secondary #{"active" if @render_chart}",
-          data: {turbo_action: "advance"} %>
-      </div>
-
-      <% if @render_results %>
-        <%= render partial: "results" %>
-      <% else %>
-        <%#
-          Hidden until JS reveals it - without JS the eager src never loads, so
-          a no-JS user would otherwise be stuck on a spinner that never resolves
-        %>
-        <div hidden data-search-loading>
-          <%= render UI::LoadingSpinner::Component.new(text: "Loading results...") %>
-        </div>
-      <% end %>
-    <% end %>
-
-    <div class="search-loading-overlay">
-      <%= render UI::LoadingSpinner::Component.new(text: "Loading results...") %>
+    <div class="tw:mt-2 tw:text-right">
+      <%= link_to t(".render_chart", default: "Render chart"),
+        organization_registrations_path(sortable_search_params.merge(organization_id: current_organization.to_param, render_chart: !@render_chart)),
+        class: "btn btn-sm btn-outline-secondary #{"active" if @render_chart}",
+        data: {turbo_action: "advance"} %>
     </div>
-  </div>
+
+    <%= render partial: "results" %>
+  <% end %>
 </div>

--- a/app/views/search/marketplace/index.html.erb
+++ b/app/views/search/marketplace/index.html.erb
@@ -17,30 +17,10 @@
   </div>
 <% end %>
 
-<div class="search-results-frame-wrapper">
-  <%#
-    When the results aren't rendered inline (the JS shell), give the frame a src
-    so Turbo eager-loads the results in a separate request once it connects
-  %>
-
-  <%= turbo_frame_tag :marketplace_results_frame,
-    src: (request.original_fullpath unless @render_results) do %>
-    <% if @render_results %>
-      <%= turbo_frame_tag "page_#{@pagy.page}" do %>
-        <%= render partial: "marketplace_results" %>
-      <% end %>
-    <% else %>
-      <%#
-        Hidden until JS reveals it - without JS the eager src never loads, so a
-        no-JS user would otherwise be stuck on a spinner that never resolves
-      %>
-      <div hidden data-search-loading>
-        <%= render UI::LoadingSpinner::Component.new(text: t(".loading_results")) %>
-      </div>
-    <% end %>
+<%= render Search::ResultsFrame::Component.new(frame_id: :marketplace_results_frame,
+  render_results: @render_results, current_path: request.original_fullpath,
+  loading_text: t(".loading_results")) do %>
+  <%= turbo_frame_tag "page_#{@pagy.page}" do %>
+    <%= render partial: "marketplace_results" %>
   <% end %>
-
-  <div class="search-loading-overlay">
-    <%= render UI::LoadingSpinner::Component.new(text: t(".loading_results")) %>
-  </div>
-</div>
+<% end %>

--- a/app/views/search/registrations/index.html.erb
+++ b/app/views/search/registrations/index.html.erb
@@ -15,28 +15,8 @@
   </div>
 <% end %>
 
-<div class="search-results-frame-wrapper">
-  <%#
-    When the results aren't rendered inline (the JS shell), give the frame a src
-    so Turbo eager-loads the results in a separate request once it connects
-  %>
-
-  <%= turbo_frame_tag :search_registrations_results_frame,
-    src: (request.original_fullpath unless @render_results) do %>
-    <% if @render_results %>
-      <%= render partial: "results" %>
-    <% else %>
-      <%#
-        Hidden until JS reveals it: without JS the eager src never loads, so a
-        no-JS user would otherwise be stuck looking at a spinner that never resolves
-      %>
-      <div hidden data-search-loading>
-        <%= render UI::LoadingSpinner::Component.new(text: t(".loading_results")) %>
-      </div>
-    <% end %>
-  <% end %>
-
-  <div class="search-loading-overlay">
-    <%= render UI::LoadingSpinner::Component.new(text: t(".loading_results")) %>
-  </div>
-</div>
+<%= render Search::ResultsFrame::Component.new(frame_id: :search_registrations_results_frame,
+  render_results: @render_results, current_path: request.original_fullpath,
+  loading_text: t(".loading_results")) do %>
+  <%= render partial: "results" %>
+<% end %>

--- a/spec/components/search/results_frame/component_spec.rb
+++ b/spec/components/search/results_frame/component_spec.rb
@@ -29,4 +29,8 @@ RSpec.describe Search::ResultsFrame::Component, type: :component do
       expect(component).to have_css(".search-loading-overlay")
     end
   end
+
+  # `disable_snapshot_cache: true` writes the no-cache <meta> to content_for(:header),
+  # which is view-context-scoped and not observable through render_inline. It's
+  # covered at the integration layer (organized/impound_records_spec).
 end

--- a/spec/components/search/results_frame/component_spec.rb
+++ b/spec/components/search/results_frame/component_spec.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Search::ResultsFrame::Component, type: :component do
+  let(:options) { {frame_id: :test_results_frame, render_results:, current_path: "/search?query=x"} }
+  let(:component) { render_inline(described_class.new(**options)) { "<p>the results</p>".html_safe } }
+
+  context "with results rendered inline" do
+    let(:render_results) { true }
+
+    it "renders the block and omits the eager src" do
+      expect(component).to have_css("div.search-results-frame-wrapper")
+      expect(component).to have_css("turbo-frame#test_results_frame:not([src])")
+      expect(component).to have_text("the results")
+      expect(component).not_to have_css("[data-search-loading]")
+      # overlay spinner is always present
+      expect(component).to have_css(".search-loading-overlay")
+    end
+  end
+
+  context "with the JS shell (results not inline)" do
+    let(:render_results) { false }
+
+    it "sets the eager src and renders the hidden spinner instead of the block" do
+      expect(component).to have_css("turbo-frame#test_results_frame[src='/search?query=x']")
+      expect(component).to have_css("[hidden][data-search-loading]", visible: :all)
+      expect(component).not_to have_text("the results")
+      expect(component).to have_css(".search-loading-overlay")
+    end
+  end
+end

--- a/spec/components/search/results_frame/component_spec.rb
+++ b/spec/components/search/results_frame/component_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe Search::ResultsFrame::Component, type: :component do
     end
   end
 
-  # `disable_snapshot_cache: true` writes the no-cache <meta> to content_for(:header),
-  # which is view-context-scoped and not observable through render_inline. It's
-  # covered at the integration layer (organized/impound_records_spec).
+  # The component writes the no-cache <meta> to content_for(:header), which is
+  # view-context-scoped and not observable through render_inline. It's covered at
+  # the integration layer (organized/impound_records_spec).
 end

--- a/spec/integration/organized/impound_records_spec.rb
+++ b/spec/integration/organized/impound_records_spec.rb
@@ -67,6 +67,8 @@ RSpec.describe "Organized impound records index", :js, type: :system do
   end
 
   it "loads results via turbo, filters by unregisteredness, then applies multi-updates" do
+    # The results-frame component opts the page out of Turbo's snapshot cache
+    expect(page).to have_css('meta[name="turbo-cache-control"][content="no-cache"]', visible: :all)
     # Results load into the turbo-frame via its eager src
     expect(page).to have_css("turbo-frame#impound_records_results_frame table tbody tr", count: 4, wait: 10)
     # search_no_js should NOT be in the URL (removed by the JS controller)


### PR DESCRIPTION
Dedup pass over the search index views, which had accumulated copy-pasted Turbo scaffolding.

- **Results-frame ViewComponent:** the `search-results-frame-wrapper` skeleton (eager turbo-frame + no-JS hidden spinner + loading overlay) was repeated across all five search views. Extracted `Search::ResultsFrame::Component`; each view passes `frame_id`/`loading_text` and keeps its per-page chrome and results partial in the render block.
- **No-cache opt-out, now uniform:** every page using the component has the same form-outside-frame + `turbo_action="advance"` pattern, so any of them can restore a stale frame on back/forward. The component now emits the `turbo-cache-control` no-cache meta unconditionally — extending the opt-out to `search/registrations`, `search/marketplace`, and `organized/registrations`, which previously (inconsistently) lacked it. Verified by removing it: the back-nav specs restore stale form/frame state without it.

Per-page chrome (period select, render-chart link) now sits inside the component's `@render_results` branch, so it no longer emits into the JS shell's throwaway frame placeholder — the eager `src` fetch replaces it regardless, so no user-visible change; the no-JS path renders chrome + results as before.

Covered by a component spec and the existing integration specs across all five pages (JS + no-JS), with an assertion that the no-cache meta reaches the head.
