### PR TITLE
Harden SpamEstimator against bot/scanner bike registrations

### DIFF
--- a/app/services/spam_estimator.rb
+++ b/app/services/spam_estimator.rb
@@ -29,11 +29,13 @@ module SpamEstimator
   def estimate_bike(bike, stolen_record = nil)
     estimate = 0
     return estimate if bike.blank?
-    return 100 if looks_malicious?(bike.cached_data)
+    # serial_number isn't in cached_data, and it's the most common injection target
+    return 100 if looks_malicious?(bike.cached_data) || looks_malicious?(bike.serial_number)
 
     estimate += 35 if bike.creation_organization&.spam_registrations
     estimate += 0.2 * string_spaminess(bike.frame_model)
     estimate += 0.4 * string_spaminess(bike.manufacturer_other)
+    estimate += 0.2 * string_spaminess(bike.serial_number)
     estimate += domain_estimate(bike.owner_email)
     estimate += estimate_stolen_record(stolen_record || bike.current_stolen_record)
 

--- a/app/services/spam_estimator.rb
+++ b/app/services/spam_estimator.rb
@@ -35,7 +35,6 @@ module SpamEstimator
     estimate += 35 if bike.creation_organization&.spam_registrations
     estimate += 0.2 * string_spaminess(bike.frame_model)
     estimate += 0.4 * string_spaminess(bike.manufacturer_other)
-    estimate += 0.2 * string_spaminess(bike.serial_number)
     estimate += domain_estimate(bike.owner_email)
     estimate += estimate_stolen_record(stolen_record || bike.current_stolen_record)
 

--- a/app/services/spam_estimator.rb
+++ b/app/services/spam_estimator.rb
@@ -11,8 +11,19 @@ module SpamEstimator
     \b(?:drop|truncate)\s+table\b |
     \b(?:delete\s+from|insert\s+into)\b |
     ['"]\s*or\s+['"]?\d+['"]?\s*=\s*['"]?\d+ |
-    \bpg_sleep\s*\( |
+    \b(?:pg_sleep|sleep)\s*\( |
+    \bwaitfor\s+delay\b |
+    \bdbms_pipe\.receive_message\b |
+    \bxor\s*\( |
+    \bselect\b[^;]*\bfrom\s+dual\b |
+    \bsysdate\s*\( |
     ;\s*(?:drop|delete|truncate|exec)\b
+  /xi
+
+  # RFC 2606 / 6761 reserved domains, which can never be a real registrant
+  RESERVED_EMAIL_DOMAIN_REGEX = /
+    \A(?:.+\.)?example\.(?:com|net|org)\z |
+    (?:\A|\.)(?:test|example|invalid|localhost)\z
   /xi
 
   def estimate_bike(bike, stolen_record = nil)
@@ -58,8 +69,17 @@ module SpamEstimator
     str.match?(MALICIOUS_REGEX)
   end
 
+  def reserved_email_domain?(email)
+    domain = email&.split("@")&.last&.strip
+    return false if domain.blank?
+
+    domain.match?(RESERVED_EMAIL_DOMAIN_REGEX)
+  end
+
   def domain_estimate(email)
     return 0 unless EmailDomain::VERIFICATION_ENABLED
+    # RFC-reserved domains (e.g. example.com) are never a real registrant
+    return 100 if reserved_email_domain?(email)
 
     email_domain = EmailDomain.find_or_create_for(email)
 
@@ -185,7 +205,7 @@ module SpamEstimator
     I18n.transliterate(str).downcase
   end
 
-  conceal :looks_malicious?, :domain_estimate, :estimate_stolen_record,
+  conceal :looks_malicious?, :reserved_email_domain?, :domain_estimate, :estimate_stolen_record,
     :vowel_frequency_suspiciousness, :vowel_ratio,
     :capital_count_suspiciousness, :non_letter_count_suspiciousness,
     :space_count_suspiciousness, :within_bounds, :downcase_transliterate

--- a/app/services/spam_estimator.rb
+++ b/app/services/spam_estimator.rb
@@ -11,7 +11,8 @@ module SpamEstimator
     \b(?:drop|truncate)\s+table\b |
     \b(?:delete\s+from|insert\s+into)\b |
     ['"]\s*or\s+['"]?\d+['"]?\s*=\s*['"]?\d+ |
-    \b(?:pg_sleep|sleep)\s*\( |
+    \bpg_sleep\s*\( |
+    \bsleep\s*\(\s*\d |
     \bwaitfor\s+delay\b |
     \bdbms_pipe\.receive_message\b |
     \bxor\s*\( |

--- a/app/services/spam_estimator.rb
+++ b/app/services/spam_estimator.rb
@@ -35,6 +35,7 @@ module SpamEstimator
     estimate += 35 if bike.creation_organization&.spam_registrations
     estimate += 0.2 * string_spaminess(bike.frame_model)
     estimate += 0.4 * string_spaminess(bike.manufacturer_other)
+    estimate += 50 if low_entropy_fingerprint?(bike)
     estimate += domain_estimate(bike.owner_email)
     estimate += estimate_stolen_record(stolen_record || bike.current_stolen_record)
 
@@ -68,6 +69,15 @@ module SpamEstimator
     return false if str.blank?
 
     str.match?(MALICIOUS_REGEX)
+  end
+
+  # Bots reuse one junk value across every field; matching 1-2 char fields are never a real bike
+  def low_entropy_fingerprint?(bike)
+    fields = [bike.serial_number, bike.frame_model, bike.manufacturer_other]
+      .map { |value| value&.strip&.downcase }
+    return false if fields.any?(&:blank?)
+
+    fields.uniq.one? && fields.first.length <= 2
   end
 
   def reserved_email_domain?(email)
@@ -206,7 +216,7 @@ module SpamEstimator
     I18n.transliterate(str).downcase
   end
 
-  conceal :looks_malicious?, :reserved_email_domain?, :domain_estimate, :estimate_stolen_record,
+  conceal :looks_malicious?, :low_entropy_fingerprint?, :reserved_email_domain?, :domain_estimate, :estimate_stolen_record,
     :vowel_frequency_suspiciousness, :vowel_ratio,
     :capital_count_suspiciousness, :non_letter_count_suspiciousness,
     :space_count_suspiciousness, :within_bounds, :downcase_transliterate

--- a/app/services/spam_estimator.rb
+++ b/app/services/spam_estimator.rb
@@ -72,7 +72,7 @@ module SpamEstimator
     str.match?(MALICIOUS_REGEX)
   end
 
-  # Bots reuse one junk value across every field; matching 1-2 char fields are never a real bike
+  # Bots reuse one junk value across every field; matching 1-2 char fields are probably not a real bike
   def low_entropy_fingerprint?(bike)
     fields = [bike.serial_number, bike.frame_model, bike.manufacturer_other]
       .map { |value| value&.strip&.downcase }

--- a/spec/factories/b_params.rb
+++ b/spec/factories/b_params.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :b_param do
     transient do
-      owner_email { "bike_owner@example.com" }
+      owner_email { "bike_owner@bikeindex.org" }
     end
     creator { FactoryBot.create(:user) }
     params { {bike: {owner_email: owner_email}} }

--- a/spec/factories/bikes.rb
+++ b/spec/factories/bikes.rb
@@ -5,7 +5,7 @@ FactoryBot.define do
     creator { FactoryBot.create(:user) }
     serial_number
     manufacturer { FactoryBot.create(:manufacturer) }
-    sequence(:owner_email) { |n| "bike_owner#{n}@example.com" }
+    sequence(:owner_email) { |n| "bike_owner#{n}@bikeindex.org" }
     primary_frame_color { Color.black }
     cycle_type { CycleType.slugs.first }
     propulsion_type { "foot-pedal" }

--- a/spec/jobs/email/ownership_invitation_job_spec.rb
+++ b/spec/jobs/email/ownership_invitation_job_spec.rb
@@ -51,6 +51,8 @@ RSpec.describe Email::OwnershipInvitationJob, type: :job do
   end
   context "ownership is for a banned domain" do
     before { stub_const("EmailDomain::VERIFICATION_ENABLED", true) }
+    # non-reserved domain, so the status under test - not RFC-reserved detection - drives spaminess
+    let(:bike) { FactoryBot.create(:bike, :with_ownership, owner_email: "rider@registrant-domain.com") }
     let!(:email_domain) { FactoryBot.create(:email_domain, domain: bike.owner_email.gsub(/\A.*@/, ""), status:) }
     let(:status) { :permitted }
 

--- a/spec/jobs/email/ownership_invitation_job_spec.rb
+++ b/spec/jobs/email/ownership_invitation_job_spec.rb
@@ -51,7 +51,6 @@ RSpec.describe Email::OwnershipInvitationJob, type: :job do
   end
   context "ownership is for a banned domain" do
     before { stub_const("EmailDomain::VERIFICATION_ENABLED", true) }
-    # non-reserved domain, so the status under test - not RFC-reserved detection - drives spaminess
     let(:bike) { FactoryBot.create(:bike, :with_ownership, owner_email: "rider@registrant-domain.com") }
     let!(:email_domain) { FactoryBot.create(:email_domain, domain: bike.owner_email.gsub(/\A.*@/, ""), status:) }
     let(:status) { :permitted }

--- a/spec/services/spam_estimator_spec.rb
+++ b/spec/services/spam_estimator_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe SpamEstimator do
       end
     end
     context "manufacturer_other" do
-      let(:bike) { FactoryBot.build(:bike, manufacturer: Manufacturer.other, manufacturer_other: str, serial_number: "unknown") }
+      let(:bike) { FactoryBot.build(:bike, manufacturer: Manufacturer.other, manufacturer_other: str) }
       context "garbage" do
         let(:str) { "VhriBJhD1nuwHoI9VhriBJhD1nuwHoI9" }
         it "estimate is percentage" do
@@ -71,11 +71,10 @@ RSpec.describe SpamEstimator do
           expect(described_class.estimate_bike(bike)).to eq 100
         end
       end
-      context "garbage" do
+      context "random-looking but not malicious" do
         let(:serial) { "VhriBJhD1nuwHoI9VhriBJhD1nuwHoI9" }
-        it "contributes to the estimate" do
-          expect(described_class.string_spaminess(serial)).to eq 100
-          expect(described_class.estimate_bike(bike)).to eq 20
+        it "is 0 (serial only scores via the injection check)" do
+          expect(described_class.estimate_bike(bike)).to eq 0
         end
       end
     end

--- a/spec/services/spam_estimator_spec.rb
+++ b/spec/services/spam_estimator_spec.rb
@@ -62,6 +62,13 @@ RSpec.describe SpamEstimator do
         expect(described_class.estimate_bike(bike)).to eq 100
       end
     end
+    context "reserved owner_email domain" do
+      before { stub_const("EmailDomain::VERIFICATION_ENABLED", true) }
+      let(:bike) { Bike.new(owner_email: "testing@example.com") }
+      it "returns 100" do
+        expect(described_class.estimate_bike(bike)).to eq 100
+      end
+    end
     context "stolen_record" do
       let(:bike) { Bike.new }
       let(:stolen_record) { StolenRecord.new(theft_description: str, street: street) }
@@ -282,6 +289,29 @@ RSpec.describe SpamEstimator do
       expect(described_class.send(:looks_malicious?, "x'; DELETE FROM bikes WHERE 1=1; --")).to be_truthy
       expect(described_class.send(:looks_malicious?, "admin'; INSERT INTO users VALUES('a')--")).to be_truthy
       expect(described_class.send(:looks_malicious?, "ndbGRKFw')) OR 96=(SELECT 96 FROM PG_SLEEP(15))--")).to be_truthy
+    end
+
+    it "detects time-based blind SQL injection attempts" do
+      expect(described_class.send(:looks_malicious?, "1-1 waitfor delay '0:0:15' --")).to be_truthy
+      expect(described_class.send(:looks_malicious?, "1*if(now()=sysdate(),sleep(15),0)")).to be_truthy
+      expect(described_class.send(:looks_malicious?, "1'||DBMS_PIPE.RECEIVE_MESSAGE(CHR(98)||CHR(98),15)||'")).to be_truthy
+      expect(described_class.send(:looks_malicious?, "10\"XOR(1*if(now()=sysdate(),sleep(15),0))XOR\"Z")).to be_truthy
+      expect(described_class.send(:looks_malicious?, "(select 198766*667891 from DUAL)")).to be_truthy
+    end
+  end
+
+  describe "reserved_email_domain?" do
+    it "is false for normal domains" do
+      expect(described_class.send(:reserved_email_domain?, "rider@gmail.com")).to be_falsey
+      expect(described_class.send(:reserved_email_domain?, "rider@myexample.com")).to be_falsey
+      expect(described_class.send(:reserved_email_domain?, nil)).to be_falsey
+    end
+
+    it "is true for RFC 2606 reserved domains" do
+      expect(described_class.send(:reserved_email_domain?, "testing@example.com")).to be_truthy
+      expect(described_class.send(:reserved_email_domain?, "a@sub.example.org")).to be_truthy
+      expect(described_class.send(:reserved_email_domain?, "a@thing.test")).to be_truthy
+      expect(described_class.send(:reserved_email_domain?, "a@localhost")).to be_truthy
     end
   end
 

--- a/spec/services/spam_estimator_spec.rb
+++ b/spec/services/spam_estimator_spec.rb
@@ -78,6 +78,19 @@ RSpec.describe SpamEstimator do
         end
       end
     end
+    context "low-entropy fingerprint" do
+      let(:bike) { Bike.new(serial_number: str, frame_model: str, manufacturer_other: str) }
+      let(:str) { "xy" }
+      it "adds a penalty" do
+        expect(described_class.estimate_bike(bike)).to eq 50
+      end
+      context "longer than 2 chars" do
+        let(:str) { "xyz" }
+        it "is not penalized" do
+          expect(described_class.estimate_bike(bike)).to eq 0
+        end
+      end
+    end
     context "reserved owner_email domain" do
       before { stub_const("EmailDomain::VERIFICATION_ENABLED", true) }
       let(:bike) { Bike.new(owner_email: "testing@example.com") }
@@ -313,6 +326,23 @@ RSpec.describe SpamEstimator do
       expect(described_class.send(:looks_malicious?, "1'||DBMS_PIPE.RECEIVE_MESSAGE(CHR(98)||CHR(98),15)||'")).to be_truthy
       expect(described_class.send(:looks_malicious?, "10\"XOR(1*if(now()=sysdate(),sleep(15),0))XOR\"Z")).to be_truthy
       expect(described_class.send(:looks_malicious?, "(select 198766*667891 from DUAL)")).to be_truthy
+    end
+  end
+
+  describe "low_entropy_fingerprint?" do
+    def fingerprint?(bike)
+      described_class.send(:low_entropy_fingerprint?, bike)
+    end
+
+    it "is true when serial/frame_model/manufacturer_other match and are 1-2 chars" do
+      expect(fingerprint?(Bike.new(serial_number: "x", frame_model: "x", manufacturer_other: "x"))).to be_truthy
+      expect(fingerprint?(Bike.new(serial_number: "AB", frame_model: " ab", manufacturer_other: "ab "))).to be_truthy
+    end
+
+    it "is false when a field is blank, fields differ, or longer than 2 chars" do
+      expect(fingerprint?(Bike.new(serial_number: "x", frame_model: "x"))).to be_falsey
+      expect(fingerprint?(Bike.new(serial_number: "x", frame_model: "y", manufacturer_other: "z"))).to be_falsey
+      expect(fingerprint?(Bike.new(serial_number: "xyz", frame_model: "xyz", manufacturer_other: "xyz"))).to be_falsey
     end
   end
 

--- a/spec/services/spam_estimator_spec.rb
+++ b/spec/services/spam_estimator_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe SpamEstimator do
       end
     end
     context "manufacturer_other" do
-      let(:bike) { FactoryBot.build(:bike, manufacturer: Manufacturer.other, manufacturer_other: str) }
+      let(:bike) { FactoryBot.build(:bike, manufacturer: Manufacturer.other, manufacturer_other: str, serial_number: "unknown") }
       context "garbage" do
         let(:str) { "VhriBJhD1nuwHoI9VhriBJhD1nuwHoI9" }
         it "estimate is percentage" do
@@ -60,6 +60,23 @@ RSpec.describe SpamEstimator do
       it "returns 100" do
         expect(bike.cached_data).to include("union select")
         expect(described_class.estimate_bike(bike)).to eq 100
+      end
+    end
+    context "serial_number" do
+      let(:bike) { Bike.new(serial_number: serial) }
+      context "malicious" do
+        let(:serial) { "x'; DROP TABLE bikes; --" }
+        it "returns 100" do
+          expect(bike.cached_data).to be_blank # the payload is in serial_number, not cached_data
+          expect(described_class.estimate_bike(bike)).to eq 100
+        end
+      end
+      context "garbage" do
+        let(:serial) { "VhriBJhD1nuwHoI9VhriBJhD1nuwHoI9" }
+        it "contributes to the estimate" do
+          expect(described_class.string_spaminess(serial)).to eq 100
+          expect(described_class.estimate_bike(bike)).to eq 20
+        end
       end
     end
     context "reserved owner_email domain" do

--- a/spec/services/spam_estimator_spec.rb
+++ b/spec/services/spam_estimator_spec.rb
@@ -320,6 +320,10 @@ RSpec.describe SpamEstimator do
       expect(described_class.send(:looks_malicious?, "ndbGRKFw')) OR 96=(SELECT 96 FROM PG_SLEEP(15))--")).to be_truthy
     end
 
+    it "is false for benign words that brush against SQL tokens" do
+      expect(described_class.send(:looks_malicious?, "Time to sleep (soon)")).to be_falsey
+    end
+
     it "detects time-based blind SQL injection attempts" do
       expect(described_class.send(:looks_malicious?, "1-1 waitfor delay '0:0:15' --")).to be_truthy
       expect(described_class.send(:looks_malicious?, "1*if(now()=sysdate(),sleep(15),0)")).to be_truthy


### PR DESCRIPTION
Hardens `SpamEstimator` against the bot/scanner traffic registering bikes, which was scoring well under `MARK_SPAM_PERCENT` despite obvious payloads.

- **Reserved email domains** — RFC 2606/6761 domains (`example.com/.net/.org`, `.test/.invalid/.localhost`) are treated as spam ahead of the `EmailDomain` lookup, behind `VERIFICATION_ENABLED` so test fixtures are unaffected.
- **Time-based blind SQLi** — `MALICIOUS_REGEX` now catches the families it was missing (`WAITFOR DELAY`, MySQL `sleep()`, Oracle `DBMS_PIPE.RECEIVE_MESSAGE`, `XOR`/`sysdate`, `FROM DUAL`).
- **serial_number** — the most common injection target was absent from `cached_data` and every scored field, so payloads in the serial scored 0. It now runs the malicious check (hard 100). Real serials are random-looking, so it's deliberately not run through the linguistic spaminess score.
- **Low-entropy fingerprint** — bots reuse one junk value across `serial_number`, `frame_model`, and `manufacturer_other`; matching 1-2 char fields add a 50-point penalty.
- Factory `owner_email`s moved off `example.com` so they aren't caught by the new reserved-domain rule.
