### PR TITLE
ShortId: keep short ids decimal, add UI::ShortId component

### DIFF
--- a/app/components/ui/short_id/component.rb
+++ b/app/components/ui/short_id/component.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+module UI
+  module ShortId
+    # Renders a record's short_id (see ShortIdable) as a monospace code block.
+    # Pass a record that responds to short_id, or a raw short_id string.
+    class Component < ApplicationComponent
+      BASE_CLASSES = "tw:font-mono tw:text-sm tw:rounded tw:px-1 tw:py-0.5 " \
+        "tw:bg-gray-100 tw:text-gray-800 tw:dark:bg-gray-800 tw:dark:text-gray-200"
+
+      def initialize(record: nil, short_id: nil, html_class: nil)
+        @short_id = short_id || record&.short_id
+        @html_class = html_class
+      end
+
+      def call
+        content_tag(:code, @short_id, class: [BASE_CLASSES, @html_class].compact.join(" "))
+      end
+
+      private
+
+      def render?
+        @short_id.present?
+      end
+    end
+  end
+end

--- a/app/components/ui/short_id/component.rb
+++ b/app/components/ui/short_id/component.rb
@@ -5,8 +5,7 @@ module UI
     # Renders a record's short_id (see ShortIdable) as a monospace code block.
     # Pass a record that responds to short_id, or a raw short_id string.
     class Component < ApplicationComponent
-      BASE_CLASSES = "tw:font-mono tw:text-sm tw:rounded tw:px-1 tw:py-0.5 " \
-        "tw:bg-gray-100 tw:text-gray-800 tw:dark:bg-gray-800 tw:dark:text-gray-200"
+      BASE_CLASSES = "tw:font-mono tw:text-sm"
 
       def initialize(record: nil, short_id: nil, html_class: nil)
         @short_id = short_id || record&.short_id

--- a/app/components/ui/short_id/component_preview.rb
+++ b/app/components/ui/short_id/component_preview.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module UI
+  module ShortId
+    class ComponentPreview < ApplicationComponentPreview
+      def default
+        render(UI::ShortId::Component.new(short_id: "r/21J-HW"))
+      end
+
+      # @label short (decimal) id
+      def decimal
+        render(UI::ShortId::Component.new(short_id: "r/36"))
+      end
+
+      # @label with extra classes appended
+      def with_html_class
+        render(UI::ShortId::Component.new(short_id: "r/21J-HW", html_class: "tw:text-base"))
+      end
+    end
+  end
+end

--- a/app/components/ui/short_id/component_preview.rb
+++ b/app/components/ui/short_id/component_preview.rb
@@ -3,8 +3,9 @@
 module UI
   module ShortId
     class ComponentPreview < ApplicationComponentPreview
-      def default
-        render(UI::ShortId::Component.new(short_id: "r/21J-HW"))
+      # @param id text "ID to render"
+      def default(id: "r/21J-HW")
+        render(UI::ShortId::Component.new(short_id: id))
       end
 
       # @label short (decimal) id

--- a/app/services/short_id.rb
+++ b/app/services/short_id.rb
@@ -4,11 +4,15 @@ module ShortId
   # Prefix per model class, so a short_id self-identifies
   PREFIXES = {"Bike" => "r", "BikeVersion" => "v", "MarketplaceListing" => "m"}.freeze
 
-  # Compact, prefixed alias for an id, e.g. ShortId.encode("Bike", 3431156) => "r/21J-HW"
+  # Compact, prefixed alias for an id, e.g. ShortId.encode("Bike", 3431156) => "r/21J-HW".
+  # Ids whose base36 form is under 3 digits stay decimal, so they never collide with
+  # the all-digit decimal ids that decode reads back verbatim (e.g. 36 => "r/36", not "r/10").
   def encode(class_name, id)
     return if id.blank?
 
-    "#{PREFIXES.fetch(class_name)}/#{id.to_s(36).upcase.scan(/.{1,3}/).join("-")}"
+    base36 = id.to_s(36).upcase
+    body = (base36.length < 3) ? id.to_s : base36.scan(/.{1,3}/).join("-")
+    "#{PREFIXES.fetch(class_name)}/#{body}"
   end
 
   # Resolve a short_id back to an id. The class prefix and its separator are

--- a/spec/components/ui/short_id/component_spec.rb
+++ b/spec/components/ui/short_id/component_spec.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe UI::ShortId::Component, type: :component do
+  let(:instance) { described_class.new(**options) }
+  let(:component) { render_inline(instance) }
+  let(:options) { {short_id: "r/21J-HW"} }
+
+  it "renders the short_id in a monospace code block" do
+    expect(component).to have_css("code", text: "r/21J-HW")
+    expect(component.to_html).to include("tw:font-mono")
+  end
+
+  context "with a record" do
+    let(:record) { Bike.new(id: 36) }
+    let(:options) { {record:} }
+
+    it "renders the record's short_id" do
+      expect(component).to have_css("code", text: record.short_id)
+    end
+  end
+
+  context "with html_class" do
+    let(:options) { {short_id: "r/36", html_class: "tw:text-base"} }
+
+    it "appends the extra classes" do
+      expect(component).to have_css("code.tw\\:text-base", text: "r/36")
+    end
+  end
+
+  context "with a blank short_id" do
+    let(:options) { {short_id: nil} }
+
+    it "renders nothing" do
+      expect(component.to_html).to be_blank
+    end
+  end
+end

--- a/spec/requests/bike_versions_request_spec.rb
+++ b/spec/requests/bike_versions_request_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe BikeVersionsController, type: :request do
     context "short_id" do
       let(:bike_version) { FactoryBot.create(:bike_version, owner: current_user, id: 35) }
       it "finds the version via short_id and the /v/ short URL" do
-        expect(bike_version.short_id).to eq "v/Z"
+        expect(bike_version.short_id).to eq "v/35"
         ["#{base_url}/35", "#{base_url}/z", "/v/z", "/V/Z", "/v/Z"].each do |path|
           get path
           expect(response).to render_template(:show)

--- a/spec/requests/bikes/show_request_spec.rb
+++ b/spec/requests/bikes/show_request_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe "BikesController#show", type: :request do
   context "short_id" do
     let(:ownership) { FactoryBot.create(:ownership, bike: FactoryBot.create(:bike, id: 35)) }
     it "finds the bike from any short_id form and the /r/ short URL" do
-      expect(bike.short_id).to eq "r/Z"
+      expect(bike.short_id).to eq "r/35"
       ["#{base_url}/35", "#{base_url}/z", "#{base_url}/r/z", "#{base_url}/R/Z", "#{base_url}/r/35", "#{base_url}/R.Z-", "/r/z", "/R/Z", "/r/Z"].each do |path|
         get path
         expect(response).to render_template(:show)
@@ -30,9 +30,9 @@ RSpec.describe "BikesController#show", type: :request do
       end
     end
     context "short_id body starting with the prefix letter" do
-      let(:ownership) { FactoryBot.create(:ownership, bike: FactoryBot.create(:bike, id: 27)) }
+      let(:ownership) { FactoryBot.create(:ownership, bike: FactoryBot.create(:bike, id: 34992)) }
       it "does not double-strip the prefix" do
-        expect(bike.short_id).to eq "r/R"
+        expect(bike.short_id).to eq "r/R00"
         get "/#{bike.short_id}"
         expect(response).to render_template(:show)
         expect(assigns(:bike)).to eq bike

--- a/spec/requests/marketplace_listings_request_spec.rb
+++ b/spec/requests/marketplace_listings_request_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe MarketplaceListingsController, type: :request do
   describe "show" do
     let(:marketplace_listing) { FactoryBot.create(:marketplace_listing, id: 35) }
     it "redirects to the item from the /m/ short URL" do
-      expect(marketplace_listing.short_id).to eq "m/Z"
+      expect(marketplace_listing.short_id).to eq "m/35"
       ["/m/z", "/M/Z", "/m/Z"].each do |path|
         get path
         expect(response).to redirect_to(marketplace_listing.item)

--- a/spec/services/short_id_spec.rb
+++ b/spec/services/short_id_spec.rb
@@ -8,6 +8,13 @@ RSpec.describe ShortId do
       expect(ShortId.encode("MarketplaceListing", 3431156)).to eq "m/21J-HW"
       expect(ShortId.encode("Bike", nil)).to be_nil
     end
+    it "keeps ids with an under-3-digit base36 form as decimals, round-tripping cleanly" do
+      [1, 35, 36, 37, 1295].each do |id|
+        short_id = ShortId.encode("Bike", id)
+        expect(short_id).to eq "r/#{id}"
+        expect(ShortId.decode("Bike", short_id)).to eq id.to_s
+      end
+    end
   end
 
   describe "decode" do


### PR DESCRIPTION
Tightens `ShortId` encoding and adds a component for displaying short ids.

- Short ids whose base36 form is under 3 digits now stay decimal, e.g. bike 36 encodes to `r/36` instead of `r/10`. This fixes a silent round-trip collision, since `decode` treats any all-digit string as a decimal id (the old base36 `"10"` decoded back to bike 10). Large ids are unchanged (`3431156` → `r/21J-HW`).
- Adds `UI::ShortId::Component`, rendering a record's `short_id` as plain monospace text. Accepts a record responding to `short_id`, or a raw string.
