### PR TITLE
404 user profile pages for banned and email-banned users

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -97,7 +97,7 @@ class UsersController < ApplicationController
 
   def show
     user = User.find_by_username(params[:id])
-    unless user
+    if user.nil? || user.banned? || user.email_banned?
       raise ActionController::RoutingError.new("Not Found")
     end
 

--- a/spec/requests/users_request_spec.rb
+++ b/spec/requests/users_request_spec.rb
@@ -466,18 +466,22 @@ RSpec.describe UsersController, type: :request do
       expect(response.status).to eq 404
     end
 
-    it "404s if the user is banned" do
-      user.update(show_bikes: true, banned: true)
-      get "#{base_url}/#{user.username}"
-      expect(response.status).to eq 404
+    context "banned user" do
+      let(:user) { FactoryBot.create(:user_confirmed, show_bikes: true, banned: true) }
+      it "404s" do
+        get "#{base_url}/#{user.username}"
+        expect(response.status).to eq 404
+      end
     end
 
-    it "404s if the user is email banned" do
-      user.update(show_bikes: true)
-      FactoryBot.create(:email_ban, user:)
-      expect(user.reload.email_banned?).to be_truthy
-      get "#{base_url}/#{user.username}"
-      expect(response.status).to eq 404
+    context "email banned user" do
+      let(:user) { FactoryBot.create(:user_confirmed, show_bikes: true) }
+      let!(:email_ban) { FactoryBot.create(:email_ban, user:) }
+      it "404s" do
+        expect(user.reload.email_banned?).to be_truthy
+        get "#{base_url}/#{user.username}"
+        expect(response.status).to eq 404
+      end
     end
 
     it "redirects to user home url if the user exists but doesn't want to show their page" do

--- a/spec/requests/users_request_spec.rb
+++ b/spec/requests/users_request_spec.rb
@@ -460,45 +460,48 @@ RSpec.describe UsersController, type: :request do
   end
 
   describe "show" do
-    let(:user) { FactoryBot.create(:user_confirmed) }
+    let(:user) { FactoryBot.create(:user_confirmed, show_bikes:) }
+    let(:show_bikes) { false }
+
     it "404s if the user doesn't exist" do
       get "#{base_url}/fake_user-extra-stuff"
       expect(response.status).to eq 404
     end
 
-    context "banned user" do
-      let(:user) { FactoryBot.create(:user_confirmed, show_bikes: true, banned: true) }
-      it "404s" do
+    context "user doesn't show their page" do
+      it "redirects to user home url" do
         get "#{base_url}/#{user.username}"
-        expect(response.status).to eq 404
+        expect(response).to redirect_to my_account_url
       end
     end
 
-    context "email banned user" do
-      let(:user) { FactoryBot.create(:user_confirmed, show_bikes: true) }
-      let!(:email_ban) { FactoryBot.create(:email_ban, user:) }
-      it "404s" do
-        expect(user.reload.email_banned?).to be_truthy
-        get "#{base_url}/#{user.username}"
-        expect(response.status).to eq 404
+    context "user shows their page" do
+      let(:show_bikes) { true }
+
+      it "renders" do
+        get "#{base_url}/#{user.username}?page=1&per_page=1"
+        expect(response).to render_template :show
+        expect(assigns(:per_page)).to eq 1
+        # Test some header tag properties
+        expect(response.body).to match(/<title>#{user.name}</)
       end
-    end
 
-    it "redirects to user home url if the user exists but doesn't want to show their page" do
-      user.show_bikes = false
-      user.save
-      get "#{base_url}/#{user.username}"
-      expect(response).to redirect_to my_account_url
-    end
+      context "banned user" do
+        let(:user) { FactoryBot.create(:user_confirmed, show_bikes:, banned: true) }
+        it "404s" do
+          get "#{base_url}/#{user.username}"
+          expect(response.status).to eq 404
+        end
+      end
 
-    it "shows the page if the user exists and wants to show their page" do
-      user.update(show_bikes: true)
-      get "#{base_url}/#{user.username}?page=1&per_page=1"
-      expect(response).to render_template :show
-      expect(assigns(:per_page)).to eq 1
-      # Test some header tag properties
-      html_response = response.body
-      expect(html_response).to match(/<title>#{user.name}</)
+      context "email banned user" do
+        let!(:email_ban) { FactoryBot.create(:email_ban, user:) }
+        it "404s" do
+          expect(user.reload.email_banned?).to be_truthy
+          get "#{base_url}/#{user.username}"
+          expect(response.status).to eq 404
+        end
+      end
     end
   end
 

--- a/spec/requests/users_request_spec.rb
+++ b/spec/requests/users_request_spec.rb
@@ -466,6 +466,20 @@ RSpec.describe UsersController, type: :request do
       expect(response.status).to eq 404
     end
 
+    it "404s if the user is banned" do
+      user.update(show_bikes: true, banned: true)
+      get "#{base_url}/#{user.username}"
+      expect(response.status).to eq 404
+    end
+
+    it "404s if the user is email banned" do
+      user.update(show_bikes: true)
+      FactoryBot.create(:email_ban, user:)
+      expect(user.reload.email_banned?).to be_truthy
+      get "#{base_url}/#{user.username}"
+      expect(response.status).to eq 404
+    end
+
     it "redirects to user home url if the user exists but doesn't want to show their page" do
       user.show_bikes = false
       user.save


### PR DESCRIPTION
Banned and email-banned users' public profile pages now 404 instead of rendering.

- `UsersController#show` raises `RoutingError` when the looked-up user is `banned?` or `email_banned?`, matching the existing not-found behavior and avoiding leaking that the username exists.
- Added request specs covering both the banned and email-banned 404 cases.
