### PR TITLE
iOS E2E: run UITests and report failures as a commit status

### DIFF
--- a/.github/workflows/ios-e2e.yml
+++ b/.github/workflows/ios-e2e.yml
@@ -10,18 +10,8 @@ permissions:
 # the sandbox deploy with GITHUB_TOKEN, and runs started by GITHUB_TOKEN don't
 # emit the downstream events (like workflow_run) that would fire this. Also
 # dispatchable manually (against whatever sandbox currently serves).
-#
-# status_sha is the bike_index commit the deploy is testing; sandbox.yml passes
-# it so we can publish an "iOS E2E CI" commit status back onto that commit —
-# otherwise this run lands in its own check-suite and never shows up in the
-# commit's checks list. Blank (manual runs) skips status reporting.
 on:
   workflow_dispatch:
-    inputs:
-      status_sha:
-        description: "bike_index commit SHA to report the 'iOS E2E CI' status against (blank to skip)"
-        required: false
-        default: ""
 
 jobs:
   test-suite:
@@ -88,28 +78,3 @@ jobs:
           name: "test_output_${{ matrix.device }}_${{ matrix.only-testing }}"
           path: "fastlane/test_output/*"
           compression-level: 9 # maximum compression
-
-  # Publish the suite result as an "iOS E2E CI" commit status on the tested
-  # commit so it surfaces (green/red) in that commit's checks list — the run's
-  # own check-suite doesn't. Skipped for manual runs (no status_sha).
-  report-status:
-    name: Report iOS E2E status
-    needs: test-suite
-    if: ${{ always() && inputs.status_sha != '' }}
-    runs-on: ubuntu-latest
-    permissions:
-      statuses: write
-    env:
-      GH_TOKEN: ${{ github.token }}
-      STATUS_SHA: ${{ inputs.status_sha }}
-      RESULT: ${{ needs.test-suite.result }}
-    steps:
-      - name: Publish commit status
-        run: |
-          state=failure
-          [ "$RESULT" = success ] && state=success
-          gh api "repos/$GITHUB_REPOSITORY/statuses/$STATUS_SHA" \
-            -f state="$state" \
-            -f context="iOS E2E CI" \
-            -f description="$RESULT" \
-            -f target_url="$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID"

--- a/.github/workflows/ios-e2e.yml
+++ b/.github/workflows/ios-e2e.yml
@@ -10,8 +10,20 @@ permissions:
 # the sandbox deploy with GITHUB_TOKEN, and runs started by GITHUB_TOKEN don't
 # emit the downstream events (like workflow_run) that would fire this. Also
 # dispatchable manually (against whatever sandbox currently serves).
+#
+# status_sha (passed by sandbox.yml) is the bike_index commit under test. On
+# failure, report-failure publishes a red "iOS E2E CI" commit status so it shows
+# in that commit's checks list. Nothing is posted on success, and a failure is
+# written only after the ~15-min suite finishes — long after CI passed and Cloud
+# 66's redeploy fired — so this never adds a status during the deploy window and
+# can't affect the deploy. Blank (manual runs) skips reporting.
 on:
   workflow_dispatch:
+    inputs:
+      status_sha:
+        description: "bike_index commit SHA to report an 'iOS E2E CI' failure status against (blank to skip)"
+        required: false
+        default: ""
 
 jobs:
   test-suite:
@@ -78,3 +90,27 @@ jobs:
           name: "test_output_${{ matrix.device }}_${{ matrix.only-testing }}"
           path: "fastlane/test_output/*"
           compression-level: 9 # maximum compression
+
+  # On failure only, publish a red "iOS E2E CI" commit status so the failure
+  # surfaces in the tested commit's checks list. Nothing is posted on success,
+  # and this runs only after the suite completes — well after Cloud 66's post-CI
+  # redeploy — so it never touches the deploy path. Skipped for manual runs.
+  report-failure:
+    name: Report iOS E2E failure
+    needs: test-suite
+    if: ${{ always() && inputs.status_sha != '' && needs.test-suite.result != 'success' }}
+    runs-on: ubuntu-latest
+    permissions:
+      statuses: write
+    env:
+      GH_TOKEN: ${{ github.token }}
+      STATUS_SHA: ${{ inputs.status_sha }}
+      RESULT: ${{ needs.test-suite.result }}
+    steps:
+      - name: Publish failing commit status
+        run: |
+          gh api "repos/$GITHUB_REPOSITORY/statuses/$STATUS_SHA" \
+            -f state=failure \
+            -f context="iOS E2E CI" \
+            -f description="iOS E2E $RESULT" \
+            -f target_url="$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID"

--- a/.github/workflows/ios-e2e.yml
+++ b/.github/workflows/ios-e2e.yml
@@ -10,8 +10,18 @@ permissions:
 # the sandbox deploy with GITHUB_TOKEN, and runs started by GITHUB_TOKEN don't
 # emit the downstream events (like workflow_run) that would fire this. Also
 # dispatchable manually (against whatever sandbox currently serves).
+#
+# status_sha is the bike_index commit the deploy is testing; sandbox.yml passes
+# it so we can publish an "iOS E2E CI" commit status back onto that commit —
+# otherwise this run lands in its own check-suite and never shows up in the
+# commit's checks list. Blank (manual runs) skips status reporting.
 on:
   workflow_dispatch:
+    inputs:
+      status_sha:
+        description: "bike_index commit SHA to report the 'iOS E2E CI' status against (blank to skip)"
+        required: false
+        default: ""
 
 jobs:
   test-suite:
@@ -21,7 +31,7 @@ jobs:
       max-parallel: 1
       matrix:
         device: ["iPhone 17"] # "iPhone 17 Pro", "iPad (A16)"
-        only-testing: ["UnitTests"] # UITests: add after UnitTests working end-to-end
+        only-testing: ["UnitTests", "UITests"]
 
     steps:
       - name: Checkout bike_index_ios
@@ -78,3 +88,28 @@ jobs:
           name: "test_output_${{ matrix.device }}_${{ matrix.only-testing }}"
           path: "fastlane/test_output/*"
           compression-level: 9 # maximum compression
+
+  # Publish the suite result as an "iOS E2E CI" commit status on the tested
+  # commit so it surfaces (green/red) in that commit's checks list — the run's
+  # own check-suite doesn't. Skipped for manual runs (no status_sha).
+  report-status:
+    name: Report iOS E2E status
+    needs: test-suite
+    if: ${{ always() && inputs.status_sha != '' }}
+    runs-on: ubuntu-latest
+    permissions:
+      statuses: write
+    env:
+      GH_TOKEN: ${{ github.token }}
+      STATUS_SHA: ${{ inputs.status_sha }}
+      RESULT: ${{ needs.test-suite.result }}
+    steps:
+      - name: Publish commit status
+        run: |
+          state=failure
+          [ "$RESULT" = success ] && state=success
+          gh api "repos/$GITHUB_REPOSITORY/statuses/$STATUS_SHA" \
+            -f state="$state" \
+            -f context="iOS E2E CI" \
+            -f description="$RESULT" \
+            -f target_url="$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID"

--- a/.github/workflows/sandbox.yml
+++ b/.github/workflows/sandbox.yml
@@ -53,22 +53,10 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       actions: write
-      statuses: write
     env:
       GH_TOKEN: ${{ github.token }}
-      STATUS_SHA: ${{ github.sha }}
     steps:
-      # Mark the commit pending immediately so "iOS E2E CI" shows up in its checks
-      # list right away; ios-e2e.yml's report-status job resolves it to
-      # success/failure. Without this the suite is invisible until it finishes.
-      - name: Mark iOS E2E pending on the deployed commit
-        run: |
-          gh api "repos/$GITHUB_REPOSITORY/statuses/$STATUS_SHA" \
-            -f state=pending \
-            -f context="iOS E2E CI" \
-            -f description="Running against sandbox" \
-            -f target_url="$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/workflows/ios-e2e.yml"
       - name: Dispatch iOS E2E against the freshly deployed sandbox
         run: |
           retry() { local n=1; until "$@"; do [ $n -ge 3 ] && return 1; echo "attempt $n failed; retrying in 15s..." >&2; n=$((n+1)); sleep 15; done; }
-          retry gh workflow run ios-e2e.yml --repo "$GITHUB_REPOSITORY" --ref main -f status_sha="$STATUS_SHA"
+          retry gh workflow run ios-e2e.yml --repo "$GITHUB_REPOSITORY" --ref main

--- a/.github/workflows/sandbox.yml
+++ b/.github/workflows/sandbox.yml
@@ -55,8 +55,11 @@ jobs:
       actions: write
     env:
       GH_TOKEN: ${{ github.token }}
+      STATUS_SHA: ${{ github.sha }}
     steps:
+      # Pass the deployed commit so ios-e2e.yml can report a failure status back
+      # onto it. No status is written here — see report-failure in ios-e2e.yml.
       - name: Dispatch iOS E2E against the freshly deployed sandbox
         run: |
           retry() { local n=1; until "$@"; do [ $n -ge 3 ] && return 1; echo "attempt $n failed; retrying in 15s..." >&2; n=$((n+1)); sleep 15; done; }
-          retry gh workflow run ios-e2e.yml --repo "$GITHUB_REPOSITORY" --ref main
+          retry gh workflow run ios-e2e.yml --repo "$GITHUB_REPOSITORY" --ref main -f status_sha="$STATUS_SHA"

--- a/.github/workflows/sandbox.yml
+++ b/.github/workflows/sandbox.yml
@@ -53,10 +53,22 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       actions: write
+      statuses: write
     env:
       GH_TOKEN: ${{ github.token }}
+      STATUS_SHA: ${{ github.sha }}
     steps:
+      # Mark the commit pending immediately so "iOS E2E CI" shows up in its checks
+      # list right away; ios-e2e.yml's report-status job resolves it to
+      # success/failure. Without this the suite is invisible until it finishes.
+      - name: Mark iOS E2E pending on the deployed commit
+        run: |
+          gh api "repos/$GITHUB_REPOSITORY/statuses/$STATUS_SHA" \
+            -f state=pending \
+            -f context="iOS E2E CI" \
+            -f description="Running against sandbox" \
+            -f target_url="$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/workflows/ios-e2e.yml"
       - name: Dispatch iOS E2E against the freshly deployed sandbox
         run: |
           retry() { local n=1; until "$@"; do [ $n -ge 3 ] && return 1; echo "attempt $n failed; retrying in 15s..." >&2; n=$((n+1)); sleep 15; done; }
-          retry gh workflow run ios-e2e.yml --repo "$GITHUB_REPOSITORY" --ref main
+          retry gh workflow run ios-e2e.yml --repo "$GITHUB_REPOSITORY" --ref main -f status_sha="$STATUS_SHA"


### PR DESCRIPTION
Two iOS E2E changes:

- **Run UITests** alongside UnitTests (`only-testing: ["UnitTests", "UITests"]`) now that UnitTests are green end-to-end.
- **Surface E2E failures** as a red `iOS E2E CI` commit status on the tested commit, so a failure shows up in that commit's checks list instead of being buried in the Actions tab.

The status is deliberately kept clear of the deploy path: it's written **only on failure** and **only after the ~15-min suite finishes** — long after CI passes and Cloud 66's redeploy has already fired. On the happy path nothing is added to the commit at all, so it can't delay or block a deploy regardless of whether C66 triggers off a deploy-hook or the combined GitHub status. Manual dispatches (no SHA) skip reporting.
