### PR TITLE
Refine Lexxy TextEditor component and scope its previews

### DIFF
--- a/app/assets/tailwind/lexxy_overrides.css
+++ b/app/assets/tailwind/lexxy_overrides.css
@@ -4,12 +4,14 @@
    inherited app line-heights don't bloat the controls. Overrides only — the gem's lexxy stylesheet
    still provides the base styling, and editors without this class keep the normal size. */
 lexxy-editor.lexxy-editor--compact {
-  font-size: 0.75rem;
+  font-size: 0.875rem;
   line-height: 1.4;
-  border: 0;
+  /* keep the input box (matches .twinput) rather than the gem's heavier frame */
+  border: 1px solid #d1d5db; /* gray-300 */
+  border-radius: 0.25rem; /* rounded-sm */
 
-  /* content box: a couple of lines instead of the default 8 */
-  --lexxy-editor-rows: 2.4em;
+  /* content box: a single line (it still grows as text wraps) instead of the default 8 */
+  --lexxy-editor-rows: 1.4em;
   --lexxy-editor-padding: 0.4ch;
 }
 
@@ -20,6 +22,15 @@ lexxy-editor.lexxy-editor--compact lexxy-toolbar {
 
 lexxy-editor.lexxy-editor--compact .lexxy-editor__toolbar-button {
   block-size: 1.6em;
+}
+
+/* Keep single-line content tight: pad the left edge and drop the default paragraph margin */
+lexxy-editor.lexxy-editor--compact .lexxy-editor__content {
+  padding-left: 0.4ch;
+}
+
+lexxy-editor.lexxy-editor--compact .lexxy-editor__content p {
+  margin-bottom: 0;
 }
 
 /* Per-instance toolbar trimming: the component adds a lexxy-editor--hide-<button> class per button

--- a/app/components/form/group/component_preview.rb
+++ b/app/components/form/group/component_preview.rb
@@ -20,6 +20,10 @@ module Form
         {template: "form/group/component_preview/check_box"}
       end
 
+      def content_block
+        {template: "form/group/component_preview/content_block"}
+      end
+
       def custom_label
         {template: "form/group/component_preview/custom_label"}
       end

--- a/app/components/form/group/component_preview/content_block.html.erb
+++ b/app/components/form/group/component_preview/content_block.html.erb
@@ -1,6 +1,6 @@
 <%# kind: :content_block renders the label, then yields to a content block -- here a Lexxy text editor. %>
 <%= form_with(model: OrganizationFeature.new(description: "<p>A rich-text description</p>"), url: "#", builder: BikeIndexFormBuilder) do |f| %>
   <%= render(Form::Group::Component.new(form_builder: f, attribute: :description, kind: :content_block)) do %>
-    <%= render(Form::TextEditor::Component.new(form_builder: f, attribute: :description)) %>
+    <%= render(Form::TextEditor::Component.new(form_builder: f, attribute: :description, standalone: false)) %>
   <% end %>
 <% end %>

--- a/app/components/form/group/component_preview/content_block.html.erb
+++ b/app/components/form/group/component_preview/content_block.html.erb
@@ -1,0 +1,6 @@
+<%# kind: :content_block renders the label, then yields to a content block -- here a Lexxy text editor. %>
+<%= form_with(model: OrganizationFeature.new(description: "<p>A rich-text description</p>"), url: "#", builder: BikeIndexFormBuilder) do |f| %>
+  <%= render(Form::Group::Component.new(form_builder: f, attribute: :description, kind: :content_block)) do %>
+    <%= render(Form::TextEditor::Component.new(form_builder: f, attribute: :description)) %>
+  <% end %>
+<% end %>

--- a/app/components/form/text_editor/component.rb
+++ b/app/components/form/text_editor/component.rb
@@ -2,11 +2,8 @@
 
 module Form
   module TextEditor
-    # Bare Lexxy editor. A standalone editor (the default) derives its aria-label from the attribute
-    # for an accessible name. Pair with Form::Group (kind: :content_block) and pass standalone: false
-    # so the group's <label> is the accessible name instead -- both run through the form builder, so
-    # the label's `for` matches the editor id. Carries data-controller="lexxy", which loads the editor
-    # JS and stylesheet on demand.
+    # Bare Lexxy editor; pair with Form::Group (kind: :content_block, standalone: false) for a label.
+    # Carries data-controller="lexxy", which loads the editor JS and stylesheet on demand.
     class Component < ApplicationComponent
       SIZE = %i[default single_line].freeze
 
@@ -17,7 +14,6 @@ module Form
       # The compact single-line editor gets a trimmed toolbar unless the caller overrides it.
       SINGLE_LINE_TOOLBAR_BUTTONS = %i[bold italic link undo redo].freeze
 
-      # value: overrides the editor's initial HTML, for editors not backed by a model attribute
       def initialize(form_builder:, attribute:, size: :default, toolbar_buttons: nil, value: nil, standalone: true)
         raise ArgumentError, "size must be one of #{SIZE.inspect}, got #{size.inspect}" unless SIZE.include?(size)
 

--- a/app/components/form/text_editor/component.rb
+++ b/app/components/form/text_editor/component.rb
@@ -15,12 +15,14 @@ module Form
       # The compact single-line editor gets a trimmed toolbar unless the caller overrides it.
       SINGLE_LINE_TOOLBAR_BUTTONS = %i[bold italic link undo redo].freeze
 
-      def initialize(form_builder:, attribute:, size: :default, toolbar_buttons: nil)
+      # value: overrides the editor's initial HTML, for editors not backed by a model attribute
+      def initialize(form_builder:, attribute:, size: :default, toolbar_buttons: nil, value: nil)
         raise ArgumentError, "size must be one of #{SIZE.inspect}, got #{size.inspect}" unless SIZE.include?(size)
 
         @form_builder = form_builder
         @attribute = attribute
         @size = size
+        @value = value
         @toolbar_buttons = toolbar_buttons || (SINGLE_LINE_TOOLBAR_BUTTONS if size == :single_line)
 
         unknown = (@toolbar_buttons || []) - TOOLBAR_BUTTONS
@@ -34,7 +36,8 @@ module Form
       private
 
       def options
-        {attachments: "false", class: editor_class, data: asset_data}
+        base = {attachments: "false", class: editor_class, data: asset_data}
+        @value.nil? ? base : base.merge(value: @value)
       end
 
       def asset_data

--- a/app/components/form/text_editor/component.rb
+++ b/app/components/form/text_editor/component.rb
@@ -2,10 +2,11 @@
 
 module Form
   module TextEditor
-    # Bare Lexxy editor; pair with Form::Group (kind: :content_block) for a label -- both run through
-    # the form builder, so the label's `for` matches the editor id for a given attribute. Standalone
-    # (unlabelled) editors should pass aria_label: for an accessible name. Carries
-    # data-controller="lexxy", which loads the editor JS and stylesheet on demand.
+    # Bare Lexxy editor. A standalone editor (the default) derives its aria-label from the attribute
+    # for an accessible name. Pair with Form::Group (kind: :content_block) and pass standalone: false
+    # so the group's <label> is the accessible name instead -- both run through the form builder, so
+    # the label's `for` matches the editor id. Carries data-controller="lexxy", which loads the editor
+    # JS and stylesheet on demand.
     class Component < ApplicationComponent
       SIZE = %i[default single_line].freeze
 
@@ -17,14 +18,14 @@ module Form
       SINGLE_LINE_TOOLBAR_BUTTONS = %i[bold italic link undo redo].freeze
 
       # value: overrides the editor's initial HTML, for editors not backed by a model attribute
-      def initialize(form_builder:, attribute:, size: :default, toolbar_buttons: nil, value: nil, aria_label: nil)
+      def initialize(form_builder:, attribute:, size: :default, toolbar_buttons: nil, value: nil, standalone: true)
         raise ArgumentError, "size must be one of #{SIZE.inspect}, got #{size.inspect}" unless SIZE.include?(size)
 
         @form_builder = form_builder
         @attribute = attribute
         @size = size
         @value = value
-        @aria_label = aria_label
+        @standalone = standalone
         @toolbar_buttons = toolbar_buttons || (SINGLE_LINE_TOOLBAR_BUTTONS if size == :single_line)
 
         unknown = (@toolbar_buttons || []) - TOOLBAR_BUTTONS
@@ -40,11 +41,11 @@ module Form
       def options
         {attachments: "false", class: editor_class, data: asset_data}
           .merge(@value.nil? ? {} : {value: @value})
-          .merge(@aria_label.nil? ? {} : {aria: {label: @aria_label}})
+          .merge(@standalone ? {aria: {label: @attribute.to_s.humanize}} : {})
       end
 
       def asset_data
-        {controller: "lexxy", lexxy_stylesheet_value: helpers.stylesheet_path("lexxy")}
+        {controller: "lexxy", action: "click->lexxy#focusEditor", lexxy_stylesheet_value: helpers.stylesheet_path("lexxy")}
       end
 
       def editor_class

--- a/app/components/form/text_editor/component.rb
+++ b/app/components/form/text_editor/component.rb
@@ -3,7 +3,8 @@
 module Form
   module TextEditor
     # Bare Lexxy editor; pair with Form::Group (kind: :content_block) for a label -- both run through
-    # the form builder, so the label's `for` matches the editor id for a given attribute. Carries
+    # the form builder, so the label's `for` matches the editor id for a given attribute. Standalone
+    # (unlabelled) editors should pass aria_label: for an accessible name. Carries
     # data-controller="lexxy", which loads the editor JS and stylesheet on demand.
     class Component < ApplicationComponent
       SIZE = %i[default single_line].freeze
@@ -16,13 +17,14 @@ module Form
       SINGLE_LINE_TOOLBAR_BUTTONS = %i[bold italic link undo redo].freeze
 
       # value: overrides the editor's initial HTML, for editors not backed by a model attribute
-      def initialize(form_builder:, attribute:, size: :default, toolbar_buttons: nil, value: nil)
+      def initialize(form_builder:, attribute:, size: :default, toolbar_buttons: nil, value: nil, aria_label: nil)
         raise ArgumentError, "size must be one of #{SIZE.inspect}, got #{size.inspect}" unless SIZE.include?(size)
 
         @form_builder = form_builder
         @attribute = attribute
         @size = size
         @value = value
+        @aria_label = aria_label
         @toolbar_buttons = toolbar_buttons || (SINGLE_LINE_TOOLBAR_BUTTONS if size == :single_line)
 
         unknown = (@toolbar_buttons || []) - TOOLBAR_BUTTONS
@@ -36,8 +38,9 @@ module Form
       private
 
       def options
-        base = {attachments: "false", class: editor_class, data: asset_data}
-        @value.nil? ? base : base.merge(value: @value)
+        {attachments: "false", class: editor_class, data: asset_data}
+          .merge(@value.nil? ? {} : {value: @value})
+          .merge(@aria_label.nil? ? {} : {aria: {label: @aria_label}})
       end
 
       def asset_data

--- a/app/components/form/text_editor/component_preview/default.html.erb
+++ b/app/components/form/text_editor/component_preview/default.html.erb
@@ -1,6 +1,4 @@
 <%# The editor carries data-controller="lexxy", which loads the JS bundle and stylesheet itself. %>
 <%= form_with(model: OrganizationFeature.new(description: "<p>A rich-text description</p>"), url: "#", builder: BikeIndexFormBuilder) do |f| %>
-  <%= render(Form::Group::Component.new(form_builder: f, attribute: :description, kind: :content_block)) do %>
-    <%= render(Form::TextEditor::Component.new(form_builder: f, attribute: :description, size: local_assigns.fetch(:size, :default), toolbar_buttons: local_assigns.fetch(:toolbar_buttons, nil))) %>
-  <% end %>
+  <%= render(Form::TextEditor::Component.new(form_builder: f, attribute: :description, size: local_assigns.fetch(:size, :default), toolbar_buttons: local_assigns.fetch(:toolbar_buttons, nil))) %>
 <% end %>

--- a/app/components/form/text_editor/component_preview/default.html.erb
+++ b/app/components/form/text_editor/component_preview/default.html.erb
@@ -1,4 +1,4 @@
 <%# The editor carries data-controller="lexxy", which loads the JS bundle and stylesheet itself. %>
 <%= form_with(model: OrganizationFeature.new(description: "<p>A rich-text description</p>"), url: "#", builder: BikeIndexFormBuilder) do |f| %>
-  <%= render(Form::TextEditor::Component.new(form_builder: f, attribute: :description, size: local_assigns.fetch(:size, :default), toolbar_buttons: local_assigns.fetch(:toolbar_buttons, nil))) %>
+  <%= render(Form::TextEditor::Component.new(form_builder: f, attribute: :description, size: local_assigns.fetch(:size, :default), toolbar_buttons: local_assigns.fetch(:toolbar_buttons, nil), aria_label: "Description")) %>
 <% end %>

--- a/app/components/form/text_editor/component_preview/default.html.erb
+++ b/app/components/form/text_editor/component_preview/default.html.erb
@@ -1,4 +1,4 @@
 <%# The editor carries data-controller="lexxy", which loads the JS bundle and stylesheet itself. %>
 <%= form_with(model: OrganizationFeature.new(description: "<p>A rich-text description</p>"), url: "#", builder: BikeIndexFormBuilder) do |f| %>
-  <%= render(Form::TextEditor::Component.new(form_builder: f, attribute: :description, size: local_assigns.fetch(:size, :default), toolbar_buttons: local_assigns.fetch(:toolbar_buttons, nil), aria_label: "Description")) %>
+  <%= render(Form::TextEditor::Component.new(form_builder: f, attribute: :description, size: local_assigns.fetch(:size, :default), toolbar_buttons: local_assigns.fetch(:toolbar_buttons, nil))) %>
 <% end %>

--- a/app/javascript/controllers/lexxy_controller.js
+++ b/app/javascript/controllers/lexxy_controller.js
@@ -14,6 +14,14 @@ export default class extends Controller {
     this.#addStylesheet()
   }
 
+  // A <label for> click forwards a click to this host element (not the inner editor), so the caret
+  // never lands in the box. Move focus into the contenteditable so the label acts like a field label.
+  focusEditor (event) {
+    if (event.target !== this.element) return
+
+    this.element.querySelector('[contenteditable="true"]')?.focus()
+  }
+
   #addStylesheet () {
     const href = this.stylesheetValue
     if (!href || document.querySelector(`link[rel="stylesheet"][href="${href}"]`)) return

--- a/spec/components/form/group/component_system_spec.rb
+++ b/spec/components/form/group/component_system_spec.rb
@@ -20,4 +20,18 @@ RSpec.describe Form::Group::Component, :js, type: :system do
       expect(page).not_to have_css "#{checkbox_selector}:checked", visible: :all
     end
   end
+
+  context "content_block" do
+    it "focuses the paired Lexxy editor when the label is clicked" do
+      visit("#{base_path}content_block")
+
+      # Lexxy upgrades the <lexxy-editor> asynchronously -- wait for the toolbar before interacting.
+      expect(page).to have_css("lexxy-editor lexxy-toolbar", wait: 10)
+
+      find("label", text: "Description").click
+
+      # the label click moves the caret into Lexxy's contenteditable box
+      expect(page).to have_css("#organization_feature_description-content:focus")
+    end
+  end
 end

--- a/spec/components/form/text_editor/component_spec.rb
+++ b/spec/components/form/text_editor/component_spec.rb
@@ -27,6 +27,13 @@ RSpec.describe Form::TextEditor::Component, type: :component do
       .to have_css("lexxy-editor[data-controller='lexxy'][data-lexxy-stylesheet-value*='lexxy']")
   end
 
+  context "with aria_label:" do
+    it "sets the editor's accessible name (Lexxy copies it onto the contenteditable box)" do
+      expect(rendered_component(record, aria_label: "Description"))
+        .to have_css("lexxy-editor[aria-label='Description']")
+    end
+  end
+
   context "size: :single_line" do
     it "adds the compact modifier class and defaults to the trimmed toolbar" do
       component = rendered_component(record, size: :single_line)

--- a/spec/components/form/text_editor/component_spec.rb
+++ b/spec/components/form/text_editor/component_spec.rb
@@ -27,10 +27,13 @@ RSpec.describe Form::TextEditor::Component, type: :component do
       .to have_css("lexxy-editor[data-controller='lexxy'][data-lexxy-stylesheet-value*='lexxy']")
   end
 
-  context "with aria_label:" do
-    it "sets the editor's accessible name (Lexxy copies it onto the contenteditable box)" do
-      expect(rendered_component(record, aria_label: "Description"))
-        .to have_css("lexxy-editor[aria-label='Description']")
+  it "derives the standalone editor's accessible name from the attribute (Lexxy copies aria-label onto the box)" do
+    expect(rendered_component(record)).to have_css("lexxy-editor[aria-label='Description']")
+  end
+
+  context "standalone: false" do
+    it "omits aria-label so the paired Form::Group label is the accessible name" do
+      expect(rendered_component(record, standalone: false)).to have_no_css("lexxy-editor[aria-label]")
     end
   end
 

--- a/spec/components/form/text_editor/component_system_spec.rb
+++ b/spec/components/form/text_editor/component_system_spec.rb
@@ -63,6 +63,6 @@ RSpec.describe Form::TextEditor::Component, :js, type: :system do
 
     # The compact override sets a custom property only on .lexxy-editor--compact
     rows = page.evaluate_script("getComputedStyle(document.querySelector('lexxy-editor')).getPropertyValue('--lexxy-editor-rows').trim()")
-    expect(rows).to eq("2.4em")
+    expect(rows).to eq("1.4em")
   end
 end


### PR DESCRIPTION
Tidies up the Lexxy `Form::TextEditor` component and its Lookbook previews, and pulls the compact-editor styling forward from `registration_sequences-secondary`.

- Each preview now previews its own component: `Form::TextEditor` renders a bare editor, and `Form::Group` gains a `content_block` example that pairs its label with an editor.
- A standalone editor (the default) derives its accessible name from the attribute; pass `standalone: false` when a `Form::Group` `<label>` supplies the name. Also adds a `value:` param for editors not backed by a model attribute.
- Clicking a `Form::Group` label now focuses the paired editor like a native field (the label-forwarded click is routed into the contenteditable).
- Refines the compact (`size: :single_line`) styling — `twinput`-style border, larger font, true single-line content box.
