### PR TITLE
iOS E2E: temporarily disable failing UITests

### DIFF
--- a/.github/workflows/ios-e2e.yml
+++ b/.github/workflows/ios-e2e.yml
@@ -56,7 +56,7 @@ jobs:
       max-parallel: 1
       matrix:
         device: ["iPhone 17"] # "iPhone 17 Pro", "iPad (A16)"
-        only-testing: ["UnitTests", "UITests"]
+        only-testing: ["UnitTests"] # "UITests" (failing, temporarily disabled)
 
     steps:
       - name: Checkout bike_index_ios


### PR DESCRIPTION
Comment out the iOS `UITests` in the E2E matrix so only `UnitTests` run — the UITests added in #3888 are failing. The failure-reporting jobs and everything else are untouched, so the green UnitTests suite keeps reporting its commit status.
