### PR TITLE
Seed a found bike and an unregistered parking notification

### DIFF
--- a/db/seeds/seed_bikes.rb
+++ b/db/seeds/seed_bikes.rb
@@ -119,6 +119,39 @@ found_locations.each_with_index do |loc, i|
   end
 end
 
+# --- 1 found bike reported by the primary test user (user@bikeindex.org) ---
+puts "Creating found bike reported by user@bikeindex.org..."
+found_bike_location = {latitude: 37.7691, longitude: -122.4449, street: "1000 Stanyan St", city: "San Francisco", zipcode: "94117"}
+specialized_manufacturer = Manufacturer.friendly_find("Specialized")
+
+user_found_bike = seed_bike(
+  creator:, user:, label: "Found bike",
+  params: {
+    bike: bike_params(owner_email: user.email, manufacturer_id: specialized_manufacturer&.id).merge(
+      frame_model: "Sirrus",
+      description: "Found unlocked near the Golden Gate Park tennis courts",
+      status: "status_impounded"
+    ),
+    impound_record: {
+      address_record_attributes: {
+        street: found_bike_location[:street],
+        city: found_bike_location[:city],
+        zipcode: found_bike_location[:zipcode],
+        state_id: ca_state&.id.to_s,
+        country_id: us&.id.to_s,
+        skip_geocoding: true
+      }
+    }
+  }
+)
+unless user_found_bike.errors.any?
+  impound_record = user_found_bike.current_impound_record
+  ProcessImpoundUpdatesJob.new.perform(impound_record.id)
+  impound_record.reload
+  impound_record.address_record&.update_columns(latitude: found_bike_location[:latitude], longitude: found_bike_location[:longitude])
+  puts "  Created found bike at #{found_bike_location[:street]}, #{found_bike_location[:city]}"
+end
+
 # --- 3 Cannondale bikes registered to Cannondale org ---
 cannondale_org = Organization.friendly_find("Cannondale")
 cannondale_manufacturer = Manufacturer.friendly_find("Cannondale")

--- a/db/seeds/seed_organization_bikes_and_associations.rb
+++ b/db/seeds/seed_organization_bikes_and_associations.rb
@@ -66,6 +66,24 @@ def seed_org_bike(creator:, user:, owner_email:, creation_organization_id: Organ
   bike
 end
 
+# Register an unknown-serial bike together with its parking notification, the way
+# the organized "unregistered" flow does (no ProcessParkingNotificationJob email).
+def seed_unregistered_parking_notification(creator:, member:, owner_email:, loc:, kind:, region_record_id:, country_id:)
+  b_param = BParam.create!(
+    creator: member,
+    params: {
+      bike: org_bike_params(owner_email:).merge(serial_number: "unknown"),
+      parking_notification: {kind:, street: loc[:street], city: loc[:city], postal_code: loc[:postal_code], region_record_id:, country_id:, skip_geocoding: true}
+    }
+  )
+  b_param.origin = "organization_form"
+  bike = creator.create_bike(b_param)
+  raise "Unregistered bike creation failed: #{b_param.bike_errors}" if bike.errors.any?
+  bike.parking_notifications.last&.update_columns(latitude: loc[:latitude], longitude: loc[:longitude])
+  puts "  Created unregistered parking notification at #{loc[:street]}"
+  bike
+end
+
 puts "Creating parking notifications in San Francisco..."
 
 # Create 10 initial parking notifications
@@ -116,29 +134,11 @@ end
   puts "  Created impound notification ##{i + 1} with ImpoundRecord ##{pn.impound_record_id}"
 end
 
-# Create 1 unregistered_parking_notification via BikeServices::Creator
-loc = sf_locations[10]
-unreg_b_param = BParam.create!(
-  creator: member,
-  params: {
-    bike: org_bike_params(owner_email: member.email)
-      .merge(serial_number: "unknown"),
-    parking_notification: {
-      kind: "parked_incorrectly_notification",
-      street: loc[:street],
-      city: loc[:city],
-      postal_code: loc[:postal_code],
-      region_record_id: ca_state&.id,
-      country_id: us&.id,
-      skip_geocoding: true
-    }
-  }
-)
-unreg_b_param.origin = "organization_form"
-unreg_bike = creator.create_bike(unreg_b_param)
-raise "Unregistered bike creation failed: #{unreg_b_param.bike_errors}" if unreg_bike.errors.any?
-unreg_bike.parking_notifications.last&.update_columns(latitude: loc[:latitude], longitude: loc[:longitude])
-puts "  Created unregistered parking notification at #{loc[:street]}"
+# Create 2 unregistered_parking_notifications: one for the member, one owned by the primary test user
+seed_unregistered_parking_notification(creator:, member:, owner_email: member.email, loc: sf_locations[10],
+  kind: "parked_incorrectly_notification", region_record_id: ca_state&.id, country_id: us&.id)
+seed_unregistered_parking_notification(creator:, member:, owner_email: user.email, loc: sf_locations[11],
+  kind: "appears_abandoned_notification", region_record_id: ca_state&.id, country_id: us&.id)
 
 puts "Parking notifications seeded successfully!"
 


### PR DESCRIPTION
Give the primary demo account (`user@bikeindex.org`) both a found bike and an unregistered parking notification, so those states are visible after seeding without digging into the anonymous `testuser+N` / `member` records.

- **Found bike** — a Specialized Sirrus reported as found (impound record, no organization → `kind: found`) at 1000 Stanyan St, SF, owned by `user@bikeindex.org`.
- **Unregistered parking notification** — a second `unregistered_parking_notification` owned by `user@bikeindex.org`, alongside the existing member-owned one.
- Extracted a `seed_unregistered_parking_notification` helper so both notifications share one flow instead of duplicating the block.
