### PR TITLE
Fill missing Spanish footer translations

### DIFF
--- a/config/locales/.translation_io
+++ b/config/locales/.translation_io
@@ -5,4 +5,4 @@
 # ignore the conflicts and "sync" again, it will fix this file for you.
 
 ---
-timestamp: 1780694144
+timestamp: 1780715125

--- a/config/locales/translation.es.yml
+++ b/config/locales/translation.es.yml
@@ -3848,8 +3848,8 @@ es:
       vendor_terms: condiciones de venta
       where_we_are: Dónde estamos
       who_we_serve: A quién servimos
-      strava_search:
-      dev_and_design_resources:
+      strava_search: Búsqueda y actualización de Strava
+      dev_and_design_resources: Recursos de desarrollo y diseño
     form_well_footer_save:
       save_changes:
     header_nav:


### PR DESCRIPTION
Fills in the Spanish footer translations that were left empty by the translation sync.

- The redesigned footer renders `footer_revised.dev_and_design_resources` for every locale, but the Spanish value was nil. In test, `raise_on_missing_translations` is on with no es→en fallback, so rendering the homepage in Spanish raised `I18n::MissingTranslationData` (failing `locale_detection_request_spec`).
- Translate `dev_and_design_resources` and the adjacent nil `strava_search` footer string, matching the already-translated nb/nl locales.
