### PR TITLE
Fix organized registrations crash for claimed_ownerships orgs without bike_search

### DIFF
--- a/app/controllers/organized/registrations_controller.rb
+++ b/app/controllers/organized/registrations_controller.rb
@@ -256,13 +256,13 @@ module Organized
 
     def claimed_ownerships_search
       bikes = organization_bikes
-      if %w[transferred initial].include?(params[:search_claimedness])
-        @search_claimedness = params[:search_claimedness]
-        bikes = if @search_claimedness == "initial"
-          bikes.joins(:ownerships).where(ownerships: {current: true, previous_ownership_id: nil})
-        else
-          bikes.joins(:ownerships).where.not(ownerships: {previous_ownership_id: nil})
-        end
+      @search_claimedness = %w[transferred initial].include?(params[:search_claimedness]) ? params[:search_claimedness] : "all"
+      bikes = if @search_claimedness == "initial"
+        bikes.joins(:ownerships).where(ownerships: {current: true, previous_ownership_id: nil})
+      elsif @search_claimedness == "transferred"
+        bikes.joins(:ownerships).where.not(ownerships: {previous_ownership_id: nil})
+      else
+        bikes
       end
       bikes.where(created_at: @time_range)
     end

--- a/spec/requests/organized/registrations_request_spec.rb
+++ b/spec/requests/organized/registrations_request_spec.rb
@@ -239,6 +239,24 @@ RSpec.describe Organized::RegistrationsController, type: :request do
         expect(assigns(:bikes).pluck(:id)).to eq([])
       end
     end
+    context "claimed_ownerships without bike_search" do
+      let(:enabled_feature_slugs) { %w[claimed_ownerships] }
+
+      it "renders the claimedness dropdown, defaulting to all" do
+        get base_url
+        expect(response.status).to eq(200)
+        expect(response).to render_template :index
+        expect(assigns(:search_claimedness)).to eq "all"
+        expect(assigns(:bikes).pluck(:id)).to match_array([bike.id])
+      end
+
+      it "filters by search_claimedness" do
+        get base_url, params: {search_claimedness: "initial"}
+        expect(response.status).to eq(200)
+        expect(assigns(:search_claimedness)).to eq "initial"
+        expect(assigns(:bikes).pluck(:id)).to match_array([bike.id])
+      end
+    end
     context "unsupported format" do
       it "returns 406 for json" do
         get "#{base_url}.json", params: {period: "custom", start_time: "2025-04-01", end_time: "2026-04-30", per_page: "1"}


### PR DESCRIPTION
Fixes a `NoMethodError: undefined method 'titleize' for nil` (Honeybadger #129887433) on the organized registrations index for organizations with `claimed_ownerships` enabled but `bike_search` disabled.

- `@search_claimedness` was only assigned on the `bike_search` path and when the `search_claimedness` param was `"transferred"`/`"initial"`, so a plain index load left it `nil` and crashed the bikes list partial's `@search_claimedness.titleize`.
- Default `@search_claimedness` to `"all"` in `claimed_ownerships_search`, matching the dropdown's expected values.
- Adds a regression request spec covering the default render and the `initial` filter for that org configuration.
