### PR TITLE
Fix "load! is not supported" in Facebook ad insights

### DIFF
--- a/spec/services/facebook_ads_integration_spec.rb
+++ b/spec/services/facebook_ads_integration_spec.rb
@@ -202,6 +202,21 @@ if !ENV["CI"] && facebook_imported && Facebook::AdsIntegration::TOKEN.present?
             end
           end
         end
+        context "insights missing unique_clicks" do
+          let(:amount_cents_facebook) { 3800 }
+          let(:facebook_data) { {ad_id: "6720937606414", adset_id: "6720937162214", campaign_id: "6720937063014", activating_at: Time.current.to_i, effective_object_story_id: "500198263370025_1118473403646138"} }
+          # Regression: reading a requested-but-unreturned field via the SDK reader raised
+          # "load! is not supported for this object"
+          it "sets engagement with a nil unique_clicks" do
+            VCR.use_cassette("facebook/ads_integration-update_facebook_data-no_unique_clicks", match_requests_on: [:method]) do
+              expect { instance.update_facebook_data(theft_alert) }.not_to raise_error
+              theft_alert.reload
+              expect(theft_alert.reach).to eq 16_092
+              expect(theft_alert.engagement["unique_clicks"]).to be_nil
+              expect(theft_alert.engagement["link_click"]).to eq "17"
+            end
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
Fixes Honeybadger [#132764599](https://app.honeybadger.io/projects/35931/faults/132764599) — `StolenBike::UpdateTheftAlertFacebookJob` raised `RuntimeError: load! is not supported for this object` whenever an ad's insights came back with `actions` but no `unique_clicks`.

- The FacebookAds SDK marks an object "loaded" only when every requested field (`reach,spend,unique_clicks,actions`) is returned, so a missing `unique_clicks` made each field reader fire `load!` — which `AdsInsights` objects refuse. `get_insights` now reads from the `as_json` snapshot, so a missing field is `nil` instead of a raise
- Adds a regression spec for the actions-present / unique_clicks-absent case.
