### PR TITLE
Tidy admin ctypes & manufacturers index headers

### DIFF
--- a/app/components/admin/index_skeleton/component.html.erb
+++ b/app/components/admin/index_skeleton/component.html.erb
@@ -41,6 +41,8 @@
 
 <%= render(current_header_component) %>
 
+<%= @header_content %>
+
 <% if show_chart? %>
   <% if @rendered_chart.nil? %>
     <%= default_chart %>

--- a/app/components/admin/index_skeleton/component.rb
+++ b/app/components/admin/index_skeleton/component.rb
@@ -16,7 +16,9 @@ module Admin
         time_range_column: nil,
         admin_search_form: nil,
         table_view: nil,
-        chart_collection: nil
+        chart_collection: nil,
+        header_content: nil,
+        count_detail: nil
       )
         @collection = collection
         @viewing = viewing
@@ -29,6 +31,8 @@ module Admin
         @admin_search_form = admin_search_form
         @table_view = table_view
         @chart_collection = chart_collection
+        @header_content = header_content
+        @count_detail = count_detail
       end
 
       def before_render
@@ -78,6 +82,7 @@ module Admin
       def pagination_component(skip_total: false)
         Admin::PaginationWithCount::Component.new(
           collection: @collection, viewing:, skip_total:,
+          count_detail: skip_total ? nil : @count_detail,
           pagy: @pagy, per_page: @per_page, time_range: @time_range,
           period: @period, time_range_column: @time_range_column, params: @params
         )

--- a/app/components/admin/pagination_with_count/component.html.erb
+++ b/app/components/admin/pagination_with_count/component.html.erb
@@ -19,6 +19,10 @@
             (<%= number_with_delimiter(today_count) %> today)
           </em>
         <% end %>
+
+        <% if @count_detail.present? %>
+          <span class="less-strong"><%= @count_detail %></span>
+        <% end %>
       </p>
     </div>
   <% end %>

--- a/app/components/admin/pagination_with_count/component.rb
+++ b/app/components/admin/pagination_with_count/component.rb
@@ -5,9 +5,10 @@ module Admin
     class Component < ApplicationComponent
       include GraphingHelper # for humanized_time_range_column
 
-      def initialize(collection:, count: nil, skip_total: false, skip_today: false, skip_pagination: false, humanized_time_range_column_override: nil, viewing: nil, pagy: nil, per_page: nil, time_range: nil, period: nil, time_range_column: nil, params: {})
+      def initialize(collection:, count: nil, count_detail: nil, skip_total: false, skip_today: false, skip_pagination: false, humanized_time_range_column_override: nil, viewing: nil, pagy: nil, per_page: nil, time_range: nil, period: nil, time_range_column: nil, params: {})
         @collection = collection
         @count = count
+        @count_detail = count_detail
         @skip_total = skip_total
         @skip_today = skip_today
         @skip_pagination = skip_pagination

--- a/app/controllers/admin/manufacturers_controller.rb
+++ b/app/controllers/admin/manufacturers_controller.rb
@@ -73,9 +73,9 @@ module Admin
 
     def searched_manufacturers
       manufacturers = Manufacturer
-      @with_logos = Binxtils::InputNormalizer.boolean(params[:search_with_logos])
-      manufacturers = manufacturers.with_websites if @with_logos
       @with_websites = Binxtils::InputNormalizer.boolean(params[:search_with_websites])
+      manufacturers = manufacturers.with_websites if @with_websites
+      @with_logos = Binxtils::InputNormalizer.boolean(params[:search_with_logos])
       manufacturers = manufacturers.with_logos if @with_logos
       manufacturers
     end

--- a/app/views/admin/b_params/index.html.erb
+++ b/app/views/admin/b_params/index.html.erb
@@ -41,7 +41,7 @@
   &mdash;
   <%= number_display(matching_b_params.where("created_at > ?", Time.current - 24.hours).count) %>
   today
-<% end %>
+<% end if request.query_parameters.blank? %>
 
 <% admin_search_form = capture do %>
   <%= form_tag admin_b_params_path, method: :get, class: "form-inline mt-4 mb-4 justify-content-md-end" do %>

--- a/app/views/admin/b_params/index.html.erb
+++ b/app/views/admin/b_params/index.html.erb
@@ -37,29 +37,22 @@
   <% end %>
 <% end %>
 
+<% count_detail = capture do %>
+  &mdash;
+  <%= number_display(matching_b_params.where("created_at > ?", Time.current - 24.hours).count) %>
+  today
+<% end %>
+
 <% admin_search_form = capture do %>
-  <div class="row mt-4">
-    <div class="col-md-5">
-      <p>
-        <%= number_with_delimiter(matching_b_params.count, delimiter: ',') %>
-        partial bikes <em><%= humanized_time_range(@time_range) %>,</em>
-        <strong><%= number_with_delimiter(matching_b_params.where("created_at > ?", Time.current - 24.hours).count) %></strong>
-        today
-      </p>
+  <%= form_tag admin_b_params_path, method: :get, class: "form-inline mt-4 mb-4 justify-content-md-end" do %>
+    <%= hidden_field_tag :search_completeness, params[:search_completeness] %>
+
+    <div class="form-group mr-2 mb-2">
+      <%= text_field_tag :query, params[:query], placeholder: "Find by email", class: "form-control" %>
     </div>
 
-    <div class="col-md-7">
-      <%= form_tag admin_b_params_path, method: :get, class: "form-inline" do %>
-        <%= hidden_field_tag :search_completeness, params[:search_completeness] %>
-
-        <div class="form-group ml-auto mr-2 mb-2">
-          <%= text_field_tag :query, params[:query], placeholder: "Find by email", class: "form-control" %>
-        </div>
-
-        <%= submit_tag "Search", name: "search", class: "btn btn-primary mb-2" %>
-      <% end %>
-    </div>
-  </div>
+    <%= submit_tag "Search", name: "search", class: "btn btn-primary mb-2" %>
+  <% end %>
 <% end %>
 
 <%= render(Admin::IndexSkeleton::Component.new(
@@ -67,5 +60,6 @@
   viewing: "Partial bikes",
   rendered_chart:,
   nav_header_list_items:,
-  admin_search_form:
+  admin_search_form:,
+  count_detail:
 )) %>

--- a/app/views/admin/bikes/index.html.erb
+++ b/app/views/admin/bikes/index.html.erb
@@ -246,22 +246,15 @@
   </div>
 <% end %>
 
-<% table_view = capture do %>
-  <% unless admin_nav_display_view_all %>
-    <p>
-      There are currently <%= number_with_delimiter(PublicImage.count) %> bike
-      images
-      <em>(<%= PublicImage.where("created_at >= ?", Time.current.beginning_of_day).count %> today)</em>
-    </p>
-    <p>
-      <%= number_with_delimiter(Bike.count) %> publicly registered,
-      <em>(<%= Bike.where("created_at >= ?", Time.current.beginning_of_day).count %> today)</em>
-      &nbsp;
-      <%= number_with_delimiter(Ownership.where(current: true).where(claimed: true).count) %>
-      are claimed
-    </p>
-  <% end %>
+<% count_detail = capture do %>
+  &mdash; <%= number_display(Bike.count) %> publicly registered
+  <em>(<%= number_display(Bike.where("created_at >= ?", Time.current.beginning_of_day).count) %> today)</em>,
+  <%= number_display(Ownership.where(current: true, claimed: true).count) %>
+  claimed, <%= number_display(PublicImage.count) %> bike images
+  <em>(<%= number_display(PublicImage.where("created_at >= ?", Time.current.beginning_of_day).count) %> today)</em>
+<% end unless admin_nav_display_view_all %>
 
+<% table_view = capture do %>
   <%= render partial: "/admin/bikes/table", locals: {render_sortable: true, render_multi_check: @multi_delete} %>
 <% end %>
 
@@ -272,4 +265,5 @@
   rendered_chart:,
   admin_search_form:,
   table_view:,
+  count_detail:,
 )) %>

--- a/app/views/admin/ctypes/_cgroups_table.html.erb
+++ b/app/views/admin/ctypes/_cgroups_table.html.erb
@@ -8,6 +8,7 @@
       <th>Name</th>
       <th>Priority</th>
       <th>Component types</th>
+      <th>Updated</th>
     </thead>
 
     <tbody>
@@ -16,6 +17,10 @@
           <td><%= cgroup.name.titleize %></td>
           <td><%= number_display(cgroup.priority) %></td>
           <td><%= number_display(ctype_counts[cgroup.id] || 0) %></td>
+
+          <td class="localizeTime">
+            <%= l(cgroup.updated_at, format: :convert_time) %>
+          </td>
         </tr>
       <% end %>
     </tbody>

--- a/app/views/admin/ctypes/index.html.erb
+++ b/app/views/admin/ctypes/index.html.erb
@@ -4,8 +4,11 @@
   </li>
 <% end %>
 
-<% table_view = capture do %>
+<% header_content = capture do %>
   <%= render partial: "cgroups_table", locals: {cgroups: @cgroups, ctype_counts: @ctype_counts} %>
+<% end %>
+
+<% table_view = capture do %>
   <%= render partial: "table", locals: {collection: @ctypes, render_sortable: true} %>
 <% end %>
 
@@ -14,5 +17,6 @@
   viewing: "Component Types",
   skip_charting: true,
   nav_header_list_items:,
+  header_content:,
   table_view:
 )) %>

--- a/app/views/admin/manufacturers/index.html.erb
+++ b/app/views/admin/manufacturers/index.html.erb
@@ -4,32 +4,14 @@
   </li>
 <% end %>
 
-<% table_view = capture do %>
-  <div class="col-12 mt-4">
-    <% if sortable_search_params? %>
-      <% if @with_websites %>
-        <p>
-          Manufacturers with <strong>websites</strong>
-          <%= link_to "view with and without websites", url_for(sortable_search_params.merge(search_with_websites: nil)), class: "gray-link small" %>
-        </p>
-      <% end %>
-      <% if @with_logos %>
-        <p>
-          Manufacturers with <strong>with logos</strong>
-          <%= link_to "view with and without logos", url_for(sortable_search_params.merge(search_with_logos: nil)), class: "gray-link small" %>
-        </p>
-      <% end %>
-      <h4 class="mt-4">
-        <%= number_display(@manufacturers.count) %> matching manufacturers
-      </h4>
-    <% else %>
-      <h4>
-        <%= number_display(@manufacturers.count) %> total,
-        <span class="less-strong"><%= number_display(Manufacturer.with_websites.count) %> with <%= link_to "websites", url_for(sortable_search_params.merge(search_with_websites: !@with_websites)) %>, <%= number_display(Manufacturer.with_logos.count) %> with <%= link_to "logos", url_for(sortable_search_params.merge(search_with_logos: !@with_logos)) %>.</span>
-      </h4>
-    <% end %>
-  </div>
+<% count_detail = capture do %>
+  &mdash; <%= number_display(Manufacturer.with_websites.count) %> with
+  <%= link_to "websites", url_for(sortable_search_params.merge(search_with_websites: !@with_websites)), class: ("active" if @with_websites) %>,
+  <%= number_display(Manufacturer.with_logos.count) %> with
+  <%= link_to "logos", url_for(sortable_search_params.merge(search_with_logos: !@with_logos)), class: ("active" if @with_logos) %>.
+<% end %>
 
+<% table_view = capture do %>
   <%= render partial: "/admin/manufacturers/table", locals: {collection: @manufacturers, render_sortable: true} %>
 
   <%= form_tag import_admin_manufacturers_path, multipart: true do %>
@@ -47,5 +29,6 @@
   viewing: "Manufacturers",
   nav_header_list_items:,
   table_view:,
+  count_detail:,
   skip_charting: true
 )) %>

--- a/app/views/admin/manufacturers/index.html.erb
+++ b/app/views/admin/manufacturers/index.html.erb
@@ -9,7 +9,7 @@
   <%= link_to "websites", url_for(sortable_search_params.merge(search_with_websites: !@with_websites)), class: ("active" if @with_websites) %>,
   <%= number_display(Manufacturer.with_logos.count) %> with
   <%= link_to "logos", url_for(sortable_search_params.merge(search_with_logos: !@with_logos)), class: ("active" if @with_logos) %>.
-<% end %>
+<% end if request.query_parameters.blank? %>
 
 <% table_view = capture do %>
   <%= render partial: "/admin/manufacturers/table", locals: {collection: @manufacturers, render_sortable: true} %>

--- a/app/views/admin/news/index.html.erb
+++ b/app/views/admin/news/index.html.erb
@@ -32,19 +32,14 @@
   </li>
 <% end %>
 
-<% table_view = capture do %>
-  <p>
-    <% count = available_blogs.count %>
-    <% count = count.keys.count if count.is_a?(Hash) %>
-    <%= number_with_delimiter(count) %> matching
-    <em><%= humanized_time_range(@time_range) %></em>
-    <% if @tags.present? %>
-      <span class="less-strong">
-        with tags: <%= @tags.pluck(:name).join(", ") %>
-      </span>
-    <% end %>
-  </p>
+<% count_detail = capture do %>
+  <% if @tags.present? %>
+    &mdash; with tags:
+    <%= @tags.pluck(:name).join(", ") %>
+  <% end %>
+<% end %>
 
+<% table_view = capture do %>
   <%= render partial: "/admin/news/table", locals: {blogs: @blogs, skip_kind: @search_kind != "all"} %>
 <% end %>
 
@@ -53,5 +48,6 @@
   viewing: "News/Blogs/Info",
   nav_header_list_items:,
   table_view:,
+  count_detail:,
   chart_collection: @render_chart && available_blogs
 )) %>

--- a/app/views/admin/paints/index.html.erb
+++ b/app/views/admin/paints/index.html.erb
@@ -4,31 +4,18 @@
   </li>
 <% end %>
 
+<% count_detail = capture do %>
+  &mdash;
+  <%= number_display(matching_paints.where("created_at >= ?", Time.current.beginning_of_day).count) %>
+  today, <%= number_display(Paint.unlinked.count) %> unlinked
+<% end unless sortable_search_params? %>
+
 <% admin_search_form = capture do %>
-  <div class="row mt-4">
-    <div class="col-sm-7">
-      <p>
-        <%= number_display(matching_paints.count) %> matching paints
-        <em><%= humanized_time_range(@time_range) %></em>
-        <em>(<%= number_display(matching_paints.where("created_at >= ?", Time.current.beginning_of_day).count) %> today)</em>
-
-
-        <% unless sortable_search_params? %>
-          <strong>
-            <%= number_display(Paint.unlinked.count) %> are unlinked
-          </strong>
-        <% end %>
-      </p>
-    </div>
-
-    <div class="col-sm-5">
-      <%= form_tag admin_paints_path, method: :get, class: "form-inline" do %>
-        <%= render partial: "/shared/hidden_search_fields" %>
-        <%= text_field_tag :search_name, params[:name], placeholder: "Search paints by name", class: "form-control mr-2" %>
-        <%= submit_tag "Search", name: "search", class: "btn btn-success" %>
-      <% end %>
-    </div>
-  </div>
+  <%= form_tag admin_paints_path, method: :get, class: "form-inline mt-4 mb-4 justify-content-md-end" do %>
+    <%= render partial: "/shared/hidden_search_fields" %>
+    <%= text_field_tag :search_name, params[:name], placeholder: "Search paints by name", class: "form-control mr-2" %>
+    <%= submit_tag "Search", name: "search", class: "btn btn-success" %>
+  <% end %>
 <% end %>
 
 <%= render(Admin::IndexSkeleton::Component.new(
@@ -36,5 +23,6 @@
   viewing: "Paints",
   chart_collection: @render_chart && matching_paints,
   nav_header_list_items:,
-  admin_search_form:
+  admin_search_form:,
+  count_detail:
 )) %>

--- a/app/views/admin/paints/index.html.erb
+++ b/app/views/admin/paints/index.html.erb
@@ -8,7 +8,7 @@
   &mdash;
   <%= number_display(matching_paints.where("created_at >= ?", Time.current.beginning_of_day).count) %>
   today, <%= number_display(Paint.unlinked.count) %> unlinked
-<% end unless sortable_search_params? %>
+<% end if request.query_parameters.blank? %>
 
 <% admin_search_form = capture do %>
   <%= form_tag admin_paints_path, method: :get, class: "form-inline mt-4 mb-4 justify-content-md-end" do %>

--- a/app/views/admin/recoveries/index.html.erb
+++ b/app/views/admin/recoveries/index.html.erb
@@ -96,42 +96,26 @@
 <% end %>
 
 <% admin_search_form = capture do %>
-  <div class="row mb-4 mt-4">
-    <div class="col-md-5">
-      <%= number_display(available_recoveries.count) %>
-      <%= "matching recovery".pluralize(available_recoveries.count) %>
+  <%= form_tag admin_recoveries_path, method: :get, class: "form-inline mb-4 mt-4" do %>
+    <%= hidden_field_tag :search_recovery_display_status, @recovery_display_status %>
+    <%= hidden_field_tag :search_index_helped_recovery, params[:search_index_helped_recovery] %>
+    <%= hidden_field_tag :search_shareable, params[:search_shareable] %>
+    <%= hidden_field_tag :search_displayed, params[:search_displayed] %>
+    <%= render partial: "/shared/hidden_search_fields" %>
 
-      <em>
-        <%= humanized_time_range_column(@time_range_column) %>
-        <%= humanized_time_range(@time_range) %>
-      </em>
+    <div class="form-group ml-auto mr-1 mb-2">
+      <em class="small less-strong mr-1 d-md-inline d-none">within</em>
+      <%= number_field_tag :search_distance, @distance, class: "form-control", style: "width: 5rem;" %>
+
+      <em class="small less-strong ml-1 mr-1 d-md-inline d-none"> miles of </em>
     </div>
 
-    <div class="col-md-7">
-      <%= form_tag admin_recoveries_path, method: :get, class: "form-inline" do %>
-        <%= hidden_field_tag :search_recovery_display_status, @recovery_display_status %>
-        <%= hidden_field_tag :search_index_helped_recovery, params[:search_index_helped_recovery] %>
-        <%= hidden_field_tag :search_shareable, params[:search_shareable] %>
-        <%= hidden_field_tag :search_displayed, params[:search_displayed] %>
-        <%= render partial: "/shared/hidden_search_fields" %>
-
-        <div class="form-group ml-auto mr-1 mb-2">
-          <em class="small less-strong mr-1 d-md-inline d-none">within</em>
-          <%= number_field_tag :search_distance, @distance, class: "form-control", style: "width: 5rem;" %>
-
-          <em class="small less-strong ml-1 mr-1 d-md-inline d-none">
-            miles of
-          </em>
-        </div>
-
-        <div class="form-group mr-2 mb-2">
-          <%= text_field_tag :search_location, params[:search_location], placeholder: "anywhere", class: "form-control" %>
-        </div>
-
-        <%= submit_tag "Search", name: "search", class: "btn btn-primary mb-2" %>
-      <% end %>
+    <div class="form-group mr-2 mb-2">
+      <%= text_field_tag :search_location, params[:search_location], placeholder: "anywhere", class: "form-control" %>
     </div>
-  </div>
+
+    <%= submit_tag "Search", name: "search", class: "btn btn-primary mb-2" %>
+  <% end %>
 <% end %>
 
 <% table_view = capture do %>
@@ -144,5 +128,6 @@
   rendered_chart:,
   nav_header_list_items:,
   admin_search_form:,
-  table_view:
+  table_view:,
+  time_range_column: @time_range_column
 )) %>

--- a/app/views/admin/social_posts/index.html.erb
+++ b/app/views/admin/social_posts/index.html.erb
@@ -46,8 +46,6 @@
 <% admin_search_form = capture do %>
   <div class="row mt-4 mb-4">
     <div class="col-sm-5">
-      <%= number_with_delimiter(matching_social_posts.size) %> matching posts
-      <em><%= humanized_time_range(@time_range) %></em>
       <% if @social_account.present? %>
         <strong>
           from

--- a/spec/requests/admin/manufacturers_request_spec.rb
+++ b/spec/requests/admin/manufacturers_request_spec.rb
@@ -25,6 +25,22 @@ RSpec.describe Admin::ManufacturersController, type: :request do
       expect(response.status).to eq(200)
       expect(response).to render_template(:index)
     end
+
+    context "with filters" do
+      let!(:with_website) { FactoryBot.create(:manufacturer, website: "http://stuff.com") }
+      let!(:without_website) { FactoryBot.create(:manufacturer, website: nil) }
+
+      it "filters by search_with_websites" do
+        get base_url, params: {search_with_websites: true}
+        expect(response.status).to eq(200)
+        expect(assigns(:manufacturers).pluck(:id)).to eq([with_website.id])
+      end
+
+      it "does not filter without the param" do
+        get base_url
+        expect(assigns(:manufacturers).pluck(:id)).to match_array([with_website.id, without_website.id])
+      end
+    end
   end
 
   describe "show" do

--- a/spec/requests/admin/manufacturers_request_spec.rb
+++ b/spec/requests/admin/manufacturers_request_spec.rb
@@ -20,26 +20,18 @@ RSpec.describe Admin::ManufacturersController, type: :request do
   end
 
   describe "index" do
-    it "renders" do
+    let!(:with_website) { FactoryBot.create(:manufacturer, website: "http://stuff.com") }
+    let!(:without_website) { FactoryBot.create(:manufacturer, website: nil) }
+
+    it "renders, and filters by search_with_websites" do
       get base_url
       expect(response.status).to eq(200)
       expect(response).to render_template(:index)
-    end
+      expect(assigns(:manufacturers).pluck(:id)).to match_array([with_website.id, without_website.id])
 
-    context "with filters" do
-      let!(:with_website) { FactoryBot.create(:manufacturer, website: "http://stuff.com") }
-      let!(:without_website) { FactoryBot.create(:manufacturer, website: nil) }
-
-      it "filters by search_with_websites" do
-        get base_url, params: {search_with_websites: true}
-        expect(response.status).to eq(200)
-        expect(assigns(:manufacturers).pluck(:id)).to eq([with_website.id])
-      end
-
-      it "does not filter without the param" do
-        get base_url
-        expect(assigns(:manufacturers).pluck(:id)).to match_array([with_website.id, without_website.id])
-      end
+      get base_url, params: {search_with_websites: true}
+      expect(response.status).to eq(200)
+      expect(assigns(:manufacturers).pluck(:id)).to eq([with_website.id])
     end
   end
 


### PR DESCRIPTION
Tidies up admin index page headers via two new slots on the shared `Admin::IndexSkeleton` component: `header_content` (renders above the pagination) and `count_detail` (folds supplementary stats into the single "N Matching …" count line).

- **ctypes**: Component groups table now renders in the header above the pagination, and gained an Updated column.
- **manufacturers**: one count with the website/logo breakdown inline (was duplicated); also fixes broken `search_with_websites`/`search_with_logos` filtering, with request-spec coverage.
- **bikes / paints / b_params**: supplementary stats (today / claimed / unlinked / image totals) now show via `count_detail` on the unfiltered index instead of a separate block.
- **news / social_posts / recoveries**: dropped the count line that just duplicated the skeleton's Matching count, keeping only filter context; recoveries now passes its `time_range_column` so the count shows the right date range.
