### PR TITLE
Add frame_maker: option to Form::ComboboxManufacturer

### DIFF
--- a/app/components/form/combobox_manufacturer/component.rb
+++ b/app/components/form/combobox_manufacturer/component.rb
@@ -4,14 +4,15 @@ module Form
   module ComboboxManufacturer
     # Form::Combobox preconfigured for picking a Manufacturer.
     #
-    # Defaults `name` to :manufacturer_id and the options to frame makers; pass a
-    # different `manufacturers` relation to widen the list. Every other keyword
-    # (form:, label:, value:, required:, include_blank:, placeholder:, etc.) is
-    # forwarded to Form::Combobox::Component.
+    # Defaults `name` to :manufacturer_id and the options to every manufacturer;
+    # pass `frame_maker: true` to limit the list to frame makers, or a `manufacturers`
+    # relation to set it explicitly. Every other keyword (form:, label:, value:,
+    # required:, include_blank:, placeholder:, etc.) is forwarded to
+    # Form::Combobox::Component.
     class Component < ApplicationComponent
-      def initialize(name: :manufacturer_id, manufacturers: Manufacturer.frame_makers, **combobox_options)
+      def initialize(name: :manufacturer_id, frame_maker: false, manufacturers: nil, **combobox_options)
         @name = name
-        @manufacturers = manufacturers
+        @manufacturers = manufacturers || (frame_maker ? Manufacturer.frame_makers : Manufacturer.all)
         @combobox_options = combobox_options
       end
 

--- a/app/components/form/combobox_manufacturer/component_preview.rb
+++ b/app/components/form/combobox_manufacturer/component_preview.rb
@@ -5,9 +5,14 @@ module Form
     class ComponentPreview < ApplicationComponentPreview
       # @!group Variants
 
-      # Frame makers, keyed to :manufacturer_id
+      # Every manufacturer, keyed to :manufacturer_id
       def default
         render(Form::ComboboxManufacturer::Component.new)
+      end
+
+      # Limited to frame makers
+      def frame_makers
+        render(Form::ComboboxManufacturer::Component.new(frame_maker: true))
       end
 
       # Pre-selected value, custom label

--- a/app/views/admin/bikes/edit.html.haml
+++ b/app/views/admin/bikes/edit.html.haml
@@ -36,7 +36,7 @@
           Manufacturer
           %em.small
             = link_to "mfg bikes", admin_bikes_path(search_manufacturer: @bike.mnfg_name), class: "less-strong"
-        = render Form::ComboboxManufacturer::Component.new(form: f, label: manufacturer_label, required: true)
+        = render Form::ComboboxManufacturer::Component.new(frame_maker: true, form: f, label: manufacturer_label, required: true)
     .col-6.col-md-4.col-lg-3
       .form-group
         = f.label :manufacturer_other do

--- a/app/views/admin/bikes/missing_manufacturer.html.haml
+++ b/app/views/admin/bikes/missing_manufacturer.html.haml
@@ -46,7 +46,7 @@
 = form_tag update_manufacturers_admin_bikes_path, data: {controller: "table-multi-checkbox"} do
   .row
     .col-md-4
-      = render Form::ComboboxManufacturer::Component.new(placeholder: "Choose manufacturer", include_blank: true)
+      = render Form::ComboboxManufacturer::Component.new(frame_maker: true, placeholder: "Choose manufacturer", include_blank: true)
     .col-md-2
       = submit_tag 'Update selected', class: 'btn btn-primary'
 

--- a/app/views/admin/organizations/_form.html.haml
+++ b/app/views/admin/organizations/_form.html.haml
@@ -141,7 +141,7 @@
 
     - if @organization.official_manufacturer?
       .form-group
-        = render Form::ComboboxManufacturer::Component.new(form: f, label: Organization.human_attribute_name(:manufacturer), required: true)
+        = render Form::ComboboxManufacturer::Component.new(frame_maker: true, form: f, label: Organization.human_attribute_name(:manufacturer), required: true)
         %small
           %strong This organization has <code>Official manufacturer organization</code> enabled.
           Select a manufacturer to give them manufacturer access.

--- a/spec/components/form/combobox_manufacturer/component_spec.rb
+++ b/spec/components/form/combobox_manufacturer/component_spec.rb
@@ -9,19 +9,28 @@ RSpec.describe Form::ComboboxManufacturer::Component, type: :component do
   let!(:frame_maker) { FactoryBot.create(:manufacturer, name: "Surly", frame_maker: true) }
   let!(:component_maker) { FactoryBot.create(:manufacturer, name: "Shimano", frame_maker: false) }
 
-  it "renders a manufacturer_id combobox of frame makers" do
+  it "renders a manufacturer_id combobox of every manufacturer" do
     expect(component).to have_css("input[type='hidden'][name='manufacturer_id']", visible: :all)
     expect(component).to have_css("label", text: "Manufacturer")
     expect(component).to have_css("[role='option'][data-value='#{frame_maker.id}']", text: "Surly", visible: :all)
-    expect(component).not_to have_css("[role='option']", text: "Shimano", visible: :all)
+    expect(component).to have_css("[role='option'][data-value='#{component_maker.id}']", text: "Shimano", visible: :all)
+  end
+
+  context "with frame_maker: true" do
+    let(:options) { {frame_maker: true} }
+
+    it "renders only frame makers" do
+      expect(component).to have_css("[role='option'][data-value='#{frame_maker.id}']", text: "Surly", visible: :all)
+      expect(component).not_to have_css("[role='option']", text: "Shimano", visible: :all)
+    end
   end
 
   context "with a custom manufacturers relation" do
-    let(:options) { {manufacturers: Manufacturer.all} }
+    let(:options) { {manufacturers: Manufacturer.frame_makers} }
 
-    it "renders every manufacturer" do
+    it "renders the given manufacturers" do
       expect(component).to have_css("[role='option']", text: "Surly", visible: :all)
-      expect(component).to have_css("[role='option']", text: "Shimano", visible: :all)
+      expect(component).not_to have_css("[role='option']", text: "Shimano", visible: :all)
     end
   end
 


### PR DESCRIPTION
Adds a `frame_maker:` argument to `Form::ComboboxManufacturer` so the combobox can offer every manufacturer, not just frame makers.

- The default now sources options from all manufacturers; pass `frame_maker: true` to limit the list to frame makers (or a `manufacturers:` relation to set it explicitly).
- The three existing call sites — admin bike edit, missing-manufacturer, and the org form — opt into `frame_maker: true` to preserve their frame-maker-only behavior.
