### PR TITLE
Move production deploy to its own main-only workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -340,16 +340,6 @@ jobs:
           name: test-results-${{ env.KNAPSACK_PRO_CI_NODE_INDEX }}
           path: tmp/rspec-${{ env.KNAPSACK_PRO_CI_NODE_INDEX }}.xml
 
-  deploy_production:
-    name: "Deploy to production"
-    runs-on: ubuntu-latest
-    needs: [test, lint_and_scan]
-    if: github.ref == 'refs/heads/main'
-    steps:
-      - name: Deploy to Cloud66 production
-        run: |
-          curl --insecure -X POST -d "" https://hooks.cloud66.com/stacks/redeploy/${{ secrets.CLOUD66_REDEPLOYMENT_KEY }}
-
   # Commenting out for now - it doesn't work for forked pull requests,
   # Which means forked PRs always fail
   # Also - I want to fix the thousands separator

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -1,0 +1,31 @@
+name: Deploy production
+
+# Fires the Cloud 66 production redeploy after CI passes on main. Split out of
+# ci.yml (rather than a job gated with `if: github.ref == 'refs/heads/main'`) so
+# it doesn't leave a skipped "Deploy to production" check on every PR and branch.
+#
+# workflow_run — not `on: push` — because the deploy must wait for CI's test and
+# lint_and_scan jobs, which live in a separate workflow. CI is triggered by a real
+# push, so its completion emits the workflow_run event (the GITHUB_TOKEN
+# downstream-event limitation only applies to runs GITHUB_TOKEN itself started).
+# branches: [main] limits this to CI runs on main; the conclusion == 'success'
+# gate below requires the whole CI run to be green before deploying.
+
+on:
+  workflow_run:
+    workflows: ["CI"]
+    types: [completed]
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  deploy_production:
+    name: "Deploy to production"
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Deploy to Cloud66 production
+        run: |
+          curl --insecure -X POST -d "" https://hooks.cloud66.com/stacks/redeploy/${{ secrets.CLOUD66_REDEPLOYMENT_KEY }}

--- a/.github/workflows/ios-e2e.yml
+++ b/.github/workflows/ios-e2e.yml
@@ -16,9 +16,9 @@ permissions:
 # suite is dispatched, then report-result replaces it with success or failure once
 # the ~15-min suite finishes — so the check surfaces in the tested commit's list
 # for the whole run, not just on failure at the end. This is safe because Cloud 66
-# deploys from CI's own deploy_production job (needs: [test, lint_and_scan]), which
-# doesn't wait on commit statuses — a pending E2E status can't hold up the deploy.
-# Blank status_sha (manual runs) skips reporting.
+# deploys from a separate workflow gated on CI's success (deploy-production.yml),
+# which doesn't wait on commit statuses — a pending E2E status can't hold up the
+# deploy. Blank status_sha (manual runs) skips reporting.
 on:
   workflow_dispatch:
     inputs:


### PR DESCRIPTION
Follow-up to #3890. Moves the Cloud 66 production deploy out of `ci.yml` into its own `deploy-production.yml` so it no longer leaves a skipped "Deploy to production" check on every PR and branch.

- Triggered by CI's `workflow_run` completion on `main`, gated on `conclusion == 'success'` — same "only deploy after CI passes" behavior, but now the whole CI run must be green rather than just `test` + `lint_and_scan`.
- The check now attaches only to `main` commits, so PRs stay clean.
