### PR TITLE
Show the PR title in the review-app banner

### DIFF
--- a/.github/workflows/review-app.yml
+++ b/.github/workflows/review-app.yml
@@ -64,6 +64,7 @@ jobs:
       head_sha:  ${{ steps.set.outputs.head_sha }}
       action:    ${{ steps.set.outputs.action }}
       proceed:   ${{ steps.set.outputs.proceed }}
+      pr_title:  ${{ steps.set.outputs.pr_title }}
     steps:
       - name: Resolve PR + action from the trigger
         id: set
@@ -82,10 +83,12 @@ jobs:
             pr="$INPUT_PR"
             action="$INPUT_ACTION"
             head_sha=$(gh pr view "$pr" --repo "$REPO" --json headRefOid -q .headRefOid)
+            title=$(gh pr view "$pr" --repo "$REPO" --json title -q .title)
             proceed=true
           else
             pr="$PR_NUMBER_EVENT"
             head_sha="$PR_HEAD_SHA_EVENT"
+            title=""  # destroy doesn't render the banner, so no title needed
             action="destroy"  # `closed` is the only pull_request trigger
             # Label presence is enforced by this job's `if:`.
             if [[ "$PR_HEAD_REPO_EVENT" != "$REPO" ]]; then
@@ -99,6 +102,12 @@ jobs:
           echo "head_sha=$head_sha" >> "$GITHUB_OUTPUT"
           echo "action=$action"  >> "$GITHUB_OUTPUT"
           echo "proceed=$proceed" >> "$GITHUB_OUTPUT"
+          # Heredoc form — a PR title is arbitrary text (may contain `=`, `#`, …).
+          {
+            echo "pr_title<<__PR_TITLE_EOF__"
+            echo "$title"
+            echo "__PR_TITLE_EOF__"
+          } >> "$GITHUB_OUTPUT"
 
   # Builds + pushes the image for deploys. Separate from `update` so that a
   # newer push can cancel a superseded build via concurrency — the kamal deploy
@@ -212,6 +221,9 @@ jobs:
     env:
       IMAGE_TAG: pr-${{ needs.resolve.outputs.pr_number }}-${{ needs.resolve.outputs.head_sha }}
       REVIEW_APP_HOST: ${{ vars.REVIEW_APP_HOST }}
+      # Baked into the container's env by config/deploy.review.yml so the banner
+      # shows the PR title (falls back to "PR #<number>" when empty).
+      REVIEW_APP_PR_TITLE: ${{ needs.resolve.outputs.pr_title }}
       KAMAL_REGISTRY_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
       POSTGRES_PASSWORD: ${{ secrets.REVIEW_APP_POSTGRES_PASSWORD }}
       SECRET_KEY_BASE: ${{ secrets.REVIEW_APP_SECRET_KEY_BASE }}

--- a/app/components/page_block/review_app_banner/component.en.yml
+++ b/app/components/page_block/review_app_banner/component.en.yml
@@ -3,7 +3,7 @@ en:
   components:
     page_block:
       review_app_banner:
-        disclaimer: not production, data is ephemeral
+        disclaimer: data is ephemeral
         label: Review app
         letter_opener_link: email outbox
         letter_opener_tooltip: View the email sent by this review app

--- a/app/components/page_block/review_app_banner/component.html.erb
+++ b/app/components/page_block/review_app_banner/component.html.erb
@@ -18,7 +18,7 @@
       target="_blank"
       rel="noopener"
     >
-      <%= translation(".pr_link", number: @pr_number) %>
+      <%= pr_link_text %>
     </a>
   <% end %>
   &middot; <%= translation(".disclaimer") %> &middot;

--- a/app/components/page_block/review_app_banner/component.html.erb
+++ b/app/components/page_block/review_app_banner/component.html.erb
@@ -12,14 +12,7 @@
   <%= translation(".label") %>
   <% if @pr_number %>
     &middot;
-    <a
-      class="tw:underline"
-      href="<%= pr_url %>"
-      target="_blank"
-      rel="noopener"
-    >
-      <%= pr_link_text %>
-    </a>
+    <a class="tw:underline" href="<%= pr_url %>"><%= pr_link_text %></a>
   <% end %>
   &middot; <%= translation(".disclaimer") %> &middot;
   <%= link_to translation(".letter_opener_link"), "/letter_opener", class: "tw:font-normal tw:underline" %>

--- a/app/components/page_block/review_app_banner/component.rb
+++ b/app/components/page_block/review_app_banner/component.rb
@@ -4,12 +4,14 @@ module PageBlock
   module ReviewAppBanner
     # Banner shown across the top of every page on review-app deploys, so
     # there's no chance of confusing a review environment with production.
-    # Callers pass `ENV["REVIEW_APP"]` and `ENV["REVIEW_APP_PR_NUMBER"]`; the
-    # component renders only when `review_app` is present.
+    # Callers pass `ENV["REVIEW_APP"]`, `ENV["REVIEW_APP_PR_NUMBER"]`, and
+    # `ENV["REVIEW_APP_PR_TITLE"]`; the component renders only when `review_app`
+    # is present.
     class Component < ApplicationComponent
-      def initialize(review_app:, pr_number: nil)
+      def initialize(review_app:, pr_number: nil, pr_title: nil)
         @review_app = review_app
         @pr_number = pr_number
+        @pr_title = pr_title
       end
 
       def render?
@@ -17,6 +19,11 @@ module PageBlock
       end
 
       private
+
+      # The PR title when known, falling back to "PR #<number>".
+      def pr_link_text
+        @pr_title.presence || translation(".pr_link", number: @pr_number)
+      end
 
       def pr_url
         "https://github.com/bikeindex/bike_index/pull/#{@pr_number}"

--- a/app/components/page_block/review_app_banner/component_preview.rb
+++ b/app/components/page_block/review_app_banner/component_preview.rb
@@ -4,6 +4,12 @@ module PageBlock
   module ReviewAppBanner
     class ComponentPreview < ApplicationComponentPreview
       def with_pr_link
+        render(PageBlock::ReviewAppBanner::Component.new(review_app: "1", pr_number: 3664,
+          pr_title: "Add Promoted section to marketplace index"))
+      end
+
+      # No title available — link falls back to "PR #<number>".
+      def without_pr_title
         render(PageBlock::ReviewAppBanner::Component.new(review_app: "1", pr_number: 3664))
       end
     end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -48,7 +48,7 @@
   </head>
 
   <body id="<%= page_id %>" class="<%= body_class %>">
-    <%= render(PageBlock::ReviewAppBanner::Component.new(review_app: ENV["REVIEW_APP"], pr_number: ENV["REVIEW_APP_PR_NUMBER"])) %>
+    <%= render(PageBlock::ReviewAppBanner::Component.new(review_app: ENV["REVIEW_APP"], pr_number: ENV["REVIEW_APP_PR_NUMBER"], pr_title: ENV["REVIEW_APP_PR_TITLE"])) %>
 
     <%# Cache navbar to speed stuff up, on per-user, per-page %>
     <% cache(["main_navbar4", page_id, current_user_or_unconfirmed_user, passive_organization]) do %>

--- a/config/deploy.review.yml
+++ b/config/deploy.review.yml
@@ -25,12 +25,15 @@
 
 <%# The role/database naming scheme must stay in lockstep with bin/kamal_review,
     which re-derives the same names to DROP them on destroy. %>
+<% require "json" %>
 <% pr      = ENV.fetch("REVIEW_APP_PR_NUMBER") %>
 <% host    = ENV.fetch("REVIEW_APP_HOST") %>
 <% slug    = "pr-#{pr}" %>
 <% appname = "bike-index-#{slug}" %>
 <% role    = "bike_index_pr_#{pr}" %>
 <% redis_url = "redis://shared-redis:6379/#{ENV.fetch("REVIEW_APP_REDIS_DB", "1")}" %>
+<%# .to_json quotes/escapes the title into a valid (double-quoted) YAML scalar. %>
+<% pr_title_json = ENV.fetch("REVIEW_APP_PR_TITLE", "").to_json %>
 
 service: <%= appname %>
 # NOTE: no registry host here — kamal prepends `registry.server` (configuration.rb
@@ -88,6 +91,9 @@ env:
     RAILS_ENV: staging
     REVIEW_APP: "1"
     REVIEW_APP_PR_NUMBER: "<%= pr %>"
+    # Empty unless the deployer exports REVIEW_APP_PR_TITLE (the workflow does);
+    # the banner then falls back to "PR #<number>".
+    REVIEW_APP_PR_TITLE: <%= pr_title_json %>
     BASE_URL: "https://<%= slug %>.review.bikeindex.org"
 
     # Postgres (shared-db accessory; per-PR role + databases). The staging

--- a/spec/components/page_block/review_app_banner/component_spec.rb
+++ b/spec/components/page_block/review_app_banner/component_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe PageBlock::ReviewAppBanner::Component, type: :component do
 
     it "renders the label and disclaimer" do
       expect(component.text).to include("Review app")
-      expect(component.text).to include("not production")
+      expect(component.text).to include("data is ephemeral")
     end
 
     it "links to the letter_opener outbox with a tooltip" do

--- a/spec/components/page_block/review_app_banner/component_spec.rb
+++ b/spec/components/page_block/review_app_banner/component_spec.rb
@@ -9,8 +9,9 @@ RSpec.describe PageBlock::ReviewAppBanner::Component, type: :component do
   end
 
   context "when review_app is present" do
-    let(:component) { render_inline(described_class.new(review_app: "1", pr_number:)) }
+    let(:component) { render_inline(described_class.new(review_app: "1", pr_number:, pr_title:)) }
     let(:pr_number) { nil }
+    let(:pr_title) { nil }
 
     it "renders the label and disclaimer" do
       expect(component.text).to include("Review app")
@@ -35,6 +36,16 @@ RSpec.describe PageBlock::ReviewAppBanner::Component, type: :component do
         link = component.css("a[href^='https://github.com']").first
         expect(link[:href]).to eq("https://github.com/bikeindex/bike_index/pull/1234")
         expect(link.text).to include("PR #1234")
+      end
+
+      context "with a pr_title" do
+        let(:pr_title) { "Add Promoted section" }
+
+        it "uses the title as the PR link text" do
+          link = component.css("a[href^='https://github.com']").first
+          expect(link[:href]).to eq("https://github.com/bikeindex/bike_index/pull/1234")
+          expect(link.text.strip).to eq("Add Promoted section")
+        end
       end
     end
   end


### PR DESCRIPTION
The review-app banner's PR link showed "PR #<number>"; it now shows the **PR title** (falling back to the number when unavailable). Also trims the disclaimer text.

- The title is fetched once at deploy time — `review-app.yml`'s `resolve` job reads it (`gh pr view --json title`) and the deploy bakes it into the container env as `REVIEW_APP_PR_TITLE`.
- The layout injects it into the component as a `pr_title:` kwarg (same pattern as `pr_number`); the component falls back to "PR #<number>" when it's blank.
- Drops "not production, " from the disclaimer (now just "data is ephemeral") — the "Review app" label already signals it's not production.
