### PR TITLE
Allow connect-src to our own image CDNs (fix CSP blocks)

### DIFF
--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -41,6 +41,9 @@ Rails.application.configure do
       "https://cdn.jsdelivr.net",
       "https://api.mapbox.com"
     policy.connect_src :self,
+      # Our own image CDNs — third-party scripts (Facebook Pixel) fetch bike photos, not just <img> them
+      "https://files.bikeindex.org",
+      "https://uploads.bikeindex.org",
       "https://bikebook.herokuapp.com",
       "https://www.google-analytics.com",
       "https://*.google-analytics.com",


### PR DESCRIPTION
Fixes a cluster of `connect-src` CSP violations on bike show pages that started the evening of July 4, reporting blocks on bikes' own photos at `files.bikeindex.org`.

The trigger was #3799, which fixed the Facebook Pixel's inline-script `SyntaxError` — the pixel hadn't actually executed since 2019, and now that it does, `fbevents.js` fetches the page's primary image via `fetch()` (a `connect-src` operation, not `img-src`).

- Add `files.bikeindex.org` and `uploads.bikeindex.org` to `connect_src`. They were already trusted in `img_src`, so `<img>` loads worked but `fetch()` didn't.
- The "caller" is Facebook's third-party script we can't modify, and the target is our own image CDN — allowing the connect is the correct, low-risk fix.
