### PR TITLE
Add BikeSticker short_id (s/) and accept short_ids on the bikes API

### DIFF
--- a/app/controllers/api/v2/bikes.rb
+++ b/app/controllers/api/v2/bikes.rb
@@ -97,11 +97,14 @@ module API
         end
 
         def find_bike
-          @bike = if params[:id].to_s.match?(/\As[\W_]/i) # sticker short_id, e.g. "s/A1029"
-            BikeSticker.lookup_with_fallback(params[:id].to_s.sub(/\As[\W_]*/i, ""))&.bike
+          # short_id "/" separator arrives split across :prefix and :id (Grape's :id can't span a slash)
+          short_id = params[:prefix].present? ? "#{params[:prefix]}/#{params[:id]}" : params[:id]
+          @bike = if short_id.to_s.match?(/\As[\W_]/i) # sticker short_id, e.g. "s/A1029"
+            BikeSticker.lookup_with_fallback(short_id.to_s.sub(/\As[\W_]*/i, ""))&.bike
           else
-            Bike.unscoped.find_id(params[:id])
+            Bike.unscoped.find_id(short_id)
           end
+          @bike || raise(ActiveRecord::RecordNotFound) # sticker lookup returns nil rather than raising
         end
 
         def owner_duplicate_bike(bikes: nil)
@@ -163,6 +166,15 @@ module API
           requires :id, type: String, desc: "Bike id, or a short_id (bike: 'r/21J-HW', sticker: 's/A1029')"
         end
         get ":id" do
+          BikeV2ShowSerializer.new(find_bike, root: "bike").as_json
+        end
+
+        desc "View bike by a short_id with a '/' separator (bike 'r/35', sticker 's/a044')"
+        params do
+          requires :prefix, type: String, desc: "Short_id prefix ('r' bike, 's' sticker)"
+          requires :id, type: String, desc: "Short_id body"
+        end
+        get ":prefix/:id", requirements: {prefix: /[rs]/i} do
           BikeV2ShowSerializer.new(find_bike, root: "bike").as_json
         end
 

--- a/app/controllers/api/v2/bikes.rb
+++ b/app/controllers/api/v2/bikes.rb
@@ -99,7 +99,11 @@ module API
         def find_bike
           # short_id "/" separator arrives split across :prefix and :id (Grape's :id can't span a slash)
           short_id = (params[:prefix].present? ? "#{params[:prefix]}/#{params[:id]}" : params[:id]).to_s
-          return @bike = Bike.unscoped.find_id(short_id) unless short_id.match?(/\As[\W_]/i)
+          unless short_id.match?(/\As[\W_]/i)
+            @bike = Bike.unscoped.find_id(short_id)
+            raise ActiveRecord::RecordNotFound unless @bike.visible_by?(current_user)
+            return @bike
+          end
 
           code = short_id.sub(/\As[\W_]*/i, "") # sticker short_id, e.g. "s/A1029"
           bike_sticker = BikeSticker.lookup_with_fallback(code)

--- a/app/controllers/api/v2/bikes.rb
+++ b/app/controllers/api/v2/bikes.rb
@@ -97,7 +97,11 @@ module API
         end
 
         def find_bike
-          @bike = Bike.unscoped.find_id(params[:id])
+          @bike = if params[:id].to_s.match?(/\As[\W_]/i) # sticker short_id, e.g. "s/A1029"
+            BikeSticker.lookup_with_fallback(params[:id].to_s.sub(/\As[\W_]*/i, ""))&.bike
+          else
+            Bike.unscoped.find_id(params[:id])
+          end
         end
 
         def owner_duplicate_bike(bikes: nil)
@@ -156,7 +160,7 @@ module API
       resource :bikes do
         desc "View bike with a given ID"
         params do
-          requires :id, type: Integer, desc: "Bike id"
+          requires :id, type: String, desc: "Bike id, or a short_id (bike: 'r/21J-HW', sticker: 's/A1029')"
         end
         get ":id" do
           BikeV2ShowSerializer.new(find_bike, root: "bike").as_json

--- a/app/controllers/api/v2/bikes.rb
+++ b/app/controllers/api/v2/bikes.rb
@@ -98,9 +98,9 @@ module API
 
         def find_bike
           # short_id "/" separator arrives split across :prefix and :id (Grape's :id can't span a slash)
-          short_id = params[:prefix].present? ? "#{params[:prefix]}/#{params[:id]}" : params[:id]
-          @bike = if short_id.to_s.match?(/\As[\W_]/i) # sticker short_id, e.g. "s/A1029"
-            BikeSticker.lookup_with_fallback(short_id.to_s.sub(/\As[\W_]*/i, ""))&.bike
+          short_id = (params[:prefix].present? ? "#{params[:prefix]}/#{params[:id]}" : params[:id]).to_s
+          @bike = if short_id.match?(/\As[\W_]/i) # sticker short_id, e.g. "s/A1029"
+            BikeSticker.lookup_with_fallback(short_id.sub(/\As[\W_]*/i, ""))&.bike
           else
             Bike.unscoped.find_id(short_id)
           end

--- a/app/controllers/api/v2/bikes.rb
+++ b/app/controllers/api/v2/bikes.rb
@@ -99,12 +99,13 @@ module API
         def find_bike
           # short_id "/" separator arrives split across :prefix and :id (Grape's :id can't span a slash)
           short_id = (params[:prefix].present? ? "#{params[:prefix]}/#{params[:id]}" : params[:id]).to_s
-          @bike = if short_id.match?(/\As[\W_]/i) # sticker short_id, e.g. "s/A1029"
-            BikeSticker.lookup_with_fallback(short_id.sub(/\As[\W_]*/i, ""))&.bike
-          else
-            Bike.unscoped.find_id(short_id)
-          end
-          @bike || raise(ActiveRecord::RecordNotFound) # sticker lookup returns nil rather than raising
+          return @bike = Bike.unscoped.find_id(short_id) unless short_id.match?(/\As[\W_]/i)
+
+          code = short_id.sub(/\As[\W_]*/i, "") # sticker short_id, e.g. "s/A1029"
+          bike_sticker = BikeSticker.lookup_with_fallback(code)
+          error!("Unable to find bike sticker: #{code}", 404) if bike_sticker.blank?
+          error!("Bike sticker #{bike_sticker.code} is not assigned to a bike", 404) if bike_sticker.bike.blank?
+          @bike = bike_sticker.bike
         end
 
         def owner_duplicate_bike(bikes: nil)

--- a/app/models/bike_sticker.rb
+++ b/app/models/bike_sticker.rb
@@ -221,6 +221,11 @@ class BikeSticker < ApplicationRecord
     ].compact.join("")
   end
 
+  # Short_id is the sticker code, e.g. "s/A1029"; the /s/<code> route redirects to the scanned lookup
+  def short_id
+    "#{ShortId::PREFIXES.fetch(self.class.name)}/#{code}"
+  end
+
   def next_unclaimed_code
     BikeSticker.where(organization_id: organization_id).next_unclaimed_code(id)
   end

--- a/app/services/short_id.rb
+++ b/app/services/short_id.rb
@@ -2,7 +2,7 @@ module ShortId
   extend Functionable
 
   # Prefix per model class, so a short_id self-identifies
-  PREFIXES = {"Bike" => "r", "BikeVersion" => "v", "MarketplaceListing" => "m"}.freeze
+  PREFIXES = {"Bike" => "r", "BikeVersion" => "v", "MarketplaceListing" => "m", "BikeSticker" => "s"}.freeze
 
   # Compact, prefixed alias for an id, e.g. ShortId.encode("Bike", 3431156) => "r/21J-HW".
   # Ids whose base36 form is under 3 digits stay decimal, so they never collide with
@@ -16,11 +16,12 @@ module ShortId
   end
 
   # Resolve a short_id back to an id. The class prefix and its separator are
-  # both optional ("r/21J-HW", "r-21JHW", "r21jhw" all match) and other
-  # separators are ignored. A leftover with letters is base36; an all-digit
-  # leftover is a plain decimal id, so "35", "r/35", and "z" all find bike 35.
+  # both optional ("r/21J-HW", "r-21JHW", "r_21JHW", "r21jhw" all match) and
+  # other separators (including "_") are ignored. A leftover with letters is
+  # base36; an all-digit leftover is a plain decimal id, so "35", "r/35", and
+  # "z" all find bike 35.
   def decode(class_name, short_id)
-    str = short_id.to_s.sub(/\A#{PREFIXES.fetch(class_name)}\W*/i, "").gsub(/\W/, "")
+    str = short_id.to_s.sub(/\A#{PREFIXES.fetch(class_name)}[\W_]*/i, "").gsub(/[\W_]/, "")
     str.match?(/[a-z]/i) ? str.to_i(36) : str
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -194,6 +194,10 @@ Rails.application.routes.draw do
   get "bikes/:id/edit(/:edit_template)", to: "bikes/edits#show", as: :edit_bike
   get "bikes/scanned/:scanned_id", to: "bikes#scanned"
   get "stickers/:scanned_id", to: "bikes#scanned"
+  # Short sticker URL (BikeSticker short_id): /s/<code> redirects to the canonical scanned path
+  get "s/:scanned_id", to: redirect { |params, request|
+    ["/bikes/scanned/#{params[:scanned_id]}", request.query_string.presence].compact.join("?")
+  }
 
   resources :bike_versions, except: [:edit]
   get "bike_versions/:id/edit(/:edit_template)", to: "bike_versions/edits#show", as: :edit_bike_version

--- a/spec/models/bike_sticker_spec.rb
+++ b/spec/models/bike_sticker_spec.rb
@@ -245,6 +245,13 @@ RSpec.describe BikeSticker, type: :model do
     end
   end
 
+  describe "short_id" do
+    it "is the code prefixed with s/" do
+      bike_sticker = FactoryBot.create(:bike_sticker, code: "UC1101")
+      expect(bike_sticker.short_id).to eq "s/UC1101"
+    end
+  end
+
   describe "code_integer code_prefix and pretty_lookup" do
     let(:bike_sticker) { BikeSticker.new(code: "b02012012") }
     before { bike_sticker.set_calculated_attributes }

--- a/spec/requests/api/v3/bikes_request_spec.rb
+++ b/spec/requests/api/v3/bikes_request_spec.rb
@@ -150,6 +150,29 @@ RSpec.describe "Bikes API V3", type: :request do
           expect(json_result["error"]).to eq "Bike sticker B22 is not assigned to a bike"
         end
       end
+
+      context "soft-deleted bike with an assigned sticker" do
+        let!(:bike_sticker) { FactoryBot.create(:bike_sticker, code: "C55", bike: bike) }
+        before { bike.destroy }
+
+        it "404s identically by id and short_id, and reads the sticker as unassigned" do
+          expect(bike.deleted_at).to be_present
+
+          # the bike id and its r/ short_id are no longer visible - identical 404
+          get "/api/v3/bikes/#{bike.id}", params: {format: :json}
+          expect(response.code).to eq("404")
+          by_id_error = json_result["error"]
+
+          get "/api/v3/bikes/#{bike.short_id}", params: {format: :json}
+          expect(response.code).to eq("404")
+          expect(json_result["error"]).to eq by_id_error
+
+          # the sticker still points at the now-invisible bike, so it reads as unassigned
+          get "/api/v3/bikes/s/C55", params: {format: :json}
+          expect(response.code).to eq("404")
+          expect(json_result["error"]).to eq "Bike sticker C55 is not assigned to a bike"
+        end
+      end
     end
   end
 

--- a/spec/requests/api/v3/bikes_request_spec.rb
+++ b/spec/requests/api/v3/bikes_request_spec.rb
@@ -139,7 +139,7 @@ RSpec.describe "Bikes API V3", type: :request do
         it "responds with 404 for an unknown sticker" do
           get "/api/v3/bikes/s/nope999", params: {format: :json}
           expect(response.code).to eq("404")
-          expect(json_result["error"].present?).to be_truthy
+          expect(json_result["error"]).to eq "Unable to find bike sticker: nope999"
         end
 
         it "responds with 404 for an unassigned sticker" do
@@ -147,7 +147,7 @@ RSpec.describe "Bikes API V3", type: :request do
           expect(unassigned.bike_id).to be_nil
           get "/api/v3/bikes/#{unassigned.short_id}", params: {format: :json}
           expect(response.code).to eq("404")
-          expect(json_result["error"].present?).to be_truthy
+          expect(json_result["error"]).to eq "Bike sticker B22 is not assigned to a bike"
         end
       end
     end

--- a/spec/requests/api/v3/bikes_request_spec.rb
+++ b/spec/requests/api/v3/bikes_request_spec.rb
@@ -113,10 +113,11 @@ RSpec.describe "Bikes API V3", type: :request do
     end
 
     describe "short_id" do
-      # A short_id's "/" must be URL-encoded (%2F) in a path segment; the "_" and "-"
-      # separators (see ShortId.decode) are equivalent and avoid the encoding.
+      # The short_id "/" is a real path separator here (e.g. /api/v3/bikes/r/35); the "_" and
+      # "-" separators (see ShortId.decode) are accepted equivalents.
       it "finds the bike from its short_id (r/ and r_)" do
-        [bike.short_id.sub("/", "%2F"), bike.short_id.tr("/", "_")].each do |short_id|
+        expect(bike.short_id).to eq "r/#{bike.id}"
+        [bike.short_id, bike.short_id.tr("/", "_")].each do |short_id|
           get "/api/v3/bikes/#{short_id}", params: {format: :json}
           expect(response.code).to eq("200")
           expect(json_result["bike"]["id"]).to eq bike.id
@@ -124,15 +125,21 @@ RSpec.describe "Bikes API V3", type: :request do
       end
 
       context "bike_sticker short_id" do
-        let!(:bike_sticker) { FactoryBot.create(:bike_sticker, code: "A1029", bike: bike) }
+        let!(:bike_sticker) { FactoryBot.create(:bike_sticker, code: "A044", bike: bike) }
 
-        it "finds the sticker's bike (s/ and s-)" do
-          expect(bike_sticker.short_id).to eq "s/A1029"
-          ["s%2FA1029", "s-A1029"].each do |short_id|
+        it "finds the sticker's bike (s/, lowercase, and s-)" do
+          expect(bike_sticker.short_id).to eq "s/A44" # code normalizes, stripping the leading zero
+          ["s/A44", "s/a044", "s-A44"].each do |short_id|
             get "/api/v3/bikes/#{short_id}", params: {format: :json}
             expect(response.code).to eq("200")
             expect(json_result["bike"]["id"]).to eq bike.id
           end
+        end
+
+        it "responds with 404 for an unknown sticker" do
+          get "/api/v3/bikes/s/nope999", params: {format: :json}
+          expect(response.code).to eq("404")
+          expect(json_result["error"].present?).to be_truthy
         end
       end
     end

--- a/spec/requests/api/v3/bikes_request_spec.rb
+++ b/spec/requests/api/v3/bikes_request_spec.rb
@@ -141,6 +141,14 @@ RSpec.describe "Bikes API V3", type: :request do
           expect(response.code).to eq("404")
           expect(json_result["error"].present?).to be_truthy
         end
+
+        it "responds with 404 for an unassigned sticker" do
+          unassigned = FactoryBot.create(:bike_sticker, code: "B22")
+          expect(unassigned.bike_id).to be_nil
+          get "/api/v3/bikes/#{unassigned.short_id}", params: {format: :json}
+          expect(response.code).to eq("404")
+          expect(json_result["error"].present?).to be_truthy
+        end
       end
     end
   end

--- a/spec/requests/api/v3/bikes_request_spec.rb
+++ b/spec/requests/api/v3/bikes_request_spec.rb
@@ -111,6 +111,31 @@ RSpec.describe "Bikes API V3", type: :request do
       expect(response.headers["Access-Control-Allow-Origin"]).to eq("*")
       expect(response.headers["Access-Control-Request-Method"]).to eq("*")
     end
+
+    describe "short_id" do
+      # A short_id's "/" must be URL-encoded (%2F) in a path segment; the "_" and "-"
+      # separators (see ShortId.decode) are equivalent and avoid the encoding.
+      it "finds the bike from its short_id (r/ and r_)" do
+        [bike.short_id.sub("/", "%2F"), bike.short_id.tr("/", "_")].each do |short_id|
+          get "/api/v3/bikes/#{short_id}", params: {format: :json}
+          expect(response.code).to eq("200")
+          expect(json_result["bike"]["id"]).to eq bike.id
+        end
+      end
+
+      context "bike_sticker short_id" do
+        let!(:bike_sticker) { FactoryBot.create(:bike_sticker, code: "A1029", bike: bike) }
+
+        it "finds the sticker's bike (s/ and s-)" do
+          expect(bike_sticker.short_id).to eq "s/A1029"
+          ["s%2FA1029", "s-A1029"].each do |short_id|
+            get "/api/v3/bikes/#{short_id}", params: {format: :json}
+            expect(response.code).to eq("200")
+            expect(json_result["bike"]["id"]).to eq bike.id
+          end
+        end
+      end
+    end
   end
 
   describe "check_if_registered" do

--- a/spec/requests/bikes_request_spec.rb
+++ b/spec/requests/bikes_request_spec.rb
@@ -438,6 +438,12 @@ RSpec.describe BikesController, type: :request do
       expect(assigns(:bike_sticker)&.id).to eq bike_sticker1.id
       expect(assigns(:organization))
     end
+    it "redirects the /s/ short URL to scanned, preserving the query string" do
+      get "/s/UC1101"
+      expect(response).to redirect_to("/bikes/scanned/UC1101")
+      get "/s/UC1101?organization_id=UCLA"
+      expect(response).to redirect_to("/bikes/scanned/UC1101?organization_id=UCLA")
+    end
     context "UI" do
       let!(:bike_sticker2) { FactoryBot.create(:bike_sticker, code: "UI1101", organization: organization) }
       let!(:bike_sticker3) { FactoryBot.create(:bike_sticker, code: "U1101", organization: organization2) }

--- a/spec/services/short_id_spec.rb
+++ b/spec/services/short_id_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe ShortId do
 
   describe "decode" do
     it "ignores the prefix, its separator, other separators, and case" do
-      ["r/21J-HW", "R/21JHW", "r/21J HW", "r/21J+HW", "r-21JHW", "r21jhw", "21J-HW", "21jhw"].each do |str|
+      ["r/21J-HW", "R/21JHW", "r/21J HW", "r/21J+HW", "r-21JHW", "r_21JHW", "r_21J_HW", "r21jhw", "21J-HW", "21jhw"].each do |str|
         expect(ShortId.decode("Bike", str)).to eq 3431156
       end
     end


### PR DESCRIPTION
Adds a `BikeSticker` short_id variety and lets the bikes API resolve short_ids.

- `BikeSticker#short_id` is `s/<code>`, and the new `/s/<code>` route redirects to the canonical `/bikes/scanned/<code>` (preserving the query string).
- `GET /api/{v2,v3}/bikes/:id` now resolves a bike short_id (`bikes/r/35`) or a sticker short_id (`bikes/s/a044`, resolving to the sticker's bike) — the `id` param was Integer-only, so short_ids previously 404'd. A `:prefix/:id` route handles the literal `/` separator (Grape's `:id` can't span it); the `_`/`-` forms work too, and an unknown sticker 404s.
- `ShortId.decode` also treats `_` as a separator, alongside `/`, `-`, and space.
