### PR TITLE
Eager-build CarrierWave versions to fix avatar NoMethodError

### DIFF
--- a/config/initializers/carrierwave.rb
+++ b/config/initializers/carrierwave.rb
@@ -59,3 +59,7 @@ end
 CarrierWave::Backgrounder.configure do |c|
   c.backend :sidekiq, queue: :med_priority, retry: 2
 end
+
+# Build version subclasses up front so their lazy, thread-unsafe construction
+# can't race under Puma. See CarrierWaveVersionWarmer.
+Rails.application.config.after_initialize { CarrierWaveVersionWarmer.warm! }

--- a/lib/carrier_wave_version_warmer.rb
+++ b/lib/carrier_wave_version_warmer.rb
@@ -1,0 +1,18 @@
+# Eager-build every CarrierWave version subclass at boot.
+#
+# CarrierWave builds a version's uploader subclass lazily on first access
+# (CarrierWave::Uploader::Versions::Builder#build), and that build isn't
+# thread-safe: under Puma a second thread can grab the half-built class before
+# `version_options` is assigned, raising "undefined method '[]' for nil" in
+# `version_active?`. Building them once, single-threaded, removes the race.
+module CarrierWaveVersionWarmer
+  # Subclasses of CarrierWave::Uploader::Base are instances of its singleton
+  # class, so this enumerates the base uploader and everything derived from it.
+  def self.warm!
+    ObjectSpace.each_object(CarrierWave::Uploader::Base.singleton_class) { |klass| build(klass) }
+  end
+
+  def self.build(uploader_class)
+    uploader_class.versions.each_value { |builder| build(builder.build(uploader_class)) }
+  end
+end

--- a/spec/lib/carrier_wave_version_warmer_spec.rb
+++ b/spec/lib/carrier_wave_version_warmer_spec.rb
@@ -1,0 +1,20 @@
+require "rails_helper"
+
+RSpec.describe CarrierWaveVersionWarmer do
+  describe ".warm!" do
+    it "builds every version subclass with its version_options assigned" do
+      described_class.warm!
+
+      version_classes = ObjectSpace
+        .each_object(CarrierWave::Uploader::Base.singleton_class)
+        .select { |klass| klass.version_names.any? }
+
+      expect(version_classes).to include(AvatarUploader.const_get(:VersionUploaderMedium))
+      version_classes.each do |klass|
+        # The race the warmer prevents leaves version_options nil, which blows up
+        # in CarrierWave's version_active?.
+        expect(klass.version_options).not_to be_nil
+      end
+    end
+  end
+end


### PR DESCRIPTION
Fixes Honeybadger fault 132710180 (`NoMethodError: undefined method '[]' for nil`) on the user profile page. Rendering `@user.avatar` makes CarrierWave build its version uploader subclasses (thumb/medium/large/biggest) lazily on first access, and that build is not thread-safe — under Puma a second thread can read the half-built class before `version_options` is assigned, so `versions[name].class.version_options[:if]` raises in `version_active?`.

- Add `CarrierWaveVersionWarmer.warm!`, which builds every version subclass once at boot (`after_initialize`, single-threaded) so the race can't happen at request time.
- Cover the warmer with a spec asserting each version subclass ends up with `version_options` populated.
