### PR TITLE
Fix review-app build: create /rails/storage as root

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -84,7 +84,6 @@ FROM base
 
 RUN groupadd --system --gid 1000 rails && \
     useradd rails --uid 1000 --gid 1000 --create-home --shell /bin/bash
-USER 1000:1000
 
 COPY --chown=rails:rails --from=build "${BUNDLE_PATH}" "${BUNDLE_PATH}"
 COPY --chown=rails:rails --from=build /rails /rails
@@ -94,7 +93,9 @@ COPY --chown=rails:rails --from=build /rails /rails
 # rails ownership into an empty volume on first mount; without it Docker creates
 # /rails/storage root-owned and letter_opener_web can't mkdir its inbox there
 # (Errno::EACCES, see config/environments/staging.rb).
-RUN mkdir -p /rails/storage
+# Runs as root: WORKDIR created /rails root-owned, so the rails user can't mkdir here.
+RUN mkdir -p /rails/storage && chown rails:rails /rails/storage
+USER 1000:1000
 
 ENTRYPOINT ["/rails/bin/docker-entrypoint"]
 


### PR DESCRIPTION
Review-app image builds were failing at the final stage with `mkdir: cannot create directory '/rails/storage': Permission denied`.

The `RUN mkdir -p /rails/storage` (added in #3738) executed after `USER 1000:1000`, but `/rails` itself is root-owned — `WORKDIR /rails` creates it as root and `COPY --chown=rails:rails` only sets ownership on the copied contents, not the mountpoint dir — so the unprivileged `rails` user couldn't create a subdirectory in it.

This moves `USER 1000:1000` to after the `mkdir`, so it runs as root, and adds an explicit `chown rails:rails /rails/storage` to preserve the intent that the dir be rails-owned before the per-PR volume mounts over it.
