### PR TITLE
Switch marketplace primary_activity filter to a Form::Combobox

### DIFF
--- a/app/components/form/combobox/component.rb
+++ b/app/components/form/combobox/component.rb
@@ -12,14 +12,17 @@ module Form
     # Any other keyword (label:, id:, value:, open:, free_text:, autocomplete:,
     # placeholder:, etc.) is forwarded to `hw_combobox_tag`.
     class Component < ApplicationComponent
-      def initialize(name:, options: [], src: nil, **combobox_options)
+      def initialize(name:, options: [], src: nil, label_class: nil, **combobox_options)
         @name = name
         @options_or_src = src || options
+        @label_class = label_class
         @combobox_options = combobox_options
       end
 
       def call
-        helpers.hw_combobox_tag(@name, @options_or_src, **@combobox_options)
+        helpers.hw_combobox_tag(@name, @options_or_src, **@combobox_options) do |combobox|
+          combobox.customize_label(class: @label_class) if @label_class
+        end
       end
     end
   end

--- a/app/components/search/form/component.html.erb
+++ b/app/components/search/form/component.html.erb
@@ -36,13 +36,18 @@
             "
           >
             <% if render_primary_activity_field? %>
-              <%= label_tag :primary_activity,
-              translation(".search_for_primary_activity"),
-              class: "twlabel tw:sr-only" %>
-              <%= select_tag :primary_activity,
-              primary_activity_select_opts,
-              prompt: translation(".search_for_primary_activity"),
-              class: "twinput tw:md:max-w-xl fieldResetsCounts" %>
+              <div class="tw:w-full tw:md:max-w-xl">
+                <%= render(::Form::Combobox::Component.new(
+                  name: :primary_activity,
+                  id: "primary_activity",
+                  options: primary_activity_combobox_options,
+                  value: @interpreted_params[:primary_activity],
+                  include_blank: true,
+                  placeholder: translation(".search_for_primary_activity"),
+                  label: translation(".search_for_primary_activity"),
+                  label_class: "tw:sr-only",
+                )) %>
+              </div>
             <% end %>
 
             <% if render_price_field? %>

--- a/app/components/search/form/component.rb
+++ b/app/components/search/form/component.rb
@@ -77,11 +77,8 @@ module Search
         @interpreted_params[:primary_activity].present?
       end
 
-      def primary_activity_select_opts
-        options_for_select(
-          PrimaryActivity.by_priority.map { |pa| [pa.display_name_search, pa.id] },
-          selected: @interpreted_params[:primary_activity]
-        )
+      def primary_activity_combobox_options
+        PrimaryActivity.by_priority.map { |pa| {display: pa.display_name_search, value: pa.id} }
       end
     end
   end

--- a/app/javascript/controllers/search/kind_select_fields_controller.js
+++ b/app/javascript/controllers/search/kind_select_fields_controller.js
@@ -14,6 +14,10 @@ export default class extends Controller {
     this.updateForSaleLink()
     this.form?.addEventListener('change', this.updateForSaleLink.bind(this))
     this.form?.addEventListener('turbo:submit-end', this.performSubmitActions.bind(this))
+    // Plain filter comboboxes (eg primary_activity) don't fire a native change
+    // event, so reset the counts when their selection changes
+    this.form?.addEventListener('hw-combobox:selection', this.onComboboxSelection)
+    this.form?.addEventListener('hw-combobox:removal', this.onComboboxSelection)
 
     // Add function to window so it can be called by select2 callback
     window.kindControllerUpdateAfterComboboxChange = this.updateAfterComboboxChange.bind(this)
@@ -29,6 +33,16 @@ export default class extends Controller {
     this.form?.removeEventListener('turbo:submit-end', this.performSubmitActions.bind(this))
     // Remove reset count function from window
     window.kindControllerUpdateAfterComboboxChange = null
+    this.form?.removeEventListener('hw-combobox:selection', this.onComboboxSelection)
+    this.form?.removeEventListener('hw-combobox:removal', this.onComboboxSelection)
+  }
+
+  // The everything-combobox manages its own reset after mirroring its values
+  // into query_items[], so only the plain filter comboboxes route through here
+  onComboboxSelection = (event) => {
+    if (event.target.closest('[data-controller~="search--everything-combobox"]')) { return }
+
+    this.updateAfterComboboxChange()
   }
 
   get form () {

--- a/spec/components/search/form/component_system_spec.rb
+++ b/spec/components/search/form/component_system_spec.rb
@@ -159,7 +159,7 @@ RSpec.describe Search::Form::Component, :js, type: :system do
       it "renders and updates" do
         expect(combobox_values).to eq([])
         expect(page_text(page.text)).not_to match("miles of")
-        expect(find("#primary_activity", visible: false).value).to eq ""
+        expect(find("#primary_activity-hw-hidden-field", visible: false).value).to eq ""
 
         %w[for_sale for_sale_proximity].each { |kind_scope| expect_count(kind_scope, 0) }
 
@@ -184,7 +184,7 @@ RSpec.describe Search::Form::Component, :js, type: :system do
         it "renders and updates" do
           expect(combobox_values).to eq([])
           expect(page_text(page.text)).to match("miles of")
-          expect(find("#primary_activity", visible: false).value).to eq primary_activity.id.to_s
+          expect(find("#primary_activity-hw-hidden-field", visible: false).value).to eq primary_activity.id.to_s
 
           kind_scopes.each { |kind_scope| expect_count(kind_scope, 0) }
         end

--- a/spec/integration/search_marketplace_spec.rb
+++ b/spec/integration/search_marketplace_spec.rb
@@ -6,13 +6,16 @@ RSpec.describe "Marketplace infinite scroll", :js, type: :system do
   let(:seller) { FactoryBot.create(:user, :with_address_record) }
   let!(:manufacturer1) { FactoryBot.create(:manufacturer, name: "Yuba", id: 1003, frame_maker: true) }
   let!(:manufacturer2) { FactoryBot.create(:manufacturer, name: "Salsa", id: 764, frame_maker: true) }
+  let!(:primary_activity) { FactoryBot.create(:primary_activity, name: "Mountain biking") }
+  let!(:other_primary_activity) { FactoryBot.create(:primary_activity, name: "Road cycling") }
 
   before do
     # Create enough listings to span multiple pages (12 per page)
 
     15.times do |i|
-      item = FactoryBot.create(:bike, :with_primary_activity,
-        manufacturer: (i % 2 == 0) ? manufacturer1 : manufacturer2)
+      item = FactoryBot.create(:bike,
+        manufacturer: (i % 2 == 0) ? manufacturer1 : manufacturer2,
+        primary_activity: (i < 6) ? primary_activity : other_primary_activity)
       listing = FactoryBot.create(:marketplace_listing, :for_sale,
         address_record: seller.address_record,
         seller:,
@@ -107,5 +110,20 @@ RSpec.describe "Marketplace infinite scroll", :js, type: :system do
     expect(page).to have_css("[data-test-id^='vehicle-thumbnail-linkspan-']", wait: 10, count: 8)
     # Should NOT have a lazy-loading frame for page 2
     expect(page).not_to have_css("turbo-frame#page_2")
+  end
+
+  it "filters listings by primary activity" do
+    visit_marketplace_via_nav
+    # Wait for the initial results to load - all 15 listings span multiple pages
+    expect(page).to have_css("[data-test-id^='vehicle-thumbnail-linkspan-']", wait: 10, count: 12)
+
+    # Narrow to the 6 listings with the "Mountain biking" primary activity
+    select "Mountain biking", from: "primary_activity"
+    find("#search-button").click
+    expect(page).to have_css("[data-test-id^='vehicle-thumbnail-linkspan-']", wait: 10, count: 6)
+    # Only 6 results, so there's nothing to lazy-load on a second page
+    expect(page).not_to have_css("turbo-frame#page_2")
+    # The selection persists after the search
+    expect(page).to have_select("primary_activity", selected: "Mountain biking")
   end
 end

--- a/spec/integration/search_marketplace_spec.rb
+++ b/spec/integration/search_marketplace_spec.rb
@@ -101,10 +101,13 @@ RSpec.describe "Marketplace infinite scroll", :js, type: :system do
     # And then search "Yuba" without price filter
     # Which will return 8 bikes - so the page won't have the ability to scroll. Verify that it works correctly
     fill_in "price_max_amount", with: ""
-    find(".hw-combobox__input").set("Yuba")
-    # Wait for the combobox autocomplete to load
-    expect(page).to have_css(".hw-combobox__option", text: "Listings made by Yuba", wait: 5)
-    find(".hw-combobox__option", text: "Listings made by Yuba", match: :first).click
+    # Scope to the everything-combobox - the primary_activity field is also a combobox
+    within("[data-controller~='search--everything-combobox']") do
+      find(".hw-combobox__input").set("Yuba")
+      # Wait for the combobox autocomplete to load
+      expect(page).to have_css(".hw-combobox__option", text: "Listings made by Yuba", wait: 5)
+      find(".hw-combobox__option", text: "Listings made by Yuba", match: :first).click
+    end
     find("#search-button").click
     # Should load new results
     expect(page).to have_css("[data-test-id^='vehicle-thumbnail-linkspan-']", wait: 10, count: 8)
@@ -117,13 +120,18 @@ RSpec.describe "Marketplace infinite scroll", :js, type: :system do
     # Wait for the initial results to load - all 15 listings span multiple pages
     expect(page).to have_css("[data-test-id^='vehicle-thumbnail-linkspan-']", wait: 10, count: 12)
 
-    # Narrow to the 6 listings with the "Mountain biking" primary activity
-    select "Mountain biking", from: "primary_activity"
+    # Narrow to the 6 listings with the "Mountain biking" primary activity by
+    # typing into the combobox and clicking its matching autocomplete option
+    find("#primary_activity").set("Mountain")
+    expect(page).to have_css(".hw-combobox__option", text: "Mountain biking", wait: 5)
+    find(".hw-combobox__option", text: "Mountain biking", match: :first).click
     find("#search-button").click
     expect(page).to have_css("[data-test-id^='vehicle-thumbnail-linkspan-']", wait: 10, count: 6)
     # Only 6 results, so there's nothing to lazy-load on a second page
     expect(page).not_to have_css("turbo-frame#page_2")
-    # The selection persists after the search
-    expect(page).to have_select("primary_activity", selected: "Mountain biking")
+    # The selection persists after the search - the hidden field carries the id,
+    # the visible input shows the display name
+    expect(find("#primary_activity-hw-hidden-field", visible: false).value).to eq primary_activity.id.to_s
+    expect(find("#primary_activity").value).to eq "Mountain biking"
   end
 end


### PR DESCRIPTION
Switch the marketplace primary-activity filter from a plain `<select>` to a typeahead `Form::Combobox`, and rename/expand the marketplace system spec.

- **Combobox filter** — the marketplace primary-activity field is now a searchable `Form::Combobox` styled to match the existing query combobox; `Form::Combobox` gains a `label_class:` option for an sr-only label.
- **Counts reset** — comboboxes don't fire a native `change`, so the kind-select controller resets the kind counts on `hw-combobox:selection`/`removal` (skipping the everything-combobox, which manages its own reset).
- **Spec** — renamed `marketplace_infinite_scroll_spec` → `search_marketplace_spec` and added coverage for filtering listings by primary activity, driving the new combobox.
