### PR TITLE
Components.csv export, admin ctypes and import hardening

### DIFF
--- a/app/controllers/admin/ctypes_controller.rb
+++ b/app/controllers/admin/ctypes_controller.rb
@@ -48,7 +48,7 @@ module Admin
     protected
 
     def sortable_columns
-      %w[name slug cgroup image created_at updated_at]
+      %w[name secondary_name slug cgroup image created_at updated_at]
     end
 
     def default_direction = "asc"

--- a/app/controllers/components_controller.rb
+++ b/app/controllers/components_controller.rb
@@ -1,0 +1,9 @@
+class ComponentsController < ApplicationController
+  def index
+    @ctypes = Ctype.includes(:cgroup).order(:name)
+
+    respond_to do |format|
+      format.csv { render plain: Spreadsheets::Components.to_csv(@ctypes) }
+    end
+  end
+end

--- a/app/jobs/spreadsheets/importer_job.rb
+++ b/app/jobs/spreadsheets/importer_job.rb
@@ -6,6 +6,7 @@ module Spreadsheets
 
     def perform(name = nil)
       return IMPORTERS.each { |n| perform(n) } if name.blank?
+      raise ArgumentError, "Unknown importer: #{name.inspect} (expected one of #{IMPORTERS.join(", ")})" unless IMPORTERS.include?(name)
 
       # binmode: write the downloaded bytes verbatim. The CSVs are UTF-8 and Faraday
       # returns ASCII-8BIT, which text mode tries to transcode (failing on CI, where

--- a/app/models/cgroup.rb
+++ b/app/models/cgroup.rb
@@ -23,6 +23,6 @@ class Cgroup < ApplicationRecord
 
   def self.additional_parts
     # friendly_find (slug-based) tolerates stored-casing drift
-    friendly_find("Additional Parts") || create(name: "Additional Parts", priority: 4)
+    friendly_find("Additional Parts") || create(name: "Additional Parts", priority: 6)
   end
 end

--- a/app/services/spreadsheets/primary_activities.rb
+++ b/app/services/spreadsheets/primary_activities.rb
@@ -55,10 +55,11 @@ module Spreadsheets
       end
     end
 
-    # Find by exact slug and correct the stored name, or create. Slug, not friendly_find, keeps re-imports idempotent
+    # Match by slug or exact name (not friendly_find's substring search), correct the stored name, or create
     def upsert!(scope, name, **create_attrs)
       name = name.strip
-      existing = scope.find_by(slug: Slugifyer.slugify(name))
+      existing = scope.find_by(slug: Slugifyer.slugify(name)) ||
+        scope.where("lower(name) = ?", name.downcase).first
       return PrimaryActivity.create!(name:, **create_attrs) unless existing
 
       existing.update!(name:) unless existing.name == name

--- a/app/services/spreadsheets/primary_activities.rb
+++ b/app/services/spreadsheets/primary_activities.rb
@@ -63,6 +63,8 @@ module Spreadsheets
 
       existing.update!(name:) unless existing.name == name
       existing
+    rescue ActiveRecord::RecordInvalid => e
+      raise "PrimaryActivity #{name.inspect} — #{e.message}"
     end
 
     conceal :names_and_families, :update_or_create_for!, :upsert!

--- a/app/views/admin/ctypes/_table.html.erb
+++ b/app/views/admin/ctypes/_table.html.erb
@@ -4,6 +4,11 @@
   <table class="table table-striped table-bordered">
     <thead class="thead-light">
       <th><%= sortable "name", render_sortable: %></th>
+
+      <th>
+        <%= sortable "secondary_name", "Secondary name", render_sortable: %>
+      </th>
+
       <th><%= sortable "slug", render_sortable: %></th>
       <th><%= sortable "cgroup", "Component group", render_sortable: %></th>
 
@@ -19,6 +24,7 @@
       <% collection.each do |ctype| %>
         <tr>
           <td><%= link_to ctype.name, edit_admin_ctype_url(ctype) %></td>
+          <td><%= ctype.secondary_name %></td>
           <td><%= ctype.slug %></td>
           <td><%= ctype.cgroup.name.titleize %></td>
           <td class="large-screens"><%= check_mark if ctype.image? %></td>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -362,6 +362,8 @@ Rails.application.routes.draw do
   end
   get "manufacturers_tsv", to: "manufacturers#tsv" # TODO: can we delete this?
 
+  resources :components, only: %i[index]
+
   get "theft-rings", to: "stolen_bike_listings#index" # Temporary, may switch to being an info post
   get "theft-ring", to: redirect("theft-rings")
   resources :stolen_bike_listings, only: %i[index]

--- a/spec/jobs/spreadsheets/importer_job_spec.rb
+++ b/spec/jobs/spreadsheets/importer_job_spec.rb
@@ -28,5 +28,11 @@ RSpec.describe Spreadsheets::ImporterJob, type: :job do
         end
       end
     end
+
+    context "with an unknown name" do
+      it "raises" do
+        expect { described_class.new.perform("bikes") }.to raise_error(ArgumentError, /Unknown importer/)
+      end
+    end
   end
 end

--- a/spec/requests/components_request_spec.rb
+++ b/spec/requests/components_request_spec.rb
@@ -1,0 +1,17 @@
+require "rails_helper"
+
+RSpec.describe ComponentsController, type: :request do
+  describe "index" do
+    let!(:ctype) { FactoryBot.create(:ctype, name: "Headset") }
+
+    context "csv" do
+      it "gets a csv" do
+        get "/components.csv"
+        expect(response.status).to eq(200)
+        expect(response.content_type).to match("text/csv")
+        expect(response.body).to start_with("name,secondary_name,has_multiple_locations,group")
+        expect(response.body).to include("Headset")
+      end
+    end
+  end
+end

--- a/spec/services/spreadsheets/primary_activities_spec.rb
+++ b/spec/services/spreadsheets/primary_activities_spec.rb
@@ -70,15 +70,20 @@ RSpec.describe Spreadsheets::PrimaryActivities do
         expect(PrimaryActivity.all.map(&:display_name)).to match_array target_display_names
       end
 
-      it "names the offending activity when a create fails validation" do
+      it "self-heals slug drift on re-import (no collision)" do
         described_class.import(csv_path)
-        # Drift the slug so the slug lookup misses and the create collides on name uniqueness
+        # Drift the slug so the slug lookup misses; the exact-name fallback should still find it
         PrimaryActivity.flavor.top_level.friendly_find("Bike Polo").update_columns(slug: "drifted")
 
+        expect { described_class.import(csv_path) }.not_to change(PrimaryActivity, :count)
+      end
+
+      it "names the offending activity when a create fails validation" do
+        # A top-level flavor sharing a name with an existing family is a genuine conflict
         Tempfile.create(["primary_activities", ".csv"], Rails.root.join("tmp")) do |file|
-          file.write("Flavor,Families\nBike Polo,\n")
+          file.write("Flavor,Families\nRoad Biking,\n")
           file.flush
-          expect { described_class.import(file.path) }.to raise_error(/Bike Polo/)
+          expect { described_class.import(file.path) }.to raise_error(/Road Biking/)
         end
       end
 

--- a/spec/services/spreadsheets/primary_activities_spec.rb
+++ b/spec/services/spreadsheets/primary_activities_spec.rb
@@ -70,6 +70,18 @@ RSpec.describe Spreadsheets::PrimaryActivities do
         expect(PrimaryActivity.all.map(&:display_name)).to match_array target_display_names
       end
 
+      it "names the offending activity when a create fails validation" do
+        described_class.import(csv_path)
+        # Drift the slug so the slug lookup misses and the create collides on name uniqueness
+        PrimaryActivity.flavor.top_level.friendly_find("Bike Polo").update_columns(slug: "drifted")
+
+        Tempfile.create(["primary_activities", ".csv"], Rails.root.join("tmp")) do |file|
+          file.write("Flavor,Families\nBike Polo,\n")
+          file.flush
+          expect { described_class.import(file.path) }.to raise_error(/Bike Polo/)
+        end
+      end
+
       it "corrects the stored name of an existing activity (e.g. casing)" do
         described_class.import(csv_path)
         bike_polo = PrimaryActivity.flavor.top_level.friendly_find("Bike Polo")


### PR DESCRIPTION
Improvements to the component / reference-data import and export flow.

- Add `/components.csv`, exporting the live `Ctype` reference data via `Spreadsheets::Components.to_csv` — the components counterpart to `/manufacturers.csv`.
- Show a sortable **Secondary name** column in the admin ctypes table.
- Harden `Spreadsheets::ImporterJob`: raise on an unknown importer name rather than failing obscurely downstream.
- Primary-activities import: name the offending activity when a row fails validation, and self-heal slug drift (fall back to an exact name match when the slug lookup misses) so re-imports correct rows instead of crashing.
- Bump the default Cgroup "Additional Parts" priority to 6.
