### PR TITLE
Fix NoMethodError on ungeocodable proximity search

### DIFF
--- a/app/services/bike_services/searcher.rb
+++ b/app/services/bike_services/searcher.rb
@@ -169,10 +169,7 @@ module BikeServices
       stolen_ids = @bikes.pluck(:current_stolen_record_id)
       return unless stolen_ids.present?
 
-      if @params[:proximity_radius].present? && @params[:proximity_radius].to_i > 1
-        radius = @params[:proximity_radius].to_i
-      end
-      radius ||= 100
+      radius = GeocodeHelper.permitted_distance(@params[:proximity_radius])
       location = GeocodeHelper.address_string_for(@params[:proximity]) if @params[:reverse_geocode]
       box = GeocodeHelper.bounding_box(location || @params[:proximity], radius)
       if box.present?

--- a/app/services/bike_services/searcher.rb
+++ b/app/services/bike_services/searcher.rb
@@ -175,7 +175,7 @@ module BikeServices
       radius ||= 100
       location = GeocodeHelper.address_string_for(@params[:proximity]) if @params[:reverse_geocode]
       box = GeocodeHelper.bounding_box(location || @params[:proximity], radius)
-      unless box[0].nan?
+      if box.present?
         bike_ids = StolenRecord.where(id: stolen_ids).within_bounding_box(box).pluck(:bike_id)
         @bikes = @bikes.where(id: bike_ids)
       end

--- a/spec/services/bike_services/searcher_spec.rb
+++ b/spec/services/bike_services/searcher_spec.rb
@@ -60,10 +60,8 @@ RSpec.describe BikeServices::Searcher do
   end
 
   describe "by_proximity" do
-    let(:bike) { FactoryBot.create(:stolen_bike) }
+    let!(:bike) { FactoryBot.create(:stolen_bike) }
     let(:search) { BikeServices::Searcher.new(stolen: true, proximity: "New York, NY", proximity_radius: 100) }
-
-    before { bike } # ensure the stolen bike exists before searching
 
     context "ungeocodable proximity" do
       # An unresolvable proximity makes Geocoder return NaN coordinates, which

--- a/spec/services/bike_services/searcher_spec.rb
+++ b/spec/services/bike_services/searcher_spec.rb
@@ -76,6 +76,16 @@ RSpec.describe BikeServices::Searcher do
         expect(search.by_proximity.pluck(:id)).to eq([bike.id])
       end
     end
+
+    context "with an out-of-range radius" do
+      let(:search) { BikeServices::Searcher.new(stolen: true, proximity: "New York, NY", proximity_radius: "9000") }
+
+      it "clamps the radius via GeocodeHelper.permitted_distance" do
+        search.instance_variable_set(:@bikes, Bike.where(id: bike.id))
+        expect(GeocodeHelper).to receive(:bounding_box).with("New York, NY", GeocodeHelper::MAX_DISTANCE).and_return([])
+        search.by_proximity
+      end
+    end
   end
 
   describe "matching_serial" do

--- a/spec/services/bike_services/searcher_spec.rb
+++ b/spec/services/bike_services/searcher_spec.rb
@@ -59,6 +59,25 @@ RSpec.describe BikeServices::Searcher do
     end
   end
 
+  describe "by_proximity" do
+    let(:bike) { FactoryBot.create(:stolen_bike) }
+    let(:search) { BikeServices::Searcher.new(stolen: true, proximity: "New York, NY", proximity_radius: 100) }
+
+    before { bike } # ensure the stolen bike exists before searching
+
+    context "ungeocodable proximity" do
+      # An unresolvable proximity makes Geocoder return NaN coordinates, which
+      # GeocodeHelper.bounding_box collapses to an empty array - skip the proximity filter then
+      before { allow(Geocoder::Calculations).to receive(:bounding_box).and_return([Float::NAN] * 4) }
+
+      it "does not raise and returns the unfiltered bikes" do
+        search.instance_variable_set(:@bikes, Bike.where(id: bike.id))
+        expect { search.by_proximity }.not_to raise_error
+        expect(search.by_proximity.pluck(:id)).to eq([bike.id])
+      end
+    end
+  end
+
   describe "matching_serial" do
     it "finds matching bikes" do
       bike = FactoryBot.create(:bike, serial_number: "st00d-ffer")


### PR DESCRIPTION
Fixes a production `NoMethodError` (Honeybadger 131736920): API stolen-bike searches with an ungeocodable `proximity` value crashed on `box[0].nan?` because `GeocodeHelper.bounding_box` returns `[]` for NaN coordinates. `BikeServices::Searcher#by_proximity` now skips the proximity filter when the box is empty, matching every other `bounding_box` caller.

- Replace the hand-rolled radius parsing with `GeocodeHelper.permitted_distance`, the same helper `BikeSearchable` uses — centralizing the 1–1000 mile clamp and float handling.
- Add `by_proximity` specs covering the ungeocodable input and radius clamping.
