### PR TITLE
Seed dev@bikeindex.org developer user; drop admin developer flag

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -34,7 +34,7 @@ _Bike Index also requires some additional libraries. We recommend installing the
 Follow [the Getting Started guide](docs/getting-started.markdown) for a complete set up. Or if you're familiar with developing Ruby on Rails applications start with these steps and a local Postgresql installation:
 
 - `bin/setup` sets up the application and seeds test organizations, bikes and users:
-  - Three test user accounts: admin@bikeindex.org, member@bikeindex.org, user@bikeindex.org (all have password `pleaseplease12`)
+  - Four test user accounts: admin@bikeindex.org, dev@bikeindex.org (developer), member@bikeindex.org, user@bikeindex.org (all have password `pleaseplease12`)
   - Gives user@bikeindex.org 50 bikes
   - Give test organization Hogwarts all organization features and some test parking notifications
 

--- a/db/seeds/seed_test_users.rb
+++ b/db/seeds/seed_test_users.rb
@@ -2,7 +2,8 @@
 # Note: you have to seed the users first, or else the bikes don't have anywhere to go.
 
 user_attrs = {
-  admin: {name: "Admin User", email: "admin@bikeindex.org", password: "pleaseplease12", password_confirmation: "pleaseplease12", terms_of_service: true, vendor_terms_of_service: true, when_vendor_terms_of_service: Time.current, developer: true},
+  admin: {name: "Admin User", email: "admin@bikeindex.org", password: "pleaseplease12", password_confirmation: "pleaseplease12", terms_of_service: true, vendor_terms_of_service: true, when_vendor_terms_of_service: Time.current},
+  dev: {name: "Dev User", email: "dev@bikeindex.org", password: "pleaseplease12", password_confirmation: "pleaseplease12", terms_of_service: true, vendor_terms_of_service: true, when_vendor_terms_of_service: Time.current, developer: true},
   member: {name: "Member User", email: "member@bikeindex.org", password: "pleaseplease12", password_confirmation: "pleaseplease12", terms_of_service: true, vendor_terms_of_service: true, when_vendor_terms_of_service: Time.current},
   user: {name: "Test User", email: "user@bikeindex.org", password: "pleaseplease12", password_confirmation: "pleaseplease12", terms_of_service: true},
   api_accessor: {name: "Api Accessor", email: "api@bikeindex.org", password: "pleaseplease12", password_confirmation: "pleaseplease12", terms_of_service: true},


### PR DESCRIPTION
Adds a dedicated `dev@bikeindex.org` ("Dev User") seed account flagged as a developer, and removes the `developer: true` flag from `admin@bikeindex.org` so the admin account is no longer also a developer.

- New `dev` test user mirrors the admin's vendor terms-of-service attributes, with the standard seed password.
- Admin user keeps its superuser ability but is no longer a developer.
- README's test-account list updated to include the new `dev@bikeindex.org` developer account.
