### PR TITLE
Merge Form::Combobox + full-page screenshot skill updates

### DIFF
--- a/.claude/skills/frontend-conventions/SKILL.md
+++ b/.claude/skills/frontend-conventions/SKILL.md
@@ -4,7 +4,8 @@ description: >-
   Bike Index's frontend conventions — Tailwind class prefixing (`tw:`),
   the standard `twinput`/`twlabel`/`twlink` form/link classes, the
   `number_display` helper for numbers, the UI component library rule
-  (every button is `UI::Button`/`UI::ButtonLink`, never hand-rolled
+  (every button is `UI::Button`/`UI::ButtonLink`, every
+  typeahead/autocomplete is `Form::Combobox`, never hand-rolled
   markup), ViewComponent rules (keyword arguments, instance variables,
   `helpers.` prefix in templates), and `UI::Time::Component` for every
   date/time. Trigger
@@ -47,7 +48,11 @@ The `bin/dev` command handles building and updating Tailwind and JS.
 - A link styled as a button: `UI::ButtonLink::Component.new(href:, text:, color:, size:)` — same palette, renders an `<a>`.
 - A standalone action button (POST/DELETE/etc. to a URL) — a link that performs an action: pass `method:` to `ButtonLink` and it renders `button_to` for you (`render UI::ButtonLink::Component.new(text: "Delete", color: :error, href: bike_path(@bike), method: :delete)`), so don't hand-roll a `button_to` or wrap a submit button in a bare form. Extra `html_options` flow through: pass `params:` for a POST that carries params (they render as hidden fields — no manual `form_with`/`hidden_field_tag` needed), and `form: {onsubmit: …}` for a confirm on the wrapping form.
 
-The same instinct applies beyond buttons: **check `app/components/ui/` before hand-rolling any UI primitive** (dropdowns → `UI::Dropdown`, tooltips → `UI::Tooltip`, badges, modals, pagination, tables…). If a `UI::*` component exists for the pattern, use it; if it almost fits, extend it rather than forking its markup inline.
+The same instinct applies beyond buttons: **check `app/components/ui/` and `app/components/form/` before hand-rolling any UI primitive** (dropdowns → `UI::Dropdown`, tooltips → `UI::Tooltip`, badges, modals, pagination, tables…). If a `UI::*`/`Form::*` component exists for the pattern, use it; if it almost fits, extend it rather than forking its markup inline.
+
+## Typeaheads: always `Form::Combobox`
+
+**Every typeahead / autocomplete / combobox goes through `Form::Combobox::Component`** — never a new Stimulus controller that fetches matches and renders its own menu. See `app/components/form/combobox/` (component + `component_preview.rb`) and `spec/components/form/combobox` for how to invoke it.
 
 ## Showing and hiding elements: always use the collapse helpers
 

--- a/.claude/skills/frontend-screenshots/SKILL.md
+++ b/.claude/skills/frontend-screenshots/SKILL.md
@@ -58,10 +58,21 @@ If it's set but not one of the seeded emails, **stop and ask** — you're signed
 Clear stale shots: `rm -f tmp/pr_screenshots/<branch>-<page>-*.png 2>/dev/null || true`.
 
 Two viewports — resize once each, then walk every URL:
-1. `browser_resize` 1440×900 → for each URL: navigate → settle → `browser_take_screenshot` (`fullPage: false`) to `...-desktop.png`.
+1. `browser_resize` 1440×900 → for each URL: navigate → settle → hide the footer → `browser_take_screenshot` (`fullPage: true`) to `...-desktop.png`.
 2. `browser_resize` 390×844 → same loop → `...-mobile.png`.
 
-**`fullPage: false` and no `target:` arg.** Reviewers need the page as a browser of that size actually renders it. `fullPage: true` produces a 2000–3000px scroll capture (not how mobile renders); element-only crops slice context off.
+**Full page, minus the footer, no `target:` arg.** Capture the whole page (`fullPage: true`) so nothing below the fold is cut off, but hide the site footer first — it's identical on every page and just pads every capture. After each navigation (hiding doesn't persist across page loads), run:
+
+```js
+browser_evaluate: () => {
+  document.querySelector('.primary-footer, footer, [role="contentinfo"]')?.style.setProperty('display', 'none');
+  return document.body.scrollHeight; // content height with the footer gone
+}
+```
+
+If the returned content height is **less than the viewport height**, `browser_resize` the height down to it before the shot (the `<html>` element's near-black background fills the gap otherwise), then resize back to the standard viewport before the next URL. Taller-than-viewport pages need no resize — `fullPage` scroll-stitches them.
+
+Element-only crops (`target:`) still slice context off — don't use them for page captures.
 
 **Settle before the screenshot.** Stimulus + Chartkick render after document load; either `browser_wait_for` on a known element or pause ~500ms–1s. Otherwise charts capture mid-draw.
 


### PR DESCRIPTION
Brings over the two `.claude/skills/` updates the `sethherr/new-registration-flow` branch intentionally made, without regressing skills that branch left stale.

- **frontend-conventions**: adds the "always `Form::Combobox`" typeahead rule, pointing to the component, preview, and specs rather than inlining API details.
- **frontend-screenshots**: switches PR captures to full-page with the site footer hidden.
