### PR TITLE
Add OAuth app to Dev seeds for local iOS dev

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -24,6 +24,7 @@ require File.expand_path("db/seeds/seed_organization_bikes_and_associations", Ra
 require File.expand_path("db/seeds/seed_organized_emails", Rails.root)
 require File.expand_path("db/seeds/seed_registration_sequence_template", Rails.root)
 require File.expand_path("db/seeds/seed_counts", Rails.root)
+require File.expand_path("db/seeds/seed_oauth_app", Rails.root)
 
 # Load the search autocomplete (Redis) from the seeded manufacturers/colors/etc.
 # so it matches the database. Without this, a freshly seeded app (e.g. a review

--- a/db/seeds/seed_oauth_app.rb
+++ b/db/seeds/seed_oauth_app.rb
@@ -1,0 +1,17 @@
+# Seed a local dev iOS OAuth application.
+
+user = User.find_by_email("user@bikeindex.org")
+raise "No user found" unless user.present?
+
+app = Doorkeeper::Application.create!(
+  owner: user,
+  name: "Localhost Dev iOS",
+  uid: "9cBuxnqbhums1vun26ZfMv-91rInzdc6_G9HCulFxKs",
+  secret: "Tcw_4Cr1-Yowsjs-E2Te0YZnVdYmeES3UJ0AhbeBE10",
+  redirect_uri: "bikeindex://",
+  scopes: [:read_user, :write_user, :read_bikes, :write_bikes],
+  is_internal: true
+)
+
+puts "  Created OAuth application ##{app.id}: #{app.name} (uid=#{app.uid[0..12]}...)" if Rails.env.development?
+puts "Done seeding OAuth application!"


### PR DESCRIPTION
# Description

- Adding no-click OAuth seeds in the dev environment simplifies first-time set up and an easier entry to iOS dev + contributions
- These seeds are limited to Dev environment and thus safe to publicly share and hard-code in https://github.com/bikeindex/bike_index_ios/