### PR TITLE
Install ImageMagick outside cache-apt-pkgs-action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -140,15 +140,20 @@ jobs:
       - name: Get CPU cores
         id: cpu-info
         run: echo "cpu-cores=$(nproc)" >> $GITHUB_OUTPUT
-      # install system dependencies, imagemagick included — apt ships v6, which
-      # matches production and is what mini_magick 5 uses when no `magick` (v7)
-      # binary is present.
+      # install system dependencies
       - uses: awalsh128/cache-apt-pkgs-action@latest
         with:
-          packages: google-chrome-stable curl gettext imagemagick libvips libcurl4-gnutls-dev libexpat1-dev libssl-dev libz-dev postgresql-client ripgrep
+          packages: google-chrome-stable curl gettext libvips libcurl4-gnutls-dev libexpat1-dev libssl-dev libz-dev postgresql-client ripgrep
           version: 1.3
-      - name: Ensure ImageMagick is available
-        run: echo $(identify --version)
+      # imagemagick can't go in the cached step above: `identify`/`convert` are
+      # update-alternatives symlinks created by the package's postinst, which
+      # doesn't run on cache restore. apt ships v6, matching production —
+      # mini_magick 5 uses `identify`/`convert` when there's no `magick` (v7).
+      - name: Install ImageMagick
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends imagemagick
+          identify --version
       # Checkout persists this App token (below) as the git creds so the sync
       # branch is pushed as the App — only a non-default-token push fires
       # `on: push`, which is what attaches the required checks to the PR.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -140,19 +140,16 @@ jobs:
       - name: Get CPU cores
         id: cpu-info
         run: echo "cpu-cores=$(nproc)" >> $GITHUB_OUTPUT
-      # install system dependencies
-      - uses: awalsh128/cache-apt-pkgs-action@latest
-        with:
-          packages: google-chrome-stable curl gettext libvips libcurl4-gnutls-dev libexpat1-dev libssl-dev libz-dev postgresql-client ripgrep
-          version: 1.3
-      # imagemagick can't go in the cached step above: `identify`/`convert` are
-      # update-alternatives symlinks created by the package's postinst, which
-      # doesn't run on cache restore. apt ships v6, matching production —
-      # mini_magick 5 uses `identify`/`convert` when there's no `magick` (v7).
-      - name: Install ImageMagick
+      # Plain apt, not cache-apt-pkgs-action: its restore skips package
+      # postinst scripts (losing update-alternatives binaries like imagemagick's
+      # `identify`), and on cache miss it pins versions from the runner's stale
+      # apt lists, 404s, silently installs nothing, and caches the empty result.
+      # imagemagick from apt is v6, matching production — mini_magick 5 uses
+      # `identify`/`convert` when there's no `magick` (v7) binary.
+      - name: Install system dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y --no-install-recommends imagemagick
+          sudo apt-get install -y --no-install-recommends google-chrome-stable curl gettext imagemagick libvips libcurl4-gnutls-dev libexpat1-dev libssl-dev libz-dev postgresql-client ripgrep
           identify --version
       # Checkout persists this App token (below) as the git creds so the sync
       # branch is pushed as the App — only a non-default-token push fires

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -39,18 +39,14 @@ jobs:
       - name: Get CPU cores
         id: cpu-info
         run: echo "cpu-cores=$(nproc)" >> $GITHUB_OUTPUT
-      # install system dependencies
-      - uses: awalsh128/cache-apt-pkgs-action@latest
-        with:
-          packages: google-chrome-stable curl gettext libvips libcurl4-gnutls-dev libexpat1-dev libssl-dev libz-dev postgresql-client ripgrep
-          version: 1.0
-      # imagemagick can't go in the cached step above: `identify`/`convert` are
-      # update-alternatives symlinks created by the package's postinst, which
-      # doesn't run on cache restore.
-      - name: Install ImageMagick
+      # Plain apt, not cache-apt-pkgs-action: its restore skips package
+      # postinst scripts (losing update-alternatives binaries like imagemagick's
+      # `identify`), and on cache miss it pins versions from the runner's stale
+      # apt lists, 404s, silently installs nothing, and caches the empty result.
+      - name: Install system dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y --no-install-recommends imagemagick
+          sudo apt-get install -y --no-install-recommends google-chrome-stable curl gettext imagemagick libvips libcurl4-gnutls-dev libexpat1-dev libssl-dev libz-dev postgresql-client ripgrep
           identify --version
       - name: Checkout code
         uses: actions/checkout@v7

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -64,3 +64,8 @@ jobs:
         run: bin/rails assets:precompile
       - name: Set up database
         run: bin/rails db:create db:schema:load:primary db:schema:load:analytics db:migrate db:seed
+        env:
+          # Seed bikes are registered to RFC-reserved domains (example.com),
+          # which SpamEstimator marks likely_spam — hiding every seeded org bike
+          # and crashing later seed steps that expect them to be visible.
+          SKIP_EMAIL_DOMAIN_VERIFICATION: "true"

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -64,8 +64,3 @@ jobs:
         run: bin/rails assets:precompile
       - name: Set up database
         run: bin/rails db:create db:schema:load:primary db:schema:load:analytics db:migrate db:seed
-        env:
-          # Seed bikes are registered to RFC-reserved domains (example.com),
-          # which SpamEstimator marks likely_spam — hiding every seeded org bike
-          # and crashing later seed steps that expect them to be visible.
-          SKIP_EMAIL_DOMAIN_VERIFICATION: "true"

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -42,8 +42,16 @@ jobs:
       # install system dependencies
       - uses: awalsh128/cache-apt-pkgs-action@latest
         with:
-          packages: google-chrome-stable curl gettext imagemagick libvips libcurl4-gnutls-dev libexpat1-dev libssl-dev libz-dev postgresql-client ripgrep
+          packages: google-chrome-stable curl gettext libvips libcurl4-gnutls-dev libexpat1-dev libssl-dev libz-dev postgresql-client ripgrep
           version: 1.0
+      # imagemagick can't go in the cached step above: `identify`/`convert` are
+      # update-alternatives symlinks created by the package's postinst, which
+      # doesn't run on cache restore.
+      - name: Install ImageMagick
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends imagemagick
+          identify --version
       - name: Checkout code
         uses: actions/checkout@v7
       # Install Ruby dependencies

--- a/bin/setup
+++ b/bin/setup
@@ -94,7 +94,10 @@ chdir APP_ROOT do
     system! "bin/rails dartsass:build"
 
     puts "\n== Seeding database =="
-    system! "bin/rake db:seed"
+    # Seed bikes are registered to RFC-reserved domains (example.com), which
+    # SpamEstimator marks likely_spam — hiding every seeded org bike and
+    # crashing later seed steps that expect them to be visible.
+    system!({"SKIP_EMAIL_DOMAIN_VERIFICATION" => "true"}, "bin/rake db:seed")
 
     puts "\n== Preparing test database (including parallelism) =="
     system! "bin/rake parallel:prepare"

--- a/bin/setup
+++ b/bin/setup
@@ -94,10 +94,7 @@ chdir APP_ROOT do
     system! "bin/rails dartsass:build"
 
     puts "\n== Seeding database =="
-    # Seed bikes are registered to RFC-reserved domains (example.com), which
-    # SpamEstimator marks likely_spam — hiding every seeded org bike and
-    # crashing later seed steps that expect them to be visible.
-    system!({"SKIP_EMAIL_DOMAIN_VERIFICATION" => "true"}, "bin/rake db:seed")
+    system! "bin/rake db:seed"
 
     puts "\n== Preparing test database (including parallelism) =="
     system! "bin/rake parallel:prepare"

--- a/db/seeds/seed_organization_bikes_and_associations.rb
+++ b/db/seeds/seed_organization_bikes_and_associations.rb
@@ -149,9 +149,11 @@ sample_notes = [
   "Frequent visitor, registered at orientation",
   "Needs new sticker - old one damaged"
 ]
-hogwarts.bike_organizations.limit(5).each_with_index do |bike_organization, index|
-  BikeOrganizationNote.upsert(bike: bike_organization.bike, organization: bike_organization.organization, body: sample_notes[index], user: member)
-  puts "  Added note for bike ##{bike_organization.bike_id} in #{bike_organization.organization.short_name}"
+# hogwarts.bikes rather than bike_organizations: the unregistered parking
+# notification bikes above are user_hidden, so their bike_organization.bike is nil
+hogwarts.bikes.limit(5).each_with_index do |bike, index|
+  BikeOrganizationNote.upsert(bike:, organization: hogwarts, body: sample_notes[index], user: member)
+  puts "  Added note for bike ##{bike.id} in #{hogwarts.short_name}"
 end
 
 # --- 5 impound records via BikeServices::Creator with status_impounded ---

--- a/db/seeds/seed_organization_bikes_and_associations.rb
+++ b/db/seeds/seed_organization_bikes_and_associations.rb
@@ -32,11 +32,13 @@ sf_locations = [
 
 pn_kinds = %w[appears_abandoned_notification parked_incorrectly_notification appears_abandoned_notification parked_incorrectly_notification]
 
+# Not @example.com: SpamEstimator scores RFC-reserved domains as 100, which
+# would mark every seeded bike likely_spam and hide it from Bike's default scope
 owner_emails = %w[
-  alice@example.com bob@example.com carol@example.com dave@example.com
-  eve@example.com frank@example.com grace@example.com heidi@example.com
-  ivan@example.com judy@example.com kevin@example.com laura@example.com
-  mike@example.com nora@example.com oscar@example.com
+  alice@bikeindex.org bob@bikeindex.org carol@bikeindex.org dave@bikeindex.org
+  eve@bikeindex.org frank@bikeindex.org grace@bikeindex.org heidi@bikeindex.org
+  ivan@bikeindex.org judy@bikeindex.org kevin@bikeindex.org laura@bikeindex.org
+  mike@bikeindex.org nora@bikeindex.org oscar@bikeindex.org
 ]
 
 creator = BikeServices::Creator.new

--- a/db/seeds/seed_organized_emails.rb
+++ b/db/seeds/seed_organized_emails.rb
@@ -220,7 +220,7 @@ unless transferred_bike_exists
         primary_frame_color_id: Color.pluck(:id).sample,
         rear_tire_narrow: "true",
         handlebar_type: HandlebarType.slugs.first,
-        owner_email: "previous-owner@example.com"
+        owner_email: "previous-owner@bikeindex.org"
       }
     })
   )
@@ -229,7 +229,7 @@ unless transferred_bike_exists
   BikeServices::Updator.new(
     user: user,
     bike: bike,
-    permitted_params: {bike: {owner_email: "new-owner@example.com"}}.as_json
+    permitted_params: {bike: {owner_email: "new-owner@bikeindex.org"}}.as_json
   ).update_available_attributes
   CallbackJob::AfterBikeSaveJob.new.perform(bike.id, true, true)
   puts "  Created transferred bike ##{bike.id}"


### PR DESCRIPTION
Fixes the CI failures on #3789/#3792 (MiniMagick `identify` missing) plus two more breakages that surfaced while verifying, all with the same theme: recent changes made CI setup silently install or hide less than it claimed.

**`cache-apt-pkgs-action` is broken two ways, so drop it.** On cache hit its restore skips package postinst scripts, losing `update-alternatives` symlinks — that's why `identify` vanished after #3790 despite imagemagick "being installed" (the `echo $(identify --version)` guard exits 0 even when the substitution fails). On cache miss it pins versions from the runner image's stale apt lists, 404s, silently installs nothing, and saves the empty result — poisoning the cache and leaving libvips missing. Both `ci.yml` and `copilot-setup-steps.yml` now install system deps with plain `apt-get update && apt-get install`, with a real `identify --version` guard (imagemagick from apt is v6, matching production).

**db:seed broken since #3780.** SpamEstimator now scores RFC-reserved email domains as 100, so every seeded org bike (registered to `alice@example.com` and friends) was marked `likely_spam` and hidden by `Bike`'s default scope — seeding crashed at sticker assignment and a fresh dev site showed no org bikes. Reproduced on a scratch database.

- Register seed bikes to `@bikeindex.org` addresses (the domain `seed_bikes.rb` already uses), which SpamEstimator doesn't flag — verified: full `db:seed` completes with zero `likely_spam` bikes
- Seed org notes from `hogwarts.bikes` instead of `bike_organizations` (the unregistered parking-notification bike is `user_hidden`, so its `bike_organization.bike` is nil)

After this merges, #3789 and #3792 just need main merged in and CI re-run.
