### PR TITLE
Make admin/ctypes sortable; add component groups table

### DIFF
--- a/app/controllers/admin/ctypes_controller.rb
+++ b/app/controllers/admin/ctypes_controller.rb
@@ -1,12 +1,17 @@
 module Admin
   class CtypesController < Admin::BaseController
-    include Binxtils::SetPeriod
+    include Binxtils::SortableTable
 
-    before_action :set_period, only: %i[index]
     before_action :find_ctypes, only: [:edit, :update, :destroy]
 
     def index
-      @ctypes = Ctype.all
+      @cgroups = Cgroup.commonness
+      @ctype_counts = Ctype.group(:cgroup_id).count
+      @ctypes = if sort_column == "cgroup"
+        Ctype.includes(:cgroup).joins(:cgroup).reorder("cgroups.name #{sort_direction}")
+      else
+        Ctype.includes(:cgroup).reorder("ctypes.#{sort_column} #{sort_direction}")
+      end
     end
 
     def new
@@ -41,6 +46,12 @@ module Admin
     end
 
     protected
+
+    def sortable_columns
+      %w[name slug cgroup image created_at updated_at]
+    end
+
+    def default_direction = "asc"
 
     def permitted_parameters
       params.require(:ctype).permit(:name, :slug, :secondary_name, :image, :image_cache, :cgroup_id, :cgroup, :has_multiple, :cgroup_name)

--- a/app/views/admin/ctypes/_cgroups_table.html.erb
+++ b/app/views/admin/ctypes/_cgroups_table.html.erb
@@ -1,0 +1,23 @@
+<%# locals: (cgroups:, ctype_counts:) %>
+
+<h3 class="tw:mt-4">Component groups</h3>
+
+<div class="full-screen-table mb-4">
+  <table class="table table-striped table-bordered table-sm">
+    <thead class="thead-light">
+      <th>Name</th>
+      <th>Priority</th>
+      <th>Component types</th>
+    </thead>
+
+    <tbody>
+      <% cgroups.each do |cgroup| %>
+        <tr>
+          <td><%= cgroup.name.titleize %></td>
+          <td><%= number_display(cgroup.priority) %></td>
+          <td><%= number_display(ctype_counts[cgroup.id] || 0) %></td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+</div>

--- a/app/views/admin/ctypes/_table.html.erb
+++ b/app/views/admin/ctypes/_table.html.erb
@@ -3,10 +3,16 @@
 <div class="full-screen-table mt-4 mb-4">
   <table class="table table-striped table-bordered">
     <thead class="thead-light">
-      <th>Name</th>
-      <th>Slug</th>
-      <th>Component group</th>
-      <th class="large-screens">Has image?</th>
+      <th><%= sortable "name", render_sortable: %></th>
+      <th><%= sortable "slug", render_sortable: %></th>
+      <th><%= sortable "cgroup", "Component group", render_sortable: %></th>
+
+      <th class="large-screens">
+        <%= sortable "image", "Has image?", render_sortable: %>
+      </th>
+
+      <th><%= sortable "created_at", render_sortable: %></th>
+      <th><%= sortable "updated_at", render_sortable: %></th>
     </thead>
 
     <tbody>
@@ -16,6 +22,14 @@
           <td><%= ctype.slug %></td>
           <td><%= ctype.cgroup.name.titleize %></td>
           <td class="large-screens"><%= check_mark if ctype.image? %></td>
+
+          <td class="localizeTime">
+            <%= l(ctype.created_at, format: :convert_time) %>
+          </td>
+
+          <td class="localizeTime">
+            <%= l(ctype.updated_at, format: :convert_time) %>
+          </td>
         </tr>
       <% end %>
     </tbody>

--- a/app/views/admin/ctypes/index.html.erb
+++ b/app/views/admin/ctypes/index.html.erb
@@ -4,9 +4,15 @@
   </li>
 <% end %>
 
+<% table_view = capture do %>
+  <%= render partial: "cgroups_table", locals: {cgroups: @cgroups, ctype_counts: @ctype_counts} %>
+  <%= render partial: "table", locals: {collection: @ctypes, render_sortable: true} %>
+<% end %>
+
 <%= render(Admin::IndexSkeleton::Component.new(
   collection: @ctypes,
   viewing: "Component Types",
   skip_charting: true,
-  nav_header_list_items:
+  nav_header_list_items:,
+  table_view:
 )) %>

--- a/spec/requests/admin/ctypes_request_spec.rb
+++ b/spec/requests/admin/ctypes_request_spec.rb
@@ -1,0 +1,36 @@
+require "rails_helper"
+
+RSpec.describe Admin::CtypesController, type: :request do
+  base_url = "/admin/ctypes"
+
+  context "given a logged-in superuser" do
+    include_context :request_spec_logged_in_as_superuser
+
+    describe "index" do
+      let!(:ctype_b) { FactoryBot.create(:ctype, name: "Brakes") }
+      let!(:ctype_a) { FactoryBot.create(:ctype, name: "Axle") }
+
+      it "responds with 200 OK and renders the index template" do
+        get base_url
+        expect(response).to be_ok
+        expect(response).to render_template(:index)
+      end
+
+      it "sorts by the requested column and direction" do
+        get base_url, params: {sort: "name", direction: "asc"}
+        expect(assigns(:ctypes).pluck(:id)).to eq([ctype_a.id, ctype_b.id])
+
+        get base_url, params: {sort: "name", direction: "desc"}
+        expect(assigns(:ctypes).pluck(:id)).to eq([ctype_b.id, ctype_a.id])
+      end
+
+      it "sorts by component group name" do
+        ctype_a.update!(cgroup: FactoryBot.create(:cgroup, name: "Wheels"))
+        ctype_b.update!(cgroup: FactoryBot.create(:cgroup, name: "Additional parts"))
+
+        get base_url, params: {sort: "cgroup", direction: "asc"}
+        expect(assigns(:ctypes).pluck(:id)).to eq([ctype_b.id, ctype_a.id])
+      end
+    end
+  end
+end

--- a/spec/requests/admin/ctypes_request_spec.rb
+++ b/spec/requests/admin/ctypes_request_spec.rb
@@ -7,27 +7,21 @@ RSpec.describe Admin::CtypesController, type: :request do
     include_context :request_spec_logged_in_as_superuser
 
     describe "index" do
-      let!(:ctype_b) { FactoryBot.create(:ctype, name: "Brakes") }
-      let!(:ctype_a) { FactoryBot.create(:ctype, name: "Axle") }
+      let!(:ctype_a) { FactoryBot.create(:ctype, name: "Axle", cgroup: FactoryBot.create(:cgroup, name: "Wheels")) }
+      let!(:ctype_b) { FactoryBot.create(:ctype, name: "Brakes", cgroup: FactoryBot.create(:cgroup, name: "Additional parts")) }
 
-      it "responds with 200 OK and renders the index template" do
+      it "renders and sorts by the requested column and direction" do
         get base_url
         expect(response).to be_ok
         expect(response).to render_template(:index)
-      end
 
-      it "sorts by the requested column and direction" do
         get base_url, params: {sort: "name", direction: "asc"}
         expect(assigns(:ctypes).pluck(:id)).to eq([ctype_a.id, ctype_b.id])
 
         get base_url, params: {sort: "name", direction: "desc"}
         expect(assigns(:ctypes).pluck(:id)).to eq([ctype_b.id, ctype_a.id])
-      end
 
-      it "sorts by component group name" do
-        ctype_a.update!(cgroup: FactoryBot.create(:cgroup, name: "Wheels"))
-        ctype_b.update!(cgroup: FactoryBot.create(:cgroup, name: "Additional parts"))
-
+        # Sorts by component group name, not the cgroup_id foreign key
         get base_url, params: {sort: "cgroup", direction: "asc"}
         expect(assigns(:ctypes).pluck(:id)).to eq([ctype_b.id, ctype_a.id])
       end


### PR DESCRIPTION
Make the admin Component Types index (`/admin/ctypes`) sortable and add a compact reference table for component groups.

- Every column is now sortable (name, slug, component group, has-image, created/updated), using the shared `Binxtils::SortableTable` concern.
- Added **Created** and **Updated** timestamp columns to the table.
- Component group sorts by the group's name (via a join) rather than the raw `cgroup_id` foreign key, so the order matches what's displayed.
- Added a small read-only **Component groups** table above the main list showing each group's priority and its count of component types (component groups have no admin page of their own).
