### PR TITLE
Require login to create an organization

### DIFF
--- a/app/controllers/organizations_controller.rb
+++ b/app/controllers/organizations_controller.rb
@@ -24,6 +24,10 @@ class OrganizationsController < ApplicationController
   end
 
   def create
+    if current_user.blank?
+      flash[:error] = translation(:must_create_an_account_first)
+      redirect_to(new_user_path) && return
+    end
     @organization = Organization.new(permitted_create_params)
     if @organization.save
       OrganizationRole.create(user_id: current_user.id, role: "admin", organization_id: @organization.id)

--- a/config/locales/.translation_io
+++ b/config/locales/.translation_io
@@ -5,4 +5,4 @@
 # ignore the conflicts and "sync" again, it will fix this file for you.
 
 ---
-timestamp: 1781050325
+timestamp: 1781106792

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1815,6 +1815,8 @@ en:
     organizations:
       create:
         organization_created: Organization Created successfully!
+        must_create_an_account_first: >-
+          You have to sign up for an account on Bike Index before you can create an organization
       find_organization:
         not_found: >-
           We're sorry, that organization isn't on Bike Index yet. Email contact@bikeindex.org

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1814,9 +1814,10 @@ en:
           not_your_application: That isn't your application
     organizations:
       create:
-        organization_created: Organization Created successfully!
         must_create_an_account_first: >-
-          You have to sign up for an account on Bike Index before you can create an organization
+          You have to sign up for an account on Bike Index before you can create an
+          organization
+        organization_created: Organization Created successfully!
       find_organization:
         not_found: >-
           We're sorry, that organization isn't on Bike Index yet. Email contact@bikeindex.org

--- a/config/locales/translation.es.yml
+++ b/config/locales/translation.es.yml
@@ -2095,6 +2095,7 @@ es:
     organizations:
       create:
         organization_created:
+        must_create_an_account_first:
       find_organization:
         not_found:
       lightspeed_interface:

--- a/config/locales/translation.it.yml
+++ b/config/locales/translation.it.yml
@@ -2135,6 +2135,7 @@ it:
     organizations:
       create:
         organization_created:
+        must_create_an_account_first:
       find_organization:
         not_found:
       lightspeed_interface:

--- a/config/locales/translation.nb.yml
+++ b/config/locales/translation.nb.yml
@@ -2229,6 +2229,8 @@ nb:
     organizations:
       create:
         organization_created: Organisasjon opprettet vellykket!
+        must_create_an_account_first: Du må registrere deg for en konto på Bike Index
+          før du kan opprette en organisasjon.
       find_organization:
         not_found: Vi beklager, den organisasjonen er ikke på Bike Index ennå. Send
           e-post til contact@bikeindex.org hvis dette virker som en feil.

--- a/config/locales/translation.nl.yml
+++ b/config/locales/translation.nl.yml
@@ -1921,6 +1921,8 @@ nl:
     organizations:
       create:
         organization_created: Organisatie met succes gemaakt!
+        must_create_an_account_first: Je moet eerst een account aanmaken op Bike Index
+          voordat je een organisatie kunt creëren.
       find_organization:
         not_found: Het spijt ons, die organisatie staat nog niet op Bike Index. E-mail
           contact@bikeindex.org als dit op een fout lijkt.

--- a/spec/requests/organizations_request_spec.rb
+++ b/spec/requests/organizations_request_spec.rb
@@ -113,6 +113,16 @@ RSpec.describe OrganizationsController, type: :request do
         end
       end
     end
+
+    context "no current_user" do
+      let(:current_user) { false }
+      it "doesn't create" do
+        expect {
+          post base_url, params: {organization: org_attrs}
+        }.to_not change(Organization, :count)
+        expect(flash[:error]).to match "an account"
+      end
+    end
   end
 
   describe "legacy embeds" do


### PR DESCRIPTION
Guards `OrganizationsController#create` against a blank `current_user`, which previously raised when building the admin `OrganizationRole` with a nil `user_id`. Anonymous submissions now redirect to signup with a flash error.

- Add the `current_user.blank?` guard redirecting to `new_user_path`
- Add the `controllers.organizations.create.must_create_an_account_first` translation
- Cover the no-user case with a request spec
