### PR TITLE
Always show vehicle select fields in organization embed forms

### DIFF
--- a/app/assets/javascripts/embed.js.erb
+++ b/app/assets/javascripts/embed.js.erb
@@ -3,7 +3,7 @@
 //
 //= require external_scripts/embed_dependencies.js
 //= require revised/components/check_email.js
+//= require revised/components/update_propulsion_type.js
 //= require external_scripts/selectize_placeholder_plugin.js
-//= require external_scripts/bootstrap-transition.js
-//= require external_scripts/bootstrap-alert.js
+//= require external_scripts/bootstrap
 //= require embed_scripts/embed_script

--- a/app/assets/javascripts/embed_scripts/embed_script.coffee
+++ b/app/assets/javascripts/embed_scripts/embed_script.coffee
@@ -242,6 +242,9 @@ $(document).ready ->
 
   new window.CheckEmail('#bike_owner_email')
 
+  # cycleTypes are only defined on pages rendering the embed_fields partial
+  new window.UpdatePropulsionType('bike') if window.cycleTypesAlwaysMotorized?
+
   if $("#new-unregistered-parking-notification").length
     initializeUnregisteredParkingNotification()
 

--- a/app/assets/stylesheets/embed_styles.scss
+++ b/app/assets/stylesheets/embed_styles.scss
@@ -288,6 +288,7 @@ a {
   clear: both;
   padding-top: 1.25em;
 
+  // new_iframe still renders a cycle_type select in the submit row
   select {
     margin: 0;
   }
@@ -301,12 +302,6 @@ a {
     &[disabled]:hover {
       background: #cacaca !important;
     }
-  }
-
-  .what-you-register {
-    color: $grayLight;
-    display: inline-block;
-    margin: 0 0.5em;
   }
 
   .please-wait-text {
@@ -667,9 +662,11 @@ a {
 }
 
 // cursor classes required for #motorizedWrapper
-.cusor-pointer {
+.cusor-pointer,
+.cursor-pointer {
   cursor: pointer;
 }
-.cursor-not-allowed {
+.cursor-not-allowed,
+.optional-checkbox label.cursor-not-allowed {
   cursor: not-allowed;
 }

--- a/app/assets/stylesheets/embed_styles.scss
+++ b/app/assets/stylesheets/embed_styles.scss
@@ -5,12 +5,16 @@
 }
 
 // Ellipsize long items (e.g. cycle_type names) so selectize's focus input
-// isn't pushed onto an empty row below
+// isn't pushed onto an empty row below. The hanging indent from
+// custom_selects would clip the first character once overflow is hidden,
+// and a single-line item never wraps — reset it.
 .control-group .selectize-control.single .selectize-input > .item {
   max-width: calc(100% - 12px);
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
+  margin-left: 0;
+  text-indent: 0;
 }
 
 @import "legacy_includes/_colors.scss";
@@ -19,6 +23,7 @@
 @import "legacy_includes/component-animations.scss";
 @import "legacy_includes/dropdowns.scss";
 @import "legacy_includes/embed_form_styles.scss";
+@import "revised/sections/custom_selects.scss";
 
 $newStolenColor: #d25627;
 

--- a/app/assets/stylesheets/embed_styles.scss
+++ b/app/assets/stylesheets/embed_styles.scss
@@ -4,6 +4,15 @@
   width: 210px;
 }
 
+// Ellipsize long items (e.g. cycle_type names) so selectize's focus input
+// isn't pushed onto an empty row below
+.control-group .selectize-control.single .selectize-input > .item {
+  max-width: calc(100% - 12px);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
 @import "legacy_includes/_colors.scss";
 @import "legacy_includes/_variables.scss";
 @import "legacy_includes/_mixins.scss";

--- a/app/assets/stylesheets/embed_styles.scss
+++ b/app/assets/stylesheets/embed_styles.scss
@@ -1,22 +1,4 @@
 @import "legacy_includes/selectize_bootstrap3.scss";
-
-.control-group .selectize-control {
-  width: 210px;
-}
-
-// Ellipsize long items (e.g. cycle_type names) so selectize's focus input
-// isn't pushed onto an empty row below. The hanging indent from
-// custom_selects would clip the first character once overflow is hidden,
-// and a single-line item never wraps — reset it.
-.control-group .selectize-control.single .selectize-input > .item {
-  max-width: calc(100% - 12px);
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  margin-left: 0;
-  text-indent: 0;
-}
-
 @import "legacy_includes/_colors.scss";
 @import "legacy_includes/_variables.scss";
 @import "legacy_includes/_mixins.scss";
@@ -83,6 +65,19 @@ $newStolenColor: #d25627;
     font-size: 16px;
     min-height: 29px;
   }
+}
+
+// Ellipsize long items (e.g. cycle_type names) so selectize's focus input
+// isn't pushed onto an empty row below. The hanging indent from
+// custom_selects would clip the first character once overflow is hidden,
+// and a single-line item never wraps — reset it.
+.control-group .selectize-control.single .selectize-input > .item {
+  max-width: calc(100% - 12px);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  margin-left: 0;
+  text-indent: 0;
 }
 
 label.strong {
@@ -328,7 +323,8 @@ a {
 }
 
 .select-jsonified .select2-container,
-.chosen-select .controls .select2-container {
+.chosen-select .controls .select2-container,
+.control-group .selectize-control {
   width: 210px;
 }
 

--- a/app/assets/stylesheets/embed_styles.scss
+++ b/app/assets/stylesheets/embed_styles.scss
@@ -71,7 +71,7 @@ $newStolenColor: #d25627;
 // isn't pushed onto an empty row below. The hanging indent from
 // custom_selects would clip the first character once overflow is hidden,
 // and a single-line item never wraps — reset it.
-.control-group .selectize-control.single .selectize-input > .item {
+.selectize-control.single .selectize-input > .item {
   max-width: calc(100% - 12px);
   white-space: nowrap;
   overflow: hidden;
@@ -333,7 +333,8 @@ a {
 
 .select-jsonified .select2-container,
 .chosen-select .controls .select2-container,
-.control-group .selectize-control {
+.control-group .selectize-control,
+.vehicle-select .selectize-control {
   width: 210px;
 }
 

--- a/app/assets/stylesheets/embed_styles.scss
+++ b/app/assets/stylesheets/embed_styles.scss
@@ -297,9 +297,18 @@ a {
   clear: both;
   padding-top: 1.25em;
 
-  // new_iframe still renders a cycle_type select in the submit row
   select {
     margin: 0;
+    max-width: 100%;
+  }
+
+  .vehicle-select {
+    clear: both;
+    padding: 0.25em 0 0.5em;
+
+    label {
+      margin-left: 0.25em;
+    }
   }
 
   input.button-submit {

--- a/app/assets/stylesheets/embed_styles.scss
+++ b/app/assets/stylesheets/embed_styles.scss
@@ -682,11 +682,9 @@ a {
 }
 
 // cursor classes required for #motorizedWrapper
-.cusor-pointer,
 .cursor-pointer {
   cursor: pointer;
 }
-.cursor-not-allowed,
-.optional-checkbox label.cursor-not-allowed {
+.cursor-not-allowed {
   cursor: not-allowed;
 }

--- a/app/views/organizations/_embed_fields.html.erb
+++ b/app/views/organizations/_embed_fields.html.erb
@@ -354,7 +354,7 @@
   <div class="submit-registration">
     <%= submit_tag t(".register"), class: "button-submit" %>
 
-    <div class="vehicle-select">
+    <div class="vehicle-select special-select-single">
       <%= f.select :cycle_type, CycleType.select_options(traditional_bike: true), {}, {required: true} %>
 
       <label id="motorizedWrapper">

--- a/app/views/organizations/_embed_fields.html.erb
+++ b/app/views/organizations/_embed_fields.html.erb
@@ -5,6 +5,30 @@
 <%= f.hidden_field :creation_organization_id %>
 <%= f.hidden_field :embeded, value: true %>
 
+<script>
+  window.cycleTypesPedals = <%= CycleType::PEDAL.to_json.html_safe %>;
+  window.cycleTypesAlwaysMotorized = <%= CycleType::ALWAYS_MOTORIZED.to_json.html_safe %>;
+  window.cycleTypesNeverMotorized = <%= CycleType::NEVER_MOTORIZED.to_json.html_safe %>;
+</script>
+
+<div class="input-group">
+  <div class="control-group special-select-single">
+    <%= f.label :cycle_type, t(".vehicle_type") %>
+
+    <div class="controls">
+      <%= f.select :cycle_type, CycleType.select_options(traditional_bike: true), {}, {required: true} %>
+    </div>
+  </div>
+
+  <div class="optional-checkbox">
+    <label id="motorizedWrapper" style="margin-top: 0.25em">
+      <%= check_box_tag :propulsion_type_motorized, true, @bike.motorized? %>
+      <strong>⚡️</strong>
+      <%= t(".electric_motorized") %>
+    </label>
+  </div>
+</div>
+
 <div class="input-group">
   <div class="control-group">
     <%= f.label :serial_number %>
@@ -347,8 +371,6 @@
 
   <div class="submit-registration">
     <%= submit_tag t(".register"), class: "button-submit" %>
-    <span class="what-you-register"><%= t(".this") %></span>
-    <%= select(:bike, :cycle_type, CycleType.select_options, { required: true }) %>
 
     <div class="please-wait-text less-strong"><%= t(".please_wait") %></div>
   </div>

--- a/app/views/organizations/_embed_fields.html.erb
+++ b/app/views/organizations/_embed_fields.html.erb
@@ -12,24 +12,6 @@
 </script>
 
 <div class="input-group">
-  <div class="control-group special-select-single">
-    <%= f.label :cycle_type, t(".vehicle_type") %>
-
-    <div class="controls">
-      <%= f.select :cycle_type, CycleType.select_options(traditional_bike: true), {}, {required: true} %>
-    </div>
-  </div>
-
-  <div class="optional-checkbox">
-    <label id="motorizedWrapper" style="margin-top: 0.25em">
-      <%= check_box_tag :propulsion_type_motorized, true, @bike.motorized? %>
-      <strong>⚡️</strong>
-      <%= t(".electric_motorized") %>
-    </label>
-  </div>
-</div>
-
-<div class="input-group">
   <div class="control-group">
     <%= f.label :serial_number %>
 
@@ -371,6 +353,16 @@
 
   <div class="submit-registration">
     <%= submit_tag t(".register"), class: "button-submit" %>
+
+    <div class="vehicle-select">
+      <%= f.select :cycle_type, CycleType.select_options(traditional_bike: true), {}, {required: true} %>
+
+      <label id="motorizedWrapper">
+        <%= check_box_tag :propulsion_type_motorized, true, @bike.motorized? %>
+        <strong>⚡️</strong>
+        <%= t(".electric_motorized") %>
+      </label>
+    </div>
 
     <div class="please-wait-text less-strong"><%= t(".please_wait") %></div>
   </div>

--- a/bin/setup
+++ b/bin/setup
@@ -88,6 +88,11 @@ chdir APP_ROOT do
   system "bin/rake db:create db:schema:load:primary db:schema:load:analytics db:migrate"
 
   unless without_seeds
+    # Build stylesheets so seeding can render emails. Seeding delivers mailers
+    # without compilation Sprockets tries to compile email.scss and with sassc, but should use dartsass
+    puts "\n== Building stylesheets =="
+    system! "bin/rails dartsass:build"
+
     puts "\n== Seeding database =="
     system! "bin/rake db:seed"
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -4170,6 +4170,7 @@ en:
       description_of_the_theft: Description of the theft
       eg_if_we_tweet_about_or_someone_searches: e.g., if we tweet about or someone
         searches for its serial number
+      electric_motorized: Electric (motorized)
       email_address_owner: Owner's email address
       email_address_you: Your email address
       filing_a_police_report_is_important_html: >-
@@ -4200,10 +4201,10 @@ en:
       sticker_id: Sticker ID
       student_id: Student ID
       third_color: Third color
-      this: this
       unknown_serial: Unknown serial
       unknown_year: Unknown year
       unsure_or_unknown: Unsure or unknown
+      vehicle_type: Vehicle type
       when_was_it_stolen: When was it stolen?
       where_was_it_stolen: Where was it stolen?
       zipcode: Postal Code

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -4204,7 +4204,6 @@ en:
       unknown_serial: Unknown serial
       unknown_year: Unknown year
       unsure_or_unknown: Unsure or unknown
-      vehicle_type: Vehicle type
       when_was_it_stolen: When was it stolen?
       where_was_it_stolen: Where was it stolen?
       zipcode: Postal Code

--- a/spec/requests/bikes/create_request_spec.rb
+++ b/spec/requests/bikes/create_request_spec.rb
@@ -473,6 +473,24 @@ RSpec.describe "BikesController#create", type: :request do
       expect(bike_sticker.bike&.id).to eq new_bike.id
       expect(bike_sticker.bike_sticker_updates.count).to eq 1
     end
+    context "electric (motorized) checkbox" do
+      it "creates a motorized bike" do
+        expect {
+          # The embed form submits propulsion_type_motorized as a top-level param
+          post base_url, params: {
+            bike: bike_params.except(:embeded_extended).merge(cycle_type: "bike"),
+            propulsion_type_motorized: "true"
+          }
+        }.to change(Bike, :count).by(1)
+
+        new_bike = b_param.reload.created_bike
+        expect(response).to redirect_to(embed_create_success_organization_path(organization.slug, bike_id: new_bike.id))
+        # for_vehicle coerces motorized to the cycle_type's default motorized propulsion
+        expect(new_bike).to have_attributes(cycle_type: "bike", propulsion_type: "pedal-assist")
+        expect(new_bike.motorized?).to be_truthy
+        expect(new_bike.current_ownership.origin).to eq "embed"
+      end
+    end
     context "no organization" do
       it "registers" do
         b_param.reload


### PR DESCRIPTION
The organization embed forms (`/organizations/:id/embed` and `embed_extended`) now have the vehicle select fields the registration widget has — always visible, with no `@vehicle_select` toggle.

- Add the ⚡️ Electric (motorized) checkbox below the cycle type select in the submit row of `organizations/_embed_fields`, and give the select the registration widget's options (`CycleType.select_options(traditional_bike: true)`).
- Wire up the matching JS in the embed bundle: include the shared `UpdatePropulsionType` component (auto-check/disable the checkbox for always/never-motorized types) and swap the standalone bootstrap-2 alert/transition files for the full bootstrap bundle the registration widget already uses (the component needs the collapse plugin).
- Match the embed styles: import `revised/sections/custom_selects` into `embed_styles`, add the cursor classes the JS toggles, and ellipsize selectize items so long names don't push the focus input onto an empty row.
- Also: `bin/setup` builds stylesheets (dartsass) before seeding, so seed mailers don't hit a sassc error compiling `email.scss`.
