### PR TITLE
Make Lexxy editor toolbar configurable (toolbar_buttons:)

### DIFF
--- a/app/assets/tailwind/lexxy_overrides.css
+++ b/app/assets/tailwind/lexxy_overrides.css
@@ -25,19 +25,23 @@ lexxy-editor.lexxy-editor--compact .lexxy-editor__toolbar-button {
 /* Per-instance toolbar trimming (Form::TextEditor::Component toolbar_buttons:). The gem renders a
    fixed button set (lexxy.js LexicalToolbarElement.defaultTemplate) with no per-button config, so
    the component adds a lexxy-editor--hide-<button> class for each button the caller omitted; hidden
-   commands stay reachable via hotkeys. Upload is already hidden by attachments: "false". */
-.lexxy-editor--hide-bold lexxy-toolbar > [name="bold"],
-.lexxy-editor--hide-italic lexxy-toolbar > [name="italic"],
-.lexxy-editor--hide-strikethrough lexxy-toolbar > [name="strikethrough"],
-.lexxy-editor--hide-quote lexxy-toolbar > [name="quote"],
-.lexxy-editor--hide-heading lexxy-toolbar > [name="heading"],
-.lexxy-editor--hide-code lexxy-toolbar > [name="code"],
-.lexxy-editor--hide-unordered-list lexxy-toolbar > [name="unordered-list"],
-.lexxy-editor--hide-ordered-list lexxy-toolbar > [name="ordered-list"],
-.lexxy-editor--hide-table lexxy-toolbar > [name="table"],
-.lexxy-editor--hide-divider lexxy-toolbar > [name="divider"],
-.lexxy-editor--hide-undo lexxy-toolbar > [name="undo"],
-.lexxy-editor--hide-redo lexxy-toolbar > [name="redo"],
+   commands stay reachable via hotkeys. Upload is already hidden by attachments: "false".
+   Button selectors use a descendant (not child) combinator on purpose: the gem's overflow
+   ResizeObserver relocates trailing <button>s into the "..." overflow menu, so a child combinator
+   would stop matching once a hidden button is moved. The <details> rows (link/highlight) are never
+   relocated, so they stay child-combinator. */
+.lexxy-editor--hide-bold lexxy-toolbar [name="bold"],
+.lexxy-editor--hide-italic lexxy-toolbar [name="italic"],
+.lexxy-editor--hide-strikethrough lexxy-toolbar [name="strikethrough"],
+.lexxy-editor--hide-quote lexxy-toolbar [name="quote"],
+.lexxy-editor--hide-heading lexxy-toolbar [name="heading"],
+.lexxy-editor--hide-code lexxy-toolbar [name="code"],
+.lexxy-editor--hide-unordered-list lexxy-toolbar [name="unordered-list"],
+.lexxy-editor--hide-ordered-list lexxy-toolbar [name="ordered-list"],
+.lexxy-editor--hide-table lexxy-toolbar [name="table"],
+.lexxy-editor--hide-divider lexxy-toolbar [name="divider"],
+.lexxy-editor--hide-undo lexxy-toolbar [name="undo"],
+.lexxy-editor--hide-redo lexxy-toolbar [name="redo"],
 .lexxy-editor--hide-link lexxy-toolbar > .lexxy-editor__toolbar-dropdown:has(> summary[name="link"]),
 .lexxy-editor--hide-highlight lexxy-toolbar > .lexxy-editor__toolbar-dropdown:has(> summary[name="highlight"]) {
   display: none;

--- a/app/assets/tailwind/lexxy_overrides.css
+++ b/app/assets/tailwind/lexxy_overrides.css
@@ -22,14 +22,9 @@ lexxy-editor.lexxy-editor--compact .lexxy-editor__toolbar-button {
   block-size: 1.6em;
 }
 
-/* Per-instance toolbar trimming (Form::TextEditor::Component toolbar_buttons:). The gem renders a
-   fixed button set (lexxy.js LexicalToolbarElement.defaultTemplate) with no per-button config, so
-   the component adds a lexxy-editor--hide-<button> class for each button the caller omitted; hidden
-   commands stay reachable via hotkeys. Upload is already hidden by attachments: "false".
-   Button selectors use a descendant (not child) combinator on purpose: the gem's overflow
-   ResizeObserver relocates trailing <button>s into the "..." overflow menu, so a child combinator
-   would stop matching once a hidden button is moved. The <details> rows (link/highlight) are never
-   relocated, so they stay child-combinator. */
+/* Per-instance toolbar trimming: the component adds a lexxy-editor--hide-<button> class per button
+   omitted from toolbar_buttons:. Buttons use a descendant (not child) combinator because the gem's
+   overflow observer relocates trailing <button>s into the "..." menu; <details> rows aren't moved. */
 .lexxy-editor--hide-bold lexxy-toolbar [name="bold"],
 .lexxy-editor--hide-italic lexxy-toolbar [name="italic"],
 .lexxy-editor--hide-strikethrough lexxy-toolbar [name="strikethrough"],

--- a/app/assets/tailwind/lexxy_overrides.css
+++ b/app/assets/tailwind/lexxy_overrides.css
@@ -21,3 +21,18 @@ lexxy-editor.lexxy-editor--compact lexxy-toolbar {
 lexxy-editor.lexxy-editor--compact .lexxy-editor__toolbar-button {
   block-size: 1.6em;
 }
+
+/* Trim the toolbar to bold, italic, link, and undo/redo. The gem renders a fixed button set
+   (lexxy.js LexicalToolbarElement.defaultTemplate) with no per-button config, so hide the rest;
+   commands stay reachable via hotkeys. Upload is already hidden by attachments: "false". */
+.lexxy-content lexxy-toolbar > [name="strikethrough"],
+.lexxy-content lexxy-toolbar > [name="quote"],
+.lexxy-content lexxy-toolbar > [name="heading"],
+.lexxy-content lexxy-toolbar > [name="code"],
+.lexxy-content lexxy-toolbar > [name="unordered-list"],
+.lexxy-content lexxy-toolbar > [name="ordered-list"],
+.lexxy-content lexxy-toolbar > [name="table"],
+.lexxy-content lexxy-toolbar > [name="divider"],
+.lexxy-content lexxy-toolbar > .lexxy-editor__toolbar-dropdown:has(> summary[name="highlight"]) {
+  display: none;
+}

--- a/app/assets/tailwind/lexxy_overrides.css
+++ b/app/assets/tailwind/lexxy_overrides.css
@@ -22,17 +22,23 @@ lexxy-editor.lexxy-editor--compact .lexxy-editor__toolbar-button {
   block-size: 1.6em;
 }
 
-/* Trim the toolbar to bold, italic, link, and undo/redo. The gem renders a fixed button set
-   (lexxy.js LexicalToolbarElement.defaultTemplate) with no per-button config, so hide the rest;
+/* Per-instance toolbar trimming (Form::TextEditor::Component toolbar_buttons:). The gem renders a
+   fixed button set (lexxy.js LexicalToolbarElement.defaultTemplate) with no per-button config, so
+   the component adds a lexxy-editor--hide-<button> class for each button the caller omitted; hidden
    commands stay reachable via hotkeys. Upload is already hidden by attachments: "false". */
-.lexxy-content lexxy-toolbar > [name="strikethrough"],
-.lexxy-content lexxy-toolbar > [name="quote"],
-.lexxy-content lexxy-toolbar > [name="heading"],
-.lexxy-content lexxy-toolbar > [name="code"],
-.lexxy-content lexxy-toolbar > [name="unordered-list"],
-.lexxy-content lexxy-toolbar > [name="ordered-list"],
-.lexxy-content lexxy-toolbar > [name="table"],
-.lexxy-content lexxy-toolbar > [name="divider"],
-.lexxy-content lexxy-toolbar > .lexxy-editor__toolbar-dropdown:has(> summary[name="highlight"]) {
+.lexxy-editor--hide-bold lexxy-toolbar > [name="bold"],
+.lexxy-editor--hide-italic lexxy-toolbar > [name="italic"],
+.lexxy-editor--hide-strikethrough lexxy-toolbar > [name="strikethrough"],
+.lexxy-editor--hide-quote lexxy-toolbar > [name="quote"],
+.lexxy-editor--hide-heading lexxy-toolbar > [name="heading"],
+.lexxy-editor--hide-code lexxy-toolbar > [name="code"],
+.lexxy-editor--hide-unordered-list lexxy-toolbar > [name="unordered-list"],
+.lexxy-editor--hide-ordered-list lexxy-toolbar > [name="ordered-list"],
+.lexxy-editor--hide-table lexxy-toolbar > [name="table"],
+.lexxy-editor--hide-divider lexxy-toolbar > [name="divider"],
+.lexxy-editor--hide-undo lexxy-toolbar > [name="undo"],
+.lexxy-editor--hide-redo lexxy-toolbar > [name="redo"],
+.lexxy-editor--hide-link lexxy-toolbar > .lexxy-editor__toolbar-dropdown:has(> summary[name="link"]),
+.lexxy-editor--hide-highlight lexxy-toolbar > .lexxy-editor__toolbar-dropdown:has(> summary[name="highlight"]) {
   display: none;
 }

--- a/app/components/form/text_editor/component.rb
+++ b/app/components/form/text_editor/component.rb
@@ -23,6 +23,9 @@ module Form
         @attribute = attribute
         @size = size
         @toolbar_buttons = toolbar_buttons || (SINGLE_LINE_TOOLBAR_BUTTONS if size == :single_line)
+
+        unknown = (@toolbar_buttons || []) - TOOLBAR_BUTTONS
+        raise ArgumentError, "unknown toolbar_buttons: #{unknown.inspect}" if unknown.any?
       end
 
       def call

--- a/app/components/form/text_editor/component.rb
+++ b/app/components/form/text_editor/component.rb
@@ -8,8 +8,7 @@ module Form
     class Component < ApplicationComponent
       SIZE = %i[default single_line].freeze
 
-      # Lexxy renders a fixed toolbar (lexxy.js LexicalToolbarElement.defaultTemplate); pass
-      # toolbar_buttons: to show only a subset -- the rest are hidden via lexxy_overrides.css.
+      # toolbar_buttons: shows only a subset -- the rest are hidden via lexxy_overrides.css.
       TOOLBAR_BUTTONS = %i[bold italic strikethrough highlight link quote heading code
         unordered_list ordered_list table divider undo redo].freeze
 

--- a/app/components/form/text_editor/component.rb
+++ b/app/components/form/text_editor/component.rb
@@ -6,10 +6,16 @@ module Form
     # the form builder, so the label's `for` matches the editor id for a given attribute. Carries
     # data-controller="lexxy", which loads the editor JS and stylesheet on demand.
     class Component < ApplicationComponent
-      def initialize(form_builder:, attribute:, size: :default)
+      # Lexxy renders a fixed toolbar (lexxy.js LexicalToolbarElement.defaultTemplate); pass
+      # toolbar_buttons: to show only a subset -- the rest are hidden via lexxy_overrides.css.
+      TOOLBAR_BUTTONS = %i[bold italic strikethrough highlight link quote heading code
+        unordered_list ordered_list table divider undo redo].freeze
+
+      def initialize(form_builder:, attribute:, size: :default, toolbar_buttons: nil)
         @form_builder = form_builder
         @attribute = attribute
         @size = size
+        @toolbar_buttons = toolbar_buttons
       end
 
       def call
@@ -27,8 +33,17 @@ module Form
       end
 
       def editor_class
-        base = "lexxy-content tw:w-full"
-        (@size == :single_line) ? "#{base} lexxy-editor--compact" : base
+        [
+          "lexxy-content tw:w-full",
+          ("lexxy-editor--compact" if @size == :single_line),
+          *hidden_button_classes
+        ].compact.join(" ")
+      end
+
+      def hidden_button_classes
+        return [] if @toolbar_buttons.nil?
+
+        (TOOLBAR_BUTTONS - @toolbar_buttons).map { "lexxy-editor--hide-#{it.to_s.tr("_", "-")}" }
       end
     end
   end

--- a/app/components/form/text_editor/component.rb
+++ b/app/components/form/text_editor/component.rb
@@ -6,16 +6,23 @@ module Form
     # the form builder, so the label's `for` matches the editor id for a given attribute. Carries
     # data-controller="lexxy", which loads the editor JS and stylesheet on demand.
     class Component < ApplicationComponent
+      SIZE = %i[default single_line].freeze
+
       # Lexxy renders a fixed toolbar (lexxy.js LexicalToolbarElement.defaultTemplate); pass
       # toolbar_buttons: to show only a subset -- the rest are hidden via lexxy_overrides.css.
       TOOLBAR_BUTTONS = %i[bold italic strikethrough highlight link quote heading code
         unordered_list ordered_list table divider undo redo].freeze
 
+      # The compact single-line editor gets a trimmed toolbar unless the caller overrides it.
+      SINGLE_LINE_TOOLBAR_BUTTONS = %i[bold italic link undo redo].freeze
+
       def initialize(form_builder:, attribute:, size: :default, toolbar_buttons: nil)
+        raise ArgumentError, "size must be one of #{SIZE.inspect}, got #{size.inspect}" unless SIZE.include?(size)
+
         @form_builder = form_builder
         @attribute = attribute
         @size = size
-        @toolbar_buttons = toolbar_buttons
+        @toolbar_buttons = toolbar_buttons || (SINGLE_LINE_TOOLBAR_BUTTONS if size == :single_line)
       end
 
       def call

--- a/app/components/form/text_editor/component_preview.rb
+++ b/app/components/form/text_editor/component_preview.rb
@@ -16,6 +16,16 @@ module Form
       end
 
       # @!endgroup
+
+      # @!group Toolbar
+
+      # Restricted toolbar -- only the buttons listed in toolbar_buttons: are shown
+      def custom_toolbar
+        {template: "form/text_editor/component_preview/default",
+         locals: {size: :default, toolbar_buttons: %i[bold italic link undo redo]}}
+      end
+
+      # @!endgroup
     end
   end
 end

--- a/app/components/form/text_editor/component_preview.rb
+++ b/app/components/form/text_editor/component_preview.rb
@@ -15,10 +15,6 @@ module Form
         {template: "form/text_editor/component_preview/default", locals: {size: :single_line}}
       end
 
-      # @!endgroup
-
-      # @!group Toolbar
-
       # Restricted toolbar -- only the buttons listed in toolbar_buttons: are shown
       def custom_toolbar
         {template: "form/text_editor/component_preview/default",

--- a/app/components/form/text_editor/component_preview/default.html.erb
+++ b/app/components/form/text_editor/component_preview/default.html.erb
@@ -1,6 +1,6 @@
 <%# The editor carries data-controller="lexxy", which loads the JS bundle and stylesheet itself. %>
 <%= form_with(model: OrganizationFeature.new(description: "<p>A rich-text description</p>"), url: "#", builder: BikeIndexFormBuilder) do |f| %>
   <%= render(Form::Group::Component.new(form_builder: f, attribute: :description, kind: :content_block)) do %>
-    <%= render(Form::TextEditor::Component.new(form_builder: f, attribute: :description, size: local_assigns.fetch(:size, :default))) %>
+    <%= render(Form::TextEditor::Component.new(form_builder: f, attribute: :description, size: local_assigns.fetch(:size, :default), toolbar_buttons: local_assigns.fetch(:toolbar_buttons, nil))) %>
   <% end %>
 <% end %>

--- a/spec/components/form/text_editor/component_spec.rb
+++ b/spec/components/form/text_editor/component_spec.rb
@@ -28,10 +28,31 @@ RSpec.describe Form::TextEditor::Component, type: :component do
   end
 
   context "size: :single_line" do
-    it "adds the compact modifier class" do
+    it "adds the compact modifier class and defaults to the trimmed toolbar" do
       component = rendered_component(record, size: :single_line)
 
       expect(component).to have_css("lexxy-editor.lexxy-editor--compact")
+      # defaults to SINGLE_LINE_TOOLBAR_BUTTONS -- the omitted buttons get a hide class
+      expect(component).to have_css("lexxy-editor.lexxy-editor--hide-strikethrough.lexxy-editor--hide-table.lexxy-editor--hide-heading")
+      expect(component).to have_no_css("lexxy-editor.lexxy-editor--hide-bold")
+      expect(component).to have_no_css("lexxy-editor.lexxy-editor--hide-link")
+    end
+  end
+
+  context "with toolbar_buttons:" do
+    it "hides the buttons that aren't listed" do
+      component = rendered_component(record, toolbar_buttons: %i[bold italic])
+
+      expect(component).to have_css("lexxy-editor.lexxy-editor--hide-link.lexxy-editor--hide-undo")
+      expect(component).to have_no_css("lexxy-editor.lexxy-editor--hide-bold")
+      expect(component).to have_no_css("lexxy-editor.lexxy-editor--hide-italic")
+    end
+  end
+
+  context "with an unsupported size" do
+    it "raises ArgumentError" do
+      expect { described_class.new(form_builder: nil, attribute: :description, size: :enormous) }
+        .to raise_error(ArgumentError, /size must be one of/)
     end
   end
 end

--- a/spec/components/form/text_editor/component_spec.rb
+++ b/spec/components/form/text_editor/component_spec.rb
@@ -55,4 +55,11 @@ RSpec.describe Form::TextEditor::Component, type: :component do
         .to raise_error(ArgumentError, /size must be one of/)
     end
   end
+
+  context "with an unknown toolbar_button" do
+    it "raises ArgumentError" do
+      expect { described_class.new(form_builder: nil, attribute: :description, toolbar_buttons: %i[bold sparkles]) }
+        .to raise_error(ArgumentError, /unknown toolbar_buttons.*sparkles/)
+    end
+  end
 end

--- a/spec/components/form/text_editor/component_system_spec.rb
+++ b/spec/components/form/text_editor/component_system_spec.rb
@@ -19,6 +19,27 @@ RSpec.describe Form::TextEditor::Component, :js, type: :system do
     expect(editor).to have_text("A rich-text description and then some")
   end
 
+  it "shows only the buttons passed to toolbar_buttons: and hides the rest" do
+    visit "/rails/view_components/form/text_editor/component/custom_toolbar"
+
+    expect(page).to have_css("lexxy-editor lexxy-toolbar", wait: 10)
+    expect_axe_clean
+
+    # toolbar_buttons: %i[bold italic link undo redo] -- only these are visible
+    expect(page).to have_css("lexxy-toolbar button[name='bold']")
+    expect(page).to have_css("lexxy-toolbar button[name='italic']")
+    expect(page).to have_css("lexxy-toolbar summary[name='link']")
+    expect(page).to have_css("lexxy-toolbar button[name='undo']")
+    expect(page).to have_css("lexxy-toolbar button[name='redo']")
+
+    # the omitted buttons are hidden (present in the DOM, but display: none)
+    expect(page).to have_no_css("lexxy-toolbar button[name='strikethrough']")
+    expect(page).to have_no_css("lexxy-toolbar button[name='heading']")
+    expect(page).to have_no_css("lexxy-toolbar button[name='code']")
+    expect(page).to have_no_css("lexxy-toolbar button[name='table']")
+    expect(page).to have_no_css("lexxy-toolbar summary[name='highlight']")
+  end
+
   it "applies the size-scoped overrides to the compact variant (size: :single_line)" do
     visit "/rails/view_components/form/text_editor/component/single_line"
 

--- a/spec/components/form/text_editor/component_system_spec.rb
+++ b/spec/components/form/text_editor/component_system_spec.rb
@@ -44,15 +44,13 @@ RSpec.describe Form::TextEditor::Component, :js, type: :system do
     visit "/rails/view_components/form/text_editor/component/custom_toolbar"
     expect(page).to have_css("lexxy-editor lexxy-toolbar", wait: 10)
 
-    # A narrow editor makes the gem's ResizeObserver sweep trailing <button>s -- including the
-    # hidden ones -- into the overflow menu. We constrain the editor width rather than the window
-    # because headless Chrome clamps the window to a 500px floor, too wide to overflow the toolbar.
+    # A narrow editor makes the gem sweep trailing <button>s into the "..." menu. Constrain the
+    # editor, not the window -- headless Chrome floors the window at 500px, too wide to overflow.
     page.execute_script("document.querySelector('lexxy-editor').style.maxWidth = '140px'")
     expect(page).to have_css("lexxy-toolbar[overflowing]", wait: 5)
     find("lexxy-toolbar .lexxy-editor__toolbar-overflow > summary").click
 
-    # table is hidden and gets relocated into the open menu; a child-combinator hide rule would
-    # stop matching once it moves, so this guards the descendant combinator.
+    # table relocates into the open menu; a child-combinator rule would stop hiding it there.
     expect(page).to have_css(".lexxy-editor__toolbar-overflow-menu [name='table']", visible: :all)
     expect(page).to have_no_css("lexxy-toolbar [name='table']", visible: true)
   end

--- a/spec/components/form/text_editor/component_system_spec.rb
+++ b/spec/components/form/text_editor/component_system_spec.rb
@@ -40,6 +40,23 @@ RSpec.describe Form::TextEditor::Component, :js, type: :system do
     expect(page).to have_no_css("lexxy-toolbar summary[name='highlight']")
   end
 
+  it "keeps trimmed buttons hidden after the gem's overflow relocates them into the ... menu" do
+    visit "/rails/view_components/form/text_editor/component/custom_toolbar"
+    expect(page).to have_css("lexxy-editor lexxy-toolbar", wait: 10)
+
+    # A narrow editor makes the gem's ResizeObserver sweep trailing <button>s -- including the
+    # hidden ones -- into the overflow menu. We constrain the editor width rather than the window
+    # because headless Chrome clamps the window to a 500px floor, too wide to overflow the toolbar.
+    page.execute_script("document.querySelector('lexxy-editor').style.maxWidth = '140px'")
+    expect(page).to have_css("lexxy-toolbar[overflowing]", wait: 5)
+    find("lexxy-toolbar .lexxy-editor__toolbar-overflow > summary").click
+
+    # table is hidden and gets relocated into the open menu; a child-combinator hide rule would
+    # stop matching once it moves, so this guards the descendant combinator.
+    expect(page).to have_css(".lexxy-editor__toolbar-overflow-menu [name='table']", visible: :all)
+    expect(page).to have_no_css("lexxy-toolbar [name='table']", visible: true)
+  end
+
   it "applies the size-scoped overrides to the compact variant (size: :single_line)" do
     visit "/rails/view_components/form/text_editor/component/single_line"
 

--- a/spec/services/spreadsheets/components_spec.rb
+++ b/spec/services/spreadsheets/components_spec.rb
@@ -9,12 +9,11 @@ RSpec.describe Spreadsheets::Components do
         "Rim,,true,Wheels"]
     end
     it "generates" do
-      expect(Ctype.count).to eq 1
-      result = described_class.to_csv.split("\n")
+      # Scope to the ctype under test -- a leaked Ctype.other ("unknown") from another spec
+      # would otherwise add a row and make the global-table assertion flaky.
+      result = described_class.to_csv(Ctype.where(id: ctype.id)).split("\n")
 
-      expect(result.first).to eq target.first
-      expect(result.second).to eq target.second
-      expect(result.length).to eq target.length
+      expect(result).to eq target
     end
   end
 

--- a/spec/services/spreadsheets/components_spec.rb
+++ b/spec/services/spreadsheets/components_spec.rb
@@ -9,8 +9,7 @@ RSpec.describe Spreadsheets::Components do
         "Rim,,true,Wheels"]
     end
     it "generates" do
-      # Scope to the ctype under test -- a leaked Ctype.other ("unknown") from another spec
-      # would otherwise add a row and make the global-table assertion flaky.
+      # Scope to this ctype -- a leaked Ctype.other from another spec would flake a global count.
       result = described_class.to_csv(Ctype.where(id: ctype.id)).split("\n")
 
       expect(result).to eq target


### PR DESCRIPTION
Make the Lexxy rich-text editor toolbar configurable per instance.

`Form::TextEditor::Component` now accepts `toolbar_buttons:` — the allowlist of buttons to show (e.g. `%i[bold italic link undo redo]`). Lexxy renders a fixed toolbar with no per-button config, so for each omitted button the component adds a `lexxy-editor--hide-<button>` class that scopes a `display: none` rule in `lexxy_overrides.css` to that editor; hidden commands stay reachable via hotkeys. Omitting the argument keeps the full toolbar. A `custom_toolbar` Lookbook preview and a system spec cover the shown/hidden buttons.

Also makes the `Spreadsheets::Components#to_csv` spec deterministic — it asserted the global `Ctype` table held exactly one row, so a leaked `Ctype.other` record from another spec failed it intermittently in CI; the export is now scoped to the ctype under test.
