### PR TITLE
Deterministic by_priority ordering to fix flaky spec

### DIFF
--- a/app/models/primary_activity.rb
+++ b/app/models/primary_activity.rb
@@ -46,7 +46,7 @@ class PrimaryActivity < ApplicationRecord
 
   scope :family, -> { where(family: true) }
   scope :flavor, -> { where(family: false) }
-  scope :by_priority, -> { order(priority: :desc) }
+  scope :by_priority, -> { order(priority: :desc, id: :asc) }
   scope :alphabetized, -> { order(Arel.sql("LOWER(name)")) }
   # top_level means that there isn't a family
   scope :top_level, -> { where("primary_activity_family_id = id") }


### PR DESCRIPTION
Fixes a flaky failure in `PrimaryActivity#friendly_find_id_and_family_ids` where equal-priority rows came back in arbitrary Postgres order (`[82, 84, 83]` vs the expected `[82, 83, 84]`).

- Add an `id: :asc` tiebreak to the `by_priority` scope so ordering is deterministic when priorities are equal.
