### PR TITLE
Fix blind frontend Honeybadger (+esm pin); allow DoubleClick GA beacons in CSP

### DIFF
--- a/config/importmap.rb
+++ b/config/importmap.rb
@@ -25,7 +25,9 @@ pin_all_from "app/javascript/controllers", under: "controllers"
 pin_all_from "app/components", under: "components"
 pin_all_from "app/javascript/utils", under: "utils", to: "utils"
 
-pin "@honeybadger-io/js", to: "https://cdn.jsdelivr.net/npm/@honeybadger-io/js@6.12.3/dist/browser/honeybadger.min.js"
+# +esm build: the dist/browser UMD bundle's default export is undefined under import(),
+# which silently breaks Honeybadger.configure and leaves frontend errors unreported
+pin "@honeybadger-io/js", to: "https://cdn.jsdelivr.net/npm/@honeybadger-io/js@6.12.3/+esm"
 
 # Lexxy rich text editor (Action Text). Assets served by the lexxy/activestorage gems.
 pin "lexxy", to: "lexxy.js"

--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -45,6 +45,8 @@ Rails.application.configure do
       "https://*.tiles.mapbox.com",
       # GA4 also routes /g/collect beacons to analytics.google.com and (region-redirected) www.google.com
       "https://analytics.google.com",
+      # GA4 ad-personalization beacons to DoubleClick (/g/collect)
+      "https://stats.g.doubleclick.net",
       "https://api.honeybadger.io",
       "https://api.mapbox.com",
       "https://bikebook.herokuapp.com",


### PR DESCRIPTION
Two CSP/analytics fixes uncovered while investigating why the [frontend Honeybadger project](https://app.honeybadger.io/projects/61305) had gone quiet.

- **Frontend error reporting was blind.** The `@honeybadger-io/js` pin used the `dist/browser` UMD bundle, whose `default` export is `undefined` under `import()` — so `Honeybadger.configure()` threw and was silently swallowed by the `.catch(() => {})` in `application.js`. The script loaded but was never configured, so nothing got reported. Repinned to jsdelivr's `+esm` build, which exposes a real module (verified `configure`/`beforeNotify`/`notify` all work under the production CSP). Not a CSP block — `cdn.jsdelivr.net` was always allowed.
- **DoubleClick beacon noise.** Added `stats.g.doubleclick.net` to `connect-src` so GA4 `/g/collect` ad-personalization beacons stop generating hundreds of unique [CSP report faults](https://app.honeybadger.io/projects/138070).
