### PR TITLE
Add UI::ColorSwatch component and Color swatch helpers

### DIFF
--- a/app/components/search/everything_combobox/component.html.erb
+++ b/app/components/search/everything_combobox/component.html.erb
@@ -13,19 +13,6 @@
       color: #bbb;
       display: inline-block;
     }
-
-    .hw-combobox__option .sclr {
-      border-radius: 3px;
-      display: inline-block;
-      width: 24px;
-      height: 24px;
-      border: 1px solid rgba(0, 0, 0, 0.2);
-      line-height: 0.8em;
-      margin: 0 6px -6px;
-      font-size: 0.5em;
-      text-align: center;
-      padding-top: 1em;
-    }
   </style>
 
   <%# The combobox is hidden until the stimulus controller connects, so users %>

--- a/app/components/search/everything_combobox_options/component.rb
+++ b/app/components/search/everything_combobox_options/component.rb
@@ -69,11 +69,7 @@ module Search
         case match["category"]
         when "colors"
           prefix = tag.span("#{@search_obj_name} #{translation(".that_are")} ", class: "sch_")
-          swatch = if match["display"].present?
-            tag.span("", class: "sclr", style: "background: #{match["display"]}")
-          else
-            tag.span("stckrs", class: "sclr")
-          end
+          swatch = render(UI::ColorSwatch::Component.new(display: match["display"], name: match["text"]))
           safe_join([prefix, swatch])
         when "cmp_mnfg", "frame_mnfg"
           tag.span("#{@search_obj_name} #{translation(".made_by")}", class: "sch_")

--- a/app/components/ui/color_swatch/component.rb
+++ b/app/components/ui/color_swatch/component.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+module UI
+  module ColorSwatch
+    # A small square showing a bike color. The display-less "cover-up" color
+    # renders Color::COVER_UP_SWATCH's multicolor blend instead of a solid fill.
+    class Component < ApplicationComponent
+      BASE_CLASSES = "tw:inline-block tw:h-6 tw:w-6 tw:rounded-xs tw:border tw:border-black/20 tw:align-middle"
+
+      def initialize(display: nil, name: nil)
+        @display = display.presence
+        @name = name.presence
+      end
+
+      def call
+        content_tag(:span, "", class: BASE_CLASSES, style: swatch_style, title: @name)
+      end
+
+      private
+
+      def cover_up?
+        @name == Color::COVER_UP_NAME
+      end
+
+      def swatch_style
+        "background: #{cover_up? ? Color::COVER_UP_SWATCH : @display}"
+      end
+    end
+  end
+end

--- a/app/components/ui/color_swatch/component_preview.rb
+++ b/app/components/ui/color_swatch/component_preview.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module UI
+  module ColorSwatch
+    class ComponentPreview < ApplicationComponentPreview
+      def black
+        render(UI::ColorSwatch::Component.new(display: "#000", name: "Black"))
+      end
+
+      def blue
+        render(UI::ColorSwatch::Component.new(display: "#386ed2", name: "Blue"))
+      end
+
+      # The display-less cover-up color renders the multicolor blend
+      def cover_up
+        render(UI::ColorSwatch::Component.new(name: Color::COVER_UP_NAME))
+      end
+    end
+  end
+end

--- a/app/components/ui/color_swatch/component_preview.rb
+++ b/app/components/ui/color_swatch/component_preview.rb
@@ -3,17 +3,9 @@
 module UI
   module ColorSwatch
     class ComponentPreview < ApplicationComponentPreview
-      def black
-        render(UI::ColorSwatch::Component.new(display: "#000", name: "Black"))
-      end
-
-      def blue
-        render(UI::ColorSwatch::Component.new(display: "#386ed2", name: "Blue"))
-      end
-
-      # The display-less cover-up color renders the multicolor blend
-      def cover_up
-        render(UI::ColorSwatch::Component.new(name: Color::COVER_UP_NAME))
+      # Every registration color on one page — the cover-up color renders its blend
+      def all_colors
+        {template: "ui/color_swatch/component_preview/all_colors", locals: {colors: Color.commonness}}
       end
     end
   end

--- a/app/components/ui/color_swatch/component_preview/all_colors.html.erb
+++ b/app/components/ui/color_swatch/component_preview/all_colors.html.erb
@@ -1,0 +1,8 @@
+<ul class="tw:flex tw:flex-col tw:gap-2">
+  <% colors.each do |color| %>
+    <li class="tw:flex tw:items-center tw:gap-2">
+      <%= render(UI::ColorSwatch::Component.new(display: color.display, name: color.name)) %>
+      <span><%= color.name %></span>
+    </li>
+  <% end %>
+</ul>

--- a/app/models/color.rb
+++ b/app/models/color.rb
@@ -21,8 +21,9 @@ class Color < ApplicationRecord
 
   COVER_UP_NAME = "Stickers tape or other cover-up"
 
-  # The cover-up "color" has no real display value, so its swatch is a rainbow gradient
-  COVER_UP_SWATCH = "linear-gradient(90deg, #ec1313, #ff8d1d, #fff44b, #1ba100, #386ed2, #a745c0)"
+  # The cover-up "color" has no real display value, so its swatch is a rainbow arch drawn on white
+  COVER_UP_SWATCH = "radial-gradient(circle at 50% 100%, transparent 0 24%, #a745c0 24% 36%, " \
+    "#386ed2 36% 48%, #1ba100 48% 60%, #fff44b 60% 72%, #ff8d1d 72% 84%, #ec1313 84% 96%, transparent 96%), #fff"
 
   has_many :bikes
   has_many :paints

--- a/app/models/color.rb
+++ b/app/models/color.rb
@@ -22,8 +22,8 @@ class Color < ApplicationRecord
   COVER_UP_NAME = "Stickers tape or other cover-up"
 
   # The cover-up "color" has no real display value, so its swatch is a rainbow arch drawn on white
-  COVER_UP_SWATCH = "radial-gradient(circle at 50% 100%, transparent 0 24%, #a745c0 24% 36%, " \
-    "#386ed2 36% 48%, #1ba100 48% 60%, #fff44b 60% 72%, #ff8d1d 72% 84%, #ec1313 84% 96%, transparent 96%), #fff"
+  COVER_UP_SWATCH = "radial-gradient(circle at 50% 100%, transparent 0 20%, #a745c0 20% 30%, " \
+    "#386ed2 30% 40%, #1ba100 40% 50%, #fff44b 50% 60%, #ff8d1d 60% 70%, #ec1313 70% 80%, transparent 80%), #fff"
 
   has_many :bikes
   has_many :paints

--- a/app/models/color.rb
+++ b/app/models/color.rb
@@ -19,6 +19,11 @@ class Color < ApplicationRecord
     "Silver, gray or bare metal", "Stickers tape or other cover-up", "Teal", "White",
     "Yellow or Gold"].freeze
 
+  COVER_UP_NAME = "Stickers tape or other cover-up"
+
+  # The cover-up "color" has no real display value, so its swatch is a multicolor blend
+  COVER_UP_SWATCH = "conic-gradient(#ec1313, #ff8d1d, #fff44b, #1ba100, #386ed2, #a745c0, #ec1313)"
+
   has_many :bikes
   has_many :paints
 
@@ -67,6 +72,15 @@ class Color < ApplicationRecord
 
   def search_id
     "c_#{id}"
+  end
+
+  def cover_up?
+    name == COVER_UP_NAME
+  end
+
+  # CSS background for a color swatch
+  def swatch_style
+    "background: #{cover_up? ? COVER_UP_SWATCH : display}"
   end
 
   def slug

--- a/app/models/color.rb
+++ b/app/models/color.rb
@@ -21,8 +21,8 @@ class Color < ApplicationRecord
 
   COVER_UP_NAME = "Stickers tape or other cover-up"
 
-  # The cover-up "color" has no real display value, so its swatch is a multicolor blend
-  COVER_UP_SWATCH = "conic-gradient(#ec1313, #ff8d1d, #fff44b, #1ba100, #386ed2, #a745c0, #ec1313)"
+  # The cover-up "color" has no real display value, so its swatch is a rainbow gradient
+  COVER_UP_SWATCH = "linear-gradient(90deg, #ec1313, #ff8d1d, #fff44b, #1ba100, #386ed2, #a745c0)"
 
   has_many :bikes
   has_many :paints

--- a/spec/components/search/everything_combobox_options/component_spec.rb
+++ b/spec/components/search/everything_combobox_options/component_spec.rb
@@ -11,8 +11,17 @@ RSpec.describe Search::EverythingComboboxOptions::Component, type: :component do
     it "renders an option with the color swatch and 'that are' prefix" do
       expect(rendered.css(".hw-combobox__option").size).to eq 1
       expect(rendered.css(".hw-combobox__option .sch_").text).to include("Registrations that are")
-      expect(rendered.css(".hw-combobox__option .sclr").attr("style").value).to include("background: #00f")
+      expect(rendered.css(".hw-combobox__option span[title='Blue']").attr("style").value).to include("background: #00f")
       expect(rendered.css(".hw-combobox__option .label").text).to eq "Blue"
+    end
+  end
+
+  context "with the cover-up color match" do
+    let(:matches) { [{"search_id" => "c_9", "text" => Color::COVER_UP_NAME, "category" => "colors", "display" => nil}] }
+
+    it "renders the multicolor swatch instead of a display fill" do
+      swatch = rendered.css(".hw-combobox__option span[title='#{Color::COVER_UP_NAME}']")
+      expect(swatch.attr("style").value).to eq "background: #{Color::COVER_UP_SWATCH}"
     end
   end
 

--- a/spec/components/ui/color_swatch/component_spec.rb
+++ b/spec/components/ui/color_swatch/component_spec.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe UI::ColorSwatch::Component, type: :component do
+  let(:instance) { described_class.new(**options) }
+  let(:component) { render_inline(instance) }
+  let(:options) { {display:, name:}.compact }
+  let(:display) { nil }
+  let(:name) { nil }
+
+  context "with a display color" do
+    let(:display) { "#386ed2" }
+    let(:name) { "Blue" }
+
+    it "renders a solid swatch using the display color" do
+      swatch = component.css("span").first
+      expect(swatch["style"]).to eq "background: #386ed2"
+      expect(swatch["title"]).to eq "Blue"
+      expect(component.to_html).to include("tw:inline-block")
+      expect(component.to_html).to include("tw:rounded-xs")
+    end
+  end
+
+  context "with the cover-up color" do
+    let(:name) { Color::COVER_UP_NAME }
+
+    it "renders the multicolor blend instead of a solid fill" do
+      swatch = component.css("span").first
+      expect(swatch["style"]).to eq "background: #{Color::COVER_UP_SWATCH}"
+      expect(swatch["title"]).to eq Color::COVER_UP_NAME
+    end
+  end
+end

--- a/spec/models/color_spec.rb
+++ b/spec/models/color_spec.rb
@@ -29,6 +29,23 @@ RSpec.describe Color, type: :model do
     end
   end
 
+  describe "#swatch_style" do
+    it "uses the display color" do
+      color = FactoryBot.create(:color, name: "Blue", display: "#386ed2")
+      expect(color.cover_up?).to be_falsey
+      expect(color.swatch_style).to eq("background: #386ed2")
+    end
+
+    context "cover-up color" do
+      let(:color) { FactoryBot.create(:color, name: Color::COVER_UP_NAME, display: "#fff") }
+
+      it "renders a multicolor swatch instead of the white display" do
+        expect(color.cover_up?).to be_truthy
+        expect(color.swatch_style).to eq("background: #{Color::COVER_UP_SWATCH}")
+      end
+    end
+  end
+
   describe "black" do
     context "not-existing" do
       it "creates it on first pass" do


### PR DESCRIPTION
Adds a `UI::ColorSwatch` component for rendering a bike color's swatch, plus swatch helpers on `Color` (ported from #3797).

- `Color#swatch_style` / `cover_up?` + `COVER_UP_NAME` / `COVER_UP_SWATCH` — the display-less "Stickers tape or other cover-up" color renders a multicolor conic-gradient instead of a solid fill.
- `UI::ColorSwatch::Component` encapsulates the swatch markup (Tailwind, no more `.sclr` SCSS) and is now rendered by the search autocomplete options; the cover-up option shows the gradient blend instead of the old "stckrs" text.
- Lookbook preview lists every color's swatch on one page.

Screenshots of the swatch in the search combobox are in a comment below.
