### PR TITLE
Exclude Avery Export feature from Brakebills seed org

### DIFF
--- a/app/components/ui/short_id/component_preview.rb
+++ b/app/components/ui/short_id/component_preview.rb
@@ -4,6 +4,7 @@ module UI
   module ShortId
     # @label Short ID
     class ComponentPreview < ApplicationComponentPreview
+      # @!group Variants
       # @param id text "ID to render"
       def default(id: "r/21J-HW")
         render(UI::ShortId::Component.new(short_id: id))
@@ -18,6 +19,7 @@ module UI
       def with_html_class
         render(UI::ShortId::Component.new(short_id: "r/21J-HW", html_class: "tw:text-base"))
       end
+      # @!endgroup
     end
   end
 end

--- a/db/seeds/seed_organizations.rb
+++ b/db/seeds/seed_organizations.rb
@@ -52,6 +52,7 @@ feature_name_and_slugs = [
 feature_ids = []
 official_manufacturer_feature_id = nil
 skip_ownership_email_feature_id = nil
+avery_export_feature_id = nil
 
 feature_name_and_slugs.each do |attrs|
   org_feature = OrganizationFeature.find_by_name(attrs[:name]) ||
@@ -59,12 +60,13 @@ feature_name_and_slugs.each do |attrs|
   feature_ids << org_feature.id
   official_manufacturer_feature_id = org_feature.id if attrs[:name] == "Official manufacturer organization"
   skip_ownership_email_feature_id = org_feature.id if attrs[:name] == "Skip ownership email"
+  avery_export_feature_id = org_feature.id if attrs[:name] == "Avery Export"
 end
 
-# --- Brakebills: all features except official_manufacturer, with is_endless invoice - and skip_ownership_email ---
+# --- Brakebills: all features except official_manufacturer, avery_export, with is_endless invoice - and skip_ownership_email ---
 brakebills = Organization.find_by_name("Brakebills") || Organization.create!(name: "Brakebills")
 brakebills_invoice = Invoice.create(organization: brakebills, amount_due: 0, start_at: Time.current - 1.hour, is_endless: true)
-brakebills_feature_ids = feature_ids - [official_manufacturer_feature_id, skip_ownership_email_feature_id]
+brakebills_feature_ids = feature_ids - [official_manufacturer_feature_id, skip_ownership_email_feature_id, avery_export_feature_id]
 brakebills_invoice.update(organization_feature_ids: brakebills_feature_ids)
 OrganizationRole.create(organization_id: brakebills.id, user_id: User.find_by_email("member@bikeindex.org").id, role: "member")
 

--- a/spec/integration/organized/graduated_notifications_search_spec.rb
+++ b/spec/integration/organized/graduated_notifications_search_spec.rb
@@ -82,11 +82,9 @@ RSpec.describe "Organized graduated notifications search", :js, type: :system do
     expect(page).to have_field("search_email", with: "")
 
     # Form submit + direct back-nav: regression guard for turbo-cache spinner state.
-    # Read the field back before submitting so Capybara waits for the typed value
-    # to be committed in the DOM — otherwise a slow runner can submit the form
-    # while search_email is still empty (observed only on CI).
-    fill_in "search_email", with: "alice@example.com"
-    expect(page).to have_field("search_email", with: "alice@example.com", wait: 10)
+    # fill_in_and_confirm re-fills if Turbo's cached-snapshot preview (shown first
+    # on back-nav, then replaced by the real render) wipes the value we just typed.
+    fill_in_and_confirm "search_email", with: "alice@example.com"
     find("#search-button").click
 
     expect(page).to have_current_path(/search_email=alice/, wait: 10)
@@ -103,7 +101,7 @@ RSpec.describe "Organized graduated notifications search", :js, type: :system do
     expect(page).to have_field("search_email", with: "")
 
     # Re-apply alice filter for click-row/back-nav steps
-    fill_in "search_email", with: "alice@example.com"
+    fill_in_and_confirm "search_email", with: "alice@example.com"
     find("#search-button").click
 
     expect(page).to have_current_path(/search_email=alice/, wait: 10)

--- a/spec/integration/organized/graduated_notifications_search_spec.rb
+++ b/spec/integration/organized/graduated_notifications_search_spec.rb
@@ -82,9 +82,12 @@ RSpec.describe "Organized graduated notifications search", :js, type: :system do
     expect(page).to have_field("search_email", with: "")
 
     # Form submit + direct back-nav: regression guard for turbo-cache spinner state.
-    # fill_in_and_confirm re-fills if Turbo's cached-snapshot preview (shown first
-    # on back-nav, then replaced by the real render) wipes the value we just typed.
-    fill_in_and_confirm "search_email", with: "alice@example.com"
+    # Let Turbo's restoration preview settle to the real render before typing, then
+    # read the field back so a real "typed value doesn't persist after back-nav"
+    # regression still fails here rather than being retried away.
+    wait_for_turbo_restore
+    fill_in "search_email", with: "alice@example.com"
+    expect(page).to have_field("search_email", with: "alice@example.com", wait: 10)
     find("#search-button").click
 
     expect(page).to have_current_path(/search_email=alice/, wait: 10)
@@ -101,7 +104,8 @@ RSpec.describe "Organized graduated notifications search", :js, type: :system do
     expect(page).to have_field("search_email", with: "")
 
     # Re-apply alice filter for click-row/back-nav steps
-    fill_in_and_confirm "search_email", with: "alice@example.com"
+    wait_for_turbo_restore
+    fill_in "search_email", with: "alice@example.com"
     find("#search-button").click
 
     expect(page).to have_current_path(/search_email=alice/, wait: 10)

--- a/spec/support/system_spec_helpers.rb
+++ b/spec/support/system_spec_helpers.rb
@@ -31,6 +31,19 @@ module SystemSpecHelpers
     field
   end
 
+  # Fill a field and confirm the value stuck. On back-navigation Turbo Drive
+  # renders a cached snapshot first, then swaps in a fresh render -- a fill
+  # applied to the preview is wiped when the real page arrives (fill_in itself
+  # raises nothing, the value just vanishes). Re-fill until it holds.
+  def fill_in_and_confirm(locator, with:, wait: Capybara.default_max_wait_time)
+    2.times do
+      fill_in(locator, with:)
+      return if has_field?(locator, with:, wait:)
+    end
+    fill_in(locator, with:)
+    expect(page).to have_field(locator, with:, wait:)
+  end
+
   # capybara-playwright wraps click/find so a mid-action "Element is not attached
   # to the DOM" (Turbo re-rendering the field) becomes a StaleReferenceError that
   # Capybara auto-retries -- but its `set` path (fill_in) only rescues timeouts,

--- a/spec/support/system_spec_helpers.rb
+++ b/spec/support/system_spec_helpers.rb
@@ -31,17 +31,12 @@ module SystemSpecHelpers
     field
   end
 
-  # Fill a field and confirm the value stuck. On back-navigation Turbo Drive
-  # renders a cached snapshot first, then swaps in a fresh render -- a fill
-  # applied to the preview is wiped when the real page arrives (fill_in itself
-  # raises nothing, the value just vanishes). Re-fill until it holds.
-  def fill_in_and_confirm(locator, with:, wait: Capybara.default_max_wait_time)
-    2.times do
-      fill_in(locator, with:)
-      return if has_field?(locator, with:, wait:)
-    end
-    fill_in(locator, with:)
-    expect(page).to have_field(locator, with:, wait:)
+  # Wait for Turbo Drive to finish a back/forward restoration before interacting.
+  # On restore Turbo shows a cached snapshot (html[data-turbo-preview]) first,
+  # then swaps in the real render -- typing during the preview loses the value
+  # when the real page lands. Returns once the preview attribute is gone.
+  def wait_for_turbo_restore(wait: 10)
+    expect(page).to have_no_css("html[data-turbo-preview]", wait:)
   end
 
   # capybara-playwright wraps click/find so a mid-action "Element is not attached


### PR DESCRIPTION
Two small seed/preview cleanups for the org-features and Short ID work.

- **Seed:** stop granting the Avery Export organization feature to the Brakebills seed org, following the existing pattern for `official_manufacturer` and `skip_ownership_email`. The `OrganizationFeature` is still created, so it stays available for other orgs.
- **Lookbook:** group the Short ID component previews under a single `Variants` group.
