### PR TITLE
Add staging deploy of main to staging.review.bikeindex.org

### DIFF
--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -1,0 +1,157 @@
+name: Staging Deploy
+
+# Deploys `main` to the persistent staging app (staging.review.bikeindex.org)
+# with Kamal, on the same host + shared accessories as the per-PR review apps.
+# See config/deploy.staging.yml and docs/review-apps.md.
+#
+# Triggers:
+#   - workflow_run   : after CI succeeds on main, so a red main never ships.
+#   - workflow_dispatch : manual redeploy of the current main.
+#
+# There is no destroy path — staging is long-lived. Its Postgres role/databases
+# and Redis DB 0 persist across deploys (first boot seeds, later boots migrate).
+
+on:
+  workflow_run:
+    workflows: ["CI"]
+    types: [completed]
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write       # push to GHCR
+  deployments: write    # surface the staging deployment + URL
+
+# Serialize deploys without cancellation — killing kamal mid-deploy can strand
+# the deploy lock on the host. A newer queued run supersedes an older pending one.
+concurrency:
+  group: staging-deploy
+  cancel-in-progress: false
+
+jobs:
+  build:
+    name: Build image
+    # Skip unless CI passed (workflow_dispatch has no conclusion, so allow it).
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-latest
+    outputs:
+      head_sha: ${{ steps.vars.outputs.head_sha }}
+    env:
+      REGISTRY: ghcr.io
+      IMAGE_NAME: ${{ github.repository }}
+      # workflow_run carries the CI'd commit; workflow_dispatch falls back to the
+      # branch head. Both are the main commit we want to ship.
+      HEAD_SHA: ${{ github.event.workflow_run.head_sha || github.sha }}
+    steps:
+      - name: Expose head sha
+        id: vars
+        run: echo "head_sha=$HEAD_SHA" >> "$GITHUB_OUTPUT"
+      - name: Checkout the CI'd commit
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ env.HEAD_SHA }}
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v4
+      # Persist sprockets' incremental cache across runners (its own build mount
+      # doesn't survive an ephemeral runner). A dedicated key — the review-app and
+      # CI asset bundles bake different BASE_URLs, so their caches can't be shared.
+      - name: Restore sprockets asset cache
+        id: sprockets-cache
+        uses: actions/cache@v6
+        with:
+          path: sprockets-cache
+          key: staging-sprockets-${{ hashFiles('app/assets/**', 'app/views/**', 'app/components/**', 'app/helpers/**/*.rb', 'app/javascript/**', 'config/initializers/dartsass.rb', 'config/initializers/assets.rb', 'Gemfile.lock') }}
+          restore-keys: |
+            staging-sprockets-
+      - name: Inject sprockets cache into the docker build
+        uses: reproducible-containers/buildkit-cache-dance@v3
+        with:
+          builder: ${{ steps.buildx.outputs.name }}
+          cache-map: |
+            {
+              "sprockets-cache": "/rails/tmp/cache/assets"
+            }
+          skip-extraction: ${{ steps.sprockets-cache.outputs.cache-hit }}
+      - name: Log in to GHCR
+        uses: docker/login-action@v4
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build and push image
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          push: true
+          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:staging-${{ env.HEAD_SHA }}
+          # kamal verifies the deployed image carries a `service` label matching
+          # the config; CI builds + deploys with --skip-push, so set it here.
+          labels: service=bike-index-staging
+          cache-from: type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:buildcache
+          cache-to: type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:buildcache,mode=max
+
+  deploy:
+    name: Deploy staging
+    needs: build
+    runs-on: ubuntu-latest
+    # Reuse the review-app GitHub Environment — staging runs on the same host,
+    # shared-db/shared-redis, and sandbox secrets, so its REVIEW_APP_* secrets +
+    # REVIEW_APP_HOST variable apply unchanged. (Split into its own environment
+    # later if staging needs distinct secrets.)
+    environment:
+      name: review-app
+      url: https://staging.review.bikeindex.org
+    env:
+      IMAGE_TAG: staging-${{ needs.build.outputs.head_sha }}
+      # kamal deploys against the staging config; the post-deploy Honeybadger
+      # hook reads KAMAL_CONFIG for the same reason.
+      KAMAL_CONFIG: config/deploy.staging.yml
+      REVIEW_APP_HOST: ${{ vars.REVIEW_APP_HOST }}
+      KAMAL_REGISTRY_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
+      POSTGRES_PASSWORD: ${{ secrets.REVIEW_APP_POSTGRES_PASSWORD }}
+      SECRET_KEY_BASE: ${{ secrets.REVIEW_APP_SECRET_KEY_BASE }}
+      SESSION_SECRET: ${{ secrets.REVIEW_APP_SESSION_SECRET }}
+      VERIFICATION_SECRET: ${{ secrets.REVIEW_APP_VERIFICATION_SECRET }}
+      GOOGLE_MAPS: ${{ secrets.REVIEW_APP_GOOGLE_MAPS }}
+      GOOGLE_MAPS_STATIC: ${{ secrets.REVIEW_APP_GOOGLE_MAPS_STATIC }}
+      GOOGLE_GEOCODER: ${{ secrets.REVIEW_APP_GOOGLE_GEOCODER }}
+      MAPBOX_GEOCODER: ${{ secrets.REVIEW_APP_MAPBOX_GEOCODER }}
+      MAPBOX_MAPPING: ${{ secrets.REVIEW_APP_MAPBOX_MAPPING }}
+      R2_DEV_ENDPOINT: ${{ secrets.REVIEW_APP_R2_DEV_ENDPOINT }}
+      R2_DEV_ACCESS_KEY: ${{ secrets.REVIEW_APP_R2_DEV_ACCESS_KEY }}
+      R2_DEV_ACCESS_KEY_SECRET: ${{ secrets.REVIEW_APP_R2_DEV_ACCESS_KEY_SECRET }}
+      HONEYBADGER_API_KEY: ${{ secrets.REVIEW_APP_HONEYBADGER_API_KEY }}
+      HONEYBADGER_FRONTEND_API_KEY: ${{ secrets.REVIEW_APP_HONEYBADGER_FRONTEND_API_KEY }}
+    steps:
+      - name: Checkout the CI'd commit
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ needs.build.outputs.head_sha }}
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "4.0.5"
+      - name: Install Kamal
+        run: gem install kamal -v "~> 2.0"
+      - name: Set up SSH agent
+        uses: webfactory/ssh-agent@v0.10.0
+        with:
+          ssh-private-key: ${{ secrets.REVIEW_APP_SSH_KEY }}
+      - name: Trust review host
+        # Scan the hostname AND resolved IP un-hashed — kamal's net-ssh verifies
+        # both (check_host_ip on by default). See review-app.yml.
+        run: |
+          mkdir -p ~/.ssh
+          host='${{ vars.REVIEW_APP_HOST }}'
+          ip="$(getent hosts "$host" | awk 'NR==1 { print $1 }')"
+          ssh-keyscan "$host" $ip >> ~/.ssh/known_hosts
+      - name: Stage CI secrets file
+        run: cp .kamal/secrets-ci .kamal/secrets
+      - name: Deploy
+        # CI already built + pushed the image, so kamal just pulls it (--skip-push
+        # also avoids kamal cloning the private app/services/facebook submodule).
+        run: kamal deploy --version "$IMAGE_TAG" --skip-push --config-file config/deploy.staging.yml

--- a/config/deploy.staging.yml
+++ b/config/deploy.staging.yml
@@ -1,0 +1,125 @@
+# Kamal config for the persistent `staging` app — a long-lived deploy of `main`
+# at staging.review.bikeindex.org. It's essentially a review app that never gets
+# a PR number and never gets destroyed: same host, same shared-db/shared-redis
+# accessories, same RAILS_ENV=staging. See config/deploy.review.yml (the per-PR
+# template this mirrors) and docs/review-apps.md.
+#
+# Usage (called from .github/workflows/staging.yml):
+#
+#   export REVIEW_APP_HOST=host.review.bikeindex.org
+#   kamal deploy --version staging-<sha> --skip-push --config-file config/deploy.staging.yml
+#
+# Secrets flow exactly as review apps (.kamal/secrets, CI copies secrets-ci over).
+# This file is NOT used by production (Cloud66).
+
+<% host = ENV.fetch("REVIEW_APP_HOST") %>
+
+service: bike-index-staging
+# No registry host — kamal prepends registry.server (see config/deploy.review.yml).
+image: bikeindex/bike_index
+
+# First boot runs the full db:prepare (schema + seed) before Puma answers /up;
+# redeploys only migrate and boot fast. Same rationale as review apps.
+deploy_timeout: 240
+
+servers:
+  web:
+    - <%= host %>
+  worker:
+    hosts:
+      - <%= host %>
+    cmd: bundle exec sidekiq -c 2
+  cron:
+    hosts:
+      - <%= host %>
+    cmd: bash -c "(env && cat config/crontab) | crontab - && cron -f"
+    options:
+      user: root
+
+proxy:
+  ssl: true
+  host: staging.review.bikeindex.org
+  app_port: 80
+  healthcheck:
+    path: /up
+    interval: 5
+    timeout: 60
+
+registry:
+  server: ghcr.io
+  username: bikeindex
+  password:
+    - KAMAL_REGISTRY_PASSWORD
+
+env:
+  clear:
+    RAILS_ENV: staging
+    # Renders the non-production banner + review favicon (no PR number, so the
+    # banner shows no PR link). See PageBlock::ReviewAppBanner.
+    REVIEW_APP: "1"
+    BASE_URL: "https://staging.review.bikeindex.org"
+
+    # Postgres — a persistent role + databases on the shared-db accessory (unlike
+    # review apps these are never dropped). bin/docker-entrypoint creates the role
+    # on first boot; db:prepare creates the databases.
+    POSTGRESQL_ADDRESS: shared-db
+    POSTGRESQL_USERNAME: bike_index_staging
+    POSTGRESQL_DATABASE: bike_index_staging_primary
+    POSTGRESQL_ANALYTICS_ADDRESS: shared-db
+    ANALYTICS_DB_USERNAME: bike_index_staging
+    ANALYTICS_DB_DATABASE: bike_index_staging_analytics
+    ANALYTICS_DB_PORT: "5432"
+
+    # Redis — logical DB 0 on shared-redis, the one bin/kamal_review's mod-31
+    # allocation (1..31) never hands to a PR, so staging can't collide with one.
+    REDIS_URL: "redis://shared-redis:6379/0"
+    REDIS_RACK_ATTACK_URL: "redis://shared-redis:6379/0"
+
+    # Jobs that can't work with review-app sandbox secrets / host egress (see
+    # config/deploy.review.yml for the details).
+    SIDEKIQ_SKIP_UPDATE_EXCHANGE_RATES_JOB: "1"
+    SIDEKIQ_SKIP_UPDATE_MANUFACTURER_LOGO_AND_PRIORITY_JOB: "1"
+
+    RAILS_LOG_TO_STDOUT: "1"
+    RAILS_SERVE_STATIC_FILES: "1"
+    WEB_CONCURRENCY: "1"
+    RAILS_MAX_THREADS: "3"
+    DB_POOL: "5"
+
+  secret:
+    - POSTGRES_PASSWORD
+    - POSTGRESQL_PASSWORD
+    - ANALYTICS_DB_PASSWORD
+    - SECRET_KEY_BASE
+    - SESSION_SECRET
+    - VERIFICATION_SECRET
+    - GOOGLE_MAPS
+    - GOOGLE_MAPS_STATIC
+    - GOOGLE_GEOCODER
+    - MAPBOX_GEOCODER
+    - MAPBOX_MAPPING
+    - R2_DEV_ENDPOINT
+    - R2_DEV_ACCESS_KEY
+    - R2_DEV_ACCESS_KEY_SECRET
+    - HONEYBADGER_API_KEY
+    - HONEYBADGER_FRONTEND_API_KEY
+
+aliases:
+  console: app exec --interactive --reuse "bin/rails console"
+  shell:   app exec --interactive --reuse "bash"
+  logs:    app logs -f
+  dbc:     app exec --interactive --reuse "bin/rails dbconsole --include-password"
+
+# Persistent active-storage volume (letter_opener inbox lives here — see
+# config/environments/staging.rb).
+volumes:
+  - "bike-index-staging_storage:/rails/storage"
+
+asset_path: /rails/public/assets
+
+builder:
+  arch: amd64
+
+# No `accessories:` block on purpose — shared-db and shared-redis are declared,
+# booted, and owned by config/deploy.review.yml. Redeclaring them here would let
+# a staging deploy reboot/remove the shared infra every PR review app depends on.

--- a/docs/review-apps.md
+++ b/docs/review-apps.md
@@ -4,6 +4,14 @@ Per-PR review apps deployed with [Kamal](https://kamal-deploy.org/) to a single 
 
 Review apps run the **staging Rails environment** `RAILS_ENV=staging`, a near-duplicate of production (`config/environments/staging.rb` imports production.rb)
 
+## Staging (persistent `main` deploy)
+
+Alongside the per-PR apps, `main` is continuously deployed to **`staging.review.bikeindex.org`** — think of it as a review app that never gets a PR number and is never destroyed. It shares the same host, the `shared-db`/`shared-redis` accessories, `RAILS_ENV=staging`, and the `review-app` GitHub Environment secrets. It differs only in fixed names: service `bike-index-staging`, Postgres role `bike_index_staging` + databases `bike_index_staging_{primary,analytics}`, and Redis logical DB `0` (the one the PR mod-31 allocation never hands out).
+
+- **Config:** `config/deploy.staging.yml` (no `accessories:` block — the shared infra is owned by `deploy.review.yml`).
+- **Workflow:** `.github/workflows/staging.yml` deploys on `workflow_run` after **CI succeeds on `main`** (so a red main never ships), plus a `workflow_dispatch` for manual redeploys. Its data persists across deploys: first boot seeds, later boots migrate only.
+- **One-time setup:** none beyond the review-app host — the `*.review.bikeindex.org` wildcard already resolves `staging.`, kamal-proxy auto-issues its TLS cert on first deploy, and the shared accessories are already booted. Deploy manually the first time via the workflow's "Run workflow" button (or `kamal deploy --version staging-<sha> --skip-push --config-file config/deploy.staging.yml` locally).
+
 ## How to trigger one
 
 1. Open the [Review App workflow](https://github.com/bikeindex/bike_index/actions/workflows/review-app.yml) in Actions.
@@ -92,6 +100,8 @@ Each app gets a `cron` container (a Kamal [`servers` role](https://kamal-deploy.
 | `bin/thrust` | Thruster binstub used by the image's `CMD` |
 | `bin/kamal_review` | Run kamal against one review app — `deploy`/`destroy` lifecycle plus arbitrary passthrough commands (resolves the PR number from any id form, sets `REVIEW_APP_*` + `--config-file`) |
 | `config/deploy.review.yml` | Kamal config, ERB-templated per PR via `REVIEW_APP_PR_NUMBER` |
+| `config/deploy.staging.yml` | Kamal config for the persistent `staging.review.bikeindex.org` deploy of `main` (fixed names; no accessories) |
+| `.github/workflows/staging.yml` | Deploys `main` to staging after CI passes (`workflow_run`) — see [Staging](#staging-persistent-main-deploy) |
 | `config/crontab` | Scheduled rake tasks run by the `cron` server role |
 | `.kamal/secrets` | Local secrets — pulls from 1Password and `gh auth token` |
 | `.kamal/secrets-ci` | CI secrets — dotenv passthrough for GitHub Actions env vars; the workflow copies this over `.kamal/secrets` before running kamal |


### PR DESCRIPTION
Continuously deploys `main` to **staging.review.bikeindex.org** with Kamal — a persistent review app that never gets a PR number and is never destroyed. It reuses the review-app host, the `shared-db`/`shared-redis` accessories, `RAILS_ENV=staging`, and the `review-app` GitHub Environment secrets, differing only in fixed names (service `bike-index-staging`, role/dbs `bike_index_staging*`, Redis DB `0`).

- `config/deploy.staging.yml` — Kamal config with fixed names and **no `accessories:` block**, so a staging deploy can't tear down the shared infra the PR apps depend on.
- `.github/workflows/staging.yml` — deploys on `workflow_run` after **CI passes on `main`** (a red main never ships), plus a manual `workflow_dispatch`. Data persists across deploys: first boot seeds, later boots migrate.
- No new host/DNS/secret setup — the `*.review.bikeindex.org` wildcard already resolves `staging.`, kamal-proxy auto-issues TLS, and the shared accessories are already booted. Trigger the first deploy manually via the workflow.

Reusing the `review-app` Environment (rather than a dedicated `staging` one) is a deliberate low-setup choice, noted in the config/docs — easy to split later if staging needs distinct secrets.
