### PR TITLE
Default Rack::Attack Redis to the cache Redis URL

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -24,15 +24,7 @@ module Bikeindex
   class Application < Rails::Application
     config.redis_default_url = ENV["REDIS_URL"]
     config.redis_cache_url = ENV.fetch("REDIS_CACHE_URL", config.redis_default_url)
-    # Prefer a separate Redis instance for Rack::Attack so cache eviction can't
-    # drop rate-limit keys. Falls back to the next database on the cache Redis.
-    config.redis_rack_attack_url = ENV.fetch("REDIS_RACK_ATTACK_URL") do
-      if config.redis_cache_url.match?(%r{/\d+\z})
-        config.redis_cache_url.sub(%r{/(\d+)\z}) { "/#{$1.to_i + 1}" }
-      else
-        "#{config.redis_cache_url}/1"
-      end
-    end
+    config.redis_rack_attack_url = ENV.fetch("REDIS_RACK_ATTACK_URL", config.redis_cache_url)
 
     config.load_defaults 8.0
 


### PR DESCRIPTION
Simplify the Rack::Attack Redis configuration. Production sets `REDIS_RACK_ATTACK_URL` to a dedicated Redis instance; everywhere else now falls back to the same instance as the cache (`redis_cache_url`).

This drops the previous db-increment fallback, which could compute an out-of-range Redis database (e.g. cache on db 15 → db 16) and cause `RedisCacheStore` to silently drop every rate-limit write.
