### PR TITLE
Fix CI chromedriver/Chrome mismatch causing :js spec flakes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -151,6 +151,11 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends google-chrome-stable curl gettext imagemagick libvips libcurl4-gnutls-dev libexpat1-dev libssl-dev libz-dev postgresql-client ripgrep
           identify --version
+          # The runner image ships a chromedriver that lags the apt google-chrome-stable
+          # version; leaving it on PATH makes Selenium use a mismatched driver (flaky
+          # keystroke/focus handling in :js specs). Remove it so Selenium Manager
+          # provisions a chromedriver matching the installed Chrome.
+          sudo rm -f "$(command -v chromedriver)" /usr/local/bin/chromedriver /usr/bin/chromedriver 2>/dev/null || true
       # Checkout persists this App token (below) as the git creds so the sync
       # branch is pushed as the App — only a non-default-token push fires
       # `on: push`, which is what attaches the required checks to the PR.

--- a/spec/integration/registration/edit_spec.rb
+++ b/spec/integration/registration/edit_spec.rb
@@ -43,14 +43,11 @@ RSpec.describe "Editing a registration", :js, type: :system do
   end
 
   # Types into a remote-autocomplete selectize (manufacturer fields) and picks the match.
-  # The option is loaded over AJAX, so nudge a keyup to ensure selectize fires its
-  # debounced remote load, then wait generously for the option to render on busy CI.
+  # The option is loaded over AJAX, so allow a longer wait for it to appear.
   def pick_remote_selectize(control, text)
     control.find(".selectize-input").click
-    input = control.find(".selectize-input input")
-    input.set(text)
-    input.send_keys(:space, :backspace)
-    control.find(".selectize-dropdown-content .option", text:, wait: 20).click
+    control.find(".selectize-input input").set(text)
+    control.find(".selectize-dropdown-content .option", text:, wait: 10).click
   end
 
   def save_bike

--- a/spec/integration/registration/edit_spec.rb
+++ b/spec/integration/registration/edit_spec.rb
@@ -43,11 +43,14 @@ RSpec.describe "Editing a registration", :js, type: :system do
   end
 
   # Types into a remote-autocomplete selectize (manufacturer fields) and picks the match.
-  # The option is loaded over AJAX, so allow a longer wait for it to appear.
+  # The option is loaded over AJAX, so nudge a keyup to ensure selectize fires its
+  # debounced remote load, then wait generously for the option to render on busy CI.
   def pick_remote_selectize(control, text)
     control.find(".selectize-input").click
-    control.find(".selectize-input input").set(text)
-    control.find(".selectize-dropdown-content .option", text:, wait: 10).click
+    input = control.find(".selectize-input input")
+    input.set(text)
+    input.send_keys(:space, :backspace)
+    control.find(".selectize-dropdown-content .option", text:, wait: 20).click
   end
 
   def save_bike


### PR DESCRIPTION
`spec/integration/registration/edit_spec.rb` intermittently fails at the manufacturer-correction step — the AJAX-loaded "Trek" option never renders ([example flake](https://github.com/bikeindex/bike_index/actions/runs/28601825299/job/84811756623)).

Root cause is a driver mismatch: the GitHub runner image ships a `chromedriver` that lags the apt-installed `google-chrome-stable`, so Selenium drives a mismatched driver (Selenium even warns about it), which intermittently drops keystrokes/focus in the correction modal so the autocomplete queries the wrong string. Bumping the Capybara wait didn't help (it still failed at 20s), confirming it's not a timing issue.

Fix: remove the stale `chromedriver` from PATH in CI so Selenium Manager provisions one matching the installed Chrome.
