### PR TITLE
Update Ruby 4.0.2 → 4.0.5

### DIFF
--- a/.github/workflows/review-app.yml
+++ b/.github/workflows/review-app.yml
@@ -260,7 +260,7 @@ jobs:
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: "4.0.2"
+          ruby-version: "4.0.5"
       - name: Install Kamal
         run: gem install kamal -v "~> 2.0"
       - name: Set up SSH agent

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,4 +1,4 @@
-ruby 4.0.2
+ruby 4.0.5
 # NOTE: If updating node version, also update .cloud66/manifest.yml
 nodejs 24.15.0
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@
 # This Dockerfile is used only by review apps (and any future Kamal-based deploys).
 # Production runs on Cloud66 — not from this file.
 
-ARG RUBY_VERSION=4.0.2
+ARG RUBY_VERSION=4.0.5
 FROM docker.io/library/ruby:$RUBY_VERSION-slim AS base
 
 WORKDIR /rails

--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ source "https://rubygems.org"
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 git_source(:gitlab) { |repo| "https://gitlab.com/#{repo}.git" }
 
-ruby "4.0.2"
+ruby "4.0.5"
 
 # Gems that are no longer in standard library as of Ruby 3.4
 gem "csv"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1042,7 +1042,7 @@ DEPENDENCIES
   webmock
 
 RUBY VERSION
-  ruby 4.0.2
+  ruby 4.0.5
 
 BUNDLED WITH
   4.0.0.beta2

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1045,4 +1045,4 @@ RUBY VERSION
   ruby 4.0.5
 
 BUNDLED WITH
-  4.0.0.beta2
+  4.0.15

--- a/lib/tasks/setup_tasks.rake
+++ b/lib/tasks/setup_tasks.rake
@@ -11,7 +11,7 @@ namespace :setup do
 
   desc "import manufacturers from GitHub"
   task import_manufacturers_csv: :environment do
-    url = "https://raw.githubusercontent.com/bikeindex/resources/refs/heads/main/manufacturers.csv"
+    url = "https://raw.githubusercontent.com/bikeindex/bike_data/refs/heads/main/data/manufacturers.csv"
     file_path = Rails.root.join("tmp/manufacturers.csv")
     system("wget -q #{url} -O #{file_path}", exception: true)
     Spreadsheets::Manufacturers.import(file_path)
@@ -21,7 +21,7 @@ namespace :setup do
   # NOTE: This doesn't actually do a good job updating existing primary activities.
   # If that is required, probably do it manually via console
   task import_primary_activities_csv: :environment do
-    url = "https://raw.githubusercontent.com/bikeindex/resources/refs/heads/main/primary_activities.csv"
+    url = "https://raw.githubusercontent.com/bikeindex/bike_data/refs/heads/main/data/primary_activities.csv"
     file_path = Rails.root.join("tmp/primary_activities.csv")
     system("wget -q #{url} -O #{file_path}", exception: true)
     Spreadsheets::PrimaryActivities.import(file_path)


### PR DESCRIPTION
Bumps the Ruby version pin from 4.0.2 to 4.0.5, and bundler to its latest release.

- Updated the Ruby pin in `.tool-versions`, `Gemfile`, `Gemfile.lock` (`RUBY VERSION`), the review-app `Dockerfile`, and the `review-app.yml` CI workflow
- Bumped `BUNDLED WITH` from `4.0.0.beta2` to `4.0.15`
- `ci.yml` and `copilot-setup-steps.yml` auto-detect the Ruby version from `.tool-versions`/`Gemfile`, so no change was needed there
