### PR TITLE
Revert "Point Strava API client at www.api-v3.strava.com" (#3828)

### DIFF
--- a/app/jobs/spreadsheets/importer_job.rb
+++ b/app/jobs/spreadsheets/importer_job.rb
@@ -4,11 +4,9 @@ module Spreadsheets
     # Maps each importer module (e.g. Spreadsheets::Manufacturers) to its CSV filename in the resources repo
     IMPORTERS = {"manufacturers" => "manufacturers", "primary_activities" => "primary_activities", "components" => "component_types"}.freeze
     # db/seeds.rb runs this inline, so a transient blip reaching GitHub would abort the
-    # whole seed (e.g. CI). Retry a few times before giving up. Parallel CI shards all
-    # hit raw.githubusercontent.com at once, so 429 rate-limits are the common failure.
-    DOWNLOAD_ATTEMPTS = 4
+    # whole seed (e.g. CI). Retry a few times before giving up.
+    DOWNLOAD_ATTEMPTS = 3
     RETRY_DELAY_SECONDS = 2
-    RETRYABLE_STATUSES = [429, 500, 502, 503, 504].freeze
 
     def perform(name = nil)
       return IMPORTERS.each_key { |n| perform(n) } if name.blank?
@@ -32,14 +30,12 @@ module Spreadsheets
       begin
         attempt += 1
         response = connection.get(url)
-        return response.body if response.success?
+        raise "Failed to fetch #{url}: #{response.status}" unless response.success?
 
-        # Faraday::Error (not a plain RuntimeError) so the rescue below retries it
-        raise Faraday::Error, "Failed to fetch #{url}: #{response.status}" if RETRYABLE_STATUSES.include?(response.status)
-        raise "Failed to fetch #{url}: #{response.status}"
-      rescue Faraday::Error
+        response.body
+      rescue Faraday::ConnectionFailed, Faraday::TimeoutError
         raise if attempt >= DOWNLOAD_ATTEMPTS
-        sleep RETRY_DELAY_SECONDS * attempt
+        sleep RETRY_DELAY_SECONDS
         retry
       end
     end

--- a/app/services/integrations/strava/client.rb
+++ b/app/services/integrations/strava/client.rb
@@ -6,7 +6,7 @@ module Integrations
       extend Functionable
 
       BASE_URL = "https://www.strava.com"
-      API_URL = "https://www.api-v3.strava.com"
+      API_URL = "https://www.strava.com/api/v3"
       DEFAULT_SCOPE = "read,activity:read_all,profile:read_all"
       STRAVA_SEARCH_SCOPE = "#{DEFAULT_SCOPE},activity:write"
       STRAVA_KEY = ENV["STRAVA_KEY"]
@@ -88,7 +88,7 @@ module Integrations
       end
 
       def create_webhook_subscription
-        oauth_connection.post("#{API_URL}/push_subscriptions") do |req|
+        oauth_connection.post("api/v3/push_subscriptions") do |req|
           req.body = {
             client_id: STRAVA_KEY,
             client_secret: STRAVA_SECRET,
@@ -99,7 +99,7 @@ module Integrations
       end
 
       def view_webhook_subscriptions
-        oauth_connection.get("#{API_URL}/push_subscriptions") do |req|
+        oauth_connection.get("api/v3/push_subscriptions") do |req|
           req.params = {client_id: STRAVA_KEY, client_secret: STRAVA_SECRET}
         end
       end
@@ -113,7 +113,7 @@ module Integrations
       end
 
       def delete_webhook_subscription(subscription_id)
-        oauth_connection.delete("#{API_URL}/push_subscriptions/#{subscription_id}") do |req|
+        oauth_connection.delete("api/v3/push_subscriptions/#{subscription_id}") do |req|
           req.body = {client_id: STRAVA_KEY, client_secret: STRAVA_SECRET}
         end
       end

--- a/spec/jobs/spreadsheets/importer_job_spec.rb
+++ b/spec/jobs/spreadsheets/importer_job_spec.rb
@@ -52,20 +52,6 @@ RSpec.describe Spreadsheets::ImporterJob, type: :job do
         expect(Manufacturer.friendly_find("Retry Bikes")).to be_present
       end
 
-      it "retries a 429 rate-limit response, then imports" do
-        WebMock.stub_request(:get, url)
-          .to_return(status: 429).then.to_return(status: 200, body: csv)
-        expect { job.perform("manufacturers") }.to change(Manufacturer, :count).by(1)
-        expect(Manufacturer.friendly_find("Retry Bikes")).to be_present
-      end
-
-      it "does not retry a non-retryable status, and raises" do
-        # 404 then 200: a retry would consume the 200 and succeed, so raising proves no retry
-        WebMock.stub_request(:get, url)
-          .to_return(status: 404).then.to_return(status: 200, body: csv)
-        expect { job.perform("manufacturers") }.to raise_error(/Failed to fetch.*404/)
-      end
-
       it "gives up after DOWNLOAD_ATTEMPTS and raises" do
         WebMock.stub_request(:get, url).to_timeout
         expect { job.perform("manufacturers") }.to raise_error(Faraday::Error)

--- a/spec/vcr_cassettes/strava-create_webhook_subscription.yml
+++ b/spec/vcr_cassettes/strava-create_webhook_subscription.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: https://www.api-v3.strava.com/push_subscriptions
+    uri: https://www.strava.com/api/v3/push_subscriptions
     body:
       encoding: UTF-8
       string: client_id=<STRAVA_KEY>&client_secret=<STRAVA_SECRET>&callback_url=http%3A%2F%2Flocalhost%3A3042%2Fwebhooks%2Fstrava&verify_token=<STRAVA_WEBHOOK_VERIFY_TOKEN>

--- a/spec/vcr_cassettes/strava-delete_webhook_subscription.yml
+++ b/spec/vcr_cassettes/strava-delete_webhook_subscription.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: delete
-    uri: https://www.api-v3.strava.com/push_subscriptions/123456
+    uri: https://www.strava.com/api/v3/push_subscriptions/123456
     body:
       encoding: UTF-8
       string: client_id=<STRAVA_KEY>&client_secret=<STRAVA_SECRET>

--- a/spec/vcr_cassettes/strava-get_activity-401.yml
+++ b/spec/vcr_cassettes/strava-get_activity-401.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://www.api-v3.strava.com/activities/17323701543
+    uri: https://www.strava.com/api/v3/activities/17323701543
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/vcr_cassettes/strava-get_activity.yml
+++ b/spec/vcr_cassettes/strava-get_activity.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://www.api-v3.strava.com/activities/17323701543
+    uri: https://www.strava.com/api/v3/activities/17323701543
     body:
       encoding: US-ASCII
       string: ''
@@ -75,7 +75,7 @@ http_interactions:
   recorded_at: Sat, 28 Feb 2026 00:07:00 GMT
 - request:
     method: get
-    uri: https://www.api-v3.strava.com/activities/12345
+    uri: https://www.strava.com/api/v3/activities/12345
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/vcr_cassettes/strava-get_athlete.yml
+++ b/spec/vcr_cassettes/strava-get_athlete.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://www.api-v3.strava.com/athlete
+    uri: https://www.strava.com/api/v3/athlete
     body:
       encoding: US-ASCII
       string: ''
@@ -75,7 +75,7 @@ http_interactions:
   recorded_at: Sun, 08 Feb 2026 22:46:40 GMT
 - request:
     method: get
-    uri: https://www.api-v3.strava.com/athlete/2430215
+    uri: https://www.strava.com/api/v3/athlete/2430215
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/vcr_cassettes/strava-get_athlete_500.yml
+++ b/spec/vcr_cassettes/strava-get_athlete_500.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://www.api-v3.strava.com/athlete
+    uri: https://www.strava.com/api/v3/athlete
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/vcr_cassettes/strava-get_athlete_stats.yml
+++ b/spec/vcr_cassettes/strava-get_athlete_stats.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://www.api-v3.strava.com/athletes/2430215/stats
+    uri: https://www.strava.com/api/v3/athletes/2430215/stats
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/vcr_cassettes/strava-get_athlete_stats_rate_limited.yml
+++ b/spec/vcr_cassettes/strava-get_athlete_stats_rate_limited.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://www.api-v3.strava.com/athletes/2430215/stats
+    uri: https://www.strava.com/api/v3/athletes/2430215/stats
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/vcr_cassettes/strava-get_gear.yml
+++ b/spec/vcr_cassettes/strava-get_gear.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://www.api-v3.strava.com/gear/b12345
+    uri: https://www.strava.com/api/v3/gear/b12345
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/vcr_cassettes/strava-list_activities-last_page.yml
+++ b/spec/vcr_cassettes/strava-list_activities-last_page.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://www.api-v3.strava.com/athlete/activities?page=13&per_page=200
+    uri: https://www.strava.com/api/v3/athlete/activities?page=13&per_page=200
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/vcr_cassettes/strava-list_activities.yml
+++ b/spec/vcr_cassettes/strava-list_activities.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://www.api-v3.strava.com/athlete/activities?page=1&per_page=1
+    uri: https://www.strava.com/api/v3/athlete/activities?page=1&per_page=1
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/vcr_cassettes/strava-proxy_not_found.yml
+++ b/spec/vcr_cassettes/strava-proxy_not_found.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://www.api-v3.strava.com/activities/3333/dddd
+    uri: https://www.strava.com/api/v3/activities/3333/dddd
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/vcr_cassettes/strava-proxy_rate_limited.yml
+++ b/spec/vcr_cassettes/strava-proxy_rate_limited.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://www.api-v3.strava.com/activities/6969
+    uri: https://www.strava.com/api/v3/activities/6969
     body:
       encoding: US-ASCII
       string: ''
@@ -35,7 +35,7 @@ http_interactions:
   recorded_at: Sun, 08 Feb 2026 22:46:00 GMT
 - request:
     method: get
-    uri: https://www.api-v3.strava.com/activities/12345
+    uri: https://www.strava.com/api/v3/activities/12345
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/vcr_cassettes/strava-proxy_request_401_retry.yml
+++ b/spec/vcr_cassettes/strava-proxy_request_401_retry.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://www.api-v3.strava.com/athlete
+    uri: https://www.strava.com/api/v3/athlete
     body:
       encoding: US-ASCII
       string: ''
@@ -52,7 +52,7 @@ http_interactions:
   recorded_at: Sun, 08 Feb 2026 22:46:01 GMT
 - request:
     method: get
-    uri: https://www.api-v3.strava.com/athlete
+    uri: https://www.strava.com/api/v3/athlete
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/vcr_cassettes/strava-proxy_server_error.yml
+++ b/spec/vcr_cassettes/strava-proxy_server_error.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://www.api-v3.strava.com/activities/6969
+    uri: https://www.strava.com/api/v3/activities/6969
     body:
       encoding: US-ASCII
       string: ''
@@ -30,7 +30,7 @@ http_interactions:
   recorded_at: Sun, 08 Feb 2026 22:46:00 GMT
 - request:
     method: get
-    uri: https://www.api-v3.strava.com/activities/12345
+    uri: https://www.strava.com/api/v3/activities/12345
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/vcr_cassettes/strava-proxy_update_activity-insufficient.yml
+++ b/spec/vcr_cassettes/strava-proxy_update_activity-insufficient.yml
@@ -68,7 +68,7 @@ http_interactions:
   recorded_at: Thu, 19 Feb 2026 23:25:02 GMT
 - request:
     method: put
-    uri: https://www.api-v3.strava.com/activities/17419209324
+    uri: https://www.strava.com/api/v3/activities/17419209324
     body:
       encoding: UTF-8
       string: '{"gear_id":"b11099574"}'

--- a/spec/vcr_cassettes/strava-proxy_update_activity.yml
+++ b/spec/vcr_cassettes/strava-proxy_update_activity.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: put
-    uri: https://www.api-v3.strava.com/activities/17419209324
+    uri: https://www.strava.com/api/v3/activities/17419209324
     body:
       encoding: UTF-8
       string: '{"gear_id":"b11099574"}'
@@ -81,7 +81,7 @@ http_interactions:
   recorded_at: Sat, 28 Feb 2026 00:07:01 GMT
 - request:
     method: get
-    uri: https://www.api-v3.strava.com/activities/17419209324
+    uri: https://www.strava.com/api/v3/activities/17419209324
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/vcr_cassettes/strava-rate_limited.yml
+++ b/spec/vcr_cassettes/strava-rate_limited.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://www.api-v3.strava.com/athlete/activities?per_page=200
+    uri: https://www.strava.com/api/v3/athlete/activities?per_page=200
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/vcr_cassettes/strava-server_error.yml
+++ b/spec/vcr_cassettes/strava-server_error.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://www.api-v3.strava.com/athlete/activities?per_page=200
+    uri: https://www.strava.com/api/v3/athlete/activities?per_page=200
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/vcr_cassettes/strava-unauthorized.yml
+++ b/spec/vcr_cassettes/strava-unauthorized.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://www.api-v3.strava.com/athlete/activities?per_page=200
+    uri: https://www.strava.com/api/v3/athlete/activities?per_page=200
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/vcr_cassettes/strava-update_from_strava-dunes_trip.yml
+++ b/spec/vcr_cassettes/strava-update_from_strava-dunes_trip.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://www.api-v3.strava.com/activities/630203151
+    uri: https://www.strava.com/api/v3/activities/630203151
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/vcr_cassettes/strava-update_from_strava.yml
+++ b/spec/vcr_cassettes/strava-update_from_strava.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://www.api-v3.strava.com/activities/17419209324
+    uri: https://www.strava.com/api/v3/activities/17419209324
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/vcr_cassettes/strava-view_webhook_subscriptions.yml
+++ b/spec/vcr_cassettes/strava-view_webhook_subscriptions.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://www.api-v3.strava.com/push_subscriptions?client_id=<STRAVA_KEY>&client_secret=<STRAVA_SECRET>
+    uri: https://www.strava.com/api/v3/push_subscriptions?client_id=<STRAVA_KEY>&client_secret=<STRAVA_SECRET>
     body:
       encoding: UTF-8
       string: ''


### PR DESCRIPTION
Reverts #3828 ("Point Strava API client at www.api-v3.strava.com").

- Points the Strava v3 API client back to `https://www.strava.com/api/v3` (and reverts the matching VCR cassettes).
- Restores `Spreadsheets::ImporterJob` to retrying only connection/timeout errors, dropping the 429/5xx retry-with-backoff behavior.

I updated based on the email they sent which said

> The API base URL is changing from https://www.strava.com/api/v3 to https://www.api-v3.strava.com. 

The URL doesn't resolve. Should've verified :/
