### PR TITLE
Remove connection_pool pin

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -51,7 +51,6 @@ gem "translation"
 # Redis and Redis dependents
 gem "redis"
 gem "sidekiq" # Background job processing
-gem "connection_pool", "< 4" # temporary - see github.com/mperham/connection_pool/issues/212
 gem "sidekiq-failures" # Sidekiq failure tracking and viewing
 gem "sidekiq-logstash" # Better sidekiq logging
 gem "redlock" # Locking

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -950,7 +950,6 @@ DEPENDENCIES
   chunky_png
   coderay
   coffee-rails
-  connection_pool (< 4)
   csv
   dartsass-rails
   database_cleaner


### PR DESCRIPTION
No longer necessary - since #3153 which updated the gem and the comment - and should have just removed the pin 🤦 