### PR TITLE
Route contact@ inbound email to bug reports

### DIFF
--- a/app/mailboxes/application_mailbox.rb
+++ b/app/mailboxes/application_mailbox.rb
@@ -1,3 +1,3 @@
 class ApplicationMailbox < ActionMailbox::Base
-  routing(/bugs@/i => :bug_reports)
+  routing(/(?:bugs|contact)@/i => :bug_reports)
 end

--- a/spec/mailboxes/bug_reports_mailbox_spec.rb
+++ b/spec/mailboxes/bug_reports_mailbox_spec.rb
@@ -21,6 +21,19 @@ RSpec.describe BugReportsMailbox do
     expect(BugReport.last.received_at).to be_present
   end
 
+  it "creates a bug report from an email to contact@" do
+    expect do
+      receive_inbound_email_from_mail(
+        from: user.email,
+        to: "contact@bikeindex.org",
+        subject: "Question",
+        body: "How do I register?"
+      )
+    end.to change(BugReport, :count).by 1
+
+    expect(BugReport.last).to have_attributes(email: user.email, user_id: user.id, subject: "Question")
+  end
+
   context "with attachments" do
     let(:mail) do
       Mail.new do


### PR DESCRIPTION
Route `contact@bikeindex.org` inbound email to `BugReportsMailbox` so it creates a `BugReport` exactly like `bugs@` already does — same sender matching, image-attachment handling, and admin triage.

- Widen the `ApplicationMailbox` route to `/(?:bugs|contact)@/i`.
- Add a spec covering the `contact@` route.
