### PR TITLE
Fix review-app scheduled-job staging errors

### DIFF
--- a/app/services/spreadsheets/tsv_creator.rb
+++ b/app/services/spreadsheets/tsv_creator.rb
@@ -3,7 +3,9 @@ module Spreadsheets
     attr_reader :file_prefix
 
     def initialize
-      @file_prefix = Rails.env.test? ? "/spec/fixtures/tsv_creation/" : ""
+      # tmp/ is writable by the container's rails user; the app root (Rails.root) is
+      # not. These files are transient staging for send_to_uploader (see FileCacheMaintenanceJob).
+      @file_prefix = Rails.env.test? ? "/spec/fixtures/tsv_creation/" : "tmp/"
     end
 
     def manufacturers_header

--- a/bin/setup
+++ b/bin/setup
@@ -80,7 +80,7 @@ chdir APP_ROOT do
   system "redis-server &"
 
   # Install JavaScript dependencies
-  system('npm install')
+  system("npm install")
 
   puts "\n== Preparing database =="
 
@@ -94,8 +94,9 @@ chdir APP_ROOT do
     puts "\n== Preparing test database (including parallelism) =="
     system! "bin/rake parallel:prepare"
 
-    puts "\n== loading typeahead and bike counts =="
-    system! "bin/rake setup:reset_autocomplete setup:load_counts"
+    # Autocomplete (typeahead) is loaded by db:seed above; here we just load counts
+    puts "\n== loading bike counts =="
+    system! "bin/rake setup:load_counts"
   end
 
   puts "\n== Removing old logs and tempfiles =="

--- a/config/deploy.review.yml
+++ b/config/deploy.review.yml
@@ -109,6 +109,12 @@ env:
     REDIS_URL: "<%= redis_url %>"
     REDIS_RACK_ATTACK_URL: "<%= redis_url %>"
 
+    # Scheduled jobs that can't work in review apps (run by config/crontab's
+    # run_scheduler). The exchange-rate API uses placeholder review-app secrets,
+    # so its response has no `rates` key (KeyError). Skipped via ApplicationJob's
+    # SIDEKIQ_SKIP_<job> mechanism.
+    SIDEKIQ_SKIP_UPDATE_EXCHANGE_RATES_JOB: "1"
+
     # Runtime
     RAILS_LOG_TO_STDOUT: "1"
     RAILS_SERVE_STATIC_FILES: "1"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -12,3 +12,9 @@ require File.expand_path("db/seeds/seed_bikes", Rails.root)
 require File.expand_path("db/seeds/seed_organization_bikes_and_associations", Rails.root)
 require File.expand_path("db/seeds/seed_organized_emails", Rails.root)
 require File.expand_path("db/seeds/seed_counts", Rails.root)
+
+# Load the search autocomplete (Redis) from the seeded manufacturers/colors/etc.
+# so it matches the database. Without this, a freshly seeded app (e.g. a review
+# app on first boot) has manufacturers in the DB but an empty autocomplete, which
+# makes ScheduledAutocompleteCheckJob raise "Missing Manufacturers!".
+AutocompleteLoaderJob.new.perform(nil, true)


### PR DESCRIPTION
Fixes the Honeybadger staging faults coming from scheduled jobs that behave differently in the new Kamal review apps than in production.

- **TsvCreator `Errno::EACCES`** — wrote transient staging files to the read-only `Rails.root`; now writes to `tmp/`, matching the existing `FileCacheMaintenanceJob` fix.
- **`ScheduledAutocompleteCheckJob` "Missing Manufacturers!"** — review-app first boot seeded manufacturers but never loaded the autocomplete Redis. Autocomplete is now loaded in `db:seed`, so every seeding path (`bin/setup` and the review-app `db:prepare` entrypoint) populates it; the now-redundant `setup:reset_autocomplete` is dropped from `bin/setup`.
- **`UpdateExchangeRatesJob` `KeyError "rates"`** — skipped in review apps, whose placeholder API secret returns a response with no `rates` key.
