### PR TITLE
Fix SQLi and IDOR in ambassador task assignments

### DIFF
--- a/app/controllers/organized/ambassador_task_assignments_controller.rb
+++ b/app/controllers/organized/ambassador_task_assignments_controller.rb
@@ -4,7 +4,7 @@ module Organized
     skip_before_action :ensure_not_ambassador_organization!
 
     def update
-      ambassador_task_assignment = AmbassadorTaskAssignment.find(params[:id])
+      ambassador_task_assignment = current_user.ambassador_task_assignments.find(params[:id])
       completed_at = (params[:completed] == "true") ? Time.current : nil
 
       if ambassador_task_assignment.update(completed_at: completed_at)

--- a/app/models/ambassador_task_assignment.rb
+++ b/app/models/ambassador_task_assignment.rb
@@ -91,9 +91,9 @@ class AmbassadorTaskAssignment < ApplicationRecord
       SQL
 
       filter_to_sql_clause = {
-        organization_id: ->(filter_val) { "AND organizations.id = #{filter_val} " },
-        ambassador_task_id: ->(filter_val) { "AND ambassador_tasks.id = #{filter_val} " },
-        ambassador_id: ->(filter_val) { "AND users.id = #{filter_val} " }
+        organization_id: ->(filter_val) { "AND organizations.id = #{filter_val.to_i} " },
+        ambassador_task_id: ->(filter_val) { "AND ambassador_tasks.id = #{filter_val.to_i} " },
+        ambassador_id: ->(filter_val) { "AND users.id = #{filter_val.to_i} " }
       }
       sql << filters
         .map { |col, val| filter_to_sql_clause[col]&.call(val) }

--- a/spec/requests/organized/ambassador_task_assignments_request_spec.rb
+++ b/spec/requests/organized/ambassador_task_assignments_request_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Organized::AmbassadorTaskAssignmentsController, type: :request do
 
     context "given completed: false" do
       it "unsets the task's completed_at value" do
-        assignment = FactoryBot.create(:ambassador_task_assignment, :completed)
+        assignment = FactoryBot.create(:ambassador_task_assignment, :completed, ambassador: current_user)
 
         patch "#{base_url}/#{assignment.to_param}",
           params: {
@@ -24,7 +24,7 @@ RSpec.describe Organized::AmbassadorTaskAssignmentsController, type: :request do
 
     context "given completed: true" do
       it "sets the task's completed_at value" do
-        assignment = FactoryBot.create(:ambassador_task_assignment)
+        assignment = FactoryBot.create(:ambassador_task_assignment, ambassador: current_user)
         expect(assignment.reload.completed_at).to be_nil
 
         patch "#{base_url}/#{assignment.to_param}",
@@ -41,9 +41,8 @@ RSpec.describe Organized::AmbassadorTaskAssignmentsController, type: :request do
 
     context "given a failed update" do
       it "sets the flash error message" do
-        assignment = FactoryBot.create(:ambassador_task_assignment)
-        allow(assignment).to receive(:update).and_return(false)
-        allow(AmbassadorTaskAssignment).to receive(:find).and_return(assignment)
+        assignment = FactoryBot.create(:ambassador_task_assignment, ambassador: current_user)
+        allow_any_instance_of(AmbassadorTaskAssignment).to receive(:update).and_return(false)
 
         patch "#{base_url}/#{assignment.to_param}",
           params: {
@@ -54,6 +53,17 @@ RSpec.describe Organized::AmbassadorTaskAssignmentsController, type: :request do
         expect(assignment.reload.completed_at).to_not be_present
         expect(flash[:info]).to be_blank
         expect(flash[:error]).to match("Could not update")
+      end
+    end
+
+    context "given another ambassador's assignment" do
+      it "does not update it" do
+        assignment = FactoryBot.create(:ambassador_task_assignment, :completed)
+
+        patch "#{base_url}/#{assignment.to_param}", params: {completed: "false"}
+
+        expect(response.status).to eq(404)
+        expect(assignment.reload.completed_at).to be_present
       end
     end
   end


### PR DESCRIPTION
Closes two security issues in the ambassador task assignment flow.

- **SQL injection** in `AmbassadorTaskAssignment.completed_assignments`: the `organization_id`/`ambassador_task_id`/`ambassador_id` filter values were interpolated straight into the raw `find_by_sql` query (the existing `sanitize_sql` no-ops on plain strings), so request params like `?search_organization_id=1; ...` reached the database. The three values are IDs, so they're now cast with `.to_i`.
- **IDOR** in `Organized::AmbassadorTaskAssignmentsController#update`: the unscoped `AmbassadorTaskAssignment.find` let any ambassador toggle another's `completed_at` by guessing IDs. Scoped to `current_user.ambassador_task_assignments`, so a foreign id now 404s.
