### PR TITLE
Cut CSP frame-src report noise driving the Honeybadger spike

### DIFF
--- a/app/controllers/csp_reports_controller.rb
+++ b/app/controllers/csp_reports_controller.rb
@@ -6,6 +6,9 @@ class CspReportsController < ApplicationController
   EXTENSION_SCHEME = %r{\A(chrome|moz|safari|safari-web)-extension://}
   IN_APP_BROWSER = /\b(FBAN|FBAV|FB_IAB|Instagram|Line\/)\b/
   TRANSLATE_DOCUMENT = /\.translate\.goog\z|translate\.google(apis)?\.com/
+  # Corporate proxies, antivirus, and carriers inject frames pointing at private
+  # or loopback IPs — the user's own network, nothing we serve or can fix.
+  PRIVATE_IP_FRAME = %r{\Ahttps?://(10\.|127\.|169\.254\.|192\.168\.|172\.(1[6-9]|2\d|3[01])\.)}
 
   def create
     # Browsers/bots occasionally send malformed byte sequences (e.g. overlong
@@ -28,7 +31,11 @@ class CspReportsController < ApplicationController
 
   def send_report?(report)
     report.present? && !request.user_agent.to_s.match?(IN_APP_BROWSER) &&
-      !extension_noise?(report) && !translate_noise?(report)
+      !extension_noise?(report) && !translate_noise?(report) && !private_ip_noise?(report)
+  end
+
+  def private_ip_noise?(report)
+    report["blocked-uri"].to_s.match?(PRIVATE_IP_FRAME)
   end
 
   def extension_noise?(report)
@@ -40,7 +47,8 @@ class CspReportsController < ApplicationController
   def translate_noise?(report)
     blocked = report["blocked-uri"].to_s
     return true if report["document-uri"].to_s.match?(TRANSLATE_DOCUMENT)
-    return true if blocked.match?(%r{\Ahttps://www\.google\.[a-z.]+/})
+    # Frame violations report the bare origin (no path), so match a trailing slash or end
+    return true if blocked.match?(%r{\Ahttps://www\.google\.[a-z.]+(/|\z)})
 
     report["effective-directive"] == "media-src" && blocked == "data"
   end

--- a/app/controllers/csp_reports_controller.rb
+++ b/app/controllers/csp_reports_controller.rb
@@ -1,55 +1,14 @@
-# Receives browser CSP violation reports, drops known noise (browser extensions,
-# in-app browsers, translate proxies), and forwards the rest to Honeybadger.
+# Receives browser CSP violation reports and hands them to the forward job,
+# which drops known noise and forwards the rest to Honeybadger in production.
 class CspReportsController < ApplicationController
   skip_before_action :verify_authenticity_token
 
-  EXTENSION_SCHEME = %r{\A(chrome|moz|safari|safari-web)-extension://}
-  IN_APP_BROWSER = /\b(FBAN|FBAV|FB_IAB|Instagram|Line\/)\b/
-  TRANSLATE_DOCUMENT = /\.translate\.goog\z|translate\.google(apis)?\.com/
-  # Corporate proxies, antivirus, and carriers inject frames pointing at private
-  # or loopback IPs — the user's own network, nothing we serve or can fix.
-  PRIVATE_IP_FRAME = %r{\Ahttps?://(10\.|127\.|169\.254\.|192\.168\.|172\.(1[6-9]|2\d|3[01])\.)}
-
   def create
     # Browsers/bots occasionally send malformed byte sequences (e.g. overlong
-    # UTF-8) that raise downstream, both from Regexp#match? and from Sidekiq's
-    # JSON-encoding of the job args, so scrub once at the boundary.
+    # UTF-8) that raise when Sidekiq JSON-encodes the job args, so scrub once
+    # at the boundary before enqueuing.
     body = request.raw_post.dup.force_encoding(Encoding::UTF_8).scrub
-    report = parsed_report(body)
-    ForwardCspReportJob.perform_async(body, current_user&.id) if send_report?(report)
+    ForwardCspReportJob.perform_async(body, current_user&.id, request.user_agent)
     head :no_content
-  end
-
-  private
-
-  def parsed_report(body)
-    parsed = JSON.parse(body)
-    parsed["csp-report"] if parsed.is_a?(Hash) && parsed["csp-report"].is_a?(Hash)
-  rescue JSON::ParserError, TypeError
-    nil
-  end
-
-  def send_report?(report)
-    report.present? && !request.user_agent.to_s.match?(IN_APP_BROWSER) &&
-      !extension_noise?(report) && !translate_noise?(report) && !private_ip_noise?(report)
-  end
-
-  def private_ip_noise?(report)
-    report["blocked-uri"].to_s.match?(PRIVATE_IP_FRAME)
-  end
-
-  def extension_noise?(report)
-    [report["blocked-uri"], report["source-file"]].compact
-      .any? { |uri| uri.match?(EXTENSION_SCHEME) }
-  end
-
-  # Google Translate reskins the page and injects google.<tld> frames + read-aloud TTS audio
-  def translate_noise?(report)
-    blocked = report["blocked-uri"].to_s
-    return true if report["document-uri"].to_s.match?(TRANSLATE_DOCUMENT)
-    # Frame violations report the bare origin (no path), so match a trailing slash or end
-    return true if blocked.match?(%r{\Ahttps://www\.google\.[a-z.]+(/|\z)})
-
-    report["effective-directive"] == "media-src" && blocked == "data"
   end
 end

--- a/app/jobs/forward_csp_report_job.rb
+++ b/app/jobs/forward_csp_report_job.rb
@@ -6,6 +6,10 @@ class ForwardCspReportJob < ApplicationJob
   EXTENSION_SCHEME = %r{\A(chrome|moz|safari|safari-web)-extension://}
   IN_APP_BROWSER = /\b(FBAN|FBAV|FB_IAB|Instagram|Line\/)\b/
   TRANSLATE_DOCUMENT = /\.translate\.goog\z|translate\.google(apis)?\.com/
+  # Google Ads conversion iframes load on country-specific google.<tld> domains;
+  # CSP frame_src allowlists common ones, we silence reports for the rest. Frame
+  # violations report the bare origin, hence the trailing slash-or-end.
+  GOOGLE_FRAME = %r{\Ahttps://www\.google\.[a-z.]+(/|\z)}
   # Corporate proxies, antivirus, and carriers inject frames pointing at private
   # or loopback IPs — the user's own network, nothing we serve or can fix.
   PRIVATE_IP_FRAME = %r{\Ahttps?://(10\.|127\.|169\.254\.|192\.168\.|172\.(1[6-9]|2\d|3[01])\.)}
@@ -35,7 +39,8 @@ class ForwardCspReportJob < ApplicationJob
 
   def forward?(report, user_agent)
     report.present? && !user_agent.to_s.match?(IN_APP_BROWSER) &&
-      !extension_noise?(report) && !translate_noise?(report) && !private_ip_noise?(report)
+      !extension_noise?(report) && !translate_noise?(report) &&
+      !google_frame_noise?(report) && !private_ip_noise?(report)
   end
 
   def extension_noise?(report)
@@ -43,13 +48,14 @@ class ForwardCspReportJob < ApplicationJob
       .any? { |uri| uri.match?(EXTENSION_SCHEME) }
   end
 
-  # Google Translate reskins the page and injects google.<tld> frames + read-aloud TTS audio
+  # Google Translate reskins the page and injects read-aloud TTS audio as data: media
   def translate_noise?(report)
-    blocked = report["blocked-uri"].to_s
     return true if report["document-uri"].to_s.match?(TRANSLATE_DOCUMENT)
-    # Frame violations report the bare origin (no path), so match a trailing slash or end
-    return true if blocked.match?(%r{\Ahttps://www\.google\.[a-z.]+(/|\z)})
-    report["effective-directive"] == "media-src" && blocked == "data"
+    report["effective-directive"] == "media-src" && report["blocked-uri"].to_s == "data"
+  end
+
+  def google_frame_noise?(report)
+    report["blocked-uri"].to_s.match?(GOOGLE_FRAME)
   end
 
   def private_ip_noise?(report)

--- a/app/jobs/forward_csp_report_job.rb
+++ b/app/jobs/forward_csp_report_job.rb
@@ -6,6 +6,10 @@ class ForwardCspReportJob < ApplicationJob
   # The query is rebuilt here, not forwarded from the client, so the API key and
   # user context never ride in the browser-facing CSP report_uri.
   def perform(body, user_id)
+    # Only production forwards to Honeybadger; dev/staging browsers still emit
+    # reports, but we never want their noise in the production CSP project.
+    return unless Rails.env.production?
+
     api_key = ENV["HONEYBADGER_CSP_API_KEY"]
     return if api_key.blank?
 

--- a/app/jobs/forward_csp_report_job.rb
+++ b/app/jobs/forward_csp_report_job.rb
@@ -2,19 +2,57 @@ class ForwardCspReportJob < ApplicationJob
   sidekiq_options queue: "low_priority", retry: 2
 
   HONEYBADGER_URL = "https://api.honeybadger.io/v1/browser/csp"
+  HONEYBADGER_CSP_API_KEY = ENV["HONEYBADGER_CSP_API_KEY"]
+  EXTENSION_SCHEME = %r{\A(chrome|moz|safari|safari-web)-extension://}
+  IN_APP_BROWSER = /\b(FBAN|FBAV|FB_IAB|Instagram|Line\/)\b/
+  TRANSLATE_DOCUMENT = /\.translate\.goog\z|translate\.google(apis)?\.com/
+  # Corporate proxies, antivirus, and carriers inject frames pointing at private
+  # or loopback IPs — the user's own network, nothing we serve or can fix.
+  PRIVATE_IP_FRAME = %r{\Ahttps?://(10\.|127\.|169\.254\.|192\.168\.|172\.(1[6-9]|2\d|3[01])\.)}
 
   # The query is rebuilt here, not forwarded from the client, so the API key and
   # user context never ride in the browser-facing CSP report_uri.
-  def perform(body, user_id)
-    # Only production forwards to Honeybadger; dev/staging browsers still emit
-    # reports, but we never want their noise in the production CSP project.
-    return unless Rails.env.production?
+  def perform(body, user_id, user_agent = nil)
+    # dev/staging browsers still emit reports; only production forwards to Honeybadger
+    return unless Rails.env.production? && HONEYBADGER_CSP_API_KEY.present?
 
-    api_key = ENV["HONEYBADGER_CSP_API_KEY"]
-    return if api_key.blank?
+    report = parsed_report(body)
+    return unless forward?(report, user_agent)
 
-    query = URI.encode_www_form(api_key:, report_only: false,
+    query = URI.encode_www_form(api_key: HONEYBADGER_CSP_API_KEY, report_only: false,
       env: Rails.env, "context[user_id]": user_id.to_s)
     Faraday.post("#{HONEYBADGER_URL}?#{query}", body, "Content-Type" => "application/csp-report")
+  end
+
+  private
+
+  def parsed_report(body)
+    parsed = JSON.parse(body)
+    parsed["csp-report"] if parsed.is_a?(Hash) && parsed["csp-report"].is_a?(Hash)
+  rescue JSON::ParserError, TypeError
+    nil
+  end
+
+  def forward?(report, user_agent)
+    report.present? && !user_agent.to_s.match?(IN_APP_BROWSER) &&
+      !extension_noise?(report) && !translate_noise?(report) && !private_ip_noise?(report)
+  end
+
+  def extension_noise?(report)
+    [report["blocked-uri"], report["source-file"]].compact
+      .any? { |uri| uri.match?(EXTENSION_SCHEME) }
+  end
+
+  # Google Translate reskins the page and injects google.<tld> frames + read-aloud TTS audio
+  def translate_noise?(report)
+    blocked = report["blocked-uri"].to_s
+    return true if report["document-uri"].to_s.match?(TRANSLATE_DOCUMENT)
+    # Frame violations report the bare origin (no path), so match a trailing slash or end
+    return true if blocked.match?(%r{\Ahttps://www\.google\.[a-z.]+(/|\z)})
+    report["effective-directive"] == "media-src" && blocked == "data"
+  end
+
+  def private_ip_noise?(report)
+    report["blocked-uri"].to_s.match?(PRIVATE_IP_FRAME)
   end
 end

--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -71,6 +71,7 @@ Rails.application.configure do
       "https://www.google.fr",
       "https://www.google.it",
       "https://www.google.nl",
+      "https://www.google.co.id",
       "https://www.google.co.in",
       "https://www.google.co.jp",
       "https://www.google.com.mx",

--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -63,6 +63,7 @@ Rails.application.configure do
       "https://www.google.com",
       # Google Ads conversion tracking iframes use country-specific Google domains
       "https://www.google.ca",
+      "https://www.google.co.id",
       "https://www.google.co.uk",
       "https://www.google.com.au",
       "https://www.google.com.br",
@@ -71,7 +72,6 @@ Rails.application.configure do
       "https://www.google.fr",
       "https://www.google.it",
       "https://www.google.nl",
-      "https://www.google.co.id",
       "https://www.google.co.in",
       "https://www.google.co.jp",
       "https://www.google.com.mx",

--- a/spec/jobs/forward_csp_report_job_spec.rb
+++ b/spec/jobs/forward_csp_report_job_spec.rb
@@ -1,0 +1,32 @@
+require "rails_helper"
+
+RSpec.describe ForwardCspReportJob, type: :job do
+  let(:body) { {"csp-report" => {"blocked-uri" => "https://evil.example.com/x.js"}}.to_json }
+  let(:forwarded) { [] }
+
+  before { stub_const("ENV", ENV.to_hash.merge("HONEYBADGER_CSP_API_KEY" => "abc123")) }
+
+  describe "#perform" do
+    before do
+      WebMock.stub_request(:post, /api\.honeybadger\.io/).to_return {
+        forwarded << true
+        {status: 201}
+      }
+    end
+    after { WebMock.reset! }
+
+    it "does not forward outside production, even with an API key" do
+      described_class.new.perform(body, nil)
+      expect(forwarded).to be_empty
+    end
+
+    context "in production" do
+      before { allow(Rails).to receive(:env).and_return("production".inquiry) }
+
+      it "forwards the report to Honeybadger" do
+        described_class.new.perform(body, nil)
+        expect(forwarded).to contain_exactly(true)
+      end
+    end
+  end
+end

--- a/spec/jobs/forward_csp_report_job_spec.rb
+++ b/spec/jobs/forward_csp_report_job_spec.rb
@@ -1,10 +1,13 @@
 require "rails_helper"
 
 RSpec.describe ForwardCspReportJob, type: :job do
-  let(:body) { {"csp-report" => {"blocked-uri" => "https://evil.example.com/x.js"}}.to_json }
+  let(:blocked_uri) { "https://evil.example.com/x.js" }
+  let(:report) { {"csp-report" => {"blocked-uri" => blocked_uri, "document-uri" => "https://bikeindex.org/bikes/1", "effective-directive" => "script-src"}} }
+  let(:body) { report.to_json }
+  let(:user_agent) { "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) Chrome/148.0.0.0 Safari/537.36" }
   let(:forwarded) { [] }
 
-  before { stub_const("ENV", ENV.to_hash.merge("HONEYBADGER_CSP_API_KEY" => "abc123")) }
+  before { stub_const("ForwardCspReportJob::HONEYBADGER_CSP_API_KEY", "abc123") }
 
   describe "#perform" do
     before do
@@ -15,17 +18,78 @@ RSpec.describe ForwardCspReportJob, type: :job do
     end
     after { WebMock.reset! }
 
+    def perform(request_body = body)
+      described_class.new.perform(request_body, nil, user_agent)
+    end
+
     it "does not forward outside production, even with an API key" do
-      described_class.new.perform(body, nil)
+      perform
       expect(forwarded).to be_empty
     end
 
     context "in production" do
       before { allow(Rails).to receive(:env).and_return("production".inquiry) }
 
-      it "forwards the report to Honeybadger" do
-        described_class.new.perform(body, nil)
+      it "forwards a real violation to Honeybadger" do
+        perform
         expect(forwarded).to contain_exactly(true)
+      end
+
+      context "without an API key" do
+        before { stub_const("ForwardCspReportJob::HONEYBADGER_CSP_API_KEY", "") }
+        it "does not forward" do
+          perform
+          expect(forwarded).to be_empty
+        end
+      end
+
+      context "browser-extension noise" do
+        let(:blocked_uri) { "chrome-extension://0dca8e62/fonts/Inter-Variable.ttf" }
+        it "does not forward" do
+          perform
+          expect(forwarded).to be_empty
+        end
+      end
+
+      context "in-app browser user agent" do
+        let(:user_agent) { "Mozilla/5.0 (Linux; Android 12) Mobile Safari/537.36 [FB_IAB/FB4A;FBAV/488.0.0.78.79;]" }
+        it "does not forward" do
+          perform
+          expect(forwarded).to be_empty
+        end
+      end
+
+      context "google country-domain frame (origin only, no path)" do
+        let(:blocked_uri) { "https://www.google.co.id" }
+        it "does not forward" do
+          perform
+          expect(forwarded).to be_empty
+        end
+      end
+
+      context "private-ip frame injection" do
+        let(:blocked_uri) { "https://10.255.99.112" }
+        it "does not forward" do
+          perform
+          expect(forwarded).to be_empty
+        end
+      end
+
+      context "read-aloud data: media" do
+        let(:report) { {"csp-report" => {"blocked-uri" => "data", "effective-directive" => "media-src"}} }
+        it "does not forward" do
+          perform
+          expect(forwarded).to be_empty
+        end
+      end
+
+      context "malformed body" do
+        ["not json", "null", "123", {"csp-report" => 5}.to_json].each do |raw_body|
+          it "does not forward for #{raw_body.inspect}" do
+            perform(raw_body)
+            expect(forwarded).to be_empty
+          end
+        end
       end
     end
   end

--- a/spec/requests/csp_reports_request_spec.rb
+++ b/spec/requests/csp_reports_request_spec.rb
@@ -45,8 +45,17 @@ RSpec.describe CspReportsController, type: :request do
       end
     end
 
-    context "translate proxy frame" do
-      let(:blocked_uri) { "https://www.google.co.id/" }
+    context "google country-domain frame (origin only, no path)" do
+      let(:blocked_uri) { "https://www.google.co.id" }
+      it "drops the report" do
+        post_report
+        expect(ForwardCspReportJob.jobs.count).to eq 0
+      end
+    end
+
+    context "private-ip frame injection" do
+      let(:blocked_uri) { "https://10.255.99.112" }
+      let(:report) { {"csp-report" => {"blocked-uri" => blocked_uri, "document-uri" => "https://bikeindex.org/bikes/1", "effective-directive" => "frame-src"}} }
       it "drops the report" do
         post_report
         expect(ForwardCspReportJob.jobs.count).to eq 0

--- a/spec/requests/csp_reports_request_spec.rb
+++ b/spec/requests/csp_reports_request_spec.rb
@@ -3,8 +3,8 @@ require "rails_helper"
 base_url = "/csp_reports"
 RSpec.describe CspReportsController, type: :request do
   describe "create" do
-    let(:report) { {"csp-report" => {"blocked-uri" => blocked_uri, "document-uri" => "https://bikeindex.org/bikes/1", "effective-directive" => "script-src"}} }
     let(:blocked_uri) { "https://evil.example.com/x.js" }
+    let(:report) { {"csp-report" => {"blocked-uri" => blocked_uri, "document-uri" => "https://bikeindex.org/bikes/1", "effective-directive" => "script-src"}} }
     let(:user_agent) { "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) Chrome/148.0.0.0 Safari/537.36" }
 
     def post_report
@@ -12,10 +12,10 @@ RSpec.describe CspReportsController, type: :request do
         headers: {"CONTENT_TYPE" => "application/csp-report", "HTTP_USER_AGENT" => user_agent}
     end
 
-    it "forwards a real violation to Honeybadger" do
+    it "enqueues the forward job with the body, user, and user agent" do
       post_report
       expect(response.status).to eq(204)
-      expect(ForwardCspReportJob).to have_enqueued_sidekiq_job(report.to_json, nil)
+      expect(ForwardCspReportJob).to have_enqueued_sidekiq_job(report.to_json, nil, user_agent)
     end
 
     context "with a signed-in user" do
@@ -24,49 +24,7 @@ RSpec.describe CspReportsController, type: :request do
         post "#{base_url}?context[user_id]=999", params: report.to_json,
           headers: {"CONTENT_TYPE" => "application/csp-report", "HTTP_USER_AGENT" => user_agent}
         expect(response.status).to eq(204)
-        expect(ForwardCspReportJob).to have_enqueued_sidekiq_job(report.to_json, current_user.id)
-      end
-    end
-
-    context "browser-extension noise" do
-      let(:blocked_uri) { "chrome-extension://0dca8e62/fonts/Inter-Variable.ttf" }
-      it "drops the report" do
-        post_report
-        expect(response.status).to eq(204)
-        expect(ForwardCspReportJob.jobs.count).to eq 0
-      end
-    end
-
-    context "in-app browser" do
-      let(:user_agent) { "Mozilla/5.0 (Linux; Android 12) Mobile Safari/537.36 [FB_IAB/FB4A;FBAV/488.0.0.78.79;]" }
-      it "drops the report" do
-        post_report
-        expect(ForwardCspReportJob.jobs.count).to eq 0
-      end
-    end
-
-    context "google country-domain frame (origin only, no path)" do
-      let(:blocked_uri) { "https://www.google.co.id" }
-      it "drops the report" do
-        post_report
-        expect(ForwardCspReportJob.jobs.count).to eq 0
-      end
-    end
-
-    context "private-ip frame injection" do
-      let(:blocked_uri) { "https://10.255.99.112" }
-      let(:report) { {"csp-report" => {"blocked-uri" => blocked_uri, "document-uri" => "https://bikeindex.org/bikes/1", "effective-directive" => "frame-src"}} }
-      it "drops the report" do
-        post_report
-        expect(ForwardCspReportJob.jobs.count).to eq 0
-      end
-    end
-
-    context "read-aloud data: media" do
-      let(:report) { {"csp-report" => {"blocked-uri" => "data", "effective-directive" => "media-src"}} }
-      it "drops the report" do
-        post_report
-        expect(ForwardCspReportJob.jobs.count).to eq 0
+        expect(ForwardCspReportJob).to have_enqueued_sidekiq_job(report.to_json, current_user.id, user_agent)
       end
     end
 
@@ -75,22 +33,11 @@ RSpec.describe CspReportsController, type: :request do
         report.to_json.sub(blocked_uri, "#{blocked_uri}\xC0\xA7\xC0\xA2".force_encoding(Encoding::ASCII_8BIT))
       end
 
-      it "scrubs the body instead of raising, and forwards the report" do
+      it "scrubs the body before enqueuing instead of raising" do
         post base_url, params: raw_body,
           headers: {"CONTENT_TYPE" => "application/csp-report", "HTTP_USER_AGENT" => user_agent}
         expect(response.status).to eq(204)
         expect(ForwardCspReportJob.jobs.count).to eq 1
-      end
-    end
-
-    context "malformed body" do
-      ["not json", "null", "123", {"csp-report" => 5}.to_json].each do |raw_body|
-        it "returns 204 without enqueuing for #{raw_body.inspect}" do
-          post base_url, params: raw_body,
-            headers: {"CONTENT_TYPE" => "application/csp-report"}
-          expect(response.status).to eq(204)
-          expect(ForwardCspReportJob.jobs.count).to eq 0
-        end
       end
     end
 


### PR DESCRIPTION
CSP report volume on Honeybadger spiked ~14× (≈1k/day → 14.8k on Jul 8), almost entirely `frame-src` violations we can't act on. Cuts the noise at its sources:

- **Google Ads country-domain iframes** — allowlist `www.google.co.id` (the top offender), and fix the translate-noise backstop so it silences the long tail: the regex required a trailing `/`, but frame violations report the bare origin, so every un-allowlisted `google.<tld>` leaked to Honeybadger.
- **Private-IP frame injection** — corporate proxy / antivirus / carrier frames pointing at private or loopback IPs (e.g. `https://10.255.99.112`) are the user's own network, not anything we serve; dropped at the report boundary.
- **Non-production leakage** — the forward job had no environment guard, so developers with `HONEYBADGER_CSP_API_KEY` set were POSTing localhost violations into the production CSP project (75 development-env reports). Only production forwards now.
