### PR TITLE
Add component previews & purple alert; route deep component i18n to sidecars

### DIFF
--- a/app/components/emails/partials/bike_box/component.en.yml
+++ b/app/components/emails/partials/bike_box/component.en.yml
@@ -1,0 +1,15 @@
+---
+en:
+  components:
+    emails:
+      partials:
+        bike_box:
+          bike_photo: Bike photo
+          color: Color
+          color_may_be_incorrect: Color may be incorrect because it was set during
+            POS import
+          found: 'Found:'
+          make: 'Make:'
+          serial: 'Serial:'
+          stolen_at: 'Stolen at:'
+          stolen_from: 'Stolen from:'

--- a/app/components/form/legacy_form_well/address_record/component.en.yml
+++ b/app/components/form/legacy_form_well/address_record/component.en.yml
@@ -1,0 +1,18 @@
+---
+en:
+  components:
+    form:
+      legacy_form_well:
+        address_record:
+          address: Street address
+          address_no_street: Address
+          address_or_intersection: Address or intersection
+          address_school: Campus mailing address
+          choose_country: Choose country
+          city: City
+          postal_code: Postal Code
+          region: Region / Province
+          state: State
+          street_2: Street address line 2 (optional)
+          where_was_it_status: Where was it %{bike_status}?
+          your_full_address_is_required: Your full address is required by %{org_name}

--- a/app/components/form/legacy_form_well/address_record_with_default/component.en.yml
+++ b/app/components/form/legacy_form_well/address_record_with_default/component.en.yml
@@ -1,0 +1,8 @@
+---
+en:
+  components:
+    form:
+      legacy_form_well:
+        address_record_with_default:
+          edit_my_account_path: edit on my account
+          use_account_address: Use account address

--- a/app/components/org/impound_records_index/component.en.yml
+++ b/app/components/org/impound_records_index/component.en.yml
@@ -9,6 +9,9 @@ en:
         hide_update: Hide update
         impound_records: Impound_records
         interpreted_params: Interpreted_params
+        matching_impound_record:
+          one: matching impound record
+          other: matching impound records
         only_unregistered: Only unregistered
         only_user_registered: Only user registered
         pagy: Pagy

--- a/app/components/page_block/strava_integration/component.en.yml
+++ b/app/components/page_block/strava_integration/component.en.yml
@@ -3,6 +3,9 @@ en:
   components:
     page_block:
       strava_integration:
+        activities_synced:
+          one: activity synced
+          other: activities synced
         connect_with_strava: Connect with Strava
         connected_to_strava: Connected to Strava
         disconnect_confirm: >-

--- a/app/components/ui/alert/component.html.erb
+++ b/app/components/ui/alert/component.html.erb
@@ -4,17 +4,21 @@
   data-controller="ui--alert"
 >
   <div class="tw:w-4">
-    <svg
-      class="tw:-mb-0.5 tw:h-4 tw:w-4 tw:shrink-0"
-      aria-hidden="true"
-      xmlns="http://www.w3.org/2000/svg"
-      fill="currentColor"
-      viewBox="0 0 20 20"
-    >
-      <path
-        d="M10 .5a9.5 9.5 0 1 0 9.5 9.5A9.51 9.51 0 0 0 10 .5ZM9.5 4a1.5 1.5 0 1 1 0 3 1.5 1.5 0 0 1 0-3ZM12 15H8a1 1 0 0 1 0-2h1v-3H8a1 1 0 0 1 0-2h2a1 1 0 0 1 1 1v4h1a1 1 0 0 1 0 2Z"
-      />
-    </svg>
+    <% if @icon.present? %>
+      <%= @icon %>
+    <% else %>
+      <svg
+        class="tw:-mb-0.5 tw:h-4 tw:w-4 tw:shrink-0"
+        aria-hidden="true"
+        xmlns="http://www.w3.org/2000/svg"
+        fill="currentColor"
+        viewBox="0 0 20 20"
+      >
+        <path
+          d="M10 .5a9.5 9.5 0 1 0 9.5 9.5A9.51 9.51 0 0 0 10 .5ZM9.5 4a1.5 1.5 0 1 1 0 3 1.5 1.5 0 0 1 0-3ZM12 15H8a1 1 0 0 1 0-2h1v-3H8a1 1 0 0 1 0-2h2a1 1 0 0 1 1 1v4h1a1 1 0 0 1 0 2Z"
+        />
+      </svg>
+    <% end %>
 
     <span class="tw:sr-only"><%= @kind.to_s.titleize %></span>
   </div>

--- a/app/components/ui/alert/component.rb
+++ b/app/components/ui/alert/component.rb
@@ -12,7 +12,9 @@ module UI
         purple: "tw:text-purple-800 tw:dark:text-purple-400"
       }.freeze
 
-      def initialize(text: nil, header: nil, kind: nil, dismissable: false, margin_classes: "tw:mb-4")
+      # icon: rendered markup, e.g. inline_svg_tag("icons/envelope.svg", class: "tw:h-4 tw:w-4") -
+      # replaces the default info icon
+      def initialize(text: nil, header: nil, kind: nil, dismissable: false, margin_classes: "tw:mb-4", icon: nil)
         @text = text
         @header = header
         @kind = if KINDS.include?(kind&.to_sym)
@@ -22,6 +24,7 @@ module UI
         end
         @dismissable = dismissable
         @margin_classes = margin_classes
+        @icon = icon
       end
 
       private

--- a/app/components/ui/alert/component.rb
+++ b/app/components/ui/alert/component.rb
@@ -3,12 +3,13 @@
 module UI
   module Alert
     class Component < ApplicationComponent
-      KINDS = %i[notice error warning success]
+      KINDS = %i[notice error warning success purple]
       TEXT_CLASSES = {
         notice: "tw:text-blue-800 tw:dark:text-blue-400",
         error: "tw:text-red-800 tw:dark:text-red-400",
         warning: "tw:text-yellow-800 tw:dark:text-yellow-400",
-        success: "tw:text-green-800 tw:dark:text-green-400"
+        success: "tw:text-green-800 tw:dark:text-green-400",
+        purple: "tw:text-purple-800 tw:dark:text-purple-400"
       }.freeze
 
       def initialize(text: nil, header: nil, kind: nil, dismissable: false, margin_classes: "tw:mb-4")
@@ -35,6 +36,8 @@ module UI
           "#{text_color_classes} tw:bg-yellow-50 tw:dark:bg-yellow-950 tw:border-yellow-300 tw:dark:border-yellow-800"
         when :success
           "#{text_color_classes} tw:bg-green-50 tw:dark:bg-green-950 tw:border-green-300 tw:dark:border-green-800"
+        when :purple
+          "#{text_color_classes} tw:bg-purple-50 tw:dark:bg-purple-950 tw:border-purple-300 tw:dark:border-purple-800"
         end
       end
 
@@ -57,6 +60,8 @@ module UI
           "tw:bg-yellow-50 tw:focus:ring-yellow-400 tw:hover:bg-yellow-200 tw:dark:bg-yellow-950 tw:dark:hover:bg-yellow-900"
         when :success
           "tw:bg-green-50 tw:focus:ring-green-400 tw:hover:bg-green-200 tw:dark:bg-green-950 tw:dark:hover:bg-green-900"
+        when :purple
+          "tw:bg-purple-50 tw:focus:ring-purple-400 tw:hover:bg-purple-200 tw:dark:bg-purple-950 tw:dark:hover:bg-purple-900"
         end
       end
     end

--- a/app/components/ui/alert/component_preview.rb
+++ b/app/components/ui/alert/component_preview.rb
@@ -19,6 +19,10 @@ module UI
       def success
         render(UI::Alert::Component.new(text: "This is a success alert", kind: :success))
       end
+
+      def purple
+        render(UI::Alert::Component.new(text: "We've sent a confirmation link to your email. No need to wait — you can finish registering right now.", kind: :purple))
+      end
       # @!endgroup
 
       # @!group Dismissable variants

--- a/app/components/ui/alert/component_preview.rb
+++ b/app/components/ui/alert/component_preview.rb
@@ -23,6 +23,12 @@ module UI
       def purple
         render(UI::Alert::Component.new(text: "We've sent a confirmation link to your email. No need to wait — you can finish registering right now.", kind: :purple))
       end
+
+      def custom_icon
+        envelope = ActionController::Base.helpers.inline_svg_tag("icons/envelope.svg",
+          class: "tw:-mb-0.5 tw:h-4 tw:w-4 tw:shrink-0", aria_hidden: true)
+        render(UI::Alert::Component.new(text: "Check your email", kind: :notice, icon: envelope))
+      end
       # @!endgroup
 
       # @!group Dismissable variants

--- a/app/components/ui/badge/component_preview.rb
+++ b/app/components/ui/badge/component_preview.rb
@@ -41,6 +41,23 @@ module UI
         render_with_template(template: "ui/badge/preview/empty_md_with_content")
       end
       # @!endgroup
+
+      # @!group Redesign options
+      # Saturated background + white text (SOLID_COLORS palette)
+      def solid
+        render(UI::Badge::Component.new(text: "Member", color: :purple, solid: true))
+      end
+
+      # Leading status dot inheriting the text color
+      def indicator
+        render(UI::Badge::Component.new(text: "Active", color: :success, indicator: true))
+      end
+
+      # Leading inline SVG (path under app/assets/images, sans .svg)
+      def icon
+        render(UI::Badge::Component.new(text: "Registered", color: :notice, icon: "link"))
+      end
+      # @!endgroup
     end
   end
 end

--- a/app/components/ui/badge/component_preview.rb
+++ b/app/components/ui/badge/component_preview.rb
@@ -40,9 +40,7 @@ module UI
       def empty_md_with_content
         render_with_template(template: "ui/badge/preview/empty_md_with_content")
       end
-      # @!endgroup
 
-      # @!group Redesign options
       # Saturated background + white text (SOLID_COLORS palette)
       def solid
         render(UI::Badge::Component.new(text: "Member", color: :purple, solid: true))

--- a/app/components/ui/button/component_preview.rb
+++ b/app/components/ui/button/component_preview.rb
@@ -44,6 +44,23 @@ module UI
       end
       # @!endgroup
 
+      # @!group Redesign variants
+      # Filled purple primary
+      def purple
+        render(UI::Button::Component.new(text: "Purple", color: :purple))
+      end
+
+      # White button with a soft danger outline
+      def danger_outline
+        render(UI::Button::Component.new(text: "Mark stolen", color: :danger_outline))
+      end
+
+      # White button with a neutral outline
+      def outline
+        render(UI::Button::Component.new(text: "Share", color: :outline))
+      end
+      # @!endgroup
+
       # @!group Sizes
       def small
         render(UI::Button::Component.new(text: "Small", size: :sm))

--- a/app/components/ui/button/component_preview.rb
+++ b/app/components/ui/button/component_preview.rb
@@ -42,9 +42,7 @@ module UI
       def link_active
         render(UI::Button::Component.new(text: "Link Active", color: :link, active: true))
       end
-      # @!endgroup
 
-      # @!group Redesign variants
       # Filled purple primary
       def purple
         render(UI::Button::Component.new(text: "Purple", color: :purple))

--- a/app/components/ui/definition_list/row/component.en.yml
+++ b/app/components/ui/definition_list/row/component.en.yml
@@ -1,0 +1,7 @@
+---
+en:
+  components:
+    ui:
+      definition_list:
+        row:
+          no_value: none

--- a/config/i18n-tasks.yml
+++ b/config/i18n-tasks.yml
@@ -23,10 +23,18 @@ data:
   # `i18n-tasks normalize -p` will force move the keys according to these rules
   write:
     - ["{doorkeeper}.*", 'config/locales/\1.%{locale}.yml']
-    # handle namespaced components manually.
-    # This is definitely hack :/
-    - ['components.{:}.{:}.:', 'app/components/\1/\2/component.%{locale}.yml']
-    - ['components.{:}.:', 'app/components/\1/component.%{locale}.yml']
+    # Deeply-namespaced components (namespace/sub-namespace/name) route to their
+    # own sidecar. These must precede the generic rules below, which can't tell a
+    # sub-namespace segment from a nested/plural key and would otherwise land
+    # these in the parent namespace's directory. Add a line here per sub-namespace.
+    - ['components.admin.badges.{:}.*', 'app/components/admin/badges/\1/component.%{locale}.yml']
+    - ['components.emails.partials.{:}.*', 'app/components/emails/partials/\1/component.%{locale}.yml']
+    - ['components.form.legacy_form_well.{:}.*', 'app/components/form/legacy_form_well/\1/component.%{locale}.yml']
+    - ['components.org.registration_sequence.{:}.*', 'app/components/org/registration_sequence/\1/component.%{locale}.yml']
+    - ['components.ui.definition_list.{:}.*', 'app/components/ui/definition_list/\1/component.%{locale}.yml']
+    # namespace/name components. `*` (not `:`) so nested/plural keys stay in the sidecar too.
+    - ['components.{:}.{:}.*', 'app/components/\1/\2/component.%{locale}.yml']
+    - ['components.{:}.*', 'app/components/\1/component.%{locale}.yml']
     ## Catch-all default:
     - config/locales/%{locale}.yml
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1604,51 +1604,6 @@ en:
       wide: Wide
       wide_help: "> 38mm (1.5in)"
       wide_title: Tires that are at least 39mm (1.5 inches) wide
-  components:
-    emails:
-      partials:
-        bike_box:
-          bike_photo: Bike photo
-          color: Color
-          color_may_be_incorrect: Color may be incorrect because it was set during
-            POS import
-          found: 'Found:'
-          make: 'Make:'
-          serial: 'Serial:'
-          stolen_at: 'Stolen at:'
-          stolen_from: 'Stolen from:'
-    form:
-      legacy_form_well:
-        address_record:
-          address: Street address
-          address_no_street: Address
-          address_or_intersection: Address or intersection
-          address_school: Campus mailing address
-          choose_country: Choose country
-          city: City
-          postal_code: Postal Code
-          region: Region / Province
-          state: State
-          street_2: Street address line 2 (optional)
-          where_was_it_status: Where was it %{bike_status}?
-          your_full_address_is_required: Your full address is required by %{org_name}
-        address_record_with_default:
-          edit_my_account_path: edit on my account
-          use_account_address: Use account address
-    org:
-      impound_records_index:
-        matching_impound_record:
-          one: matching impound record
-          other: matching impound records
-    page_block:
-      strava_integration:
-        activities_synced:
-          one: activity synced
-          other: activities synced
-    ui:
-      definition_list:
-        row:
-          no_value: none
   controllers:
     application:
       handle_unverified_request:

--- a/spec/components/ui/alert/component_spec.rb
+++ b/spec/components/ui/alert/component_spec.rb
@@ -23,6 +23,17 @@ RSpec.describe UI::Alert::Component, type: :component do
     end
   end
 
+  describe "purple" do
+    let(:options) { {text: "some text", kind: "purple"} }
+    it "renders" do
+      expect(component).to have_content "some text"
+      expect(component).to have_css('[role="alert"].tw:text-purple-800')
+      expect(component.to_html).to include("tw:bg-purple-50")
+      # It doesn't have dismissable button
+      expect(component).to_not have_selector("button")
+    end
+  end
+
   context "success dismissable" do
     let(:options) { {text: "some text", kind: "success", dismissable: true} }
     it "renders with dismissable" do

--- a/spec/components/ui/alert/component_spec.rb
+++ b/spec/components/ui/alert/component_spec.rb
@@ -34,6 +34,16 @@ RSpec.describe UI::Alert::Component, type: :component do
     end
   end
 
+  describe "custom icon" do
+    let(:options) { {text: "some text", icon: '<svg class="custom-icon"></svg>'.html_safe} }
+    it "renders the given markup instead of the default icon" do
+      html = component.to_html
+      expect(html).to include('<svg class="custom-icon">')
+      # The default info icon is not rendered
+      expect(html).to_not include("M10 .5a9.5")
+    end
+  end
+
   context "success dismissable" do
     let(:options) { {text: "some text", kind: "success", dismissable: true} }
     it "renders with dismissable" do

--- a/spec/services/file_cache_maintainer_spec.rb
+++ b/spec/services/file_cache_maintainer_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 RSpec.describe FileCacheMaintainer do
   describe "cached_all_stolen" do
     it "returns the most recent all_stolen" do
-      FileCacheMaintainer.update_file_info("1456863086_all_stolen_cache.json", 1456863086)
+      FileCacheMaintainer.reset_file_info("1456863086_all_stolen_cache.json", 1456863086)
       t = Time.current.to_i
       FileCacheMaintainer.update_file_info("#{t}_all_stolen_cache.json", t)
       target = {


### PR DESCRIPTION
Small, independent frontend/i18n cleanups following #3832's component restyle, plus an unrelated flaky-spec fix surfaced by CI.

- **Component previews** — add Lookbook previews for #3832's new versions: `UI::Badge`'s `solid`/`indicator`/`icon` options and `UI::Button`'s `purple`/`danger_outline`/`outline` variants (listed alongside each component's existing colors).
- **`UI::Alert`** — add a soft-purple `kind` and an `icon:` option (rendered markup replacing the default info icon, pulled ahead from `sethherr/new-registration-flow`), each with a preview and spec.
- **Sidecar translation routing** — i18n-tasks write rules only captured two namespace segments, so component keys 4+ segments deep (`form/legacy_form_well/*`, `ui/definition_list/row`, and 2-level components with nested/plural keys) fell back to `config/locales/en.yml`. Add explicit sub-namespace rules and switch the generic rules to `*`, moving the parked keys into their `component.en.yml` sidecars.
- **Flaky spec** — `FileCacheMaintainer#cached_all_stolen` resets its redis state first (like its sibling examples) instead of appending, so a leftover full-path cache key can't collide on a same-second timestamp.
