### PR TITLE
Defer b_param image resizing to fix bikes#create Rack::Timeout

### DIFF
--- a/app/models/b_param.rb
+++ b/app/models/b_param.rb
@@ -69,8 +69,8 @@ class BParam < ApplicationRecord
     stolen
     street
   ].freeze
-  mount_uploader :image, ImageUploader
-  process_in_background :image, CarrierWaveStoreJob
+  mount_uploader :image, ImageUploaderBackgrounded
+  process_in_background :image, CarrierWaveProcessJob # Defer version generation so large uploads don't hit the 30s Rack::Timeout
 
   belongs_to :created_bike, class_name: "Bike"
   belongs_to :creator, class_name: "User"

--- a/spec/models/b_param_spec.rb
+++ b/spec/models/b_param_spec.rb
@@ -262,6 +262,26 @@ RSpec.describe BParam, type: :model do
     end
   end
 
+  describe "image processing" do
+    let(:image_file) { File.open(Rails.root.join("spec", "fixtures", "bike.jpg")) }
+    let(:b_param) { FactoryBot.build(:b_param) }
+
+    # Regression: process_in_background with a non-Delay uploader resized inline in the
+    # request, hitting the 30s Rack::Timeout on bikes#create (Honeybadger 132565677)
+    it "defers version generation to the background job instead of resizing inline" do
+      ImageUploaderBackgrounded.enable_processing = true
+      b_param.image = image_file
+      expect { b_param.save! }.to change(CarrierWaveProcessJob.jobs, :size).by(1)
+      expect(b_param.process_image_upload).to be_nil
+      expect(b_param.image.file).to be_present # original stored synchronously
+      expect(b_param.image.large.file).to be_blank # resized versions deferred to the job
+    ensure
+      ImageUploaderBackgrounded.enable_processing = false
+      b_param.image&.remove!
+      image_file.close
+    end
+  end
+
   describe "additional_registration_fields" do
     let(:params_hash) { {bike: bike_params}.as_json }
     let(:b_param) { BParam.new(params: params_hash) }


### PR DESCRIPTION
Fixes the `Rack::Timeout::RequestTimeoutException` on `bikes#create` ([Honeybadger 132565677](https://app.honeybadger.io/projects/35931/faults/132565677)).

`b_param` mounted the plain `ImageUploader` (which lacks `Backgrounder::Delay`) alongside a `StoreAsset` worker that is a no-op for `process_in_background`, so on an embedded registration with a photo the image version resizing ran **inline in the request** and blew past the 30s timeout. Now it mounts `ImageUploaderBackgrounded` and uses `CarrierWaveProcessJob`, storing the original synchronously and deferring resizing to the background — the same pattern as the earlier `public_image` timeout fix (#3704).

Safe to defer unconditionally (unlike `public_image`) because b_param's own image versions are never rendered — the only consumer copies the original into a `PublicImage`, which builds its own versions and strips EXIF.
