### PR TITLE
Pull redesign UI-component changes (Badge/Button/DefinitionList) from #3797

### DIFF
--- a/.claude/skills/rspec-testing/SKILL.md
+++ b/.claude/skills/rspec-testing/SKILL.md
@@ -167,3 +167,53 @@ end
 ```
 
 The bad version repeats setup, mocks the object, and doesn't communicate what each case represents.
+
+## One example per distinct setup — combine same-setup `it` blocks
+
+`context`/`let`/`before` isolate what *varies*. The corollary runs the other way: if two sibling `it` blocks share the **same** setup — no differing `context`, `before`, or `let` override between them — collapse them into **one** example. Each distinct setup earns exactly one `it`; put all of that setup's assertions (and all of its requests/renders) in that single block.
+
+This is the same instinct as "everything making the same request should be in a single test", generalized: splitting same-setup assertions across sibling `it` blocks re-runs identical setup (factories, HTTP requests, renders) once per block for zero isolation benefit, and scatters one logical behavior across the file. Two `it` blocks that differ *only* in the request params or the assertion — with identical `let`s and no `before` between them — are one example.
+
+After writing a spec, scan each `context`/`describe`: if it holds multiple `it` blocks and they don't each sit behind a distinct `context`/`before`/`let`, merge them.
+
+### Good
+
+```ruby
+context "superuser" do
+  let(:current_user) { FactoryBot.create(:superuser) }
+
+  it "offers every view and renders the owner and org-limited perspectives" do
+    get "#{base_url}/#{bike.id}"
+    expect(body_text).to match("View as owner of bike")
+
+    get "#{base_url}/#{bike.id}", params: {view_as: "owner"}
+    expect(body_text).to match("Your bike")
+
+    get "#{base_url}/#{bike.id}", params: {view_as: "#{org.to_param}.limited"}
+    expect(body_text).to match("Limited")
+  end
+end
+```
+
+### Bad
+
+```ruby
+context "superuser" do
+  let(:current_user) { FactoryBot.create(:superuser) }   # re-created for every it below
+
+  it "offers every view" do
+    get "#{base_url}/#{bike.id}"
+    expect(body_text).to match("View as owner of bike")
+  end
+  it "renders the owner view" do
+    get "#{base_url}/#{bike.id}", params: {view_as: "owner"}
+    expect(body_text).to match("Your bike")
+  end
+  it "renders an org panel as limited" do
+    get "#{base_url}/#{bike.id}", params: {view_as: "#{org.to_param}.limited"}
+    expect(body_text).to match("Limited")
+  end
+end
+```
+
+This only merges blocks whose setup is identical. Different setup still means separate examples, each in its own `context` with the `let`/`before` that differs — that's the section above, not a contradiction of it.

--- a/app/components/ui/badge/component.rb
+++ b/app/components/ui/badge/component.rb
@@ -11,45 +11,79 @@ module UI
         lg: "tw:text-md tw:font-extrabold tw:px-3 tw:py-1"
       }
 
+      # Soft tinted pills matching the redesign: light background + saturated text
       COLORS = {
-        notice: "tw:bg-blue-300 tw:text-blue-900 tw:dark:bg-blue-800 tw:dark:text-blue-200",
-        error: "tw:bg-red-300 tw:text-red-950 tw:dark:bg-red-800 tw:dark:text-red-300",
-        warning: "tw:bg-amber-300 tw:text-amber-900 tw:dark:bg-amber-800 tw:dark:text-amber-200",
-        success: "tw:bg-emerald-500 tw:text-emerald-900 tw:dark:bg-emerald-800 tw:dark:text-emerald-200",
+        notice: "tw:bg-blue-50 tw:text-blue-700 tw:border-transparent tw:dark:bg-blue-950 tw:dark:text-blue-200",
+        error: "tw:bg-red-50 tw:text-red-700 tw:border-transparent tw:dark:bg-red-950 tw:dark:text-red-200",
+        warning: "tw:bg-amber-50 tw:text-amber-700 tw:border-transparent tw:dark:bg-amber-950 tw:dark:text-amber-200",
+        success: "tw:bg-green-50 tw:text-green-700 tw:border-transparent tw:dark:bg-green-950 tw:dark:text-green-200",
         # Special badge classes:
-        cyan: "tw:bg-cyan-400 tw:text-cyan-900 tw:dark:bg-cyan-800 tw:dark:text-cyan-200",
-        gray: "tw:bg-gray-300 tw:text-gray-900 tw:dark:bg-gray-700 tw:dark:text-gray-200",
-        purple: "tw:bg-purple-300 tw:text-purple-900 tw:dark:bg-purple-800 tw:dark:text-purple-200",
-        rose: "tw:bg-rose-400 tw:text-rose-950 tw:dark:bg-rose-800 tw:dark:text-rose-300",
-        orange: "tw:bg-orange-400 tw:text-orange-950 tw:dark:bg-orange-800 tw:dark:text-orange-300",
+        cyan: "tw:bg-cyan-50 tw:text-cyan-700 tw:border-transparent tw:dark:bg-cyan-950 tw:dark:text-cyan-200",
+        gray: "tw:bg-gray-100 tw:text-gray-700 tw:border-transparent tw:dark:bg-gray-800 tw:dark:text-gray-200",
+        purple: "tw:bg-purple-50 tw:text-purple-700 tw:border-transparent tw:dark:bg-purple-950 tw:dark:text-purple-200",
+        rose: "tw:bg-rose-50 tw:text-rose-700 tw:border-transparent tw:dark:bg-rose-950 tw:dark:text-rose-200",
+        orange: "tw:bg-orange-50 tw:text-orange-700 tw:border-transparent tw:dark:bg-orange-950 tw:dark:text-orange-200",
         empty: "tw:bg-white tw:text-gray-700 tw:border-gray-300 tw:dark:bg-gray-900 tw:dark:text-gray-200 tw:dark:border-gray-600"
       }.freeze
 
-      def self.badge_classes(color:, size:, cursor: "tw:cursor-default")
-        [BASE_CLASSES, cursor, COLORS[color], SIZES[size]].join(" ")
+      # Solid pills (saturated background + white text) — e.g. the redesign audience pill
+      SOLID_COLORS = {
+        notice: "tw:bg-blue-500 tw:text-white tw:border-transparent",
+        error: "tw:bg-red-600 tw:text-white tw:border-transparent",
+        warning: "tw:bg-amber-500 tw:text-white tw:border-transparent",
+        success: "tw:bg-green-600 tw:text-white tw:border-transparent",
+        cyan: "tw:bg-cyan-500 tw:text-white tw:border-transparent",
+        gray: "tw:bg-gray-500 tw:text-white tw:border-transparent",
+        purple: "tw:bg-purple-500 tw:text-white tw:border-transparent",
+        rose: "tw:bg-rose-500 tw:text-white tw:border-transparent",
+        orange: "tw:bg-orange-500 tw:text-white tw:border-transparent",
+        empty: "tw:bg-gray-500 tw:text-white tw:border-transparent"
+      }.freeze
+
+      def self.badge_classes(color:, size:, cursor: "tw:cursor-default", solid: false)
+        palette = solid ? SOLID_COLORS : COLORS
+        [BASE_CLASSES, cursor, palette[color], SIZES[size]].join(" ")
       end
 
-      def initialize(text:, title: nil, color: :gray, size: :md)
+      def initialize(text:, title: nil, color: :gray, size: :md, indicator: false, solid: false, icon: nil)
         @text = text
         @title = title
         @color = COLORS.key?(color) ? color : :gray
         @size = SIZES.include?(size) ? size : :md
+        @indicator = indicator
+        @solid = solid
+        @icon = icon
       end
 
       def call
-        badge = content_tag(:span, content.presence || @text, class: badge_class)
+        leading = leading_element
+        label = content.presence || @text
+        label = safe_join([leading, label]) if leading
+        badge = content_tag(:span, label, class: badge_class)
         return badge unless custom_title?
         render(UI::Tooltip::Component.new(text: @title)) { badge }
       end
 
       private
 
+      # An inline icon (@icon is a path under app/assets/images, sans .svg) takes
+      # precedence over the status dot
+      def leading_element
+        return helpers.inline_svg_tag("#{@icon}.svg", class: "tw:mr-1 tw:size-3.5") if @icon.present?
+        indicator_dot if @indicator
+      end
+
+      # A small status dot inheriting the badge's text color
+      def indicator_dot
+        content_tag(:span, "", class: "tw:mr-1.5 tw:inline-block tw:size-1.5 tw:rounded-full tw:bg-current")
+      end
+
       def custom_title?
         @title.present? && @title != @text
       end
 
       def badge_class
-        self.class.badge_classes(color: @color, size: @size, cursor: custom_title? ? "tw:cursor-help" : "tw:cursor-default")
+        self.class.badge_classes(color: @color, size: @size, solid: @solid, cursor: custom_title? ? "tw:cursor-help" : "tw:cursor-default")
       end
     end
   end

--- a/app/components/ui/button/component.rb
+++ b/app/components/ui/button/component.rb
@@ -18,6 +18,12 @@ module UI
         primary: "tw:text-white tw:bg-blue-600 tw:border tw:border-blue-600 tw:hover:bg-blue-700 tw:active:bg-blue-800 tw:focus:ring-blue-500/40 tw:dark:bg-blue-500 tw:dark:border-blue-500 tw:dark:hover:bg-blue-600 tw:dark:active:bg-blue-700",
         secondary: "tw:text-gray-700 tw:bg-gray-50 tw:border tw:border-gray-300 tw:hover:bg-gray-200 tw:hover:border-gray-400 tw:active:bg-gray-300 tw:focus:ring-blue-500/40 tw:dark:text-gray-200 tw:dark:bg-gray-700 tw:dark:border-gray-500 tw:dark:hover:bg-gray-800 tw:dark:hover:border-gray-600 tw:dark:active:bg-gray-900",
         error: "tw:text-white tw:bg-red-600 tw:border tw:border-red-600 tw:hover:bg-red-700 tw:active:bg-red-800 tw:focus:ring-red-500/40 tw:dark:bg-red-500 tw:dark:border-red-500 tw:dark:hover:bg-red-600 tw:dark:active:bg-red-700",
+        # Redesign: filled purple primary (#715eb2)
+        purple: "tw:text-white tw:bg-[#715eb2] tw:border tw:border-[#715eb2] tw:hover:bg-[#5d4b9c] tw:hover:border-[#5d4b9c] tw:active:bg-[#5d4b9c] tw:focus:ring-[#715eb2]/40",
+        # Redesign: white button with a soft danger outline (Mark stolen)
+        danger_outline: "tw:text-[#c0392b] tw:bg-white tw:border tw:border-[#f3c9c9] tw:hover:bg-red-50 tw:active:bg-red-100 tw:focus:ring-red-500/40 tw:dark:bg-transparent tw:dark:text-red-400 tw:dark:border-red-900 tw:dark:hover:bg-red-950",
+        # Redesign: crisp white button with a neutral outline (Share)
+        outline: "tw:text-gray-800 tw:bg-white tw:border tw:border-gray-300 tw:hover:bg-gray-50 tw:hover:border-gray-400 tw:active:bg-gray-100 tw:focus:ring-blue-500/40 tw:dark:bg-transparent tw:dark:text-gray-100 tw:dark:border-gray-600 tw:dark:hover:bg-gray-800",
         link: "tw:text-blue-600 tw:hover:text-blue-800 tw:dark:text-blue-400 tw:dark:hover:text-blue-300 tw:underline tw:active:text-blue-800 tw:active:dark:text-blue-300 tw:active:font-bold tw:p-0 tw:focus:outline-none"
       }.freeze
 

--- a/app/components/ui/definition_list/container/component.html.erb
+++ b/app/components/ui/definition_list/container/component.html.erb
@@ -1,9 +1,18 @@
-<% if @multi_columns %>
-  <div class="tw:@container tw:w-full">
-    <dl class="tw:@container tw:gap-x-4 tw:break-words tw:@md:grid tw:@md:grid-cols-2">
-      <%= content %>
-    </dl>
-  </div>
+<% if @term == :left_align %>
+  <% if @multi_columns %>
+    <div class="tw:@container tw:w-full">
+      <dl
+        class="
+          tw:@container tw:gap-x-4 tw:break-words tw:@md:grid
+          tw:@md:grid-cols-2
+        "
+      >
+        <%= content %>
+      </dl>
+    </div>
+  <% else %>
+    <dl class="tw:@container tw:break-words"><%= content %></dl>
+  <% end %>
 <% else %>
-  <dl class="tw:@container tw:break-words"><%= content %></dl>
+  <dl class="<%= dl_classes %>"><%= content %></dl>
 <% end %>

--- a/app/components/ui/definition_list/container/component.rb
+++ b/app/components/ui/definition_list/container/component.rb
@@ -4,8 +4,51 @@ module UI
   module DefinitionList
     module Container
       class Component < ApplicationComponent
-        def initialize(multi_columns: false)
+        # term: placement of each row's term (dt) relative to its definition (dd).
+        # The non-default terms style the child Row divs/dt/dd via descendant
+        # selectors (which out-specify the Row's own utility classes), so Rows
+        # need no term awareness. Spacing and fonts follow the bike show redesign.
+        #
+        # :left_align  — term left, definition right-aligned (supports multi_columns)
+        # :right_align — term right-aligned in a fixed column, definition beside it
+        # :below       — definition below the term, three columns desktop / two mobile
+        TERMS = %i[left_align right_align below].freeze
+
+        # Summary panel (single column): keeps the Row's label-left / value-right
+        # layout (justify-between), just resizing to consumer_desktop.html — label
+        # 13px, value 13.5px semibold
+        PANEL_CLASSES = "tw:flex tw:flex-col tw:gap-2.5 tw:break-words " \
+          "tw:[&>div]:pt-0 " \
+          "tw:[&>div>dt]:text-[13px] " \
+          "tw:[&>div>dd]:text-[13.5px] tw:[&>div>dd]:font-semibold"
+
+        # Spec-sheet lists (multi column): right-aligned label column beside
+        # normal-weight values, two columns on desktop
+        SPECS_CLASSES = "tw:grid tw:grid-cols-1 tw:gap-x-[22px] tw:gap-y-[13px] tw:break-words tw:sm:grid-cols-2 " \
+          "tw:[&>div]:pt-0 tw:[&>div]:gap-x-3 " \
+          "tw:[&>div>dt]:w-28 tw:[&>div>dt]:flex-none tw:[&>div>dt]:text-right tw:[&>div>dt]:text-[13px] " \
+          "tw:[&>div>dd]:flex-1 tw:[&>div>dd]:text-left tw:[&>div>dd]:text-[13.5px]"
+
+        BELOW_CLASSES = "tw:grid tw:grid-cols-2 tw:gap-x-5 tw:gap-y-[18px] tw:break-words tw:lg:grid-cols-3 " \
+          "tw:[&>div]:block tw:[&>div]:pt-0 " \
+          "tw:[&>div>dt]:mb-[3px] tw:[&>div>dt]:text-[11.5px] " \
+          "tw:[&>div>dd]:text-left tw:[&>div>dd]:text-[14px] tw:[&>div>dd]:font-medium"
+
+        def initialize(term: :left_align, multi_columns: false)
+          raise ArgumentError, "term must be one of #{TERMS.inspect}, got #{term.inspect}" unless TERMS.include?(term)
+
+          @term = term
           @multi_columns = multi_columns
+        end
+
+        private
+
+        def dl_classes
+          return BELOW_CLASSES if @term == :below
+
+          # A right_align list is a spec sheet when multi-column, otherwise a
+          # single-column summary panel (label left, value right)
+          @multi_columns ? SPECS_CLASSES : PANEL_CLASSES
         end
       end
     end

--- a/app/components/ui/definition_list/container/component_preview.rb
+++ b/app/components/ui/definition_list/container/component_preview.rb
@@ -4,13 +4,23 @@ module UI
   module DefinitionList
     module Container
       class ComponentPreview < ApplicationComponentPreview
-        # @!group Multi Column
+        # @!group Left aligned (default)
         def default
           {template: "ui/definition_list/container/component_preview/default", locals: {multi_columns: false}}
         end
 
         def multi_columns_true
           {template: "ui/definition_list/container/component_preview/default", locals: {multi_columns: true}}
+        end
+        # @!endgroup
+
+        # @!group Redesign terms
+        def right_align
+          {template: "ui/definition_list/container/component_preview/default", locals: {term: :right_align}}
+        end
+
+        def below
+          {template: "ui/definition_list/container/component_preview/default", locals: {term: :below}}
         end
         # @!endgroup
       end

--- a/app/components/ui/definition_list/container/component_preview/default.html.erb
+++ b/app/components/ui/definition_list/container/component_preview/default.html.erb
@@ -1,6 +1,7 @@
 <% multi_columns ||= false %>
+<% term ||= :left_align %>
 
-<%= render(UI::DefinitionList::Container::Component.new(multi_columns:)) do %>
+<%= render(UI::DefinitionList::Container::Component.new(multi_columns:, term:)) do %>
   <% description =
     "I'm baby microdosing church-key try-hard, yuccie small batch lumbersexual craft beer skateboard slow-carb neutral milk hotel big mood enamel pin gatekeep chartreuse schlitz. Deep v try-hard green juice retro shaman occupy artisan shabby chic vinyl.\n\nStreet art kickstarter JOMO chillwave heirloom drinking vinegar single-origin coffee banh mi try-hard air plant." %>
 

--- a/app/components/ui/definition_list/row/component.html.erb
+++ b/app/components/ui/definition_list/row/component.html.erb
@@ -3,7 +3,7 @@
   <dt class="<%= dt_classes %>"><%= @label %></dt>
 
   <%# bootstrap sets margin_bottom on dd %>
-  <dd class="tw:mb-0!">
+  <dd class="<%= dd_classes %>">
     <% if render_convertime? %>
       <span class="<%= @time_localizer_classes %>">
         <%= l @value, format: :convert_time %>

--- a/app/components/ui/definition_list/row/component.rb
+++ b/app/components/ui/definition_list/row/component.rb
@@ -37,7 +37,7 @@ module UI
           if @full_width
             "tw:col-span-full"
           else
-            "tw:items-center tw:@sm:flex tw:@sm:gap-x-2 tw:@sm:pt-2"
+            "tw:flex tw:items-baseline tw:justify-between tw:gap-x-4"
           end + " tw:pt-3 tw:leading-tight"
         end
 
@@ -45,8 +45,12 @@ module UI
           if @full_width
             "tw:pb-1"
           else
-            "tw:@sm:text-right tw:@sm:w-1/4 tw:min-w-[100px]"
-          end + " tw:text-sm tw:leading-none tw:opacity-65 tw:font-bold!"
+            "tw:flex-none"
+          end + " tw:text-sm tw:leading-tight tw:opacity-65"
+        end
+
+        def dd_classes
+          @full_width ? "tw:mb-0!" : "tw:mb-0! tw:text-right"
         end
 
         def time_localizer_classes(time_localizer_settings)

--- a/spec/components/search_results/multi_result_chip/component_spec.rb
+++ b/spec/components/search_results/multi_result_chip/component_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe SearchResults::MultiResultChip::Component, type: :component do
     end
 
     it "uses success badge classes" do
-      expect(component.to_html).to include("tw:bg-emerald-500")
+      expect(component.to_html).to include("tw:bg-green-50")
     end
 
     it "underlines the link" do
@@ -35,7 +35,7 @@ RSpec.describe SearchResults::MultiResultChip::Component, type: :component do
     end
 
     it "uses gray badge classes" do
-      expect(component.to_html).to include("tw:bg-gray-300")
+      expect(component.to_html).to include("tw:bg-gray-100")
     end
 
     it "does not underline the serial span" do
@@ -63,7 +63,7 @@ RSpec.describe SearchResults::MultiResultChip::Component, type: :component do
     end
 
     it "uses error badge classes" do
-      expect(component.to_html).to include("tw:bg-red-300")
+      expect(component.to_html).to include("tw:bg-red-50")
     end
 
     context "with error_message" do

--- a/spec/components/ui/badge/component_spec.rb
+++ b/spec/components/ui/badge/component_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe UI::Badge::Component, type: :component do
     expect(component).not_to have_css("[role='tooltip']")
 
     html = component.to_html
-    expect(html).to include("tw:bg-gray-300")
+    expect(html).to include("tw:bg-gray-100")
     expect(html).to include("tw:inline-flex")
     expect(html).to include("tw:rounded-full")
     expect(html).to include("tw:cursor-default")
@@ -41,15 +41,15 @@ RSpec.describe UI::Badge::Component, type: :component do
 
   describe "colors" do
     {
-      success: "tw:bg-emerald-500",
-      notice: "tw:bg-blue-300",
-      purple: "tw:bg-purple-300",
-      warning: "tw:bg-amber-300",
-      cyan: "tw:bg-cyan-400",
-      error: "tw:bg-red-300",
-      gray: "tw:bg-gray-300",
-      rose: "tw:bg-rose-400",
-      orange: "tw:bg-orange-400",
+      success: "tw:bg-green-50",
+      notice: "tw:bg-blue-50",
+      purple: "tw:bg-purple-50",
+      warning: "tw:bg-amber-50",
+      cyan: "tw:bg-cyan-50",
+      error: "tw:bg-red-50",
+      gray: "tw:bg-gray-100",
+      rose: "tw:bg-rose-50",
+      orange: "tw:bg-orange-50",
       empty: "tw:bg-white"
     }.each do |color_name, css_class|
       context "with #{color_name}" do
@@ -64,7 +64,7 @@ RSpec.describe UI::Badge::Component, type: :component do
   context "with invalid color" do
     let(:color) { :invalid_color }
     it "falls back to gray" do
-      expect(component.to_html).to include("tw:bg-gray-300")
+      expect(component.to_html).to include("tw:bg-gray-100")
     end
   end
 

--- a/spec/components/ui/definition_list/container/component_spec.rb
+++ b/spec/components/ui/definition_list/container/component_spec.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe UI::DefinitionList::Container::Component, type: :component do
+  it "accepts the valid terms and raises for anything else" do
+    %i[left_align right_align below].each do |term|
+      expect { render_inline(described_class.new(term:)) }.not_to raise_error
+    end
+    expect { described_class.new(term: :center) }.to raise_error(ArgumentError, /term must be one of/)
+  end
+end

--- a/spec/integration/organized/registrations_search_spec.rb
+++ b/spec/integration/organized/registrations_search_spec.rb
@@ -367,7 +367,7 @@ RSpec.describe "Organized registrations search", :js, type: :system do
       click_button "Search serials"
 
       # Chips update with results
-      expect(page).to have_css("#chip_2.tw\\:bg-gray-300", wait: 15)
+      expect(page).to have_css("#chip_2.tw\\:bg-gray-100", wait: 15)
 
       # Results sorted by chip order, empty results removed
       expect(page).to have_css(".multi-search-serial-result", count: 2)
@@ -425,11 +425,11 @@ RSpec.describe "Organized registrations search", :js, type: :system do
         click_button "Search stickers"
 
         # Chips for unclaimed and non-org stickers show gray (no bikes)
-        expect(page).to have_css("#chip_1.tw\\:bg-gray-300", wait: 15)
-        expect(page).to have_css("#chip_2.tw\\:bg-gray-300")
+        expect(page).to have_css("#chip_1.tw\\:bg-gray-100", wait: 15)
+        expect(page).to have_css("#chip_2.tw\\:bg-gray-100")
 
         # Only claimed org sticker has a bike result
-        expect(page).to have_css("#chip_0.tw\\:bg-emerald-500")
+        expect(page).to have_css("#chip_0.tw\\:bg-green-50")
 
         # Switch back to serials
         choose "Serials", allow_label_click: true, visible: :all


### PR DESCRIPTION
Pulls the shared UI-component restyle from the `/registrations/:id` redesign (#3797) onto `main` ahead of the views themselves, so the design changes land independently.

- **`UI::Badge`** — soft-tinted color palette, plus new `solid:`, `indicator:` (status dot), and `icon:` (inline SVG) options and a matching `SOLID_COLORS` palette.
- **`UI::Button`** — three redesign variants (`purple`, `danger_outline`, `outline`); not used anywhere yet, so no existing page changes.
- **`UI::DefinitionList`** — a validated `term:` layout (`:left_align` / `:right_align` / `:below`) with redesign spacing; rows now right-align values.
- Specs updated to the new badge classes; adds a `rspec-testing` skill section on combining same-setup `it` blocks.

### Appearance changes on existing pages

`UI::Badge` (palette) and `UI::DefinitionList` (layout) are shared, so these pages restyle even though this PR adds no views. The new button variants are unused, so buttons are unaffected.

- **Bike show / bike-version show** (`/bikes/:id`, `/bike_versions/:id`) — heaviest DefinitionList use (spec rows plus stolen & impound records); the marketplace-listing panel adds a purple "member" badge and its own definition list.
- **Marketplace search** (`/search/marketplace`) — purple "member" badge on each result thumbnail.
- **Organization multi-search** (`/o/:id/.../multi_search`) — result chips seeded from badge classes (empty/success/gray/error).
- **Badge-only, lower traffic:** OAuth applications (`/oauth/applications`), org & admin exports, admin Strava pages, and the admin bike/user badge cells rendered across admin tables.

Before/after screenshots in the comment below.
