### PR TITLE
Add Responder dropdown to admin/strava_requests

### DIFF
--- a/app/controllers/admin/strava_requests_controller.rb
+++ b/app/controllers/admin/strava_requests_controller.rb
@@ -43,10 +43,14 @@ module Admin
         strava_requests = case params[:search_response_status]
         when "pending_or_success" then strava_requests.where(response_status: StravaRequest::PENDING_OR_SUCCESS)
         when "not_successful" then strava_requests.where(response_status: StravaRequest::NOT_SUCCESSFUL)
-        when "only_binx_response" then strava_requests.where(response_status: StravaRequest::BINX_RESPONSE)
-        when "only_strava_response" then strava_requests.strava_response
         else strava_requests.where(response_status: params[:search_response_status])
         end
+      end
+
+      strava_requests = case params[:search_responder]
+      when "only_binx_response" then strava_requests.where(response_status: StravaRequest::BINX_RESPONSE)
+      when "only_strava_response" then strava_requests.strava_response
+      else strava_requests
       end
 
       @proxy_request = Binxtils::InputNormalizer.boolean(params[:search_proxy_requests])

--- a/app/controllers/admin/strava_requests_controller.rb
+++ b/app/controllers/admin/strava_requests_controller.rb
@@ -43,6 +43,7 @@ module Admin
         strava_requests = case params[:search_response_status]
         when "pending_or_success" then strava_requests.where(response_status: StravaRequest::PENDING_OR_SUCCESS)
         when "not_successful" then strava_requests.where(response_status: StravaRequest::NOT_SUCCESSFUL)
+        when "not_successful_not_skipped" then strava_requests.not_successful_not_skipped
         else strava_requests.where(response_status: params[:search_response_status])
         end
       end

--- a/app/controllers/admin/strava_requests_controller.rb
+++ b/app/controllers/admin/strava_requests_controller.rb
@@ -43,7 +43,7 @@ module Admin
         strava_requests = case params[:search_response_status]
         when "pending_or_success" then strava_requests.where(response_status: StravaRequest::PENDING_OR_SUCCESS)
         when "not_successful" then strava_requests.where(response_status: StravaRequest::NOT_SUCCESSFUL)
-        when "not_successful_not_skipped" then strava_requests.not_successful_not_skipped
+        when "errors_and_failures" then strava_requests.errors_and_failures
         else strava_requests.where(response_status: params[:search_response_status])
         end
       end

--- a/app/models/strava_request.rb
+++ b/app/models/strava_request.rb
@@ -76,6 +76,7 @@ class StravaRequest < AnalyticsRecord
   scope :proxy_request, -> { where(proxy_request: true) }
   scope :pending_or_success, -> { where(status: PENDING_OR_SUCCESS) }
   scope :not_successful, -> { where(status: NOT_SUCCESSFUL) }
+  scope :not_successful_not_skipped, -> { where(response_status: NOT_SUCCESSFUL - [:skipped]) }
   scope :strava_response, -> { where(response_status: NOT_BINX_RESPONSE).where.not(requested_at: nil) }
   scope :priority_ordered, -> { reorder(:priority) }
 

--- a/app/models/strava_request.rb
+++ b/app/models/strava_request.rb
@@ -76,7 +76,7 @@ class StravaRequest < AnalyticsRecord
   scope :proxy_request, -> { where(proxy_request: true) }
   scope :pending_or_success, -> { where(status: PENDING_OR_SUCCESS) }
   scope :not_successful, -> { where(status: NOT_SUCCESSFUL) }
-  scope :not_successful_not_skipped, -> { where(response_status: NOT_SUCCESSFUL - [:skipped]) }
+  scope :errors_and_failures, -> { where(response_status: NOT_SUCCESSFUL - %i[skipped binx_response]) }
   scope :strava_response, -> { where(response_status: NOT_BINX_RESPONSE).where.not(requested_at: nil) }
   scope :priority_ordered, -> { reorder(:priority) }
 

--- a/app/views/admin/strava_requests/index.html.erb
+++ b/app/views/admin/strava_requests/index.html.erb
@@ -54,7 +54,7 @@
       <%= link_to "All statuses", url_for(sortable_search_params.merge(search_response_status: nil)), class: "dropdown-item #{params[:search_response_status].present? ? '' : 'active'}" %>
       <%= link_to "Pending or successful", url_for(sortable_search_params.merge(search_response_status: "pending_or_success")), class: "dropdown-item #{params[:search_response_status] == 'pending_or_success' ? 'active' : ''}" %>
       <%= link_to "Not successful", url_for(sortable_search_params.merge(search_response_status: "not_successful")), class: "dropdown-item #{params[:search_response_status] == 'not_successful' ? 'active' : ''}" %>
-      <%= link_to "Not successful, not skipped", url_for(sortable_search_params.merge(search_response_status: "not_successful_not_skipped")), class: "dropdown-item #{params[:search_response_status] == 'not_successful_not_skipped' ? 'active' : ''}" %>
+      <%= link_to "Errors and failures", url_for(sortable_search_params.merge(search_response_status: "errors_and_failures")), class: "dropdown-item #{params[:search_response_status] == 'errors_and_failures' ? 'active' : ''}" %>
 
       <div class="dropdown-divider"></div>
 

--- a/app/views/admin/strava_requests/index.html.erb
+++ b/app/views/admin/strava_requests/index.html.erb
@@ -54,6 +54,7 @@
       <%= link_to "All statuses", url_for(sortable_search_params.merge(search_response_status: nil)), class: "dropdown-item #{params[:search_response_status].present? ? '' : 'active'}" %>
       <%= link_to "Pending or successful", url_for(sortable_search_params.merge(search_response_status: "pending_or_success")), class: "dropdown-item #{params[:search_response_status] == 'pending_or_success' ? 'active' : ''}" %>
       <%= link_to "Not successful", url_for(sortable_search_params.merge(search_response_status: "not_successful")), class: "dropdown-item #{params[:search_response_status] == 'not_successful' ? 'active' : ''}" %>
+      <%= link_to "Not successful, not skipped", url_for(sortable_search_params.merge(search_response_status: "not_successful_not_skipped")), class: "dropdown-item #{params[:search_response_status] == 'not_successful_not_skipped' ? 'active' : ''}" %>
 
       <div class="dropdown-divider"></div>
 

--- a/app/views/admin/strava_requests/index.html.erb
+++ b/app/views/admin/strava_requests/index.html.erb
@@ -54,14 +54,35 @@
       <%= link_to "All statuses", url_for(sortable_search_params.merge(search_response_status: nil)), class: "dropdown-item #{params[:search_response_status].present? ? '' : 'active'}" %>
       <%= link_to "Pending or successful", url_for(sortable_search_params.merge(search_response_status: "pending_or_success")), class: "dropdown-item #{params[:search_response_status] == 'pending_or_success' ? 'active' : ''}" %>
       <%= link_to "Not successful", url_for(sortable_search_params.merge(search_response_status: "not_successful")), class: "dropdown-item #{params[:search_response_status] == 'not_successful' ? 'active' : ''}" %>
-      <%= link_to "Only Binx response", url_for(sortable_search_params.merge(search_response_status: "only_binx_response")), class: "dropdown-item #{params[:search_response_status] == 'only_binx_response' ? 'active' : ''}" %>
-      <%= link_to "Only Strava Response (NOT Binx response)", url_for(sortable_search_params.merge(search_response_status: "only_strava_response")), class: "dropdown-item #{params[:search_response_status] == 'only_strava_response' ? 'active' : ''}" %>
 
       <div class="dropdown-divider"></div>
 
       <% StravaRequest::RESPONSE_STATUS_ENUM.each_key do |kind| %>
         <%= link_to kind.to_s.humanize, url_for(sortable_search_params.merge(search_response_status: kind)), class: "dropdown-item #{params[:search_response_status] == kind.to_s ? 'active' : ''}" %>
       <% end %>
+    </div>
+  </li>
+
+  <li class="nav-item dropdown dropleft">
+    <a
+      class="nav-link dropdown-toggle <%= params[:search_responder].present? ? "active" : "" %>"
+      href="#"
+      role="button"
+      data-toggle="dropdown"
+      aria-haspopup="true"
+      aria-expanded="false"
+    >
+      <% if params[:search_responder].blank? %>
+        Any responder
+      <% else %>
+        <%= params[:search_responder].humanize %>
+      <% end %>
+    </a>
+
+    <div class="dropdown-menu">
+      <%= link_to "Any responder", url_for(sortable_search_params.merge(search_responder: nil)), class: "dropdown-item #{params[:search_responder].present? ? '' : 'active'}" %>
+      <%= link_to "Only Binx response", url_for(sortable_search_params.merge(search_responder: "only_binx_response")), class: "dropdown-item #{params[:search_responder] == 'only_binx_response' ? 'active' : ''}" %>
+      <%= link_to "Only Strava Response", url_for(sortable_search_params.merge(search_responder: "only_strava_response")), class: "dropdown-item #{params[:search_responder] == 'only_strava_response' ? 'active' : ''}" %>
     </div>
   </li>
 <% end %>

--- a/spec/requests/admin/strava_requests_request_spec.rb
+++ b/spec/requests/admin/strava_requests_request_spec.rb
@@ -21,6 +21,17 @@ RSpec.describe Admin::StravaRequestsController, type: :request do
       expect(assigns(:collection).pluck(:id)).to eq([strava_request.id])
     end
 
+    context "with search_response_status not_successful_not_skipped" do
+      let!(:skipped_request) { FactoryBot.create(:strava_request, response_status: :skipped) }
+      let!(:error_request) { FactoryBot.create(:strava_request, response_status: :error) }
+
+      it "excludes successful and skipped" do
+        get base_url, params: {search_response_status: "not_successful_not_skipped"}
+        expect(response.status).to eq(200)
+        expect(assigns(:collection).pluck(:id)).to eq([error_request.id])
+      end
+    end
+
     context "with search_responder" do
       let!(:binx_request) { FactoryBot.create(:strava_request, response_status: :binx_response) }
       let!(:strava_response_request) { FactoryBot.create(:strava_request, response_status: :success, requested_at: Time.current) }

--- a/spec/requests/admin/strava_requests_request_spec.rb
+++ b/spec/requests/admin/strava_requests_request_spec.rb
@@ -21,6 +21,23 @@ RSpec.describe Admin::StravaRequestsController, type: :request do
       expect(assigns(:collection).pluck(:id)).to eq([strava_request.id])
     end
 
+    context "with search_responder" do
+      let!(:binx_request) { FactoryBot.create(:strava_request, response_status: :binx_response) }
+      let!(:strava_response_request) { FactoryBot.create(:strava_request, response_status: :success, requested_at: Time.current) }
+
+      it "filters to only Binx responses" do
+        get base_url, params: {search_responder: "only_binx_response"}
+        expect(response.status).to eq(200)
+        expect(assigns(:collection).pluck(:id)).to eq([binx_request.id])
+      end
+
+      it "filters to only Strava responses" do
+        get base_url, params: {search_responder: "only_strava_response"}
+        expect(response.status).to eq(200)
+        expect(assigns(:collection).pluck(:id)).to eq([strava_response_request.id])
+      end
+    end
+
     context "with render_chart" do
       it "renders chart including integration pie chart" do
         get base_url, params: {render_chart: true, period: "year"}

--- a/spec/requests/admin/strava_requests_request_spec.rb
+++ b/spec/requests/admin/strava_requests_request_spec.rb
@@ -21,12 +21,13 @@ RSpec.describe Admin::StravaRequestsController, type: :request do
       expect(assigns(:collection).pluck(:id)).to eq([strava_request.id])
     end
 
-    context "with search_response_status not_successful_not_skipped" do
+    context "with search_response_status errors_and_failures" do
       let!(:skipped_request) { FactoryBot.create(:strava_request, response_status: :skipped) }
+      let!(:binx_request) { FactoryBot.create(:strava_request, response_status: :binx_response) }
       let!(:error_request) { FactoryBot.create(:strava_request, response_status: :error) }
 
-      it "excludes successful and skipped" do
-        get base_url, params: {search_response_status: "not_successful_not_skipped"}
+      it "excludes successful, skipped, and binx_response" do
+        get base_url, params: {search_response_status: "errors_and_failures"}
         expect(response.status).to eq(200)
         expect(assigns(:collection).pluck(:id)).to eq([error_request.id])
       end


### PR DESCRIPTION
Adds a dedicated "Responder" dropdown to `admin/strava_requests`, separating "who responded" from the response status.

- Moves "Only Binx response" and "Only Strava response" out of the status dropdown into a new "Responder" dropdown backed by a `search_responder` param.
- Adds request-spec coverage for both responder filters.

Note: bookmarked URLs using `search_response_status=only_binx_response`/`only_strava_response` no longer apply that filter — those now live under `search_responder`.
