### PR TITLE
Redirect bikehub logout to parkit.bikehub.com

### DIFF
--- a/app/controllers/concerns/controller_helpers.rb
+++ b/app/controllers/concerns/controller_helpers.rb
@@ -425,10 +425,6 @@ module ControllerHelpers
     "#{valid_partner_domain || "https://parkit.bikehub.com"}/#{path}"
   end
 
-  def bikehub_website_url(path = nil)
-    "#{valid_partner_domain || "https://bikehub.com"}/#{path}"
-  end
-
   def currency_from_params
     Currency.friendly_find(params.permit(:currency)[:currency])
   end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -65,7 +65,7 @@ class SessionsController < ApplicationController
   def destroy
     remove_session
     if params[:partner] == "bikehub"
-      redirect_to(bikehub_website_url, allow_other_host: true) && return
+      redirect_to(bikehub_url, allow_other_host: true) && return
     elsif params[:redirect_location].present?
       if params[:redirect_location].match?("new_user")
         redirect_to(new_user_path, notice: "Logged out!") && return

--- a/spec/controllers/sessions_controller_spec.rb
+++ b/spec/controllers/sessions_controller_spec.rb
@@ -192,7 +192,7 @@ RSpec.describe SessionsController, type: :controller do
         get :destroy, params: {partner: "bikehub"}
         expect(cookies.signed[:auth]).to be_nil
         expect(session[:user_id]).to be_nil
-        expect(response).to redirect_to "https://bikehub.com/"
+        expect(response).to redirect_to "https://parkit.bikehub.com/"
         expect(session[:return_to]).to be_nil
         expect(session[:partner]).to be_nil
         expect(session[:passive_organization_id]).to be_nil
@@ -216,7 +216,7 @@ RSpec.describe SessionsController, type: :controller do
             get :destroy, params: {partner: "bikehub", return_to: "https://badplace.stuff.com/"}
             expect(cookies.signed[:auth]).to be_nil
             expect(session[:user_id]).to be_nil
-            expect(response).to redirect_to "https://bikehub.com/"
+            expect(response).to redirect_to "https://parkit.bikehub.com/"
             expect(session[:return_to]).to be_nil
             expect(session[:partner]).to be_nil
             expect(session[:passive_organization_id]).to be_nil


### PR DESCRIPTION
The `?partner=bikehub` logout previously redirected to `https://bikehub.com` (which forwards to `www.bikehub.com`); it now lands on `https://parkit.bikehub.com`.

- Point the logout redirect at `bikehub_url`, which already falls back to `https://parkit.bikehub.com`.
- Remove the now-unused `bikehub_website_url` helper (it was identical to `bikehub_url` apart from the old fallback host).
- A valid partner `return_to`/`redirect_uri` (e.g. `staging.bikehub.com`) still takes precedence — only the default fallback changed.
