### PR TITLE
Fix flaky impound status by bumping all shared parking notifications

### DIFF
--- a/app/jobs/process_impound_updates_job.rb
+++ b/app/jobs/process_impound_updates_job.rb
@@ -25,8 +25,10 @@ class ProcessImpoundUpdatesJob < ApplicationJob
       impound_record_update.update(processed: true, skip_update: true)
     end
     impound_record.reload.update(skip_update: true)
-    # Bump the parking notification to ensure it reflects current state (resolving if relevant)
-    impound_record.parking_notification&.update(updated_at: Time.current)
+    # Bump every parking notification on this record so each reflects the current state (resolving if
+    # relevant). They share impound_record_id, so has_one :parking_notification would pick one arbitrarily.
+    ParkingNotification.where(impound_record_id: impound_record.id)
+      .find_each { |parking_notification| parking_notification.update(updated_at: Time.current) }
     if claim_retrieved.present?
       merge_impound_claim(impound_record, claim_retrieved)
     else

--- a/spec/models/parking_notification_spec.rb
+++ b/spec/models/parking_notification_spec.rb
@@ -241,7 +241,7 @@ RSpec.describe ParkingNotification, type: :model do
     end
 
     context "when a repeat notification impounds" do
-      it "creates an impound record", :flaky do
+      it "creates an impound record" do
         bike.reload
         expect(bike.status).to eq "unregistered_parking_notification"
         expect(bike.user_hidden).to be_truthy


### PR DESCRIPTION
A repeat parking notification that impounds a bike intermittently left its status stuck at `impounded` instead of `impounded_retrieved` after ownership transfer ([flaky CI run](https://github.com/bikeindex/bike_index/actions/runs/27361959725/job/80851375688)).

- `ProcessParkingNotificationJob` propagates `impound_record_id` onto every notification in the chain, so multiple `parking_notifications` share one impound record. `ProcessImpoundUpdatesJob` then refreshed via `has_one :parking_notification`, which — lacking an `ORDER BY` — returned an arbitrary row; when it picked a replaced sibling, the impound notification was never recomputed.
- Fix: bump every notification sharing the `impound_record_id` so each reflects current state, deterministically. Reproduced locally (~1/60 runs) and verified 0 failures across 30+ seeds after the fix.
- Drops the now-unneeded `:flaky` tag on the spec.
