### PR TITLE
Show hidden and banned user profiles to superusers with an alert

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -119,6 +119,10 @@ class UsersController < ApplicationController
       redirect_to(my_account_url, notice: translation(:user_not_sharing)) && return
     end
 
+    unless @user.show_bikes
+      @profile_hidden_reason = (user == current_user) ? :owner : :superuser
+    end
+
     @per_page = permitted_per_page(default: 15)
     @pagy, @bikes = pagy(:countish, user.bikes(false), limit: @per_page, page: permitted_page)
   end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -106,13 +106,16 @@ class UsersController < ApplicationController
 
   def show
     user = User.find_by_username(params[:id])
-    if user.nil? || user.banned? || user.email_banned?
+    raise ActionController::RoutingError.new("Not Found") if user.nil?
+
+    @user_banned = user.banned? || user.email_banned?
+    if @user_banned && !current_user&.superuser?
       raise ActionController::RoutingError.new("Not Found")
     end
 
     @owner = user
     @user = user
-    unless user == current_user || @user.show_bikes
+    unless user == current_user || @user.show_bikes || current_user&.superuser?
       redirect_to(my_account_url, notice: translation(:user_not_sharing)) && return
     end
 

--- a/app/views/users/show.html.haml
+++ b/app/views/users/show.html.haml
@@ -2,6 +2,8 @@
   .container
     - if @user_banned
       = render(UI::Alert::Component.new(kind: :error, header: t(".banned_user"), text: t(".banned_only_visible_to_superusers")))
+    - elsif @profile_hidden_reason
+      = render(UI::Alert::Component.new(kind: :notice, header: t(".profile_hidden"), text: t(".profile_hidden_#{@profile_hidden_reason}")))
     .row
       .col-md-6
         .row

--- a/app/views/users/show.html.haml
+++ b/app/views/users/show.html.haml
@@ -1,5 +1,7 @@
 .user-page
   .container
+    - if @user_banned
+      = render(UI::Alert::Component.new(kind: :error, header: t(".banned_user"), text: t(".banned_only_visible_to_superusers")))
     .row
       .col-md-6
         .row

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -5222,6 +5222,9 @@ en:
         a superuser.
       banned_user: This user is banned
       bikes: Bikes
+      profile_hidden: This profile isn't shared publicly
+      profile_hidden_owner: It's only visible to you because it's your page.
+      profile_hidden_superuser: It's only visible because you're a superuser.
       stolen: Stolen!
       this_user_has_no_bikes_yet: This user has no bikes yet!
       this_users_bikes: This user's bikes

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -5218,6 +5218,9 @@ en:
       weve_sent_an_email: We've sent an email to the address you have on file with
         us.
     show:
+      banned_only_visible_to_superusers: Their profile is only visible because you're
+        a superuser.
+      banned_user: This user is banned
       bikes: Bikes
       stolen: Stolen!
       this_user_has_no_bikes_yet: This user has no bikes yet!

--- a/spec/requests/users_request_spec.rb
+++ b/spec/requests/users_request_spec.rb
@@ -492,6 +492,19 @@ RSpec.describe UsersController, type: :request do
       end
     end
 
+    context "owner viewing their own hidden page" do
+      include_context :request_spec_logged_in_as_user
+      let(:current_user) { FactoryBot.create(:user_confirmed, show_bikes: false) }
+
+      it "renders with a notice that only they can see it" do
+        get "#{base_url}/#{current_user.username}"
+        expect(response.status).to eq 200
+        expect(response).to render_template :show
+        expect(assigns(:profile_hidden_reason)).to eq :owner
+        expect(response.body).to match(/only visible to you/i)
+      end
+    end
+
     context "user shows their page" do
       let(:show_bikes) { true }
 
@@ -531,6 +544,17 @@ RSpec.describe UsersController, type: :request do
         expect(response).to render_template :show
         expect(assigns(:user_banned)).to be_truthy
         expect(response.body).to match(/is banned/)
+      end
+    end
+
+    context "superuser viewing a hidden unbanned user" do
+      include_context :request_spec_logged_in_as_superuser
+
+      it "renders with a notice that only a superuser can see it" do
+        get "#{base_url}/#{user.username}"
+        expect(response.status).to eq 200
+        expect(assigns(:profile_hidden_reason)).to eq :superuser
+        expect(response.body).to match(/only visible because you/i)
       end
     end
   end

--- a/spec/requests/users_request_spec.rb
+++ b/spec/requests/users_request_spec.rb
@@ -520,6 +520,19 @@ RSpec.describe UsersController, type: :request do
         end
       end
     end
+
+    context "superuser viewing a banned user" do
+      include_context :request_spec_logged_in_as_superuser
+      let(:user) { FactoryBot.create(:user_confirmed, show_bikes:, banned: true) }
+
+      it "renders the profile with a banned alert" do
+        get "#{base_url}/#{user.username}"
+        expect(response.status).to eq 200
+        expect(response).to render_template :show
+        expect(assigns(:user_banned)).to be_truthy
+        expect(response.body).to match(/is banned/)
+      end
+    end
   end
 
   describe "unsubscribe" do


### PR DESCRIPTION
Banned (and email-banned) users' profiles previously returned a 404 for everyone, and profiles with public sharing turned off were only reachable by their owner. Superusers can now open both, each topped with an alert explaining why it's visible to them.

- Let superusers through the ban check and the `show_bikes` privacy redirect in `UsersController#show`
- Red alert on a banned profile ("This user is banned — only visible because you're a superuser")
- Notice on an unshared profile, worded for whoever can see it — the owner ("only visible to you because it's your page") or a superuser
