### PR TITLE
Fall back to a default BASE_URL during asset precompile

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,7 +19,7 @@ Ruby is formatted with the standard gem. Run `bin/lint` to automatically format 
 - Omit named arguments' values from hashes (ie prefer `{x:, y:}` instead of `{x: x, y: y}`)
 - Prefer less code, by character count (excluding whitespace and comments). Use `bin/char_count {FILE OR FOLDER}` to get the non-whitespace character count
 - prefer un-abbreviated variable names
-- Keep comments pithy, and only where they add value (often none is needed). Write for a future reader, not as a changelog: explain *why* the code is the way it is, and omit what was only relevant to the change that introduced it (the failure you hit, the env vars in play at the time, what the line used to be)
+- Keep comments pithy and only where they add value — often none. Explain *why* for a future reader; don't narrate the change that introduced the code
 
 ## Testing
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,7 +19,7 @@ Ruby is formatted with the standard gem. Run `bin/lint` to automatically format 
 - Omit named arguments' values from hashes (ie prefer `{x:, y:}` instead of `{x: x, y: y}`)
 - Prefer less code, by character count (excluding whitespace and comments). Use `bin/char_count {FILE OR FOLDER}` to get the non-whitespace character count
 - prefer un-abbreviated variable names
-- Keep comments pithy and only where they add value — often none. Explain *why* for a future reader; don't narrate the change that introduced the code
+- Keep comments pithy — often they aren't necessary. Explain *why* for a future reader; don't narrate the change that introduced the code
 
 ## Testing
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,7 +19,7 @@ Ruby is formatted with the standard gem. Run `bin/lint` to automatically format 
 - Omit named arguments' values from hashes (ie prefer `{x:, y:}` instead of `{x: x, y: y}`)
 - Prefer less code, by character count (excluding whitespace and comments). Use `bin/char_count {FILE OR FOLDER}` to get the non-whitespace character count
 - prefer un-abbreviated variable names
-- Keep comments pithy — ideally one line. Write for a future reader, not as a changelog: explain *why* the code is the way it is, and omit what was only relevant to the change that introduced it (the failure you hit, the env vars in play at the time, what the line used to be)
+- Keep comments pithy, and only where they add value (often none is needed). Write for a future reader, not as a changelog: explain *why* the code is the way it is, and omit what was only relevant to the change that introduced it (the failure you hit, the env vars in play at the time, what the line used to be)
 
 ## Testing
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,6 +19,7 @@ Ruby is formatted with the standard gem. Run `bin/lint` to automatically format 
 - Omit named arguments' values from hashes (ie prefer `{x:, y:}` instead of `{x: x, y: y}`)
 - Prefer less code, by character count (excluding whitespace and comments). Use `bin/char_count {FILE OR FOLDER}` to get the non-whitespace character count
 - prefer un-abbreviated variable names
+- Keep comments pithy — ideally one line. Write for a future reader, not as a changelog: explain *why* the code is the way it is, and omit what was only relevant to the change that introduced it (the failure you hit, the env vars in play at the time, what the line used to be)
 
 ## Testing
 

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -107,7 +107,6 @@ Rails.application.configure do
   # Do not dump schema after migrations.
   config.active_record.dump_schema_after_migration = false
 
-  # Fallback for asset precompile, which boots without BASE_URL; deploys set it.
   base_url = URI.parse(ENV.fetch("BASE_URL", "https://bikeindex.org"))
   config.action_mailer.default_url_options = {protocol: base_url.scheme, host: base_url.host}
   routes.default_url_options = config.action_mailer.default_url_options

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -107,9 +107,7 @@ Rails.application.configure do
   # Do not dump schema after migrations.
   config.active_record.dump_schema_after_migration = false
 
-  # Fallback so assets:precompile works at Docker build time, where BASE_URL
-  # isn't set (only SECRET_KEY_BASE/REDIS_URL are). The value is irrelevant
-  # during precompile; real deploys set BASE_URL.
+  # Fallback for asset precompile, which boots without BASE_URL; deploys set it.
   base_url = URI.parse(ENV.fetch("BASE_URL", "https://bikeindex.org"))
   config.action_mailer.default_url_options = {protocol: base_url.scheme, host: base_url.host}
   routes.default_url_options = config.action_mailer.default_url_options

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -107,7 +107,10 @@ Rails.application.configure do
   # Do not dump schema after migrations.
   config.active_record.dump_schema_after_migration = false
 
-  base_url = URI.parse(ENV.fetch("BASE_URL"))
+  # Fallback so assets:precompile works at Docker build time, where BASE_URL
+  # isn't set (only SECRET_KEY_BASE/REDIS_URL are). The value is irrelevant
+  # during precompile; real deploys set BASE_URL.
+  base_url = URI.parse(ENV.fetch("BASE_URL", "https://bikeindex.org"))
   config.action_mailer.default_url_options = {protocol: base_url.scheme, host: base_url.host}
   routes.default_url_options = config.action_mailer.default_url_options
 


### PR DESCRIPTION
Review-app builds were failing at `assets:precompile` with `KeyError: key not found: "BASE_URL"`.

- The build precompiles with `RAILS_ENV=staging`, which loads `config/environments/production.rb`. `#3664` made it read `ENV.fetch("BASE_URL")`, but that only worked because `config/boot.rb` loaded `bin/env` in staging, which defaulted `BASE_URL`.
- `#3688` stopped loading `bin/env` in staging, dropping that default — so the latent `ENV.fetch` started raising and broke every build (the precompile step sets only `SECRET_KEY_BASE`/`REDIS_URL`).
- Fix: default to `https://bikeindex.org` when `BASE_URL` is absent. The value is irrelevant during precompile, real deploys (`deploy.review.yml`, production) set it at runtime, and the default matches production's pre-`#3664` host so production stays safe even if its env omits `BASE_URL`.
- Also adds an `AGENTS.md` guideline to keep code comments pithy and reader-focused.
