### PR TITLE
Point CSV seed imports at resources repo data/ folder

### DIFF
--- a/lib/tasks/setup_tasks.rake
+++ b/lib/tasks/setup_tasks.rake
@@ -11,7 +11,7 @@ namespace :setup do
 
   desc "import manufacturers from GitHub"
   task import_manufacturers_csv: :environment do
-    url = "https://raw.githubusercontent.com/bikeindex/resources/refs/heads/main/manufacturers.csv"
+    url = "https://raw.githubusercontent.com/bikeindex/resources/refs/heads/main/data/manufacturers.csv"
     file_path = Rails.root.join("tmp/manufacturers.csv")
     system("wget -q #{url} -O #{file_path}", exception: true)
     Spreadsheets::Manufacturers.import(file_path)
@@ -21,7 +21,7 @@ namespace :setup do
   # NOTE: This doesn't actually do a good job updating existing primary activities.
   # If that is required, probably do it manually via console
   task import_primary_activities_csv: :environment do
-    url = "https://raw.githubusercontent.com/bikeindex/resources/refs/heads/main/primary_activities.csv"
+    url = "https://raw.githubusercontent.com/bikeindex/resources/refs/heads/main/data/primary_activities.csv"
     file_path = Rails.root.join("tmp/primary_activities.csv")
     system("wget -q #{url} -O #{file_path}", exception: true)
     Spreadsheets::PrimaryActivities.import(file_path)


### PR DESCRIPTION
The manufacturers and primary_activities seed CSVs moved into a `data/` subfolder in the `bikeindex/resources` repo, and the old root-level URLs now 404.

- Point `setup:import_manufacturers_csv` and `setup:import_primary_activities_csv` at the new `data/`-prefixed raw URLs so `db:seed` can fetch the CSVs again.
