### PR TITLE
Keyboard accessibility for landing pages & carousels

### DIFF
--- a/app/assets/stylesheets/kelsey/homepage.css
+++ b/app/assets/stylesheets/kelsey/homepage.css
@@ -733,3 +733,10 @@
     padding: 2rem 0 1.5rem;
   }
 }
+
+/* Keyboard focus indicators (WCAG 2.4.7) */
+.kelsey_styles .nav-arrow:focus-visible,
+.kelsey_styles .step-arrow:focus-visible {
+  outline: 3px solid var(--redesign-blue-500);
+  outline-offset: 2px;
+}

--- a/app/assets/stylesheets/kelsey/homepage.css
+++ b/app/assets/stylesheets/kelsey/homepage.css
@@ -733,10 +733,3 @@
     padding: 2rem 0 1.5rem;
   }
 }
-
-/* Keyboard focus indicators (WCAG 2.4.7) */
-.kelsey_styles .nav-arrow:focus-visible,
-.kelsey_styles .step-arrow:focus-visible {
-  outline: 3px solid var(--redesign-blue-500);
-  outline-offset: 2px;
-}

--- a/app/assets/stylesheets/kelsey/landing_pages.css
+++ b/app/assets/stylesheets/kelsey/landing_pages.css
@@ -843,3 +843,24 @@
     grid-template-columns: 1fr;
   }
 }
+
+/* Keyboard focus indicators (WCAG 2.4.7) */
+.kelsey_styles .le-btn-primary:focus-visible,
+.kelsey_styles .le-btn-secondary:focus-visible,
+.kelsey_styles .le-tab-button:focus-visible,
+.kelsey_styles .le-testimonial-arrow:focus-visible,
+.kelsey_styles .le-testimonial-dot:focus-visible {
+  outline: 3px solid var(--redesign-blue-500);
+  outline-offset: 2px;
+}
+
+/* Pause the auto-scrolling partners strip for keyboard focus and reduced-motion preference (WCAG 2.2.2) */
+.kelsey_styles .le-partners-grid:focus-within {
+  animation-play-state: paused;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .kelsey_styles .le-partners-grid {
+    animation: none;
+  }
+}

--- a/app/assets/stylesheets/kelsey/landing_pages.css
+++ b/app/assets/stylesheets/kelsey/landing_pages.css
@@ -844,16 +844,6 @@
   }
 }
 
-/* Keyboard focus indicators (WCAG 2.4.7) */
-.kelsey_styles .le-btn-primary:focus-visible,
-.kelsey_styles .le-btn-secondary:focus-visible,
-.kelsey_styles .le-tab-button:focus-visible,
-.kelsey_styles .le-testimonial-arrow:focus-visible,
-.kelsey_styles .le-testimonial-dot:focus-visible {
-  outline: 3px solid var(--redesign-blue-500);
-  outline-offset: 2px;
-}
-
 /* Pause the auto-scrolling partners strip for keyboard focus and reduced-motion preference (WCAG 2.2.2) */
 .kelsey_styles .le-partners-grid:focus-within {
   animation-play-state: paused;

--- a/app/components/page_block/homepage_top/component.html.erb
+++ b/app/components/page_block/homepage_top/component.html.erb
@@ -122,7 +122,9 @@
 
             <div class="testimonial-nav">
               <button
+                type="button"
                 class="nav-arrow prev"
+                aria-label="Previous recovery story"
                 data-homepage--recovery-showcase-target="prev"
                 data-action="click->homepage--recovery-showcase#prev"
               >
@@ -130,7 +132,9 @@
               </button>
 
               <button
+                type="button"
                 class="nav-arrow next"
+                aria-label="Next recovery story"
                 data-homepage--recovery-showcase-target="next"
                 data-action="click->homepage--recovery-showcase#next"
               >
@@ -187,7 +191,9 @@
 
           <div class="step-navigation">
             <button
+              type="button"
               class="step-arrow prev"
+              aria-label="Previous step"
               data-action="click->homepage--what-happens#prevStep"
             >
               ‹
@@ -196,7 +202,9 @@
             <span class="step-indicator" id="stepIndicator">1 / 4</span>
 
             <button
+              type="button"
               class="step-arrow next"
+              aria-label="Next step"
               data-action="click->homepage--what-happens#nextStep"
             >
               ›

--- a/app/components/page_block/landing_for_law_enforcement/component.html.erb
+++ b/app/components/page_block/landing_for_law_enforcement/component.html.erb
@@ -90,21 +90,32 @@
 
       <%# Tabbed Widget %>
       <div class="le-tabbed-widget" data-controller="landing-pages--tabs">
-        <div class="le-tab-buttons">
+        <div class="le-tab-buttons" role="tablist">
           <button
+            type="button"
             class="le-tab-button active"
+            id="tab-button-database"
+            role="tab"
+            aria-selected="true"
+            aria-controls="tab-database"
             data-tab="database"
             data-landing-pages--tabs-target="button"
-            data-action="click->landing-pages--tabs#select"
+            data-action="click->landing-pages--tabs#select keydown->landing-pages--tabs#keydown"
           >
             All-in-One Database Management for Operational Efficiency
           </button>
 
           <button
+            type="button"
             class="le-tab-button"
+            id="tab-button-defense"
+            role="tab"
+            aria-selected="false"
+            aria-controls="tab-defense"
+            tabindex="-1"
             data-tab="defense"
             data-landing-pages--tabs-target="button"
-            data-action="click->landing-pages--tabs#select"
+            data-action="click->landing-pages--tabs#select keydown->landing-pages--tabs#keydown"
           >
             First Line of Defense Against Theft for Your Citizens
           </button>
@@ -114,6 +125,9 @@
           <div
             class="le-tab-panel active"
             id="tab-database"
+            role="tabpanel"
+            aria-labelledby="tab-button-database"
+            tabindex="0"
             data-landing-pages--tabs-target="panel"
           >
             <div class="le-tab-panel-content">
@@ -155,6 +169,9 @@
           <div
             class="le-tab-panel"
             id="tab-defense"
+            role="tabpanel"
+            aria-labelledby="tab-button-defense"
+            tabindex="0"
             data-landing-pages--tabs-target="panel"
           >
             <div class="le-tab-panel-content">
@@ -250,16 +267,25 @@
 
         <div class="le-testimonial-nav">
           <button
+            type="button"
             class="le-testimonial-arrow"
+            aria-label="Previous testimonial"
             data-action="click->landing-pages--testimonials#prev"
           >
             &lsaquo;
           </button>
 
-          <div class="le-testimonial-dots" data-testimonials-dots></div>
+          <div
+            class="le-testimonial-dots"
+            role="group"
+            aria-label="Testimonial selection"
+            data-testimonials-dots
+          ></div>
 
           <button
+            type="button"
             class="le-testimonial-arrow"
+            aria-label="Next testimonial"
             data-action="click->landing-pages--testimonials#next"
           >
             &rsaquo;

--- a/app/components/page_block/landing_for_schools/component.html.erb
+++ b/app/components/page_block/landing_for_schools/component.html.erb
@@ -85,21 +85,32 @@
 
       <%# Tabbed Widget %>
       <div class="le-tabbed-widget" data-controller="landing-pages--tabs">
-        <div class="le-tab-buttons">
+        <div class="le-tab-buttons" role="tablist">
           <button
+            type="button"
             class="le-tab-button active"
+            id="tab-button-database"
+            role="tab"
+            aria-selected="true"
+            aria-controls="tab-database"
             data-tab="database"
             data-landing-pages--tabs-target="button"
-            data-action="click->landing-pages--tabs#select"
+            data-action="click->landing-pages--tabs#select keydown->landing-pages--tabs#keydown"
           >
             All-in-One Database Management for Operational Efficiency
           </button>
 
           <button
+            type="button"
             class="le-tab-button"
+            id="tab-button-defense"
+            role="tab"
+            aria-selected="false"
+            aria-controls="tab-defense"
+            tabindex="-1"
             data-tab="defense"
             data-landing-pages--tabs-target="button"
-            data-action="click->landing-pages--tabs#select"
+            data-action="click->landing-pages--tabs#select keydown->landing-pages--tabs#keydown"
           >
             First Line of Defense Against Theft for Your Campus Members
           </button>
@@ -109,6 +120,9 @@
           <div
             class="le-tab-panel active"
             id="tab-database"
+            role="tabpanel"
+            aria-labelledby="tab-button-database"
+            tabindex="0"
             data-landing-pages--tabs-target="panel"
           >
             <div class="le-tab-panel-content">
@@ -148,6 +162,9 @@
           <div
             class="le-tab-panel"
             id="tab-defense"
+            role="tabpanel"
+            aria-labelledby="tab-button-defense"
+            tabindex="0"
             data-landing-pages--tabs-target="panel"
           >
             <div class="le-tab-panel-content">
@@ -236,7 +253,7 @@
                 </div>
 
                 <div class="le-testimonial-image">
-                  <%= image_tag testimonial[:image], alt: "Bike Love" %>
+                  <%= image_tag testimonial[:image], alt: testimonial[:author] %>
                 </div>
               </div>
             </div>
@@ -245,16 +262,25 @@
 
         <div class="le-testimonial-nav">
           <button
+            type="button"
             class="le-testimonial-arrow"
+            aria-label="Previous testimonial"
             data-action="click->landing-pages--testimonials#prev"
           >
             &lsaquo;
           </button>
 
-          <div class="le-testimonial-dots" data-testimonials-dots></div>
+          <div
+            class="le-testimonial-dots"
+            role="group"
+            aria-label="Testimonial selection"
+            data-testimonials-dots
+          ></div>
 
           <button
+            type="button"
             class="le-testimonial-arrow"
+            aria-label="Next testimonial"
             data-action="click->landing-pages--testimonials#next"
           >
             &rsaquo;

--- a/app/javascript/controllers/landing_pages/tabs_controller.js
+++ b/app/javascript/controllers/landing_pages/tabs_controller.js
@@ -10,17 +10,17 @@ export default class extends Controller {
   }
 
   keydown (event) {
-    if (!['ArrowLeft', 'ArrowRight', 'Home', 'End'].includes(event.key)) return
-
-    event.preventDefault()
     const buttons = this.buttonTargets
     const currentIndex = buttons.indexOf(event.currentTarget)
-    let nextIndex
-    if (event.key === 'ArrowLeft') nextIndex = (currentIndex - 1 + buttons.length) % buttons.length
-    else if (event.key === 'ArrowRight') nextIndex = (currentIndex + 1) % buttons.length
-    else if (event.key === 'Home') nextIndex = 0
-    else nextIndex = buttons.length - 1
+    const nextIndex = {
+      ArrowLeft: (currentIndex - 1 + buttons.length) % buttons.length,
+      ArrowRight: (currentIndex + 1) % buttons.length,
+      Home: 0,
+      End: buttons.length - 1
+    }[event.key]
+    if (nextIndex === undefined) return
 
+    event.preventDefault()
     this.activate(buttons[nextIndex])
     buttons[nextIndex].focus()
   }

--- a/app/javascript/controllers/landing_pages/tabs_controller.js
+++ b/app/javascript/controllers/landing_pages/tabs_controller.js
@@ -6,14 +6,40 @@ export default class extends Controller {
 
   // Tab functionality
   select (event) {
-    const tabName = event.currentTarget.dataset.tab
+    this.activate(event.currentTarget)
+  }
 
-    // Remove active class from all buttons and panels
-    this.buttonTargets.forEach(btn => btn.classList.remove('active'))
+  keydown (event) {
+    if (!['ArrowLeft', 'ArrowRight', 'Home', 'End'].includes(event.key)) return
+
+    event.preventDefault()
+    const buttons = this.buttonTargets
+    const currentIndex = buttons.indexOf(event.currentTarget)
+    let nextIndex
+    if (event.key === 'ArrowLeft') nextIndex = (currentIndex - 1 + buttons.length) % buttons.length
+    else if (event.key === 'ArrowRight') nextIndex = (currentIndex + 1) % buttons.length
+    else if (event.key === 'Home') nextIndex = 0
+    else nextIndex = buttons.length - 1
+
+    this.activate(buttons[nextIndex])
+    buttons[nextIndex].focus()
+  }
+
+  activate (button) {
+    const tabName = button.dataset.tab
+
+    // Remove active state from all buttons and panels (roving tabindex)
+    this.buttonTargets.forEach(btn => {
+      btn.classList.remove('active')
+      btn.setAttribute('aria-selected', 'false')
+      btn.setAttribute('tabindex', '-1')
+    })
     this.panelTargets.forEach(panel => panel.classList.remove('active'))
 
-    // Add active class to clicked button and corresponding panel
-    event.currentTarget.classList.add('active')
+    // Add active state to the selected button and corresponding panel
+    button.classList.add('active')
+    button.setAttribute('aria-selected', 'true')
+    button.removeAttribute('tabindex')
     const panel = this.panelTargets.find(p => p.id === `tab-${tabName}`)
     if (panel) panel.classList.add('active')
   }

--- a/app/javascript/controllers/landing_pages/testimonials_controller.js
+++ b/app/javascript/controllers/landing_pages/testimonials_controller.js
@@ -9,11 +9,15 @@ export default class extends Controller {
     this.currentIndex = 0
     // Create dots
     this.createDots()
-    // Auto-advance testimonials every 8 seconds, pause on hover
+    // Auto-advance testimonials every 8 seconds, pause on hover or keyboard focus
     this.startAutoAdvance()
     const wrapper = this.element.querySelector('.le-testimonials-carousel-wrapper')
     wrapper.addEventListener('mouseenter', () => this.pauseAutoAdvance())
     wrapper.addEventListener('mouseleave', () => this.startAutoAdvance())
+    this.element.addEventListener('focusin', () => this.pauseAutoAdvance())
+    this.element.addEventListener('focusout', (e) => {
+      if (!this.element.contains(e.relatedTarget)) this.startAutoAdvance()
+    })
   }
 
   disconnect () {
@@ -22,6 +26,8 @@ export default class extends Controller {
 
   startAutoAdvance () {
     clearInterval(this.autoAdvanceInterval)
+    if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) return
+
     this.autoAdvanceInterval = setInterval(() => this.next(), 8000)
   }
 
@@ -35,10 +41,15 @@ export default class extends Controller {
 
     this.testimonialTargets.forEach((_, index) => {
       const dot = document.createElement('button')
+      dot.type = 'button'
       dot.className = 'le-testimonial-dot'
       dot.dataset.index = index
+      dot.setAttribute('aria-label', `Testimonial ${index + 1}`)
       dot.addEventListener('click', () => this.goTo(index))
-      if (index === 0) dot.classList.add('active')
+      if (index === 0) {
+        dot.classList.add('active')
+        dot.setAttribute('aria-current', 'true')
+      }
       this.dotsContainer.appendChild(dot)
     })
   }
@@ -71,11 +82,15 @@ export default class extends Controller {
 
   show () {
     this.testimonialTargets.forEach(t => t.classList.remove('active'))
-    this.dots.forEach(d => d.classList.remove('active'))
+    this.dots.forEach(d => {
+      d.classList.remove('active')
+      d.removeAttribute('aria-current')
+    })
 
     this.testimonialTargets[this.currentIndex].classList.add('active')
     if (this.dots[this.currentIndex]) {
       this.dots[this.currentIndex].classList.add('active')
+      this.dots[this.currentIndex].setAttribute('aria-current', 'true')
     }
   }
 }

--- a/app/javascript/controllers/landing_pages/testimonials_controller.js
+++ b/app/javascript/controllers/landing_pages/testimonials_controller.js
@@ -7,26 +7,33 @@ export default class extends Controller {
   // Testimonials carousel functionality
   connect () {
     this.currentIndex = 0
-    // Create dots
+    this.reducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)')
     this.createDots()
     // Auto-advance testimonials every 8 seconds, pause on hover or keyboard focus
     this.startAutoAdvance()
-    const wrapper = this.element.querySelector('.le-testimonials-carousel-wrapper')
-    wrapper.addEventListener('mouseenter', () => this.pauseAutoAdvance())
-    wrapper.addEventListener('mouseleave', () => this.startAutoAdvance())
-    this.element.addEventListener('focusin', () => this.pauseAutoAdvance())
-    this.element.addEventListener('focusout', (e) => {
+    this.pauseHandler = () => this.pauseAutoAdvance()
+    this.resumeHandler = () => this.startAutoAdvance()
+    this.focusOutHandler = (e) => {
       if (!this.element.contains(e.relatedTarget)) this.startAutoAdvance()
-    })
+    }
+    this.wrapper = this.element.querySelector('.le-testimonials-carousel-wrapper')
+    this.wrapper.addEventListener('mouseenter', this.pauseHandler)
+    this.wrapper.addEventListener('mouseleave', this.resumeHandler)
+    this.element.addEventListener('focusin', this.pauseHandler)
+    this.element.addEventListener('focusout', this.focusOutHandler)
   }
 
   disconnect () {
     clearInterval(this.autoAdvanceInterval)
+    this.wrapper.removeEventListener('mouseenter', this.pauseHandler)
+    this.wrapper.removeEventListener('mouseleave', this.resumeHandler)
+    this.element.removeEventListener('focusin', this.pauseHandler)
+    this.element.removeEventListener('focusout', this.focusOutHandler)
   }
 
   startAutoAdvance () {
     clearInterval(this.autoAdvanceInterval)
-    if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) return
+    if (this.reducedMotion.matches) return
 
     this.autoAdvanceInterval = setInterval(() => this.next(), 8000)
   }


### PR DESCRIPTION
Keyboard and screen-reader accessibility for the homepage and law-enforcement/schools landing pages, split out from the larger accessibility audit branch (#3702).

- **Tab widget**: roving tabindex with arrow/Home/End keyboard navigation and proper `tablist`/`tab`/`tabpanel` ARIA roles.
- **Testimonial carousel**: pauses auto-advance on keyboard focus, honors `prefers-reduced-motion`, and exposes `aria-current`/`aria-label` on the dots.
- **Carousel & step arrows**: add `type="button"`, `aria-label`s, and `:focus-visible` outlines; the partners strip pauses on focus and stops animating under reduced-motion.
