### PR TITLE
Sync translations branch via GitHub App token so PR gets required checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -150,8 +150,24 @@ jobs:
           install-libfuse2: false
       - name: Ensure ImageMagick is available
         run: echo $(identify --version)
+      # Mint a token from the translations-sync GitHub App and have checkout persist
+      # it as the git credentials, so the sync branch is pushed as the App rather
+      # than the default GITHUB_TOKEN. Only an App-authenticated push fires
+      # `on: push` and attaches the required check runs to the PR; the default
+      # token is blocked from triggering those events. Skipped (falling back to
+      # the default checkout creds) until the App secrets exist, so main CI keeps
+      # passing in the meantime.
+      - name: Mint translations-sync token
+        id: translations_token
+        if: matrix.ci_node_index == 1 && github.ref == 'refs/heads/main' && env.TRANSLATIONS_SYNC_APP_ID != ''
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.TRANSLATIONS_SYNC_APP_ID }}
+          private-key: ${{ secrets.TRANSLATIONS_SYNC_APP_PRIVATE_KEY }}
       - name: Checkout code
         uses: actions/checkout@v6
+        with:
+          token: ${{ steps.translations_token.outputs.token || github.token }}
       # Install Ruby dependencies
       - name: Install Ruby and gems
         uses: ruby/setup-ruby@v1
@@ -160,19 +176,6 @@ jobs:
       - run: bundle install
       - name: Set up database
         run: bin/rails db:create db:schema:load:primary db:schema:load:analytics db:migrate
-      # Mint a token from the translations-sync GitHub App. Pushing the sync
-      # branch with this (rather than the default GITHUB_TOKEN) is what lets the
-      # subsequent push fire `on: push` and attach real, required check runs to
-      # the PR — the default token is blocked from triggering those events.
-      # Skipped (with a github.token fallback) until the App secrets exist, so
-      # main CI keeps passing in the meantime.
-      - name: Mint translations-sync token
-        id: translations_token
-        if: matrix.ci_node_index == 1 && github.ref == 'refs/heads/main' && env.TRANSLATIONS_SYNC_APP_ID != ''
-        uses: actions/create-github-app-token@v2
-        with:
-          app-id: ${{ secrets.TRANSLATIONS_SYNC_APP_ID }}
-          private-key: ${{ secrets.TRANSLATIONS_SYNC_APP_PRIVATE_KEY }}
       - name: Sync translations (only on main by default)
         if: matrix.ci_node_index == 1
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -150,13 +150,10 @@ jobs:
           install-libfuse2: false
       - name: Ensure ImageMagick is available
         run: echo $(identify --version)
-      # Mint a token from the translations-sync GitHub App and have checkout persist
-      # it as the git credentials, so the sync branch is pushed as the App rather
-      # than the default GITHUB_TOKEN. Only an App-authenticated push fires
-      # `on: push` and attaches the required check runs to the PR; the default
-      # token is blocked from triggering those events. Skipped (falling back to
-      # the default checkout creds) until the App secrets exist, so main CI keeps
-      # passing in the meantime.
+      # Checkout persists this App token (below) as the git creds so the sync
+      # branch is pushed as the App — only a non-default-token push fires
+      # `on: push`, which is what attaches the required checks to the PR.
+      # Falls back to default creds until the App secrets exist.
       - name: Mint translations-sync token
         id: translations_token
         if: matrix.ci_node_index == 1 && github.ref == 'refs/heads/main' && env.TRANSLATIONS_SYNC_APP_ID != ''

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,10 +2,6 @@ name: CI
 
 on:
   push:
-  # Allows bin/check_translations to trigger CI on the translations-sync branch.
-  # Pushes made with the default GITHUB_TOKEN don't fire `on: push`, so the
-  # automated translations PR otherwise gets no checks.
-  workflow_dispatch:
 
 permissions:
   actions: write
@@ -126,6 +122,7 @@ jobs:
       COVERAGE: false # additional configuration is needed for parallelized tests
       CC_TEST_REPORTER_ID: 04daa6564351115dc1515504790cd379ad8dc25e7778f0641e0f8c63185f887c
       TRANSLATION_BRANCH: main
+      TRANSLATIONS_SYNC_APP_ID: ${{ secrets.TRANSLATIONS_SYNC_APP_ID }}
       RETRY_FLAKY: true
       KNAPSACK_PRO_TEST_SUITE_TOKEN_RSPEC: ${{ secrets.KNAPSACK_PRO_TEST_SUITE_TOKEN_RSPEC }}
       KNAPSACK_PRO_CI_NODE_TOTAL: ${{ matrix.ci_node_total }}
@@ -163,10 +160,23 @@ jobs:
       - run: bundle install
       - name: Set up database
         run: bin/rails db:create db:schema:load:primary db:schema:load:analytics db:migrate
+      # Mint a token from the translations-sync GitHub App. Pushing the sync
+      # branch with this (rather than the default GITHUB_TOKEN) is what lets the
+      # subsequent push fire `on: push` and attach real, required check runs to
+      # the PR — the default token is blocked from triggering those events.
+      # Skipped (with a github.token fallback) until the App secrets exist, so
+      # main CI keeps passing in the meantime.
+      - name: Mint translations-sync token
+        id: translations_token
+        if: matrix.ci_node_index == 1 && github.ref == 'refs/heads/main' && env.TRANSLATIONS_SYNC_APP_ID != ''
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.TRANSLATIONS_SYNC_APP_ID }}
+          private-key: ${{ secrets.TRANSLATIONS_SYNC_APP_PRIVATE_KEY }}
       - name: Sync translations (only on main by default)
         if: matrix.ci_node_index == 1
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ steps.translations_token.outputs.token || github.token }}
         run: bin/check_translations ${{ secrets.TRANSLATION_IO_API_KEY }}
       # Cache compiled assets + sprockets' incremental cache.
       # Key hashes every input the three asset tools read:

--- a/bin/check_translations
+++ b/bin/check_translations
@@ -69,7 +69,13 @@ else
     git stash pop || true
     git add config/locales/
     git commit -m "translations sync"
-    git push origin "$branch_name"
+
+    # Push authenticated as $GH_TOKEN (the translations-sync GitHub App token in
+    # CI) rather than via the checkout's embedded GITHUB_TOKEN. A push from a
+    # non-default token fires `on: push`, so the branch gets the real CI run
+    # whose check runs attach to the PR and satisfy branch protection. A push
+    # with the default GITHUB_TOKEN would run no workflows at all.
+    git push "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" "$branch_name"
 
     gh pr create \
       --title "Automated translations sync from CI" \
@@ -77,13 +83,7 @@ else
       --base main \
       --head "$branch_name"
 
-    # Pushes made with the default GITHUB_TOKEN don't trigger workflows, so the
-    # branch we just pushed won't run `on: push` CI. Dispatch it explicitly so
-    # the PR gets checks. (ci.yml must declare `workflow_dispatch`.)
-    output "${YELLOW}" "Dispatching CI on ${branch_name}"
-    gh workflow run ci.yml --ref "$branch_name"
-
-    output "${YELLOW}" "PR created. Build will fail until the PR is merged."
+    output "${YELLOW}" "PR created with CI running. Build will fail until the PR is merged."
   fi
 
   exit 1

--- a/bin/check_translations
+++ b/bin/check_translations
@@ -70,12 +70,12 @@ else
     git add config/locales/
     git commit -m "translations sync"
 
-    # Push authenticated as $GH_TOKEN (the translations-sync GitHub App token in
-    # CI) rather than via the checkout's embedded GITHUB_TOKEN. A push from a
-    # non-default token fires `on: push`, so the branch gets the real CI run
-    # whose check runs attach to the PR and satisfy branch protection. A push
-    # with the default GITHUB_TOKEN would run no workflows at all.
-    git push "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" "$branch_name"
+    # In CI the checkout persists the translations-sync GitHub App token as the
+    # git credentials, so this push authenticates as the App, not the default
+    # GITHUB_TOKEN. Only an App-authenticated push fires `on: push`, giving the
+    # branch the CI run whose check runs attach to the PR and satisfy branch
+    # protection. A default-token push would run no workflows at all.
+    git push origin "$branch_name"
 
     gh pr create \
       --title "Automated translations sync from CI" \

--- a/bin/check_translations
+++ b/bin/check_translations
@@ -70,11 +70,9 @@ else
     git add config/locales/
     git commit -m "translations sync"
 
-    # In CI the checkout persists the translations-sync GitHub App token as the
-    # git credentials, so this push authenticates as the App, not the default
-    # GITHUB_TOKEN. Only an App-authenticated push fires `on: push`, giving the
-    # branch the CI run whose check runs attach to the PR and satisfy branch
-    # protection. A default-token push would run no workflows at all.
+    # In CI the checkout persists the App token as git creds, so this pushes as
+    # the App — a non-default-token push is what fires `on: push` and gives the
+    # PR its required checks. A default-token push triggers no workflows at all.
     git push origin "$branch_name"
 
     gh pr create \


### PR DESCRIPTION
The automated translations sync ([#3669](https://github.com/bikeindex/bike_index/pull/3669)) made CI *run* on the sync branch, but those runs never satisfied branch protection — `main` requires six GitHub Actions check runs (`lint_and_scan`, `Run tests (5, 0..4)`), and a `workflow_dispatch` run isn't linked to the PR, so its checks don't count. Root cause: the branch is pushed with the default `GITHUB_TOKEN`, which is blocked from firing the `on: push` event that produces PR-linked checks.

- `ci.yml` mints a GitHub App installation token (`actions/create-github-app-token`, node 1 / `main` only) and passes it to `actions/checkout` as the `token:`, so the checkout persists the App identity as the git credentials. Removes the `workflow_dispatch` trigger.
- `bin/check_translations` pushes the sync branch with a plain `git push origin`; because checkout persisted the App token, the push authenticates as the App and fires `on: push` → the branch's real CI run attaches the six required checks to the PR. Drops the superseded `gh workflow run ci.yml` dispatch.
- Falls back to the default checkout creds until the App secrets exist, so main CI keeps passing in the meantime.

Verified end-to-end on a throwaway branch before merge: the App token mints, an App-authenticated push succeeds, and it creates an `event=push` CI run (so checks attach). A first attempt that embedded the token in the push URL was proven *not* to work — `actions/checkout@v6` keeps the default token in an `includeIf`'d credentials file that overrides URL-embedded auth — which is why this uses the checkout `token:` input instead.

Requires two repo secrets (already added): `TRANSLATIONS_SYNC_APP_ID` and `TRANSLATIONS_SYNC_APP_PRIVATE_KEY` — a GitHub App with Contents + Pull requests read/write, installed on this repo.
