### PR TITLE
Run review-app destroy from the default branch

### DIFF
--- a/.github/workflows/review-app.yml
+++ b/.github/workflows/review-app.yml
@@ -230,10 +230,21 @@ jobs:
       HONEYBADGER_API_KEY: ${{ secrets.REVIEW_APP_HONEYBADGER_API_KEY }}
       HONEYBADGER_FRONTEND_API_KEY: ${{ secrets.REVIEW_APP_HONEYBADGER_FRONTEND_API_KEY }}
     steps:
-      - name: Checkout PR head
+      # Deploy runs the PR's own review-app tooling/config. Destroy instead checks
+      # out the default branch: it only tears down by PR number (needs none of the
+      # PR's code), and a PR predating a bin/kamal_review change — e.g. the destroy
+      # subcommand added in #3715 — would otherwise fail with
+      # "bin/kamal_review: No such file or directory" on its stale checkout.
+      - name: Checkout PR head (deploy)
+        if: needs.resolve.outputs.action == 'deploy'
         uses: actions/checkout@v6
         with:
           ref: ${{ needs.resolve.outputs.head_sha }}
+      - name: Checkout default branch (destroy)
+        if: needs.resolve.outputs.action == 'destroy'
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.repository.default_branch }}
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:


### PR DESCRIPTION
The review-app `update` job checked out the PR head and ran `bin/kamal_review destroy` from it. A PR predating a tooling change — e.g. the `destroy` subcommand added in #3715 — has a stale or missing `bin/kamal_review`, so **closing such a PR failed** with `bin/kamal_review: No such file or directory` (exit 127), leaving its containers + databases stranded on the shared host. (Hit this destroying merged PR #3690 during the review-host OOM cleanup.)

- Destroy now checks out the **default branch** (it only tears down by PR number — it needs none of the PR's code).
- Deploy is unchanged: it still uses the PR's own checkout, since it deploys that PR's config.
