### PR TITLE
Add Form::FileUpload input component

### DIFF
--- a/app/components/form/file_upload/component.html.erb
+++ b/app/components/form/file_upload/component.html.erb
@@ -1,5 +1,5 @@
 <div
-  class="twinput tw:relative tw:flex tw:cursor-pointer tw:items-center tw:gap-3"
+  class="tw:relative tw:inline-flex tw:cursor-pointer tw:items-center tw:gap-3"
   data-controller="form--file-upload"
   data-form--file-upload-placeholder-value="<%= @placeholder %>"
 >

--- a/app/components/form/file_upload/component.html.erb
+++ b/app/components/form/file_upload/component.html.erb
@@ -1,0 +1,24 @@
+<div
+  class="twinput tw:relative tw:flex tw:cursor-pointer tw:items-center tw:gap-3"
+  data-controller="form--file-upload"
+  data-form--file-upload-placeholder-value="<%= @placeholder %>"
+>
+  <span
+    class="
+      tw:rounded-sm tw:bg-gray-100 tw:px-2.5 tw:py-1 tw:text-sm
+      tw:whitespace-nowrap tw:text-gray-700 tw:dark:bg-gray-600
+      tw:dark:text-gray-200
+    "
+  >
+    <%= @button_text %>
+  </span>
+
+  <span
+    class="tw:truncate tw:text-gray-500 tw:dark:text-gray-400"
+    data-form--file-upload-target="filename"
+  >
+    <%= @placeholder %>
+  </span>
+
+  <%= @form_builder.file_field(@attribute, @html_options) %>
+</div>

--- a/app/components/form/file_upload/component.html.erb
+++ b/app/components/form/file_upload/component.html.erb
@@ -1,24 +1,17 @@
 <div
-  class="tw:relative tw:inline-flex tw:cursor-pointer tw:items-center tw:gap-3"
+  class="tw:relative tw:inline-flex tw:items-center tw:gap-3"
   data-controller="form--file-upload"
   data-form--file-upload-placeholder-value="<%= @placeholder %>"
 >
-  <span
-    class="
-      tw:rounded-sm tw:bg-gray-100 tw:px-2.5 tw:py-1 tw:text-sm
-      tw:whitespace-nowrap tw:text-gray-700 tw:dark:bg-gray-600
-      tw:dark:text-gray-200
-    "
-  >
-    <%= @button_text %>
-  </span>
+  <%# sr-only keeps the native input focusable and in the accessibility tree; the label below is the visible, clickable button. %>
+  <%= @form_builder.file_field(@attribute, @html_options) %>
+
+  <%= @form_builder.label @attribute, @button_text, class: @label_classes %>
 
   <span
-    class="tw:truncate tw:text-gray-500 tw:dark:text-gray-400"
+    class="tw:min-w-0 tw:truncate tw:text-gray-500 tw:dark:text-gray-400"
     data-form--file-upload-target="filename"
   >
     <%= @placeholder %>
   </span>
-
-  <%= @form_builder.file_field(@attribute, @html_options) %>
 </div>

--- a/app/components/form/file_upload/component.rb
+++ b/app/components/form/file_upload/component.rb
@@ -3,13 +3,14 @@
 module Form
   module FileUpload
     class Component < ApplicationComponent
-      def initialize(form_builder:, attribute:, button_text: "Choose file", placeholder: "No file chosen", html_options: {})
+      def initialize(form_builder:, attribute:, accept: nil, button_text: "Choose file", placeholder: "No file chosen", html_options: {})
         @form_builder = form_builder
         @attribute = attribute
         @button_text = button_text
         @placeholder = placeholder
         @html_options = {
           class: "tw:absolute tw:inset-0 tw:size-full tw:cursor-pointer tw:opacity-0",
+          accept: Array(accept).join(",").presence,
           data: {"form--file-upload-target": "input", action: "form--file-upload#display"}
         }.merge(html_options)
       end

--- a/app/components/form/file_upload/component.rb
+++ b/app/components/form/file_upload/component.rb
@@ -3,14 +3,15 @@
 module Form
   module FileUpload
     class Component < ApplicationComponent
-      def initialize(form_builder:, attribute:, html_options: {})
+      def initialize(form_builder:, attribute:, button_text: "Choose file", placeholder: "No file chosen", html_options: {})
         @form_builder = form_builder
         @attribute = attribute
-        @html_options = {class: "twinput tw:cursor-pointer"}.merge(html_options)
-      end
-
-      def call
-        @form_builder.file_field(@attribute, @html_options)
+        @button_text = button_text
+        @placeholder = placeholder
+        @html_options = {
+          class: "tw:absolute tw:inset-0 tw:size-full tw:cursor-pointer tw:opacity-0",
+          data: {"form--file-upload-target": "input", action: "form--file-upload#display"}
+        }.merge(html_options)
       end
     end
   end

--- a/app/components/form/file_upload/component.rb
+++ b/app/components/form/file_upload/component.rb
@@ -9,10 +9,13 @@ module Form
         @button_text = button_text
         @placeholder = placeholder
         @html_options = {
-          class: "tw:absolute tw:inset-0 tw:size-full tw:cursor-pointer tw:opacity-0",
+          class: "tw:peer tw:sr-only",
           accept: Array(accept).join(",").presence,
           data: {"form--file-upload-target": "input", action: "form--file-upload#display"}
         }.merge(html_options)
+
+        # Style the label as a UI::Button; the focus ring is driven by the peer (sr-only) input.
+        @label_classes = UI::Button::Component.build_classes(color: :secondary, size: :md, html_class: "tw:whitespace-nowrap tw:peer-focus-visible:ring-3 tw:peer-focus-visible:ring-blue-500/40")
       end
     end
   end

--- a/app/components/form/file_upload/component.rb
+++ b/app/components/form/file_upload/component.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module Form
+  module FileUpload
+    class Component < ApplicationComponent
+      def initialize(form_builder:, attribute:, html_options: {})
+        @form_builder = form_builder
+        @attribute = attribute
+        @html_options = {class: "twinput tw:cursor-pointer"}.merge(html_options)
+      end
+
+      def call
+        @form_builder.file_field(@attribute, @html_options)
+      end
+    end
+  end
+end

--- a/app/components/form/file_upload/component_preview.rb
+++ b/app/components/form/file_upload/component_preview.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module Form
+  module FileUpload
+    class ComponentPreview < ApplicationComponentPreview
+      def default
+        {template: "form/file_upload/component_preview/default"}
+      end
+    end
+  end
+end

--- a/app/components/form/file_upload/component_preview/default.html.erb
+++ b/app/components/form/file_upload/component_preview/default.html.erb
@@ -1,0 +1,3 @@
+<%= form_with(url: "#", builder: BikeIndexFormBuilder) do |f| %>
+  <%= render(Form::FileUpload::Component.new(form_builder: f, attribute: :file)) %>
+<% end %>

--- a/app/components/form/group/component_preview.rb
+++ b/app/components/form/group/component_preview.rb
@@ -24,6 +24,10 @@ module Form
         {template: "form/group/component_preview/content_block"}
       end
 
+      def file_upload
+        {template: "form/group/component_preview/file_upload"}
+      end
+
       def custom_label
         {template: "form/group/component_preview/custom_label"}
       end

--- a/app/components/form/group/component_preview/file_upload.html.erb
+++ b/app/components/form/group/component_preview/file_upload.html.erb
@@ -1,0 +1,6 @@
+<%# kind: :content_block renders the label, then yields to a content block -- here a file upload input. %>
+<%= form_with(url: "#", builder: BikeIndexFormBuilder) do |f| %>
+  <%= render(Form::Group::Component.new(form_builder: f, attribute: :avatar, kind: :content_block)) do %>
+    <%= render(Form::FileUpload::Component.new(form_builder: f, attribute: :avatar)) %>
+  <% end %>
+<% end %>

--- a/app/javascript/controllers/form/file_upload_controller.js
+++ b/app/javascript/controllers/form/file_upload_controller.js
@@ -1,0 +1,16 @@
+import { Controller } from '@hotwired/stimulus'
+
+// Connects to data-controller='form--file-upload'
+// Shows the selected filename (or a count for multiple files) in the field.
+export default class extends Controller {
+  static targets = ['input', 'filename']
+  static values = { placeholder: String }
+
+  display () {
+    const { files } = this.inputTarget
+    this.filenameTarget.textContent =
+      files.length === 0
+        ? this.placeholderValue
+        : files.length === 1 ? files[0].name : `${files.length} files`
+  }
+}

--- a/app/views/organized/manages/show.html.haml
+++ b/app/views/organized/manages/show.html.haml
@@ -66,11 +66,8 @@
       - if @organization.avatar?
         = link_to image_tag(@organization.avatar_url(:thumb)), @organization.avatar_url
 
-      %label.file
-        = f.file_field :avatar, class: "avatar-upload-field", accept: ImageUploader.permitted_extensions.join(",")
-        %span.file-custom
-          %span.file-upload-text= t(".choose_file")
-        = f.hidden_field :avatar_cache
+      = render(Form::FileUpload::Component.new(form_builder: f, attribute: :avatar, button_text: t(".choose_file"), html_options: {accept: ImageUploader.permitted_extensions.join(",")}))
+      = f.hidden_field :avatar_cache
       %span.below-input-help
         = t(".square_image")
 

--- a/app/views/organized/manages/show.html.haml
+++ b/app/views/organized/manages/show.html.haml
@@ -66,7 +66,7 @@
       - if @organization.avatar?
         = link_to image_tag(@organization.avatar_url(:thumb)), @organization.avatar_url
 
-      = render(Form::FileUpload::Component.new(form_builder: f, attribute: :avatar, button_text: t(".choose_file"), html_options: {accept: ImageUploader.permitted_extensions.join(",")}))
+      = render(Form::FileUpload::Component.new(form_builder: f, attribute: :avatar, button_text: t(".choose_file"), accept: ImageUploader.permitted_extensions))
       = f.hidden_field :avatar_cache
       %span.below-input-help
         = t(".square_image")

--- a/spec/components/form/file_upload/component_spec.rb
+++ b/spec/components/form/file_upload/component_spec.rb
@@ -11,20 +11,19 @@ RSpec.describe Form::FileUpload::Component, type: :component do
   let(:attribute) { :avatar }
   let(:options) { {} }
 
-  it "renders a labelless file input with a filename display" do
-    expect(component).to have_css("input[type='file'][name='user[avatar]']")
-    expect(component).to have_no_css("label")
+  it "renders a file input with an associated label and filename display" do
+    expect(component).to have_css("input#user_avatar[type='file'][name='user[avatar]']")
+    expect(component).to have_css("label[for='user_avatar']", text: "Choose file")
     expect(component).to have_css("[data-controller='form--file-upload']")
     expect(component).to have_css("[data-form--file-upload-target='input']")
     expect(component).to have_css("[data-form--file-upload-target='filename']", text: "No file chosen")
-    expect(component).to have_text("Choose file")
   end
 
   context "with custom button_text and placeholder" do
     let(:options) { {button_text: "Browse", placeholder: "Pick an image"} }
 
     it "uses the provided text" do
-      expect(component).to have_text("Browse")
+      expect(component).to have_css("label[for='user_avatar']", text: "Browse")
       expect(component).to have_css("[data-form--file-upload-target='filename']", text: "Pick an image")
     end
   end

--- a/spec/components/form/file_upload/component_spec.rb
+++ b/spec/components/form/file_upload/component_spec.rb
@@ -7,32 +7,35 @@ RSpec.describe Form::FileUpload::Component, type: :component do
   let(:form_builder) do
     BikeIndexFormBuilder.new(:user, user, ActionView::Base.new(ActionView::LookupContext.new([]), {}, nil), {})
   end
-  let(:component) { render_inline(described_class.new(form_builder:, attribute:, html_options:)) }
+  let(:component) { render_inline(described_class.new(form_builder:, attribute:, **options)) }
   let(:attribute) { :avatar }
-  let(:html_options) { {} }
+  let(:options) { {} }
 
-  it "renders a labelless file input" do
+  it "renders a labelless file input with a filename display" do
     expect(component).to have_css("input[type='file'][name='user[avatar]']")
     expect(component).to have_no_css("label")
     expect(component.to_html).to include("twinput")
-    expect(component.to_html).to include("tw:cursor-pointer")
+    expect(component).to have_css("[data-controller='form--file-upload']")
+    expect(component).to have_css("[data-form--file-upload-target='input']")
+    expect(component).to have_css("[data-form--file-upload-target='filename']", text: "No file chosen")
+    expect(component).to have_text("Choose file")
+  end
+
+  context "with custom button_text and placeholder" do
+    let(:options) { {button_text: "Browse", placeholder: "Pick an image"} }
+
+    it "uses the provided text" do
+      expect(component).to have_text("Browse")
+      expect(component).to have_css("[data-form--file-upload-target='filename']", text: "Pick an image")
+    end
   end
 
   context "with html_options" do
-    let(:html_options) { {accept: "image/png", multiple: true} }
+    let(:options) { {html_options: {accept: "image/png", multiple: true}} }
 
-    it "passes options through" do
+    it "passes options through to the input" do
       expect(component).to have_css("input[type='file'][accept='image/png']")
       expect(component).to have_css("input[multiple]")
-    end
-
-    context "when overriding class" do
-      let(:html_options) { {class: "custom-upload"} }
-
-      it "replaces the default class" do
-        expect(component).to have_css("input.custom-upload")
-        expect(component.to_html).to_not include("twinput")
-      end
     end
   end
 end

--- a/spec/components/form/file_upload/component_spec.rb
+++ b/spec/components/form/file_upload/component_spec.rb
@@ -14,7 +14,6 @@ RSpec.describe Form::FileUpload::Component, type: :component do
   it "renders a labelless file input with a filename display" do
     expect(component).to have_css("input[type='file'][name='user[avatar]']")
     expect(component).to have_no_css("label")
-    expect(component.to_html).to include("twinput")
     expect(component).to have_css("[data-controller='form--file-upload']")
     expect(component).to have_css("[data-form--file-upload-target='input']")
     expect(component).to have_css("[data-form--file-upload-target='filename']", text: "No file chosen")

--- a/spec/components/form/file_upload/component_spec.rb
+++ b/spec/components/form/file_upload/component_spec.rb
@@ -37,4 +37,28 @@ RSpec.describe Form::FileUpload::Component, type: :component do
       expect(component).to have_css("input[multiple]")
     end
   end
+
+  context "with accept" do
+    context "as a string" do
+      let(:options) { {accept: "image/png,image/jpeg"} }
+
+      it "sets the accept attribute" do
+        expect(component).to have_css("input[type='file'][accept='image/png,image/jpeg']")
+      end
+    end
+
+    context "as an array" do
+      let(:options) { {accept: %w[.png .jpg]} }
+
+      it "joins into the accept attribute" do
+        expect(component).to have_css("input[type='file'][accept='.png,.jpg']")
+      end
+    end
+
+    context "when omitted" do
+      it "renders no accept attribute" do
+        expect(component).to have_no_css("input[type='file'][accept]")
+      end
+    end
+  end
 end

--- a/spec/components/form/file_upload/component_spec.rb
+++ b/spec/components/form/file_upload/component_spec.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Form::FileUpload::Component, type: :component do
+  let(:user) { User.new }
+  let(:form_builder) do
+    BikeIndexFormBuilder.new(:user, user, ActionView::Base.new(ActionView::LookupContext.new([]), {}, nil), {})
+  end
+  let(:component) { render_inline(described_class.new(form_builder:, attribute:, html_options:)) }
+  let(:attribute) { :avatar }
+  let(:html_options) { {} }
+
+  it "renders a labelless file input" do
+    expect(component).to have_css("input[type='file'][name='user[avatar]']")
+    expect(component).to have_no_css("label")
+    expect(component.to_html).to include("twinput")
+    expect(component.to_html).to include("tw:cursor-pointer")
+  end
+
+  context "with html_options" do
+    let(:html_options) { {accept: "image/png", multiple: true} }
+
+    it "passes options through" do
+      expect(component).to have_css("input[type='file'][accept='image/png']")
+      expect(component).to have_css("input[multiple]")
+    end
+
+    context "when overriding class" do
+      let(:html_options) { {class: "custom-upload"} }
+
+      it "replaces the default class" do
+        expect(component).to have_css("input.custom-upload")
+        expect(component.to_html).to_not include("twinput")
+      end
+    end
+  end
+end

--- a/spec/components/form/file_upload/component_system_spec.rb
+++ b/spec/components/form/file_upload/component_system_spec.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Form::FileUpload::Component, :js, type: :system do
+  let(:base_path) { "/rails/view_components/form/file_upload/component/" }
+
+  context "default" do
+    it "shows the selected filename in the field" do
+      visit("#{base_path}default")
+
+      expect(page).to have_css("[data-form--file-upload-target='filename']", text: "No file chosen")
+
+      attach_file("file", Rails.root.join("spec/fixtures/bike.jpg").to_s, make_visible: true)
+
+      expect(page).to have_css("[data-form--file-upload-target='filename']", text: "bike.jpg")
+    end
+  end
+end

--- a/spec/integration/organized/manage_spec.rb
+++ b/spec/integration/organized/manage_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Organized manage", :js, type: :system do
+  let(:organization) { FactoryBot.create(:organization) }
+  let(:user) { FactoryBot.create(:organization_admin, organization:) }
+
+  before do
+    visit new_session_path
+    fill_in "Email", with: user.email
+    fill_in "Password", with: "testthisthing7$"
+    click_button "Log in"
+  end
+
+  it "shows the chosen filename in the organization logo field" do
+    visit "/o/#{organization.to_param}/manage"
+
+    expect(page).to have_css("[data-form--file-upload-target='filename']", text: "No file chosen")
+
+    attach_file("organization[avatar]", Rails.root.join("spec/fixtures/bike.jpg").to_s, make_visible: true)
+
+    expect(page).to have_css("[data-form--file-upload-target='filename']", text: "bike.jpg")
+  end
+end

--- a/spec/integration/organized/manage_spec.rb
+++ b/spec/integration/organized/manage_spec.rb
@@ -3,8 +3,10 @@
 require "rails_helper"
 
 RSpec.describe "Organized manage", :js, type: :system do
-  let(:organization) { FactoryBot.create(:organization) }
+  let(:organization) { FactoryBot.create(:organization, name: "Old name", website: nil) }
   let(:user) { FactoryBot.create(:organization_admin, organization:) }
+  # An existing location keeps the manage form from rendering the required new-location sub-form
+  let!(:location) { FactoryBot.create(:location, organization:) }
 
   before do
     visit new_session_path
@@ -13,13 +15,27 @@ RSpec.describe "Organized manage", :js, type: :system do
     click_button "Log in"
   end
 
-  it "shows the chosen filename in the organization logo field" do
+  it "updates organization fields and attaches the logo" do
     visit "/o/#{organization.to_param}/manage"
 
+    fill_in "Name", with: "New name"
+    fill_in "Website", with: "https://example.com"
+    check "Send emails directly to unclaimed bike owners."
+
     expect(page).to have_css("[data-form--file-upload-target='filename']", text: "No file chosen")
-
     attach_file("organization[avatar]", Rails.root.join("spec/fixtures/bike.jpg").to_s, make_visible: true)
-
+    # the Form::FileUpload Stimulus controller reflects the chosen file in the field
     expect(page).to have_css("[data-form--file-upload-target='filename']", text: "bike.jpg")
+
+    within("form.organized-form") { click_button "Update" }
+
+    expect(page).to have_content("updated successfully")
+
+    organization.reload
+    expect(organization.name).to eq "New name"
+    expect(organization.website).to eq "https://example.com"
+    expect(organization.direct_unclaimed_notifications).to be true
+    expect(organization.avatar?).to be_truthy
+    expect(organization.avatar_identifier).to eq "bike.jpg"
   end
 end


### PR DESCRIPTION
Adds a `Form::FileUpload` ViewComponent and uses it for the organization logo upload.

The control is a native file input presented as a button plus a selected-filename display, built on standard form semantics so it's accessible by default:

- **Accessible, button-styled control** — a real `form_builder.label` associated with the input, styled as a secondary `UI::Button` via `UI::Button::Component.build_classes` (so it inherits the hover/active states); the keyboard-focus ring is surfaced on the button through `peer-focus-visible`.
- **Native input, hidden not removed** — the `file_field` is `sr-only` (visually hidden but still focusable and in the accessibility tree), so the label provides the accessible name while the OS picker keeps working.
- **Selected-filename display** — a `form--file-upload` Stimulus controller shows the chosen filename (or "N files" when multiple is set), with a configurable placeholder; long names truncate.
- **API** — `form_builder:` and `attribute:`, plus optional `accept:` (string or array of extensions), `button_text:`, `placeholder:`, and merged `html_options:`.
- **Adoption, previews & specs** — replaces the old `%label.file` Bootstrap markup on the org manage page (logo field), keeping `avatar_cache`; adds Lookbook previews (standalone and within `Form::Group`) and component/system/integration specs.
