### PR TITLE
Handle null-origin CSRF failures on signup

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -13,6 +13,8 @@ class ApplicationController < ActionController::Base
   around_action :set_locale
   rescue_from Money::Bank::UnknownRate, with: :localization_failure
   rescue_from Pagy::RangeError, with: :redirect_to_last_page
+  # A "null" Origin raises from Rails' origin check rather than calling handle_unverified_request
+  rescue_from ActionController::InvalidAuthenticityToken, with: :handle_unverified_request
 
   def allow_x_frame
     SecureHeaders.opt_out_of_header(request, :x_frame_options)

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -28,7 +28,7 @@ class UsersController < ApplicationController
     return super unless action_name == "create"
 
     @user = User.new(email: params.dig(:user, :email))
-    flash.now[:error] = translation(:csrf_invalid, scope: [:controllers, :application, :handle_unverified_request])
+    flash.now[:error] = translation(:invalid_authenticity_token, scope: [:controllers, :application, :handle_unverified_request])
     render_partner_or_default_signin_layout(render_action: :new)
   end
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -23,6 +23,15 @@ class UsersController < ApplicationController
     end
   end
 
+  # Rather than dumping a would-be signup at user_root_url, hand back the form they submitted
+  def handle_unverified_request
+    return super unless action_name == "create"
+
+    @user = User.new(email: params.dig(:user, :email))
+    flash.now[:error] = translation(:csrf_invalid, scope: [:controllers, :application, :handle_unverified_request])
+    render_partner_or_default_signin_layout(render_action: :new)
+  end
+
   def please_confirm_email
     redirect_to(user_root_url) && return if current_user.present?
 

--- a/config/locales/.translation_io
+++ b/config/locales/.translation_io
@@ -5,4 +5,4 @@
 # ignore the conflicts and "sync" again, it will fix this file for you.
 
 ---
-timestamp: 1784306008
+timestamp: 1784307041

--- a/config/locales/.translation_io
+++ b/config/locales/.translation_io
@@ -5,4 +5,4 @@
 # ignore the conflicts and "sync" again, it will fix this file for you.
 
 ---
-timestamp: 1783615571
+timestamp: 1784306008

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1607,12 +1607,11 @@ en:
   controllers:
     application:
       handle_unverified_request:
-        csrf_invalid: >-
-          We couldn't verify your submission. Your session may have expired, so please
-          try again. If it keeps happening, a VPN, a privacy extension, or a strict
-          browser privacy setting is probably stripping the information we need —
-          try turning those off for bikeindex.org, or use a different browser. Contact
-          us if you're still stuck.
+        invalid_authenticity_token: >-
+          Form submission failed, please try again. If this keeps happening, a VPN
+          or a privacy extension is probably stripping information we need — try turning
+          those off for bikeindex.org. Email contact@bikeindex.org if you're still
+          stuck.
     bike_stickers:
       find_bike_sticker:
         must_be_signed_in: You must be signed in to do that.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1608,8 +1608,10 @@ en:
     application:
       handle_unverified_request:
         csrf_invalid: >-
-          CSRF invalid. If you don't know why you're receiving this message, please
-          contact us.
+          We couldn't verify your submission. Your session may have expired, so please try
+          again. If it keeps happening, a VPN, a privacy extension, or a strict browser
+          privacy setting is probably stripping the information we need — try turning those
+          off for bikeindex.org, or use a different browser. Contact us if you're still stuck.
     bike_stickers:
       find_bike_sticker:
         must_be_signed_in: You must be signed in to do that.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1608,10 +1608,11 @@ en:
     application:
       handle_unverified_request:
         csrf_invalid: >-
-          We couldn't verify your submission. Your session may have expired, so please try
-          again. If it keeps happening, a VPN, a privacy extension, or a strict browser
-          privacy setting is probably stripping the information we need — try turning those
-          off for bikeindex.org, or use a different browser. Contact us if you're still stuck.
+          We couldn't verify your submission. Your session may have expired, so please
+          try again. If it keeps happening, a VPN, a privacy extension, or a strict
+          browser privacy setting is probably stripping the information we need —
+          try turning those off for bikeindex.org, or use a different browser. Contact
+          us if you're still stuck.
     bike_stickers:
       find_bike_sticker:
         must_be_signed_in: You must be signed in to do that.

--- a/config/locales/translation.es.yml
+++ b/config/locales/translation.es.yml
@@ -4995,20 +4995,21 @@ es:
       you_should_be_signed_in_automatically: Deberías iniciar sesión automáticamente.
       your_email_address: Su dirección de correo electrónico
     new:
-      dont_have_an_account: "¿No tienes una cuenta?"
       email: correo electrónico
       forgot_your_password: "¿Olvidaste tu contraseña?"
       get_on_bike_index: Índice de bicicletas
       keep_me_logged_in: Mantenme conectado
       log_in: Acceso
-      no_bike_index_account: "¿No tienes cuenta en Bike Index?"
-      or: O
       password: contraseña
-      sign_in_using_facebook: Inicia sesión con Facebook
-      sign_in_using_globalid: Inicia sesión con globaliD
-      sign_in_using_magic_link: Enlace de inicio de sesión enviado por correo electrónico
-      sign_in_using_strava: Inicia sesión con Strava
-      sign_up: inscribirse
+      continue: Continuar
+      email_me_the_link: Envíame el enlace por correo electrónico.
+      log_in_or_sign_up: Inicia sesión o regístrate
+      org_uses_passwordless: Su organización inicia sesión sin contraseña.
+      passwordless_help: Te enviaremos por correo electrónico un enlace seguro para
+        que inicies sesión.
+      sign_in_without_password: Iniciar sesión sin contraseña
+    identify:
+      different_email: Inicia sesión con un correo electrónico diferente.
   shared:
     bike_search_form:
       anywhere: En cualquier lugar

--- a/config/locales/translation.es.yml
+++ b/config/locales/translation.es.yml
@@ -2124,10 +2124,6 @@ es:
       sync_not_finished: La sincronización con Strava aún no ha finalizado, por lo
         que es posible que no aparezcan todas las bicicletas en la lista.
   controllers:
-    application:
-      handle_unverified_request:
-        csrf_invalid: CSRF no válido. Si desconoce el motivo de este mensaje, póngase
-          en contacto con nosotros.
     bike_stickers:
       find_bike_sticker:
         must_be_signed_in: Para hacerlo, debes iniciar sesión.
@@ -2520,6 +2516,12 @@ es:
           we_dont_know_location: Lo sentimos, no conocemos la ubicación "%{location}".
             Por favor, intente buscar en otra ubicación para encontrar alojamientos
             cercanos.
+    application:
+      handle_unverified_request:
+        invalid_authenticity_token: El envío del formulario falló. Inténtelo de nuevo.
+          Si el problema persiste, es probable que una VPN o una extensión de privacidad
+          esté ocultando información necesaria. Intente desactivarlas para bikeindex.org.
+          Si el problema continúa, envíe un correo electrónico a contact@bikeindex.org.
   customer_mailer:
     additional_email_confirmation:
       html:

--- a/config/locales/translation.it.yml
+++ b/config/locales/translation.it.yml
@@ -5015,20 +5015,20 @@ it:
       you_should_be_signed_in_automatically: Dovresti essere connesso automaticamente.
       your_email_address: Il tuo indirizzo di posta elettronica
     new:
-      dont_have_an_account: Non hai un account?
       email: e-mail
       forgot_your_password: Hai dimenticato la password?
       get_on_bike_index: Indice di accesso alla bicicletta
       keep_me_logged_in: Resta collegato
       log_in: Login
-      no_bike_index_account: Non hai un account Bike Index?
-      or: O
       password: password
-      sign_in_using_facebook: Accedi tramite Facebook
-      sign_in_using_globalid: Accedi utilizzando globaliD
-      sign_in_using_magic_link: Link di accesso ricevuto via email
-      sign_in_using_strava: Accedi utilizzando Strava
-      sign_up: iscrizione
+      continue: Continuare
+      email_me_the_link: Inviami il link via email
+      log_in_or_sign_up: Accedi o registrati
+      org_uses_passwordless: La tua organizzazione effettua l'accesso senza password.
+      passwordless_help: Ti invieremo via email un link sicuro per accedere.
+      sign_in_without_password: Accedi senza password
+    identify:
+      different_email: Accedi con un indirizzo email diverso
   shared:
     bike_search_form:
       anywhere: Ovunque

--- a/config/locales/translation.it.yml
+++ b/config/locales/translation.it.yml
@@ -2125,10 +2125,6 @@ it:
       sync_not_finished: La sincronizzazione con Strava non è ancora completa, quindi
         non tutte le biciclette potrebbero essere presenti nell'elenco.
   controllers:
-    application:
-      handle_unverified_request:
-        csrf_invalid: CSRF non valido. Se non sai perché ricevi questo messaggio,
-          contattaci.
     bike_stickers:
       find_bike_sticker:
         must_be_signed_in: Per farlo devi aver effettuato l'accesso.
@@ -2517,6 +2513,12 @@ it:
         set_interpreted_params:
           we_dont_know_location: Siamo spiacenti, non conosciamo la località "%{location}".
             Prova a cercare in una località diversa nelle vicinanze.
+    application:
+      handle_unverified_request:
+        invalid_authenticity_token: 'L''invio del modulo non è riuscito, riprova.
+          Se il problema persiste, è probabile che una VPN o un''estensione per la
+          privacy stia bloccando le informazioni necessarie: prova a disattivarle
+          per bikeindex.org. Se il problema persiste, invia un''e-mail a contact@bikeindex.org.'
   customer_mailer:
     additional_email_confirmation:
       html:

--- a/config/locales/translation.nb.yml
+++ b/config/locales/translation.nb.yml
@@ -4779,20 +4779,20 @@ nb:
       you_should_be_signed_in_automatically: Du bør logges på automatisk.
       your_email_address: Din epostadresse
     new:
-      dont_have_an_account: har du ikke en konto?
       email: e-post
       forgot_your_password: Glemt passordet?
       get_on_bike_index: Få på Bike Index
       keep_me_logged_in: Hold meg pålogget
       log_in: Logg Inn
-      no_bike_index_account: Ingen Bike Index-konto?
-      or: Eller
       password: passord
-      sign_in_using_facebook: Logg på med Facebook
-      sign_in_using_globalid: Logg på med globaliD
-      sign_in_using_magic_link: E-post påloggingslenke
-      sign_in_using_strava: Logg på med Strava
-      sign_up: melde deg på
+      continue: Fortsette
+      email_me_the_link: Send meg lenken på e-post
+      log_in_or_sign_up: Logg inn eller registrer deg
+      org_uses_passwordless: Organisasjonen din logger på uten passord.
+      passwordless_help: Vi sender deg en sikker lenke på e-post for å logge på.
+      sign_in_without_password: Logg inn uten passord
+    identify:
+      different_email: Logg inn med en annen e-postadresse
   shared:
     bike_search_form:
       anywhere: Hvor som helst

--- a/config/locales/translation.nb.yml
+++ b/config/locales/translation.nb.yml
@@ -2080,10 +2080,6 @@ nb:
       sync_not_finished: Strava-synkroniseringen er ikke fullført ennå, så det er
         ikke sikkert at alle syklene er oppført.
   controllers:
-    application:
-      handle_unverified_request:
-        csrf_invalid: CSRF ugyldig. Hvis du ikke vet hvorfor du mottar denne meldingen,
-          vennligst kontakt oss.
     bike_stickers:
       find_bike_sticker:
         must_be_signed_in: Du må være pålogget for å gjøre det.
@@ -2455,6 +2451,12 @@ nb:
         set_interpreted_params:
           we_dont_know_location: Beklager, vi vet ikke hvor «%{location}» ligger.
             Prøv et annet sted for å søke etter oppføringer i nærheten.
+    application:
+      handle_unverified_request:
+        invalid_authenticity_token: Innsending av skjema mislyktes. Prøv på nytt.
+          Hvis dette fortsetter, er det sannsynlig at et VPN eller en personvernutvidelse
+          fjerner informasjonen vi trenger. Prøv å slå av disse for bikeindex.org.
+          Send en e-post til contact@bikeindex.org hvis du fortsatt står fast.
   customer_mailer:
     additional_email_confirmation:
       html:

--- a/config/locales/translation.nl.yml
+++ b/config/locales/translation.nl.yml
@@ -1899,10 +1899,6 @@ nl:
         unable_to_find_graduated_notification: Kan die afgestudeerde melding niet
           vinden!
         unable_to_find_parking_notification: Kan die parkeermelding niet vinden!
-    application:
-      handle_unverified_request:
-        csrf_invalid: CSRF ongeldig. Neem contact met ons op als u niet weet waarom
-          u dit bericht ontvangt.
     feedbacks:
       block_the_spam:
         please_sign_in: Meld je aan om dat bericht te verzenden
@@ -2222,6 +2218,13 @@ nl:
         set_interpreted_params:
           we_dont_know_location: Sorry, we kennen de locatie "%{location}" niet. Probeer
             een andere locatie om te zoeken naar nabijgelegen locaties.
+    application:
+      handle_unverified_request:
+        invalid_authenticity_token: Het verzenden van het formulier is mislukt, probeer
+          het opnieuw. Als dit blijft gebeuren, wordt waarschijnlijk informatie die
+          we nodig hebben geblokkeerd door een VPN of een privacy-extensie. Probeer
+          deze uit te schakelen voor bikeindex.org. Stuur een e-mail naar contact@bikeindex.org
+          als het probleem zich blijft voordoen.
   customer_mailer:
     additional_email_confirmation:
       html:

--- a/config/locales/translation.nl.yml
+++ b/config/locales/translation.nl.yml
@@ -4200,20 +4200,20 @@ nl:
       sign_in: Log in
       you_should_be_signed_in_automatically: Je zou automatisch ingelogd moeten zijn.
     new:
-      dont_have_an_account: Heb je nog geen account?
       email: E-mail
       forgot_your_password: Wachtwoord vergeten?
       get_on_bike_index: Ga op Bike Index
       keep_me_logged_in: Ik wil ingelogd blijven
       log_in: Log in
-      no_bike_index_account: geen Bike Index-account?
-      or: of
       password: Wachtwoord
-      sign_in_using_facebook: Log in met Facebook
-      sign_in_using_magic_link: E-mail aanmelden link
-      sign_in_using_strava: Log in met Strava
-      sign_up: Registreren
-      sign_in_using_globalid: Log in met globaliD
+      continue: Doorgaan
+      email_me_the_link: Stuur me de link via e-mail.
+      log_in_or_sign_up: Log in of registreer je
+      org_uses_passwordless: Uw organisatie meldt zich aan zonder wachtwoord.
+      passwordless_help: We sturen je een beveiligde link per e-mail om in te loggen.
+      sign_in_without_password: Aanmelden zonder wachtwoord
+    identify:
+      different_email: Aanmelden met een ander e-mailadres
   shared:
     email_bike_box:
       color: Kleur

--- a/spec/requests/users_request_spec.rb
+++ b/spec/requests/users_request_spec.rb
@@ -3,6 +3,28 @@ require "rails_helper"
 RSpec.describe UsersController, type: :request do
   base_url = "/users"
 
+  describe "create with a null origin" do
+    let(:email) { "ruther99@msu.edu" }
+
+    around do |example|
+      ActionController::Base.allow_forgery_protection = true
+      example.run
+      ActionController::Base.allow_forgery_protection = false
+    end
+
+    # Privacy extensions and VPNs strip the Origin header, which Rails rejects outright
+    it "re-renders the signup form with the email and an explanation" do
+      expect {
+        post base_url, params: {user: {email:, password: "somethinggreat", terms_of_service: "1"}},
+          headers: {"HTTP_ORIGIN" => "null"}
+      }.to_not change(User, :count)
+      expect(response).to render_template(:new)
+      expect(response.body).to match(email)
+      expect(flash[:error]).to match(/couldn't verify/i)
+      expect(response.body).to include("privacy extension")
+    end
+  end
+
   describe "update" do
     include_context :request_spec_logged_in_as_user
 

--- a/spec/requests/users_request_spec.rb
+++ b/spec/requests/users_request_spec.rb
@@ -4,13 +4,8 @@ RSpec.describe UsersController, type: :request do
   base_url = "/users"
 
   describe "create with a null origin" do
+    include_context :test_csrf_token
     let(:email) { "ruther99@msu.edu" }
-
-    around do |example|
-      ActionController::Base.allow_forgery_protection = true
-      example.run
-      ActionController::Base.allow_forgery_protection = false
-    end
 
     # Privacy extensions and VPNs strip the Origin header, which Rails rejects outright
     it "re-renders the signup form with the email and an explanation" do

--- a/spec/requests/users_request_spec.rb
+++ b/spec/requests/users_request_spec.rb
@@ -15,8 +15,8 @@ RSpec.describe UsersController, type: :request do
       }.to_not change(User, :count)
       expect(response).to render_template(:new)
       expect(response.body).to match(email)
-      expect(flash[:error]).to match(/couldn't verify/i)
-      expect(response.body).to include("privacy extension")
+      expect(flash[:error]).to match(/try again.*a VPN/i)
+      expect(response.body).to match(/try again.*a VPN/i)
     end
   end
 


### PR DESCRIPTION
A `"null"` Origin header (stripped by VPNs, privacy extensions, and strict browser privacy settings) makes Rails raise `InvalidAuthenticityToken` directly from its origin check, bypassing `handle_unverified_request` — so a would-be signup got dumped at `user_root_url` with an opaque "CSRF invalid" flash.

- Rescue `InvalidAuthenticityToken` in `ApplicationController` and route it back through `handle_unverified_request`, restoring consistent handling for the null-Origin path.
- On `users#create`, re-render the signup form with the submitted email and a plain-language explanation (session may have expired; a VPN/privacy extension/browser setting may be stripping the Origin) instead of redirecting away.
- Rewrote the `csrf_invalid` copy to be actionable for the non-technical case.
