### PR TITLE
Don't show impound claim for org-impounded bikes unless unregistered

### DIFF
--- a/app/services/bike_services/displayer.rb
+++ b/app/services/bike_services/displayer.rb
@@ -28,7 +28,10 @@ module BikeServices
 
     def display_impound_claim?(bike, user = nil)
       return false if bike.owner.present? && bike.owner == user
-      return true if bike.current_impound_record.present?
+      if (impound_record = bike.current_impound_record).present?
+        # Bikes impounded by an organization can't be claimed, unless unregistered
+        return impound_record.unregistered_bike? || !impound_record.organized?
+      end
       return false if user.blank?
 
       bike.impound_claims_submitting.active.where(user_id: user.id).any? ||

--- a/spec/services/bike_services/displayer_spec.rb
+++ b/spec/services/bike_services/displayer_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe BikeServices::Displayer do
     it "is falsey if bike doesn't have impounded" do
       expect(BikeServices::Displayer.display_impound_claim?(bike)).to be_falsey
     end
-    context "impound bike" do
+    context "found bike (no organization)" do
       let(:impound_record) { ImpoundRecord.new(bike: bike) }
       before { allow(bike).to receive(:current_impound_record) { impound_record } }
       it "is truthy" do
@@ -52,6 +52,25 @@ RSpec.describe BikeServices::Displayer do
         expect(BikeServices::Displayer.display_impound_claim?(bike, User.new)).to be_truthy
         expect(BikeServices::Displayer.display_impound_claim?(bike, admin)).to be_truthy
         expect(BikeServices::Displayer.display_impound_claim?(bike, owner)).to be_falsey
+      end
+    end
+    context "impounded by an organization" do
+      let(:impound_record) { ImpoundRecord.new(bike: bike, organization: Organization.new) }
+      before { allow(bike).to receive(:current_impound_record) { impound_record } }
+      it "is falsey" do
+        expect(BikeServices::Displayer.display_impound_claim?(bike)).to be_falsey
+        expect(BikeServices::Displayer.display_impound_claim?(bike, User.new)).to be_falsey
+        expect(BikeServices::Displayer.display_impound_claim?(bike, admin)).to be_falsey
+        expect(BikeServices::Displayer.display_impound_claim?(bike, owner)).to be_falsey
+      end
+      context "unregistered parking notification" do
+        let(:impound_record) { ImpoundRecord.new(bike: bike, organization: Organization.new, unregistered_bike: true) }
+        it "is truthy" do
+          expect(BikeServices::Displayer.display_impound_claim?(bike)).to be_truthy
+          expect(BikeServices::Displayer.display_impound_claim?(bike, User.new)).to be_truthy
+          expect(BikeServices::Displayer.display_impound_claim?(bike, admin)).to be_truthy
+          expect(BikeServices::Displayer.display_impound_claim?(bike, owner)).to be_falsey
+        end
       end
     end
     context "impound_claim for bike" do


### PR DESCRIPTION
Bikes impounded by an organization can no longer be claimed through the impound-claim UI, since the impounding org already knows who has the bike.

- `BikeServices::Displayer.display_impound_claim?` now returns false when the current impound record is `organized?`, unless the record is for an unregistered parking notification (`unregistered_bike?`).
- Found (non-org) bikes are unaffected and remain claimable.
