### PR TITLE
Seed real why-donate blog; drop skip_ownership_email from Hogwarts

### DIFF
--- a/bin/dev
+++ b/bin/dev
@@ -1,11 +1,6 @@
 #!/bin/bash
-touch log/development.log
-> log/development.log # Clear out development log, otherwise it balloons
-> log/test.log # Clear out test log too
-touch log/bullet.log
-> log/test.log # Clear out bullet log
-# Clear out temp - mainly used by tests, preserve .txt toggle files (e.g. caching-dev.txt)
-find tmp -mindepth 1 -not -name '*.txt' -delete 2>/dev/null
+# Clear out logs (they balloon) and tmp (mainly used by tests)
+bin/rails log:clear tmp:clear
 
 # Start Redis in the background, if it isn't started already
 touch log/redis.log

--- a/db/seeds/seed_info_blogs.rb
+++ b/db/seeds/seed_info_blogs.rb
@@ -4,17 +4,32 @@
 # must exist for /why-donate and /membership to work (e.g. on review apps).
 author = User.find_by(email: "admin@bikeindex.org") || User.first
 
-[
-  ["End 2020 with a donation to Bike Index", Blog.why_donate_slug],
-  ["Bike Index Membership", Blog.membership_slug]
-].each do |title, slug|
-  next if Blog.friendly_find(slug).present?
+why_donate_body = <<~HTML
+  # <strong>10+ Years of Bike Index and Counting!!!</strong>
+  Thank you to everyone who has been part of Bike Index's journey! Each year we grow more than ever, registering and recovering bikes at rates we dreamed of when all of this started over a decade ago. <strong>We rely on your continued support</strong>.
 
-  Blog.create!(
-    title:,
-    body: "Seeded \"#{title}\" content for review apps.",
+  <a class="btn btn-primary" href="/donate?source=why-donate">Donate today</a>
+
+  2024 has been a big year for us, we officially passed over <strong>1 Million bikes registered on Bike Index</strong>. We added over 100 new partner organizations ranging from advocacy groups to bike shops to University and law enforcement. We're continually refining and improving our offerings to help more people register and recover their bikes for free. This is an exciting period for us and we need you more than ever to continue this work and keep it free for everyone.
+
+  <img width="100%" class='post-image' src='https://files.bikeindex.org/uploads/Pu/365516/hi.png' alt='recovery 2'>
+HTML
+
+[
+  {title: "Donate to Bike Index", slug: Blog.why_donate_slug, body: why_donate_body,
+   secondary_title: "Thank you to everyone who has been part of Bike Index's journey! 10+ years and counting!"},
+  {title: "Bike Index Membership", slug: Blog.membership_slug}
+].each do |attrs|
+  next if Blog.friendly_find(attrs[:slug]).present?
+
+  blog = Blog.create!(
+    title: attrs[:title],
+    secondary_title: attrs[:secondary_title],
+    body: attrs[:body] || "Seeded \"#{attrs[:title]}\" content for review apps.",
     user: author,
     info_kind: true, # kind: info — top-level info page, not a news post
     published: true
   )
+  # Pin the slug the info page looks up, since it's derived from the title
+  blog.update(title_slug: attrs[:slug]) if blog.title_slug != attrs[:slug]
 end

--- a/db/seeds/seed_organizations.rb
+++ b/db/seeds/seed_organizations.rb
@@ -61,7 +61,7 @@ feature_name_and_slugs.each do |attrs|
   skip_ownership_email_feature_id = org_feature.id if attrs[:name] == "Skip ownership email"
 end
 
-# --- Hogwarts: all features except official_manufacturer and skip_ownership_email, with is_endless invoice ---
+# --- Hogwarts: all features except official_manufacturer, with is_endless invoice - and skip_ownership_email ---
 hogwarts = Organization.find_by_name("Hogwarts") || Organization.create!(name: "Hogwarts")
 hogwarts_invoice = Invoice.create(organization: hogwarts, amount_due: 0, start_at: Time.current - 1.hour, is_endless: true)
 hogwarts_feature_ids = feature_ids - [official_manufacturer_feature_id, skip_ownership_email_feature_id]

--- a/db/seeds/seed_organizations.rb
+++ b/db/seeds/seed_organizations.rb
@@ -51,18 +51,20 @@ feature_name_and_slugs = [
 
 feature_ids = []
 official_manufacturer_feature_id = nil
+skip_ownership_email_feature_id = nil
 
 feature_name_and_slugs.each do |attrs|
   org_feature = OrganizationFeature.find_by_name(attrs[:name]) ||
     OrganizationFeature.create(attrs.merge(amount_cents: 500_00))
   feature_ids << org_feature.id
   official_manufacturer_feature_id = org_feature.id if attrs[:name] == "Official manufacturer organization"
+  skip_ownership_email_feature_id = org_feature.id if attrs[:name] == "Skip ownership email"
 end
 
-# --- Hogwarts: all features except official_manufacturer, with is_endless invoice ---
+# --- Hogwarts: all features except official_manufacturer and skip_ownership_email, with is_endless invoice ---
 hogwarts = Organization.find_by_name("Hogwarts") || Organization.create!(name: "Hogwarts")
 hogwarts_invoice = Invoice.create(organization: hogwarts, amount_due: 0, start_at: Time.current - 1.hour, is_endless: true)
-hogwarts_feature_ids = feature_ids - [official_manufacturer_feature_id]
+hogwarts_feature_ids = feature_ids - [official_manufacturer_feature_id, skip_ownership_email_feature_id]
 hogwarts_invoice.update(organization_feature_ids: hogwarts_feature_ids)
 OrganizationRole.create(organization_id: hogwarts.id, user_id: User.find_by_email("member@bikeindex.org").id, role: "member")
 


### PR DESCRIPTION
Improves dev/review-app seeds and tidies `bin/dev` startup.

- Give the seeded **why-donate** blog real content — title "Donate to Bike Index", a secondary title, and the full 10+ years donation body — pinning `title_slug` to `Blog.why_donate_slug` so `/why-donate` still resolves even though the slug is otherwise derived from the title.
- Stop granting **Hogwarts** the `skip_ownership_email` feature (alongside the existing `official_manufacturer` exclusion), so seeded Hogwarts registrations send ownership emails.
- Replace the manual log/tmp clearing in **`bin/dev`** with `bin/rails log:clear tmp:clear`, dropping a couple of stale lines (a duplicate `test.log` clear) in the process.
