### PR TITLE
Add short_id for bikes, versions and marketplace listings

### DIFF
--- a/app/components/admin/bike_cell/component_preview.rb
+++ b/app/components/admin/bike_cell/component_preview.rb
@@ -40,7 +40,7 @@ module Admin
       private
 
       def bike
-        Bike.find(35)
+        Bike.find_id(35)
       end
     end
   end

--- a/app/components/emails/finished_registration/component.rb
+++ b/app/components/emails/finished_registration/component.rb
@@ -97,7 +97,7 @@ module Emails
       end
 
       def bike
-        @bike ||= Bike.unscoped.find(@ownership.bike_id)
+        @bike ||= Bike.unscoped.find_id(@ownership.bike_id)
       end
 
       def user

--- a/app/controllers/admin/bikes_controller.rb
+++ b/app/controllers/admin/bikes_controller.rb
@@ -149,7 +149,7 @@ module Admin
     end
 
     def find_bike
-      @bike = Bike.unscoped.find(params[:id])
+      @bike = Bike.unscoped.find_id(params[:id])
     end
 
     def matching_bikes

--- a/app/controllers/admin/ownerships_controller.rb
+++ b/app/controllers/admin/ownerships_controller.rb
@@ -85,7 +85,7 @@ module Admin
 
     def find_ownership
       @ownership = Ownership.find(params[:id])
-      @bike = Bike.unscoped.find(@ownership.bike_id)
+      @bike = Bike.unscoped.find_id(@ownership.bike_id)
       @users = User.all
     end
 

--- a/app/controllers/admin/theft_alerts_controller.rb
+++ b/app/controllers/admin/theft_alerts_controller.rb
@@ -77,7 +77,7 @@ module Admin
     def find_theft_alert
       @theft_alert ||= TheftAlert.find(params[:id])
       @stolen_record ||= @theft_alert.stolen_record
-      @bike ||= Bike.unscoped.find(@stolen_record.bike_id)
+      @bike ||= Bike.unscoped.find_id(@stolen_record.bike_id)
     end
 
     def permitted_update_params

--- a/app/controllers/admin/user_alerts_controller.rb
+++ b/app/controllers/admin/user_alerts_controller.rb
@@ -34,7 +34,7 @@ module Admin
         user_alerts = user_alerts.where(user_id: user_subject&.id || params[:user_id])
       end
       if params[:search_bike_id].present?
-        @bike = Bike.unscoped.find(params[:search_bike_id])
+        @bike = Bike.unscoped.find_id(params[:search_bike_id])
         user_alerts = user_alerts.where(bike_id: @bike.id) if @bike.present?
       end
       @with_notification = Binxtils::InputNormalizer.boolean(params[:search_with_notification])

--- a/app/controllers/api/v1/bikes_controller.rb
+++ b/app/controllers/api/v1/bikes_controller.rb
@@ -55,7 +55,7 @@ module API
       end
 
       def show
-        render json: Bike.unscoped.find(params[:id]), serializer: SingleBikeSerializer
+        render json: Bike.unscoped.find_id(params[:id]), serializer: SingleBikeSerializer
       end
 
       def create

--- a/app/controllers/api/v1/notifications_controller.rb
+++ b/app/controllers/api/v1/notifications_controller.rb
@@ -5,7 +5,7 @@ module API
       skip_before_action :verify_authenticity_token
 
       def create
-        bike = Bike.find(params[:notification_hash][:bike_id])
+        bike = Bike.find_id(params[:notification_hash][:bike_id])
         if params[:notification_hash][:notification_type].to_s.match("stolen_twitter_alerter").present?
           if bike.fetch_current_stolen_record.present?
             customer_contact = CustomerContact.new(body: "EMPTY",

--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -22,7 +22,7 @@ module API
         reason = params[:request_reason]
         feedback_type = params[:request_type]
         if current_user.present? && reason.present? && bike_id.present? && feedback_type.present?
-          bike = Bike.find(bike_id)
+          bike = Bike.find_id(bike_id)
           if bike.authorized?(current_user)
             feedback = Feedback.new(email: current_user.email, body: reason, title: feedback_type.titleize.to_s, feedback_type: feedback_type)
             feedback.name = (current_user.name.present? && current_user.name) || "no name"

--- a/app/controllers/api/v2/bikes.rb
+++ b/app/controllers/api/v2/bikes.rb
@@ -97,7 +97,7 @@ module API
         end
 
         def find_bike
-          @bike = Bike.unscoped.find(params[:id])
+          @bike = Bike.unscoped.find_id(params[:id])
         end
 
         def owner_duplicate_bike(bikes: nil)

--- a/app/controllers/bike_versions_controller.rb
+++ b/app/controllers/bike_versions_controller.rb
@@ -60,7 +60,7 @@ class BikeVersionsController < ApplicationController
 
   def find_bike_version
     begin
-      @bike_version = BikeVersion.unscoped.find(params[:id])
+      @bike_version = BikeVersion.unscoped.find_id(params[:id])
     rescue ActiveRecord::StatementInvalid => e
       raise e.to_s.match?(/PG..NumericValueOutOfRange/) ? ActiveRecord::RecordNotFound : e
     end

--- a/app/controllers/bike_versions_controller.rb
+++ b/app/controllers/bike_versions_controller.rb
@@ -16,7 +16,7 @@ class BikeVersionsController < ApplicationController
   end
 
   def create
-    bike = Bike.unscoped.find(params[:bike_id])
+    bike = Bike.unscoped.find_id(params[:bike_id])
     if bike&.authorized?(current_user)
       # Do it inline because it's blocking
       bike_version = BikeVersionCreatorJob.new.perform(bike.id)

--- a/app/controllers/bikes/base_controller.rb
+++ b/app/controllers/bikes/base_controller.rb
@@ -44,7 +44,7 @@ module Bikes
         return
       end
       begin
-        @bike = Bike.unscoped.find(params[:bike_id] || params[:id])
+        @bike = Bike.unscoped.find(Bike.integer_id(params[:bike_id] || params[:id]))
       rescue ActiveRecord::StatementInvalid => e
         raise e.to_s.match?(/PG..NumericValueOutOfRange/) ? ActiveRecord::RecordNotFound : e
       end

--- a/app/controllers/bikes/base_controller.rb
+++ b/app/controllers/bikes/base_controller.rb
@@ -44,7 +44,7 @@ module Bikes
         return
       end
       begin
-        @bike = Bike.unscoped.find(Bike.integer_id(params[:bike_id] || params[:id]))
+        @bike = Bike.unscoped.find(ShortId.decode(params[:bike_id] || params[:id]))
       rescue ActiveRecord::StatementInvalid => e
         raise e.to_s.match?(/PG..NumericValueOutOfRange/) ? ActiveRecord::RecordNotFound : e
       end

--- a/app/controllers/bikes/base_controller.rb
+++ b/app/controllers/bikes/base_controller.rb
@@ -44,7 +44,7 @@ module Bikes
         return
       end
       begin
-        @bike = Bike.unscoped.find(ShortId.decode(params[:bike_id] || params[:id]))
+        @bike = Bike.unscoped.find_id(params[:bike_id] || params[:id])
       rescue ActiveRecord::StatementInvalid => e
         raise e.to_s.match?(/PG..NumericValueOutOfRange/) ? ActiveRecord::RecordNotFound : e
       end

--- a/app/controllers/bikes_controller.rb
+++ b/app/controllers/bikes_controller.rb
@@ -74,7 +74,7 @@ class BikesController < Bikes::BaseController
   end
 
   def spokecard
-    @qrcode = "#{bike_url(Bike.find(params[:id]))}.png"
+    @qrcode = "#{bike_url(Bike.find_id(params[:id]))}.png"
     render layout: false
   end
 

--- a/app/controllers/marketplace_listings_controller.rb
+++ b/app/controllers/marketplace_listings_controller.rb
@@ -1,0 +1,8 @@
+class MarketplaceListingsController < ApplicationController
+  # Public short URL (/m/<short_id>). A listing has no page of its own, so send
+  # the visitor to the item it's selling.
+  def show
+    @marketplace_listing = MarketplaceListing.find_id(params[:id])
+    redirect_to(@marketplace_listing.item)
+  end
+end

--- a/app/controllers/my_accounts/marketplace_listings_controller.rb
+++ b/app/controllers/my_accounts/marketplace_listings_controller.rb
@@ -60,7 +60,7 @@ module MyAccounts
     end
 
     def find_marketplace_listing
-      @bike = Bike.unscoped.find(params[:id].delete_prefix("b"))
+      @bike = Bike.unscoped.find_id(params[:id].delete_prefix("b"))
       ml_id = params.dig(:marketplace_listing, :id)
 
       @marketplace_listing = @bike.marketplace_listings.find_by(id: ml_id) if ml_id.present?

--- a/app/controllers/organizations_controller.rb
+++ b/app/controllers/organizations_controller.rb
@@ -63,7 +63,7 @@ class OrganizationsController < ApplicationController
 
   def embed_create_success
     find_organization
-    @bike = Bike.find(params[:bike_id])
+    @bike = Bike.find_id(params[:bike_id])
     render layout: "embed_layout"
   end
 

--- a/app/controllers/organized/bikes_controller.rb
+++ b/app/controllers/organized/bikes_controller.rb
@@ -71,7 +71,7 @@ module Organized
     end
 
     def update
-      bike = Bike.unscoped.find(params[:id])
+      bike = Bike.unscoped.find_id(params[:id])
 
       unless bike.organized?(current_organization) && current_organization.enabled?("registration_notes")
         flash[:error] = "Not authorized to update notes"

--- a/app/controllers/ownerships_controller.rb
+++ b/app/controllers/ownerships_controller.rb
@@ -4,7 +4,7 @@ class OwnershipsController < ApplicationController
   before_action :authenticate_user_and_set_flash
 
   def show
-    bike = Bike.unscoped.find(@ownership.bike_id)
+    bike = Bike.unscoped.find_id(@ownership.bike_id)
     if @ownership.claimable_by?(current_user)
       if @ownership.current
         @ownership.mark_claimed

--- a/app/controllers/public_images_controller.rb
+++ b/app/controllers/public_images_controller.rb
@@ -96,7 +96,7 @@ class PublicImagesController < ApplicationController
       @bike = if params[:imageable_type] == "BikeVersion"
         BikeVersion.unscoped.find(params[:bike_id])
       else
-        Bike.unscoped.find(params[:bike_id])
+        Bike.unscoped.find_id(params[:bike_id])
       end
       return true if @bike.authorized?(current_user)
     end

--- a/app/jobs/email/bike_possibly_found_notification_job.rb
+++ b/app/jobs/email/bike_possibly_found_notification_job.rb
@@ -5,7 +5,7 @@ module Email
     sidekiq_options queue: "notify", retry: 3
 
     def perform(bike_id, match_class, match_id)
-      bike = Bike.find(bike_id)
+      bike = Bike.find_id(bike_id)
       matched_bike = match_class.to_s.constantize.find(match_id)
 
       return if bike == matched_bike

--- a/app/jobs/email/scheduled_survey_job.rb
+++ b/app/jobs/email/scheduled_survey_job.rb
@@ -12,7 +12,7 @@ module Email
     def perform(bike_id = nil, force_send = false)
       return enqueue_workers(SURVEY_COUNT) if bike_id.blank?
 
-      bike = Bike.unscoped.find(bike_id)
+      bike = Bike.unscoped.find_id(bike_id)
       return if !force_send && no_survey?(bike)
 
       notification = Notification.create(kind: :theft_survey_2023, bike: bike, user: bike.user)

--- a/app/jobs/stolen_bike/approve_stolen_listing_job.rb
+++ b/app/jobs/stolen_bike/approve_stolen_listing_job.rb
@@ -7,7 +7,7 @@ module StolenBike
     def perform(bike_id)
       return if TWEETING_DISABLED
 
-      bike = Bike.find(bike_id)
+      bike = Bike.find_id(bike_id)
       new_post = Integrations::SocialPoster.new(bike).create_post
       send_stolen_bike_alert_email(bike, new_post)
     end

--- a/app/mailers/organized_mailer.rb
+++ b/app/mailers/organized_mailer.rb
@@ -24,7 +24,7 @@ class OrganizedMailer < ApplicationMailer
   end
 
   def finished_registration(ownership)
-    bike = Bike.unscoped.find(ownership.bike_id)
+    bike = Bike.unscoped.find_id(ownership.bike_id)
     @organization = ownership.organization
     component = Emails::FinishedRegistration::Component.new(ownership:, bike:)
     subject = I18n.t("organized_mailer.finished#{finished_registration_type(bike, ownership)}_registration.subject", **default_subject_vars(bike:))

--- a/app/models/bike.rb
+++ b/app/models/bike.rb
@@ -100,6 +100,7 @@ class Bike < ApplicationRecord
   include ActiveModel::Dirty
   include BikeSearchable
   include BikeAttributable
+  include ShortIdable
   include AddressRecorded
   include AddressRecordedWithinBoundingBox
   include PgSearch::Model
@@ -260,12 +261,6 @@ class Bike < ApplicationRecord
       unscoped.includes(:stolen_records)
         .where("stolen_records.phone ILIKE ? OR stolen_records.secondary_phone ILIKE ?", q, q)
         .distinct.references(:stolen_records)
-    end
-
-    # Find by id, decoding a short_id (e.g. "r/21J-HW") when present. Prepend
-    # .unscoped to also find hidden/example/deleted bikes.
-    def find_id(id)
-      find(ShortId.decode(:bike, id))
     end
 
     def friendly_find(bike_str)
@@ -515,11 +510,6 @@ class Bike < ApplicationRecord
   # Prevent returning ip address, rather than the TLD URL
   def html_url
     "#{ENV["BASE_URL"]}/bikes/#{id}"
-  end
-
-  # Type-prefixed alphanumeric alias for the id, e.g. "r/21J-HW"
-  def short_id
-    ShortId.encode(:bike, id)
   end
 
   # We may eventually remove the boolean. For now, we're just going with it.

--- a/app/models/bike.rb
+++ b/app/models/bike.rb
@@ -262,6 +262,12 @@ class Bike < ApplicationRecord
         .distinct.references(:stolen_records)
     end
 
+    # Find by id, decoding a short_id (e.g. "r/21J-HW") when present. Prepend
+    # .unscoped to also find hidden/example/deleted bikes.
+    def find_id(id)
+      find(ShortId.decode(:bike, id))
+    end
+
     def friendly_find(bike_str)
       return nil unless bike_str.present?
 
@@ -511,9 +517,9 @@ class Bike < ApplicationRecord
     "#{ENV["BASE_URL"]}/bikes/#{id}"
   end
 
-  # Compact alphanumeric alias for the id, usable in /bikes/:id URLs
+  # Type-prefixed alphanumeric alias for the id, e.g. "r/21J-HW"
   def short_id
-    ShortId.encode(id)
+    ShortId.encode(:bike, id)
   end
 
   # We may eventually remove the boolean. For now, we're just going with it.

--- a/app/models/bike.rb
+++ b/app/models/bike.rb
@@ -278,12 +278,6 @@ class Bike < ApplicationRecord
       where(id: bike_id).first
     end
 
-    # Resolve a /bikes/:id param, which may be a numeric id or a base36 short_id
-    def integer_id(param)
-      param = param.to_s
-      param.match?(/[a-z]/i) ? param.to_i(36) : param
-    end
-
     # This method only accepts numerical org ids
     def bike_sticker(organization_id = nil)
       return includes(:bike_stickers).where.not(bike_stickers: {bike_id: nil}) if organization_id.blank?
@@ -519,7 +513,7 @@ class Bike < ApplicationRecord
 
   # Compact alphanumeric alias for the id, usable in /bikes/:id URLs
   def short_id
-    id&.to_s(36)&.upcase
+    ShortId.encode(id)
   end
 
   # We may eventually remove the boolean. For now, we're just going with it.

--- a/app/models/bike.rb
+++ b/app/models/bike.rb
@@ -278,6 +278,12 @@ class Bike < ApplicationRecord
       where(id: bike_id).first
     end
 
+    # Resolve a /bikes/:id param, which may be a numeric id or a base36 short_id
+    def integer_id(param)
+      param = param.to_s
+      param.match?(/[a-z]/i) ? param.to_i(36) : param
+    end
+
     # This method only accepts numerical org ids
     def bike_sticker(organization_id = nil)
       return includes(:bike_stickers).where.not(bike_stickers: {bike_id: nil}) if organization_id.blank?
@@ -509,6 +515,11 @@ class Bike < ApplicationRecord
   # Prevent returning ip address, rather than the TLD URL
   def html_url
     "#{ENV["BASE_URL"]}/bikes/#{id}"
+  end
+
+  # Compact alphanumeric alias for the id, usable in /bikes/:id URLs
+  def short_id
+    id&.to_s(36)&.upcase
   end
 
   # We may eventually remove the boolean. For now, we're just going with it.

--- a/app/models/bike_version.rb
+++ b/app/models/bike_version.rb
@@ -102,6 +102,12 @@ class BikeVersion < ApplicationRecord
       year frame_size frame_size_unit frame_size_number]
   end
 
+  # Find by id, decoding a short_id (e.g. "v/21J-HW") when present. Prepend
+  # .unscoped to also find hidden/deleted versions.
+  def self.find_id(id)
+    find(ShortId.decode(:bike_version, id))
+  end
+
   # Get it unscoped, because unregistered_bike notifications
   def bike
     @bike ||= bike_id.present? ? Bike.unscoped.find_by_id(bike_id) : nil
@@ -185,6 +191,11 @@ class BikeVersion < ApplicationRecord
   # Prevent returning ip address, rather than the TLD URL
   def html_url
     "#{ENV["BASE_URL"]}/bike_versions/#{id}"
+  end
+
+  # Type-prefixed alphanumeric alias for the id, e.g. "v/21J-HW"
+  def short_id
+    ShortId.encode(:bike_version, id)
   end
 
   def authorized?(passed_user, no_superuser_override: false)

--- a/app/models/bike_version.rb
+++ b/app/models/bike_version.rb
@@ -58,6 +58,7 @@ class BikeVersion < ApplicationRecord
   include BikeSearchable
   include BikeAttributable
   include PgSearch::Model
+  include ShortIdable
 
   acts_as_paranoid without_default_scope: true
 
@@ -100,12 +101,6 @@ class BikeVersion < ApplicationRecord
   def self.bike_override_attributes
     %i[manufacturer_id manufacturer_other mnfg_name frame_model frame_material
       year frame_size frame_size_unit frame_size_number]
-  end
-
-  # Find by id, decoding a short_id (e.g. "v/21J-HW") when present. Prepend
-  # .unscoped to also find hidden/deleted versions.
-  def self.find_id(id)
-    find(ShortId.decode(:bike_version, id))
   end
 
   # Get it unscoped, because unregistered_bike notifications
@@ -191,11 +186,6 @@ class BikeVersion < ApplicationRecord
   # Prevent returning ip address, rather than the TLD URL
   def html_url
     "#{ENV["BASE_URL"]}/bike_versions/#{id}"
-  end
-
-  # Type-prefixed alphanumeric alias for the id, e.g. "v/21J-HW"
-  def short_id
-    ShortId.encode(:bike_version, id)
   end
 
   def authorized?(passed_user, no_superuser_override: false)

--- a/app/models/concerns/short_idable.rb
+++ b/app/models/concerns/short_idable.rb
@@ -1,0 +1,15 @@
+module ShortIdable
+  extend ActiveSupport::Concern
+
+  module ClassMethods
+    # Find by id, decoding a short_id (e.g. "r/21J-HW") when present.
+    def find_id(id)
+      find(ShortId.decode(name, id))
+    end
+  end
+
+  # Prefixed alphanumeric alias for the id, e.g. "r/21J-HW"
+  def short_id
+    ShortId.encode(self.class.name, id)
+  end
+end

--- a/app/models/marketplace_listing.rb
+++ b/app/models/marketplace_listing.rb
@@ -117,6 +117,11 @@ class MarketplaceListing < ApplicationRecord
       where(seller_id: user_id).or(where(buyer_id: user_id))
     end
 
+    # Find by id, decoding a short_id (e.g. "m/21J-HW") when present
+    def find_id(id)
+      find(ShortId.decode(:marketplace_listing, id))
+    end
+
     private
 
     def item_address_record(item)
@@ -216,6 +221,11 @@ class MarketplaceListing < ApplicationRecord
     return true if passed_user.id == seller_id
 
     sold? && passed_user.id == buyer_id
+  end
+
+  # Type-prefixed alphanumeric alias for the id, e.g. "m/21J-HW"
+  def short_id
+    ShortId.encode(:marketplace_listing, id)
   end
 
   private

--- a/app/models/marketplace_listing.rb
+++ b/app/models/marketplace_listing.rb
@@ -37,6 +37,7 @@ class MarketplaceListing < ApplicationRecord
   include AddressRecordedWithinBoundingBox
   include Amountable
   include Currencyable
+  include ShortIdable
 
   STATUS_ENUM = {draft: 0, for_sale: 1, sold: 2, removed: 3}.freeze
   CONDITION_ENUM = {new_in_box: 0, excellent: 1, good: 2, poor: 3, salvage: 4}.freeze
@@ -115,11 +116,6 @@ class MarketplaceListing < ApplicationRecord
     def for_user(user_or_id)
       user_id = user_or_id.is_a?(User) ? user_or_id.id : user_or_id
       where(seller_id: user_id).or(where(buyer_id: user_id))
-    end
-
-    # Find by id, decoding a short_id (e.g. "m/21J-HW") when present
-    def find_id(id)
-      find(ShortId.decode(:marketplace_listing, id))
     end
 
     private
@@ -221,11 +217,6 @@ class MarketplaceListing < ApplicationRecord
     return true if passed_user.id == seller_id
 
     sold? && passed_user.id == buyer_id
-  end
-
-  # Type-prefixed alphanumeric alias for the id, e.g. "m/21J-HW"
-  def short_id
-    ShortId.encode(:marketplace_listing, id)
   end
 
   private

--- a/app/services/short_id.rb
+++ b/app/services/short_id.rb
@@ -1,22 +1,22 @@
 module ShortId
   extend Functionable
 
-  # Type prefix for each object kind, so a short_id self-identifies
-  PREFIXES = {bike: "r", bike_version: "v", marketplace_listing: "m"}.freeze
+  # Prefix per model class, so a short_id self-identifies
+  PREFIXES = {"Bike" => "r", "BikeVersion" => "v", "MarketplaceListing" => "m"}.freeze
 
-  # Compact, type-prefixed alias for an id, e.g. ShortId.encode(:bike, 3431156) => "r/21J-HW"
-  def encode(type, id)
+  # Compact, prefixed alias for an id, e.g. ShortId.encode("Bike", 3431156) => "r/21J-HW"
+  def encode(class_name, id)
     return if id.blank?
 
-    "#{PREFIXES.fetch(type)}/#{id.to_s(36).upcase.scan(/.{1,3}/).join("-")}"
+    "#{PREFIXES.fetch(class_name)}/#{id.to_s(36).upcase.scan(/.{1,3}/).join("-")}"
   end
 
-  # Resolve a short_id back to an id. The type prefix and its separator are
+  # Resolve a short_id back to an id. The class prefix and its separator are
   # both optional ("r/21J-HW", "r-21JHW", "r21jhw" all match) and other
   # separators are ignored. A leftover with letters is base36; an all-digit
   # leftover is a plain decimal id, so "35", "r/35", and "z" all find bike 35.
-  def decode(type, short_id)
-    str = short_id.to_s.sub(/\A#{PREFIXES.fetch(type)}\W*/i, "").gsub(/\W/, "")
+  def decode(class_name, short_id)
+    str = short_id.to_s.sub(/\A#{PREFIXES.fetch(class_name)}\W*/i, "").gsub(/\W/, "")
     str.match?(/[a-z]/i) ? str.to_i(36) : str
   end
 end

--- a/app/services/short_id.rb
+++ b/app/services/short_id.rb
@@ -2,7 +2,7 @@ module ShortId
   extend Functionable
 
   # Type prefix for each object kind, so a short_id self-identifies
-  PREFIXES = {bike: "r"}.freeze
+  PREFIXES = {bike: "r", bike_version: "v"}.freeze
 
   # Compact, type-prefixed alias for an id, e.g. ShortId.encode(:bike, 3431156) => "r/21J-HW"
   def encode(type, id)

--- a/app/services/short_id.rb
+++ b/app/services/short_id.rb
@@ -1,15 +1,24 @@
 module ShortId
   extend Functionable
 
-  # Compact alphanumeric alias for an id, usable in /bikes/:id URLs
-  def encode(id)
-    id&.to_s(36)&.upcase
+  # Type prefix for each object kind, so a short_id self-identifies
+  PREFIXES = {bike: "r"}.freeze
+
+  # Compact, type-prefixed alias for an id, e.g. ShortId.encode(:bike, 3431156) => "r/21J-HW"
+  def encode(type, id)
+    return if id.blank?
+
+    "#{PREFIXES.fetch(type)}/#{id.to_s(36).upcase.scan(/.{1,3}/).join("-")}"
   end
 
-  # Resolve a param that may be a numeric id or a base36 short_id.
-  # Plain-digit params stay decimal ids, so existing numeric URLs are unchanged.
-  def decode(param)
-    param = param.to_s
-    param.match?(/[a-z]/i) ? param.to_i(36) : param
+  # Resolve a short_id back to an id. The type prefix and its separator are
+  # both optional ("r/21J-HW", "r-21JHW", "r21jhw" all match), other separators
+  # are ignored, and plain numeric ids pass through unchanged so existing
+  # numeric URLs still work.
+  def decode(type, short_id)
+    prefix = /\A#{PREFIXES.fetch(type)}\W*/i
+    prefixed = short_id.to_s.match?(prefix)
+    str = short_id.to_s.sub(prefix, "").gsub(/\W/, "")
+    (prefixed || str.match?(/[a-z]/i)) ? str.to_i(36) : str
   end
 end

--- a/app/services/short_id.rb
+++ b/app/services/short_id.rb
@@ -12,13 +12,11 @@ module ShortId
   end
 
   # Resolve a short_id back to an id. The type prefix and its separator are
-  # both optional ("r/21J-HW", "r-21JHW", "r21jhw" all match), other separators
-  # are ignored, and plain numeric ids pass through unchanged so existing
-  # numeric URLs still work.
+  # both optional ("r/21J-HW", "r-21JHW", "r21jhw" all match) and other
+  # separators are ignored. A leftover with letters is base36; an all-digit
+  # leftover is a plain decimal id, so "35", "r/35", and "z" all find bike 35.
   def decode(type, short_id)
-    prefix = /\A#{PREFIXES.fetch(type)}\W*/i
-    prefixed = short_id.to_s.match?(prefix)
-    str = short_id.to_s.sub(prefix, "").gsub(/\W/, "")
-    (prefixed || str.match?(/[a-z]/i)) ? str.to_i(36) : str
+    str = short_id.to_s.sub(/\A#{PREFIXES.fetch(type)}\W*/i, "").gsub(/\W/, "")
+    str.match?(/[a-z]/i) ? str.to_i(36) : str
   end
 end

--- a/app/services/short_id.rb
+++ b/app/services/short_id.rb
@@ -1,0 +1,15 @@
+module ShortId
+  extend Functionable
+
+  # Compact alphanumeric alias for an id, usable in /bikes/:id URLs
+  def encode(id)
+    id&.to_s(36)&.upcase
+  end
+
+  # Resolve a param that may be a numeric id or a base36 short_id.
+  # Plain-digit params stay decimal ids, so existing numeric URLs are unchanged.
+  def decode(param)
+    param = param.to_s
+    param.match?(/[a-z]/i) ? param.to_i(36) : param
+  end
+end

--- a/app/services/short_id.rb
+++ b/app/services/short_id.rb
@@ -2,7 +2,7 @@ module ShortId
   extend Functionable
 
   # Type prefix for each object kind, so a short_id self-identifies
-  PREFIXES = {bike: "r", bike_version: "v"}.freeze
+  PREFIXES = {bike: "r", bike_version: "v", marketplace_listing: "m"}.freeze
 
   # Compact, type-prefixed alias for an id, e.g. ShortId.encode(:bike, 3431156) => "r/21J-HW"
   def encode(type, id)

--- a/app/views/admin/stolen_bikes/_table.html.erb
+++ b/app/views/admin/stolen_bikes/_table.html.erb
@@ -31,7 +31,7 @@
     <tbody>
       <% @stolen_records.each do |stolen_record| %>
         <%# Handle cases where bike is user hidden or deleted %>
-        <% bike = stolen_record.bike || Bike.unscoped.find(stolen_record.bike_id) %>
+        <% bike = stolen_record.bike || Bike.unscoped.find_id(stolen_record.bike_id) %>
 
         <tr>
           <td class="display-multi-check table-checkbox-select">

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -117,20 +117,20 @@
     {
       "warning_type": "File Access",
       "warning_code": 16,
-      "fingerprint": "166fe865092e012918499aecabf56ec00d19e14320c875c4998e5b1b7ac76761",
+      "fingerprint": "4db2f0d5c124fd2ecf9020ea27b071859c47776e45a1bc2ffb74cbc2da4c4e90",
       "check_name": "FileAccess",
       "message": "Model attribute used in file name",
       "file": "app/controllers/bikes_controller.rb",
       "line": 48,
       "link": "https://brakemanscanner.org/docs/warning_types/file_access/",
-      "code": "File.open(\"#{Rails.root}/tmp/#{(\"Registration_\" + Bike.unscoped.find((params[:bike_id] or params[:id])).updated_at.strftime(\"%m%d_%H%M\")[(0..)])}.pdf\", \"wb\")",
+      "code": "File.open(\"#{Rails.root}/tmp/#{(\"Registration_\" + Bike.unscoped.find_id((params[:bike_id] or params[:id])).updated_at.strftime(\"%m%d_%H%M\")[(0..)])}.pdf\", \"wb\")",
       "render_path": null,
       "location": {
         "type": "method",
         "class": "BikesController",
         "method": "pdf"
       },
-      "user_input": "Bike.unscoped.find((params[:bike_id] or params[:id]))",
+      "user_input": "Bike.unscoped.find_id((params[:bike_id] or params[:id]))",
       "confidence": "Weak",
       "cwe_id": [
         22
@@ -264,20 +264,20 @@
     {
       "warning_type": "Redirect",
       "warning_code": 18,
-      "fingerprint": "2843118e7bef96258449dfb2f745e07476f8a3193835936f63af1254bdf24a9c",
+      "fingerprint": "d1de06806c36414ad7d4dd99a60fd5145753bc0292b61683f7160182186c3d2c",
       "check_name": "Redirect",
       "message": "Possible unprotected redirect",
       "file": "app/controllers/bikes/theft_alerts_controller.rb",
-      "line": 45,
+      "line": 46,
       "link": "https://brakemanscanner.org/docs/warning_types/redirect/",
-      "code": "redirect_to(Payment.new(create_parameters(TheftAlert.create!(:stolen_record => Bike.unscoped.find((params[:bike_id] or params[:id])).current_stolen_record, :theft_alert_plan => TheftAlertPlan.find(params[:theft_alert_plan_id]), :user => current_user))).stripe_checkout_session.url, :allow_other_host => true)",
+      "code": "redirect_to(Payment.new(create_parameters(TheftAlert.create!(:stolen_record => Bike.unscoped.find_id((params[:bike_id] or params[:id])).current_stolen_record, :theft_alert_plan => TheftAlertPlan.find(params[:theft_alert_plan_id]), :user => current_user))).stripe_checkout_session.url, :allow_other_host => true)",
       "render_path": null,
       "location": {
         "type": "method",
         "class": "Bikes::TheftAlertsController",
         "method": "create"
       },
-      "user_input": "Payment.new(create_parameters(TheftAlert.create!(:stolen_record => Bike.unscoped.find((params[:bike_id] or params[:id])).current_stolen_record, :theft_alert_plan => TheftAlertPlan.find(params[:theft_alert_plan_id]), :user => current_user))).stripe_checkout_session.url",
+      "user_input": "Payment.new(create_parameters(TheftAlert.create!(:stolen_record => Bike.unscoped.find_id((params[:bike_id] or params[:id])).current_stolen_record, :theft_alert_plan => TheftAlertPlan.find(params[:theft_alert_plan_id]), :user => current_user))).stripe_checkout_session.url",
       "confidence": "Weak",
       "cwe_id": [
         601
@@ -1927,20 +1927,20 @@
     {
       "warning_type": "File Access",
       "warning_code": 16,
-      "fingerprint": "f7d454b573455bc594427f5e95e9375abcc9216a36f98b0b998a0011ba85e347",
+      "fingerprint": "3d0ef73451bf50f96f6d663daba322f85529f31bd7845c55cdbced8109dd7212",
       "check_name": "FileAccess",
       "message": "Model attribute used in file name",
       "file": "app/controllers/bikes_controller.rb",
       "line": 52,
       "link": "https://brakemanscanner.org/docs/warning_types/file_access/",
-      "code": "File.open(\"#{Rails.root}/tmp/#{(\"Registration_\" + Bike.unscoped.find((params[:bike_id] or params[:id])).updated_at.strftime(\"%m%d_%H%M\")[(0..)])}.pdf\")",
+      "code": "File.open(\"#{Rails.root}/tmp/#{(\"Registration_\" + Bike.unscoped.find_id((params[:bike_id] or params[:id])).updated_at.strftime(\"%m%d_%H%M\")[(0..)])}.pdf\")",
       "render_path": null,
       "location": {
         "type": "method",
         "class": "BikesController",
         "method": "pdf"
       },
-      "user_input": "Bike.unscoped.find((params[:bike_id] or params[:id]))",
+      "user_input": "Bike.unscoped.find_id((params[:bike_id] or params[:id]))",
       "confidence": "Weak",
       "cwe_id": [
         22

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -449,5 +449,9 @@ Rails.application.routes.draw do
   get "/bikes", to: redirect("search/registrations")
   get "/marketplace", to: redirect("search/marketplace")
 
+  # Short bike URLs: /r/<short_id> (and /R/...). The whole path is passed through
+  # so ShortId#decode strips the "r/" prefix itself, even when the body starts with "r".
+  get "*id", to: "bikes#show", constraints: {id: %r{[rR]/.*}}, format: false
+
   get "*unmatched_route", to: "errors#not_found" if Rails.env.production? || Rails.env.staging? # Handle 404s with lograge
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -452,6 +452,8 @@ Rails.application.routes.draw do
   # Short bike URLs: /r/<short_id> (and /R/...). The whole path is passed through
   # so ShortId#decode strips the "r/" prefix itself, even when the body starts with "r".
   get "*id", to: "bikes#show", constraints: {id: %r{[rR]/.*}}, format: false
+  # Short bike_version URLs: /v/<short_id> (and /V/...)
+  get "*id", to: "bike_versions#show", constraints: {id: %r{[vV]/.*}}, format: false
 
   get "*unmatched_route", to: "errors#not_found" if Rails.env.production? || Rails.env.staging? # Handle 404s with lograge
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -454,6 +454,8 @@ Rails.application.routes.draw do
   get "*id", to: "bikes#show", constraints: {id: %r{[rR]/.*}}, format: false
   # Short bike_version URLs: /v/<short_id> (and /V/...)
   get "*id", to: "bike_versions#show", constraints: {id: %r{[vV]/.*}}, format: false
+  # Short marketplace_listing URLs: /m/<short_id> (and /M/...)
+  get "*id", to: "marketplace_listings#show", constraints: {id: %r{[mM]/.*}}, format: false
 
   get "*unmatched_route", to: "errors#not_found" if Rails.env.production? || Rails.env.staging? # Handle 404s with lograge
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -177,6 +177,9 @@ Rails.application.routes.draw do
     end
   end
 
+  # Short_id forms the resources :id segment can't match (prefix + slash, dots).
+  # Before resources so it wins for "r/..." paths; its constraint leaves plain ids alone.
+  get "bikes/*id", to: "bikes#show", constraints: {id: /r\W.*/i}, format: false
   resources :bikes, except: %i[index edit] do
     collection { get :scanned }
     member do

--- a/spec/controllers/bikes_controller_spec.rb
+++ b/spec/controllers/bikes_controller_spec.rb
@@ -25,6 +25,16 @@ RSpec.describe BikesController, type: :controller do
       expect(assigns(:bike)).to be_present
       expect(flash).to_not be_present
     end
+    context "short_id" do
+      it "shows the bike" do
+        expect(bike.short_id).to eq bike.id.to_s(36).upcase
+        get :show, params: {id: bike.short_id}
+        expect(response.status).to eq(200)
+        expect(response).to render_template(:show)
+        expect(assigns(:bike)).to eq bike
+        expect(flash).to_not be_present
+      end
+    end
     context "illegally set passive_organization" do
       include_context :logged_in_as_user
       it "renders, resets passive_organization_id" do

--- a/spec/controllers/bikes_controller_spec.rb
+++ b/spec/controllers/bikes_controller_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe BikesController, type: :controller do
     end
     context "short_id" do
       it "shows the bike" do
-        expect(bike.short_id).to eq bike.id.to_s(36).upcase
+        expect(bike.short_id).to eq ShortId.encode(:bike, bike.id)
         get :show, params: {id: bike.short_id}
         expect(response.status).to eq(200)
         expect(response).to render_template(:show)

--- a/spec/controllers/bikes_controller_spec.rb
+++ b/spec/controllers/bikes_controller_spec.rb
@@ -25,16 +25,6 @@ RSpec.describe BikesController, type: :controller do
       expect(assigns(:bike)).to be_present
       expect(flash).to_not be_present
     end
-    context "short_id" do
-      it "shows the bike" do
-        expect(bike.short_id).to eq ShortId.encode(:bike, bike.id)
-        get :show, params: {id: bike.short_id}
-        expect(response.status).to eq(200)
-        expect(response).to render_template(:show)
-        expect(assigns(:bike)).to eq bike
-        expect(flash).to_not be_present
-      end
-    end
     context "illegally set passive_organization" do
       include_context :logged_in_as_user
       it "renders, resets passive_organization_id" do

--- a/spec/models/bike_spec.rb
+++ b/spec/models/bike_spec.rb
@@ -65,11 +65,12 @@ RSpec.describe Bike, type: :model do
       end
     end
 
-    describe "short_id" do
-      let(:bike) { FactoryBot.create(:bike, id: 1000000) }
-      it "round-trips through ShortId" do
-        expect(bike.short_id).to eq "LFLS"
-        expect(Bike.unscoped.find(ShortId.decode(bike.short_id))).to eq bike
+    describe "short_id and find_id" do
+      let(:bike) { FactoryBot.create(:bike, id: 3431156) }
+      it "round-trips through find_id" do
+        expect(bike.short_id).to eq "r/21J-HW"
+        expect(Bike.find_id(bike.short_id)).to eq bike
+        expect(Bike.find_id(bike.id)).to eq bike
       end
     end
 

--- a/spec/models/bike_spec.rb
+++ b/spec/models/bike_spec.rb
@@ -67,13 +67,9 @@ RSpec.describe Bike, type: :model do
 
     describe "short_id" do
       let(:bike) { FactoryBot.create(:bike, id: 1000000) }
-      it "round-trips through integer_id" do
+      it "round-trips through ShortId" do
         expect(bike.short_id).to eq "LFLS"
-        expect(Bike.integer_id(bike.short_id)).to eq 1000000
-        expect(Bike.integer_id(bike.short_id.downcase)).to eq 1000000
-        # Plain numeric params stay decimal ids
-        expect(Bike.integer_id("123")).to eq "123"
-        expect(Bike.unscoped.find(Bike.integer_id(bike.short_id))).to eq bike
+        expect(Bike.unscoped.find(ShortId.decode(bike.short_id))).to eq bike
       end
     end
 

--- a/spec/models/bike_spec.rb
+++ b/spec/models/bike_spec.rb
@@ -65,6 +65,18 @@ RSpec.describe Bike, type: :model do
       end
     end
 
+    describe "short_id" do
+      let(:bike) { FactoryBot.create(:bike, id: 1000000) }
+      it "round-trips through integer_id" do
+        expect(bike.short_id).to eq "LFLS"
+        expect(Bike.integer_id(bike.short_id)).to eq 1000000
+        expect(Bike.integer_id(bike.short_id.downcase)).to eq 1000000
+        # Plain numeric params stay decimal ids
+        expect(Bike.integer_id("123")).to eq "123"
+        expect(Bike.unscoped.find(Bike.integer_id(bike.short_id))).to eq bike
+      end
+    end
+
     describe ".currently_stolen_in" do
       context "given no matching state or country" do
         it "returns none" do

--- a/spec/models/bike_version_spec.rb
+++ b/spec/models/bike_version_spec.rb
@@ -99,4 +99,13 @@ RSpec.describe BikeVersion, type: :model do
       expect(BikeVersion.pluck(:id)).to eq([bike_version_1.id, bike_version_2.id, bike_version_3.id])
     end
   end
+
+  describe "short_id and find_id" do
+    let(:bike_version) { FactoryBot.create(:bike_version, id: 3431156) }
+    it "round-trips through find_id" do
+      expect(bike_version.short_id).to eq "v/21J-HW"
+      expect(BikeVersion.find_id(bike_version.short_id)).to eq bike_version
+      expect(BikeVersion.find_id(bike_version.id)).to eq bike_version
+    end
+  end
 end

--- a/spec/models/marketplace_listing_spec.rb
+++ b/spec/models/marketplace_listing_spec.rb
@@ -296,4 +296,13 @@ RSpec.describe MarketplaceListing, type: :model do
       end
     end
   end
+
+  describe "short_id and find_id" do
+    let(:marketplace_listing) { FactoryBot.create(:marketplace_listing, id: 3431156) }
+    it "round-trips through find_id" do
+      expect(marketplace_listing.short_id).to eq "m/21J-HW"
+      expect(MarketplaceListing.find_id(marketplace_listing.short_id)).to eq marketplace_listing
+      expect(MarketplaceListing.find_id(marketplace_listing.id)).to eq marketplace_listing
+    end
+  end
 end

--- a/spec/requests/bike_versions_request_spec.rb
+++ b/spec/requests/bike_versions_request_spec.rb
@@ -27,6 +27,17 @@ RSpec.describe BikeVersionsController, type: :request do
   end
 
   describe "show" do
+    context "short_id" do
+      let(:bike_version) { FactoryBot.create(:bike_version, owner: current_user, id: 35) }
+      it "finds the version via short_id and the /v/ short URL" do
+        expect(bike_version.short_id).to eq "v/Z"
+        ["#{base_url}/35", "#{base_url}/z", "/v/z", "/V/Z", "/v/Z"].each do |path|
+          get path
+          expect(response).to render_template(:show)
+          expect(assigns(:bike_version)).to eq bike_version
+        end
+      end
+    end
     it "renders" do
       get "#{base_url}/#{bike_version.to_param}"
       expect(response.code).to eq "200"

--- a/spec/requests/bikes/show_request_spec.rb
+++ b/spec/requests/bikes/show_request_spec.rb
@@ -29,6 +29,22 @@ RSpec.describe "BikesController#show", type: :request do
         expect(assigns(:bike)).to eq bike
       end
     end
+    it "finds the bike from the /r/ short URL" do
+      ["/r/z", "/R/Z", "/r/Z"].each do |path|
+        get path
+        expect(response).to render_template(:show)
+        expect(assigns(:bike)).to eq bike
+      end
+    end
+    context "short_id body starting with the prefix letter" do
+      let(:ownership) { FactoryBot.create(:ownership, bike: FactoryBot.create(:bike, id: 27)) }
+      it "does not double-strip the prefix" do
+        expect(bike.short_id).to eq "r/R"
+        get "/#{bike.short_id}"
+        expect(response).to render_template(:show)
+        expect(assigns(:bike)).to eq bike
+      end
+    end
   end
   context "likely_spam bike" do
     it "shows the bike" do

--- a/spec/requests/bikes/show_request_spec.rb
+++ b/spec/requests/bikes/show_request_spec.rb
@@ -21,16 +21,9 @@ RSpec.describe "BikesController#show", type: :request do
   end
   context "short_id" do
     let(:ownership) { FactoryBot.create(:ownership, bike: FactoryBot.create(:bike, id: 35)) }
-    it "finds the bike from any short_id form" do
+    it "finds the bike from any short_id form and the /r/ short URL" do
       expect(bike.short_id).to eq "r/Z"
-      ["35", "z", "r/z", "R/Z", "r/35", "R.Z-"].each do |id|
-        get "#{base_url}/#{id}"
-        expect(response).to render_template(:show)
-        expect(assigns(:bike)).to eq bike
-      end
-    end
-    it "finds the bike from the /r/ short URL" do
-      ["/r/z", "/R/Z", "/r/Z"].each do |path|
+      ["#{base_url}/35", "#{base_url}/z", "#{base_url}/r/z", "#{base_url}/R/Z", "#{base_url}/r/35", "#{base_url}/R.Z-", "/r/z", "/R/Z", "/r/Z"].each do |path|
         get path
         expect(response).to render_template(:show)
         expect(assigns(:bike)).to eq bike

--- a/spec/requests/bikes/show_request_spec.rb
+++ b/spec/requests/bikes/show_request_spec.rb
@@ -19,6 +19,17 @@ RSpec.describe "BikesController#show", type: :request do
       expect(assigns(:claim_message)).to be_blank
     end
   end
+  context "short_id" do
+    let(:ownership) { FactoryBot.create(:ownership, bike: FactoryBot.create(:bike, id: 35)) }
+    it "finds the bike from any short_id form" do
+      expect(bike.short_id).to eq "r/Z"
+      ["35", "z", "r/z", "R/Z", "r/35", "R.Z-"].each do |id|
+        get "#{base_url}/#{id}"
+        expect(response).to render_template(:show)
+        expect(assigns(:bike)).to eq bike
+      end
+    end
+  end
   context "likely_spam bike" do
     it "shows the bike" do
       ownership.bike.update(likely_spam: true)

--- a/spec/requests/marketplace_listings_request_spec.rb
+++ b/spec/requests/marketplace_listings_request_spec.rb
@@ -1,0 +1,14 @@
+require "rails_helper"
+
+RSpec.describe MarketplaceListingsController, type: :request do
+  describe "show" do
+    let(:marketplace_listing) { FactoryBot.create(:marketplace_listing, id: 35) }
+    it "redirects to the item from the /m/ short URL" do
+      expect(marketplace_listing.short_id).to eq "m/Z"
+      ["/m/z", "/M/Z", "/m/Z"].each do |path|
+        get path
+        expect(response).to redirect_to(marketplace_listing.item)
+      end
+    end
+  end
+end

--- a/spec/services/short_id_spec.rb
+++ b/spec/services/short_id_spec.rb
@@ -4,6 +4,7 @@ RSpec.describe ShortId do
   describe "encode" do
     it "returns the type-prefixed base36 id, grouped in threes" do
       expect(ShortId.encode(:bike, 3431156)).to eq "r/21J-HW"
+      expect(ShortId.encode(:bike_version, 3431156)).to eq "v/21J-HW"
       expect(ShortId.encode(:bike, nil)).to be_nil
     end
   end

--- a/spec/services/short_id_spec.rb
+++ b/spec/services/short_id_spec.rb
@@ -2,23 +2,23 @@ require "rails_helper"
 
 RSpec.describe ShortId do
   describe "encode" do
-    it "returns the type-prefixed base36 id, grouped in threes" do
-      expect(ShortId.encode(:bike, 3431156)).to eq "r/21J-HW"
-      expect(ShortId.encode(:bike_version, 3431156)).to eq "v/21J-HW"
-      expect(ShortId.encode(:marketplace_listing, 3431156)).to eq "m/21J-HW"
-      expect(ShortId.encode(:bike, nil)).to be_nil
+    it "returns the class-prefixed base36 id, grouped in threes" do
+      expect(ShortId.encode("Bike", 3431156)).to eq "r/21J-HW"
+      expect(ShortId.encode("BikeVersion", 3431156)).to eq "v/21J-HW"
+      expect(ShortId.encode("MarketplaceListing", 3431156)).to eq "m/21J-HW"
+      expect(ShortId.encode("Bike", nil)).to be_nil
     end
   end
 
   describe "decode" do
     it "ignores the prefix, its separator, other separators, and case" do
       ["r/21J-HW", "R/21JHW", "r/21J HW", "r/21J+HW", "r-21JHW", "r21jhw", "21J-HW", "21jhw"].each do |str|
-        expect(ShortId.decode(:bike, str)).to eq 3431156
+        expect(ShortId.decode("Bike", str)).to eq 3431156
       end
     end
     it "leaves plain-digit params as decimal ids" do
-      expect(ShortId.decode(:bike, "123")).to eq "123"
-      expect(ShortId.decode(:bike, 123)).to eq "123"
+      expect(ShortId.decode("Bike", "123")).to eq "123"
+      expect(ShortId.decode("Bike", 123)).to eq "123"
     end
   end
 end

--- a/spec/services/short_id_spec.rb
+++ b/spec/services/short_id_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe ShortId do
     it "returns the type-prefixed base36 id, grouped in threes" do
       expect(ShortId.encode(:bike, 3431156)).to eq "r/21J-HW"
       expect(ShortId.encode(:bike_version, 3431156)).to eq "v/21J-HW"
+      expect(ShortId.encode(:marketplace_listing, 3431156)).to eq "m/21J-HW"
       expect(ShortId.encode(:bike, nil)).to be_nil
     end
   end

--- a/spec/services/short_id_spec.rb
+++ b/spec/services/short_id_spec.rb
@@ -2,20 +2,21 @@ require "rails_helper"
 
 RSpec.describe ShortId do
   describe "encode" do
-    it "returns the upcased base36 id" do
-      expect(ShortId.encode(1000000)).to eq "LFLS"
-      expect(ShortId.encode(nil)).to be_nil
+    it "returns the type-prefixed base36 id, grouped in threes" do
+      expect(ShortId.encode(:bike, 3431156)).to eq "r/21J-HW"
+      expect(ShortId.encode(:bike, nil)).to be_nil
     end
   end
 
   describe "decode" do
-    it "decodes a base36 short_id, case insensitively" do
-      expect(ShortId.decode("LFLS")).to eq 1000000
-      expect(ShortId.decode("lfls")).to eq 1000000
+    it "ignores the prefix, its separator, other separators, and case" do
+      ["r/21J-HW", "R/21JHW", "r/21J HW", "r/21J+HW", "r-21JHW", "r21jhw", "21J-HW", "21jhw"].each do |str|
+        expect(ShortId.decode(:bike, str)).to eq 3431156
+      end
     end
     it "leaves plain-digit params as decimal ids" do
-      expect(ShortId.decode("123")).to eq "123"
-      expect(ShortId.decode(123)).to eq "123"
+      expect(ShortId.decode(:bike, "123")).to eq "123"
+      expect(ShortId.decode(:bike, 123)).to eq "123"
     end
   end
 end

--- a/spec/services/short_id_spec.rb
+++ b/spec/services/short_id_spec.rb
@@ -1,0 +1,21 @@
+require "rails_helper"
+
+RSpec.describe ShortId do
+  describe "encode" do
+    it "returns the upcased base36 id" do
+      expect(ShortId.encode(1000000)).to eq "LFLS"
+      expect(ShortId.encode(nil)).to be_nil
+    end
+  end
+
+  describe "decode" do
+    it "decodes a base36 short_id, case insensitively" do
+      expect(ShortId.decode("LFLS")).to eq 1000000
+      expect(ShortId.decode("lfls")).to eq 1000000
+    end
+    it "leaves plain-digit params as decimal ids" do
+      expect(ShortId.decode("123")).to eq "123"
+      expect(ShortId.decode(123)).to eq "123"
+    end
+  end
+end


### PR DESCRIPTION
Adds a compact, type-prefixed `short_id` to bikes, bike versions, and marketplace listings — base36 of the id, upcased and grouped in threes behind a one-letter class prefix (bike `3431156` → `r/21J-HW`, version → `v/...`, listing → `m/...`).

- New `ShortId` functionable service maps each model class name to a prefix and provides `encode`/`decode`. Decode is forgiving: the prefix and its separator are optional and other separators are ignored; an all-digit leftover is a decimal id, a leftover with letters is base36. So for bike `35` (`r/Z`): `/bikes/35`, `/bikes/z`, `/bikes/r/z`, `/bikes/R/Z`, `/bikes/r/35`, and `/bikes/R.Z-` all find it.
- New `ShortIdable` concern adds `#short_id` and `.find_id` (decode-then-find), included by `Bike`, `BikeVersion`, and `MarketplaceListing`. `find_id` stays scoped — prepend `.unscoped` for hidden/deleted records. Every `Bike.find` / `Bike.unscoped.find` call site (and `find_bike_version`) now routes through `find_id`, preserving each caller's `unscoped`.
- Routing: a `bikes/*id` glob handles the slash/dot bike variants the `:id` segment can't match, plus constrained top-level short URLs `/r/` (bikes), `/v/` (versions), and `/m/` (listings) — uppercase too. Bikes/versions render; a listing has no page of its own, so a small controller resolves it and redirects to the item it sells.

`to_param` is unchanged, so generated links stay numeric; `short_id` is a read-side alias only. `config/brakeman.ignore` fingerprints updated for the `find` → `find_id` rename.
