### PR TITLE
Fix two frontend Honeybadger errors: WebGL init + cross-page turbo-frame

### DIFF
--- a/app/assets/stylesheets/revised/pages/bikes/show.scss
+++ b/app/assets/stylesheets/revised/pages/bikes/show.scss
@@ -124,6 +124,14 @@
     height: 400px;
   }
 
+  .map-unavailable {
+    min-height: 400px;
+    padding: 2rem 1rem;
+    text-align: center;
+    color: #6b7280;
+    background: #f3f4f6;
+  }
+
   .bike-photos,
   .show-bike-details,
   .ad300x600,

--- a/app/assets/stylesheets/revised/pages/bikes/show.scss
+++ b/app/assets/stylesheets/revised/pages/bikes/show.scss
@@ -128,8 +128,8 @@
     min-height: 400px;
     padding: 2rem 1rem;
     text-align: center;
-    color: #6b7280;
-    background: #f3f4f6;
+    color: $less-strong-font-color;
+    background: $gray-lighter;
   }
 
   .bike-photos,

--- a/app/javascript/controllers/search/form_controller.js
+++ b/app/javascript/controllers/search/form_controller.js
@@ -109,7 +109,13 @@ export default class extends Controller {
     const frame = this.frameElement
     const src = frame?.getAttribute('src')
     if (!src) return
-    if (new URL(src, window.location.origin).search !== window.location.search) {
+    const srcUrl = new URL(src, window.location.origin)
+    // Only reconcile within the same search page. A back/forward restoration can
+    // briefly leave one page's frame (eg marketplace_results_frame) in the DOM
+    // while the address bar is another page (/search/registrations); pointing the
+    // frame there fetches a response without that frame, which Turbo discards.
+    if (srcUrl.pathname !== window.location.pathname) return
+    if (srcUrl.search !== window.location.search) {
       frame.setAttribute('src', window.location.href)
     }
   }

--- a/app/javascript/controllers/stolen_map_controller.js
+++ b/app/javascript/controllers/stolen_map_controller.js
@@ -16,7 +16,12 @@ export default class extends Controller {
   static values = { token: String, lng: Number, lat: Number, radiusBase: Number }
 
   connect () {
-    loadMapbox().then(() => this.renderMap())
+    // WebGL can be unavailable (crawlers, headless browsers, disabled GPU); the
+    // map just doesn't render. Swallow it so it isn't reported as an unhandled
+    // promise rejection.
+    loadMapbox()
+      .then(() => this.renderMap())
+      .catch((error) => console.warn('Stolen map failed to render:', error))
   }
 
   disconnect () {

--- a/app/javascript/controllers/stolen_map_controller.js
+++ b/app/javascript/controllers/stolen_map_controller.js
@@ -26,8 +26,10 @@ export default class extends Controller {
   // empty box - and swallow the rejection so it isn't reported as unhandled.
   showUnavailable (error) {
     console.warn('Stolen map failed to render:', error)
+    if (!this.hasUnavailableTarget) return
+
     this.canvasTarget.hidden = true
-    if (this.hasUnavailableTarget) this.unavailableTarget.hidden = false
+    this.unavailableTarget.hidden = false
   }
 
   disconnect () {

--- a/app/javascript/controllers/stolen_map_controller.js
+++ b/app/javascript/controllers/stolen_map_controller.js
@@ -12,16 +12,22 @@ const MAPBOX_JS = `https://api.mapbox.com/mapbox-gl-js/${MAPBOX_VERSION}/mapbox-
 const MAPBOX_CSS = `https://api.mapbox.com/mapbox-gl-js/${MAPBOX_VERSION}/mapbox-gl.css`
 
 export default class extends Controller {
-  static targets = ['canvas']
+  static targets = ['canvas', 'unavailable']
   static values = { token: String, lng: Number, lat: Number, radiusBase: Number }
 
   connect () {
-    // WebGL can be unavailable (crawlers, headless browsers, disabled GPU); the
-    // map just doesn't render. Swallow it so it isn't reported as an unhandled
-    // promise rejection.
     loadMapbox()
       .then(() => this.renderMap())
-      .catch((error) => console.warn('Stolen map failed to render:', error))
+      .catch((error) => this.showUnavailable(error))
+  }
+
+  // WebGL/Mapbox can be unavailable (crawlers, headless browsers, disabled GPU,
+  // CDN blocked). Replace the blank canvas with a message rather than leaving an
+  // empty box - and swallow the rejection so it isn't reported as unhandled.
+  showUnavailable (error) {
+    console.warn('Stolen map failed to render:', error)
+    this.canvasTarget.hidden = true
+    if (this.hasUnavailableTarget) this.unavailableTarget.hidden = false
   }
 
   disconnect () {

--- a/app/views/bikes/_stolen_map.html.erb
+++ b/app/views/bikes/_stolen_map.html.erb
@@ -7,4 +7,8 @@
   data-stolen-map-radius-base-value="<%= mapping_record.show_address ? 2 : 1.15 %>"
 >
   <div id="map_canvas" data-stolen-map-target="canvas"></div>
+
+  <p hidden class="map-unavailable" data-stolen-map-target="unavailable">
+    <%= t(".unavailable") %>
+  </p>
 </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1296,6 +1296,9 @@ en:
       share_widely_on_your_personal_social: Share widely on your personal social media
       supercharge_sharing_on_facebook: Supercharge sharing on Facebook with Bike Index
       your_police_report: your Police Report Number
+    stolen_map:
+      unavailable: The map couldn't be loaded — your browser or device may not support
+        it.
     theft_alerts:
       new:
         best_value: Best value


### PR DESCRIPTION
Fixes two frontend errors from Honeybadger.

- **`stolen_map` / WebGL** — WebGL is often unavailable (crawlers, headless browsers, disabled GPUs, blocked CDN), so Mapbox init rejected and was reported as an unhandled promise rejection. The controller now catches it and, instead of leaving a blank canvas, reveals a server-rendered (translatable) message explaining the map couldn't load.
- **`search/form_controller`** — `reloadFrameIfUrlStale` compared only the query string, so a back/forward restoration could point one page's results frame (e.g. `marketplace_results_frame`) at another page's URL (`/search/registrations`), whose response lacks that frame and gets discarded by Turbo. Guard on `pathname` first.

The third error from the same batch (invalid combobox selector) was already resolved on `main` by the general `hw_combobox_patch.js` override in #3860, so it needs no further change.
