### PR TITLE
Document running bin/lint (herb-format) on edited ERB

### DIFF
--- a/.claude/skills/frontend-conventions/SKILL.md
+++ b/.claude/skills/frontend-conventions/SKILL.md
@@ -20,6 +20,8 @@ This project uses **Stimulus.js** for JavaScript interactivity and **Tailwind CS
 
 The `bin/dev` command handles building and updating Tailwind and JS.
 
+**Format ERB before committing.** After editing any `.html.erb`, run `bin/lint <file>` — it runs `herb-format`, which sorts `tw:` classes and reflows long `class` attributes onto multiple lines. CI's `lint_and_scan` job runs `herb-format --check` as a step separate from `standardrb`/`rubocop`, so hand-edited ERB that skips formatting fails CI even when the Ruby is clean.
+
 ## Tailwind classes and helpers
 
 - Tailwind classes have the prefix `tw:` (e.g. `tw:text-blue`, `tw:flex`, `tw:gap-4`).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,7 +8,7 @@ Run `eval "$(ruby bin/env --export)"` once so `$DEV_PORT` (and `$BASE_URL`, `$RE
 
 ## Code style
 
-Ruby is formatted with the standard gem. Run `bin/lint` to automatically format the code.
+Ruby is formatted with the standard gem; run `bin/lint` to automatically format the code. `bin/lint` also formats `.html.erb` (via `herb-format`) and JS — CI's `lint_and_scan` job checks each formatter separately, so **after editing `.html.erb`, run `bin/lint`** (pass the file, or no args). Running `standardrb`/`rubocop` alone does not format ERB, and hand-edited templates fail `herb-format --check` even when the Ruby is clean.
 
 ### Code guidelines:
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,7 +8,7 @@ Run `eval "$(ruby bin/env --export)"` once so `$DEV_PORT` (and `$BASE_URL`, `$RE
 
 ## Code style
 
-Ruby is formatted with the standard gem; run `bin/lint` to automatically format the code. `bin/lint` also formats `.html.erb` (via `herb-format`) and JS — CI's `lint_and_scan` job checks each formatter separately, so **after editing `.html.erb`, run `bin/lint`** (pass the file, or no args). Running `standardrb`/`rubocop` alone does not format ERB, and hand-edited templates fail `herb-format --check` even when the Ruby is clean.
+Run `bin/lint` to automatically format the code. Always use `bin/lint`, don't use other formatters.
 
 ### Code guidelines:
 


### PR DESCRIPTION
Documents that contributors should always use `bin/lint` (which formats `.html.erb` via `herb-format`, plus JS), not other formatters.

- **AGENTS.md** — Code style now reads "Always use `bin/lint`, don't use other formatters."
- **frontend-conventions skill** — adds a "Format ERB before committing" note pointing at the `bin/lint <file>` / `herb-format` workflow.
