### PR TITLE
Include family PrimaryActivity rows in the CSV export

### DIFF
--- a/app/services/spreadsheets/primary_activities.rb
+++ b/app/services/spreadsheets/primary_activities.rb
@@ -9,7 +9,7 @@ module Spreadsheets
     EXPORT_COLUMNS = %i[flavor families].freeze
 
     def to_csv(primary_activities = nil)
-      primary_activities ||= PrimaryActivity.by_priority
+      primary_activities ||= PrimaryActivity.by_priority.includes(:primary_activity_family)
 
       CSV.generate do |csv|
         csv << EXPORT_COLUMNS
@@ -30,7 +30,13 @@ module Spreadsheets
     def names_and_families(primary_activities)
       flavors_families = {}
 
-      primary_activities.flavor.each do |primary_activity|
+      primary_activities.each do |primary_activity|
+        # A family exports as its own row, with the flavor and families columns matching
+        if primary_activity.family?
+          flavors_families[primary_activity.name] = primary_activity.name
+          next
+        end
+
         family_name = primary_activity.top_level? ? nil : primary_activity.family_name
         flavors_families[primary_activity.name] ||= family_name
         next if flavors_families[primary_activity.name] == family_name
@@ -43,10 +49,11 @@ module Spreadsheets
     end
 
     def update_or_create_for!(row)
-      family_ids = row[:families].presence&.split("&")&.map do |name|
-        upsert!(PrimaryActivity.family, name, family: true).id
-      end
+      family_names = row[:families].presence&.split("&")
+      family_ids = family_names&.map { upsert!(PrimaryActivity.family, it, family: true).id }
       return if row[:flavor].blank?
+      # A family exports as a row matching its own name — the family is enough, skip the flavor
+      return if family_names&.one? && Slugifyer.slugify(family_names.first) == Slugifyer.slugify(row[:flavor])
 
       (family_ids || [nil]).each do |primary_activity_family_id|
         # Top-level flavors self-reference their id, so nil never matches them

--- a/app/services/spreadsheets/primary_activities.rb
+++ b/app/services/spreadsheets/primary_activities.rb
@@ -29,11 +29,12 @@ module Spreadsheets
 
     def names_and_families(primary_activities)
       flavors_families = {}
+      # A family exports as a flavor-less row; import upserts the family and creates no flavor
+      family_rows = []
 
       primary_activities.each do |primary_activity|
-        # A family exports as its own row, with the flavor and families columns matching
         if primary_activity.family?
-          flavors_families[primary_activity.name] = primary_activity.name
+          family_rows << [nil, primary_activity.name]
           next
         end
 
@@ -45,15 +46,14 @@ module Spreadsheets
         flavors_families[primary_activity.name] += " & #{family_name}"
       end
 
-      flavors_families.to_a
+      family_rows + flavors_families.to_a
     end
 
     def update_or_create_for!(row)
-      family_names = row[:families].presence&.split("&")
-      family_ids = family_names&.map { upsert!(PrimaryActivity.family, it, family: true).id }
+      family_ids = row[:families].presence&.split("&")&.map do |name|
+        upsert!(PrimaryActivity.family, name, family: true).id
+      end
       return if row[:flavor].blank?
-      # A family exports as a row matching its own name — the family is enough, skip the flavor
-      return if family_names&.one? && Slugifyer.slugify(family_names.first) == Slugifyer.slugify(row[:flavor])
 
       (family_ids || [nil]).each do |primary_activity_family_id|
         # Top-level flavors self-reference their id, so nil never matches them

--- a/spec/services/spreadsheets/primary_activities_spec.rb
+++ b/spec/services/spreadsheets/primary_activities_spec.rb
@@ -16,7 +16,8 @@ RSpec.describe Spreadsheets::PrimaryActivities do
     context "with family" do
       let(:primary_activity_family) { FactoryBot.create(:primary_activity_family, name: "ATB (All Terrain Biking)", priority: 10) }
       let!(:primary_activity_2) { FactoryBot.create(:primary_activity, name: "All Road", primary_activity_family:, priority: 4) }
-      let(:target) { ["flavor,families", "All Road,ATB (All Terrain Biking)", "Bike Polo,"] }
+      # The family exports as its own row, with the flavor and families columns matching
+      let(:target) { ["flavor,families", "ATB (All Terrain Biking),ATB (All Terrain Biking)", "All Road,ATB (All Terrain Biking)", "Bike Polo,"] }
 
       it "generates" do
         result = described_class.to_csv.split("\n")
@@ -24,13 +25,20 @@ RSpec.describe Spreadsheets::PrimaryActivities do
         expect(result.first).to eq target.first
         expect(result.second).to eq target.second
         expect(result.third).to eq target.third
+        expect(result.fourth).to eq target.fourth
         expect(result.length).to eq target.length
       end
 
       context "with multiple families" do
         let(:primary_activity_family_2) { FactoryBot.create(:primary_activity_family, name: "Road Biking", priority: 9) }
         let!(:primary_activity_3) { FactoryBot.create(:primary_activity, name: "All Road", primary_activity_family: primary_activity_family_2, priority: 3) }
-        let(:target) { ["flavor,families", "All Road,ATB (All Terrain Biking) & Road Biking", "Bike Polo,"] }
+        let(:target) do
+          ["flavor,families",
+            "ATB (All Terrain Biking),ATB (All Terrain Biking)",
+            "Road Biking,Road Biking",
+            "All Road,ATB (All Terrain Biking) & Road Biking",
+            "Bike Polo,"]
+        end
 
         it "generates" do
           expect(primary_activity_family.reload.priority).to be > primary_activity_family_2.reload.priority
@@ -38,12 +46,26 @@ RSpec.describe Spreadsheets::PrimaryActivities do
 
           result = described_class.to_csv.split("\n")
 
-          expect(result.first).to eq target.first
-          expect(result.second).to eq target.second
-          expect(result.third).to eq target.third
-          expect(result.length).to eq target.length
+          expect(result).to eq target
         end
       end
+    end
+  end
+
+  describe "round-trips its own export" do
+    # A top-level "Bike Polo" flavor comes from the enclosing let!
+    let!(:family) { FactoryBot.create(:primary_activity_family, name: "Road Biking") }
+    let!(:flavor) { FactoryBot.create(:primary_activity, name: "Triathalon", primary_activity_family: family) }
+
+    it "re-imports the exported CSV without creating a flavor for a family self-row" do
+      Tempfile.create(["primary_activities", ".csv"], Rails.root.join("tmp")) do |file|
+        file.write(described_class.to_csv)
+        file.flush
+
+        expect { described_class.import(file.path) }.not_to change(PrimaryActivity, :count)
+      end
+
+      expect(PrimaryActivity.all.map(&:display_name)).to match_array ["Road Biking", "Road: Triathalon", "Bike Polo"]
     end
   end
 

--- a/spec/services/spreadsheets/primary_activities_spec.rb
+++ b/spec/services/spreadsheets/primary_activities_spec.rb
@@ -16,8 +16,8 @@ RSpec.describe Spreadsheets::PrimaryActivities do
     context "with family" do
       let(:primary_activity_family) { FactoryBot.create(:primary_activity_family, name: "ATB (All Terrain Biking)", priority: 10) }
       let!(:primary_activity_2) { FactoryBot.create(:primary_activity, name: "All Road", primary_activity_family:, priority: 4) }
-      # The family exports as its own row, with the flavor and families columns matching
-      let(:target) { ["flavor,families", "ATB (All Terrain Biking),ATB (All Terrain Biking)", "All Road,ATB (All Terrain Biking)", "Bike Polo,"] }
+      # The family exports as a flavor-less row (empty flavor column)
+      let(:target) { ["flavor,families", ",ATB (All Terrain Biking)", "All Road,ATB (All Terrain Biking)", "Bike Polo,"] }
 
       it "generates" do
         result = described_class.to_csv.split("\n")
@@ -34,8 +34,8 @@ RSpec.describe Spreadsheets::PrimaryActivities do
         let!(:primary_activity_3) { FactoryBot.create(:primary_activity, name: "All Road", primary_activity_family: primary_activity_family_2, priority: 3) }
         let(:target) do
           ["flavor,families",
-            "ATB (All Terrain Biking),ATB (All Terrain Biking)",
-            "Road Biking,Road Biking",
+            ",ATB (All Terrain Biking)",
+            ",Road Biking",
             "All Road,ATB (All Terrain Biking) & Road Biking",
             "Bike Polo,"]
         end
@@ -57,7 +57,7 @@ RSpec.describe Spreadsheets::PrimaryActivities do
     let!(:family) { FactoryBot.create(:primary_activity_family, name: "Road Biking") }
     let!(:flavor) { FactoryBot.create(:primary_activity, name: "Triathalon", primary_activity_family: family) }
 
-    it "re-imports the exported CSV without creating a flavor for a family self-row" do
+    it "re-imports the exported CSV without creating a flavor for a family row" do
       Tempfile.create(["primary_activities", ".csv"], Rails.root.join("tmp")) do |file|
         file.write(described_class.to_csv)
         file.flush


### PR DESCRIPTION
Family `PrimaryActivity` rows were missing from `Spreadsheets::PrimaryActivities#to_csv`, which only emitted flavors.

- Each family now exports as a flavor-less row (empty `flavor` column, `families` column set to its name). Flavors still group as before, combining a flavor that lives under multiple families into `ATB & Road Biking`.
- Import needs no change: it already upserts the family from the `families` column and returns on a blank `flavor`, so the export round-trips idempotently without creating a spurious flavor.
