### PR TITLE
Merge strava_integration in Users::MergeAdditionalEmailJob

### DIFF
--- a/app/jobs/users/merge_additional_email_job.rb
+++ b/app/jobs/users/merge_additional_email_job.rb
@@ -48,6 +48,8 @@ module Users
       # No index, so update all
       BikeSticker.where(user_id: old_user.id).update_all(user_id:)
 
+      merge_strava_integration(user_email.user, old_user)
+
       if user_email.user.stripe_id.blank? && old_user.stripe_id.present?
         user_email.user.update(stripe_id: old_user.stripe_id)
       end
@@ -65,6 +67,15 @@ module Users
         AddressRecord.user.where(user_id: old_user_id).each { |i| i.update(user_id:) }
       end
       AddressRecord.not_user.where(user_id: old_user_id).each { |i| i.update(user_id:) }
+    end
+
+    # has_one with a unique index on (user_id) where not deleted - only move if the target has none,
+    # otherwise the old integration is soft-deleted with old_user via dependent: :destroy
+    def merge_strava_integration(user, old_user)
+      return if old_user.strava_integration.blank? || user.strava_integration.present?
+
+      old_user.strava_integration.update(user_id: user.id)
+      old_user.strava_integration.strava_requests.update_all(user_id: user.id)
     end
 
     def update_marketplace_messages(user_id, old_user_id)

--- a/spec/jobs/users/merge_additional_email_job_spec.rb
+++ b/spec/jobs/users/merge_additional_email_job_spec.rb
@@ -216,6 +216,29 @@ RSpec.describe Users::MergeAdditionalEmailJob, type: :job do
       end
     end
 
+    context "strava_integration" do
+      let!(:strava_integration) { FactoryBot.create(:strava_integration, :with_athlete, user: old_user) }
+      let!(:strava_request) { FactoryBot.create(:strava_request, strava_integration:) }
+
+      it "moves the strava_integration to the user" do
+        expect(strava_integration.reload.user_id).to eq old_user.id
+        expect(strava_request.reload.user_id).to eq old_user.id
+        instance.perform(user_email.id)
+        expect(strava_integration.reload.user_id).to eq user.id
+        expect(strava_request.reload.user_id).to eq user.id
+      end
+
+      context "user already has a strava_integration" do
+        let!(:user_strava_integration) { FactoryBot.create(:strava_integration, :with_athlete, user:) }
+
+        it "keeps the user's integration and soft-deletes the old one" do
+          instance.perform(user_email.id)
+          expect(user.reload.strava_integration).to eq user_strava_integration
+          expect(StravaIntegration.unscoped.find(strava_integration.id).deleted_at).to be_present
+        end
+      end
+    end
+
     context "email_ban" do
       let!(:email_ban) { FactoryBot.create(:email_ban, user: old_user) }
       it "updates the email_ban" do


### PR DESCRIPTION
Merge a user's `strava_integration` (and its analytics-DB `strava_requests`) into the surviving account in `Users::MergeAdditionalEmailJob`.

- `StravaIntegration` is a `has_one` with a unique partial index on `user_id` (where not deleted), so the integration only moves over when the target user doesn't already have one.
- When the target already has an integration, the old one stays put and is soft-deleted with `old_user` via `dependent: :destroy` — the partial index excludes deleted rows, so there's never a uniqueness collision.
- Adds spec coverage for both the move and the already-has-an-integration cases.
