### PR TITLE
Disable Sprockets SCSS handler; stub excluded org IDs in spec

### DIFF
--- a/config/initializers/disable_sprockets_sass.rb
+++ b/config/initializers/disable_sprockets_sass.rb
@@ -1,0 +1,13 @@
+# SCSS is compiled by dartsass-rails (sass-embedded) into app/assets/builds, and
+# Sprockets only serves those prebuilt CSS files. But Sprockets 4 still ships its
+# own SCSS handler and registers the .scss/.sass extensions, so when a build is
+# missing it falls back to compiling the source .scss and raises
+# `LoadError: cannot load such file -- sassc` (the sassc gem was dropped for
+# dartsass). Remove Sprockets' SCSS/SASS extensions so it never attempts that
+# compilation — a missing build then surfaces as a clear "not precompiled" error.
+Rails.application.config.assets.configure do |env|
+  sass_exts = env.config[:mime_exts].keys.select { |ext| ext.to_s.match?(/\.(scss|sass)(\.|\z)/) }
+  next if sass_exts.empty?
+
+  env.config = env.config.merge(mime_exts: env.config[:mime_exts].except(*sass_exts)).freeze
+end

--- a/spec/models/organization_spec.rb
+++ b/spec/models/organization_spec.rb
@@ -354,8 +354,8 @@ RSpec.describe Organization, type: :model do
     context "paid" do
       let(:enabled_feature_slugs) { ["regional_bike_counts"] }
       let(:organization) { FactoryBot.create(:organization_with_organization_features, enabled_feature_slugs: enabled_feature_slugs) }
-      # Ensure auto-increment is past the hardcoded excluded IDs (1 and 36)
-      before { FactoryBot.create_list(:organization, 2) if Organization.maximum(:id).to_i < 37 }
+      # Excluded IDs are real prod orgs (SBR/BikeIndex); stub them so the test org's auto-increment id can't collide
+      before { stub_const("Organization::USER_REGISTRATION_ALL_BIKES_EXCLUDED_IDS", []) }
       it "is truthy" do
         expect(organization.user_registration_all_bikes?).to be_truthy
       end


### PR DESCRIPTION
Remove Sprockets' `.scss`/`.sass` mime extensions so it never falls back to compiling SCSS — since the `sassc` gem was dropped for dartsass, that fallback raises `LoadError: cannot load such file -- sassc`. With the handler removed, a missing dartsass build instead surfaces as a clear "not precompiled" error.

- Add `config/initializers/disable_sprockets_sass.rb` to strip the SCSS/SASS handlers from Sprockets.
- Stub `Organization::USER_REGISTRATION_ALL_BIKES_EXCLUDED_IDS` to `[]` in the organization spec so the test org's auto-increment id can't collide with the hardcoded prod IDs.
