### PR TITLE
Add axis direction support to CollapseUtils

### DIFF
--- a/app/javascript/utils/collapse_utils.js
+++ b/app/javascript/utils/collapse_utils.js
@@ -7,11 +7,12 @@
 export class CollapseUtils {
   /**
    * Handle collapsing or showing elements with animation
-   * @param {string} action - 'show' or 'hide'
+   * @param {string} action - 'show', 'hide', or 'toggle'
    * @param {HTMLElement|HTMLElement[]} element - The element(s) to manipulate
    * @param {number} duration - Animation duration in milliseconds
+   * @param {string} direction - 'vertical' (height) or 'horizontal' (width)
    */
-  static collapse (action, element, duration) {
+  static collapse (action, element, duration, direction = 'vertical') {
     if (!element) {
       console.warn('Cannot collapse undefined or null element')
       return
@@ -19,60 +20,92 @@ export class CollapseUtils {
 
     // Handle arrays of elements
     if (Array.isArray(element)) {
-      element.forEach(el => this.collapse(action, el, duration))
+      element.forEach(el => this.collapse(action, el, duration, direction))
       return
     }
 
     if (action === 'show') {
-      this.show(element, duration)
+      this.show(element, duration, direction)
     } else if (action === 'hide') {
-      this.hide(element, duration)
+      this.hide(element, duration, direction)
     } else if (action === 'toggle') {
-      this.toggle(element, duration)
+      this.toggle(element, duration, direction)
     } else {
       console.warn(`Invalid CollapseUtils action: ${action}. must be one of: 'show', 'hide', 'toggle'`)
     }
+  }
+
+  // The measured dimension, the styles to animate, and the collapse scale class
+  // for the axis. Horizontal drives flex-basis too, since a flex-row item is
+  // sized by its basis rather than its width.
+  static axis (direction) {
+    return direction === 'horizontal'
+      ? { dimension: 'width', styles: ['width', 'flexBasis'], scale: 'tw:scale-x-0' }
+      : { dimension: 'height', styles: ['height'], scale: 'tw:scale-y-0' }
+  }
+
+  // The element's natural rendered size along the axis (flex-aware, unlike
+  // scrollWidth/scrollHeight, so a shrunk flex item animates to its real size).
+  static naturalSize (element, dimension) {
+    return element.getBoundingClientRect()[dimension]
+  }
+
+  static setSize (element, styles, value) {
+    styles.forEach((style) => { element.style[style] = value })
+  }
+
+  // Reading a layout property forces a synchronous reflow, committing pending
+  // style changes so the following change animates from them.
+  static reflow (element) {
+    return element.offsetWidth
   }
 
   /**
    * Toggle element visibility
    * @param {HTMLElement} element - The element to toggle
    * @param {number} duration - Animation duration in milliseconds
+   * @param {string} direction - 'vertical' (height) or 'horizontal' (width)
    */
-  static toggle (element, duration) {
+  static toggle (element, duration, direction = 'vertical') {
     if (!element) return
 
     const isHidden = element.classList.contains('tw:hidden!') || element.classList.contains('tw:hidden')
-    this.collapse(isHidden ? 'show' : 'hide', element, duration)
+    this.collapse(isHidden ? 'show' : 'hide', element, duration, direction)
   }
 
   /**
    * Show/uncollapse an element with animation
    * @param {HTMLElement} element - The element to uncollapse
    * @param {number} duration - Animation duration in milliseconds
+   * @param {string} direction - 'vertical' (height) or 'horizontal' (width)
    */
-  static show (element, duration) {
+  static show (element, duration, direction = 'vertical') {
     // Cancel any in-flight hide() finalizer so it doesn't stamp tw:hidden! on us.
     this._cancelFinalizer(element)
+    const { dimension, styles, scale } = this.axis(direction)
     // Bail if already fully shown — but isVisible alone isn't enough: a hide()
     // mid-transition still has display:block/visibility:visible until its finalizer
-    // adds tw:hidden!, yet tw:scale-y-0 means the element is collapsed to 0.
-    if (this.isVisible(element) && !element.classList.contains('tw:scale-y-0')) return
+    // adds tw:hidden!, yet the scale class means the element is collapsed to 0.
+    if (this.isVisible(element) && !element.classList.contains(scale)) return
     // Remove the hidden
     element.classList.remove('tw:hidden!', 'tw:hidden')
+    // Measure the natural size while visible, before collapsing to 0.
+    const target = this.naturalSize(element, dimension)
     // First, ensure the hidden attributes are set
-    element.classList.add('tw:scale-y-0')
-    element.style.height = 0
+    element.classList.add(scale)
+    this.setSize(element, styles, 0)
     // Always add transition classes (moving toward a more generalizable collapse method)
     element.classList.add('tw:transition-all', `tw:duration-${duration}`)
     // Remove things that transition to hide the element
-    element.classList.remove('tw:scale-y-0')
-    // Set the element's height to its natural height to expand it
-    element.style.height = `${element.scrollHeight}px`
+    element.classList.remove(scale)
+    // Force a reflow so the browser commits the 0 size before transitioning.
+    this.reflow(element)
+    // Set the element's size to its natural size to expand it
+    this.setSize(element, styles, `${target}px`)
 
-    // After transition is complete, remove explicit height (clean up afterward)
+    // After transition is complete, remove explicit size (clean up afterward)
     element._collapseFinalizer = setTimeout(() => {
-      element.style.height = ''
+      this.setSize(element, styles, '')
       element._collapseFinalizer = null
     }, duration)
   }
@@ -81,20 +114,24 @@ export class CollapseUtils {
    * Hide/collapse an element with animation
    * @param {HTMLElement} element - The element to collapse
    * @param {number} duration - Animation duration in milliseconds
+   * @param {string} direction - 'vertical' (height) or 'horizontal' (width)
    */
-  static hide (element, duration) {
+  static hide (element, duration, direction = 'vertical') {
     this._cancelFinalizer(element)
     // Return early if already hidden
     if (!this.isVisible(element)) return
 
+    const { dimension, styles, scale } = this.axis(direction)
+    // Pin the current natural size so the transition has a starting point.
+    this.setSize(element, styles, this.naturalSize(element, dimension) + 'px')
     // Always add transition classes (moving toward a more generalizable collapse method)
     element.classList.add('tw:transition-all', `tw:duration-${duration}`)
     // Add the tailwind class to shrink
-    element.classList.add('tw:scale-y-0')
-    // Set an explicit height to enable the transition
-    element.style.height = element.scrollHeight + 'px'
-    // Transition to height 0
-    element.style.height = '0px'
+    element.classList.add(scale)
+    // Force a reflow so the browser commits the natural size before transitioning.
+    this.reflow(element)
+    // Transition to size 0
+    this.setSize(element, styles, '0px')
 
     // After transition completes, add display: none to remove element from the flow
     element._collapseFinalizer = setTimeout(() => {
@@ -130,7 +167,8 @@ export class CollapseUtils {
  * @param {string} action - 'show', 'hide', or 'toggle'
  * @param {HTMLElement} element - The element to manipulate
  * @param {number} duration - Animation duration in milliseconds
+ * @param {string} direction - 'vertical' (height) or 'horizontal' (width)
  */
-export function collapse (action, element, duration = 200) {
-  return CollapseUtils.collapse(action, element, duration)
+export function collapse (action, element, duration = 200, direction = 'vertical') {
+  return CollapseUtils.collapse(action, element, duration, direction)
 }

--- a/app/javascript/utils/collapse_utils.js
+++ b/app/javascript/utils/collapse_utils.js
@@ -89,9 +89,16 @@ export class CollapseUtils {
     if (this.isVisible(element) && !element.classList.contains(scale)) return
     // Remove the hidden
     element.classList.remove('tw:hidden!', 'tw:hidden')
+
+    // Skip animation if duration is 0
+    if (!duration) return
+
+    // A prior hide leaves the size/scale pinned to 0; reset before measuring.
+    element.classList.remove(scale)
+    this.setSize(element, styles, '')
     // Measure the natural size while visible, before collapsing to 0.
     const target = this.naturalSize(element, dimension)
-    // First, ensure the hidden attributes are set
+    // Collapse to 0 as the transition's starting point
     element.classList.add(scale)
     this.setSize(element, styles, 0)
     // Always add transition classes (moving toward a more generalizable collapse method)
@@ -120,6 +127,12 @@ export class CollapseUtils {
     this._cancelFinalizer(element)
     // Return early if already hidden
     if (!this.isVisible(element)) return
+
+    // Skip animation if duration is 0
+    if (!duration) {
+      element.classList.add('tw:hidden!')
+      return
+    }
 
     const { dimension, styles, scale } = this.axis(direction)
     // Pin the current natural size so the transition has a starting point.

--- a/spec/components/ui/period_select/component_system_spec.rb
+++ b/spec/components/ui/period_select/component_system_spec.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe UI::PeriodSelect::Component, :js, type: :system do
+  context "when toggling the custom range with the collapse controller" do
+    it "expands and collapses the custom form" do
+      # The default preview renders with period: "all", so the custom form
+      # starts collapsed (tw:hidden).
+      visit "/rails/view_components/ui/period_select/component/default"
+
+      # Collapsed (hidden), so the form's fields aren't visible.
+      expect(page).to have_no_button("Update")
+
+      click_button("custom")
+
+      # collapse#show removes the hidden class and animates the form open.
+      expect(page).to have_button("Update")
+      expect(page).to have_field("From")
+      expect(page).to have_field("To")
+
+      click_button("custom")
+
+      # collapse#hide animates it closed and re-adds the hidden class.
+      expect(page).to have_no_button("Update")
+
+      expect_axe_clean
+    end
+  end
+end


### PR DESCRIPTION
Adds axis support to `collapse_utils`, adapted to our `tw:` class-prefix convention (the `_collapseFinalizer` cancellation is preserved).

- Adds a `direction` param (`'vertical'` default, or `'horizontal'`) threaded through `collapse`/`toggle`/`show`/`hide` and the exported `collapse()`; the horizontal axis drives `flexBasis` too, since a flex-row item is sized by its basis.
- Switches measurement from `scrollHeight` to a flex-aware `getBoundingClientRect()` — resetting any size a prior `hide` pinned to 0 before measuring — and forces an explicit reflow so each transition animates from a committed starting size. A 0 `duration` short-circuits to the non-animated show/hide.
- Adds a `UI::PeriodSelect` `:js` system spec driving the collapse show/hide/toggle paths through the custom date-range form.

The horizontal path is unused today (no caller passes `'horizontal'`), so the spec exercises the vertical path.
