### PR TITLE
Replace hotwire-livereload with Mata (js-reload branch)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,7 +6,6 @@ updates:
     interval: daily
   open-pull-requests-limit: 1
   ignore:
-    - dependency-name: hotwire-livereload # see #3418
     - dependency-name: active_model_serializers # pinned ~> 0.8.3, newer versions are slower
     - dependency-name: MailchimpMarketing
     - dependency-name: stripe

--- a/Gemfile
+++ b/Gemfile
@@ -150,7 +150,7 @@ group :development do
   gem "guard", require: false
   gem "guard-rspec", require: false
   gem "rerun" # restart sidekiq processes in development on app change
-  gem "hotwire-livereload", "~> 1.4.1" # See #2759 for reasoning on version
+  gem "mata", github: "Rails-Designer/mata", branch: "js-reload" # Live reload via Rack middleware (SSE + idiomorph)
   gem "terminal-notifier"
   gem "annotaterb" # Add comments with the attributes to Rails Model
   gem "benchmark"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,4 +1,13 @@
 GIT
+  remote: https://github.com/Rails-Designer/mata.git
+  revision: 8396b858fd075f1142da051d14073b848033b6d2
+  branch: js-reload
+  specs:
+    mata (0.8.0)
+      listen (~> 3.0)
+      rack (>= 3.0)
+
+GIT
   remote: https://github.com/bikeindex/carrierwave_backgrounder.git
   revision: 7b2b0e9bc43f2ec20f09db3fea7bbc5f167f52c7
   specs:
@@ -390,10 +399,6 @@ GEM
     honeybadger (6.6.2)
       logger
       ostruct
-    hotwire-livereload (1.4.1)
-      actioncable (>= 6.0.0)
-      listen (>= 3.0.0)
-      railties (>= 6.0.0)
     hotwire_combobox (0.4.1)
       platform_agent (>= 1.0.1)
       rails (>= 7.0.7.2)
@@ -977,7 +982,6 @@ DEPENDENCIES
   haml
   herb
   honeybadger
-  hotwire-livereload (~> 1.4.1)
   hotwire_combobox
   i18n-country-translations
   i18n-js
@@ -992,6 +996,7 @@ DEPENDENCIES
   lograge
   logstash-event
   lookbook
+  mata!
   memory_profiler
   mini_magick
   money-rails (~> 1.11)

--- a/app/views/layouts/admin.html.erb
+++ b/app/views/layouts/admin.html.erb
@@ -23,7 +23,6 @@
     <%= hw_combobox_style_tag %>
     <%= javascript_importmap_tags %>
 
-    <%# = hotwire_livereload_tags if Rails.env.development? %>
     <%# assets are vendored, lazy solution %>
     <style>
       .for-sale-color {color: #2ecc71;}

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -26,7 +26,6 @@
 
     <%= javascript_include_tag 'application_revised' %>
     <%= javascript_importmap_tags %>
-    <%= hotwire_livereload_tags if Rails.env.development? %>
 
     <script>
       window.BikeIndex.translator = (keyspace) => {

--- a/app/views/layouts/payments_layout.html.erb
+++ b/app/views/layouts/payments_layout.html.erb
@@ -20,7 +20,6 @@
 
     <%= javascript_include_tag 'application_revised' %>
     <%= javascript_importmap_tags %>
-    <%= hotwire_livereload_tags if Rails.env.development? %>
 
     <!--[if IE]>$('body').prepend("<div id='old-browser-warning'><h4>Your browser is out of date!</h4><p>As a result, Bike Index will not function correctly. <a href=\"http://whatbrowser.com\">Learn more here</a>.</p></div>")<![endif]-->
     <script>

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -1,5 +1,13 @@
 require "active_support/core_ext/integer/time"
 
+# Mata live-reloads on any HTML response. Skip Lookbook, which reloads itself.
+class MataExceptLookbook < Mata
+  def call(environment)
+    return @app.call(environment) if environment["PATH_INFO"].start_with?("/lookbook")
+    super
+  end
+end
+
 Rails.application.configure do
   # In the development environment your application's code is reloaded any time
   # it changes. This slows down response time but is perfect for development
@@ -110,4 +118,13 @@ Rails.application.configure do
   # Use an evented file watcher to asynchronously detect changes in source code,
   # routes, locales, etc. This feature depends on the listen gem.
   config.file_watcher = ActiveSupport::EventedFileUpdateChecker
+
+  # Live reload via DOM morphing. CSS edits morph (the <link> is swapped and the browser
+  # refetches); JS edits trigger a full page reload (the js-reload branch's client reloads
+  # the window when any changed file ends in .js, since morphing can't re-execute modules).
+  # app/assets/builds holds the compiled CSS output from the Tailwind/Sass watchers.
+  config.middleware.insert_before(
+    ActionDispatch::Static, MataExceptLookbook,
+    watch: %w[app/views app/helpers app/components app/javascript app/assets/builds config/locales]
+  )
 end


### PR DESCRIPTION
Replaces `hotwire-livereload` with [Mata](https://github.com/Rails-Designer/mata) (tracking its `js-reload` branch), which live-reloads via Rack middleware (SSE + idiomorph DOM morphing) instead of an ActionCable channel and per-layout `hotwire_livereload_tags` — removing the `~> 1.4.1` pin (and its dependabot ignore) that existed because newer versions auto-injected into Lookbook and broke non-Turbo pages.

- A thin `MataExceptLookbook` subclass skips injection on `/lookbook`, which has its own reloader; the middleware injects globally, so the layout tags are gone and admin pages now reload too.
- The `js-reload` branch does a full `window.location.reload()` when a changed file ends in `.js` (morphing can't re-execute modules) — the gap that closed the prior attempt (#3685); CSS edits still morph the swapped `<link>`.

Verified with Playwright: view edits morph in place, JS edits full-reload, and `/lookbook` is untouched. The single-process Puma / `WEB_CONCURRENCY` groundwork this needs already landed on main separately.

See comment https://github.com/Rails-Designer/mata/issues/11
