### PR TITLE
Style dropdown active state via aria-current + Tailwind variants

### DIFF
--- a/app/assets/tailwind/application.css
+++ b/app/assets/tailwind/application.css
@@ -151,12 +151,6 @@
       tw:dark:text-gray-200 tw:dark:hover:bg-gray-700 tw:dark:hover:text-gray-100;
   }
 
-  .twdropdown li[role="menuitem"] > a.active,
-  .twdropdown li[role="menuitem"] > a:active {
-    @apply tw:bg-gray-200 tw:text-gray-900
-      tw:dark:bg-gray-600 tw:dark:text-gray-100;
-  }
-
   .twdropdown li[role="menuitem"]:has(+ li[role="separator"]) > a {
     @apply tw:pb-2;
   }

--- a/app/components/admin/index_skeleton/component.html.erb
+++ b/app/components/admin/index_skeleton/component.html.erb
@@ -23,10 +23,10 @@
           button_size: :sm,
           active: deleted_active?
         )) do |dropdown|
-          dropdown.with_entry_item { link_to "Only not deleted", url_for(sortable_search_params.merge(search_deleted: nil)), class: deleted_item_class(nil) }
+          dropdown.with_entry_item(active: deleted_item_active?(nil)) { link_to "Only not deleted", url_for(sortable_search_params.merge(search_deleted: nil)) }
           dropdown.with_entry_divider
-          dropdown.with_entry_item { link_to "Including deleted", url_for(sortable_search_params.merge(search_deleted: "including")), class: deleted_item_class("including") }
-          dropdown.with_entry_item { link_to "Only deleted", url_for(sortable_search_params.merge(search_deleted: "only")), class: deleted_item_class("only") }
+          dropdown.with_entry_item(active: deleted_item_active?("including")) { link_to "Including deleted", url_for(sortable_search_params.merge(search_deleted: "including")) }
+          dropdown.with_entry_item(active: deleted_item_active?("only")) { link_to "Only deleted", url_for(sortable_search_params.merge(search_deleted: "only")) }
         end %>
       </li>
     <% end %>

--- a/app/components/admin/index_skeleton/component.rb
+++ b/app/components/admin/index_skeleton/component.rb
@@ -104,10 +104,8 @@ module Admin
         end
       end
 
-      def deleted_item_class(value)
-        if value.nil? ? !deleted_active? : @render_deleted == value
-          "active"
-        end
+      def deleted_item_active?(value)
+        value.nil? ? !deleted_active? : @render_deleted == value
       end
 
       def default_table_view

--- a/app/components/org/impound_records_index/component.html.erb
+++ b/app/components/org/impound_records_index/component.html.erb
@@ -19,7 +19,7 @@
           <% @available_statuses.each do |status| %>
             <% status_active = @search_status == status %>
             <% status_link_params = sortable_search_params.merge(organization_id: @current_organization.id, search_status: (status_active ? nil : status)) %>
-            <% dropdown.with_entry_item { link_to display_status_for(status), organization_impound_records_path(status_link_params), class: ("active" if status_active), data: {turbo_action: "advance"} } %>
+            <% dropdown.with_entry_item(active: status_active) { link_to display_status_for(status), organization_impound_records_path(status_link_params), data: {turbo_action: "advance"} } %>
 
             <%# Divider after "all" %>
             <% dropdown.with_entry_divider if status == "all" %>
@@ -29,9 +29,9 @@
 
       <div class="tw:ml-2 tw:inline-block">
         <%= render(UI::Dropdown::Component.new(name: unregisteredness_dropdown_text, button_size: :sm, active: @search_unregisteredness != "all")) do |dropdown| %>
-          <% dropdown.with_entry_item { link_to translation(".all_bikes"), organization_impound_records_path(sortable_search_params.except(:search_unregisteredness)), class: ("active" if @search_unregisteredness == "all"), data: {turbo_action: "advance"} } %>
-          <% dropdown.with_entry_item { link_to translation(".only_unregistered"), organization_impound_records_path(sortable_search_params.merge(search_unregisteredness: "only_unregistered")), class: ("active" if @search_unregisteredness == "only_unregistered"), data: {turbo_action: "advance"} } %>
-          <% dropdown.with_entry_item { link_to translation(".only_user_registered"), organization_impound_records_path(sortable_search_params.merge(search_unregisteredness: "only_registered")), class: ("active" if @search_unregisteredness == "only_registered"), data: {turbo_action: "advance"} } %>
+          <% dropdown.with_entry_item(active: @search_unregisteredness == "all") { link_to translation(".all_bikes"), organization_impound_records_path(sortable_search_params.except(:search_unregisteredness)), data: {turbo_action: "advance"} } %>
+          <% dropdown.with_entry_item(active: @search_unregisteredness == "only_unregistered") { link_to translation(".only_unregistered"), organization_impound_records_path(sortable_search_params.merge(search_unregisteredness: "only_unregistered")), data: {turbo_action: "advance"} } %>
+          <% dropdown.with_entry_item(active: @search_unregisteredness == "only_registered") { link_to translation(".only_user_registered"), organization_impound_records_path(sortable_search_params.merge(search_unregisteredness: "only_registered")), data: {turbo_action: "advance"} } %>
         <% end %>
       </div>
     </div>

--- a/app/components/ui/dropdown/component.rb
+++ b/app/components/ui/dropdown/component.rb
@@ -3,10 +3,15 @@
 module UI
   module Dropdown
     class Component < ApplicationComponent
+      # Literal strings so Tailwind's scanner generates these aria-current:/active: variants.
+      # Applied to the <li>; the `[&>a]` variant colors the item's link (the surface).
+      # aria-current (not aria-pressed) because aria-pressed is invalid on role="menuitem".
+      ACTIVE_PREFIXED = "tw:aria-[current]:[&>a]:bg-gray-200 tw:active:[&>a]:bg-gray-200 tw:aria-[current]:[&>a]:text-gray-900 tw:active:[&>a]:text-gray-900 tw:aria-[current]:dark:[&>a]:bg-gray-600 tw:active:dark:[&>a]:bg-gray-600 tw:aria-[current]:dark:[&>a]:text-gray-100 tw:active:dark:[&>a]:text-gray-100"
+
       renders_one :button
       renders_many :entries, types: {
-        item: lambda { |&block|
-          content_tag(:li, nil, role: "menuitem", &block)
+        item: lambda { |active: false, &block|
+          content_tag(:li, capture(&block), role: "menuitem", class: ACTIVE_PREFIXED, aria: {current: active || nil})
         },
         divider: lambda {
           content_tag(:li, "", role: "separator")

--- a/app/components/ui/dropdown/component_preview.rb
+++ b/app/components/ui/dropdown/component_preview.rb
@@ -23,7 +23,7 @@ module UI
           dropdown.with_entry_item { content_tag(:span, "Last synced: 2 minutes ago", class: "tw:block tw:px-4 tw:py-2 tw:text-sm tw:text-gray-500 tw:dark:text-gray-400") }
           dropdown.with_entry_divider
           dropdown.with_entry_item { icon_link("⚙", "Settings") }
-          dropdown.with_entry_item { icon_link("↻", "Sync (active)", active: true) }
+          dropdown.with_entry_item(active: true) { icon_link("↻", "Sync (active)") }
         end
       end
 
@@ -42,8 +42,8 @@ module UI
         "tw:flex tw:items-center tw:gap-1 tw:rounded-full tw:bg-gray-100 tw:pr-3 tw:pl-1 tw:py-1 tw:text-sm tw:font-medium tw:text-gray-700 tw:hover:bg-gray-200 tw:dark:bg-gray-700 tw:dark:text-gray-200 tw:dark:hover:bg-gray-600"
       end
 
-      def icon_link(icon, label, active: false)
-        content_tag(:a, href: "#", class: "tw:flex tw:items-center tw:gap-2 #{"active" if active}".strip) do
+      def icon_link(icon, label)
+        content_tag(:a, href: "#", class: "tw:flex tw:items-center tw:gap-2") do
           safe_join([content_tag(:span, icon, class: "tw:text-base"), label])
         end
       end

--- a/app/views/admin/bug_reports/index.html.erb
+++ b/app/views/admin/bug_reports/index.html.erb
@@ -5,10 +5,10 @@
       button_size: :sm,
       active: @searched_tag.present?
     )) do |dropdown|
-      dropdown.with_entry_item { link_to "All tags", url_for(sortable_search_params.merge(search_tag: nil)), class: (@searched_tag.blank? ? "active" : nil) }
+      dropdown.with_entry_item(active: @searched_tag.blank?) { link_to "All tags", url_for(sortable_search_params.merge(search_tag: nil)) }
       dropdown.with_entry_divider
       searchable_tags.each do |tag|
-        dropdown.with_entry_item { link_to tag, url_for(sortable_search_params.merge(search_tag: tag)), class: (@searched_tag == tag ? "active" : nil) }
+        dropdown.with_entry_item(active: @searched_tag == tag) { link_to tag, url_for(sortable_search_params.merge(search_tag: tag)) }
       end
     end %>
   </li>

--- a/app/views/admin/registration_sequences/index.html.erb
+++ b/app/views/admin/registration_sequences/index.html.erb
@@ -5,10 +5,10 @@
       button_size: :sm,
       active: @status.present?
     )) do |dropdown|
-      dropdown.with_entry_item { link_to "All statuses", url_for(sortable_search_params.merge(search_status: nil)), class: (@status.blank? ? "active" : nil) }
+      dropdown.with_entry_item(active: @status.blank?) { link_to "All statuses", url_for(sortable_search_params.merge(search_status: nil)) }
       dropdown.with_entry_divider
       searchable_statuses.each do |kind|
-        dropdown.with_entry_item { link_to "#{kind.titleize} only", url_for(sortable_search_params.merge(search_status: kind)), class: (@status == kind ? "active" : nil) }
+        dropdown.with_entry_item(active: @status == kind) { link_to "#{kind.titleize} only", url_for(sortable_search_params.merge(search_status: kind)) }
       end
     end %>
   </li>

--- a/app/views/organized/graduated_notifications/_results.html.erb
+++ b/app/views/organized/graduated_notifications/_results.html.erb
@@ -43,8 +43,8 @@
         <% status_active = @search_status == status %>
         <% status_link_params = sortable_search_params.merge(organization_id: current_organization.id, search_status: (status_active ? nil : status)) %>
 
-        <% dropdown.with_entry_item do %>
-          <%= link_to status_display.call(status), organization_graduated_notifications_path(status_link_params), class: (status_active ? "active" : nil), data: {turbo_action: "advance"} %>
+        <% dropdown.with_entry_item(active: status_active) do %>
+          <%= link_to status_display.call(status), organization_graduated_notifications_path(status_link_params), data: {turbo_action: "advance"} %>
         <% end %>
       <% end %>
     <% end %>

--- a/spec/components/ui/dropdown/component_system_spec.rb
+++ b/spec/components/ui/dropdown/component_system_spec.rb
@@ -46,6 +46,9 @@ RSpec.describe UI::Dropdown::Component, :js, type: :system do
       expect(page).to have_text("Last synced: 2 minutes ago")
       expect(page).to have_text("Settings")
       expect(page).to have_text("Sync")
+      # The active item is marked aria-current; inactive items are not
+      expect(page).to have_css('li[role="menuitem"][aria-current]', text: "Sync")
+      expect(page).to have_css('li[role="menuitem"]:not([aria-current])', text: "Settings")
       expect_axe_clean
 
       send_keys(:escape)


### PR DESCRIPTION
Refactors the `UI::Dropdown` active-item styling from a bespoke `.active` CSS rule (removed from `application.css`) to `aria-current` on the `<li>`, styled by `aria-[current]:`/`active:` Tailwind variants carried in the component itself.

- `with_entry_item` now takes an `active:` keyword and sets `aria-current`; the six call sites (admin index skeleton, bug reports, registration sequences, impound records, graduated notifications, preview) pass `active:` instead of hand-setting `class: "active"`.
- Uses `aria-current` rather than `aria-pressed` since the latter is invalid on `role="menuitem"`.
