### PR TITLE
Add SAML SSO login entry UX (email-first + org-slug)

### DIFF
--- a/app/assets/images/icons/lock.svg
+++ b/app/assets/images/icons/lock.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+  <path stroke-linecap="round" stroke-linejoin="round" d="M16.5 10.5V6.75a4.5 4.5 0 1 0-9 0v3.75m-.75 11.25h10.5a2.25 2.25 0 0 0 2.25-2.25v-6.75a2.25 2.25 0 0 0-2.25-2.25H6.75a2.25 2.25 0 0 0-2.25 2.25v6.75a2.25 2.25 0 0 0 2.25 2.25Z" />
+</svg>

--- a/app/controllers/saml_controller.rb
+++ b/app/controllers/saml_controller.rb
@@ -20,6 +20,17 @@ class SamlController < ApplicationController
       content_type: "application/samlmetadata+xml"
   end
 
+  # Org-slug entry point for users whose email domain isn't auto-detected on the login form.
+  # Submitting a slug that maps to a configured org forwards to #init.
+  def login
+    return if params[:org_slug].blank?
+
+    organization = Organization.friendly_find(params[:org_slug])
+    return redirect_to saml_init_path(org_slug: organization.to_param) if organization&.saml_sso_configured?
+
+    flash.now[:error] = "We couldn't find single sign-on for that organization"
+  end
+
   # SP-initiated login: redirect to the IdP with a signed AuthnRequest, remembering the
   # request id (replay protection) and org slug (cross-tenant binding) for the callback.
   def init

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -47,6 +47,9 @@ class SessionsController < ApplicationController
   end
 
   def create
+    organization = saml_sso_organization(permitted_parameters[:email])
+    return redirect_to saml_init_path(org_slug: organization.to_param) if organization.present?
+
     @user = User.fuzzy_confirmed_or_unconfirmed_email_find(permitted_parameters[:email])
     if @user.present?
       if @user.authenticate(permitted_parameters[:password])
@@ -77,6 +80,15 @@ class SessionsController < ApplicationController
   end
 
   private
+
+  # When an email belongs to an org with live SAML SSO, send them to the IdP instead of
+  # asking for a Bike Index password.
+  def saml_sso_organization(email)
+    return if email.blank?
+
+    organization = Organization.passwordless_email_matching(email)
+    organization if organization&.saml_sso_configured?
+  end
 
   def permitted_parameters
     params.require(:session).permit(:password, :email, :remember_me)

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -353,6 +353,10 @@ class Organization < ApplicationRecord
     organization_saml_configuration || OrganizationSamlConfiguration.create(organization_id: id)
   end
 
+  def saml_sso_configured?
+    enabled?("saml_sso") && organization_saml_configuration&.configured?
+  end
+
   def hot_sheet_on?
     hot_sheet_configuration.present? && hot_sheet_configuration.on?
   end

--- a/app/views/saml/login.html.haml
+++ b/app/views/saml/login.html.haml
@@ -1,0 +1,11 @@
+.container
+  .sign-in-up-wrap
+    .main-form
+      %h3.sign-in-up-main-form-header= t(".sign_in_with_sso")
+      %p= t(".enter_your_organization")
+      = form_with url: saml_login_path, method: :get do |f|
+        .form-group
+          = f.label :org_slug, t(".organization"), class: "sr-only"
+          = f.text_field :org_slug, value: params[:org_slug], placeholder: t(".organization"), class: "form-control"
+        = f.submit t(".continue"), class: "btn btn-primary btn-lg"
+      %p= link_to t(".back_to_sign_in"), new_session_path

--- a/app/views/sessions/new.html.haml
+++ b/app/views/sessions/new.html.haml
@@ -23,6 +23,10 @@
             %span.oauth-logo-block
               = inline_svg_tag "icons/envelope.svg", class: "tw:block tw:w-6 tw:h-6 tw:mx-auto"
             %span.oauth-text-block= t(".sign_in_using_magic_link")
+          %a.magic_link-login{ href: saml_login_path }
+            %span.oauth-logo-block
+              = inline_svg_tag "icons/lock.svg", class: "tw:block tw:w-6 tw:h-6 tw:mx-auto"
+            %span.oauth-text-block= t(".sign_in_using_sso")
         .sign-in-up-or
           %h3= t(".or")
         .main-form

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -4754,6 +4754,14 @@ en:
         stolen
       vehicle_manufacturer: Vehicle manufacturer
       your: your
+  saml:
+    login:
+      back_to_sign_in: Back to sign in
+      continue: Continue
+      enter_your_organization: Enter your organization's Bike Index short name to continue
+        to single sign-on.
+      organization: Organization
+      sign_in_with_sso: Sign in with single sign-on
   search:
     marketplace:
       index:
@@ -4796,6 +4804,7 @@ en:
       sign_in_using_facebook: Sign in using Facebook
       sign_in_using_globalid: Sign in using globaliD
       sign_in_using_magic_link: Emailed sign in link
+      sign_in_using_sso: Single sign-on
       sign_in_using_strava: Sign in using Strava
       sign_up: sign up
   shared:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -67,6 +67,7 @@ Rails.application.routes.draw do
 
   # Organization SAML SSO (Service Provider). Metadata is public for IdP onboarding;
   # init begins SP-initiated login, callback is the Assertion Consumer Service.
+  get "/sso", to: "saml#login", as: :saml_login
   get "/sso/:org_slug/metadata", to: "saml#metadata", as: :saml_metadata
   get "/sso/:org_slug/init", to: "saml#init", as: :saml_init
   post "/sso/:org_slug/callback", to: "saml#callback", as: :saml_callback

--- a/spec/requests/saml_request_spec.rb
+++ b/spec/requests/saml_request_spec.rb
@@ -46,4 +46,28 @@ RSpec.describe SamlController, type: :request do
       end
     end
   end
+
+  describe "GET /sso (org-slug entry)" do
+    it "renders the entry form" do
+      get "/sso"
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("org_slug")
+    end
+
+    context "slug for a configured org" do
+      let!(:saml_configuration) { FactoryBot.create(:organization_saml_configuration, :enabled, organization:) }
+      it "forwards to init" do
+        get "/sso", params: {org_slug: organization.to_param}
+        expect(response).to redirect_to saml_init_path(org_slug: organization.to_param)
+      end
+    end
+
+    context "slug for an unconfigured org" do
+      it "re-renders with an error" do
+        get "/sso", params: {org_slug: organization.to_param}
+        expect(response).to have_http_status(:ok)
+        expect(flash.now[:error]).to be_present
+      end
+    end
+  end
 end

--- a/spec/requests/sessions_request_spec.rb
+++ b/spec/requests/sessions_request_spec.rb
@@ -124,6 +124,28 @@ RSpec.describe SessionsController, type: :request do
       end
     end
 
+    context "email belongs to an org with configured SAML SSO" do
+      let(:domain) { "saml.edu" }
+      let(:organization) do
+        FactoryBot.create(:organization_with_organization_features,
+          enabled_feature_slugs: %w[saml_sso passwordless_users], passwordless_user_domain: domain)
+      end
+      let!(:saml_configuration) { FactoryBot.create(:organization_saml_configuration, :enabled, organization:) }
+
+      it "redirects to the IdP instead of authenticating with a password" do
+        post "/session", params: {session: {email: "rider@#{domain}", password: "anything"}}
+        expect(response).to redirect_to saml_init_path(org_slug: organization.to_param)
+      end
+
+      context "SAML not configured" do
+        let!(:saml_configuration) { FactoryBot.create(:organization_saml_configuration, organization:) }
+        it "falls through to normal password auth" do
+          post "/session", params: {session: {email: user.email, password:}}
+          expect(response).to redirect_to my_account_url
+        end
+      end
+    end
+
     context "with rack_attack" do
       include_context :rack_attack
 


### PR DESCRIPTION
Email first, then follow up step to email magic link / password / SSO

- [ ] If you use a password manager, it auto fills in the password from the first page
- [ ] There is an integration test for this

---

Surfaces the SAML SSO login path (PR3) to users. Two entry points, both falling through to the existing password / magic-link flow when SSO doesn't apply.

- **Email-first auto-detect** on `/session/new`: when the submitted email belongs to an org with live SAML SSO (`passwordless_email_matching` + a configured config), redirect to the IdP instead of asking for a Bike Index password.
- **Org-slug entry** (`GET /sso`): a "Single sign-on" link + form for users whose email domain isn't the org's passwordless domain — submit the org's short name to reach its IdP.
- Adds `Organization#saml_sso_configured?`, a lock icon, and the i18n strings for the new form/link.

Stacked on #3758 — base will retarget to `main` once that merges.
