### PR TITLE
Make Strava activity import idempotent

### DIFF
--- a/app/models/strava_activity.rb
+++ b/app/models/strava_activity.rb
@@ -93,6 +93,11 @@ class StravaActivity < ApplicationRecord
       activity = strava_integration.strava_activities.find_or_initialize_by(strava_id: response["id"])
       activity.update(attrs)
       activity
+    rescue ActiveRecord::RecordNotUnique
+      # A concurrent import inserted the row after find_or_initialize_by missed it; re-find and update
+      activity = strava_integration.strava_activities.find_by!(strava_id: response["id"])
+      activity.update(attrs)
+      activity
     end
 
     def strava_attributes_from(response)

--- a/app/models/strava_activity.rb
+++ b/app/models/strava_activity.rb
@@ -94,10 +94,8 @@ class StravaActivity < ApplicationRecord
       activity.update(attrs)
       activity
     rescue ActiveRecord::RecordNotUnique
-      # A concurrent import inserted the row after find_or_initialize_by missed it; re-find and update
-      activity = strava_integration.strava_activities.find_by!(strava_id: response["id"])
-      activity.update(attrs)
-      activity
+      # A concurrent import won the insert; retry to merge our attributes onto the committed row
+      create_or_update_from_strava_response(strava_integration, response)
     end
 
     def strava_attributes_from(response)

--- a/spec/models/strava_activity_spec.rb
+++ b/spec/models/strava_activity_spec.rb
@@ -143,12 +143,12 @@ RSpec.describe StravaActivity, type: :model do
     context "when a concurrent import races the insert" do
       it "rescues RecordNotUnique and updates the existing row" do
         existing = FactoryBot.create(:strava_activity, strava_integration:, strava_id: "9876543", title: "Old Title")
-        # Simulate the TOCTOU race: find_or_initialize_by misses the row, so update hits the
-        # DB unique index (RecordNotUnique) rather than failing the app-level uniqueness check
+        # Simulate the TOCTOU race: the first find_or_initialize_by misses (its insert hits the
+        # unique index), then the retry finds the row a concurrent import committed
         activities = strava_integration.strava_activities
         allow(strava_integration).to receive(:strava_activities).and_return(activities)
         fresh = activities.build(strava_id: "9876543")
-        allow(activities).to receive(:find_or_initialize_by).and_return(fresh)
+        allow(activities).to receive(:find_or_initialize_by).and_return(fresh, existing)
         allow(fresh).to receive(:update).and_raise(ActiveRecord::RecordNotUnique)
 
         strava_activity = StravaActivity.create_or_update_from_strava_response(strava_integration, summary)

--- a/spec/models/strava_activity_spec.rb
+++ b/spec/models/strava_activity_spec.rb
@@ -140,6 +140,24 @@ RSpec.describe StravaActivity, type: :model do
       expect(strava_integration.strava_activities.count).to eq(1)
     end
 
+    context "when a concurrent import races the insert" do
+      it "rescues RecordNotUnique and updates the existing row" do
+        existing = FactoryBot.create(:strava_activity, strava_integration:, strava_id: "9876543", title: "Old Title")
+        # Simulate the TOCTOU race: find_or_initialize_by misses the row, so update hits the
+        # DB unique index (RecordNotUnique) rather than failing the app-level uniqueness check
+        activities = strava_integration.strava_activities
+        allow(strava_integration).to receive(:strava_activities).and_return(activities)
+        fresh = activities.build(strava_id: "9876543")
+        allow(activities).to receive(:find_or_initialize_by).and_return(fresh)
+        allow(fresh).to receive(:update).and_raise(ActiveRecord::RecordNotUnique)
+
+        strava_activity = StravaActivity.create_or_update_from_strava_response(strava_integration, summary)
+        expect(strava_activity.id).to eq(existing.id)
+        expect(strava_activity.title).to eq("Morning Ride")
+        expect(strava_integration.strava_activities.count).to eq(1)
+      end
+    end
+
     context "with id-only response" do
       let(:existing) do
         FactoryBot.create(:strava_activity, strava_integration:, strava_id: "9876543",


### PR DESCRIPTION
Makes the Strava activity import idempotent under concurrency. `StravaActivity.create_or_update_from_strava_response` rescues `ActiveRecord::RecordNotUnique` — raised when two imports race the same `(strava_integration_id, strava_id)` and both pass the app-level uniqueness validation before either INSERTs — and re-finds the now-existing row to update it.

- Rescue-and-retry rather than `create_or_find_by`, which is unreliable here since the model's uniqueness *validation* prevents the INSERT from ever raising `RecordNotUnique`.
- All callers still get back a persisted activity, preserving the `.proxy_serialized` / `.update_from_strava!` contract.
