### PR TITLE
Strip legacy code styling from UI::ShortId; fix Lookbook label

### DIFF
--- a/app/components/ui/short_id/component.rb
+++ b/app/components/ui/short_id/component.rb
@@ -5,7 +5,7 @@ module UI
     # Renders a record's short_id (see ShortIdable) as a monospace code block.
     # Pass a record that responds to short_id, or a raw short_id string.
     class Component < ApplicationComponent
-      BASE_CLASSES = "tw:font-mono tw:text-sm"
+      BASE_CLASSES = "tw:font-mono tw:text-sm tw:p-0 tw:bg-transparent tw:text-inherit tw:rounded-none"
 
       def initialize(record: nil, short_id: nil, html_class: nil)
         @short_id = short_id || record&.short_id

--- a/app/components/ui/short_id/component_preview.rb
+++ b/app/components/ui/short_id/component_preview.rb
@@ -2,6 +2,7 @@
 
 module UI
   module ShortId
+    # @label Short ID
     class ComponentPreview < ApplicationComponentPreview
       # @param id text "ID to render"
       def default(id: "r/21J-HW")


### PR DESCRIPTION
Removes the legacy Bootstrap `code` styling (background, red text, padding, border-radius) from `UI::ShortId` so it renders as inline monospace text in the surrounding body color.

- Add `tw:p-0 tw:bg-transparent tw:text-inherit tw:rounded-none` to the component's base classes.
- Set an explicit `@label Short ID` on the Lookbook preview — `humanize` was stripping the trailing `_id` and showing "Short" in the nav.
