### PR TITLE
Force turbo_stream format on Search::ComboboxController

### DIFF
--- a/app/controllers/search/combobox_controller.rb
+++ b/app/controllers/search/combobox_controller.rb
@@ -6,6 +6,12 @@ module Search
   class ComboboxController < ApplicationController
     PER_PAGE = 15
 
+    # Both actions only ever render turbo_stream (the hotwire_combobox partials
+    # exist solely in that format). Clients that drop the format param - e.g. a
+    # crawler following the pagination src with HTML-encoded "&amp;format=..." -
+    # would otherwise default to :html and raise ActionView::MissingTemplate.
+    before_action { request.format = :turbo_stream }
+
     def options
       matches = Autocomplete::Matcher.search(autocomplete_params)
       next_page = (matches.length >= PER_PAGE) ? current_page + 1 : nil

--- a/app/controllers/search/combobox_controller.rb
+++ b/app/controllers/search/combobox_controller.rb
@@ -6,10 +6,7 @@ module Search
   class ComboboxController < ApplicationController
     PER_PAGE = 15
 
-    # Both actions only ever render turbo_stream (the hotwire_combobox partials
-    # exist solely in that format). Clients that drop the format param - e.g. a
-    # crawler following the pagination src with HTML-encoded "&amp;format=..." -
-    # would otherwise default to :html and raise ActionView::MissingTemplate.
+    # Both actions only ever render turbo_stream
     before_action { request.format = :turbo_stream }
 
     def options

--- a/spec/requests/search/combobox_request_spec.rb
+++ b/spec/requests/search/combobox_request_spec.rb
@@ -36,6 +36,19 @@ RSpec.describe Search::ComboboxController, type: :request do
       end
     end
 
+    context "without a turbo_stream format (mangled pagination src)" do
+      # A crawler following the HTML-encoded "&amp;format=turbo_stream" sends the
+      # format param as "amp;format", so the request would default to :html and
+      # raise ActionView::MissingTemplate for the turbo_stream-only gem partials.
+      it "still renders the turbo_stream response" do
+        get "/search/combobox/options", params: {q: "burg", for_id: "test"}
+
+        expect(response.code).to eq("200")
+        expect(response.media_type).to eq("text/vnd.turbo-stream.html")
+        expect(response.body).to include("Burgundy")
+      end
+    end
+
     context "with manufacturers of differing priority" do
       let!(:high) { FactoryBot.create(:manufacturer, name: "Acme Bikes") }
       let!(:low) { FactoryBot.create(:manufacturer, name: "Acme Components") }


### PR DESCRIPTION
Fixes an unhandled `ActionView::MissingTemplate` 500 on `GET /search/combobox/options` ([Honeybadger #131651335](https://app.honeybadger.io/projects/35931/faults/131651335)).

- The combobox pagination turbo-frame `src` carries an HTML-encoded `&amp;format=turbo_stream`; a client that follows the raw, un-decoded URL sends the ampersand literally, so the format arrives as a bogus `amp;format` param and the request defaults to `:html`.
- The hotwire_combobox partials exist only as `.turbo_stream.erb`, so the `:html` request raised `MissingTemplate`.
- `Search::ComboboxController` now pins `request.format = :turbo_stream` in a `before_action` — both actions only ever serve turbo_stream — plus a regression request spec for the mangled-format case.
