### PR TITLE
Surface 429 throttling during search

### DIFF
--- a/app/components/search/results_frame/component.en.yml
+++ b/app/components/search/results_frame/component.en.yml
@@ -1,0 +1,6 @@
+---
+en:
+  components:
+    search:
+      results_frame:
+        rate_limited: Too many searches too fast — you're being rate limited. Wait a moment, then try again.

--- a/app/components/search/results_frame/component.en.yml
+++ b/app/components/search/results_frame/component.en.yml
@@ -3,4 +3,6 @@ en:
   components:
     search:
       results_frame:
-        rate_limited: Too many searches too fast — you're being rate limited. Wait a moment, then try again.
+        rate_limited: >-
+          Too many searches too fast — you're being rate limited. Wait a moment, then
+          try again.

--- a/app/components/search/results_frame/component.html.erb
+++ b/app/components/search/results_frame/component.html.erb
@@ -1,9 +1,12 @@
 <% helpers.content_for(:header) { tag.meta(name: "turbo-cache-control", content: "no-cache") } %>
 
 <div class="search-results-frame-wrapper">
-  <%# Revealed by search--form when a search request (results frame or kind
-      counts) comes back 429-throttled, so a rate limit surfaces instead of a
-      stuck spinner or silently blank counts. Hidden again on the next render. %>
+  <%#
+    Revealed by search--form when a search request (results frame or kind
+    counts) comes back 429-throttled, so a rate limit surfaces instead of a
+    stuck spinner or silently blank counts. Hidden again on the next render.
+  %>
+
   <div hidden data-search-rate-limited>
     <%= render UI::Alert::Component.new(text: translation(".rate_limited"), kind: :warning) %>
   </div>

--- a/app/components/search/results_frame/component.html.erb
+++ b/app/components/search/results_frame/component.html.erb
@@ -1,6 +1,13 @@
 <% helpers.content_for(:header) { tag.meta(name: "turbo-cache-control", content: "no-cache") } %>
 
 <div class="search-results-frame-wrapper">
+  <%# Revealed by search--form when a search request (results frame or kind
+      counts) comes back 429-throttled, so a rate limit surfaces instead of a
+      stuck spinner or silently blank counts. Hidden again on the next render. %>
+  <div hidden data-search-rate-limited>
+    <%= render UI::Alert::Component.new(text: translation(".rate_limited"), kind: :warning) %>
+  </div>
+
   <%= helpers.turbo_frame_tag @frame_id, src: @src do %>
     <% if @render_results %>
       <%= content %>

--- a/app/javascript/controllers/search/form_controller.js
+++ b/app/javascript/controllers/search/form_controller.js
@@ -32,11 +32,18 @@ export default class extends Controller {
     if (!window.timeLocalizer) window.timeLocalizer = new TimeLocalizer()
     document.addEventListener('turbo:frame-render', this.handleFrameRender)
     document.addEventListener('turbo:load', this.handleTurboLoad)
+    // Surface throttling: the eager results frame and the kind-count fetch can
+    // both come back 429 during active searching. Catch the frame's response
+    // here; the count fetch signals via the search:rate-limited window event.
+    document.addEventListener('turbo:before-fetch-response', this.handleFetchResponse)
+    window.addEventListener('search:rate-limited', this.showRateLimited)
   }
 
   disconnect () {
     document.removeEventListener('turbo:frame-render', this.handleFrameRender)
     document.removeEventListener('turbo:load', this.handleTurboLoad)
+    document.removeEventListener('turbo:before-fetch-response', this.handleFetchResponse)
+    window.removeEventListener('search:rate-limited', this.showRateLimited)
   }
 
   handleTurboLoad = () => {
@@ -76,11 +83,37 @@ export default class extends Controller {
   }
 
   handleFrameRender = () => {
+    // A frame render means results came back, so clear any rate-limit notice
+    this.hideRateLimited()
     // Run the time localization command on frame render
     if (window.timeLocalizer && typeof window.timeLocalizer.localize === 'function') {
       window.timeLocalizer.localize()
     }
     this.syncHiddenFieldsFromUrl()
+  }
+
+  // The results frame eager-loads via its src; on a 429 Turbo just logs and
+  // leaves the spinner spinning. Take over the response so the user sees why.
+  handleFetchResponse = (event) => {
+    if (event.detail?.fetchResponse?.response?.status !== 429) return
+
+    event.preventDefault() // stop Turbo's default handling of the throttled response
+    this.showRateLimited()
+
+    // Drop the in-frame loading placeholder so it doesn't spin forever
+    this.frameElement?.querySelector('[data-search-loading]')?.setAttribute('hidden', '')
+  }
+
+  get rateLimitedElement () {
+    return document.querySelector('[data-search-rate-limited]')
+  }
+
+  showRateLimited = () => {
+    this.rateLimitedElement?.removeAttribute('hidden')
+  }
+
+  hideRateLimited () {
+    this.rateLimitedElement?.setAttribute('hidden', '')
   }
 
   // The form sits outside the results frame, so frame-nav period clicks advance

--- a/app/javascript/controllers/search/kind_select_fields_controller.js
+++ b/app/javascript/controllers/search/kind_select_fields_controller.js
@@ -130,11 +130,19 @@ export default class extends Controller {
       method: 'GET',
       headers: { 'Content-Type': 'application/json' }
     })
-      .then(response => response.json())
-      .then(data => {
-        this.element.dataset.countsQuery = queryString
-        this.insertTabCounts(data)
+      .then(response => {
+        // Counts share the per-IP API throttle; surface a 429 instead of
+        // silently leaving the tab counts blank.
+        if (response.status === 429) {
+          window.dispatchEvent(new CustomEvent('search:rate-limited'))
+          return this.resetKindCounts()
+        }
+        return response.json().then(data => {
+          this.element.dataset.countsQuery = queryString
+          this.insertTabCounts(data)
+        })
       })
+      .catch(() => this.resetKindCounts())
 
     this.setResetFieldListeners()
   }

--- a/config/locales/.translation_io
+++ b/config/locales/.translation_io
@@ -5,4 +5,4 @@
 # ignore the conflicts and "sync" again, it will fix this file for you.
 
 ---
-timestamp: 1780715125
+timestamp: 1780718070

--- a/config/locales/translation.es.yml
+++ b/config/locales/translation.es.yml
@@ -4125,6 +4125,8 @@ es:
         submit:
         search_notes:
         search_owner_email_or_name:
+      results_frame:
+        rate_limited:
     search_results:
       bike_box:
         location:

--- a/config/locales/translation.it.yml
+++ b/config/locales/translation.it.yml
@@ -4207,6 +4207,8 @@ it:
         submit:
         search_notes:
         search_owner_email_or_name:
+      results_frame:
+        rate_limited:
     search_results:
       bike_box:
         location: Luogo

--- a/config/locales/translation.nb.yml
+++ b/config/locales/translation.nb.yml
@@ -5303,6 +5303,9 @@ nb:
         submit: sende inn
         search_notes: Søk i notater
         search_owner_email_or_name: Søk etter eierens e-postadresse eller navn
+      results_frame:
+        rate_limited: For mange søk for raskt – du er frekvensbegrenset. Vent et øyeblikk,
+          og prøv på nytt.
     search_results:
       bike_box:
         location: plassering

--- a/config/locales/translation.nl.yml
+++ b/config/locales/translation.nl.yml
@@ -5450,6 +5450,9 @@ nl:
         submit: Voorleggen
         search_notes: Zoeknotities
         search_owner_email_or_name: Zoek naar het e-mailadres of de naam van de eigenaar.
+      results_frame:
+        rate_limited: Te veel zoekopdrachten te snel achter elkaar — je hebt een limiet
+          bereikt. Wacht even en probeer het opnieuw.
     search_results:
       bike_box:
         location: Plaats

--- a/spec/components/search/results_frame/component_spec.rb
+++ b/spec/components/search/results_frame/component_spec.rb
@@ -16,6 +16,9 @@ RSpec.describe Search::ResultsFrame::Component, type: :component do
       expect(component).not_to have_css("[data-search-loading]")
       # overlay spinner is always present
       expect(component).to have_css(".search-loading-overlay")
+      # rate-limit notice ships hidden, revealed by search--form on a 429
+      expect(component).to have_css("[hidden][data-search-rate-limited]", visible: :all)
+      expect(component).to have_text("being rate limited", normalize_ws: true)
     end
   end
 


### PR DESCRIPTION
Active searching can trip Rack::Attack's throttle, and a 429 went unsurfaced: the eager results turbo-frame just left a stuck spinner (Turbo only logs the error) and the kind-count fetch swallowed it silently, leaving the tab counts blank.

- Added a hidden rate-limit notice above the results frame (`Search::ResultsFrame::Component`) that's revealed whenever a search request comes back 429, and hidden again on the next successful render.
- `search--form` now intercepts the results frame's 429 via `turbo:before-fetch-response`, shows the notice, and clears the dangling spinner.
- The kind-count fetch checks for 429, signals the notice through a `search:rate-limited` window event, and gained a `.catch` so other errors no longer reject silently.
