### PR TITLE
Unscope EmailDomain#calculated_bikes so spam bikes don't let a domain auto-ban itself

### DIFF
--- a/app/models/email_domain.rb
+++ b/app/models/email_domain.rb
@@ -218,7 +218,7 @@ class EmailDomain < ApplicationRecord
   end
 
   def calculated_bikes
-    Bike.matching_domain(domain)
+    Bike.unscoped.matching_domain(domain)
   end
 
   def calculated_b_params

--- a/spec/models/email_domain_spec.rb
+++ b/spec/models/email_domain_spec.rb
@@ -286,4 +286,18 @@ RSpec.describe EmailDomain, type: :model do
       end
     end
   end
+
+  describe "calculated_bikes" do
+    let(:email_domain) { FactoryBot.create(:email_domain, domain: "@example.com") }
+    let!(:bike) { FactoryBot.create(:bike, owner_email: "person@example.com") }
+    let!(:spam_bike) { FactoryBot.create(:bike, owner_email: "spammer@example.com", likely_spam: true) }
+
+    # Regression: Bike's default_scope applies `current`, which excludes likely_spam bikes.
+    # Without unscoping, banning a domain hides that domain's own bikes, dropping
+    # calculated_bike_count and bike_count_blocker?, which lets the domain auto-ban itself.
+    it "includes bikes the default scope hides (likely_spam)" do
+      expect(Bike.matching_domain(email_domain.domain).pluck(:id)).to eq([bike.id])
+      expect(email_domain.calculated_bikes.pluck(:id)).to match_array([bike.id, spam_bike.id])
+    end
+  end
 end


### PR DESCRIPTION
`EmailDomain#calculated_bikes` counted bikes through Bike's `default_scope` (`current`), which excludes `likely_spam` bikes. So once a domain accumulated spam, its own bikes dropped out of the count that powers `bike_count_blocker?` — removing the guard that keeps a domain with real registrations from auto-banning itself, and letting a legitimate domain ban itself in a feedback loop (a banned domain then scores 100 in `SpamEstimator`, flagging every registration on it, including shop/POS imports).

- Unscope `calculated_bikes` so the count includes spam/hidden/deleted bikes matching the domain.
- Add a regression spec asserting `calculated_bikes` includes a `likely_spam` bike that the default scope hides.
