### PR TITLE
Handle fetch_athlete_stats in StravaJobs::RequestRunner

### DIFF
--- a/app/jobs/strava_jobs/request_runner.rb
+++ b/app/jobs/strava_jobs/request_runner.rb
@@ -52,6 +52,8 @@ module StravaJobs
           Integrations::Strava::Client.fetch_activity(strava_integration, strava_request.parameters["strava_id"])
         when "fetch_athlete"
           Integrations::Strava::Client.fetch_athlete(strava_integration)
+        when "fetch_athlete_stats"
+          Integrations::Strava::Client.fetch_athlete_stats(strava_integration)
         when "fetch_gear"
           Integrations::Strava::Client.fetch_gear(strava_integration, strava_request.parameters["strava_gear_id"])
         else
@@ -73,6 +75,8 @@ module StravaJobs
           StravaActivity.create_or_update_from_strava_response(strava_integration, response)
         elsif strava_request.fetch_athlete?
           strava_integration.update_from_athlete_and_stats(response)
+        elsif strava_request.fetch_athlete_stats?
+          strava_integration.update_from_stats(response)
         elsif strava_request.fetch_gear?
           StravaGear.update_from_strava(strava_integration, response)
         end

--- a/app/models/strava_integration.rb
+++ b/app/models/strava_integration.rb
@@ -94,16 +94,18 @@ class StravaIntegration < ApplicationRecord
   end
 
   def update_from_athlete_and_stats(athlete, stats = nil)
-    if stats
-      self.athlete_activity_count = (stats.dig("all_ride_totals", "count") || 0) +
-        (stats.dig("all_run_totals", "count") || 0) +
-        (stats.dig("all_swim_totals", "count") || 0)
-    end
+    self.athlete_activity_count = activity_count_from_stats(stats) if stats
     update(strava_data: athlete.except("id"), strava_id: athlete["id"], status: calculated_status)
 
     bikes = (athlete["bikes"] || []).map { |g| g.merge("gear_type" => "bike") }
     shoes = (athlete["shoes"] || []).map { |g| g.merge("gear_type" => "shoe") }
     (bikes + shoes).each { |gear_data| StravaGear.update_from_strava(self, gear_data) }
+  end
+
+  def update_from_stats(stats)
+    return if stats.blank?
+
+    update(athlete_activity_count: activity_count_from_stats(stats))
   end
 
   def update_sync_status(force_update: false)
@@ -128,6 +130,12 @@ class StravaIntegration < ApplicationRecord
   end
 
   private
+
+  def activity_count_from_stats(stats)
+    (stats.dig("all_ride_totals", "count") || 0) +
+      (stats.dig("all_run_totals", "count") || 0) +
+      (stats.dig("all_swim_totals", "count") || 0)
+  end
 
   def calculated_status
     return :error if status == :error

--- a/spec/jobs/strava_jobs/request_runner_spec.rb
+++ b/spec/jobs/strava_jobs/request_runner_spec.rb
@@ -170,6 +170,25 @@ RSpec.describe StravaJobs::RequestRunner, type: :job do
       end
     end
 
+    context "with fetch_athlete_stats request" do
+      let(:strava_integration) do
+        FactoryBot.create(:strava_integration, :syncing, status: :pending,
+          strava_id: ENV["STRAVA_TEST_USER_ID"], athlete_activity_count: 5)
+      end
+      let!(:strava_request) do
+        FactoryBot.create(:strava_request, :fetch_athlete_stats, strava_integration:)
+      end
+
+      it "updates the athlete_activity_count from the stats response" do
+        VCR.use_cassette("strava-get_athlete_stats") do
+          instance.perform(strava_request.id)
+        end
+
+        expect(strava_request.reload.response_status).to eq("success")
+        expect(strava_integration.reload.athlete_activity_count).to eq(1817)
+      end
+    end
+
     context "with fetch_gear request" do
       let!(:strava_gear) do
         FactoryBot.create(:strava_gear, strava_integration:,

--- a/spec/models/strava_integration_spec.rb
+++ b/spec/models/strava_integration_spec.rb
@@ -163,6 +163,25 @@ RSpec.describe StravaIntegration, type: :model do
     end
   end
 
+  describe "update_from_stats" do
+    let(:strava_integration) { FactoryBot.create(:strava_integration, athlete_activity_count: 5) }
+    let(:stats) do
+      {"all_ride_totals" => {"count" => 100},
+       "all_run_totals" => {"count" => 40},
+       "all_swim_totals" => {"count" => 10}}
+    end
+
+    it "updates athlete_activity_count" do
+      strava_integration.update_from_stats(stats)
+      expect(strava_integration.reload.athlete_activity_count).to eq(150)
+    end
+
+    it "no-ops on blank stats" do
+      strava_integration.update_from_stats(nil)
+      expect(strava_integration.reload.athlete_activity_count).to eq(5)
+    end
+  end
+
   describe "gear_ids_to_request" do
     let(:strava_integration) { FactoryBot.create(:strava_integration) }
 


### PR DESCRIPTION
Fixes Honeybadger fault [131871099](https://app.honeybadger.io/projects/35931/faults/131871099) — `StravaJobs::RequestRunner` raising `"Unknown Request type"` (5,669 occurrences in ~13 hours).

When a `fetch_athlete_stats` Strava call was rate-limited, 503'd, or token-expired inside `FetchAthleteAndStats`, the re-enqueue path created a standalone `pending` `fetch_athlete_stats` request that `RequestRunner.make_request` had no case for, so it raised before updating the status — leaving the request `pending` and re-enqueued by `ScheduledRequestEnqueuer` every ~15s in an infinite loop.

- `RequestRunner` now processes a standalone `fetch_athlete_stats` request (`make_request` + `handle_response`), which both stops the crash and drains the stuck backlog as each request finally flips to `success`.
- Added `StravaIntegration#update_from_stats` (athlete-count-only updater), extracting the shared count math into a private helper reused by `update_from_athlete_and_stats`.
