### PR TITLE
Add --repo to review-app gh pr edit label calls

### DIFF
--- a/.github/workflows/review-app.yml
+++ b/.github/workflows/review-app.yml
@@ -37,6 +37,7 @@ permissions:
   contents: read
   packages: write       # push to GHCR
   pull-requests: write  # add/remove labels and comment
+  deployments: write    # create the PR-head deployment that surfaces the link
 
 # Concurrency is declared per-job, not per-workflow: the `build` job cancels
 # superseded builds (a stale image build is wasted work and safe to kill),
@@ -284,6 +285,37 @@ jobs:
         if: needs.resolve.outputs.action == 'deploy'
         # bin/kamal_review reads the image tag from the job-level IMAGE_TAG env.
         run: bin/kamal_review deploy --app "${{ needs.resolve.outputs.pr_number }}"
+      # The job-level `environment:` deployment attaches to the run's commit
+      # (github.sha), which surfaces the "View deployment" link on the PR only
+      # when that commit is the PR head — true for ci.yml auto-dispatches (they
+      # run on the PR branch) but NOT for a manual dispatch from another branch
+      # (e.g. main), where the deployment lands on that branch instead. Create a
+      # deployment on the PR head so the link appears regardless of the run ref.
+      - name: Link deployment to PR head
+        if: needs.resolve.outputs.action == 'deploy' && github.sha != needs.resolve.outputs.head_sha
+        uses: actions/github-script@v7
+        env:
+          HEAD_SHA: ${{ needs.resolve.outputs.head_sha }}
+          DEPLOY_URL: https://pr-${{ needs.resolve.outputs.pr_number }}.review.bikeindex.org
+        with:
+          script: |
+            const {data: deployment} = await github.rest.repos.createDeployment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              ref: process.env.HEAD_SHA,
+              environment: "review-app",
+              auto_merge: false,
+              required_contexts: [],
+              transient_environment: true,
+              description: "Per-PR Kamal review app",
+            })
+            await github.rest.repos.createDeploymentStatus({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              deployment_id: deployment.id,
+              state: "success",
+              environment_url: process.env.DEPLOY_URL,
+            })
       # A successful deploy (this step is only reached when everything above
       # passed) deletes the `report` job's now-stale failure comment.
       - name: Remove stale deploy-failure comment

--- a/.github/workflows/review-app.yml
+++ b/.github/workflows/review-app.yml
@@ -137,7 +137,7 @@ jobs:
         run: |
           gh label create "$REVIEW_LABEL" --repo "$GITHUB_REPOSITORY" \
             --color 0E8A16 --description "Per-PR Kamal review app is deployed" 2>/dev/null || true
-          gh pr edit "${{ needs.resolve.outputs.pr_number }}" --add-label "$REVIEW_LABEL" || true
+          gh pr edit "${{ needs.resolve.outputs.pr_number }}" --repo "$GITHUB_REPOSITORY" --add-label "$REVIEW_LABEL" || true
       - name: Checkout PR head
         uses: actions/checkout@v7
         with:
@@ -306,7 +306,7 @@ jobs:
         if: needs.resolve.outputs.action == 'destroy'
         env:
           GH_TOKEN: ${{ github.token }}
-        run: gh pr edit "${{ needs.resolve.outputs.pr_number }}" --remove-label "$REVIEW_LABEL" || true
+        run: gh pr edit "${{ needs.resolve.outputs.pr_number }}" --repo "$GITHUB_REPOSITORY" --remove-label "$REVIEW_LABEL" || true
       # Each push built a `pr-<N>-<sha>` image; delete every version for this PR so
       # closed/destroyed PRs don't accumulate images in GHCR. Matches on the trailing
       # dash so `pr-12-` never catches `pr-123-`. Best-effort: a delete failure (e.g.


### PR DESCRIPTION
Manual review-app dispatches from `main` (just passing a PR number) were half-broken: the PR never got labeled and never showed a "View deployment" link. Two independent causes, fixed here so a dispatch from any branch works end to end.

- **Label never applied:** `gh pr edit --add-label` ran before the checkout and lacked `--repo`, so `gh` failed with "not a git repository" and the `|| true` swallowed it. No label meant ci.yml's auto-redeploy never armed and auto-destroy-on-close never fired. Added `--repo "$GITHUB_REPOSITORY"` to both the add and the destroy-path remove-label calls (matching the `gh label create` line above).
- **No deployment link on the PR:** the `environment:` deployment attaches to the run's commit, which is the PR head only for ci.yml auto-dispatches (they run on the PR branch) — a dispatch from `main` landed it on `main`. Added a github-script step that creates a deployment on the PR head SHA, gated to `github.sha != head_sha` so the push path stays native. Needs the new `deployments: write` permission; the `environment:` key stays (the `REVIEW_APP_*` secrets are scoped to it).
