### PR TITLE
Fix staging image handling when workers can't see local uploads

### DIFF
--- a/app/models/public_image.rb
+++ b/app/models/public_image.rb
@@ -84,6 +84,16 @@ class PublicImage < ApplicationRecord
     CallbackJob::AfterBikeSaveJob.perform_async(imageable_id, false, true)
   end
 
+  # CarrierWaveProcessJob generates versions by reading the stored original back
+  # from remote storage, which only works with fog (production). With local file
+  # storage (staging/dev) the worker can't see the web box's disk, so process
+  # versions inline — otherwise the job silently skips them and thumbnails 404.
+  def process_image_upload
+    return true unless remote_storage?
+
+    @process_image_upload
+  end
+
   # Because the way we load the file is different if it's remote or local
   # This is hacky, but whatever
   def local_file?
@@ -98,5 +108,11 @@ class PublicImage < ApplicationRecord
     else
       URI.parse(image.url).open
     end
+  end
+
+  private
+
+  def remote_storage?
+    PublicImageUploader.storage == CarrierWave::Storage::Fog
   end
 end

--- a/app/models/public_image.rb
+++ b/app/models/public_image.rb
@@ -90,8 +90,13 @@ class PublicImage < ApplicationRecord
     image&._storage&.to_s == "CarrierWave::Storage::File"
   end
 
-  # To enable stream processing for both local and remote files
+  # To enable stream processing for both local and remote files.
+  # Returns nil when a local file is missing on disk (e.g. staging without synced uploads)
   def open_file
-    local_file? ? File.open(image.path, "r") : URI.parse(image.url).open
+    if local_file?
+      File.open(image.path, "r") if File.exist?(image.path)
+    else
+      URI.parse(image.url).open
+    end
   end
 end

--- a/app/services/images/stolen_processor.rb
+++ b/app/services/images/stolen_processor.rb
@@ -63,7 +63,8 @@ module Images
         return image_and_id(stolen_record, stolen_record.images_attached_id)
       end
       public_image ||= stolen_record.bike_main_image
-      return [public_image&.open_file, public_image.id] if public_image.present?
+      image = public_image&.open_file
+      return [image, public_image.id] if image.present?
 
       stock_photo_url = Bike.unscoped.find_by(id: stolen_record.bike_id)&.stock_photo_url
       if stock_photo_url.present?

--- a/spec/jobs/carrier_wave_process_job_spec.rb
+++ b/spec/jobs/carrier_wave_process_job_spec.rb
@@ -4,6 +4,10 @@ RSpec.describe CarrierWaveProcessJob, type: :job do
   before { PublicImageUploader.enable_processing = true }
   after { PublicImageUploader.enable_processing = false }
 
+  # The job only runs in production, where fog storage lets versions defer to it.
+  # Simulate that so uploads defer (test storage is local file, where they wouldn't).
+  before { allow_any_instance_of(PublicImage).to receive(:remote_storage?).and_return(true) }
+
   def image_metadata(path)
     `identify -verbose #{path} 2>/dev/null`
   end

--- a/spec/jobs/images/external_url_store_job_spec.rb
+++ b/spec/jobs/images/external_url_store_job_spec.rb
@@ -4,6 +4,10 @@ RSpec.describe Images::ExternalUrlStoreJob, type: :job do
   let(:instance) { described_class.new }
 
   context "valid performance" do
+    # Version generation only defers to CarrierWaveProcessJob with remote (fog)
+    # storage; simulate production since test uses local file storage (inline)
+    before { allow_any_instance_of(PublicImage).to receive(:remote_storage?).and_return(true) }
+
     let(:bike) { FactoryBot.create(:bike) }
     let(:is_private) { false }
     let(:public_image) do

--- a/spec/models/public_image_spec.rb
+++ b/spec/models/public_image_spec.rb
@@ -20,6 +20,40 @@ RSpec.describe PublicImage, type: :model do
     end
   end
 
+  describe "process_image_upload" do
+    let(:bike) { FactoryBot.create(:bike) }
+    let(:image_file) { File.open(Rails.root.join("spec", "fixtures", "bike.jpg")) }
+
+    context "local file storage (staging/dev)" do
+      it "generates versions inline and does not enqueue the background job" do
+        expect(PublicImageUploader.storage).to eq CarrierWave::Storage::File
+        PublicImageUploader.enable_processing = true
+        public_image = nil
+        expect do
+          public_image = PublicImage.create!(imageable: bike, image: image_file)
+        end.to change(CarrierWaveProcessJob.jobs, :size).by(0)
+        expect(public_image.process_image_upload).to be_truthy
+        expect(File.exist?(public_image.image.small.path)).to be_truthy
+      ensure
+        PublicImageUploader.enable_processing = false
+        public_image&.image&.remove!
+        image_file.close
+      end
+    end
+
+    context "fog storage (production)" do
+      it "defers version generation to the background job" do
+        public_image = PublicImage.new(imageable: bike, image: image_file)
+        allow(public_image).to receive(:remote_storage?).and_return(true)
+        expect do
+          public_image.save!
+        end.to change(CarrierWaveProcessJob.jobs, :size).by(1)
+        expect(public_image.process_image_upload).to be_nil
+        image_file.close
+      end
+    end
+  end
+
   describe "open_file" do
     let(:bike) { FactoryBot.create(:bike) }
     let(:public_image) { FactoryBot.create(:public_image, imageable: bike, image: File.open(Rails.root.join("spec", "fixtures", "bike.jpg"))) }

--- a/spec/models/public_image_spec.rb
+++ b/spec/models/public_image_spec.rb
@@ -20,6 +20,26 @@ RSpec.describe PublicImage, type: :model do
     end
   end
 
+  describe "open_file" do
+    let(:bike) { FactoryBot.create(:bike) }
+    let(:public_image) { FactoryBot.create(:public_image, imageable: bike, image: File.open(Rails.root.join("spec", "fixtures", "bike.jpg"))) }
+
+    it "opens the local file" do
+      expect(public_image.local_file?).to be_truthy
+      file = public_image.open_file
+      expect(file).to be_present
+      file.close
+    end
+
+    context "local file missing on disk" do
+      it "returns nil" do
+        expect(public_image.local_file?).to be_truthy
+        FileUtils.rm(public_image.image.path)
+        expect(public_image.open_file).to be_nil
+      end
+    end
+  end
+
   describe "enqueue_after_commit_jobs" do
     context "non-bike" do
       let(:public_image) { PublicImage.new(imageable_type: "Blog", imageable_id: 12) }

--- a/spec/requests/public_images_request_spec.rb
+++ b/spec/requests/public_images_request_spec.rb
@@ -34,6 +34,9 @@ RSpec.describe PublicImagesController, type: :request do
         context "with an image file" do
           let(:file) { Rack::Test::UploadedFile.new(File.open(File.join(Rails.root, "/spec/fixtures/bike.jpg"))) }
           it "renders the original and wires the image-fallback for the backgrounded versions" do
+            # Versions only defer to the job with remote (fog) storage; simulate production
+            # since test uses local file storage, which processes inline
+            allow_any_instance_of(PublicImage).to receive(:remote_storage?).and_return(true)
             Sidekiq::Job.clear_all
             post base_url, params: {bike_id: bike.id, public_image: {image: file}, format: :js}
             expect(response).to have_http_status(:ok)

--- a/spec/services/images/stolen_processor_spec.rb
+++ b/spec/services/images/stolen_processor_spec.rb
@@ -159,6 +159,17 @@ RSpec.describe Images::StolenProcessor do
       end
     end
 
+    context "public_image file missing on disk" do
+      it "does not raise and skips attaching images" do
+        expect(stolen_record.reload.bike_main_image.id).to eq public_image.id
+        FileUtils.rm(public_image.image.path)
+        expect do
+          described_class.update_alert_images(stolen_record)
+        end.to change(ActiveStorage::Blob, :count).by 0
+        expect(stolen_record.reload.image_four_by_five.attached?).to be_falsey
+      end
+    end
+
     context "with stock photo" do
       let(:bike) { FactoryBot.create(:bike, stock_photo_url:) }
       let(:stock_photo_url) { "https://bikebook.s3.amazonaws.com/uploads/Fr/13095/csm_INFINITO_CV_SUPER_RECORD_EPS_Compact_2a2c680c1b.jpg" }


### PR DESCRIPTION
Two staging image bugs, both rooted in staging's worker containers not sharing the web box's local `public/uploads` (uploads use local file storage there; production uses fog/S3).

- **Thumbnails 404 on the bike show page** ([#3704](https://github.com/bikeindex/bike_index/pull/3704)'s deferred version generation): `CarrierWaveProcessJob` regenerates versions by reading the stored original back from remote storage, which only works with fog. On local file storage the worker can't see the original, silently skips (`uploader.file` blank), and versions are never created. `PublicImage` now generates versions inline unless storage is fog, so the deferred job only runs where it can read the original.
- **`Errno::ENOENT` crash in stolen alert generation** (Honeybadger [#132253078](https://app.honeybadger.io/projects/35931/faults/132253078)): `PublicImage#open_file` raised on a local upload missing from the worker's disk, failing `StolenBike::AfterStolenRecordSaveJob` across all 3 retries. It now returns `nil` for a missing local file and `Images::StolenProcessor` falls through to the stock-photo / no-op path.
