### PR TITLE
Dispatch iOS E2E from sandbox deploy instead of workflow_run

### DIFF
--- a/.github/workflows/ios-e2e.yml
+++ b/.github/workflows/ios-e2e.yml
@@ -5,26 +5,17 @@ permissions:
 
 # Runs the iOS suite against the persistent sandbox server
 # (sandbox.review.bikeindex.org) rather than a Rails dev server booted on the
-# runner. Sandbox tracks main — CI dispatches its deploy on every push to main
-# (see sandbox.yml) — so this fires via workflow_run once that deploy finishes.
-#
-# workflow_run only triggers from the copy of this file on the default branch,
-# so it won't run for feature-branch pushes; use workflow_dispatch to run it
-# manually (against whatever sandbox currently serves).
+# runner. Sandbox tracks main, and its deploy job (see sandbox.yml) dispatches
+# this once the deploy finishes. A workflow_run trigger can't be used: CI starts
+# the sandbox deploy with GITHUB_TOKEN, and runs started by GITHUB_TOKEN don't
+# emit the downstream events (like workflow_run) that would fire this. Also
+# dispatchable manually (against whatever sandbox currently serves).
 on:
-  workflow_run:
-    workflows: ["Sandbox Deploy"]
-    types: [completed]
   workflow_dispatch:
 
 jobs:
   test-suite:
     name: "${{ matrix.device }} ${{ matrix.only-testing }}"
-    # Skip when the sandbox deploy failed; manual dispatches always run.
-    if: >-
-      github.event_name == 'workflow_dispatch' ||
-      (github.event.workflow_run.conclusion == 'success' &&
-       github.event.workflow_run.head_branch == 'main')
     runs-on: macos-26
     strategy:
       max-parallel: 1

--- a/.github/workflows/sandbox.yml
+++ b/.github/workflows/sandbox.yml
@@ -41,3 +41,22 @@ jobs:
       concurrency_prefix: sandbox-deploy
       environment_name: review-app
       environment_url: https://sandbox.review.bikeindex.org
+
+  # Kick off the iOS E2E suite against the sandbox we just deployed. Dispatched
+  # here rather than via a workflow_run trigger in ios-e2e.yml because this
+  # deploy is started by CI's GITHUB_TOKEN, and GITHUB_TOKEN-initiated runs don't
+  # emit downstream events like workflow_run. workflow_dispatch is the exception
+  # GITHUB_TOKEN is allowed to fire, so we dispatch explicitly.
+  dispatch-ios-e2e:
+    name: Dispatch iOS E2E
+    needs: deploy
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+    env:
+      GH_TOKEN: ${{ github.token }}
+    steps:
+      - name: Dispatch iOS E2E against the freshly deployed sandbox
+        run: |
+          retry() { local n=1; until "$@"; do [ $n -ge 3 ] && return 1; echo "attempt $n failed; retrying in 15s..." >&2; n=$((n+1)); sleep 15; done; }
+          retry gh workflow run ios-e2e.yml --repo "$GITHUB_REPOSITORY" --ref main


### PR DESCRIPTION
The iOS E2E workflow's `workflow_run` trigger never fired on main because CI dispatches the sandbox deploy with `GITHUB_TOKEN`, and GITHUB_TOKEN-initiated runs don't emit downstream events like `workflow_run`. This wires the suite up through the one event GITHUB_TOKEN *is* allowed to fire.

- `sandbox.yml`: after the deploy job succeeds, a `dispatch-ios-e2e` job (`needs: deploy`) runs `gh workflow run ios-e2e.yml --ref main`.
- `ios-e2e.yml`: dropped the dead `workflow_run` trigger and its guard `if:`; it's now `workflow_dispatch`-only.
