### PR TITLE
Bump view_component from 4.10.0 to 4.12.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -900,7 +900,7 @@ GEM
     uri (1.1.1)
     useragent (0.16.11)
     vcr (6.4.0)
-    view_component (4.10.0)
+    view_component (4.12.0)
       actionview (>= 7.1.0)
       activesupport (>= 7.1.0)
       concurrent-ruby (~> 1)


### PR DESCRIPTION
Bumps `view_component` from 4.10.0 to 4.12.0. Both releases are bug/security fixes with no API changes — the most relevant is 4.12.0's fix for stale render context on reused component instances (memoized controller/helpers/request/view-context were reused across renders via `||=`, now reset on every `render_in`), plus an `around_render` HTML-safety hardening. 4.11.0 adds Rails `render_in` signature compatibility and fixes translation-scope resolution in nested lambda-backed slots. All 162 components and their specs pass, including the `UI::Table` fragment-caching system spec.
