### PR TITLE
Add honeypot spam trap to user sign up

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -177,9 +177,7 @@ class UsersController < ApplicationController
   private
 
   def ban_spam_signup(user)
-    user.update(banned: true)
-    UserBan.create(user_id: user.id, reason: :spamming,
-      description: "Honeypot field filled on sign up")
+    EmailBan.create(user:, reason: :honeypot)
   end
 
   def permitted_parameters

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -16,7 +16,8 @@ class UsersController < ApplicationController
       @user.preferred_language = requested_locale
     end
     if @user.save
-      ban_spam_signup(@user) if @user.looks_like_spam?
+      # Honeypot filled - the EmailBan stops the confirmation email, so the account never activates
+      EmailBan.create(user: @user, reason: :honeypot) if @user.looks_like_spam?
       sign_in_and_redirect(@user)
     else
       @page_errors = @user.errors
@@ -175,10 +176,6 @@ class UsersController < ApplicationController
   end
 
   private
-
-  def ban_spam_signup(user)
-    EmailBan.create(user:, reason: :honeypot)
-  end
 
   def permitted_parameters
     params.require(:user)

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -16,6 +16,7 @@ class UsersController < ApplicationController
       @user.preferred_language = requested_locale
     end
     if @user.save
+      ban_spam_signup(@user) if @user.looks_like_spam?
       sign_in_and_redirect(@user)
     else
       @page_errors = @user.errors
@@ -175,10 +176,16 @@ class UsersController < ApplicationController
 
   private
 
+  def ban_spam_signup(user)
+    user.update(banned: true)
+    UserBan.create(user_id: user.id, reason: :spamming,
+      description: "Honeypot field filled on sign up")
+  end
+
   def permitted_parameters
     params.require(:user)
       .permit(:name, :email, :notification_newsletters, :notification_unstolen, :terms_of_service,
-        :password, :password_confirmation, :preferred_language)
+        :password, :password_confirmation, :preferred_language, :additional)
       .merge(sign_in_partner.present? ? {partner_data: {sign_up: sign_in_partner}} : {})
   end
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -16,8 +16,6 @@ class UsersController < ApplicationController
       @user.preferred_language = requested_locale
     end
     if @user.save
-      # Honeypot filled - the EmailBan stops the confirmation email, so the account never activates
-      EmailBan.create(user: @user, reason: :honeypot) if @user.looks_like_spam?
       sign_in_and_redirect(@user)
     else
       @page_errors = @user.errors

--- a/app/jobs/callback_job/after_user_create_job.rb
+++ b/app/jobs/callback_job/after_user_create_job.rb
@@ -20,6 +20,8 @@ module CallbackJob
     end
 
     def perform_create_jobs(user, email)
+      # Ban honeypot signups before enqueuing emails, so EmailBan.ban? suppresses them
+      EmailBan.create(user:, reason: :honeypot) if user.looks_like_spam?
       # This may confirm the user. We auto-confirm users that belong to orgs.
       # Auto confirming the user actually ends up running perform_confirmed_jobs.
       associate_organization_role_invites(user, email)

--- a/app/jobs/email/welcome_job.rb
+++ b/app/jobs/email/welcome_job.rb
@@ -6,6 +6,9 @@ module Email
 
     def perform(user_id)
       user = User.find(user_id)
+      # Don't send an email if the email is blocked
+      return if EmailBan.ban?(user)
+
       CustomerMailer.welcome_email(user).deliver_now
     end
   end

--- a/app/models/email_ban.rb
+++ b/app/models/email_ban.rb
@@ -21,7 +21,7 @@ class EmailBan < ApplicationRecord
   BLOCK_DUPLICATE_PERIOD = 1.day
   PRE_PERIOD_DUPLICATE_LIMIT = 2
   PERMITTED_DUPLICATE_DOMAINS = %w[bikeindex.org bikehub.com].freeze
-  REASON_ENUM = {email_domain: 0, email_duplicate: 1, delivery_failure: 2}.freeze
+  REASON_ENUM = {email_domain: 0, email_duplicate: 1, delivery_failure: 2, honeypot: 3}.freeze
 
   enum :reason, REASON_ENUM
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -138,7 +138,7 @@ class User < ApplicationRecord
 
   accepts_nested_attributes_for :user_ban
 
-  attr_accessor :my_bikes_link_target, :my_bikes_link_title, :current_password, :skip_update
+  attr_accessor :my_bikes_link_target, :my_bikes_link_title, :current_password, :skip_update, :additional
   # stripe_id, is_paid_member, paid_organization_role_info
 
   before_validation :set_calculated_attributes
@@ -283,6 +283,11 @@ class User < ApplicationRecord
 
   def banned?
     banned
+  end
+
+  # `additional` is a honeypot field on the sign up form - only bots fill it in
+  def looks_like_spam?
+    additional.present?
   end
 
   def ambassador?

--- a/app/views/users/new.html.haml
+++ b/app/views/users/new.html.haml
@@ -40,6 +40,11 @@
             - if sign_in_partner
               = hidden_field_tag :partner, sign_in_partner
 
+            -# Honeypot spam trap - hidden from people, only bots fill it in
+            .form-group.additional-field{ style: "display: none;", aria: { hidden: true } }
+              = f.label :additional, "Additional", class: "sr-only"
+              = f.text_field :additional, tabindex: -1, autocomplete: "off", class: "form-control"
+
             .form-group
               = f.label :email, class: 'sr-only'
               = f.email_field :email, placeholder: 'email', class: 'form-control'

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -271,6 +271,18 @@ RSpec.describe UsersController, type: :controller do
         end
       end
     end
+    context "honeypot filled" do
+      it "creates the user but bans them as spam" do
+        expect {
+          post :create, params: {user: user_attributes.merge(additional: "http://spam.example.com")}
+        }.to change(User, :count).by(1)
+        user = User.order(:created_at).last
+        expect(user.banned?).to be_truthy
+        user_ban = user.user_ban
+        expect(user_ban.reason).to eq "spamming"
+        expect(user_ban.description).to eq "Honeypot field filled on sign up"
+      end
+    end
     context "revised" do
       let(:user_attrs) do
         {

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -280,6 +280,10 @@ RSpec.describe UsersController, type: :controller do
         expect(user.email_banned?).to be_truthy
         email_ban = user.email_bans.last
         expect(email_ban.reason).to eq "honeypot"
+        # The ban blocks the confirmation email, so the account can't be activated
+        expect {
+          Email::ConfirmationJob.new.perform(user.id)
+        }.to_not change(ActionMailer::Base.deliveries, :count)
       end
     end
     context "revised" do

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -272,15 +272,14 @@ RSpec.describe UsersController, type: :controller do
       end
     end
     context "honeypot filled" do
-      it "creates the user but bans them as spam" do
+      it "creates the user but email bans them as spam" do
         expect {
           post :create, params: {user: user_attributes.merge(additional: "http://spam.example.com")}
         }.to change(User, :count).by(1)
         user = User.order(:created_at).last
-        expect(user.banned?).to be_truthy
-        user_ban = user.user_ban
-        expect(user_ban.reason).to eq "spamming"
-        expect(user_ban.description).to eq "Honeypot field filled on sign up"
+        expect(user.email_banned?).to be_truthy
+        email_ban = user.email_bans.last
+        expect(email_ban.reason).to eq "honeypot"
       end
     end
     context "revised" do

--- a/spec/jobs/email/welcome_job_spec.rb
+++ b/spec/jobs/email/welcome_job_spec.rb
@@ -7,4 +7,14 @@ RSpec.describe Email::WelcomeJob, type: :job do
     Email::WelcomeJob.new.perform(user.id)
     expect(ActionMailer::Base.deliveries.empty?).to be_falsey
   end
+
+  context "email banned user" do
+    let(:user) { FactoryBot.create(:user) }
+    let!(:email_ban) { FactoryBot.create(:email_ban, user:) }
+    it "does not send an email" do
+      ActionMailer::Base.deliveries = []
+      Email::WelcomeJob.new.perform(user.id)
+      expect(ActionMailer::Base.deliveries.empty?).to be_truthy
+    end
+  end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -877,6 +877,19 @@ RSpec.describe User, type: :model do
     end
   end
 
+  describe "looks_like_spam?" do
+    let(:user) { User.new }
+    it "is false without the honeypot" do
+      expect(user.looks_like_spam?).to be_falsey
+    end
+    context "with the additional honeypot filled" do
+      let(:user) { User.new(additional: "http://spam.example.com") }
+      it "is true" do
+        expect(user.looks_like_spam?).to be_truthy
+      end
+    end
+  end
+
   describe "can_create_listing?" do
     let(:user) { FactoryBot.create(:user_confirmed) }
     context "superuser" do


### PR DESCRIPTION
Adds the lead-generation honeypot spam trap (`Feedback#looks_like_spam?`) to the user sign up form.

- A hidden `additional` field on `/users/new` that only bots fill in — feeds `User#looks_like_spam?`.
- When it's tripped, the new user is created (so the bot sees a normal success) but immediately gets an `EmailBan(reason: :honeypot)`. That flows through the existing sign-up spam pipeline — `EmailBan.ban?` already runs in `ConfirmationJob` — so the account is email banned and never receives a confirmation email.
