### PR TITLE
Review-app banner: return-to redirect, z-index, de-emphasized signed-in label

### DIFF
--- a/.claude/skills/frontend-screenshots/SKILL.md
+++ b/.claude/skills/frontend-screenshots/SKILL.md
@@ -8,8 +8,11 @@ description: >-
   across branches, design review, demos — including mid-interaction states
   like an open dropdown, a modal showing, a form mid-fill, or a hover. Use it
   even when the user just says "grab a screenshot" or "show me what this looks
-  like" without naming Playwright. Inputs: `(url-path, page-slug)` pairs,
-  optionally with per-URL interaction steps. Output: local PNG paths.
+  like" without naming Playwright. For a component that only renders under an
+  env var / feature flag / hard-to-reach state (e.g. the review-app banner),
+  screenshot its ViewComponent/Lookbook preview URL instead of a full page.
+  Inputs: `(url-path, page-slug)` pairs, optionally with per-URL interaction
+  steps. Output: local PNG paths.
 allowed-tools: Bash, Read
 ---
 
@@ -65,6 +68,20 @@ Two viewports — resize once each, then walk every URL:
 **Mid-interaction states are in scope.** When the caller asks for a dropdown open, a modal showing, a hover state, a partially-filled form, etc., drive Playwright between settle and the screenshot — `browser_click`, `browser_type`, `browser_press_key`, `browser_hover`, then wait for the UI to reach the target state (`browser_wait_for` on a marker element, or check via `browser_evaluate`) before `browser_take_screenshot`. Treat the interaction sequence as part of the page-slug — e.g. capture `combobox-open` after clicking + typing, distinct from a static `search-registrations` page-load shot. For cross-branch comparisons, run the *same* interaction sequence on each branch so the screenshots actually compare like-for-like.
 
 Sanity-check each PNG: under ~5 KB usually means the page errored. Pull `browser_console_messages` and look only for **uncaught exceptions from app code** (Stimulus registration failures, `TypeError`s in `app/javascript/**`) — Webpacker logs, asset 404s, third-party deprecation warnings are noise. To diagnose a failed capture: HTTP status via `curl -s -o /dev/null -w "%{http_code}\n" "$BASE_URL/<path>"`, response body via `curl -s "$BASE_URL/<path>" | head -200`, full backtrace via `tail -200 log/development.log`.
+
+## Component previews (when no page shows the state)
+
+Some components only render in a context you can't reproduce on a normal dev page — gated by an env var (e.g. the review-app banner needs `REVIEW_APP`), a feature flag, or a hard-to-reach error/empty state. When a component has a ViewComponent/Lookbook preview, screenshot the **preview URL** instead of hunting for a page that happens to render it:
+
+```
+$BASE_URL/rails/view_components/<preview_path>/<scenario>
+```
+
+`<preview_path>` is the preview class underscored with the `Preview` suffix dropped, and `<scenario>` is the preview method. `PageBlock::ReviewAppBanner::ComponentPreview#superadmin_signed_in` → `/rails/view_components/page_block/review_app_banner/component/superadmin_signed_in`. If a scenario doesn't exist yet, add a method to the component's `*_preview.rb` first — a preview that renders the exact state (pass the args that trigger it) is often the fastest path to a clean shot.
+
+The preview page loads Tailwind and renders the component standalone (no site chrome), so capture the viewport as usual (`fullPage: false`); a small ViewComponent render-timing line at the bottom is harmless. Everything else still applies — same PII/seed-data gate, same `(url-path, page-slug)` naming (use a slug like `banner-signed-in`).
+
+Previews that query the dev DB (e.g. `User.admins.first`) render nothing when that data is missing — if the state doesn't appear, seed first with `bundle exec rails db:seed`. This is component-only: a preview can't show layout/stacking against the rest of the page (e.g. a navbar z-index fix), so use a real page for those.
 
 ## Cross-branch comparison (optional)
 

--- a/app/assets/stylesheets/revised/sections/primary_header_nav.scss
+++ b/app/assets/stylesheets/revised/sections/primary_header_nav.scss
@@ -320,6 +320,10 @@ $mainmenu-open-zindex: 10;
   }
 
   .primary-header-nav.menu-in {
+    // Lift above the review-app banner ($banner z-index: 1040) so the open menu
+    // isn't tucked under it
+    z-index: $zindex-navbar-fixed + 20;
+
     #menu-opened-backdrop {
       display: block;
     }

--- a/app/components/page_block/review_app_banner/component.html.erb
+++ b/app/components/page_block/review_app_banner/component.html.erb
@@ -25,11 +25,14 @@
   <% end %>
   <% if signed_in_as_superadmin? %>
     &middot;
-    <%= translation(".superadmin_signed_in") %>
+    <span class="tw:font-normal tw:text-black/60 tw:italic">
+      <%= translation(".superadmin_signed_in") %>
+    </span>
   <% elsif superadmin %>
     &middot;
     <%= form_with url: sign_in_with_magic_link_session_path, class: "tw:inline-block tw:align-middle" do %>
       <%= hidden_field_tag :token, superadmin_magic_link_token %>
+      <%= hidden_field_tag :return_to, @return_to if @return_to.present? %>
       <%= render UI::Button::Component.new(text: translation(".superadmin_button"), kind: :submit, size: :sm) %>
     <% end %>
   <% end %>

--- a/app/components/page_block/review_app_banner/component.html.erb
+++ b/app/components/page_block/review_app_banner/component.html.erb
@@ -9,13 +9,32 @@
     tw:px-4 tw:py-2 tw:text-center tw:font-semibold tw:text-black
   "
 >
-  <%= translation(".label") %>
+  <%#
+    "Review app" and "data is ephemeral" are just labels; hide them (and their
+    separators) on small screens so the actionable links fit
+  %>
+  <span class="tw:hidden tw:sm:inline"><%= translation(".label") %></span>
+
   <% if @pr_number %>
-    &middot;
+    <span class="tw:hidden tw:sm:inline">&middot;</span>
     <a class="tw:underline" href="<%= pr_url %>"><%= pr_link_text %></a>
   <% end %>
-  &middot; <%= translation(".disclaimer") %> &middot;
+
+  <span class="tw:hidden tw:sm:inline">
+    &middot; <%= translation(".disclaimer") %>
+  </span>
+
+  <%#
+    Separator before the outbox: keep it on small screens only when a PR link
+    precedes it, otherwise it would orphan at the start
+  %>
+
+  <span class="<%= "tw:hidden tw:sm:inline" unless @pr_number %>">
+    &middot;
+  </span>
+
   <%= link_to translation(".letter_opener_link"), "/letter_opener", class: "tw:font-normal tw:underline" %>
+
   <%= render(UI::Tooltip::Component.new(text: translation(".letter_opener_tooltip"))) do |tooltip| %>
     <% tooltip.with_tooltip_button(
       class: "tw:inline-flex tw:items-center tw:justify-center tw:h-4 tw:w-4 tw:rounded-full " \
@@ -23,6 +42,7 @@
         "tw:focus:outline-none tw:focus:ring-3 tw:focus:ring-blue-500/40"
     ) { "?" } %>
   <% end %>
+
   <% if signed_in_as_superadmin? %>
     &middot;
     <span class="tw:font-normal tw:text-black/60 tw:italic">

--- a/app/components/page_block/review_app_banner/component.rb
+++ b/app/components/page_block/review_app_banner/component.rb
@@ -8,11 +8,12 @@ module PageBlock
     # `ENV["REVIEW_APP_PR_TITLE"]`; the component renders only when `review_app`
     # is present.
     class Component < ApplicationComponent
-      def initialize(review_app:, pr_number: nil, pr_title: nil, current_user: nil)
+      def initialize(review_app:, pr_number: nil, pr_title: nil, current_user: nil, return_to: nil)
         @review_app = review_app
         @pr_number = pr_number
         @pr_title = pr_title
         @current_user = current_user
+        @return_to = return_to
       end
 
       def render?

--- a/app/components/page_block/review_app_banner/component_preview.rb
+++ b/app/components/page_block/review_app_banner/component_preview.rb
@@ -12,6 +12,18 @@ module PageBlock
       def without_pr_title
         render(PageBlock::ReviewAppBanner::Component.new(review_app: "1", pr_number: 3664))
       end
+
+      # Superadmin sign-in button, carrying the current page as return_to.
+      def superadmin_sign_in
+        render(PageBlock::ReviewAppBanner::Component.new(review_app: "1", pr_number: 3664,
+          return_to: "/bikes/12"))
+      end
+
+      # Already signed in as the superadmin — de-emphasized italic label.
+      def superadmin_signed_in
+        render(PageBlock::ReviewAppBanner::Component.new(review_app: "1", pr_number: 3664,
+          current_user: User.admins.first))
+      end
     end
   end
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -60,7 +60,7 @@
       <%= t(".skip_to_main_content") %>
     </a>
 
-    <%= render(PageBlock::ReviewAppBanner::Component.new(review_app: ENV["REVIEW_APP"], pr_number: ENV["REVIEW_APP_PR_NUMBER"], pr_title: ENV["REVIEW_APP_PR_TITLE"], current_user:)) %>
+    <%= render(PageBlock::ReviewAppBanner::Component.new(review_app: ENV["REVIEW_APP"], pr_number: ENV["REVIEW_APP_PR_NUMBER"], pr_title: ENV["REVIEW_APP_PR_TITLE"], current_user:, return_to: request.fullpath)) %>
 
     <%# Cache navbar to speed stuff up, on per-user, per-page %>
     <% cache(["main_navbar5", page_id, current_user_or_unconfirmed_user, passive_organization]) do %>

--- a/spec/components/page_block/review_app_banner/component_spec.rb
+++ b/spec/components/page_block/review_app_banner/component_spec.rb
@@ -20,6 +20,16 @@ RSpec.describe PageBlock::ReviewAppBanner::Component, type: :component do
       expect(component.text).to include("data is ephemeral")
     end
 
+    it "hides the label and disclaimer on small screens" do
+      # tw:hidden tw:sm:inline => display:none below the sm breakpoint
+      label = component.css("span.tw\\:hidden", text: "Review app").first
+      disclaimer = component.css("span.tw\\:hidden", text: "data is ephemeral").first
+      expect(label).to be_present
+      expect(disclaimer).to be_present
+      # The outbox link stays visible, so it's not inside a hidden span
+      expect(component.css("span.tw\\:hidden a[href='/letter_opener']")).to be_empty
+    end
+
     it "doesn't render the superadmin button when there is no superadmin" do
       expect(component.css("form[action='/session/sign_in_with_magic_link']")).to be_empty
     end

--- a/spec/components/page_block/review_app_banner/component_spec.rb
+++ b/spec/components/page_block/review_app_banner/component_spec.rb
@@ -9,10 +9,11 @@ RSpec.describe PageBlock::ReviewAppBanner::Component, type: :component do
   end
 
   context "when review_app is present" do
-    let(:component) { render_inline(described_class.new(review_app: "1", pr_number:, pr_title:, current_user:)) }
+    let(:component) { render_inline(described_class.new(review_app: "1", pr_number:, pr_title:, current_user:, return_to:)) }
     let(:pr_number) { nil }
     let(:pr_title) { nil }
     let(:current_user) { nil }
+    let(:return_to) { nil }
 
     it "renders the label and disclaimer" do
       expect(component.text).to include("Review app")
@@ -31,6 +32,16 @@ RSpec.describe PageBlock::ReviewAppBanner::Component, type: :component do
         expect(form).to be_present
         expect(form.css("button").text).to eq("sign in as superadmin")
         expect(form.css("input[name='token']").first[:value]).to eq superadmin.reload.magic_link_token
+        expect(form.css("input[name='return_to']")).to be_empty
+      end
+
+      context "with a return_to" do
+        let(:return_to) { "/bikes/12" }
+
+        it "posts the return_to so sign-in redirects back to the current page" do
+          form = component.css("form[action='/session/sign_in_with_magic_link']").first
+          expect(form.css("input[name='return_to']").first[:value]).to eq "/bikes/12"
+        end
       end
 
       # The banner renders on pages served under set_reading_role, so refreshing

--- a/spec/integration/organized/graduated_notifications_search_spec.rb
+++ b/spec/integration/organized/graduated_notifications_search_spec.rb
@@ -81,8 +81,12 @@ RSpec.describe "Organized graduated notifications search", :js, type: :system do
     expect(page).to have_css("tbody tr", count: 2, wait: 10)
     expect(page).to have_field("search_email", with: "")
 
-    # Form submit + direct back-nav: regression guard for turbo-cache spinner state
+    # Form submit + direct back-nav: regression guard for turbo-cache spinner state.
+    # Read the field back before submitting so Capybara waits for the typed value
+    # to be committed in the DOM — otherwise a slow runner can submit the form
+    # while search_email is still empty (observed only on CI).
     fill_in "search_email", with: "alice@example.com"
+    expect(page).to have_field("search_email", with: "alice@example.com", wait: 10)
     find("#search-button").click
 
     expect(page).to have_current_path(/search_email=alice/, wait: 10)

--- a/spec/integration/registration/edit_spec.rb
+++ b/spec/integration/registration/edit_spec.rb
@@ -143,7 +143,10 @@ RSpec.describe "Editing a registration", :js, type: :system do
       fill_in "manufacturer_update_reason", with: "It is actually a Trek"
       click_button "Submit update"
     end
-    expect(page).to have_content("Trek", wait: 10)
+    # The correction reloads the page and re-shows the stored success alert. Wait
+    # for that alert rather than the "Trek" selectize chip, which renders before
+    # the reload — otherwise click_edit_nav races the alert and can't dismiss it.
+    expect(page).to have_content("We've updated your manufacturer!", wait: 10)
     expect(bike.reload.manufacturer).to eq trek
 
     # ---- Wheels and Drivetrain ----

--- a/spec/requests/sessions_request_spec.rb
+++ b/spec/requests/sessions_request_spec.rb
@@ -83,6 +83,13 @@ RSpec.describe SessionsController, type: :request do
       expect(superadmin.reload.magic_link_token).to be_nil
       expect(superadmin.last_login_at).to be_within(1.second).of Time.current
     end
+
+    it "redirects back to return_to when passed (review-app banner)" do
+      post "/session/sign_in_with_magic_link",
+        params: {token: superadmin.refreshed_magic_link_token, return_to: "/bikes/12"}
+      expect(response).to redirect_to "/bikes/12"
+      expect(superadmin.reload.magic_link_token).to be_nil
+    end
   end
 
   describe "create" do


### PR DESCRIPTION
Small fixes to the review-app (staging) banner and the mobile nav it sits above.

- **Sign-in returns you to where you were**: the "sign in as superadmin" button posts the current path as `return_to`, so sign-in lands back on the page instead of the admin root.
- **Open mobile menu no longer hides under the banner**: `.menu-in` lifts the navbar above the banner's `z-index: 1040` stacking context.
- **Banner trimmed for phones**: "signed in as superadmin" is de-emphasized (normal-weight italic, lower contrast), and "Review app" / "data is ephemeral" are hidden below the `sm` breakpoint so the actionable links fit.

Also hardens two pre-existing flaky `:js` integration specs (registration edit, graduated-notifications search), and documents in the frontend-screenshots skill how to shoot an env-gated component via its ViewComponent preview. Lookbook previews `superadmin_sign_in` / `superadmin_signed_in` cover the banner states.
