### PR TITLE
Sync github-upload-image-to-pr skill + add project .mcp.json

### DIFF
--- a/.claude/skills/github-upload-image-to-pr/SKILL.md
+++ b/.claude/skills/github-upload-image-to-pr/SKILL.md
@@ -40,17 +40,11 @@ cp /path/to/CleanShot*keyword*.png /tmp/screenshot.png
 
 Use `ToolSearch` with a query like `"browser navigate upload"` to confirm `mcp__playwright__*` tools are registered.
 
-Playwright MCP reuses a persistent profile (`--user-data-dir`), so the github.com session persists across reuse once signed in. If GitHub logs the user out and you hit a 404 / login screen mid-task, see [references/headless-relogin.md](references/headless-relogin.md) — full login can't be driven headlessly.
+Playwright MCP runs isolated (`--isolated --storage-state=…/mcp-auth.json`), loading github.com cookies from that shared storage-state file at startup — so the session persists across sessions once the file is populated. It's load-only: the MCP never writes it back, so login can't be refreshed through the MCP browser. If GitHub logs the user out and you hit a 404 / login screen mid-task, see [references/headless-relogin.md](references/headless-relogin.md) — full login can't be driven headlessly.
 
-### If Playwright MCP is not installed
+### If Playwright MCP is not registered
 
-Recommend the user install it:
-
-```bash
-claude mcp add playwright -- npx -y @playwright/mcp@latest
-```
-
-After install, the Claude Code session must be restarted for `mcp__playwright__*` tools to register.
+The project ships a `.mcp.json` registering Playwright MCP (isolated, shared storage-state file, headless). Claude Code prompts to approve project MCP servers on first entry — if the `mcp__playwright__*` tools aren't registered, approve the `playwright` server there and restart the session (or `/mcp` → **playwright** → **reconnect**). On first use `mcp-auth.json` won't exist yet — populate it via the login helper in the re-login guide.
 
 ## Step 3: Navigate to PR page and check login state
 
@@ -179,7 +173,7 @@ Reload the page in the Playwright browser and take a screenshot to confirm the i
 | File upload fails | Ensure the file path is absolute |
 | Textarea doesn't contain URLs yet | Wait 3–5 seconds after upload before running JS eval; retry once if needed |
 | Textarea selector not found | GitHub UI changes occasionally — use the multi-selector JS in Step 4 to find the current element |
-| Playwright MCP not registered | `claude mcp add playwright -- npx -y @playwright/mcp@latest`, then restart the Claude Code session |
+| Playwright MCP not registered | Approve the `playwright` server from the project `.mcp.json` (Claude Code prompts on project entry), then restart the session or `/mcp` → reconnect |
 | PR not found / 404 | Private repos return 404 for unauthenticated users — check login state |
 
 ## Notes
@@ -187,4 +181,4 @@ Reload the page in the Playwright browser and take a screenshot to confirm the i
 - GitHub `user-attachments/assets/` URLs are **persistent** — images remain accessible even without submitting the comment
 - Editing the description directly in the browser UI is fragile due to GitHub UI structure changes — updating via `gh pr edit` is strongly preferred
 - Multiple images can be uploaded in a single session before extracting URLs
-- Playwright MCP attaches to a browser instance and preserves cookies/login state across calls
+- Playwright MCP preserves cookies/login state across calls within a session; across sessions the login comes from the shared `--storage-state` file (`mcp-auth.json`), loaded at startup

--- a/.claude/skills/github-upload-image-to-pr/references/headless-relogin.md
+++ b/.claude/skills/github-upload-image-to-pr/references/headless-relogin.md
@@ -1,67 +1,36 @@
 # Logging into GitHub when the MCP runs headless
 
-The Playwright MCP is usually configured with `--headless` (no visible window, so it never steals focus). The github.com login cookie lives in the persistent `--user-data-dir` profile and keeps working headless once it exists — but you can't *type* credentials, a 2FA code, or a passkey into a window that doesn't exist. So when GitHub has logged the user out (expired session, or first-ever use), briefly run **headed**, let the user sign in, then switch back to headless.
+The Playwright MCP is registered in the project's **`.mcp.json`** (inspect with `claude mcp get playwright`) with `--isolated --headless`, seeding each browser session's auth from a storage-state file: `--storage-state=${HOME}/.cache/ms-playwright/mcp-auth.json`. Two consequences:
 
-## First: confirm you're actually headless (the trigger gate)
+- The github.com session lives in that file, not in a browser profile. Every new browser session re-reads it at context creation.
+- The file is read-only from the MCP's perspective: `--isolated` keeps the profile in memory and never writes back to disk. A login performed inside the MCP browser is lost when the browser closes — so re-login means **regenerating the state file**, not driving the MCP browser through the login form. (This holds even if the MCP happens to be running headed: an in-browser login lasts only until that browser session ends.)
 
-Do **none** of this unless the MCP is currently headless. Check:
+Confirm the exact `--storage-state` path from `claude mcp get playwright` rather than assuming it — the commands below use `$HOME/.cache/ms-playwright/mcp-auth.json`, the current value.
 
-```bash
-claude mcp get playwright   # look for `--headless` in the Args line
-```
+## When to do this
 
-If `--headless` is **absent**, the window is already visible — just `browser_navigate` to `https://github.com/login` and ask the user to sign in there. Skip the entire config dance below.
+Hitting a GitHub login screen — or a 404 on a private repo (GitHub returns 404 to unauthenticated users) — means `mcp-auth.json` is missing or its session has expired. Confirm with `browser_snapshot`; never try to drive GitHub's login form blind (credentials, 2FA codes, and passkeys can't be typed into a headless window, and you must not type them for the user anyway).
 
-## The clean switch — one reconnect each way
+## Regenerate the storage state
 
-The trap that caused us to reconnect repeatedly: the running browser holds a lock on the shared profile dir (`mcp-chrome-shared`). If you change the config and reconnect while that browser is **still alive**, the new server can't launch — it fails with `Browser is already in use ... use --isolated` — and you're forced to kill orphaned processes, which itself drops the MCP connection and forces yet another reconnect.
-
-Avoid all of that by **closing the browser first** so the lock is released *before* each reconnect. Done this way it's exactly one reconnect per direction, no process-killing.
-
-### Headless → headed (to log in)
-
-1. `browser_close` — releases the profile lock. Login state lives on disk, so this never logs anyone out.
-2. Drop the `--headless` flag (re-register the server without it):
-   ```bash
-   claude mcp remove playwright -s user
-   claude mcp add playwright -s user -- npx -y @playwright/mcp@latest \
-     --user-data-dir="$HOME/.cache/ms-playwright/mcp-chrome-shared"
-   ```
-3. Ask the user to run `/mcp` → **playwright** → **reconnect**. A full Claude Code restart is **not** needed — reconnect re-reads the config and relaunches the server.
-4. After they confirm reconnection, `browser_navigate` to `https://github.com/login`. A visible Chrome window appears; the user types their credentials and clears any 2FA/passkey themselves. **Do not type their credentials for them.**
-5. When they say they're signed in, `browser_navigate` to `https://github.com` and `browser_snapshot` to confirm the account sidebar shows their handle.
-
-### Headed → headless (restore when done)
-
-6. `browser_close` again — releases the lock; the freshly-saved cookie is already persisted to the profile.
-7. Re-add `--headless`:
-   ```bash
-   claude mcp remove playwright -s user
-   claude mcp add playwright -s user -- npx -y @playwright/mcp@latest \
-     --user-data-dir="$HOME/.cache/ms-playwright/mcp-chrome-shared" --headless
-   ```
-8. User runs `/mcp` → reconnect once more. Verify with a `browser_navigate` + `browser_snapshot`: headless again, still signed in.
-
-> The config lives in `~/.claude.json` (often a symlink into a dotfile manager like Mackup). Prefer the `claude mcp remove/add` commands above over hand-editing that file — they handle the symlink and write the exact args. If you must edit the JSON directly, edit the real symlink target, not the link.
-
-## Fallback: "Browser is already in use" even after closing
-
-This happens when another process is still holding the lock — usually a **prior crashed session's** orphaned headless Chrome, but it can also be a **second, currently-active Claude Code session** running its own headless Playwright against the same shared profile. That second possibility is why you must never kill on your own judgment here.
-
-Inspect first — never bare "Chrome", which would take down the user's real browser ([[feedback_never_kill_non_mcp_chrome]]):
+Run a one-shot headed browser that saves storage on close — no MCP config edits, no `/mcp` reconnect dance. This is a user-run login helper, not a screenshot path: screenshots still go only through the MCP, never the Playwright CLI.
 
 ```bash
-# Inspect — the actual Chrome browser process has `--headless` BEFORE the
-# user-data-dir, so eyeball the list rather than trusting a one-shot regex.
-# (Your own shell may appear in the list because this command contains the
-# match strings — ignore the zsh/grep lines.)
-pgrep -fl "mcp-chrome-shared" | grep -- "--headless"
+npx -y playwright open --save-storage="$HOME/.cache/ms-playwright/mcp-auth.json" https://github.com/login
 ```
 
-**Stop and ask the user before killing anything.** These processes are scoped to `mcp-chrome-shared`, which is *shared across every Claude Code session on this machine* — the lock-holder might be a live Playwright session in another window, not a dead orphan, and killing it would crash that session's browser mid-task. Show the user the inspected PID list and ask them to confirm these are stale/abandoned before you `kill <those PIDs>`. Only proceed on explicit confirmation.
+If Playwright's managed Chromium isn't installed, the command errors with an install hint — either run `npx playwright install chromium` first, or append `--browser=chrome` to use the system Chrome instead.
 
-Killing the MCP processes drops this session's connection too, so reconnect via `/mcp` afterward (this is the one case where you pay an extra reconnect).
+1. The command blocks until the browser is closed, so launch it in the background (or ask the user to run it in their own terminal).
+2. A visible browser window opens at the GitHub login page. The user signs in themselves — credentials, 2FA, passkey. **Do not type their credentials for them.**
+3. When the user closes the browser window, cookies and localStorage are written to `mcp-auth.json`.
+
+## Pick up the new state
+
+1. `browser_close` — the current MCP browser session was created from the stale state.
+2. `browser_navigate` to `https://github.com`, then `browser_snapshot` — the fresh isolated context re-reads `mcp-auth.json`. Confirm the account sidebar shows the user's handle.
+3. If it still shows logged-out, ask the user to run `/mcp` → **playwright** → **reconnect**, then repeat step 2.
 
 ## Mid-task
 
-If you hit a 404 / login screen mid-task while headless, **stop** and walk the user through the headed re-login above — never try to drive GitHub's login form blind.
+If you hit a 404 / login screen mid-task, **stop**, regenerate the state file as above, pick up the new state, then resume the task.

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,14 @@
+{
+  "mcpServers": {
+    "playwright": {
+      "command": "npx",
+      "args": [
+        "-y",
+        "@playwright/mcp@latest",
+        "--isolated",
+        "--storage-state=${HOME}/.cache/ms-playwright/mcp-auth.json",
+        "--headless"
+      ]
+    }
+  }
+}


### PR DESCRIPTION
Adopts the isolated Playwright MCP setup from the kamal-rails-console branch so the `github-upload-image-to-pr` skill works out of the box.

- Adds a project `.mcp.json` registering Playwright MCP with `--isolated --headless` and a shared `--storage-state` file (`~/.cache/ms-playwright/mcp-auth.json`), so GitHub login persists across sessions.
- Updates the skill docs and headless re-login guide to match: login is refreshed by regenerating the storage-state file via `npx playwright open --save-storage`, replacing the old headed/headless config-swap dance.
