### PR TITLE
Restore Cloud66 production deploy job to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -343,7 +343,7 @@ jobs:
   deploy_production:
     name: "Deploy to production"
     runs-on: ubuntu-latest
-    needs: test
+    needs: [test, lint_and_scan]
     if: github.ref == 'refs/heads/main'
     steps:
       - name: Deploy to Cloud66 production

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -340,6 +340,16 @@ jobs:
           name: test-results-${{ env.KNAPSACK_PRO_CI_NODE_INDEX }}
           path: tmp/rspec-${{ env.KNAPSACK_PRO_CI_NODE_INDEX }}.xml
 
+  deploy_production:
+    name: "Deploy to production"
+    runs-on: ubuntu-latest
+    needs: test
+    if: github.ref == 'refs/heads/main'
+    steps:
+      - name: Deploy to Cloud66 production
+        run: |
+          curl --insecure -X POST -d "" https://hooks.cloud66.com/stacks/redeploy/${{ secrets.CLOUD66_REDEPLOYMENT_KEY }}
+
   # Commenting out for now - it doesn't work for forked pull requests,
   # Which means forked PRs always fail
   # Also - I want to fix the thousands separator

--- a/.github/workflows/ios-e2e.yml
+++ b/.github/workflows/ios-e2e.yml
@@ -11,12 +11,14 @@ permissions:
 # emit the downstream events (like workflow_run) that would fire this. Also
 # dispatchable manually (against whatever sandbox currently serves).
 #
-# status_sha (passed by sandbox.yml) is the bike_index commit under test. On
-# failure, report-failure publishes a red "iOS E2E CI" commit status so it shows
-# in that commit's checks list. Nothing is posted on success, and a failure is
-# written only after the ~15-min suite finishes — long after CI passed and Cloud
-# 66's redeploy fired — so this never adds a status during the deploy window and
-# can't affect the deploy. Blank (manual runs) skips reporting.
+# status_sha (passed by sandbox.yml) is the bike_index commit under test.
+# report-pending publishes a pending "iOS E2E CI" commit status as soon as the
+# suite is dispatched, then report-result replaces it with success or failure once
+# the ~15-min suite finishes — so the check surfaces in the tested commit's list
+# for the whole run, not just on failure at the end. This is safe because Cloud 66
+# deploys from CI's own deploy_production job (needs: [test, lint_and_scan]), which
+# doesn't wait on commit statuses — a pending E2E status can't hold up the deploy.
+# Blank status_sha (manual runs) skips reporting.
 on:
   workflow_dispatch:
     inputs:
@@ -26,6 +28,27 @@ on:
         default: ""
 
 jobs:
+  # Publish a pending "iOS E2E CI" commit status the moment the suite is
+  # dispatched, so the check appears in the tested commit's list while the
+  # ~15-min suite runs (report-result finalizes it). Skipped for manual runs.
+  report-pending:
+    name: Report iOS E2E pending
+    if: ${{ inputs.status_sha != '' }}
+    runs-on: ubuntu-latest
+    permissions:
+      statuses: write
+    env:
+      GH_TOKEN: ${{ github.token }}
+      STATUS_SHA: ${{ inputs.status_sha }}
+    steps:
+      - name: Publish pending commit status
+        run: |
+          gh api "repos/$GITHUB_REPOSITORY/statuses/$STATUS_SHA" \
+            -f state=pending \
+            -f context="iOS E2E CI" \
+            -f description="iOS E2E running" \
+            -f target_url="$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID"
+
   test-suite:
     name: "${{ matrix.device }} ${{ matrix.only-testing }}"
     runs-on: macos-26
@@ -91,14 +114,14 @@ jobs:
           path: "fastlane/test_output/*"
           compression-level: 9 # maximum compression
 
-  # On failure only, publish a red "iOS E2E CI" commit status so the failure
-  # surfaces in the tested commit's checks list. Nothing is posted on success,
-  # and this runs only after the suite completes — well after Cloud 66's post-CI
-  # redeploy — so it never touches the deploy path. Skipped for manual runs.
-  report-failure:
-    name: Report iOS E2E failure
+  # Once the suite completes, replace the pending status with the final
+  # "iOS E2E CI" result (success or failure) on the tested commit. Runs only
+  # after Cloud 66's post-CI redeploy, so it never touches the deploy path.
+  # Skipped for manual runs.
+  report-result:
+    name: Report iOS E2E result
     needs: test-suite
-    if: ${{ always() && inputs.status_sha != '' && needs.test-suite.result != 'success' }}
+    if: ${{ always() && inputs.status_sha != '' }}
     runs-on: ubuntu-latest
     permissions:
       statuses: write
@@ -107,10 +130,12 @@ jobs:
       STATUS_SHA: ${{ inputs.status_sha }}
       RESULT: ${{ needs.test-suite.result }}
     steps:
-      - name: Publish failing commit status
+      - name: Publish final commit status
         run: |
+          state=failure
+          [ "$RESULT" = "success" ] && state=success
           gh api "repos/$GITHUB_REPOSITORY/statuses/$STATUS_SHA" \
-            -f state=failure \
+            -f state="$state" \
             -f context="iOS E2E CI" \
             -f description="iOS E2E $RESULT" \
             -f target_url="$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID"


### PR DESCRIPTION
Restores the `deploy_production` job to CI, hitting the Cloud66 redeploy hook via the `CLOUD66_REDEPLOYMENT_KEY` secret.

- Runs once both the `test` and `lint_and_scan` jobs pass (`needs: [test, lint_and_scan]`), on `main` only — no dependency on the sandbox or E2E workflows.
- Originally added in "Add github actions" (#2606, `e52291ecf`) and removed four days later in "More membership fixes" (#2732, `bfd4b0279`) when deploys moved to the Cloud66 GitHub integration.

Also surfaces the iOS E2E suite as a **pending** "iOS E2E CI" commit status the moment it's dispatched (finalized to success/failure when it completes), rather than only posting on failure at the end. That was previously avoided to keep a status out of the deploy window; it's safe now that the deploy fires from CI's own job rather than waiting on commit statuses.
