### PR TITLE
Default UI::Tooltip to the "?" button trigger

### DIFF
--- a/app/components/ui/tooltip/component.rb
+++ b/app/components/ui/tooltip/component.rb
@@ -9,10 +9,10 @@ module UI
       TRIGGER_CLASS = "tw:inline-block tw:rounded tw:cursor-help " \
         "tw:focus:outline-none tw:focus:ring-3 tw:focus:ring-blue-500/40"
 
-      BUTTON_CLASS = "tw:inline-flex tw:items-center tw:justify-center tw:h-5 tw:w-5 tw:rounded-full " \
+      BUTTON_CLASS = "tw:inline-flex tw:items-center tw:justify-center tw:h-4 tw:w-4 tw:rounded-full " \
         "tw:bg-gray-200 tw:text-gray-700 tw:hover:bg-gray-300 " \
         "tw:dark:bg-gray-700 tw:dark:text-gray-200 tw:dark:hover:bg-gray-600 " \
-        "tw:text-xs tw:font-bold tw:cursor-help " \
+        "tw:text-2xs tw:font-bold tw:cursor-help " \
         "tw:focus:outline-none tw:focus:ring-3 tw:focus:ring-blue-500/40"
 
       renders_one :body

--- a/app/components/ui/tooltip/component.rb
+++ b/app/components/ui/tooltip/component.rb
@@ -9,9 +9,15 @@ module UI
       TRIGGER_CLASS = "tw:inline-block tw:rounded tw:cursor-help " \
         "tw:focus:outline-none tw:focus:ring-3 tw:focus:ring-blue-500/40"
 
+      BUTTON_CLASS = "tw:inline-flex tw:items-center tw:justify-center tw:h-5 tw:w-5 tw:rounded-full " \
+        "tw:bg-gray-200 tw:text-gray-700 tw:hover:bg-gray-300 " \
+        "tw:dark:bg-gray-700 tw:dark:text-gray-200 tw:dark:hover:bg-gray-600 " \
+        "tw:text-xs tw:font-bold tw:cursor-help " \
+        "tw:focus:outline-none tw:focus:ring-3 tw:focus:ring-blue-500/40"
+
       renders_one :body
       renders_one :tooltip_button, ->(**attrs, &block) {
-        tag.button(**trigger_attrs(**attrs)) { block ? capture(&block) : "" }
+        tag.button(**trigger_attrs(class: BUTTON_CLASS, **attrs)) { block ? capture(&block) : "?" }
       }
 
       def initialize(text: nil)
@@ -29,8 +35,11 @@ module UI
 
       private
 
+      # With no trigger content, fall back to the "?" button — the default way
+      # tooltips are rendered.
       def trigger
         return tooltip_button if tooltip_button?
+        return tag.button(**trigger_attrs(class: BUTTON_CLASS)) { "?" } if content.blank?
 
         tag.button(**trigger_attrs(class: TRIGGER_CLASS)) { content }
       end

--- a/app/components/ui/tooltip/component_preview.rb
+++ b/app/components/ui/tooltip/component_preview.rb
@@ -21,16 +21,9 @@ module UI
         end
       end
 
-      def with_tooltip_button_slot
-        render(UI::Tooltip::Component.new(text: "Visible to other riders viewing your bike")) do |tooltip|
-          tooltip.with_tooltip_button(
-            class: "tw:inline-flex tw:items-center tw:justify-center tw:h-5 tw:w-5 tw:rounded-full " \
-              "tw:bg-gray-200 tw:text-gray-700 tw:hover:bg-gray-300 " \
-              "tw:dark:bg-gray-700 tw:dark:text-gray-200 tw:dark:hover:bg-gray-600 " \
-              "tw:text-xs tw:font-bold tw:cursor-help " \
-              "tw:focus:outline-none tw:focus:ring-3 tw:focus:ring-blue-500/40"
-          ) { "?" }
-        end
+      # No trigger block: renders the default "?" button
+      def default_button
+        render(UI::Tooltip::Component.new(text: "Visible to other riders viewing your bike"))
       end
 
       # A link in the popup: click the "?" to keep it open, then click the link
@@ -39,13 +32,6 @@ module UI
           tooltip.with_body do
             'current commit: <a href="https://github.com/bikeindex/bike_index/commit/a1b2c3d" class="twlink">a1b2c3d</a>'.html_safe
           end
-          tooltip.with_tooltip_button(
-            class: "tw:inline-flex tw:items-center tw:justify-center tw:h-5 tw:w-5 tw:rounded-full " \
-              "tw:bg-gray-200 tw:text-gray-700 tw:hover:bg-gray-300 " \
-              "tw:dark:bg-gray-700 tw:dark:text-gray-200 tw:dark:hover:bg-gray-600 " \
-              "tw:text-xs tw:font-bold tw:cursor-help " \
-              "tw:focus:outline-none tw:focus:ring-3 tw:focus:ring-blue-500/40"
-          ) { "?" }
         end
       end
       # @!endgroup

--- a/app/views/organized/registrations/multi_search.html.erb
+++ b/app/views/organized/registrations/multi_search.html.erb
@@ -72,13 +72,7 @@
             data-org--multi-search-target="searchAllHint"
             class="tw:hidden tw:leading-none"
           >
-            <%= render(UI::Tooltip::Component.new(text: "Sticker search always searches all bikes")) do |tooltip| %>
-              <% tooltip.with_tooltip_button(
-                class: "tw:inline-flex tw:items-center tw:justify-center tw:h-4 tw:w-4 tw:rounded-full " \
-                  "tw:bg-gray-300 tw:text-gray-700 tw:hover:bg-gray-400 tw:dark:bg-gray-600 tw:dark:text-gray-100 " \
-                  "tw:text-2xs tw:font-bold tw:cursor-help tw:focus:outline-none tw:focus:ring-3 tw:focus:ring-blue-500/40"
-              ) { "?" } %>
-            <% end %>
+            <%= render(UI::Tooltip::Component.new(text: "Sticker search always searches all bikes")) %>
           </span>
         </div>
 

--- a/spec/components/ui/tooltip/component_spec.rb
+++ b/spec/components/ui/tooltip/component_spec.rb
@@ -22,6 +22,16 @@ RSpec.describe UI::Tooltip::Component, type: :component do
     expect(component.css("[aria-describedby]").first.name).to eq "button"
   end
 
+  context "with no trigger block" do
+    let(:component) { render_inline(described_class.new(text: "tip")) }
+
+    it "renders the default '?' button trigger" do
+      trigger = component.css("[aria-describedby]").first
+      expect(trigger.name).to eq "button"
+      expect(trigger.text.strip).to eq "?"
+    end
+  end
+
   context "with a body slot" do
     let(:component) do
       render_inline(described_class.new) do |tooltip|


### PR DESCRIPTION
`UI::Tooltip::Component` now renders the "?" info button by default, so a bare `render(UI::Tooltip::Component.new(text:))` produces a styled trigger with no block or slot required.

- Extracted the button styling into a `BUTTON_CLASS` constant and made it the default for both the `tooltip_button` slot and the no-block trigger.
- Callers/previews that hand-rolled the "?" button class no longer need to.
