### PR TITLE
Reduce ScheduledAutocompleteCheckJob frequency to daily

### DIFF
--- a/app/jobs/scheduled_autocomplete_check_job.rb
+++ b/app/jobs/scheduled_autocomplete_check_job.rb
@@ -12,6 +12,8 @@ class ScheduledAutocompleteCheckJob < ScheduledJob
     raise "Missing Manufacturers!" if too_few_autocomplete_manufacturers?
   end
 
+  private
+
   def too_few_autocomplete_manufacturers?
     Autocomplete::Loader.frame_mnfg_count < Manufacturer.frame_makers.count
   end

--- a/app/jobs/scheduled_autocomplete_check_job.rb
+++ b/app/jobs/scheduled_autocomplete_check_job.rb
@@ -1,9 +1,9 @@
-# See PR#2483 - frequency can definitely be dropped a month or 2 after 2023-11
+# See PR#2483 for background
 class ScheduledAutocompleteCheckJob < ScheduledJob
   prepend ScheduledJobRecorder
 
   def self.frequency
-    4.minutes
+    1.day
   end
 
   def perform

--- a/app/jobs/scheduled_autocomplete_check_job.rb
+++ b/app/jobs/scheduled_autocomplete_check_job.rb
@@ -7,10 +7,10 @@ class ScheduledAutocompleteCheckJob < ScheduledJob
   end
 
   def perform
-    if too_few_autocomplete_manufacturers?
-      AutocompleteLoaderJob.perform_async
-      raise "Missing Manufacturers!"
-    end
+    return unless too_few_autocomplete_manufacturers?
+
+    AutocompleteLoaderJob.new.perform
+    raise "Missing Manufacturers!" if too_few_autocomplete_manufacturers?
   end
 
   def too_few_autocomplete_manufacturers?

--- a/app/jobs/scheduled_autocomplete_check_job.rb
+++ b/app/jobs/scheduled_autocomplete_check_job.rb
@@ -1,4 +1,3 @@
-# See PR#2483 for background
 class ScheduledAutocompleteCheckJob < ScheduledJob
   prepend ScheduledJobRecorder
 

--- a/spec/jobs/scheduled_autocomplete_check_job_spec.rb
+++ b/spec/jobs/scheduled_autocomplete_check_job_spec.rb
@@ -13,21 +13,24 @@ RSpec.describe ScheduledAutocompleteCheckJob, type: :job do
 
   describe "perform" do
     before { FactoryBot.create(:manufacturer) }
-    it "throws an error if there are no manufacturers" do
+    it "loads autocomplete inline and doesn't raise" do
       Autocomplete::Loader.clear_redis
-      Sidekiq::Job.clear_all
-      expect {
-        instance.perform
-      }.to raise_error(/manufacturer/i)
-      expect(AutocompleteLoaderJob.jobs.count).to eq 1
+      expect(instance.too_few_autocomplete_manufacturers?).to be_truthy
+      instance.perform
+      expect(instance.too_few_autocomplete_manufacturers?).to be_falsey
     end
-    context "with manufacturers" do
-      it "doesn't throw and error or enqueue" do
+    context "when loading doesn't resolve the shortage" do
+      it "raises" do
+        allow(instance).to receive(:too_few_autocomplete_manufacturers?) { true }
+        expect { instance.perform }.to raise_error(/manufacturer/i)
+      end
+    end
+    context "with enough manufacturers" do
+      it "doesn't load or raise" do
         Autocomplete::Loader.load_all(["Manufacturer"])
         expect(Autocomplete::Loader.frame_mnfg_count).to be > 0
-        Sidekiq::Job.clear_all
+        expect_any_instance_of(AutocompleteLoaderJob).not_to receive(:perform)
         instance.perform
-        expect(AutocompleteLoaderJob.jobs.count).to eq 0
       end
     end
   end

--- a/spec/jobs/scheduled_autocomplete_check_job_spec.rb
+++ b/spec/jobs/scheduled_autocomplete_check_job_spec.rb
@@ -16,9 +16,9 @@ RSpec.describe ScheduledAutocompleteCheckJob, type: :job do
     context "with too few autocomplete manufacturers" do
       before { Autocomplete::Loader.clear_redis }
       it "loads autocomplete inline and doesn't raise" do
-        expect(instance.too_few_autocomplete_manufacturers?).to be_truthy
-        instance.perform
-        expect(instance.too_few_autocomplete_manufacturers?).to be_falsey
+        expect(Autocomplete::Loader.frame_mnfg_count).to eq 0
+        expect { instance.perform }.not_to raise_error
+        expect(Autocomplete::Loader.frame_mnfg_count).to be > 0
       end
       context "when loading doesn't resolve the shortage" do
         # Simulate a load that fails to populate the autocomplete data

--- a/spec/jobs/scheduled_autocomplete_check_job_spec.rb
+++ b/spec/jobs/scheduled_autocomplete_check_job_spec.rb
@@ -13,21 +13,24 @@ RSpec.describe ScheduledAutocompleteCheckJob, type: :job do
 
   describe "perform" do
     before { FactoryBot.create(:manufacturer) }
-    it "loads autocomplete inline and doesn't raise" do
-      Autocomplete::Loader.clear_redis
-      expect(instance.too_few_autocomplete_manufacturers?).to be_truthy
-      instance.perform
-      expect(instance.too_few_autocomplete_manufacturers?).to be_falsey
-    end
-    context "when loading doesn't resolve the shortage" do
-      it "raises" do
-        allow(instance).to receive(:too_few_autocomplete_manufacturers?) { true }
-        expect { instance.perform }.to raise_error(/manufacturer/i)
+    context "with too few autocomplete manufacturers" do
+      before { Autocomplete::Loader.clear_redis }
+      it "loads autocomplete inline and doesn't raise" do
+        expect(instance.too_few_autocomplete_manufacturers?).to be_truthy
+        instance.perform
+        expect(instance.too_few_autocomplete_manufacturers?).to be_falsey
+      end
+      context "when loading doesn't resolve the shortage" do
+        # Simulate a load that fails to populate the autocomplete data
+        before { allow_any_instance_of(AutocompleteLoaderJob).to receive(:perform) }
+        it "raises" do
+          expect { instance.perform }.to raise_error(/manufacturer/i)
+        end
       end
     end
     context "with enough manufacturers" do
+      before { Autocomplete::Loader.load_all(["Manufacturer"]) }
       it "doesn't load or raise" do
-        Autocomplete::Loader.load_all(["Manufacturer"])
         expect(Autocomplete::Loader.frame_mnfg_count).to be > 0
         expect_any_instance_of(AutocompleteLoaderJob).not_to receive(:perform)
         instance.perform


### PR DESCRIPTION
Reduces `ScheduledAutocompleteCheckJob` from running every 4 minutes to once a day. When the check finds too few autocomplete manufacturers, it now runs `AutocompleteLoaderJob` inline rather than enqueuing it async, then re-checks and only raises `"Missing Manufacturers!"` if loading didn't resolve the shortage. The high frequency dated back to PR #2483's initial rollout and is no longer warranted.
