### PR TITLE
Parameterize the screenshot base branch for before/after

### DIFF
--- a/.claude/skills/frontend-screenshots/SKILL.md
+++ b/.claude/skills/frontend-screenshots/SKILL.md
@@ -94,6 +94,8 @@ The preview page loads Tailwind and renders the component standalone (no site ch
 
 Previews that query the dev DB (e.g. `User.admins.first`) render nothing when that data is missing — if the state doesn't appear, seed first with `bundle exec rails db:seed`. This is component-only: a preview can't show layout/stacking against the rest of the page (e.g. a navbar z-index fix), so use a real page for those.
 
+**Editing a component while capturing 404s its preview.** Any change to a component file under a running `bin/dev` — an edit you make mid-session, or a `git checkout` that swaps the files — de-registers the ViewComponent preview, so the route 404s (`Component preview '…' not found`) and stays 404 until the dev server restarts. So capture the preview *before* touching the component, or restart `bin/dev` after editing to reshoot. Ordinary page routes reload fine and aren't affected.
+
 ## Cross-branch comparison (optional)
 
 When the caller wants before/after, repeat the capture loop against the base ref. The caller passes the base — `origin/main` by default, or the PR's actual base when it isn't `main` (a stacked PR's base often isn't). Set `BASE_REF` to that remote ref (e.g. `origin/main`, `origin/sethherr/feature-x`) and use it throughout; `git fetch origin` first so it's current.
@@ -106,7 +108,7 @@ A `Gemfile.lock` diff is **not** a reason to abort.
 
 The seeded DB persists across checkouts, so the existing session usually still works.
 
-**Lookbook/ViewComponent preview URLs can't be captured on the base this way.** Ordinary page routes reload on the next request after the checkout, so their before/after works against any `$BASE_REF`. But preview routes (`/rails/view_components/...`, `/lookbook/...`) 404 once you check out a different ref while `bin/dev` is running — the preview registry goes stale and stays 404 even after checking back, until the dev server restarts. So the base capture of a preview URL fails outright. For preview-based captures, stay branch-only and say so in the comment; the parameterized base only enables before/after for real page URLs.
+**Lookbook/ViewComponent preview URLs can't be captured on the base this way.** Ordinary page routes reload on the next request after the checkout, so their before/after works against any `$BASE_REF`. But preview routes (`/rails/view_components/...`, `/lookbook/...`) 404 once a component file changes under a running `bin/dev` — the checkout here, but also any edit you make to a component mid-session (see "Component previews" above). The preview registry de-registers and stays 404 even after the files revert, until the dev server restarts. So the base capture of a preview URL fails outright. For preview-based captures, stay branch-only and say so in the comment; the parameterized base only enables before/after for real page URLs.
 
 ## Clean up
 

--- a/.claude/skills/frontend-screenshots/SKILL.md
+++ b/.claude/skills/frontend-screenshots/SKILL.md
@@ -94,8 +94,6 @@ The preview page loads Tailwind and renders the component standalone (no site ch
 
 Previews that query the dev DB (e.g. `User.admins.first`) render nothing when that data is missing — if the state doesn't appear, seed first with `bundle exec rails db:seed`. This is component-only: a preview can't show layout/stacking against the rest of the page (e.g. a navbar z-index fix), so use a real page for those.
 
-**Editing a component while capturing 404s its preview.** Any change to a component file under a running `bin/dev` — an edit you make mid-session, or a `git checkout` that swaps the files — de-registers the ViewComponent preview, so the route 404s (`Component preview '…' not found`) and stays 404 until the dev server restarts. So capture the preview *before* touching the component, or restart `bin/dev` after editing to reshoot. Ordinary page routes reload fine and aren't affected.
-
 ## Cross-branch comparison (optional)
 
 When the caller wants before/after, repeat the capture loop against the base ref. The caller passes the base — `origin/main` by default, or the PR's actual base when it isn't `main` (a stacked PR's base often isn't). Set `BASE_REF` to that remote ref (e.g. `origin/main`, `origin/sethherr/feature-x`) and use it throughout; `git fetch origin` first so it's current.
@@ -106,9 +104,7 @@ When the caller wants before/after, repeat the capture loop against the base ref
 
 A `Gemfile.lock` diff is **not** a reason to abort.
 
-The seeded DB persists across checkouts, so the existing session usually still works.
-
-**Lookbook/ViewComponent preview URLs can't be captured on the base this way.** Ordinary page routes reload on the next request after the checkout, so their before/after works against any `$BASE_REF`. But preview routes (`/rails/view_components/...`, `/lookbook/...`) 404 once a component file changes under a running `bin/dev` — the checkout here, but also any edit you make to a component mid-session (see "Component previews" above). The preview registry de-registers and stays 404 even after the files revert, until the dev server restarts. So the base capture of a preview URL fails outright. For preview-based captures, stay branch-only and say so in the comment; the parameterized base only enables before/after for real page URLs.
+The seeded DB persists across checkouts, so the existing session usually still works. Preview routes (`/rails/view_components/...`, `/lookbook/...`) reload across the checkout like ordinary pages, so their before/after works against any `$BASE_REF` too.
 
 ## Clean up
 

--- a/.claude/skills/frontend-screenshots/SKILL.md
+++ b/.claude/skills/frontend-screenshots/SKILL.md
@@ -22,7 +22,7 @@ Drive Playwright MCP to capture viewport screenshots of pages served by `bin/dev
 
 ## Output filenames (load-bearing — callers parse these)
 
-`tmp/pr_screenshots/<branch>-<page>-<timestamp>-{desktop,mobile}.png`, where `<branch>=$(git rev-parse --abbrev-ref HEAD | tr '/' '-')` and `<timestamp>=$(date +%Y%m%d-%H%M%S)`. Cross-branch shots get an extra `-main-` segment.
+`tmp/pr_screenshots/<branch>-<page>-<timestamp>-{desktop,mobile}.png`, where `<branch>=$(git rev-parse --abbrev-ref HEAD | tr '/' '-')` and `<timestamp>=$(date +%Y%m%d-%H%M%S)`. Cross-branch shots get an extra `-base-` segment.
 
 ## Preflight
 
@@ -96,15 +96,17 @@ Previews that query the dev DB (e.g. `User.admins.first`) render nothing when th
 
 ## Cross-branch comparison (optional)
 
-When the caller wants before/after, repeat the capture loop against `main`.
+When the caller wants before/after, repeat the capture loop against the base ref. The caller passes the base — `origin/main` by default, or the PR's actual base when it isn't `main` (a stacked PR's base often isn't). Set `BASE_REF` to that remote ref (e.g. `origin/main`, `origin/sethherr/feature-x`) and use it throughout; `git fetch origin` first so it's current.
 
 1. `git status` — abort if there are uncommitted changes.
-2. Diff `db/migrate/` between the branch and `main`; abort if it changed — a branch-only migration leaves the DB schema ahead of `main`'s code, so `main` pages can error.
-3. `BRANCH=$(git rev-parse --abbrev-ref HEAD)`, `git checkout origin/main` (detached — `git checkout main` fails if a sibling worktree holds the `main` branch; detached HEAD at `origin/main` is allowed concurrently and is the same code), navigate the browser to force Rails to reload the changed files, repeat capture into `...-main-...` filenames, then `git checkout $BRANCH`.
+2. Diff `db/migrate/` between the branch and `$BASE_REF`; abort if it changed — a branch-only migration leaves the DB schema ahead of the base's code, so base pages can error.
+3. `BRANCH=$(git rev-parse --abbrev-ref HEAD)`, `git checkout --detach $BASE_REF` (detached — checking out a branch name fails if a sibling worktree holds it; detached HEAD at the remote ref is allowed concurrently and is the same code), navigate the browser to force Rails to reload the changed files, repeat capture into `...-base-...` filenames, then `git checkout $BRANCH`.
 
 A `Gemfile.lock` diff is **not** a reason to abort.
 
 The seeded DB persists across checkouts, so the existing session usually still works.
+
+**Lookbook/ViewComponent preview URLs can't be captured on the base this way.** Ordinary page routes reload on the next request after the checkout, so their before/after works against any `$BASE_REF`. But preview routes (`/rails/view_components/...`, `/lookbook/...`) 404 once you check out a different ref while `bin/dev` is running — the preview registry goes stale and stays 404 even after checking back, until the dev server restarts. So the base capture of a preview URL fails outright. For preview-based captures, stay branch-only and say so in the comment; the parameterized base only enables before/after for real page URLs.
 
 ## Clean up
 

--- a/.claude/skills/pr/references/screenshots.md
+++ b/.claude/skills/pr/references/screenshots.md
@@ -37,9 +37,9 @@ Capture the **base-branch** (`$BASE` from SKILL.md step 0.5) version of every sc
 
 Skip per-page only when the URL didn't exist on `$BASE` (a brand-new route or page added in this PR) — there's nothing to compare to.
 
-Re-invoke `frontend-screenshots` with the same `(url-path, page-slug)` pairs and tell it to capture against the base (its "Cross-branch comparison" section — checks out the base ref, captures into `...-main-...` filenames, returns to the original branch). Then re-invoke `github-upload-image-to-pr` for those PNGs (upload-only, exactly as in step 3 — collect URLs, do not post).
+Re-invoke `frontend-screenshots` with the same `(url-path, page-slug)` pairs and tell it to capture against the base — pass `$BASE` (from SKILL.md step 0.5) as its `BASE_REF` so it checks out `origin/$BASE`, whether or not that's `main` (its "Cross-branch comparison" section checks out the base ref, captures into `...-base-...` filenames, returns to the original branch). Then re-invoke `github-upload-image-to-pr` for those PNGs (upload-only, exactly as in step 3 — collect URLs, do not post).
 
-Caveat when `$BASE` isn't `main`: `frontend-screenshots` currently hardcodes `origin/main` for that capture, so it can't shoot a non-`main` base yet. Until it's parameterized, capture branch-only for a non-`main` base and say so in the comment rather than posting a mislabeled comparison.
+Caveat for preview URLs: `frontend-screenshots` can't capture the base version of a Lookbook/ViewComponent preview (`/rails/view_components/...`, `/lookbook/...`) — the base checkout leaves the preview route 404ing until `bin/dev` restarts. So for preview-based captures, stay branch-only and say so in the comment rather than posting a mislabeled comparison. Real page URLs compare cleanly against any `$BASE`.
 
 ## 5. Post the Screenshots section as a PR comment
 

--- a/.claude/skills/pr/references/screenshots.md
+++ b/.claude/skills/pr/references/screenshots.md
@@ -39,8 +39,6 @@ Skip per-page only when the URL didn't exist on `$BASE` (a brand-new route or pa
 
 Re-invoke `frontend-screenshots` with the same `(url-path, page-slug)` pairs and tell it to capture against the base — pass `$BASE` (from SKILL.md step 0.5) as its `BASE_REF` so it checks out `origin/$BASE`, whether or not that's `main` (its "Cross-branch comparison" section checks out the base ref, captures into `...-base-...` filenames, returns to the original branch). Then re-invoke `github-upload-image-to-pr` for those PNGs (upload-only, exactly as in step 3 — collect URLs, do not post).
 
-Caveat for preview URLs: `frontend-screenshots` can't capture the base version of a Lookbook/ViewComponent preview (`/rails/view_components/...`, `/lookbook/...`) — the base checkout leaves the preview route 404ing until `bin/dev` restarts. So for preview-based captures, stay branch-only and say so in the comment rather than posting a mislabeled comparison. Real page URLs compare cleanly against any `$BASE`.
-
 ## 5. Post the Screenshots section as a PR comment
 
 On a fresh PR, this comment is naturally the first one. On an update, find the existing screenshots comment (the one authored by you whose body starts with `## Screenshots`) and edit it in place rather than posting a new one:


### PR DESCRIPTION
Parameterize the base ref in the `frontend-screenshots` skill so cross-branch before/after captures work off any base, not just `main`.

- `frontend-screenshots` now takes a caller-passed `BASE_REF` (default `origin/main`), checks out that ref detached, and names the "before" shots with a `-base-` segment; the `pr` skill passes its `$BASE` through so a PR stacked on a non-`main` base gets an automated comparison.
- Drops the preview-URL 404 caveats: with the `lookbook.rb` reload fix (#3903) now on `main`, ViewComponent previews stay registered across edits and checkouts, so preview URLs compare cleanly against any base with no `bin/dev` restart.
