### PR TITLE
Fix spoofed-IP-header 500s on every route; allow analytics.google.com in CSP

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -62,7 +62,9 @@ module Bikeindex
     config.i18n.available_locales = %i[en es it nl nb]
     config.i18n.fallbacks = {"en-US": :en, "en-GB": :en}
 
-    config.middleware.insert_after ActionDispatch::RemoteIp, IpSpoofAttackFilter
+    # Must sit below DebugExceptions/ShowExceptions: those rescue the raised IpSpoofAttackError
+    # and render it as a 500 before it can reach this filter. Above them it never fires.
+    config.middleware.insert_after ActionDispatch::DebugExceptions, IpSpoofAttackFilter
     config.middleware.use Rack::Deflater
     config.middleware.insert 0, Rack::UTF8Sanitizer
 

--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -41,23 +41,24 @@ Rails.application.configure do
       "https://cdn.jsdelivr.net",
       "https://api.mapbox.com"
     policy.connect_src :self,
+      "https://*.google-analytics.com",
+      "https://*.tiles.mapbox.com",
+      # GA4 also routes /g/collect beacons to analytics.google.com and (region-redirected) www.google.com
+      "https://analytics.google.com",
+      "https://api.honeybadger.io",
+      "https://api.mapbox.com",
+      "https://bikebook.herokuapp.com",
+      "https://cdn.jsdelivr.net",
+      "https://events.mapbox.com",
       # Our own image CDNs — third-party scripts (Facebook Pixel) fetch bike photos, not just <img> them
       "https://files.bikeindex.org",
-      "https://uploads.bikeindex.org",
-      "https://bikebook.herokuapp.com",
-      "https://www.google-analytics.com",
-      "https://*.google-analytics.com",
-      # GA4 region-redirects measurement hits to www.google.com/g/collect
-      "https://www.google.com",
-      "https://www.googletagmanager.com",
       "https://maps.googleapis.com",
       "https://translate.googleapis.com", # Google Translate API
+      "https://uploads.bikeindex.org",
       "https://www.facebook.com",
-      "https://api.mapbox.com",
-      "https://events.mapbox.com",
-      "https://*.tiles.mapbox.com",
-      "https://cdn.jsdelivr.net",
-      "https://api.honeybadger.io"
+      "https://www.google-analytics.com",
+      "https://www.google.com",
+      "https://www.googletagmanager.com"
     policy.worker_src :self, :blob
     policy.frame_src :self,
       "https://www.google.com",

--- a/spec/requests/ip_spoof_attack_filter_request_spec.rb
+++ b/spec/requests/ip_spoof_attack_filter_request_spec.rb
@@ -22,21 +22,23 @@ RSpec.describe IpSpoofAttackFilter, type: :request do
       {"HTTP_CLIENT_IP" => client_ip, "HTTP_X_FORWARDED_FOR" => forwarded_for}
     end
 
-    it "returns 403 on a normal route" do
+    it "returns 403 instead of 500, across routes and skipping non-HTML formats" do
+      # A normal route
       get "/", headers: spoofed_headers
-
       expect(response.status).to eq(403)
       expect(response.body).to eq("Forbidden")
-    end
 
-    it "returns 403 on the error page, not 500" do
       # errors#not_found renders the full HTML layout — the exact path that 500'd 1,208 times
       # when a scanner walked unrouted paths (*unmatched_route → errors#not_found) with spoofed
       # headers. /404 exercises the same controller and layout without the prod-only catch-all.
       get "/404", headers: spoofed_headers
-
       expect(response.status).to eq(403)
       expect(response.body).to eq("Forbidden")
+
+      # Non-HTML formats skip the layout that reads remote_ip, so they are never spoof-blocked
+      get "/404.json", headers: spoofed_headers
+      expect(response.status).to eq(404)
+      expect(response.media_type).to eq("application/json")
     end
 
     context "with a matching HTTP_FORWARDED header" do
@@ -51,25 +53,16 @@ RSpec.describe IpSpoofAttackFilter, type: :request do
         expect(response.body).to eq("Forbidden")
       end
     end
-
-    it "does not spoof-block non-HTML formats, which skip the layout that reads remote_ip" do
-      get "/404.json", headers: spoofed_headers
-
-      expect(response.status).to eq(404)
-      expect(response.media_type).to eq("application/json")
-    end
   end
 
   context "when only one of the IP headers is present" do
-    it "does not trip the filter for HTTP_CLIENT_IP alone" do
+    it "does not trip the filter — only the contradiction between the two headers is a spoof" do
+      # Client-IP alone
       get "/404", headers: {"HTTP_CLIENT_IP" => client_ip}
-
       expect(response.status).to eq(404)
-    end
 
-    it "does not trip the filter for HTTP_X_FORWARDED_FOR alone" do
+      # X-Forwarded-For alone
       get "/404", headers: {"HTTP_X_FORWARDED_FOR" => forwarded_for}
-
       expect(response.status).to eq(404)
     end
   end

--- a/spec/requests/ip_spoof_attack_filter_request_spec.rb
+++ b/spec/requests/ip_spoof_attack_filter_request_spec.rb
@@ -1,22 +1,45 @@
 require "rails_helper"
 
 RSpec.describe IpSpoofAttackFilter, type: :request do
-  context "when IP headers are spoofed" do
+  # Reproduce production's exception handling. Test defaults to show_exceptions = :rescuable,
+  # which re-raises the (non-rescuable) IpSpoofAttackError up to the filter and masked this bug
+  # for months. Production uses :all, where ShowExceptions renders the error into a 500 before
+  # the filter — sitting above it in the stack — could ever rescue it.
+  around do |example|
+    env = Rails.application.env_config
+    original = env["action_dispatch.show_exceptions"]
+    env["action_dispatch.show_exceptions"] = :all
+    example.run
+  ensure
+    env["action_dispatch.show_exceptions"] = original
+  end
+
+  let(:client_ip) { "251.252.74.114" }
+  let(:forwarded_for) { "211.112.215.202,109.123.246.221, 172.71.131.189" }
+
+  context "when the IP-header triple is contradictory" do
     let(:spoofed_headers) do
-      {
-        "HTTP_CLIENT_IP" => "251.252.74.114",
-        "HTTP_X_FORWARDED_FOR" => "211.112.215.202,109.123.246.221, 172.71.131.189"
-      }
+      {"HTTP_CLIENT_IP" => client_ip, "HTTP_X_FORWARDED_FOR" => forwarded_for}
     end
 
-    it "returns 403" do
+    it "returns 403 on a normal route" do
       get "/", headers: spoofed_headers
 
       expect(response.status).to eq(403)
       expect(response.body).to eq("Forbidden")
     end
 
-    context "with HTTP_FORWARDED header" do
+    it "returns 403 on the error page, not 500" do
+      # errors#not_found renders the full HTML layout — the exact path that 500'd 1,208 times
+      # when a scanner walked unrouted paths (*unmatched_route → errors#not_found) with spoofed
+      # headers. /404 exercises the same controller and layout without the prod-only catch-all.
+      get "/404", headers: spoofed_headers
+
+      expect(response.status).to eq(403)
+      expect(response.body).to eq("Forbidden")
+    end
+
+    context "with a matching HTTP_FORWARDED header" do
       let(:spoofed_headers) do
         super().merge("HTTP_FORWARDED" => "for=211.112.215.202, for=109.123.246.221, for=172.71.131.189")
       end
@@ -27,6 +50,27 @@ RSpec.describe IpSpoofAttackFilter, type: :request do
         expect(response.status).to eq(403)
         expect(response.body).to eq("Forbidden")
       end
+    end
+
+    it "does not spoof-block non-HTML formats, which skip the layout that reads remote_ip" do
+      get "/404.json", headers: spoofed_headers
+
+      expect(response.status).to eq(404)
+      expect(response.media_type).to eq("application/json")
+    end
+  end
+
+  context "when only one of the IP headers is present" do
+    it "does not trip the filter for HTTP_CLIENT_IP alone" do
+      get "/404", headers: {"HTTP_CLIENT_IP" => client_ip}
+
+      expect(response.status).to eq(404)
+    end
+
+    it "does not trip the filter for HTTP_X_FORWARDED_FOR alone" do
+      get "/404", headers: {"HTTP_X_FORWARDED_FOR" => forwarded_for}
+
+      expect(response.status).to eq(404)
     end
   end
 end


### PR DESCRIPTION
Two independent fixes, both surfaced by a blocked-request error in the 404-page browser console.

- **CSP:** GA4 routes some `/g/collect` measurement beacons to `analytics.google.com`, which `connect-src` didn't allow, so the browser blocked them on every page. Added it and alphabetized the `connect_src` list.
- **Spoofed-IP 500s:** `IpSpoofAttackFilter` sat *above* `ShowExceptions`/`DebugExceptions`, so in production (`show_exceptions = :all`) the raised `IpSpoofAttackError` was rendered into a 500 before the filter could rescue it — every route 500'd on contradictory IP headers (≈1,200×/scan, invisible to Honeybadger). Moved the filter below `DebugExceptions` so it rescues first.
- The request spec passed only because the test env uses `show_exceptions = :rescuable`, which re-raises the non-rescuable error up to the filter — masking the bug since March. It now runs under `:all` and covers the error-page path that actually fired.
