### PR TITLE
Don't render Strava gear section when editing a bike version

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -157,7 +157,7 @@ GEM
       rails-html-sanitizer
     bootsnap (1.24.6)
       msgpack (~> 1.2)
-    brakeman (8.0.4)
+    brakeman (8.0.5)
       racc
     buftok (0.2.0)
     builder (3.3.0)

--- a/app/views/bikes_edit/versions.html.erb
+++ b/app/views/bikes_edit/versions.html.erb
@@ -76,7 +76,7 @@
 
         <% strava_integration = current_user.strava_integration %>
 
-        <% if strava_integration&.show_gear_link? %>
+        <% if strava_integration&.show_gear_link? && !@bike.version? %>
           <div class="form-wrap secondary-form-wrap">
             <div class="form-well-form-header-always-visible">
               <h3><%= t("bikes_edit.strava_gear.strava_gear") %></h3>

--- a/spec/requests/bike_versions/edits_request_spec.rb
+++ b/spec/requests/bike_versions/edits_request_spec.rb
@@ -33,6 +33,17 @@ RSpec.describe BikeVersions::EditsController, type: :request do
     end
   end
 
+  context "user with strava gear" do
+    let!(:strava_integration) { FactoryBot.create(:strava_integration, :synced, :with_gear, user: current_user) }
+    it "renders the versions template without the strava gear section" do
+      expect(strava_integration.show_gear_link?).to be_truthy
+      get "#{base_url}/versions"
+      expect(response.code).to eq "200"
+      expect(response).to render_template("bikes_edit/versions")
+      expect(response.body).to_not match(/strava_gear_id/)
+    end
+  end
+
   context "no current_user" do
     let!(:bike_version) { FactoryBot.create(:bike_version) }
     it "redirects" do


### PR DESCRIPTION
Fixes a production `NoMethodError: undefined method 'strava_gear' for an instance of BikeVersion` ([Honeybadger](https://app.honeybadger.io/projects/35931/faults/131741070)) raised when a user with synced Strava gear opened the versions tab of a bike *version*.

- The `versions` edit template is shared between bikes and versions, but the Strava-gear section called `@bike.strava_gear`, an association that only exists on `Bike` — guard it with `!@bike.version?` to match the controller concern's existing bike-only treatment of Strava.
- Added a request spec covering a user with a synced Strava integration editing a version's versions page.
