### PR TITLE
Fix review-app banner ReadOnlyError under set_reading_role

### DIFF
--- a/app/components/page_block/review_app_banner/component.en.yml
+++ b/app/components/page_block/review_app_banner/component.en.yml
@@ -9,3 +9,4 @@ en:
         letter_opener_tooltip: View the email sent by this review app
         pr_link: 'PR #%{number}'
         superadmin_button: sign in as superadmin
+        superadmin_signed_in: signed in as superadmin

--- a/app/components/page_block/review_app_banner/component.html.erb
+++ b/app/components/page_block/review_app_banner/component.html.erb
@@ -26,7 +26,7 @@
   <% if superadmin %>
     &middot;
     <%= form_with url: sign_in_with_magic_link_session_path, class: "tw:inline-block tw:align-middle" do %>
-      <%= hidden_field_tag :token, superadmin.refreshed_magic_link_token %>
+      <%= hidden_field_tag :token, superadmin_magic_link_token %>
       <%= render UI::Button::Component.new(text: translation(".superadmin_button"), kind: :submit, size: :sm) %>
     <% end %>
   <% end %>

--- a/app/components/page_block/review_app_banner/component.html.erb
+++ b/app/components/page_block/review_app_banner/component.html.erb
@@ -23,7 +23,10 @@
         "tw:focus:outline-none tw:focus:ring-3 tw:focus:ring-blue-500/40"
     ) { "?" } %>
   <% end %>
-  <% if superadmin %>
+  <% if signed_in_as_superadmin? %>
+    &middot;
+    <%= translation(".superadmin_signed_in") %>
+  <% elsif superadmin %>
     &middot;
     <%= form_with url: sign_in_with_magic_link_session_path, class: "tw:inline-block tw:align-middle" do %>
       <%= hidden_field_tag :token, superadmin_magic_link_token %>

--- a/app/components/page_block/review_app_banner/component.rb
+++ b/app/components/page_block/review_app_banner/component.rb
@@ -35,6 +35,14 @@ module PageBlock
 
         @superadmin = User.admins.first
       end
+
+      # Refreshing the token persists it, so force the writing role: the banner
+      # renders on pages (e.g. bikes#show) served under set_reading_role.
+      def superadmin_magic_link_token
+        ActiveRecord::Base.connected_to(role: :writing) do
+          superadmin.refreshed_magic_link_token
+        end
+      end
     end
   end
 end

--- a/app/components/page_block/review_app_banner/component.rb
+++ b/app/components/page_block/review_app_banner/component.rb
@@ -8,10 +8,11 @@ module PageBlock
     # `ENV["REVIEW_APP_PR_TITLE"]`; the component renders only when `review_app`
     # is present.
     class Component < ApplicationComponent
-      def initialize(review_app:, pr_number: nil, pr_title: nil)
+      def initialize(review_app:, pr_number: nil, pr_title: nil, current_user: nil)
         @review_app = review_app
         @pr_number = pr_number
         @pr_title = pr_title
+        @current_user = current_user
       end
 
       def render?
@@ -34,6 +35,10 @@ module PageBlock
         return @superadmin if defined?(@superadmin)
 
         @superadmin = User.admins.first
+      end
+
+      def signed_in_as_superadmin?
+        @current_user.present? && @current_user == superadmin
       end
 
       # Refreshing the token persists it, so force the writing role: the banner

--- a/app/jobs/spreadsheets/importer_job.rb
+++ b/app/jobs/spreadsheets/importer_job.rb
@@ -3,6 +3,10 @@ module Spreadsheets
     RESOURCES_URL = "https://raw.githubusercontent.com/bikeindex/resources/refs/heads/main/data".freeze
     # Maps each importer module (e.g. Spreadsheets::Manufacturers) to its CSV filename in the resources repo
     IMPORTERS = {"manufacturers" => "manufacturers", "primary_activities" => "primary_activities", "components" => "component_types"}.freeze
+    # db/seeds.rb runs this inline, so a transient blip reaching GitHub would abort the
+    # whole seed (e.g. CI). Retry a few times before giving up.
+    DOWNLOAD_ATTEMPTS = 3
+    RETRY_DELAY_SECONDS = 2
 
     def perform(name = nil)
       return IMPORTERS.each_key { |n| perform(n) } if name.blank?
@@ -22,16 +26,27 @@ module Spreadsheets
     private
 
     def download(url)
-      conn = Faraday.new do |faraday|
+      attempt = 0
+      begin
+        attempt += 1
+        response = connection.get(url)
+        raise "Failed to fetch #{url}: #{response.status}" unless response.success?
+
+        response.body
+      rescue Faraday::ConnectionFailed, Faraday::TimeoutError
+        raise if attempt >= DOWNLOAD_ATTEMPTS
+        sleep RETRY_DELAY_SECONDS
+        retry
+      end
+    end
+
+    def connection
+      Faraday.new do |faraday|
         faraday.use FaradayMiddleware::FollowRedirects, limit: 15
         faraday.adapter Faraday.default_adapter
         faraday.options.timeout = 30
-        faraday.options.open_timeout = 5
+        faraday.options.open_timeout = 10
       end
-      response = conn.get(url)
-      raise "Failed to fetch #{url}: #{response.status}" unless response.success?
-
-      response.body
     end
   end
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -60,7 +60,7 @@
       <%= t(".skip_to_main_content") %>
     </a>
 
-    <%= render(PageBlock::ReviewAppBanner::Component.new(review_app: ENV["REVIEW_APP"], pr_number: ENV["REVIEW_APP_PR_NUMBER"], pr_title: ENV["REVIEW_APP_PR_TITLE"])) %>
+    <%= render(PageBlock::ReviewAppBanner::Component.new(review_app: ENV["REVIEW_APP"], pr_number: ENV["REVIEW_APP_PR_NUMBER"], pr_title: ENV["REVIEW_APP_PR_TITLE"], current_user:)) %>
 
     <%# Cache navbar to speed stuff up, on per-user, per-page %>
     <% cache(["main_navbar5", page_id, current_user_or_unconfirmed_user, passive_organization]) do %>

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,4 +1,6 @@
-system "bin/rake setup:import_spreadsheets"
+# Abort loudly if the import fails: later steps (e.g. seed_manufacturer_priorities)
+# depend on this reference data and would otherwise raise a misleading error.
+abort "Seeding failed: bin/rake setup:import_spreadsheets" unless system("bin/rake setup:import_spreadsheets")
 
 # NOTE: this does not seed manufacturers, primary_activities or components, those are pulled via rake task
 require File.expand_path("db/seeds/seed_helpers", Rails.root)

--- a/spec/components/page_block/review_app_banner/component_spec.rb
+++ b/spec/components/page_block/review_app_banner/component_spec.rb
@@ -9,9 +9,10 @@ RSpec.describe PageBlock::ReviewAppBanner::Component, type: :component do
   end
 
   context "when review_app is present" do
-    let(:component) { render_inline(described_class.new(review_app: "1", pr_number:, pr_title:)) }
+    let(:component) { render_inline(described_class.new(review_app: "1", pr_number:, pr_title:, current_user:)) }
     let(:pr_number) { nil }
     let(:pr_title) { nil }
+    let(:current_user) { nil }
 
     it "renders the label and disclaimer" do
       expect(component.text).to include("Review app")
@@ -40,6 +41,24 @@ RSpec.describe PageBlock::ReviewAppBanner::Component, type: :component do
             .css("form[action='/session/sign_in_with_magic_link'] input[name='token']").first
         end
         expect(input[:value]).to eq superadmin.reload.magic_link_token
+      end
+
+      context "when signed in as the superadmin" do
+        let(:current_user) { superadmin }
+
+        it "shows a signed-in label instead of the button" do
+          expect(component.css("form[action='/session/sign_in_with_magic_link']")).to be_empty
+          expect(component.text).to include("signed in as superadmin")
+        end
+      end
+
+      context "when signed in as another user" do
+        let(:current_user) { FactoryBot.create(:user_confirmed) }
+
+        it "still renders the sign in button" do
+          expect(component.css("form[action='/session/sign_in_with_magic_link']")).to be_present
+          expect(component.text).not_to include("signed in as superadmin")
+        end
       end
     end
 

--- a/spec/components/page_block/review_app_banner/component_spec.rb
+++ b/spec/components/page_block/review_app_banner/component_spec.rb
@@ -31,6 +31,16 @@ RSpec.describe PageBlock::ReviewAppBanner::Component, type: :component do
         expect(form.css("button").text).to eq("sign in as superadmin")
         expect(form.css("input[name='token']").first[:value]).to eq superadmin.reload.magic_link_token
       end
+
+      # The banner renders on pages served under set_reading_role, so refreshing
+      # the (persisted) token must not raise ActiveRecord::ReadOnlyError
+      it "generates the token under the reading database role" do
+        input = ActiveRecord::Base.connected_to(role: :reading) do
+          render_inline(described_class.new(review_app: "1"))
+            .css("form[action='/session/sign_in_with_magic_link'] input[name='token']").first
+        end
+        expect(input[:value]).to eq superadmin.reload.magic_link_token
+      end
     end
 
     it "links to the letter_opener outbox with a tooltip" do

--- a/spec/jobs/spreadsheets/importer_job_spec.rb
+++ b/spec/jobs/spreadsheets/importer_job_spec.rb
@@ -34,5 +34,28 @@ RSpec.describe Spreadsheets::ImporterJob, type: :job do
         expect { described_class.new.perform("bikes") }.to raise_error(ArgumentError, /Unknown importer/)
       end
     end
+
+    context "with a transient network failure" do
+      let(:url) { "#{described_class::RESOURCES_URL}/manufacturers.csv" }
+      let(:csv) do
+        "name,alternate_name,website,makes_frames,ebike_only,open_year,close_year,logo_url\n" \
+          "Retry Bikes,,,,,,,\n"
+      end
+      let(:job) { described_class.new }
+
+      before { allow(job).to receive(:sleep) } # skip the retry backoff
+      after { WebMock.reset! } # these stubs are registered outside a VCR cassette
+
+      it "retries the download, then imports" do
+        WebMock.stub_request(:get, url).to_timeout.then.to_return(status: 200, body: csv)
+        expect { job.perform("manufacturers") }.to change(Manufacturer, :count).by(1)
+        expect(Manufacturer.friendly_find("Retry Bikes")).to be_present
+      end
+
+      it "gives up after DOWNLOAD_ATTEMPTS and raises" do
+        WebMock.stub_request(:get, url).to_timeout
+        expect { job.perform("manufacturers") }.to raise_error(Faraday::Error)
+      end
+    end
   end
 end


### PR DESCRIPTION
Fixes an `ActiveRecord::ReadOnlyError` from the review-app banner's "sign in as superadmin" button ([Honeybadger #132285289](https://app.honeybadger.io/projects/35931/faults/132285289)).

- The button refreshes and **persists** the superadmin's magic link token, but the banner renders on pages like `bikes#show` that run under `set_reading_role`, so the write hit the read-only replica and 500'd the page.
- Force the writing role for the token refresh via a new `superadmin_magic_link_token` helper.
- Adds a regression spec rendering the banner inside `connected_to(role: :reading)`.
