### PR TITLE
Fix CSP report crashes on malformed UTF-8 byte sequences

### DIFF
--- a/app/controllers/csp_reports_controller.rb
+++ b/app/controllers/csp_reports_controller.rb
@@ -8,15 +8,19 @@ class CspReportsController < ApplicationController
   TRANSLATE_DOCUMENT = /\.translate\.goog\z|translate\.google(apis)?\.com/
 
   def create
-    report = parsed_report(request.raw_post)
-    ForwardCspReportJob.perform_async(request.raw_post, current_user&.id) if send_report?(report)
+    # Browsers/bots occasionally send malformed byte sequences (e.g. overlong
+    # UTF-8) that raise downstream, both from Regexp#match? and from Sidekiq's
+    # JSON-encoding of the job args, so scrub once at the boundary.
+    body = request.raw_post.dup.force_encoding(Encoding::UTF_8).scrub
+    report = parsed_report(body)
+    ForwardCspReportJob.perform_async(body, current_user&.id) if send_report?(report)
     head :no_content
   end
 
   private
 
-  def parsed_report(raw_post)
-    parsed = JSON.parse(raw_post)
+  def parsed_report(body)
+    parsed = JSON.parse(body)
     parsed["csp-report"] if parsed.is_a?(Hash) && parsed["csp-report"].is_a?(Hash)
   rescue JSON::ParserError, TypeError
     nil

--- a/spec/requests/csp_reports_request_spec.rb
+++ b/spec/requests/csp_reports_request_spec.rb
@@ -61,6 +61,19 @@ RSpec.describe CspReportsController, type: :request do
       end
     end
 
+    context "invalid UTF-8 byte sequences" do
+      let(:raw_body) do
+        report.to_json.sub(blocked_uri, "#{blocked_uri}\xC0\xA7\xC0\xA2".force_encoding(Encoding::ASCII_8BIT))
+      end
+
+      it "scrubs the body instead of raising, and forwards the report" do
+        post base_url, params: raw_body,
+          headers: {"CONTENT_TYPE" => "application/csp-report", "HTTP_USER_AGENT" => user_agent}
+        expect(response.status).to eq(204)
+        expect(ForwardCspReportJob.jobs.count).to eq 1
+      end
+    end
+
     context "malformed body" do
       ["not json", "null", "123", {"csp-report" => 5}.to_json].each do |raw_body|
         it "returns 204 without enqueuing for #{raw_body.inspect}" do


### PR DESCRIPTION
Fixes three production Honeybadger faults (`ArgumentError: invalid byte sequence in UTF-8`, `JSON::GeneratorError`) all traced to malformed/overlong UTF-8 byte sequences in browser CSP violation reports.

- Scrub `request.raw_post` to valid UTF-8 once, at the point it enters `CspReportsController#create`, before it's regex-matched or handed to `ForwardCspReportJob`.
- Confirmed via the Honeybadger backtrace that the `JSON::GeneratorError` came from Sidekiq encoding the job args to push to Redis, not from our own JSON parsing.
- Adds a regression spec that posts a report with an injected invalid byte sequence.
