### PR TITLE
Make primary-activities import idempotent and name-correcting

### DIFF
--- a/app/services/spreadsheets/primary_activities.rb
+++ b/app/services/spreadsheets/primary_activities.rb
@@ -53,8 +53,15 @@ module Spreadsheets
       return if row[:flavor].blank?
 
       (family_ids || [nil]).each do |primary_activity_family_id|
-        PrimaryActivity.where(primary_activity_family_id:).friendly_find(row[:flavor]) ||
-          PrimaryActivity.create(name: row[:flavor], primary_activity_family_id:, family: false)
+        # Top-level flavors store their own id as the family id (see PrimaryActivity#set_calculated_attributes),
+        # so a `primary_activity_family_id: nil` lookup never matches them — scope to top_level instead
+        existing = if primary_activity_family_id
+          PrimaryActivity.where(primary_activity_family_id:).friendly_find(row[:flavor])
+        else
+          PrimaryActivity.flavor.top_level.friendly_find(row[:flavor])
+        end
+
+        existing || PrimaryActivity.create!(name: row[:flavor], primary_activity_family_id:, family: false)
       end
     end
 

--- a/app/services/spreadsheets/primary_activities.rb
+++ b/app/services/spreadsheets/primary_activities.rb
@@ -49,16 +49,13 @@ module Spreadsheets
       return if row[:flavor].blank?
 
       (family_ids || [nil]).each do |primary_activity_family_id|
-        # Top-level flavors store their own id as the family id (see PrimaryActivity#set_calculated_attributes),
-        # so a `primary_activity_family_id: nil` lookup never matches them — scope to top_level instead
+        # Top-level flavors self-reference their id, so nil never matches them
         scope = primary_activity_family_id ? PrimaryActivity.where(primary_activity_family_id:) : PrimaryActivity.flavor.top_level
         upsert!(scope, row[:flavor], primary_activity_family_id:, family: false)
       end
     end
 
-    # Find within scope by exact slug (the inverse of create's slug generation) and correct the
-    # stored name to match the CSV (e.g. casing), or create. Keying off slug rather than the lenient
-    # friendly_find keeps re-imports idempotent and avoids renaming a substring-matched record.
+    # Find by exact slug and correct the stored name, or create. Slug, not friendly_find, keeps re-imports idempotent
     def upsert!(scope, name, **create_attrs)
       name = name.strip
       existing = scope.find_by(slug: Slugifyer.slugify(name))

--- a/app/services/spreadsheets/primary_activities.rb
+++ b/app/services/spreadsheets/primary_activities.rb
@@ -43,28 +43,30 @@ module Spreadsheets
     end
 
     def update_or_create_for!(row)
-      family_ids = if row[:families].present?
-        # Find or create the matching families
-        row[:families].split("&").map do |name|
-          PrimaryActivity.family.friendly_find(name)&.id ||
-            PrimaryActivity.create!(name:, family: true).id
-        end
+      family_ids = row[:families].presence&.split("&")&.map do |name|
+        upsert!(PrimaryActivity.family, name, family: true).id
       end
       return if row[:flavor].blank?
 
       (family_ids || [nil]).each do |primary_activity_family_id|
         # Top-level flavors store their own id as the family id (see PrimaryActivity#set_calculated_attributes),
         # so a `primary_activity_family_id: nil` lookup never matches them — scope to top_level instead
-        existing = if primary_activity_family_id
-          PrimaryActivity.where(primary_activity_family_id:).friendly_find(row[:flavor])
-        else
-          PrimaryActivity.flavor.top_level.friendly_find(row[:flavor])
-        end
-
-        existing || PrimaryActivity.create!(name: row[:flavor], primary_activity_family_id:, family: false)
+        scope = primary_activity_family_id ? PrimaryActivity.where(primary_activity_family_id:) : PrimaryActivity.flavor.top_level
+        upsert!(scope, row[:flavor], primary_activity_family_id:, family: false)
       end
     end
 
-    conceal :names_and_families, :update_or_create_for!
+    # Find within scope and correct the stored name to match the CSV (e.g. casing), or create.
+    # Lookups are by slug, so a casing-only change still matches the existing row.
+    def upsert!(scope, name, **create_attrs)
+      name = name.strip
+      existing = scope.friendly_find(name)
+      return PrimaryActivity.create!(name:, **create_attrs) unless existing
+
+      existing.update!(name:) unless existing.name == name
+      existing
+    end
+
+    conceal :names_and_families, :update_or_create_for!, :upsert!
   end
 end

--- a/app/services/spreadsheets/primary_activities.rb
+++ b/app/services/spreadsheets/primary_activities.rb
@@ -56,11 +56,12 @@ module Spreadsheets
       end
     end
 
-    # Find within scope and correct the stored name to match the CSV (e.g. casing), or create.
-    # Lookups are by slug, so a casing-only change still matches the existing row.
+    # Find within scope by exact slug (the inverse of create's slug generation) and correct the
+    # stored name to match the CSV (e.g. casing), or create. Keying off slug rather than the lenient
+    # friendly_find keeps re-imports idempotent and avoids renaming a substring-matched record.
     def upsert!(scope, name, **create_attrs)
       name = name.strip
-      existing = scope.friendly_find(name)
+      existing = scope.find_by(slug: Slugifyer.slugify(name))
       return PrimaryActivity.create!(name:, **create_attrs) unless existing
 
       existing.update!(name:) unless existing.name == name

--- a/lib/tasks/setup_tasks.rake
+++ b/lib/tasks/setup_tasks.rake
@@ -18,8 +18,8 @@ namespace :setup do
   end
 
   desc "import primary activities from GitHub"
-  # NOTE: This doesn't actually do a good job updating existing primary activities.
-  # If that is required, probably do it manually via console
+  # NOTE: Corrects the name of existing activities, but doesn't re-parent or remove them.
+  # For structural changes, probably do it manually via console
   task import_primary_activities_csv: :environment do
     url = "https://raw.githubusercontent.com/bikeindex/resources/refs/heads/main/data/primary_activities.csv"
     file_path = Rails.root.join("tmp/primary_activities.csv")

--- a/spec/services/spreadsheets/primary_activities_spec.rb
+++ b/spec/services/spreadsheets/primary_activities_spec.rb
@@ -61,6 +61,13 @@ RSpec.describe Spreadsheets::PrimaryActivities do
 
         expect(PrimaryActivity.all.map(&:display_name)).to match_array target_display_names
       end
+
+      it "is idempotent on re-import (top-level flavors included)" do
+        described_class.import(csv_path)
+
+        expect { described_class.import(csv_path) }.not_to change(PrimaryActivity, :count)
+        expect(PrimaryActivity.all.map(&:display_name)).to match_array target_display_names
+      end
     end
   end
 end

--- a/spec/services/spreadsheets/primary_activities_spec.rb
+++ b/spec/services/spreadsheets/primary_activities_spec.rb
@@ -68,6 +68,15 @@ RSpec.describe Spreadsheets::PrimaryActivities do
         expect { described_class.import(csv_path) }.not_to change(PrimaryActivity, :count)
         expect(PrimaryActivity.all.map(&:display_name)).to match_array target_display_names
       end
+
+      it "corrects the stored name of an existing activity (e.g. casing)" do
+        described_class.import(csv_path)
+        bike_polo = PrimaryActivity.flavor.top_level.friendly_find("Bike Polo")
+        bike_polo.update_columns(name: "Bike polo") # bypass callbacks; slug stays "bike-polo"
+
+        expect { described_class.import(csv_path) }.not_to change(PrimaryActivity, :count)
+        expect(bike_polo.reload.name).to eq "Bike Polo"
+      end
     end
   end
 end

--- a/spec/services/spreadsheets/primary_activities_spec.rb
+++ b/spec/services/spreadsheets/primary_activities_spec.rb
@@ -1,4 +1,5 @@
 require "rails_helper"
+require "tempfile"
 
 RSpec.describe Spreadsheets::PrimaryActivities do
   let!(:primary_activity) { FactoryBot.create(:primary_activity, name: "Bike Polo", priority: 1) }
@@ -76,6 +77,21 @@ RSpec.describe Spreadsheets::PrimaryActivities do
 
         expect { described_class.import(csv_path) }.not_to change(PrimaryActivity, :count)
         expect(bike_polo.reload.name).to eq "Bike Polo"
+      end
+
+      it "matches on exact slug, not a substring, so it never renames a different activity" do
+        described_class.import(csv_path)
+        bike_polo = PrimaryActivity.flavor.top_level.friendly_find("Bike Polo")
+
+        # "Polo" is an ILIKE substring of "Bike Polo" but a distinct activity
+        Tempfile.create(["primary_activities", ".csv"], Rails.root.join("tmp")) do |file|
+          file.write("Flavor,Families\nPolo,\n")
+          file.flush
+          expect { described_class.import(file.path) }.to change(PrimaryActivity, :count).by(1)
+        end
+
+        expect(bike_polo.reload.name).to eq "Bike Polo"
+        expect(PrimaryActivity.flavor.top_level.find_by(slug: "polo")).to be_present
       end
     end
   end


### PR DESCRIPTION
Fixes two problems with `rake setup:import_primary_activities_csv` on re-import.

**Silent rollback / skipped rows.** Top-level flavors (no family) store their own id as `primary_activity_family_id` via `PrimaryActivity#set_calculated_attributes`, so the importer's `primary_activity_family_id: nil` lookup never matched them. Re-imports fell through to `create`, tripped the name-uniqueness validation, and rolled back without surfacing anything. Now top-level flavors are looked up with `.flavor.top_level`, and creates use `create!` so a genuine failure raises instead of silently rolling back.

**Names never updated.** A new `upsert!` matches an existing activity on exact slug (the inverse of create's slug generation) and rewrites the stored name when it differs, so a CSV casing change like "All road" → "All Road" is applied. The slug is unchanged, so lookups and URLs are unaffected. Keying on exact slug rather than the lenient `friendly_find` (which has an `ILIKE` substring fallback) keeps re-imports idempotent and avoids renaming a substring-matched record.

Specs cover idempotent re-import (including top-level flavors), the casing correction, and the exact-slug (no substring rename) behavior.
