### PR TITLE
Update binxtils gem to 0.5.1 and time-localizer npm to 0.3.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -150,7 +150,7 @@ GEM
     bcrypt (3.1.22)
     benchmark (0.5.0)
     bigdecimal (4.1.2)
-    binxtils (0.4.2)
+    binxtils (0.5.1)
       functionable
       loofah
       rails

--- a/app/components/ui/user_text_block_display/component.html.erb
+++ b/app/components/ui/user_text_block_display/component.html.erb
@@ -1,4 +1,0 @@
-<%# NOTE: tag open and close needs to be on one line, or the text has whitespace at the beginning %>
-<div class="tw:whitespace-pre-wrap <% @overflow_class %> <%= @additional_classes %>">
-  <%= @text.strip %>
-</div>

--- a/app/components/ui/user_text_block_display/component.rb
+++ b/app/components/ui/user_text_block_display/component.rb
@@ -5,13 +5,18 @@ module UI
     class Component < ApplicationComponent
       def initialize(text: nil, additional_classes: nil, max_height_class: "tw:max-h-80")
         @text = text&.strip
-        @additional_classes = additional_classes || ""
-        @additional_classes += " #{max_height_class}"
-        @overflow_class = max_height_class.present? ? "tw:overflow-y-auto" : ""
+        overflow_class = "tw:overflow-y-auto" if max_height_class.present?
+        @classes = ["tw:whitespace-pre-wrap", overflow_class, additional_classes, max_height_class]
       end
 
       def render?
         @text.present?
+      end
+
+      # NOTE: rendered inline rather than via a template so the text block has no
+      # leading whitespace (see spec)
+      def call
+        tag.div(@text, class: @classes)
       end
     end
   end

--- a/config/importmap.rb
+++ b/config/importmap.rb
@@ -8,7 +8,7 @@ pin "@hotwired/stimulus", to: "stimulus.min.js"
 pin "@hotwired/stimulus-loading", to: "stimulus-loading.js"
 # pin "flowbite", to: "https://cdn.jsdelivr.net/npm/flowbite@2.5.2/dist/flowbite.turbo.min.js"
 pin "luxon", to: "https://cdn.jsdelivr.net/npm/luxon@3.5.0/build/es6/luxon.js"
-pin "@bikeindex/time-localizer", to: "https://cdn.jsdelivr.net/npm/@bikeindex/time-localizer@0.2.1/dist/index.js"
+pin "@bikeindex/time-localizer", to: "https://cdn.jsdelivr.net/npm/@bikeindex/time-localizer@0.3.0/dist/index.js"
 pin "@floating-ui/dom", to: "https://cdn.jsdelivr.net/npm/@floating-ui/dom@1.7.3/+esm"
 
 # jQuery is required for select2, which is used by search. It should not be used!

--- a/spec/components/ui/user_text_block_display/component_spec.rb
+++ b/spec/components/ui/user_text_block_display/component_spec.rb
@@ -16,6 +16,22 @@ RSpec.describe UI::UserTextBlockDisplay::Component, type: :component do
     expect(component).to have_text text.strip
   end
 
+  it "renders without leading whitespace in the text block" do
+    inner_html = component.css("div").first.inner_html
+    expect(inner_html).to eq(text.strip)
+  end
+
+  it "includes the overflow class" do
+    expect(component.css("div").first["class"]).to include("tw:overflow-y-auto")
+  end
+
+  context "blank max_height_class" do
+    let(:options) { {text:, max_height_class: ""} }
+    it "omits the overflow class" do
+      expect(component.css("div").first["class"]).to_not include("tw:overflow-y-auto")
+    end
+  end
+
   context "no text" do
     let(:text) { "\n  " }
     it "does not render" do


### PR DESCRIPTION
Update binxtils from 0.4.2 to 0.5.1 and bump the gem's npm counterpart `@bikeindex/time-localizer` (pinned in `config/importmap.rb`) from 0.2.1 to 0.3.0.

Both are bug-fix releases from the [bikeindex/binxtils](https://github.com/bikeindex/binxtils) repo — no breaking changes:

- `TimeParser` infinite-recursion fix on invalid month, plus fixes for 500s from unparseable time params
- time-localizer JS fixes and deduped Luxon bundling
- `bin/release` version validation

---

Also includes a small update to the `UI::UserTextBlockDisplay` Component
