### PR TITLE
Add SAML Single Logout + opt-in IdP-initiated login

### DIFF
--- a/app/controllers/admin/organizations_controller.rb
+++ b/app/controllers/admin/organizations_controller.rb
@@ -117,8 +117,8 @@ module Admin
           :spam_registrations,
           :website,
           [locations_attributes:],
-          organization_saml_configuration_attributes: %i[id enabled idp_entity_id
-            idp_sso_target_url idp_slo_target_url idp_cert idp_cert_fingerprint
+          organization_saml_configuration_attributes: %i[id enabled allow_idp_initiated
+            idp_entity_id idp_sso_target_url idp_slo_target_url idp_cert idp_cert_fingerprint
             idp_cert_multi email_attribute_name name_id_format]
         ).merge(kind: approved_kind)
         .merge(registration_field_labels: registration_field_labels_val)

--- a/app/controllers/saml_controller.rb
+++ b/app/controllers/saml_controller.rb
@@ -46,16 +46,89 @@ class SamlController < ApplicationController
   def callback
     saml_configuration = configured_saml_configuration
     request_id = session.delete(:saml_request_id)
-    return saml_failure("SAML session mismatch") if session.delete(:saml_org_slug) != params[:org_slug]
+    expected_slug = session.delete(:saml_org_slug)
+    # No remembered request means this assertion wasn't solicited by us — IdP-initiated.
+    idp_initiated = expected_slug.blank?
+
+    if idp_initiated
+      return saml_failure("IdP-initiated login isn't enabled for this organization") unless saml_configuration.allow_idp_initiated?
+    elsif expected_slug != params[:org_slug]
+      return saml_failure("SAML session mismatch")
+    end
 
     result = Saml::AssertionProcessor.call(saml_configuration:,
-      raw_response: params[:SAMLResponse], request_id:)
+      raw_response: params[:SAMLResponse], request_id:, idp_initiated:)
     return saml_failure(result.error) unless result.success?
 
+    remember_saml_session(result)
     sign_in_and_redirect(result.user)
   end
 
+  # SP-initiated Single Logout. We sign the user out of Bike Index immediately, then
+  # best-effort notify the IdP with a signed LogoutRequest. SLO is inconsistently
+  # implemented across IdPs, so when we can't build a valid request we just land on goodbye.
+  def logout
+    organization = Organization.friendly_find(params[:org_slug])
+    redirect_url = saml_logout_request_url(organization&.organization_saml_configuration)
+    remove_session
+    return redirect_to(redirect_url, allow_other_host: true) if redirect_url
+
+    redirect_to goodbye_url, notice: "Logged out!"
+  end
+
+  # Single Logout endpoint (HTTP-Redirect binding): either an IdP-initiated LogoutRequest,
+  # or the IdP's LogoutResponse to a logout we started (we've already cleared our session).
+  def slo
+    return redirect_to(goodbye_url, notice: "Logged out!") if params[:SAMLRequest].blank?
+
+    handle_idp_logout_request
+  end
+
   private
+
+  def handle_idp_logout_request
+    saml_configuration = configured_saml_configuration
+    return saml_failure("logout request is not signed") if params[:Signature].blank?
+
+    settings = Saml::SettingsBuilder.build(saml_configuration)
+    logout_request = OneLogin::RubySaml::SloLogoutrequest.new(params[:SAMLRequest],
+      settings:, get_params: request.query_parameters, raw_get_params: raw_query_params)
+    unless logout_request.is_valid?
+      return saml_failure(logout_request.errors.join("; ").presence || "invalid logout request")
+    end
+
+    remove_session
+    return redirect_to(goodbye_url, notice: "Logged out!") unless saml_configuration.slo_configured?
+
+    redirect_to OneLogin::RubySaml::SloLogoutresponse.new.create(settings, logout_request.id),
+      allow_other_host: true
+  end
+
+  def saml_logout_request_url(saml_configuration)
+    saml_logout = session[:saml_logout]&.symbolize_keys
+    return nil unless saml_configuration&.slo_configured? && saml_logout.present?
+
+    settings = Saml::SettingsBuilder.build(saml_configuration)
+    settings.name_identifier_value = saml_logout[:name_id]
+    settings.name_identifier_format = saml_logout[:name_id_format]
+    settings.sessionindex = saml_logout[:session_index]
+    OneLogin::RubySaml::Logoutrequest.new.create(settings)
+  end
+
+  # Remember what a later LogoutRequest to the IdP needs to identify this session.
+  def remember_saml_session(result)
+    session[:saml_logout] = {org_slug: params[:org_slug], name_id: result.name_id,
+      name_id_format: result.name_id_format, session_index: result.session_index}
+  end
+
+  # Raw (still URI-encoded) query parts, so ruby-saml verifies the redirect-binding
+  # signature against exactly what the IdP signed.
+  def raw_query_params
+    request.query_string.split("&").each_with_object({}) do |pair, hash|
+      key, value = pair.split("=", 2)
+      hash[key] = value
+    end
+  end
 
   def configured_saml_configuration
     organization = Organization.friendly_find(params[:org_slug])

--- a/app/models/organization_saml_configuration.rb
+++ b/app/models/organization_saml_configuration.rb
@@ -4,6 +4,7 @@
 # Database name: primary
 #
 #  id                   :bigint           not null, primary key
+#  allow_idp_initiated  :boolean          default(FALSE)
 #  email_attribute_name :string
 #  enabled              :boolean          default(FALSE)
 #  idp_cert             :text
@@ -43,6 +44,11 @@ class OrganizationSamlConfiguration < ApplicationRecord
   # Ready to drive a live login: enabled and the IdP essentials are present
   def configured?
     enabled? && idp_entity_id.present? && idp_sso_target_url.present? && idp_cert.present?
+  end
+
+  # Single Logout additionally needs the IdP's logout endpoint
+  def slo_configured?
+    configured? && idp_slo_target_url.present?
   end
 
   def email_attribute

--- a/app/services/saml/assertion_processor.rb
+++ b/app/services/saml/assertion_processor.rb
@@ -4,7 +4,9 @@
 # we layer on email extraction and the SsoIdentity link/provision policy.
 module Saml
   class AssertionProcessor
-    Result = Struct.new(:user, :error) do
+    # name_id/name_id_format/session_index are carried through so the controller can
+    # remember them for a later Single Logout request.
+    Result = Struct.new(:user, :name_id, :name_id_format, :session_index, :error) do
       def success?
         error.nil?
       end
@@ -14,10 +16,11 @@ module Saml
       new(...).call
     end
 
-    def initialize(saml_configuration:, raw_response:, request_id:)
+    def initialize(saml_configuration:, raw_response:, request_id:, idp_initiated: false)
       @saml_configuration = saml_configuration
       @raw_response = raw_response
       @request_id = request_id
+      @idp_initiated = idp_initiated
     end
 
     def call
@@ -25,6 +28,10 @@ module Saml
 
       response = parse_response
       return failure(response.errors.join("; ").presence || "invalid SAML response") unless response.is_valid?
+
+      # IdP-initiated logins carry no InResponseTo to replay-check against, so we enforce
+      # one-time use of the assertion id instead.
+      return failure("assertion has already been used") if @idp_initiated && !claim_assertion(response)
 
       name_id = response.name_id.presence
       return failure("assertion is missing a NameID") if name_id.blank?
@@ -36,12 +43,20 @@ module Saml
       return failure("no Bike Index account for #{email}") if user.blank?
 
       record_identity(user:, name_id:, email:, name_id_format: response.name_id_format)
-      Result.new(user:)
+      Result.new(user:, name_id:, name_id_format: response.name_id_format, session_index: response.sessionindex)
     rescue OneLogin::RubySaml::ValidationError => e
       failure(e.message)
     end
 
     private
+
+    # Returns false when this assertion id has already been seen (within the validity window).
+    def claim_assertion(response)
+      assertion_id = response.assertion_id.presence
+      return false if assertion_id.blank?
+
+      Rails.cache.write("saml/idp_initiated/#{assertion_id}", true, unless_exist: true, expires_in: 12.hours)
+    end
 
     def organization
       @saml_configuration.organization

--- a/app/services/saml/settings_builder.rb
+++ b/app/services/saml/settings_builder.rb
@@ -66,6 +66,8 @@ module Saml
       settings.idp_entity_id = @saml_configuration.idp_entity_id
       settings.idp_sso_service_url = @saml_configuration.idp_sso_target_url
       settings.idp_slo_service_url = @saml_configuration.idp_slo_target_url
+      # ruby-saml keys redirect-binding query signing off idp_slo_service_binding
+      settings.idp_slo_service_binding = HTTP_REDIRECT
       settings.name_identifier_format = @saml_configuration.name_id_format.presence
 
       certs = @saml_configuration.idp_certificates
@@ -80,6 +82,8 @@ module Saml
       settings.soft = true # collect validation errors instead of raising
       settings.security[:want_assertions_signed] = true
       settings.security[:authn_requests_signed] = true
+      settings.security[:logout_requests_signed] = true
+      settings.security[:logout_responses_signed] = true
       settings.security[:digest_method] = XMLSecurity::Document::SHA256
       settings.security[:signature_method] = XMLSecurity::Document::RSA_SHA256
     end

--- a/app/views/admin/organizations/_form.html.haml
+++ b/app/views/admin/organizations/_form.html.haml
@@ -275,6 +275,9 @@
                 .form-group.mt-2
                   = saml_f.label :idp_slo_target_url, "IdP SLO target URL (optional)"
                   = saml_f.text_field :idp_slo_target_url, class: "form-control"
+                .form-check.mt-2
+                  = saml_f.check_box :allow_idp_initiated, class: "form-check-input"
+                  = saml_f.label :allow_idp_initiated, "Allow IdP-initiated login (weaker replay protection — leave off unless required)", class: "form-check-label"
                 .form-group.mt-2
                   = saml_f.label :idp_cert, "IdP certificate (PEM or base64)"
                   = saml_f.text_area :idp_cert, class: "form-control", rows: 4

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -71,6 +71,8 @@ Rails.application.routes.draw do
   get "/sso/:org_slug/metadata", to: "saml#metadata", as: :saml_metadata
   get "/sso/:org_slug/init", to: "saml#init", as: :saml_init
   post "/sso/:org_slug/callback", to: "saml#callback", as: :saml_callback
+  get "/sso/:org_slug/logout", to: "saml#logout", as: :saml_logout
+  get "/sso/:org_slug/slo", to: "saml#slo", as: :saml_slo
 
   resources :payments, only: %i[new create] do
     collection { get :success }

--- a/db/migrate/20260627120000_add_allow_idp_initiated_to_organization_saml_configurations.rb
+++ b/db/migrate/20260627120000_add_allow_idp_initiated_to_organization_saml_configurations.rb
@@ -1,0 +1,5 @@
+class AddAllowIdpInitiatedToOrganizationSamlConfigurations < ActiveRecord::Migration[8.1]
+  def change
+    add_column :organization_saml_configurations, :allow_idp_initiated, :boolean, default: false
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -2726,7 +2726,8 @@ CREATE TABLE public.organization_saml_configurations (
     email_attribute_name character varying,
     name_id_format character varying,
     created_at timestamp(6) without time zone NOT NULL,
-    updated_at timestamp(6) without time zone NOT NULL
+    updated_at timestamp(6) without time zone NOT NULL,
+    allow_idp_initiated boolean DEFAULT false
 );
 
 
@@ -7257,6 +7258,7 @@ ALTER TABLE ONLY public.ambassador_task_assignments
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20260627120000'),
 ('20260626170001'),
 ('20260626170000'),
 ('20260626162049'),

--- a/spec/factories/organization_saml_configurations.rb
+++ b/spec/factories/organization_saml_configurations.rb
@@ -8,5 +8,13 @@ FactoryBot.define do
       idp_sso_target_url { "https://idp.example.edu/idp/profile/SAML2/POST/SSO" }
       idp_cert { File.read(Rails.root.join("spec/fixtures/saml/idp_cert.pem")) }
     end
+
+    trait :with_slo do
+      idp_slo_target_url { "https://idp.example.edu/idp/profile/SAML2/Redirect/SLO" }
+    end
+
+    trait :idp_initiated do
+      allow_idp_initiated { true }
+    end
   end
 end

--- a/spec/models/organization_saml_configuration_spec.rb
+++ b/spec/models/organization_saml_configuration_spec.rb
@@ -21,6 +21,18 @@ RSpec.describe OrganizationSamlConfiguration, type: :model do
     end
   end
 
+  describe "#slo_configured?" do
+    it "is false when configured but missing the IdP logout endpoint" do
+      saml_configuration = FactoryBot.create(:organization_saml_configuration, :enabled)
+      expect(saml_configuration.slo_configured?).to be_falsey
+    end
+
+    it "is true once the IdP logout endpoint is present" do
+      saml_configuration = FactoryBot.create(:organization_saml_configuration, :enabled, :with_slo)
+      expect(saml_configuration.slo_configured?).to be_truthy
+    end
+  end
+
   describe "validations" do
     let(:saml_configuration) { FactoryBot.build(:organization_saml_configuration, enabled: true) }
     it "requires idp essentials when enabled" do

--- a/spec/requests/saml_callback_request_spec.rb
+++ b/spec/requests/saml_callback_request_spec.rb
@@ -165,4 +165,100 @@ RSpec.describe "SAML SSO login", type: :request do
       end
     end
   end
+
+  # IdP-initiated login lacks the InResponseTo binding, so it's gated behind a per-org
+  # opt-in and protected by one-time use of the assertion id.
+  describe "IdP-initiated login" do
+    let(:saml_configuration) { FactoryBot.create(:organization_saml_configuration, :enabled, :idp_initiated, organization:) }
+
+    def idp_initiated_response
+      signed_saml_response(audience: settings.sp_entity_id,
+        recipient: settings.assertion_consumer_service_url,
+        issuer: saml_configuration.idp_entity_id, email:)
+    end
+
+    it "provisions and signs in without a prior init" do
+      expect {
+        post "/sso/#{slug}/callback", params: {SAMLResponse: idp_initiated_response}
+      }.to change(User, :count).by(1)
+      expect(signed_in?).to be true
+    end
+
+    it "rejects a replayed assertion" do
+      saml_response = idp_initiated_response
+      post "/sso/#{slug}/callback", params: {SAMLResponse: saml_response}
+      expect(signed_in?).to be true
+
+      reset! # fresh session/cookies, same assertion
+      post "/sso/#{slug}/callback", params: {SAMLResponse: saml_response}
+      expect(response).to redirect_to(new_session_path)
+      expect(signed_in?).to be false
+    end
+
+    context "flag disabled" do
+      let(:saml_configuration) { FactoryBot.create(:organization_saml_configuration, :enabled, organization:) }
+      it "is rejected" do
+        expect {
+          post "/sso/#{slug}/callback", params: {SAMLResponse: idp_initiated_response}
+        }.not_to change(User, :count)
+        expect(signed_in?).to be false
+      end
+    end
+  end
+
+  # Single Logout is inconsistently supported by IdPs; we sign out locally regardless and
+  # treat the IdP round-trip as best-effort.
+  describe "Single Logout" do
+    let(:saml_configuration) { FactoryBot.create(:organization_saml_configuration, :enabled, :with_slo, organization:) }
+
+    describe "GET /sso/:org_slug/logout (SP-initiated)" do
+      it "signs out locally and redirects to the IdP with a signed LogoutRequest" do
+        post_callback
+        expect(signed_in?).to be true
+
+        get "/sso/#{slug}/logout"
+        location = response.headers["Location"]
+        expect(location).to start_with(saml_configuration.idp_slo_target_url)
+        expect(location).to include("SAMLRequest=")
+        expect(location).to include("Signature=")
+        expect(signed_in?).to be false
+      end
+
+      context "SLO not configured" do
+        let(:saml_configuration) { FactoryBot.create(:organization_saml_configuration, :enabled, organization:) }
+        it "signs out locally and lands on goodbye" do
+          post_callback
+          get "/sso/#{slug}/logout"
+          expect(response).to redirect_to(goodbye_url)
+          expect(signed_in?).to be false
+        end
+      end
+    end
+
+    describe "GET /sso/:org_slug/slo (IdP-initiated)" do
+      it "validates the request, signs out, and responds to the IdP" do
+        post_callback
+        expect(signed_in?).to be true
+
+        get signed_idp_logout_request(destination: settings.single_logout_service_url,
+          idp_entity_id: saml_configuration.idp_entity_id)
+        location = response.headers["Location"]
+        expect(location).to start_with(saml_configuration.idp_slo_target_url)
+        expect(location).to include("SAMLResponse=")
+        expect(signed_in?).to be false
+      end
+
+      it "rejects an unsigned logout request without signing out" do
+        post_callback
+        get "/sso/#{slug}/slo", params: {SAMLRequest: "Zm9v"}
+        expect(response).to redirect_to(new_session_path)
+        expect(signed_in?).to be true
+      end
+
+      it "lands on goodbye for the IdP's LogoutResponse" do
+        get "/sso/#{slug}/slo", params: {SAMLResponse: "Zm9v"}
+        expect(response).to redirect_to(goodbye_url)
+      end
+    end
+  end
 end

--- a/spec/support/saml_helpers.rb
+++ b/spec/support/saml_helpers.rb
@@ -21,7 +21,7 @@ module SamlHelpers
     Nokogiri::XML(inflated).root["ID"]
   end
 
-  def signed_saml_response(audience:, recipient:, in_response_to:, email:,
+  def signed_saml_response(audience:, recipient:, email:, in_response_to: nil,
     name_id: nil, issuer: "https://idp.example.edu/", not_on_or_after: nil,
     sign: true, tamper: false, email_attribute: EMAIL_OID)
     name_id ||= email
@@ -40,11 +40,32 @@ module SamlHelpers
     Base64.strict_encode64(wrapper.sub("SIGNED_ASSERTION", assertion))
   end
 
+  # A redirect-binding LogoutRequest signed with the IdP key, as an IdP would send for
+  # IdP-initiated Single Logout. Returns the path + query to GET against our /slo endpoint.
+  def signed_idp_logout_request(destination:, idp_entity_id:, name_id: "someone@example.edu")
+    settings = OneLogin::RubySaml::Settings.new
+    settings.idp_slo_service_url = destination
+    settings.idp_slo_service_binding = Saml::SettingsBuilder::HTTP_REDIRECT
+    settings.security[:logout_requests_signed] = true
+    settings.security[:signature_method] = XMLSecurity::Document::RSA_SHA256
+    settings.security[:digest_method] = XMLSecurity::Document::SHA256
+    settings.certificate = saml_idp_cert.to_pem
+    settings.private_key = saml_idp_key.to_pem
+    settings.sp_entity_id = idp_entity_id # becomes the LogoutRequest Issuer
+    settings.name_identifier_value = name_id
+    URI(OneLogin::RubySaml::Logoutrequest.new.create(settings)).request_uri
+  end
+
   private
 
   # Strip whitespace between tags (the signed assertion has none, so this leaves it byte-intact)
   def collapse(xml)
     xml.gsub(/>\s+</, "><").strip
+  end
+
+  # Unsolicited (IdP-initiated) responses carry no InResponseTo
+  def in_response_to_attribute(in_response_to)
+    in_response_to.present? ? %(InResponseTo="#{in_response_to}" ) : ""
   end
 
   def sign_saml_assertion(assertion_xml, assertion_id)
@@ -65,7 +86,7 @@ module SamlHelpers
         <saml:Subject>
           <saml:NameID Format="urn:oasis:names:tc:SAML:2.0:nameid-format:emailAddress">#{name_id}</saml:NameID>
           <saml:SubjectConfirmation Method="urn:oasis:names:tc:SAML:2.0:cm:bearer">
-            <saml:SubjectConfirmationData InResponseTo="#{in_response_to}" NotOnOrAfter="#{not_on_or_after}" Recipient="#{recipient}"/>
+            <saml:SubjectConfirmationData #{in_response_to_attribute(in_response_to)}NotOnOrAfter="#{not_on_or_after}" Recipient="#{recipient}"/>
           </saml:SubjectConfirmation>
         </saml:Subject>
         <saml:Conditions NotBefore="#{not_before}" NotOnOrAfter="#{not_on_or_after}">
@@ -86,7 +107,7 @@ module SamlHelpers
   def saml_response_xml(issuer:, destination:, in_response_to:, assertion:)
     now = Time.current.utc.iso8601
     <<~XML
-      <samlp:Response xmlns:samlp="#{SAMLP_NS}" xmlns:saml="#{SAML_NS}" ID="_#{SecureRandom.uuid}" Version="2.0" IssueInstant="#{now}" Destination="#{destination}" InResponseTo="#{in_response_to}">
+      <samlp:Response xmlns:samlp="#{SAMLP_NS}" xmlns:saml="#{SAML_NS}" ID="_#{SecureRandom.uuid}" Version="2.0" IssueInstant="#{now}" Destination="#{destination}" #{in_response_to_attribute(in_response_to)}>
         <saml:Issuer>#{issuer}</saml:Issuer>
         <samlp:Status><samlp:StatusCode Value="urn:oasis:names:tc:SAML:2.0:status:Success"/></samlp:Status>
         #{assertion}


### PR DESCRIPTION
Rounds out the SAML SP with Single Logout and opt-in IdP-initiated login — the two items the plan deferred as optional. Both are inconsistently implemented across IdPs, so they're built defensively and documented inline.

- **SP-initiated SLO** (`GET /sso/:slug/logout`): signs the user out of Bike Index immediately, then best-effort notifies the IdP with a signed `LogoutRequest`. Falls back to a plain local logout when SLO isn't configured.
- **IdP-initiated SLO** (`GET /sso/:slug/slo`): validates the redirect-binding signature against the IdP cert (rejects unsigned requests before clearing the session), signs out, and replies with a `LogoutResponse`. Also lands the IdP's `LogoutResponse` on goodbye.
- **IdP-initiated login**: gated behind a per-org `allow_idp_initiated` flag (default off). With no `InResponseTo` to bind, replay protection is one-time use of the assertion id via `Rails.cache`; the existing same-domain guard still blocks cross-domain provisioning.
- Supporting: `slo_configured?`, SettingsBuilder redirect-SLO binding + logout-signing flags, `AssertionProcessor` carries NameID/format/SessionIndex through, admin checkbox + permitted param.

Stacked on #3759 — base will retarget to `main` as the stack merges.
