### PR TITLE
Add inert active/pressed variants and aria support to UI::Button

### DIFF
--- a/app/components/ui/button/component.rb
+++ b/app/components/ui/button/component.rb
@@ -25,6 +25,14 @@ module UI
         link: "tw:text-blue-800 tw:dark:text-blue-300 tw:font-bold"
       }.freeze
 
+      # Literal strings so Tailwind's scanner generates these aria-pressed:/active: variants.
+      ACTIVE_PREFIXED = {
+        primary: "tw:aria-pressed:ring-2 tw:active:ring-2 tw:aria-pressed:ring-blue-500/40 tw:active:ring-blue-500/40 tw:aria-pressed:bg-blue-700 tw:active:bg-blue-700 tw:aria-pressed:dark:bg-blue-600 tw:active:dark:bg-blue-600",
+        secondary: "tw:aria-pressed:ring-2 tw:active:ring-2 tw:aria-pressed:ring-blue-500/40 tw:active:ring-blue-500/40 tw:aria-pressed:bg-gray-200 tw:active:bg-gray-200 tw:aria-pressed:border-gray-400 tw:active:border-gray-400 tw:aria-pressed:dark:bg-gray-800 tw:active:dark:bg-gray-800 tw:aria-pressed:dark:border-gray-600 tw:active:dark:border-gray-600",
+        error: "tw:aria-pressed:ring-2 tw:active:ring-2 tw:aria-pressed:ring-red-500/40 tw:active:ring-red-500/40 tw:aria-pressed:bg-red-700 tw:active:bg-red-700 tw:aria-pressed:dark:bg-red-600 tw:active:dark:bg-red-600",
+        link: "tw:aria-pressed:text-blue-800 tw:active:text-blue-800 tw:aria-pressed:dark:text-blue-300 tw:active:dark:text-blue-300 tw:aria-pressed:font-bold tw:active:font-bold"
+      }.freeze
+
       KINDS = %i[button submit]
 
       def self.build_classes(color:, size:, active: false, html_class: nil)
@@ -34,23 +42,25 @@ module UI
           classes << "tw:focus:outline-none tw:focus:ring-3 tw:font-medium tw:no-underline"
         end
         classes << ACTIVE_COLORS[color] if active
+        classes << ACTIVE_PREFIXED[color]
         classes.compact.join(" ")
       end
 
-      def initialize(text: nil, color: :secondary, size: :md, active: false, html_class: nil, kind: nil, data: {})
+      def initialize(text: nil, color: :secondary, size: :md, active: false, html_class: nil, kind: nil, data: {}, aria: {})
         @text = text
         @color = COLORS.key?(color) ? color : :secondary
         @kind = KINDS.include?(kind&.to_sym) ? kind.to_sym : KINDS.first
         @active = active
         @html_class = html_class
         @data = data
+        @aria = aria
 
         @size = SIZES.key?(size) ? size : :md
         raise ArgumentError, "size is not supported for link color" if @color == :link && @size != :md
       end
 
       def call
-        content_tag(:button, @text || content, class: button_classes, type: (@kind == :submit) ? "submit" : "button", data: @data)
+        content_tag(:button, @text || content, class: button_classes, type: (@kind == :submit) ? "submit" : "button", data: @data, aria: @aria)
       end
 
       def button_classes

--- a/spec/components/ui/button/component_spec.rb
+++ b/spec/components/ui/button/component_spec.rb
@@ -109,4 +109,38 @@ RSpec.describe UI::Button::Component, type: :component do
       expect(component).to have_css("button[data-action='click->ui--modal#open']")
     end
   end
+
+  it "always applies the prefixed active classes (inert until pressed/toggled)" do
+    tokens = component.css("button").first["class"].split
+    expect(tokens).to include("tw:aria-pressed:ring-2", "tw:active:ring-2")
+    expect(tokens).not_to include("tw:ring-2", "tw:bg-gray-200")
+  end
+
+  context "with aria-controls" do
+    let(:options) { {aria: {controls: "panel"}} }
+    it "renders aria-controls" do
+      expect(component.to_html).to include('aria-controls="panel"')
+    end
+  end
+
+  context "active: true" do
+    let(:options) { {active: true} }
+    it "applies the bare active classes statically" do
+      tokens = component.css("button").first["class"].split
+      expect(tokens).to include("tw:ring-2", "tw:bg-gray-200")
+    end
+  end
+
+  describe "ACTIVE_PREFIXED" do
+    it "prefixes every ACTIVE_COLORS class with aria-pressed: and active: for each color" do
+      expect(described_class::ACTIVE_PREFIXED.keys).to eq(described_class::ACTIVE_COLORS.keys)
+      described_class::ACTIVE_COLORS.each do |color, classes|
+        expected = classes.split.flat_map do |variant|
+          base = variant.delete_prefix("tw:")
+          ["tw:aria-pressed:#{base}", "tw:active:#{base}"]
+        end
+        expect(described_class::ACTIVE_PREFIXED[color].split).to eq(expected)
+      end
+    end
+  end
 end


### PR DESCRIPTION
Pulls the `UI::Button` updates from the design system into Bike Index, adapted to our `tw:` class-prefix convention.

- Buttons now always carry `aria-pressed:`/`active:` variants of their active styling (`ACTIVE_PREFIXED`), so they highlight when pressed or toggled without needing `active: true` baked in. The bare `ACTIVE_COLORS` still apply statically when `active: true`.
- Adds an `aria:` keyword arg passed through to the button element (enables `aria-controls` and friends).

The variants are written as literal strings so Tailwind's scanner emits them; a spec asserts `ACTIVE_PREFIXED` stays in lockstep with `ACTIVE_COLORS`.
