### PR TITLE
Handle invalid impounded_at instead of crashing BulkImportJob

### DIFF
--- a/app/models/impound_record.rb
+++ b/app/models/impound_record.rb
@@ -49,6 +49,7 @@ class ImpoundRecord < ApplicationRecord
 
   validates_presence_of :user_id
   validates_uniqueness_of :bike_id, if: :current?, conditions: -> { current }
+  validate :impounded_at_must_be_valid
 
   attr_accessor :timezone, :skip_update # timezone provides a backup and permits assignment
 
@@ -122,10 +123,18 @@ class ImpoundRecord < ApplicationRecord
 
   def impounded_at_with_timezone=(val)
     self.impounded_at = Binxtils::TimeParser.parse(val, timezone)
+  rescue ArgumentError
+    @impounded_at_invalid = val
   end
 
   def impounded_at_with_timezone
     impounded_at
+  end
+
+  def impounded_at_must_be_valid
+    return if @impounded_at_invalid.blank?
+
+    errors.add(:impounded_at, "'#{@impounded_at_invalid}' is not a valid date")
   end
 
   # Non-organizations don't "impound" bikes, they "find" them

--- a/spec/jobs/bulk_import_job_spec.rb
+++ b/spec/jobs/bulk_import_job_spec.rb
@@ -694,6 +694,24 @@ RSpec.describe BulkImportJob, type: :job do
           }.to change(Bike, :count).by 0
         end
       end
+      context "impounded with invalid impounded_at" do
+        include_context :geocoder_default_location
+        let(:impound_configuration) { FactoryBot.create(:impound_configuration) }
+        let(:organization) { impound_configuration.organization }
+        let!(:bulk_import) { FactoryBot.create(:bulk_import, progress: "pending", kind: "impounded", organization: organization) }
+        let(:row) do
+          {manufacturer: "Surly", serial_number: "na", year: "2018", model: "Midnight Special",
+           impounded_at: "32:61:61", impounded_street: "1409 Martin Luther King Jr Way",
+           impounded_city: "Berkeley", impounded_state: "CA", impounded_zipcode: "94710", impounded_country: "US"}
+        end
+        it "doesn't raise, returns the bike with an impounded_at error" do
+          expect {
+            bike = instance.send(:register_bike, instance.send(:row_to_b_param_hash, row))
+            expect(bike.id).to_not be_present
+            expect(bike.cleaned_error_messages).to include("Impound records impounded at '32:61:61' is not a valid date")
+          }.to_not change(Bike, :count)
+        end
+      end
     end
 
     describe "rescue_blank_serials" do

--- a/spec/models/impound_record_spec.rb
+++ b/spec/models/impound_record_spec.rb
@@ -300,6 +300,24 @@ RSpec.describe ImpoundRecord, type: :model do
     end
   end
 
+  describe "impounded_at_with_timezone=" do
+    let(:impound_record) { FactoryBot.build(:impound_record, bike: bike, user: user, organization: organization) }
+    context "valid date" do
+      it "assigns impounded_at" do
+        impound_record.impounded_at_with_timezone = "2021-02-04"
+        expect(impound_record.impounded_at.to_date).to eq Date.parse("2021-02-04")
+        expect(impound_record).to be_valid
+      end
+    end
+    context "unparseable date" do
+      it "adds an error rather than raising" do
+        expect { impound_record.impounded_at_with_timezone = "32:61:61" }.to_not raise_error
+        expect(impound_record).to_not be_valid
+        expect(impound_record.errors[:impounded_at]).to eq(["'32:61:61' is not a valid date"])
+      end
+    end
+  end
+
   describe "resolved factory" do
     let!(:impound_record) { FactoryBot.create(:impound_record_resolved, status: "removed_from_bike_index") }
     it "creates with resolved issue" do


### PR DESCRIPTION
A malformed `impounded_at` value (e.g. `"32:61:61"`) raised an uncaught `ArgumentError` from `Binxtils::TimeParser` during attribute assignment, which aborted the entire `BulkImportJob` as a file-level error ([Honeybadger fault 131604215](https://app.honeybadger.io/projects/35931/faults/131604215)).

- Rescue the `ArgumentError` in `ImpoundRecord#impounded_at_with_timezone=` and surface it as a validation error on `:impounded_at`, so a bad date becomes a per-row line error instead of crashing the import.
- Deferred the error to a `validate` callback rather than adding it in the setter, since `valid?` clears errors before running.
