### PR TITLE
Fix Other manufacturer entry in bike edit correction modal

### DIFF
--- a/app/assets/javascripts/revised/pages/bikes/edit_bike_details.coffee
+++ b/app/assets/javascripts/revised/pages/bikes/edit_bike_details.coffee
@@ -1,11 +1,14 @@
 class BikeIndex.BikesEditBikeDetails extends BikeIndex
   constructor: ->
-    @initializeEventListeners()
     new window.ManufacturersSelect('#manufacturer_update_manufacturer')
+    @initializeEventListeners()
+    @otherManufacturerDisplay($('#manufacturer_update_manufacturer').val())
     @setFrameSize()
     @updateYear()
 
   initializeEventListeners: ->
+    $('#manufacturer_update_manufacturer').change (e) =>
+      @otherManufacturerDisplay(e.target.value)
     $('#bike_unknown_year').change (e) =>
       @toggleUnknownYear()
     $('#bike_year').change (e) =>
@@ -70,6 +73,14 @@ class BikeIndex.BikesEditBikeDetails extends BikeIndex
         $('.frame-size-units').removeClass('ex-size')
         $('.frame-size-units .btn').removeClass('active')
 
+  otherManufacturerDisplay: (slug) ->
+    hidden_other = $('#manufacturer_update_manufacturer').parents('.related-fields').find('.hidden-other')
+    if slug == 'other' or slug == 'Other' # show the bugger!
+      hidden_other.slideDown().addClass('unhidden')
+    else if hidden_other.hasClass('unhidden') # Hide it!
+      hidden_other.find('input').val('')
+      hidden_other.removeClass('unhidden').slideUp()
+
   requestSerialUpdateRequestCallback: (data, success) ->
     if success
       msg = "We've updated your serial!"
@@ -101,14 +112,18 @@ class BikeIndex.BikesEditBikeDetails extends BikeIndex
 
   requestManufacturerUpdate: ->
     manufacturer = $('#manufacturer_update_manufacturer').val()
+    manufacturer_other = $('#manufacturer_update_manufacturer_other').val()
     reason = $('#manufacturer_update_reason').val()
     bike_id = $('#manufacturer_update_bike_id').val()
-    if manufacturer.length > 0 && reason.length > 0 && bike_id.length > 0
+    other_selected = manufacturer == 'other' or manufacturer == 'Other'
+    other_missing = other_selected && manufacturer_other.length == 0
+    if manufacturer.length > 0 && reason.length > 0 && bike_id.length > 0 && !other_missing
       data =
         request_type: 'manufacturer_update_request'
         request_bike_id: bike_id
         request_reason: reason
         manufacturer_update_manufacturer: manufacturer
+        manufacturer_update_manufacturer_other: manufacturer_other
       response_callback = @requestManufacturerUpdateRequestCallback
       new BikeIndex.SubmitUserRequest(data, response_callback)
     else

--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -38,12 +38,12 @@ module API
               feedback.feedback_hash[:old_manufacturer] = bike.mnfg_name
               if bike.manufacturer_other.present?
                 feedback.feedback_hash[:old_manufacturer] += " (#{bike.manufacturer_other})"
-                bike.manufacturer_other = nil
               end
               bike.manufacturer_id = Manufacturer.friendly_find_id(params[:manufacturer_update_manufacturer])
+              bike.manufacturer_other = bike.manufacturer&.other? ? params[:manufacturer_update_manufacturer_other] : nil
               if bike.manufacturer_id.present?
                 bike.save
-                feedback.feedback_hash[:new_manufacturer] = bike.manufacturer.name
+                feedback.feedback_hash[:new_manufacturer] = bike.mnfg_name
               end
             elsif feedback_type.match?("bike_recovery")
               recover_bike(bike, feedback)

--- a/app/views/bikes_edit/bike_details.html.haml
+++ b/app/views/bikes_edit/bike_details.html.haml
@@ -231,10 +231,16 @@
     .modal-body
       = render partial: 'shared/alert', locals: {body: t(".please_fill_in_both_fields"), class_names: "currently-hidden"}
       = hidden_field_tag :manufacturer_update_bike_id, @bike.id
-      .form-group
-        %label{for: :manufacturer_update_manufacturer}
-          = t(".manufacturer")
-        = text_field_tag :manufacturer_update_manufacturer, "", class: "form-control unfancy"
+      .related-fields
+        .form-group
+          %label{for: :manufacturer_update_manufacturer}
+            = t(".manufacturer")
+          = text_field_tag :manufacturer_update_manufacturer, "", class: "form-control unfancy"
+          %span.below-input-help= t(".select_other")
+        .form-group.hidden-other
+          %label{for: :manufacturer_update_manufacturer_other}
+            = t(".other_manufacturer")
+          = text_field_tag :manufacturer_update_manufacturer_other, "", class: "form-control"
       .form-group
         %label{for: :manufacturer_update_reason}
           = t(".reason_for_update")

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1350,12 +1350,14 @@ en:
       manufacturer: Manufacturer
       model_year: Model year
       nevermind: Nevermind
+      other_manufacturer: Other manufacturer
       other_serial_or_registration_number: Other serial or registration number
       please_fill_in_both_fields: Please fill in both fields
       reason_for_update: Reason for update
       remove_end: Remove end
       remove_start: Remove start
       seat_tube_length: Seat tube length
+      select_other: Select 'Other' if manufacturer doesn't show up when entered
       submit_manufacturer_correction: Submit Manufacturer Correction
       submit_serial_correction: Submit serial correction
       submit_update: Submit update

--- a/spec/requests/api/v1/users_request_spec.rb
+++ b/spec/requests/api/v1/users_request_spec.rb
@@ -96,68 +96,54 @@ RSpec.describe API::V1::UsersController, type: :request do
         end
       end
     end
-    context "manufacturer_update_manufacturer present" do
-      it "updates the manufacturer" do
-        o = FactoryBot.create(:ownership)
-        manufacturer = FactoryBot.create(:manufacturer)
-        user = o.creator
-        bike = o.bike
-        update_manufacturer_request = {
+    describe "manufacturer_update_manufacturer present" do
+      let(:ownership) { FactoryBot.create(:ownership) }
+      let(:user) { ownership.creator }
+      let(:bike) { ownership.bike }
+      let(:update_manufacturer_request) do
+        {
           request_type: "manufacturer_update_manufacturer",
           user_id: user.id,
           request_bike_id: bike.id,
           request_reason: "Need to update manufacturer",
-          manufacturer_update_manufacturer: manufacturer.slug
+          manufacturer_update_manufacturer: manufacturer_slug
         }
-        log_in(user)
-        post "#{base_url}/send_request", params: update_manufacturer_request
-        expect(response.code).to eq("200")
-        bike.reload
-        expect(bike.manufacturer).to eq manufacturer
       end
-    end
+      before { log_in(user) }
 
-    context "manufacturer_update_manufacturer is other" do
-      it "sets the manufacturer to other with the manual name" do
-        o = FactoryBot.create(:ownership)
-        Manufacturer.other
-        user = o.creator
-        bike = o.bike
-        update_manufacturer_request = {
-          request_type: "manufacturer_update_manufacturer",
-          user_id: user.id,
-          request_bike_id: bike.id,
-          request_reason: "Need to update manufacturer",
-          manufacturer_update_manufacturer: "other",
-          manufacturer_update_manufacturer_other: "Some obscure brand"
-        }
-        log_in(user)
-        post "#{base_url}/send_request", params: update_manufacturer_request
-        expect(response.code).to eq("200")
-        bike.reload
-        expect(bike.manufacturer).to eq Manufacturer.other
-        expect(bike.manufacturer_other).to eq "Some obscure brand"
-        expect(bike.mnfg_name).to eq "Some obscure brand"
+      context "with a known manufacturer" do
+        let!(:manufacturer) { FactoryBot.create(:manufacturer) }
+        let(:manufacturer_slug) { manufacturer.slug }
+        it "updates the manufacturer" do
+          post "#{base_url}/send_request", params: update_manufacturer_request
+          expect(response.code).to eq("200")
+          bike.reload
+          expect(bike.manufacturer).to eq manufacturer
+        end
       end
-    end
 
-    context "manufacturer_update_manufacturer present" do
-      it "does not make nil manufacturer" do
-        o = FactoryBot.create(:ownership)
-        user = o.creator
-        bike = o.bike
-        update_manufacturer_request = {
-          request_type: "manufacturer_update_manufacturer",
-          user_id: user.id,
-          request_bike_id: bike.id,
-          request_reason: "Need to update manufacturer",
-          manufacturer_update_manufacturer: "doadsfizxcv"
-        }
-        log_in(user)
-        post "#{base_url}/send_request", params: update_manufacturer_request
-        expect(response.code).to eq("200")
-        bike.reload
-        expect(bike.manufacturer).to be_present
+      context "with other and a manual name" do
+        let!(:manufacturer) { Manufacturer.other }
+        let(:manufacturer_slug) { "other" }
+        let(:update_manufacturer_request) { super().merge(manufacturer_update_manufacturer_other: "Some obscure brand") }
+        it "sets the manufacturer to other with the manual name" do
+          post "#{base_url}/send_request", params: update_manufacturer_request
+          expect(response.code).to eq("200")
+          bike.reload
+          expect(bike.manufacturer).to eq Manufacturer.other
+          expect(bike.manufacturer_other).to eq "Some obscure brand"
+          expect(bike.mnfg_name).to eq "Some obscure brand"
+        end
+      end
+
+      context "with an unknown manufacturer" do
+        let(:manufacturer_slug) { "doadsfizxcv" }
+        it "does not make nil manufacturer" do
+          post "#{base_url}/send_request", params: update_manufacturer_request
+          expect(response.code).to eq("200")
+          bike.reload
+          expect(bike.manufacturer).to be_present
+        end
       end
     end
 

--- a/spec/requests/api/v1/users_request_spec.rb
+++ b/spec/requests/api/v1/users_request_spec.rb
@@ -117,6 +117,30 @@ RSpec.describe API::V1::UsersController, type: :request do
       end
     end
 
+    context "manufacturer_update_manufacturer is other" do
+      it "sets the manufacturer to other with the manual name" do
+        o = FactoryBot.create(:ownership)
+        Manufacturer.other
+        user = o.creator
+        bike = o.bike
+        update_manufacturer_request = {
+          request_type: "manufacturer_update_manufacturer",
+          user_id: user.id,
+          request_bike_id: bike.id,
+          request_reason: "Need to update manufacturer",
+          manufacturer_update_manufacturer: "other",
+          manufacturer_update_manufacturer_other: "Some obscure brand"
+        }
+        log_in(user)
+        post "#{base_url}/send_request", params: update_manufacturer_request
+        expect(response.code).to eq("200")
+        bike.reload
+        expect(bike.manufacturer).to eq Manufacturer.other
+        expect(bike.manufacturer_other).to eq "Some obscure brand"
+        expect(bike.mnfg_name).to eq "Some obscure brand"
+      end
+    end
+
     context "manufacturer_update_manufacturer present" do
       it "does not make nil manufacturer" do
         o = FactoryBot.create(:ownership)


### PR DESCRIPTION
Fixes a bug where, when editing a bike, selecting "Other" in the manufacturer-correction modal gave you no way to type the manufacturer name manually — the new-bike form has always supported this, but the edit modal never did.

- Modal now wraps the manufacturer field in `.related-fields` with a `.hidden-other` manual-name input, toggled open when "Other" is selected (mirroring `bikes/new`).
- `edit_bike_details.coffee` adds the `otherManufacturerDisplay` toggle + change listener and submits the typed name; it blocks submission when "Other" is chosen but no name is entered.
- `Api::V1::UsersController#send_request` now stores the typed name in `manufacturer_other` (when the new manufacturer is "Other") instead of unconditionally clearing it, and records the resolved `mnfg_name` in the feedback.

## Screenshots

Bike edit → "Update manufacturer" modal with **Other** selected. On `main` the modal jumps straight to "Reason for update" with no way to type the name; with this branch the "Other manufacturer" field appears.

| Desktop | Mobile |
| --- | --- |
| <img src="https://github.com/user-attachments/assets/4e7bacf1-a4dc-439c-a604-e065ed02ab08" width="500"> | <img src="https://github.com/user-attachments/assets/6fe0b917-90e2-478f-afde-89a2891cbaf7" width="250"> |
| main 👆 | this branch 👇 |
| <img src="https://github.com/user-attachments/assets/ab97511d-217d-4495-8cb7-576532fd551c" width="500"> | <img src="https://github.com/user-attachments/assets/b209881c-e99c-43bb-93f1-7bad929031dd" width="250"> |
