### PR TITLE
Persist letter_opener_web inbox across deploys

### DIFF
--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -14,6 +14,14 @@ Rails.application.configure do
   # the :staging group.
   config.action_mailer.delivery_method = :letter_opener_web
 
+  # Persist the inbox on the storage volume (config/deploy.review.yml mounts
+  # <app>_storage at /rails/storage) instead of the gem default tmp/letter_opener
+  # — each deploy boots a fresh container with an empty tmp/, which would drop
+  # every captured message.
+  LetterOpenerWeb.configure do |letter_opener_config|
+    letter_opener_config.letters_location = Rails.root.join("storage", "letter_opener")
+  end
+
   # Upload to the dev R2 bucket so staging doesn't touch production assets
   # (see config/storage.yml).
   config.active_storage.service = :cloudflare_dev


### PR DESCRIPTION
letter_opener_web's inbox defaulted to `tmp/letter_opener`, which a fresh container wipes on every review-app deploy — so all captured messages vanished each time. This points `letters_location` at the persisted `/rails/storage` volume (already mounted in `config/deploy.review.yml`) so messages survive redeploys. Scoped to staging (review apps); development and production are unaffected.
