### PR TITLE
Force HTML response on SessionsController

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -1,6 +1,7 @@
 class SessionsController < ApplicationController
   include Sessionable
 
+  before_action :force_html_response
   before_action :skip_if_signed_in, only: [:new, :magic_link]
 
   def new

--- a/spec/requests/sessions_request_spec.rb
+++ b/spec/requests/sessions_request_spec.rb
@@ -59,6 +59,21 @@ RSpec.describe SessionsController, type: :request do
     end
   end
 
+  describe "new" do
+    it "renders" do
+      get "/session/new"
+      expect(response.code).to eq "200"
+      expect(response).to render_template(:new)
+    end
+    context "json format" do
+      it "renders html (scanners request .json)" do
+        get "/session/new.json"
+        expect(response.code).to eq "200"
+        expect(response).to render_template(:new)
+      end
+    end
+  end
+
   describe "create" do
     let(:password) { "example_password2" }
     let!(:user) { FactoryBot.create(:user_confirmed, password: password, password_confirmation: password, banned: banned) }


### PR DESCRIPTION
Fixes [Honeybadger fault 131817034](https://app.honeybadger.io/projects/35931/faults/131817034), where scanners requesting `/session/new.json` raised `ActionView::MissingTemplate` because the sign-in pages are HTML-only.

- Add `before_action :force_html_response` to `SessionsController`, reusing the existing helper already used by `LandingPagesController`/`WelcomeController`.
- Add request specs covering `/session/new` and `/session/new.json`.
