### PR TITLE
Fix Spreadsheets importer for renamed component_types.csv

### DIFF
--- a/app/jobs/spreadsheets/importer_job.rb
+++ b/app/jobs/spreadsheets/importer_job.rb
@@ -1,18 +1,19 @@
 module Spreadsheets
   class ImporterJob < ApplicationJob
     RESOURCES_URL = "https://raw.githubusercontent.com/bikeindex/resources/refs/heads/main/data".freeze
-    # Each name is both the CSV filename and the importer module (e.g. Spreadsheets::Manufacturers)
-    IMPORTERS = %w[manufacturers primary_activities components].freeze
+    # Maps each importer module (e.g. Spreadsheets::Manufacturers) to its CSV filename in the resources repo
+    IMPORTERS = {"manufacturers" => "manufacturers", "primary_activities" => "primary_activities", "components" => "component_types"}.freeze
 
     def perform(name = nil)
-      return IMPORTERS.each { |n| perform(n) } if name.blank?
-      raise ArgumentError, "Unknown importer: #{name.inspect} (expected one of #{IMPORTERS.join(", ")})" unless IMPORTERS.include?(name)
+      return IMPORTERS.each_key { |n| perform(n) } if name.blank?
+      filename = IMPORTERS[name]
+      raise ArgumentError, "Unknown importer: #{name.inspect} (expected one of #{IMPORTERS.keys.join(", ")})" unless filename
 
       # binmode: write the downloaded bytes verbatim. The CSVs are UTF-8 and Faraday
       # returns ASCII-8BIT, which text mode tries to transcode (failing on CI, where
       # the container has no UTF-8 locale).
       Tempfile.create([name, ".csv"], binmode: true) do |file|
-        file.write(download("#{RESOURCES_URL}/#{name}.csv"))
+        file.write(download("#{RESOURCES_URL}/#{filename}.csv"))
         file.flush
         Spreadsheets.const_get(name.camelize).import(file.path)
       end

--- a/spec/vcr_cassettes/Spreadsheets_ImporterJob-components.yml
+++ b/spec/vcr_cassettes/Spreadsheets_ImporterJob-components.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://raw.githubusercontent.com/bikeindex/resources/refs/heads/main/data/components.csv
+    uri: https://raw.githubusercontent.com/bikeindex/resources/refs/heads/main/data/component_types.csv
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/vcr_cassettes/Spreadsheets_ImporterJob.yml
+++ b/spec/vcr_cassettes/Spreadsheets_ImporterJob.yml
@@ -144,7 +144,7 @@ http_interactions:
   recorded_at: Sun, 28 Jun 2026 19:16:44 GMT
 - request:
     method: get
-    uri: https://raw.githubusercontent.com/bikeindex/resources/refs/heads/main/data/components.csv
+    uri: https://raw.githubusercontent.com/bikeindex/resources/refs/heads/main/data/component_types.csv
     body:
       encoding: US-ASCII
       string: ''


### PR DESCRIPTION
[bikeindex/bike_data#46](https://github.com/bikeindex/bike_data/pull/46) renamed `components.csv` to `component_types.csv`, which broke the Spreadsheets importer because it used a single name for both the CSV filename and the importer module (`Spreadsheets::Components`).

- `IMPORTERS` is now a hash mapping each importer module name to its CSV filename, so `"components"` fetches `component_types.csv` while still resolving the `Components` module.
- Updated the VCR cassettes to point at the renamed file.
