### PR TITLE
Bake CI's system deps, Node, and Playwright into a container image

### DIFF
--- a/.github/ci/Dockerfile
+++ b/.github/ci/Dockerfile
@@ -1,25 +1,32 @@
 # syntax=docker/dockerfile:1
 # check=error=true
 
-# Tooling image for CI's `test` job (see ../workflows/ci.yml). Bakes the OS
-# packages, Node runtime, and Playwright's Chromium + OS deps that otherwise
-# get reinstalled from scratch on every one of the 5 parallel test shards.
+# Tooling image for CI's `test` job (see ../workflows/ci.yml). Bakes Ruby, the
+# OS packages, the Node runtime, and Playwright's Chromium + OS deps that
+# otherwise get reinstalled from scratch on every one of the 5 parallel test
+# shards.
 #
-# Ruby itself is deliberately NOT baked here: ruby/setup-ruby's own cached
-# install is already fast and also manages the gem cache, so duplicating it
-# would be dead weight. Gems and npm packages aren't baked either — they
-# change on every dependency bump, while these inputs change rarely, and
-# bundle/npm install already run fast off actions/cache.
+# Ruby is baked here (not left to ruby/setup-ruby) because that action
+# downloads a prebuilt binary sized for the full GitHub-hosted runner image —
+# inside a minimal container it fails to dynamically link
+# ("libruby.so.4.0: cannot open shared object file"). The official `ruby`
+# image (same one the root Dockerfile builds review apps from) doesn't have
+# that problem. Gems and npm packages still aren't baked — they change on
+# every dependency bump, while these inputs change rarely, and bundle/npm
+# install already run fast off actions/cache.
 #
 # Rebuilt automatically (ci.yml's build_ci_image job) whenever this file,
 # .tool-versions, or package.json changes.
 
-FROM docker.io/library/debian:bookworm-slim
+ARG RUBY_VERSION=4.0.5
+FROM docker.io/library/ruby:$RUBY_VERSION-slim
+
+ENV BUNDLE_PATH=/usr/local/bundle
 
 # Matches ci.yml's former "Install system dependencies" step (imagemagick,
 # libvips, curl, gettext, libcurl4-gnutls-dev, libexpat1-dev, libssl-dev,
 # libz-dev, postgresql-client, ripgrep), plus packages the GitHub-hosted
-# runner ships preinstalled that this minimal base doesn't: build-essential/
+# runner ships preinstalled that this slim base doesn't: build-essential/
 # libpq-dev/libyaml-dev/pkg-config (native gem compilation, e.g. pg), git
 # (required by actions/checkout inside a container job), ca-certificates and
 # xz-utils (fetching/unpacking Node below).

--- a/.github/ci/Dockerfile
+++ b/.github/ci/Dockerfile
@@ -27,9 +27,9 @@ ENV BUNDLE_PATH=/usr/local/bundle
 # libvips, curl, gettext, libcurl4-gnutls-dev, libexpat1-dev, libssl-dev,
 # libz-dev, postgresql-client, ripgrep), plus packages the GitHub-hosted
 # runner ships preinstalled that this slim base doesn't: build-essential/
-# libpq-dev/libyaml-dev/pkg-config (native gem compilation, e.g. pg), git
-# (required by actions/checkout inside a container job), ca-certificates and
-# xz-utils (fetching/unpacking Node below).
+# libpq-dev/libyaml-dev/libffi-dev/pkg-config (native gem compilation, e.g.
+# pg, fiddle), git (required by actions/checkout inside a container job),
+# ca-certificates and xz-utils (fetching/unpacking Node below).
 RUN apt-get update -qq && \
     apt-get install --no-install-recommends -y \
       build-essential \
@@ -40,6 +40,7 @@ RUN apt-get update -qq && \
       imagemagick \
       libcurl4-gnutls-dev \
       libexpat1-dev \
+      libffi-dev \
       libpq-dev \
       libssl-dev \
       libvips \

--- a/.github/ci/Dockerfile
+++ b/.github/ci/Dockerfile
@@ -1,0 +1,60 @@
+# syntax=docker/dockerfile:1
+# check=error=true
+
+# Tooling image for CI's `test` job (see ../workflows/ci.yml). Bakes the OS
+# packages, Node runtime, and Playwright's Chromium + OS deps that otherwise
+# get reinstalled from scratch on every one of the 5 parallel test shards.
+#
+# Ruby itself is deliberately NOT baked here: ruby/setup-ruby's own cached
+# install is already fast and also manages the gem cache, so duplicating it
+# would be dead weight. Gems and npm packages aren't baked either — they
+# change on every dependency bump, while these inputs change rarely, and
+# bundle/npm install already run fast off actions/cache.
+#
+# Rebuilt automatically (ci.yml's build_ci_image job) whenever this file,
+# .tool-versions, or package.json changes.
+
+FROM docker.io/library/debian:bookworm-slim
+
+# Matches ci.yml's former "Install system dependencies" step (imagemagick,
+# libvips, curl, gettext, libcurl4-gnutls-dev, libexpat1-dev, libssl-dev,
+# libz-dev, postgresql-client, ripgrep), plus packages the GitHub-hosted
+# runner ships preinstalled that this minimal base doesn't: build-essential/
+# libpq-dev/libyaml-dev/pkg-config (native gem compilation, e.g. pg), git
+# (required by actions/checkout inside a container job), ca-certificates and
+# xz-utils (fetching/unpacking Node below).
+RUN apt-get update -qq && \
+    apt-get install --no-install-recommends -y \
+      build-essential \
+      ca-certificates \
+      curl \
+      gettext \
+      git \
+      imagemagick \
+      libcurl4-gnutls-dev \
+      libexpat1-dev \
+      libpq-dev \
+      libssl-dev \
+      libvips \
+      libyaml-dev \
+      libz-dev \
+      pkg-config \
+      postgresql-client \
+      ripgrep \
+      xz-utils && \
+    rm -rf /var/lib/apt/lists /var/cache/apt/archives
+
+# Node, matching .tool-versions (see .cloud66/manifest.yml for the other pin)
+ARG NODE_VERSION=24.15.0
+RUN curl -fsSLo /tmp/node.tar.xz "https://nodejs.org/dist/v${NODE_VERSION}/node-v${NODE_VERSION}-linux-x64.tar.xz" && \
+    tar -xJf /tmp/node.tar.xz -C /usr/local --strip-components=1 && \
+    rm /tmp/node.tar.xz
+
+# Playwright's Chromium + its OS-level deps, pinned to package.json's version.
+# PLAYWRIGHT_BROWSERS_PATH is fixed (not under $HOME): GitHub Actions
+# container jobs remap HOME to a runner-mounted path at job time, so a
+# HOME-relative cache baked at build time wouldn't be visible at runtime.
+ARG PLAYWRIGHT_VERSION=1.60.0
+ENV PLAYWRIGHT_BROWSERS_PATH=/opt/ms-playwright
+RUN npx --yes playwright@$PLAYWRIGHT_VERSION install --with-deps chromium && \
+    rm -rf /var/lib/apt/lists /var/cache/apt/archives

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,9 +98,11 @@ jobs:
       - name: Resolve build args and image tag
         id: image
         run: |
+          ruby_version=$(awk '$1=="ruby"{print $2}' .tool-versions)
           node_version=$(awk '$1=="nodejs"{print $2}' .tool-versions)
           playwright_version=$(node -p "require('./package.json').devDependencies.playwright")
           tag=${{ hashFiles('.github/ci/Dockerfile', '.tool-versions', 'package.json') }}
+          echo "ruby_version=$ruby_version" >> "$GITHUB_OUTPUT"
           echo "node_version=$node_version" >> "$GITHUB_OUTPUT"
           echo "playwright_version=$playwright_version" >> "$GITHUB_OUTPUT"
           echo "image=$REGISTRY/$IMAGE_NAME:$tag" >> "$GITHUB_OUTPUT"
@@ -120,6 +122,7 @@ jobs:
           push: true
           tags: ${{ steps.image.outputs.image }}
           build-args: |
+            RUBY_VERSION=${{ steps.image.outputs.ruby_version }}
             NODE_VERSION=${{ steps.image.outputs.node_version }}
             PLAYWRIGHT_VERSION=${{ steps.image.outputs.playwright_version }}
           cache-from: type=gha
@@ -218,12 +221,19 @@ jobs:
         uses: actions/checkout@v7
         with:
           token: ${{ steps.translations_token.outputs.token || github.token }}
-      # Install Ruby dependencies
-      - name: Install Ruby and gems
-        uses: ruby/setup-ruby@v1
+      # Ruby itself is baked into the CI image (.github/ci/Dockerfile) —
+      # ruby/setup-ruby's own toolcache binary can't dynamically link inside
+      # a minimal container. Gems still need their own cache: BUNDLE_PATH is
+      # baked as /usr/local/bundle so this restores/saves the same directory
+      # bundle install writes to.
+      - name: Restore gem cache
+        uses: actions/cache@v6
         with:
-          bundler-cache: true
-      - run: bundle install
+          path: /usr/local/bundle
+          key: ${{ runner.os }}-gems-${{ hashFiles('Gemfile.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-gems-
+      - run: bundle install --jobs 4
       # :js system specs run through capybara-playwright-driver, which drives the
       # `playwright` npm package against the Chromium baked into the CI image
       # (.github/ci/Dockerfile) at PLAYWRIGHT_BROWSERS_PATH.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,9 +75,69 @@ jobs:
       # Eventually this should be added:
       # - name: Scan for security vulnerabilities in JavaScript dependencies
       #   run: bin/importmap audit
+
+  # Builds (or reuses, via GHA layer cache) the tooling image the `test` job
+  # runs in — see .github/ci/Dockerfile for what it bakes in and why.
+  build_ci_image:
+    name: "Build CI image"
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    outputs:
+      image: ${{ steps.image.outputs.image }}
+    env:
+      REGISTRY: ghcr.io
+      IMAGE_NAME: ${{ github.repository }}-ci
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+      # Tag + build-args are both derived from the same tracked files, so a
+      # version bump always produces a new tag AND a matching rebuild —
+      # nothing to manually keep in sync.
+      - name: Resolve build args and image tag
+        id: image
+        run: |
+          node_version=$(awk '$1=="nodejs"{print $2}' .tool-versions)
+          playwright_version=$(node -p "require('./package.json').devDependencies.playwright")
+          tag=${{ hashFiles('.github/ci/Dockerfile', '.tool-versions', 'package.json') }}
+          echo "node_version=$node_version" >> "$GITHUB_OUTPUT"
+          echo "playwright_version=$playwright_version" >> "$GITHUB_OUTPUT"
+          echo "image=$REGISTRY/$IMAGE_NAME:$tag" >> "$GITHUB_OUTPUT"
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+      - name: Log in to GHCR
+        uses: docker/login-action@v4
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build and push CI image
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: .github/ci/Dockerfile
+          push: true
+          tags: ${{ steps.image.outputs.image }}
+          build-args: |
+            NODE_VERSION=${{ steps.image.outputs.node_version }}
+            PLAYWRIGHT_VERSION=${{ steps.image.outputs.playwright_version }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
   test:
     name: "Run tests"
+    needs: build_ci_image
     runs-on: ubuntu-latest
+    permissions:
+      contents: write # translations-sync push fallback (see below)
+      pull-requests: write # translations-sync PR fallback (see below)
+      packages: read # pull the CI image built by build_ci_image
+    container:
+      image: ${{ needs.build_ci_image.outputs.image }}
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
     services:
       # Service images pull from Google's pull-through cache of Docker Hub's
       # official images. Anonymous pulls from Docker Hub (and from AWS's
@@ -120,7 +180,10 @@ jobs:
         ci_node_total: [5]
         ci_node_index: [0, 1, 2, 3, 4]
     env:
-      REDIS_URL: redis://localhost:6379
+      # `test` now runs inside the CI image (container:), so services are
+      # sibling containers reachable by name, not localhost.
+      REDIS_URL: redis://redis:6379
+      PGHOST: postgres
       RAILS_ENV: test
       TZ: "America/Chicago"
       COVERAGE: false # additional configuration is needed for parallelized tests
@@ -140,18 +203,6 @@ jobs:
       - name: Get CPU cores
         id: cpu-info
         run: echo "cpu-cores=$(nproc)" >> $GITHUB_OUTPUT
-      # Plain apt, not cache-apt-pkgs-action: its restore skips package
-      # postinst scripts (losing update-alternatives binaries like imagemagick's
-      # `identify`), and on cache miss it pins versions from the runner's stale
-      # apt lists, 404s, silently installs nothing, and caches the empty result.
-      # imagemagick from apt is v6, matching production — mini_magick 5 uses
-      # `identify`/`convert` when there's no `magick` (v7) binary.
-      # No google-chrome-stable: :js specs run Playwright's bundled Chromium (below).
-      - name: Install system dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y --no-install-recommends curl gettext imagemagick libvips libcurl4-gnutls-dev libexpat1-dev libssl-dev libz-dev postgresql-client ripgrep
-          identify --version
       # Checkout persists this App token (below) as the git creds so the sync
       # branch is pushed as the App — only a non-default-token push fires
       # `on: push`, which is what attaches the required checks to the PR.
@@ -174,20 +225,13 @@ jobs:
           bundler-cache: true
       - run: bundle install
       # :js system specs run through capybara-playwright-driver, which drives the
-      # `playwright` npm package and its bundled Chromium.
+      # `playwright` npm package against the Chromium baked into the CI image
+      # (.github/ci/Dockerfile) at PLAYWRIGHT_BROWSERS_PATH.
       - name: Set up Node
         uses: actions/setup-node@v6
         with:
           cache: 'npm'
       - run: npm install
-      - name: Cache Playwright browsers
-        id: playwright-cache
-        uses: actions/cache@v6
-        with:
-          path: ~/.cache/ms-playwright
-          key: ${{ runner.os }}-playwright-${{ hashFiles('package-lock.json') }}
-      - name: Install Playwright Chromium
-        run: npx playwright install --with-deps chromium
       - name: Set up database
         run: bin/rails db:create db:schema:load:primary db:schema:load:analytics db:migrate
       - name: Sync translations (only on main by default)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,15 +106,30 @@ jobs:
           echo "node_version=$node_version" >> "$GITHUB_OUTPUT"
           echo "playwright_version=$playwright_version" >> "$GITHUB_OUTPUT"
           echo "image=$REGISTRY/$IMAGE_NAME:$tag" >> "$GITHUB_OUTPUT"
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
       - name: Log in to GHCR
         uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
+      # The tag is a content hash (see above) — if it already exists in GHCR
+      # it's byte-identical to what we'd build, so skip buildx/build/push
+      # entirely instead of paying their setup cost for a guaranteed no-op.
+      - name: Check whether this image tag already exists
+        id: existing
+        env:
+          DOCKER_CLI_EXPERIMENTAL: enabled
+        run: |
+          if docker manifest inspect ${{ steps.image.outputs.image }} > /dev/null 2>&1; then
+            echo "found=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "found=false" >> "$GITHUB_OUTPUT"
+          fi
+      - name: Set up Docker Buildx
+        if: steps.existing.outputs.found != 'true'
+        uses: docker/setup-buildx-action@v4
       - name: Build and push CI image
+        if: steps.existing.outputs.found != 'true'
         uses: docker/build-push-action@v7
         with:
           context: .

--- a/config/database.yml
+++ b/config/database.yml
@@ -7,7 +7,7 @@ default_local: &default_local
   <<: *default
   port: <%= ENV.fetch("PGPORT", 5432) %>
   <% if ENV["CI"] %>
-  host: 127.0.0.1
+  host: <%= ENV.fetch("PGHOST", "127.0.0.1") %>
   username: rails
   password: password
   <% else %>

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -213,9 +213,9 @@ RSpec.configure do |config|
     DatabaseCleaner.clean
 
     # For debugging:
-    if Manufacturer.count > 0
-      raise DirtyDatabaseError.new(example.metadata)
-    end
+    # if ModelName.count > 0
+    #   raise DirtyDatabaseError.new(example.metadata)
+    # end
   end
 
   config.after(:all, :context_state) do

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -213,9 +213,9 @@ RSpec.configure do |config|
     DatabaseCleaner.clean
 
     # For debugging:
-    # if ModelName.count > 0
-    #   raise DirtyDatabaseError.new(example.metadata)
-    # end
+    if Manufacturer.count > 0
+      raise DirtyDatabaseError.new(example.metadata)
+    end
   end
 
   config.after(:all, :context_state) do

--- a/spec/requests/api/v3/manufacturers_request_spec.rb
+++ b/spec/requests/api/v3/manufacturers_request_spec.rb
@@ -16,14 +16,12 @@ RSpec.describe "Manufacturers API V3", type: :request do
   end
 
   describe "find by id or name" do
-    before :all do
-      @manufacturer = FactoryBot.create(:manufacturer)
-    end
+    let!(:manufacturer) { FactoryBot.create(:manufacturer) }
     it "returns one with from an id" do
-      get "/api/v3/manufacturers/#{@manufacturer.id}"
+      get "/api/v3/manufacturers/#{manufacturer.id}"
       result = response.body
       expect(response.code).to eq("200")
-      expect(JSON.parse(result)["manufacturer"]["id"]).to eq(@manufacturer.id)
+      expect(JSON.parse(result)["manufacturer"]["id"]).to eq(manufacturer.id)
     end
     it "responds with missing and cors headers" do
       get "/api/v3/manufacturers/10000"


### PR DESCRIPTION
The `test` job re-runs `apt-get install`, Playwright's `--with-deps` browser install, and an implicit Node fetch from scratch on all 5 parallel shards every push — none of that is cache-accelerated the way `bundle install`/`npm install` already are.

- A new `build_ci_image` job builds/pushes a tooling image to GHCR (`.github/ci/Dockerfile`), tagged by a hash of its inputs so it only rebuilds when the Dockerfile, `.tool-versions`, or `package.json` change. `test` now runs inside it via `container:`.
- Ruby, gems, and npm packages stay uncontainerized — they're already fast off `actions/cache` and change far more often than OS-level deps do.
- Running `test` in a container means services are sibling containers rather than localhost: `REDIS_URL` and `config/database.yml`'s CI-only Postgres host now resolve via `PGHOST`/service hostnames instead of hardcoded `localhost`/`127.0.0.1`.
