### PR TITLE
Rename the staging deployment to sandbox

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -8,8 +8,8 @@
 /.bundle
 
 # Ignore local environment overrides only. The committed .env ships dev/sandbox
-# values that review apps load via dotenv in staging (see config/environments/
-# staging.rb + Gemfile); it must stay in the image build context.
+# values that review apps load via dotenv in sandbox (see config/environments/
+# sandbox.rb + Gemfile); it must stay in the image build context.
 /.env*.local
 
 # Ignore all default key files.

--- a/.env
+++ b/.env
@@ -23,7 +23,7 @@ GOOGLE_MAPS=AIzaSyDH8ejgPgtdVFMB6USR8PifSL1F_AEY8Wg
 GOOGLE_MAPS_STATIC=AIzaSyDH8ejgPgtdVFMB6USR8PifSL1F_AEY8Wg
 GOOGLE_GEOCODER=AIzaSyDH8ejgPgtdVFMB6USR8PifSL1F_AEY8Wg
 MAPBOX_GEOCODER=test
-# public mapbox token, only enabled for production and staging.review.bikeindex.org
+# public mapbox token, only enabled for production and sandbox.review.bikeindex.org
 MAPBOX_MAPPING=pk.eyJ1IjoiYmlrZWluZGV4IiwiYSI6ImNrYzNqb2dibTAwMzQycnA1czc4MWptOHcifQ.VBfcvZyLsK8Uc_-EGD3f3A
 MAILCHIMP_KEY=test
 NOTIFICATIONS_API_KEY=SomeSpecialThing

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,17 +36,17 @@ jobs:
             echo "No open PR with the 'review-app' label for branch '$GITHUB_REF_NAME' -> NOT dispatching review-app deploy"
           fi
 
-      # Staging tracks main: redeploy the persistent staging app on every push to
+      # Sandbox tracks main: redeploy the persistent sandbox app on every push to
       # main. Dispatched here (rather than via a workflow_run trigger in
-      # staging.yml) so both deploys fire from CI's single push run.
-      # NOTE: this runs in parallel with the `test` job, so staging does not wait
+      # sandbox.yml) so both deploys fire from CI's single push run.
+      # NOTE: this runs in parallel with the `test` job, so sandbox does not wait
       # for the test suite to pass.
-      - name: Dispatch staging deploy (main only)
+      - name: Dispatch sandbox deploy (main only)
         if: github.ref == 'refs/heads/main'
         run: |
           retry() { local n=1; until "$@"; do [ $n -ge 3 ] && return 1; echo "attempt $n failed; retrying in 15s..." >&2; n=$((n+1)); sleep 15; done; }
-          echo "Push to main -> dispatching staging deploy"
-          retry gh workflow run staging.yml --repo "$GITHUB_REPOSITORY" --ref main
+          echo "Push to main -> dispatching sandbox deploy"
+          retry gh workflow run sandbox.yml --repo "$GITHUB_REPOSITORY" --ref main
 
   lint_and_scan:
     runs-on: ubuntu-latest

--- a/.github/workflows/kamal-deploy.yml
+++ b/.github/workflows/kamal-deploy.yml
@@ -1,11 +1,11 @@
 name: Kamal build & deploy
 
 # Reusable (workflow_call) build+deploy for a Kamal target on the shared review
-# host. Owns the boilerplate both review apps and staging share: build+push the
+# host. Owns the boilerplate both review apps and sandbox share: build+push the
 # image to GHCR, then run a kamal command over SSH. Callers pass the bits that
 # differ (image tag, service label, the kamal command, concurrency, environment).
 #
-# Callers: review-app.yml (per-PR deploy/destroy) and staging.yml (main deploy).
+# Callers: review-app.yml (per-PR deploy/destroy) and sandbox.yml (main deploy).
 # The `run` job also handles destroy — it just runs whatever `command` it's given
 # and skips the build (there's nothing to build for a teardown).
 
@@ -85,7 +85,7 @@ jobs:
         uses: docker/setup-buildx-action@v4
       # Sprockets' incremental cache (the Dockerfile's `--mount=type=cache`) doesn't
       # survive ephemeral runners; cache-dance injects it into the buildx builder and
-      # extracts it after. A per-caller key prefix — review-app and staging bundles
+      # extracts it after. A per-caller key prefix — review-app and sandbox bundles
       # bake different BASE_URLs into ERB assets, so their caches can't be shared.
       - name: Restore sprockets asset cache
         id: sprockets-cache

--- a/.github/workflows/sandbox.yml
+++ b/.github/workflows/sandbox.yml
@@ -1,16 +1,16 @@
-name: Staging Deploy
+name: Sandbox Deploy
 
-# Deploys `main` to the persistent staging app (staging.review.bikeindex.org) via
+# Deploys `main` to the persistent sandbox app (sandbox.review.bikeindex.org) via
 # the shared kamal-deploy.yml reusable workflow — same host + shared accessories as
-# the per-PR review apps. It shares config/deploy.review.yml (the `staging` slug,
+# the per-PR review apps. It shares config/deploy.review.yml (the `sandbox` slug,
 # with no accessories block) — see that file and docs/review-apps.md.
 #
 # Trigger: workflow_dispatch only. CI's `dispatch` job fires this on every push to
 # main (see .github/workflows/ci.yml), and it's also a manual redeploy button.
-# NOTE: CI dispatches this in parallel with its own test job, so a staging deploy
+# NOTE: CI dispatches this in parallel with its own test job, so a sandbox deploy
 # does NOT wait for the test suite to pass.
 #
-# There is no destroy path — staging is long-lived. Its Postgres role/databases and
+# There is no destroy path — sandbox is long-lived. Its Postgres role/databases and
 # Redis DB 0 persist across deploys (first boot seeds, later boots migrate).
 
 on:
@@ -24,20 +24,20 @@ permissions:
 
 jobs:
   deploy:
-    name: Build & deploy staging
+    name: Build & deploy sandbox
     uses: ./.github/workflows/kamal-deploy.yml
     secrets: inherit
     with:
       ref: ${{ github.sha }}
-      image_tag: staging-${{ github.sha }}
-      service_label: bike-index-staging
-      sprockets_cache_prefix: staging-sprockets
-      # Shared config resolves the `staging` slug because no REVIEW_APP_PR_NUMBER
+      image_tag: sandbox-${{ github.sha }}
+      service_label: bike-index-sandbox
+      sprockets_cache_prefix: sandbox-sprockets
+      # Shared config resolves the `sandbox` slug because no REVIEW_APP_PR_NUMBER
       # is set; REVIEW_APP_REDIS_DB=0 is the DB reserved out of the per-PR 1..31
       # range. --skip-push: CI built + pushed the image. KAMAL_CONFIG lets the
       # post-deploy Honeybadger hook target the same config.
       kamal_config: config/deploy.review.yml
       command: REVIEW_APP_REDIS_DB=0 kamal deploy --version "$IMAGE_TAG" --skip-push --config-file config/deploy.review.yml
-      concurrency_prefix: staging-deploy
+      concurrency_prefix: sandbox-deploy
       environment_name: review-app
-      environment_url: https://staging.review.bikeindex.org
+      environment_url: https://sandbox.review.bikeindex.org

--- a/.kamal/secrets
+++ b/.kamal/secrets
@@ -24,7 +24,7 @@ VERIFICATION_SECRET=$(kamal secrets extract VERIFICATION_SECRET ${SECRETS})
 
 # External services (sandbox / scoped review-app values — do NOT reuse prod).
 # Stripe is intentionally absent — review apps read it from the committed .env
-# (dotenv in staging); see config/environments/staging.rb + Gemfile.
+# (dotenv in sandbox); see config/environments/sandbox.rb + Gemfile.
 GOOGLE_MAPS=$(kamal secrets extract GOOGLE_MAPS ${SECRETS})
 GOOGLE_MAPS_STATIC=$(kamal secrets extract GOOGLE_MAPS_STATIC ${SECRETS})
 GOOGLE_GEOCODER=$(kamal secrets extract GOOGLE_GEOCODER ${SECRETS})

--- a/.kamal/secrets-ci
+++ b/.kamal/secrets-ci
@@ -18,7 +18,7 @@ VERIFICATION_SECRET=$VERIFICATION_SECRET
 
 # External services (sandbox / scoped review-app values).
 # Stripe is intentionally absent — review apps read it from the committed .env
-# (dotenv in staging); see config/environments/staging.rb + Gemfile.
+# (dotenv in sandbox); see config/environments/sandbox.rb + Gemfile.
 GOOGLE_MAPS=$GOOGLE_MAPS
 GOOGLE_MAPS_STATIC=$GOOGLE_MAPS_STATIC
 GOOGLE_GEOCODER=$GOOGLE_GEOCODER

--- a/Dockerfile
+++ b/Dockerfile
@@ -34,10 +34,10 @@ RUN apt-get update -qq && \
     ln -s /usr/lib/$(uname -m)-linux-gnu/libjemalloc.so.2 /usr/local/lib/libjemalloc.so && \
     rm -rf /var/lib/apt/lists /var/cache/apt/archives
 
-# This image only ships to review apps, which run RAILS_ENV=staging
-# (see config/deploy.review.yml + config/environments/staging.rb). Building in
-# staging keeps build-time (asset precompile, bootsnap) and run-time consistent.
-ENV RAILS_ENV="staging" \
+# This image only ships to review apps, which run RAILS_ENV=sandbox
+# (see config/deploy.review.yml + config/environments/sandbox.rb). Building in
+# sandbox keeps build-time (asset precompile, bootsnap) and run-time consistent.
+ENV RAILS_ENV="sandbox" \
     BUNDLE_DEPLOYMENT="1" \
     BUNDLE_PATH="/usr/local/bundle" \
     BUNDLE_WITHOUT="development:test" \

--- a/Gemfile
+++ b/Gemfile
@@ -122,24 +122,24 @@ group :production do
   gem "skylight" # Performance monitoring
 end
 
-group :staging, :production do
+group :sandbox, :production do
   gem "honeybadger" # Error monitoring
 end
 
-group :staging do
+group :sandbox do
   gem "thruster", require: false # HTTP/2, asset caching, X-Sendfile for Puma (used by review-app Dockerfile)
 end
 
-group :staging, :development do
+group :sandbox, :development do
   # Captures ActionMailer deliveries in a web UI mounted at /letter_opener.
-  # Loaded in development (local dev) and staging (review apps — see config/deploy.review.yml).
+  # Loaded in development (local dev) and sandbox (review apps — see config/deploy.review.yml).
   gem "letter_opener_web", "~> 3.0"
 end
 
-# dotenv-rails is also loaded in :staging so review apps pick up the committed
-# .env dev/sandbox values at boot (see config/environments/staging.rb). dotenv
+# dotenv-rails is also loaded in :sandbox so review apps pick up the committed
+# .env dev/sandbox values at boot (see config/environments/sandbox.rb). dotenv
 # never overrides a var kamal already sets, so per-app/managed secrets win.
-group :development, :test, :staging do
+group :development, :test, :sandbox do
   gem "dotenv-rails"
 end
 

--- a/app/components/page_block/review_app_banner/component.en.yml
+++ b/app/components/page_block/review_app_banner/component.en.yml
@@ -6,7 +6,7 @@ en:
         commit_tooltip: 'current commit:'
         disclaimer: data is ephemeral
         label: Review app
-        label_staging: Staging
+        label_sandbox: Sandbox
         letter_opener_link: email outbox
         letter_opener_tooltip: View the email sent by this review app
         pr_link: 'PR #%{number}'

--- a/app/components/page_block/review_app_banner/component.html.erb
+++ b/app/components/page_block/review_app_banner/component.html.erb
@@ -9,7 +9,7 @@
     tw:px-4 tw:py-2 tw:text-center tw:font-semibold tw:text-black
   "
 >
-  <%# Hide the "Review app" label on small screens — the PR title carries the context there; "Staging" has no title, so it stays %>
+  <%# Hide the "Review app" label on small screens — the PR title carries the context there; "Sandbox" has no title, so it stays %>
   <span class="<%= "tw:hidden tw:sm:inline" if @pr_number %>">
     <%= banner_label %>
   </span>

--- a/app/components/page_block/review_app_banner/component.rb
+++ b/app/components/page_block/review_app_banner/component.rb
@@ -23,9 +23,9 @@ module PageBlock
 
       private
 
-      # No PR number means the persistent staging deploy, not a per-PR review app
+      # No PR number means the persistent sandbox deploy, not a per-PR review app
       def banner_label
-        @pr_number.present? ? translation(".label") : translation(".label_staging")
+        @pr_number.present? ? translation(".label") : translation(".label_sandbox")
       end
 
       # The PR title when known, falling back to "PR #<number>".

--- a/app/components/page_block/review_app_banner/component_preview.rb
+++ b/app/components/page_block/review_app_banner/component_preview.rb
@@ -8,8 +8,8 @@ module PageBlock
           pr_title: "Add Promoted section to marketplace index", commit: "a1b2c3d"))
       end
 
-      # Persistent staging deploy — no PR number, so the label reads "Staging".
-      def staging
+      # Persistent sandbox deploy — no PR number, so the label reads "Sandbox".
+      def sandbox
         render(PageBlock::ReviewAppBanner::Component.new(review_app: "1", commit: "a1b2c3d"))
       end
 

--- a/app/jobs/forward_csp_report_job.rb
+++ b/app/jobs/forward_csp_report_job.rb
@@ -17,7 +17,7 @@ class ForwardCspReportJob < ApplicationJob
   # The query is rebuilt here, not forwarded from the client, so the API key and
   # user context never ride in the browser-facing CSP report_uri.
   def perform(body, user_id, user_agent = nil)
-    # dev/staging browsers still emit reports; only production forwards to Honeybadger
+    # dev/sandbox browsers still emit reports; only production forwards to Honeybadger
     return unless Rails.env.production? && HONEYBADGER_CSP_API_KEY.present?
 
     report = parsed_report(body)

--- a/app/models/public_image.rb
+++ b/app/models/public_image.rb
@@ -86,7 +86,7 @@ class PublicImage < ApplicationRecord
 
   # CarrierWaveProcessJob generates versions by reading the stored original back
   # from remote storage, which only works with fog (production). With local file
-  # storage (staging/dev) the worker can't see the web box's disk, so process
+  # storage (sandbox/dev) the worker can't see the web box's disk, so process
   # versions inline — otherwise the job silently skips them and thumbnails 404.
   def process_image_upload
     return true unless remote_storage?
@@ -101,7 +101,7 @@ class PublicImage < ApplicationRecord
   end
 
   # To enable stream processing for both local and remote files.
-  # Returns nil when a local file is missing on disk (e.g. staging without synced uploads)
+  # Returns nil when a local file is missing on disk (e.g. sandbox without synced uploads)
   def open_file
     if local_file?
       File.open(image.path, "r") if File.exist?(image.path)

--- a/app/views/layouts/admin.html.erb
+++ b/app/views/layouts/admin.html.erb
@@ -66,7 +66,7 @@
             <%= active_link "Stolen", admin_stolen_bikes_path, role: "button", class: "nav-link", match_controller: true %>
           </li>
 
-          <% if Rails.env.development? || Rails.env.staging? %>
+          <% if Rails.env.development? || Rails.env.sandbox? %>
             <li class="dropdown nav-item">
               <a class="dropdown-toggle nav-link" data-toggle="dropdown">
                 Mailers

--- a/bin/kamal_review
+++ b/bin/kamal_review
@@ -11,11 +11,11 @@
 #   3594   pr-3594   pr-3594.review.bikeindex.org   https://pr-3594.review.bikeindex.org
 #
 # Passthrough sends everything else straight to kamal; --app may go anywhere and
-# defaults to the persistent `staging` app, e.g.
-#   bin/kamal_review app logs -f              # staging (default)
+# defaults to the persistent `sandbox` app, e.g.
+#   bin/kamal_review app logs -f              # sandbox (default)
 #   bin/kamal_review app logs -f --app 3594   # a PR
 # Accessory commands need an explicit `--app 0` (or any PR): the shared-db /
-# shared-redis accessories live only in the pr-* config, not staging's.
+# shared-redis accessories live only in the pr-* config, not sandbox's.
 #   bin/kamal_review accessory reboot db --app 0
 #
 # deploy/destroy require an explicit --app and run the per-PR lifecycle:
@@ -46,10 +46,10 @@ Usage:
 <review-app> is a PR, in any of these equivalent forms:
   3594   pr-3594   pr-3594.review.bikeindex.org   https://pr-3594.review.bikeindex.org
 
-Passthrough defaults --app to the persistent 'staging' app; deploy/destroy require it.
+Passthrough defaults --app to the persistent 'sandbox' app; deploy/destroy require it.
 
 Examples:
-  bin/kamal_review app logs -f                       # staging (default)
+  bin/kamal_review app logs -f                       # sandbox (default)
   bin/kamal_review app logs -f --app 3594
   bin/kamal_review app exec --reuse "bin/rails runner 'puts Bike.count'" --app pr-3594
   bin/kamal_review accessory reboot db --app 0       # accessories live in the pr-* config
@@ -85,25 +85,25 @@ export_review_app_env() {
   export REVIEW_APP_REDIS_DB="$((($1 % REDIS_DATABASES) + 1))"
 }
 
-# The persistent staging app: no PR number (config/deploy.review.yml's ERB then
-# resolves the `staging` slug), Redis DB 0 — the one the mod-N PR allocation
+# The persistent sandbox app: no PR number (config/deploy.review.yml's ERB then
+# resolves the `sandbox` slug), Redis DB 0 — the one the mod-N PR allocation
 # reserves.
-export_staging_env() {
+export_sandbox_env() {
   unset REVIEW_APP_PR_NUMBER
   export REVIEW_APP_HOST="${REVIEW_APP_HOST:-host.review.bikeindex.org}"
   export REVIEW_APP_REDIS_DB="0"
 }
 
-# True when the app id refers to staging, in any of review_app_pr_number's forms
-# (bare `staging`, host, or URL).
-is_staging() {
+# True when the app id refers to sandbox, in any of review_app_pr_number's forms
+# (bare `sandbox`, host, or URL).
+is_sandbox() {
   local s
   s="$(printf '%s' "$1" | tr '[:upper:]' '[:lower:]')"
   s="${s#http://}"
   s="${s#https://}"
   s="${s%%/*}"   # drop any /path
   s="${s%%.*}"   # drop the .review.bikeindex.org domain
-  [[ "$s" == "staging" ]]
+  [[ "$s" == "sandbox" ]]
 }
 
 not_a_review_app() {
@@ -123,10 +123,10 @@ case "$1" in
   deploy | destroy) mode="$1"; shift ;;
 esac
 
-# Passthrough: any kamal command, --app anywhere, defaults to staging. Always
+# Passthrough: any kamal command, --app anywhere, defaults to sandbox. Always
 # execs, so control never reaches the lifecycle code below.
 if [[ -z "$mode" ]]; then
-  app="staging"
+  app="sandbox"
   kamal_args=()
   while [[ $# -gt 0 ]]; do
     case "$1" in
@@ -135,9 +135,9 @@ if [[ -z "$mode" ]]; then
       *) kamal_args+=("$1"); shift ;;
     esac
   done
-  if is_staging "$app"; then
-    export_staging_env
-    slug="staging"
+  if is_sandbox "$app"; then
+    export_sandbox_env
+    slug="sandbox"
   else
     pr_number="$(review_app_pr_number "$app")" || not_a_review_app "$app"
     export_review_app_env "$pr_number"
@@ -185,7 +185,7 @@ case "$mode" in
     kamal deploy --version "$version" --skip-push
 
     # Start each review-app deploy with a clean Rails cache so new code never
-    # serves stale cached fragments. Runs only here, so staging (which deploys
+    # serves stale cached fragments. Runs only here, so sandbox (which deploys
     # via `kamal deploy` directly, not this script) is left untouched. --reuse
     # execs in the running web container; --roles web runs it once. Best-effort:
     # a failed clear must never fail the deploy.

--- a/config/boot.rb
+++ b/config/boot.rb
@@ -1,7 +1,7 @@
 ENV["BUNDLE_GEMFILE"] ||= File.expand_path("../Gemfile", __dir__)
 
 # Set default environment variables (REDIS_URL, DEV_PORT, etc.) for dev/test only
-deployed = %w[production staging]
+deployed = %w[production sandbox]
 unless deployed.include?(ENV["RAILS_ENV"]) || deployed.include?(ENV["RACK_ENV"])
   load File.expand_path("../bin/env", __dir__)
 end

--- a/config/cable.yml
+++ b/config/cable.yml
@@ -11,7 +11,7 @@ production:
   url: <%= ENV.fetch("REDIS_URL") %>
   channel_prefix: bikeindex_production
 
-staging:
+sandbox:
   adapter: redis
   url: <%= ENV.fetch("REDIS_URL") %>
-  channel_prefix: bikeindex_staging
+  channel_prefix: bikeindex_sandbox

--- a/config/database.yml
+++ b/config/database.yml
@@ -75,12 +75,12 @@ production:
     password: "<%= ENV['ANALYTICS_DB_PASSWORD'] %>"
     port: "<%= ENV['ANALYTICS_DB_PORT'] %>"
 
-# Staging mirrors production except the primary database name is taken from
-# POSTGRESQL_DATABASE so the staging database can be addressed independently. The
-# replica points at the same database as the primary (staging runs a single
+# Sandbox mirrors production except the primary database name is taken from
+# POSTGRESQL_DATABASE so the sandbox database can be addressed independently. The
+# replica points at the same database as the primary (sandbox runs a single
 # Postgres, like development).
-staging:
-  primary: &staging_primary
+sandbox:
+  primary: &sandbox_primary
     <<: *default
     database: "<%= ENV['POSTGRESQL_DATABASE'] %>"
     host: "<%= ENV['POSTGRESQL_ADDRESS'] %>"
@@ -88,7 +88,7 @@ staging:
     password: "<%= ENV['POSTGRESQL_PASSWORD'] %>"
 
   primary_replica:
-    <<: *staging_primary
+    <<: *sandbox_primary
     # Using primary database, replica not actually replicating (as in development)
     replica: true
 

--- a/config/deploy.review.yml
+++ b/config/deploy.review.yml
@@ -1,6 +1,6 @@
 # Kamal config for both non-production targets on the shared review host:
 #   - per-PR review apps      (REVIEW_APP_PR_NUMBER set → slug `pr-<N>`)
-#   - the persistent `staging` app (no PR number → slug `staging`)
+#   - the persistent `sandbox` app (no PR number → slug `sandbox`)
 # Everything below derives from `slug`; the only real fork is the `accessories:`
 # block, emitted for review apps only (see the WARNING there).
 #
@@ -8,9 +8,9 @@
 #   # review app (via .github/workflows/review-app.yml and bin/kamal_review):
 #   export REVIEW_APP_PR_NUMBER=123 REVIEW_APP_HOST=host.review.bikeindex.org
 #   kamal deploy --version pr-123-<sha> --config-file config/deploy.review.yml
-#   # staging (via .github/workflows/staging.yml): no PR number, Redis DB 0:
+#   # sandbox (via .github/workflows/sandbox.yml): no PR number, Redis DB 0:
 #   REVIEW_APP_REDIS_DB=0 REVIEW_APP_HOST=host.review.bikeindex.org \
-#     kamal deploy --version staging-<sha> --skip-push --config-file config/deploy.review.yml
+#     kamal deploy --version sandbox-<sha> --skip-push --config-file config/deploy.review.yml
 #
 # Secrets: kamal always reads .kamal/secrets. Locally that pulls from 1Password;
 # CI copies .kamal/secrets-ci over it first (see the workflows).
@@ -30,18 +30,18 @@
 # This file is NOT used by production (Cloud66).
 
 <%# The role/database naming must stay in lockstep with bin/kamal_review, which
-    re-derives it to DROP review-app databases on destroy (staging is never
+    re-derives it to DROP review-app databases on destroy (sandbox is never
     destroyed). The names reproduce both pre-existing schemes verbatim. %>
 <% require "json" %>
 <% pr      = ENV["REVIEW_APP_PR_NUMBER"].to_s %>
 <% pr      = nil if pr.empty? %>
 <% host    = ENV.fetch("REVIEW_APP_HOST") %>
-<% slug    = pr ? "pr-#{pr}" : "staging" %>
+<% slug    = pr ? "pr-#{pr}" : "sandbox" %>
 <% appname = "bike-index-#{slug}" %>
 <% role    = "bike_index_#{slug.tr("-", "_")}" %>
-<%# Review-app databases carry a `review_pr_<N>` infix; staging's are just `staging`. %>
-<% db_prefix = pr ? "bike_index_review_pr_#{pr}" : "bike_index_staging" %>
-<%# Per-PR logical Redis DB (bin/kamal_review sets 1..31); staging exports 0. %>
+<%# Review-app databases carry a `review_pr_<N>` infix; sandbox's are just `sandbox`. %>
+<% db_prefix = pr ? "bike_index_review_pr_#{pr}" : "bike_index_sandbox" %>
+<%# Per-PR logical Redis DB (bin/kamal_review sets 1..31); sandbox exports 0. %>
 <% redis_url = "redis://shared-redis:6379/#{ENV.fetch("REVIEW_APP_REDIS_DB", "1")}" %>
 <%# .to_json quotes/escapes the title into a valid (double-quoted) YAML scalar. %>
 <% pr_title_json = ENV.fetch("REVIEW_APP_PR_TITLE", "").to_json %>
@@ -99,10 +99,10 @@ registry:
 
 env:
   clear:
-    # Review apps run the dedicated staging Rails environment, which mirrors
+    # Review apps run the dedicated sandbox Rails environment, which mirrors
     # production except ActionMailer routes through letter_opener_web. See
-    # config/environments/staging.rb and config/routes.rb.
-    RAILS_ENV: staging
+    # config/environments/sandbox.rb and config/routes.rb.
+    RAILS_ENV: sandbox
     REVIEW_APP: "1"
     REVIEW_APP_PR_NUMBER: "<%= pr %>"
     # Empty unless the deployer exports REVIEW_APP_PR_TITLE (the workflow does);
@@ -111,14 +111,14 @@ env:
     REVIEW_APP_COMMIT: "<%= commit %>"
     BASE_URL: "https://<%= slug %>.review.bikeindex.org"
 
-    # Postgres (shared-db accessory; per-app role + databases). The staging
+    # Postgres (shared-db accessory; per-app role + databases). The sandbox
     # primary_replica points at the same database as the primary, so no
     # separate replica address is needed (see config/database.yml).
     POSTGRESQL_ADDRESS: shared-db
     POSTGRESQL_USERNAME: <%= role %>
     POSTGRESQL_DATABASE: <%= db_prefix %>_primary
     # Analytics lives on the same shared-db accessory (dropped alongside the
-    # primary in bin/kamal_review destroy — review apps only; staging persists).
+    # primary in bin/kamal_review destroy — review apps only; sandbox persists).
     POSTGRESQL_ANALYTICS_ADDRESS: shared-db
     ANALYTICS_DB_USERNAME: <%= role %>
     ANALYTICS_DB_DATABASE: <%= db_prefix %>_analytics
@@ -154,7 +154,7 @@ env:
     - SESSION_SECRET
     - VERIFICATION_SECRET
     # Stripe (test-mode) is NOT here — it comes from the committed .env via
-    # dotenv in staging (see config/environments/staging.rb + Gemfile).
+    # dotenv in sandbox (see config/environments/sandbox.rb + Gemfile).
     - GOOGLE_MAPS
     - GOOGLE_MAPS_STATIC
     - GOOGLE_GEOCODER
@@ -190,8 +190,8 @@ builder:
   # CI builds + pushes the image; Kamal just pulls. No remote builder needed.
 
 <%# Shared accessories — booted once during host setup, reused by every app.
-    Emitted for review-app deploys ONLY (pr present): staging must never carry
-    this block, or a staging deploy could reboot/remove the shared infra that
+    Emitted for review-app deploys ONLY (pr present): sandbox must never carry
+    this block, or a sandbox deploy could reboot/remove the shared infra that
     every PR app depends on. This is the one real fork between the two targets.
     WARNING: do not run `kamal accessory stop/remove` from a review-app deploy —
     it would tear down the shared infra and all in-flight PRs. %>

--- a/config/environments/sandbox.rb
+++ b/config/environments/sandbox.rb
@@ -1,17 +1,17 @@
-# Staging inherits from production and overrides only the bits that should
+# Sandbox inherits from production and overrides only the bits that should
 # diverge for a non-production deploy.
 #
-# Gotcha: `Rails.env.production?` is FALSE in staging even though we require
+# Gotcha: `Rails.env.production?` is FALSE in sandbox even though we require
 # production here — env-conditional code paths need to check
-# `Rails.env.production? || Rails.env.staging?` (see config/routes.rb,
+# `Rails.env.production? || Rails.env.sandbox?` (see config/routes.rb,
 # config/initializers/session_store.rb, config/initializers/rack_timeout.rb).
 require_relative "production"
 
 Rails.application.configure do
   # Capture every message in letter_opener_web instead of sending. The inbox is
-  # mounted at /letter_opener in config/routes.rb (unrestricted — staging runs
+  # mounted at /letter_opener in config/routes.rb (unrestricted — sandbox runs
   # seeded data with no PII). letter_opener_web is auto-required by Bundler via
-  # the :staging group.
+  # the :sandbox group.
   config.action_mailer.delivery_method = :letter_opener_web
 
   # Persist the inbox on the storage volume (config/deploy.review.yml mounts
@@ -22,13 +22,13 @@ Rails.application.configure do
     letter_opener_config.letters_location = Rails.root.join("storage", "letter_opener")
   end
 
-  # Upload to the dev R2 bucket so staging doesn't touch production assets
+  # Upload to the dev R2 bucket so sandbox doesn't touch production assets
   # (see config/storage.yml).
   config.active_storage.service = :cloudflare_dev
 
   # Enable ActionMailer previews (/rails/mailers, linked from the admin Mailers
   # dropdown) — production-default is off. preview_paths must be set explicitly:
-  # Rails only auto-adds spec/mailers/previews in development. Safe here: staging
+  # Rails only auto-adds spec/mailers/previews in development. Safe here: sandbox
   # runs seeded data with no PII (same rationale as the unrestricted
   # /letter_opener mount in config/routes.rb).
   config.action_mailer.show_previews = true
@@ -36,7 +36,7 @@ Rails.application.configure do
 
   # production.rb sends the log to stdout (for `kamal logs`) when
   # RAILS_LOG_TO_STDOUT is set — under that same condition, broadcast it to
-  # log/staging.log too, so the read_logged_searches cron job (config/crontab)
+  # log/sandbox.log too, so the read_logged_searches cron job (config/crontab)
   # has a file to rg. Set the formatter BEFORE wrapping in TaggedLogging (as
   # production.rb does for the stdout logger we reuse here) so the lines keep
   # the `I, [timestamp]` prefix LogSearcher::Reader matches AND tagged logging

--- a/config/initializers/carrierwave.rb
+++ b/config/initializers/carrierwave.rb
@@ -38,7 +38,7 @@ CarrierWave.configure do |config|
   config.storage = :file
   config.asset_host = ENV["BASE_URL"]
 
-  # Real production only — staging doesn't provision S3_* env vars (uploads
+  # Real production only — sandbox doesn't provision S3_* env vars (uploads
   # fall through to local file storage; ActiveStorage uses R2).
   if Rails.env.production?
     # config.fog_provider "fog/aws" # Once carrierwave is updated

--- a/config/initializers/rack_timeout.rb
+++ b/config/initializers/rack_timeout.rb
@@ -1,4 +1,4 @@
-if Rails.env.production? || Rails.env.staging?
+if Rails.env.production? || Rails.env.sandbox?
   Rails.application.config.middleware.insert_after(
     ActionDispatch::RequestId, Rack::Timeout, service_timeout: 30, wait_timeout: 10
   )

--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -1,4 +1,4 @@
-domain = if Rails.env.production? || Rails.env.staging?
+domain = if Rails.env.production? || Rails.env.sandbox?
   "bikeindex.org"
 elsif Rails.env.test?
   nil
@@ -7,7 +7,7 @@ else
 end
 
 # Include port in session key to prevent collisions across dev workspaces
-key = if Rails.env.production? || Rails.env.staging?
+key = if Rails.env.production? || Rails.env.sandbox?
   "_bikeindex_session"
 else
   port = ENV.fetch("DEV_PORT", 3042)

--- a/config/locales/translation.es.yml
+++ b/config/locales/translation.es.yml
@@ -5627,7 +5627,7 @@ es:
           de reseñas.
         pr_link: 'PR #%{number}'
         commit_tooltip: 'Commit actual:'
-        label_staging: Puesta en escena
+        label_sandbox: Sandbox
         superadmin_button: Iniciar sesión como superadministrador
         superadmin_signed_in: Sesión iniciada como superadministrador
       footer:

--- a/config/locales/translation.it.yml
+++ b/config/locales/translation.it.yml
@@ -5637,7 +5637,7 @@ it:
         letter_opener_tooltip: Visualizza l'email inviata da questa app di recensioni
         pr_link: 'PR #%{number}'
         commit_tooltip: 'Commit corrente:'
-        label_staging: Allestimento
+        label_sandbox: Sandbox
         superadmin_button: Accedi come superamministratore
         superadmin_signed_in: accesso effettuato come superamministratore
       footer:

--- a/config/locales/translation.nb.yml
+++ b/config/locales/translation.nb.yml
@@ -5373,7 +5373,7 @@ nb:
         letter_opener_tooltip: Se e-posten som ble sendt av denne anmeldelsesappen
         pr_link: PR-nummer %{number}
         commit_tooltip: 'nåværende forpliktelse:'
-        label_staging: Iscenesettelse
+        label_sandbox: Sandbox
         superadmin_button: logg inn som superadministrator
         superadmin_signed_in: logget inn som superadministrator
       footer:

--- a/config/locales/translation.nl.yml
+++ b/config/locales/translation.nl.yml
@@ -5523,7 +5523,7 @@ nl:
         letter_opener_tooltip: Bekijk de e-mail die door deze review-app is verzonden.
         pr_link: 'PR #%{number}'
         commit_tooltip: 'huidige commit:'
-        label_staging: Enscenering
+        label_sandbox: Sandbox
         superadmin_button: Meld u aan als superbeheerder.
         superadmin_signed_in: ingelogd als superbeheerder
       footer:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,8 +8,8 @@ Rails.application.routes.draw do
 
   mount Sidekiq::Web => "/sidekiq", :constraints => DeveloperRestriction
   mount PgHero::Engine, at: "/pghero", constraints: DeveloperRestriction
-  # letter_opener_web inbox — the gem's Bundler group (:development, :staging)
-  # decides where it's mounted. Unrestricted — staging runs seeded data with no PII.
+  # letter_opener_web inbox — the gem's Bundler group (:development, :sandbox)
+  # decides where it's mounted. Unrestricted — sandbox runs seeded data with no PII.
   mount LetterOpenerWeb::Engine, at: "/letter_opener" if defined?(LetterOpenerWeb)
 
   use_doorkeeper do
@@ -480,5 +480,5 @@ Rails.application.routes.draw do
   # Short marketplace_listing URLs: /m/<short_id> (and /M/...)
   get "*id", to: "marketplace_listings#show", constraints: {id: %r{[mM]/.*}}, format: false
 
-  get "*unmatched_route", to: "errors#not_found" if Rails.env.production? || Rails.env.staging? # Handle 404s with lograge
+  get "*unmatched_route", to: "errors#not_found" if Rails.env.production? || Rails.env.sandbox? # Handle 404s with lograge
 end

--- a/docs/review-apps.md
+++ b/docs/review-apps.md
@@ -2,7 +2,7 @@
 
 Per-PR review apps deployed with [Kamal](https://kamal-deploy.org/) to a single shared host. Each PR gets its own subdomain (`pr-N.review.bikeindex.org`), Postgres role + databases (primary + analytics), and Sidekiq worker.
 
-Review apps run the **staging Rails environment** `RAILS_ENV=staging`, a near-duplicate of production (`config/environments/staging.rb` imports production.rb)
+Review apps run the **sandbox Rails environment** `RAILS_ENV=sandbox`, a near-duplicate of production (`config/environments/sandbox.rb` imports production.rb)
 
 ## How to trigger one
 
@@ -21,30 +21,30 @@ bin/kamal_review app details  --app pr-3594.review.bikeindex.org
 bin/kamal_review app version  --app https://pr-3594.review.bikeindex.org
 ```
 
-All four resolve to PR `3594`; with no `--app` it defaults to the persistent staging app, and `--app staging` names it explicitly ([below](#staging-persistent-main-deploy)). (It also drives the `deploy`/`destroy` lifecycle — see [Deploying locally](#deploying-locally).) It uses `REVIEW_APP_HOST` + `.kamal/secrets`, so the 1Password setup above is a prerequisite. The `shared-db`/`shared-redis` accessories live only in the per-PR config, so accessory commands need an explicit `--app 0` (or any PR) — e.g. reboot Postgres after changing its `shared_preload_libraries`:
+All four resolve to PR `3594`; with no `--app` it defaults to the persistent sandbox app, and `--app sandbox` names it explicitly ([below](#sandbox-persistent-main-deploy)). (It also drives the `deploy`/`destroy` lifecycle — see [Deploying locally](#deploying-locally).) It uses `REVIEW_APP_HOST` + `.kamal/secrets`, so the 1Password setup above is a prerequisite. The `shared-db`/`shared-redis` accessories live only in the per-PR config, so accessory commands need an explicit `--app 0` (or any PR) — e.g. reboot Postgres after changing its `shared_preload_libraries`:
 
 ```bash
 bin/kamal_review accessory reboot db --app 0
 ```
 
-## Staging (persistent `main` deploy)
+## Sandbox (persistent `main` deploy)
 
-Alongside the per-PR apps, `main` is continuously deployed to **[staging.review.bikeindex.org](https://staging.review.bikeindex.org)** — think of it as a review app that never gets a PR number and is never destroyed. It shares `config/deploy.review.yml`: with no `REVIEW_APP_PR_NUMBER` set, the ERB resolves the `staging` slug and omits the `accessories:` block (so a staging deploy can't touch the shared infra the PR apps depend on). It differs only in using Redis logical DB `0` (the one the PR mod-31 allocation never hands out).
+Alongside the per-PR apps, `main` is continuously deployed to **[sandbox.review.bikeindex.org](https://sandbox.review.bikeindex.org)** — think of it as a review app that never gets a PR number and is never destroyed. It shares `config/deploy.review.yml`: with no `REVIEW_APP_PR_NUMBER` set, the ERB resolves the `sandbox` slug and omits the `accessories:` block (so a sandbox deploy can't touch the shared infra the PR apps depend on). It differs only in using Redis logical DB `0` (the one the PR mod-31 allocation never hands out).
 
-For `bin/kamal_review`, with no `--app` given it defaults to staging - but you can also use `--app staging` to target it. This works for passthrough commands only, since staging is deployed by its own workflow, not the `deploy`/`destroy` lifecycle:
+For `bin/kamal_review`, with no `--app` given it defaults to sandbox - but you can also use `--app sandbox` to target it. This works for passthrough commands only, since sandbox is deployed by its own workflow, not the `deploy`/`destroy` lifecycle:
 
 ```bash
-bin/kamal_review shell        --app staging   # bash on staging
-bin/kamal_review console                      # rails console, also on staging
+bin/kamal_review shell        --app sandbox   # bash on sandbox
+bin/kamal_review console                      # rails console, also on sandbox
 ```
 
 ## What about production?
 
 Production runs on Cloud66. The differences vs production:
 
-- ActionMailer routes through [`letter_opener_web`](https://github.com/fgrehm/letter_opener_web) — the gem is in the `:staging` Bundler group, so production never loads it. Inbox at `pr-N.review.bikeindex.org/letter_opener`, stored in `tmp/letter_opener/`, wiped on every deploy.
+- ActionMailer routes through [`letter_opener_web`](https://github.com/fgrehm/letter_opener_web) — the gem is in the `:sandbox` Bundler group, so production never loads it. Inbox at `pr-N.review.bikeindex.org/letter_opener`, stored in `tmp/letter_opener/`, wiped on every deploy.
 - Mailer **previews** at `/rails/mailers` (off in production), linked from the admin **Mailers** dropdown.
-- The log broadcasts to both stdout (`kamal logs`) and `log/staging.log`, so the `read_logged_searches` cron has a file to read.
+- The log broadcasts to both stdout (`kamal logs`) and `log/sandbox.log`, so the `read_logged_searches` cron has a file to read.
 
 These make information public, but review apps hold no PII - just seeded data + sandbox integrations.
 
@@ -62,7 +62,7 @@ Only CI's on-push dispatch and `closed` are wired up, so toggling the label by h
 
 ## How a deploy works
 
-Four jobs: `resolve` (PR number + deploy/destroy, and labels on deploy), `op` (calls the shared `kamal-deploy.yml` reusable workflow to build + run the kamal command), `post` (PR-side follow-ups: deployment link, failure-comment cleanup, label removal + GHCR image cleanup on destroy), `report` (failure-only). The reusable workflow's `build` job cancels superseded builds (`cancel-in-progress`) while its `run` job serializes per PR *without* cancellation, since killing kamal mid-deploy can strand the deploy lock. `kamal-deploy.yml` is shared with `staging.yml`.
+Four jobs: `resolve` (PR number + deploy/destroy, and labels on deploy), `op` (calls the shared `kamal-deploy.yml` reusable workflow to build + run the kamal command), `post` (PR-side follow-ups: deployment link, failure-comment cleanup, label removal + GHCR image cleanup on destroy), `report` (failure-only). The reusable workflow's `build` job cancels superseded builds (`cancel-in-progress`) while its `run` job serializes per PR *without* cancellation, since killing kamal mid-deploy can strand the deploy lock. `kamal-deploy.yml` is shared with `sandbox.yml`.
 
 | Trigger | Action | What runs |
 |---|---|---|
@@ -102,13 +102,13 @@ Each app gets a `cron` container (a Kamal [`servers` role](https://kamal-deploy.
 | `bin/docker-entrypoint` | Creates the per-PR Postgres **superuser** role + runs `db:prepare` (schema + seed) on first boot |
 | `bin/thrust` | Thruster binstub used by the image's `CMD` |
 | `bin/kamal_review` | Run kamal against one review app — `deploy`/`destroy` lifecycle plus arbitrary passthrough commands (resolves the PR number from any id form, sets `REVIEW_APP_*` + `--config-file`) |
-| `config/deploy.review.yml` | Kamal config for both targets — ERB derives `pr-<N>` (with `REVIEW_APP_PR_NUMBER`) or the `staging` slug (without); accessories emitted for PR apps only |
-| `.github/workflows/staging.yml` | Thin caller of `kamal-deploy.yml` for the `main`→staging deploy, dispatched on every push to `main` — see [Staging](#staging-persistent-main-deploy) |
-| `.github/workflows/kamal-deploy.yml` | Reusable (`workflow_call`) build + kamal-command workflow shared by review-app and staging deploys |
+| `config/deploy.review.yml` | Kamal config for both targets — ERB derives `pr-<N>` (with `REVIEW_APP_PR_NUMBER`) or the `sandbox` slug (without); accessories emitted for PR apps only |
+| `.github/workflows/sandbox.yml` | Thin caller of `kamal-deploy.yml` for the `main`→sandbox deploy, dispatched on every push to `main` — see [Sandbox](#sandbox-persistent-main-deploy) |
+| `.github/workflows/kamal-deploy.yml` | Reusable (`workflow_call`) build + kamal-command workflow shared by review-app and sandbox deploys |
 | `config/crontab` | Scheduled rake tasks run by the `cron` server role |
 | `.kamal/secrets` | Local secrets — pulls from 1Password and `gh auth token` |
 | `.kamal/secrets-ci` | CI secrets — dotenv passthrough for GitHub Actions env vars; the workflow copies this over `.kamal/secrets` before running kamal |
-| `.kamal/hooks/post-deploy` | Best-effort Honeybadger deploy notification (`staging` env); never fails the deploy — no-ops if `HONEYBADGER_API_KEY` is unset or the gem is absent (e.g. CI) |
+| `.kamal/hooks/post-deploy` | Best-effort Honeybadger deploy notification (`sandbox` env); never fails the deploy — no-ops if `HONEYBADGER_API_KEY` is unset or the gem is absent (e.g. CI) |
 | `.github/workflows/review-app.yml` | `resolve` + `op` (calls `kamal-deploy.yml`) + `post` + `report` jobs handling all triggers (see [How a deploy works](#how-a-deploy-works)) |
 | `.github/workflows/ci.yml` (`dispatch` job) | Auto-dispatches a deploy on every push to a labeled PR — the auto-redeploy half of the label gate |
 | `.kamal/provisioning/` | Ansible playbook for one-time host hardening |
@@ -219,4 +219,4 @@ Creates the `shared-db` (Postgres 17) and `shared-redis` (Redis 7) containers. E
   - `REVIEW_APP_R2_DEV_ENDPOINT`, `REVIEW_APP_R2_DEV_ACCESS_KEY`, `REVIEW_APP_R2_DEV_ACCESS_KEY_SECRET` — creds for the `bikeindex-dev` R2 bucket (`cloudflare_dev` in `config/storage.yml`), shared by all review apps; do NOT reuse the production R2 token.
   - `REVIEW_APP_HONEYBADGER_API_KEY` — optional; the post-deploy hook no-ops if unset
 
-Review apps also load the committed **`.env`** at boot (`dotenv-rails` is in the `:staging` group). It supplies dev/sandbox creds for third-party integrations — **Stripe (test-mode)**, Twitter, Twilio, Facebook, Strava, Mailchimp, … — so they don't fall through to empty. **kamal's `env:` wins**: dotenv never overrides a var kamal sets, so it only fills gaps. That's why **Stripe is intentionally absent** from the kamal/1Password/GitHub lists — it comes from `.env`. (Google/Mapbox/R2 stay kamal-managed, so their 1Password values must be real, not placeholders.)
+Review apps also load the committed **`.env`** at boot (`dotenv-rails` is in the `:sandbox` group). It supplies dev/sandbox creds for third-party integrations — **Stripe (test-mode)**, Twitter, Twilio, Facebook, Strava, Mailchimp, … — so they don't fall through to empty. **kamal's `env:` wins**: dotenv never overrides a var kamal sets, so it only fills gaps. That's why **Stripe is intentionally absent** from the kamal/1Password/GitHub lists — it comes from `.env`. (Google/Mapbox/R2 stay kamal-managed, so their 1Password values must be real, not placeholders.)

--- a/lib/tasks/rake_tasks.rake
+++ b/lib/tasks/rake_tasks.rake
@@ -52,7 +52,7 @@ task trigger_honeybadger_deploy: :environment do
   Honeybadger.track_deployment(environment:, revision:, local_username:, repository:)
 
   raise "Missing HONEYBADGER_FRONTEND_API_KEY" if ENV["HONEYBADGER_FRONTEND_API_KEY"].blank?
-  # The CSP key is only required in production — staging deploys without one.
+  # The CSP key is only required in production — sandbox deploys without one.
   raise "Missing HONEYBADGER_CSP_API_KEY" if environment == "production" && ENV["HONEYBADGER_CSP_API_KEY"].blank?
 
   require "net/http"

--- a/spec/components/page_block/review_app_banner/component_spec.rb
+++ b/spec/components/page_block/review_app_banner/component_spec.rb
@@ -16,17 +16,17 @@ RSpec.describe PageBlock::ReviewAppBanner::Component, type: :component do
     let(:current_user) { nil }
     let(:return_to) { nil }
 
-    it "renders the staging label and disclaimer" do
-      # No pr_number is the persistent staging deploy, not a per-PR review app
-      expect(component.text).to include("Staging")
+    it "renders the sandbox label and disclaimer" do
+      # No pr_number is the persistent sandbox deploy, not a per-PR review app
+      expect(component.text).to include("Sandbox")
       expect(component.text).not_to include("Review app")
       expect(component.text).to include("data is ephemeral")
     end
 
-    it "keeps the Staging label visible on small screens but hides the disclaimer" do
-      # tw:hidden tw:sm:inline => display:none below the sm breakpoint. Staging has
+    it "keeps the Sandbox label visible on small screens but hides the disclaimer" do
+      # tw:hidden tw:sm:inline => display:none below the sm breakpoint. Sandbox has
       # no PR title, so the label itself carries the context on small screens.
-      label = component.css("span").find { |span| span.text.strip == "Staging" }
+      label = component.css("span").find { |span| span.text.strip == "Sandbox" }
       disclaimer = component.css("span").find { |span| span.text.include?("data is ephemeral") }
       expect(label[:class].to_s).not_to include("tw:hidden")
       expect(disclaimer[:class].to_s).to include("tw:hidden")
@@ -128,9 +128,9 @@ RSpec.describe PageBlock::ReviewAppBanner::Component, type: :component do
         expect(link.text).to include("PR #1234")
       end
 
-      it "shows the review app label instead of the staging label, hidden on small screens" do
+      it "shows the review app label instead of the sandbox label, hidden on small screens" do
         expect(component.text).to include("Review app")
-        expect(component.text).not_to include("Staging")
+        expect(component.text).not_to include("Sandbox")
         # The PR title carries the context on small screens, so the label hides
         label = component.css("span").find { |span| span.text.strip == "Review app" }
         expect(label[:class].to_s).to include("tw:hidden")

--- a/spec/models/public_image_spec.rb
+++ b/spec/models/public_image_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe PublicImage, type: :model do
     let(:bike) { FactoryBot.create(:bike) }
     let(:image_file) { File.open(Rails.root.join("spec", "fixtures", "bike.jpg")) }
 
-    context "local file storage (staging/dev)" do
+    context "local file storage (sandbox/dev)" do
       it "generates versions inline and does not enqueue the background job" do
         expect(PublicImageUploader.storage).to eq CarrierWave::Storage::File
         PublicImageUploader.enable_processing = true


### PR DESCRIPTION
Renames the persistent non-production deploy and its Rails environment from `staging` to `sandbox` — a 1:1 identifier/string rename with no behavior change.

- `RAILS_ENV=sandbox` throughout: `config/environments/sandbox.rb`, the `Rails.env.sandbox?` checks, the `:sandbox` Bundler group, and the `sandbox` keys in `cable.yml`/`database.yml`.
- Kamal target renamed — slug/app/role/db become `sandbox` / `bike-index-sandbox` / `bike_index_sandbox`, the deploy workflow is now `sandbox.yml`, and the URL becomes `sandbox.review.bikeindex.org`.
- Review-app banner label reads **"Sandbox"** (`label_sandbox`); `bin/kamal_review` defaults to the `sandbox` app.

Not covered here (ops): the live `staging` app/databases get torn down and a fresh `sandbox` deploy stands up (no in-place migration), and the Mapbox token allowlist needs `sandbox.review.bikeindex.org` added.
