### PR TITLE
Fix "mapboxgl is not defined" Turbo race on stolen bike maps

### DIFF
--- a/app/javascript/controllers/stolen_map_controller.js
+++ b/app/javascript/controllers/stolen_map_controller.js
@@ -1,0 +1,83 @@
+import { Controller } from '@hotwired/stimulus'
+
+// Renders the Mapbox map showing a stolen/impounded bike's location.
+// Connects to data-controller='stolen-map'
+//
+// Mapbox GL is loaded dynamically from the CDN here rather than via a plain
+// <script src> in the view: under Turbo, a re-inserted external script loads
+// async and no longer blocks the following inline script, so init ran before
+// mapboxgl was defined (ReferenceError: mapboxgl is not defined).
+const MAPBOX_VERSION = 'v1.11.0'
+const MAPBOX_JS = `https://api.mapbox.com/mapbox-gl-js/${MAPBOX_VERSION}/mapbox-gl.js`
+const MAPBOX_CSS = `https://api.mapbox.com/mapbox-gl-js/${MAPBOX_VERSION}/mapbox-gl.css`
+
+export default class extends Controller {
+  static targets = ['canvas']
+  static values = { token: String, lng: Number, lat: Number, radiusBase: Number }
+
+  connect () {
+    loadMapbox().then(() => this.renderMap())
+  }
+
+  disconnect () {
+    this.map?.remove()
+  }
+
+  renderMap () {
+    const { mapboxgl } = window
+    mapboxgl.accessToken = this.tokenValue
+    const lngLat = [this.lngValue, this.latValue]
+
+    const map = new mapboxgl.Map({
+      container: this.canvasTarget,
+      style: 'mapbox://styles/mapbox/streets-v11',
+      center: lngLat,
+      zoom: 13,
+      maxZoom: 16
+    })
+    this.map = map
+
+    map.on('load', () => {
+      map.addSource('stolenBikeCircle', {
+        type: 'geojson',
+        data: {
+          type: 'FeatureCollection',
+          features: [{ type: 'Feature', geometry: { type: 'Point', coordinates: lngLat } }]
+        }
+      })
+
+      map.addLayer({
+        id: 'stolenBikeLocation',
+        type: 'circle',
+        source: 'stolenBikeCircle',
+        paint: {
+          'circle-radius': { stops: [[5, 5], [16, 240]], base: this.radiusBaseValue },
+          'circle-color': 'red',
+          'circle-opacity': 0.4
+        }
+      })
+    })
+  }
+}
+
+// Load the Mapbox GL script + stylesheet once, sharing the promise across maps.
+let mapboxLoading
+
+function loadMapbox () {
+  if (window.mapboxgl) return Promise.resolve()
+
+  mapboxLoading ||= new Promise((resolve, reject) => {
+    const link = document.createElement('link')
+    link.rel = 'stylesheet'
+    link.href = MAPBOX_CSS
+    document.head.appendChild(link)
+
+    const script = document.createElement('script')
+    script.src = MAPBOX_JS
+    script.onload = resolve
+    script.onerror = reject
+    document.head.appendChild(script)
+  })
+
+  return mapboxLoading
+}

--- a/app/views/bikes/_stolen_map.html.erb
+++ b/app/views/bikes/_stolen_map.html.erb
@@ -1,56 +1,10 @@
-<div class="map-holder col-md-8">
-  <div id="map_canvas"></div>
-</div>
-
-<script src="https://api.mapbox.com/mapbox-gl-js/v1.11.0/mapbox-gl.js"></script>
-
-<link
-  href="https://api.mapbox.com/mapbox-gl-js/v1.11.0/mapbox-gl.css"
-  rel="stylesheet"
+<div
+  class="map-holder col-md-8"
+  data-controller="stolen-map"
+  data-stolen-map-token-value="<%= ENV["MAPBOX_MAPPING"] %>"
+  data-stolen-map-lng-value="<%= mapping_record.longitude_public %>"
+  data-stolen-map-lat-value="<%= mapping_record.latitude_public %>"
+  data-stolen-map-radius-base-value="<%= mapping_record.show_address ? 2 : 1.15 %>"
 >
-
-<script>
-  mapboxgl.accessToken = <%== ENV['MAPBOX_MAPPING'].to_json %>;
-  var stolenBikeLngLat = [<%== mapping_record.longitude_public.to_json %>, <%== mapping_record.latitude_public.to_json %>];
-
-  var map = new mapboxgl.Map({
-    container: "map_canvas",
-    style: "mapbox://styles/mapbox/streets-v11",
-    center: stolenBikeLngLat,
-    zoom: 13,
-    maxZoom: 16,
-  });
-
-  map.on("load", function() {
-    map.addSource("stolenBikeCircle", {
-      "type": "geojson",
-      "data": {
-        "type": "FeatureCollection",
-        "features": [{
-          "type": "Feature",
-          "geometry": {
-            "type": "Point",
-            "coordinates": stolenBikeLngLat
-          }
-        }]
-      }
-    });
-
-    map.addLayer({
-      "id": "stolenBikeLocation",
-      "type": "circle",
-      "source": "stolenBikeCircle",
-      "paint": {
-        "circle-radius": {
-          stops: [
-            [5, 5],
-            [16, 240]
-          ],
-          base: <%== (mapping_record.show_address ? 2 : 1.15).to_json %>
-        },
-        "circle-color": "red",
-        "circle-opacity": 0.4
-      }
-    });
-  });
-</script>
+  <div id="map_canvas" data-stolen-map-target="canvas"></div>
+</div>

--- a/spec/requests/bikes/show_request_spec.rb
+++ b/spec/requests/bikes/show_request_spec.rb
@@ -185,6 +185,17 @@ RSpec.describe "BikesController#show", type: :request do
       expect(stolen_record.recovery_link_token).to be_present
     end
   end
+  context "stolen bike with a location" do
+    let(:ownership) { FactoryBot.create(:ownership, bike: FactoryBot.create(:stolen_bike)) }
+    it "renders the map through the stolen-map controller, without an inline mapboxgl script" do
+      get "#{base_url}/#{bike.id}"
+      expect(response).to render_template(:show)
+      expect(response.body).to include('data-controller="stolen-map"')
+      expect(response.body).to include('data-stolen-map-target="canvas"')
+      # The inline script referencing mapboxgl was the source of the Turbo race - it must be gone
+      expect(response.body).to_not include("mapboxgl")
+    end
+  end
   context "user hidden bike" do
     before { bike.update(marked_user_hidden: "true") }
     context "owner of bike viewing" do


### PR DESCRIPTION
Fixes the `ReferenceError: mapboxgl is not defined` on stolen/impounded bike pages ([Honeybadger 132669797](https://app.honeybadger.io/projects/61305/faults/132669797)). Under a Turbo body swap the re-inserted `<script src>` for mapbox-gl loaded asynchronously, so the inline init ran before the library was defined.

- Move the map init into a `stolen-map` Stimulus controller that dynamically loads mapbox-gl (JS + CSS, once) and only renders once it resolves — coords/token now flow in via data-value attributes.
- Add a request spec asserting the map renders through the controller with no inline `mapboxgl` reference.
