### PR TITLE
Fix bikes#new Rack::Timeout on b_param token lookup

### DIFF
--- a/app/models/b_param.rb
+++ b/app/models/b_param.rb
@@ -25,6 +25,7 @@
 #  index_b_params_on_bike_owner_email_trgm  ((((params -> 'bike'::text) ->> 'owner_email'::text)) gin_trgm_ops) USING gin
 #  index_b_params_on_created_bike_id        (created_bike_id)
 #  index_b_params_on_email_trgm             (email) WHERE (created_bike_id IS NULL) USING gin
+#  index_b_params_on_id_token               (id_token)
 #  index_b_params_on_organization_id        (organization_id)
 #
 
@@ -156,6 +157,8 @@ class BParam < ApplicationRecord
 
     # Because organization embed bikes might not match the creator
     def with_organization_or_no_creator(toke)
+      return if toke.blank?
+
       without_bike.where("created_at >= ?", Time.current - 1.month).where(id_token: toke)
         .detect { |b| b.creator_id.blank? || b.creation_organization_id.present? || b.params["creation_organization_id"].present? }
     end

--- a/db/migrate/20260713120000_add_index_on_b_params_id_token.rb
+++ b/db/migrate/20260713120000_add_index_on_b_params_id_token.rb
@@ -1,0 +1,7 @@
+class AddIndexOnBParamsIdToken < ActiveRecord::Migration[8.0]
+  disable_ddl_transaction!
+
+  def change
+    add_index :b_params, :id_token, algorithm: :concurrently
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -6071,6 +6071,13 @@ CREATE INDEX index_b_params_on_email_trgm ON public.b_params USING gin (email pu
 
 
 --
+-- Name: index_b_params_on_id_token; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_b_params_on_id_token ON public.b_params USING btree (id_token);
+
+
+--
 -- Name: index_b_params_on_organization_id; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -7452,6 +7459,7 @@ ALTER TABLE ONLY public.bug_reports
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20260713120000'),
 ('20260706180000'),
 ('20260706164500'),
 ('20260706164435'),

--- a/spec/models/b_param_spec.rb
+++ b/spec/models/b_param_spec.rb
@@ -531,6 +531,23 @@ RSpec.describe BParam, type: :model do
         expect(result.id).to be_nil
         expect(result.creator_id).to eq user.id
       end
+      context "with no creator" do
+        it "does not return that BParam" do
+          b_param_nil.update_columns(id_token: nil, creator_id: nil)
+          result = BParam.find_or_new_from_token(nil, user_id: user.id)
+          expect(result.is_a?(BParam)).to be_truthy
+          expect(result.id).to be_nil
+          expect(result.creator_id).to eq user.id
+        end
+      end
+    end
+  end
+
+  describe "with_organization_or_no_creator" do
+    it "returns nil for a blank token" do
+      FactoryBot.create(:b_param) # a creator-less b_param that a blank token must not match
+      expect(BParam.with_organization_or_no_creator(nil)).to be_nil
+      expect(BParam.with_organization_or_no_creator("")).to be_nil
     end
   end
 


### PR DESCRIPTION
Fixes a `Rack::Timeout::RequestTimeoutException` on `GET /bikes/new` ([Honeybadger 132651411](https://app.honeybadger.io/projects/35931/faults/132651411)). `BParam.find_or_new_from_token` looked up b_params by `id_token` with no index on that column, so Postgres scanned every creator-less b_param — slow enough to blow the 30s timeout under load.

- Add an index on `b_params.id_token` (built concurrently).
- Skip the org/no-creator lookup when the token is blank, avoiding the scan entirely on the common no-token path (and closing a latent bug where a legacy `id_token: nil` b_param with no creator could be returned to any user).
