### PR TITLE
Strip Postgres 17 pg_dump artifacts via a db:schema:dump enhancement

### DIFF
--- a/bin/fix_structure
+++ b/bin/fix_structure
@@ -1,2 +1,0 @@
-#!/usr/bin/env bash
-sed -i '' -e '/SET transaction_timeout = 0;/d' -e '/^\\restrict /d' -e '/^\\unrestrict /d' db/*.sql

--- a/bin/workspace_setup
+++ b/bin/workspace_setup
@@ -46,4 +46,3 @@ else
 end
 
 system(File.join(APP_ROOT, "bin/setup"), *ARGV) || abort("bin/setup failed")
-exec File.join(APP_ROOT, "bin/fix_structure")

--- a/conductor.json
+++ b/conductor.json
@@ -1,5 +1,5 @@
 {
-  "setup": "bin/workspace_setup --without_seeds && bin/fix_structure",
+  "setup": "bin/workspace_setup --without_seeds",
   "server": "bin/dev",
   "teardown": "bin/workspace_teardown"
 }

--- a/lib/tasks/parallel_migrate.rake
+++ b/lib/tasks/parallel_migrate.rake
@@ -11,17 +11,7 @@ if Rails.env.development? && ENV["PARALLEL_MIGRATIONS"].present?
     puts "Running parallel:migrate for test databases..."
     system("rake parallel:migrate")
     system("rake parallel:prepare")
-
-    # Remove postgres 17 additions that cause CI failures
-    Dir.glob("db/*.sql").each do |file|
-      content = File.read(file)
-      cleaned = content.lines.reject { |line|
-        line.include?("SET transaction_timeout = 0;") ||
-          line.start_with?("\\restrict ") ||
-          line.start_with?("\\unrestrict ")
-      }.join
-      File.write(file, cleaned) if cleaned != content
-    end
+    # Postgres 17 pg_dump artifacts are stripped by the db:schema:dump enhancement
   end
 
   Rake::Task["db:drop"].enhance do

--- a/lib/tasks/schema_dump.rake
+++ b/lib/tasks/schema_dump.rake
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+# Strip Postgres 17 pg_dump artifacts (SET transaction_timeout, \restrict,
+# \unrestrict) after every schema dump, so structure.sql files stay clean and
+# don't fail CI. Runs wherever the schema is dumped (db:migrate, db:schema:dump).
+Rake::Task["db:schema:dump"].enhance do
+  Dir.glob("db/*.sql").each do |file|
+    content = File.read(file)
+    cleaned = content.lines.reject { |line|
+      line.include?("SET transaction_timeout = 0;") ||
+        line.start_with?("\\restrict ") ||
+        line.start_with?("\\unrestrict ")
+    }.join
+    File.write(file, cleaned) if cleaned != content
+  end
+end


### PR DESCRIPTION
Consolidate the Postgres 17 pg_dump cleanup (`SET transaction_timeout`, `\restrict`, `\unrestrict`) into a single `db:schema:dump` enhancement so it runs automatically everywhere the schema is dumped — `db:migrate`, `db:prepare`, fresh Conductor setup — instead of a standalone script that had to be chained on.

- Add `lib/tasks/schema_dump.rake`, a tiny post-dump step that strips the artifacts from `db/*.sql`.
- Remove `bin/fix_structure` and its `conductor.json` / `bin/workspace_setup` call sites.
- Drop the now-redundant inline cleanup in `parallel_migrate.rake` (its `db:migrate` override already triggers the dump).
