### PR TITLE
Pin the Sprockets manifest to a fixed filename

### DIFF
--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -3,6 +3,14 @@
 # Version of your assets, change this if you want to expire all your assets.
 Rails.application.config.assets.version = "2.0"
 
+# Pin the Sprockets manifest to a fixed filename. Sprockets otherwise names it
+# .sprockets-manifest-<random>.json, and Kamal bridges assets across deploys with
+# `cp -n` (no-clobber), so stale manifests pile up in the shared asset volume and a
+# boot can resolve through an old one -- serving outdated digests (a relative import
+# then 404s). A fixed name keeps the current deploy's manifest authoritative. Must be
+# unconditional so precompile (any RAILS_ENV) and runtime agree on the filename.
+Rails.application.config.assets.manifest = Rails.root.join("public/assets/.sprockets-manifest.json")
+
 # Precompile additional assets.
 # application.js, application.css, and all non-JS/CSS in the app/assets
 # folder are already added.


### PR DESCRIPTION
Pin the Sprockets manifest to a fixed filename so the current deploy's manifest is authoritative.

Sprockets names the manifest `.sprockets-manifest-<random>.json`. Kamal bridges assets across deploys with `cp -n` (no-clobber), so stale manifests accumulate in the shared asset volume and sprockets-rails can resolve through an old one — serving outdated digests (and, post-PR-3744, 404ing a relative controller import so the controller never loads). A fixed filename makes the live deploy authoritative and self-heals on the next deploy.
