### PR TITLE
Add Org::OriginDisplay component with an origin-title tooltip

### DIFF
--- a/.claude/skills/frontend-conventions/SKILL.md
+++ b/.claude/skills/frontend-conventions/SKILL.md
@@ -52,7 +52,7 @@ The same instinct applies beyond buttons: **check `app/components/ui/` and `app/
 
 ## Tooltips: default `?` button trigger
 
-**Every `UI::Tooltip` uses the default `?` button trigger** unless the user explicitly says otherwise — never pass a label as the tooltip's trigger content. See `app/components/ui/tooltip/` and `Org::OriginDisplay::Component`.
+**Every `UI::Tooltip` uses the default `?` button trigger** unless the user explicitly says otherwise — never pass a label as the tooltip's trigger content. See `app/components/ui/tooltip/`.
 
 ## Typeaheads: always `Form::Combobox`
 

--- a/.claude/skills/frontend-conventions/SKILL.md
+++ b/.claude/skills/frontend-conventions/SKILL.md
@@ -50,6 +50,10 @@ The `bin/dev` command handles building and updating Tailwind and JS.
 
 The same instinct applies beyond buttons: **check `app/components/ui/` and `app/components/form/` before hand-rolling any UI primitive** (dropdowns → `UI::Dropdown`, tooltips → `UI::Tooltip`, badges, modals, pagination, tables…). If a `UI::*`/`Form::*` component exists for the pattern, use it; if it almost fits, extend it rather than forking its markup inline.
 
+## Tooltips: default `?` button trigger
+
+**Every `UI::Tooltip` uses the default `?` button trigger** unless the user explicitly says otherwise — never pass a label as the tooltip's trigger content. To keep a label visible, render it alongside the default-button tooltip. See `app/components/ui/tooltip/` and `Org::OriginDisplay::Component`.
+
 ## Typeaheads: always `Form::Combobox`
 
 **Every typeahead / autocomplete / combobox goes through `Form::Combobox::Component`** — never a new Stimulus controller that fetches matches and renders its own menu. See `app/components/form/combobox/` (component + `component_preview.rb`) and `spec/components/form/combobox` for how to invoke it.

--- a/.claude/skills/frontend-conventions/SKILL.md
+++ b/.claude/skills/frontend-conventions/SKILL.md
@@ -52,7 +52,7 @@ The same instinct applies beyond buttons: **check `app/components/ui/` and `app/
 
 ## Tooltips: default `?` button trigger
 
-**Every `UI::Tooltip` uses the default `?` button trigger** unless the user explicitly says otherwise — never pass a label as the tooltip's trigger content. To keep a label visible, render it alongside the default-button tooltip. See `app/components/ui/tooltip/` and `Org::OriginDisplay::Component`.
+**Every `UI::Tooltip` uses the default `?` button trigger** unless the user explicitly says otherwise — never pass a label as the tooltip's trigger content. See `app/components/ui/tooltip/` and `Org::OriginDisplay::Component`.
 
 ## Typeaheads: always `Form::Combobox`
 

--- a/app/components/admin/bike_cell/component.rb
+++ b/app/components/admin/bike_cell/component.rb
@@ -63,9 +63,7 @@ module Admin
             concat(content_tag(:em, " unregistered", class: "small text-warning"))
           elsif @bike.creation_description.present?
             concat(", ")
-            concat(content_tag(:small, class: "less-strong") do
-              content_tag(:span, @bike.creation_description, title: BikeServices::Displayer.origin_title(@bike.creation_description))
-            end)
+            concat(content_tag(:small, render(Org::OriginDisplay::Component.new(creation_description: @bike.creation_description)), class: "less-strong"))
           end
         end
       end

--- a/app/components/org/bike_access_panel/component.html.erb
+++ b/app/components/org/bike_access_panel/component.html.erb
@@ -197,7 +197,7 @@
 
                   <td>
                     <em>
-                      <%= origin_display(@bike.creation_description) %>
+                      <%= render(Org::OriginDisplay::Component.new(creation_description: @bike.creation_description)) %>
 
                       <% unless current_ownership.initial? %>
                         <span class="localizeTime">
@@ -211,7 +211,7 @@
                         <%= translation(".initial_registration") %>
 
                         <em>
-                          <%= origin_display(original_ownership.creation_description) %>
+                          <%= render(Org::OriginDisplay::Component.new(creation_description: original_ownership.creation_description)) %>
                         </em>
                       </small>
                     <% end %>
@@ -473,7 +473,7 @@
 
                     <td>
                       <em class="less-strong">
-                        <%= origin_display(@bike.creation_description) %>
+                        <%= render(Org::OriginDisplay::Component.new(creation_description: @bike.creation_description)) %>
                       </em>
                     </td>
 

--- a/app/components/org/origin_display/component.rb
+++ b/app/components/org/origin_display/component.rb
@@ -12,7 +12,7 @@ module Org
       end
 
       def call
-        render(UI::Tooltip::Component.new(text: BikeServices::Displayer.origin_title(@creation_description))) { @creation_description }
+        safe_join([@creation_description, render(UI::Tooltip::Component.new(text: BikeServices::Displayer.origin_title(@creation_description)))], " ")
       end
     end
   end

--- a/app/components/org/origin_display/component.rb
+++ b/app/components/org/origin_display/component.rb
@@ -3,6 +3,12 @@
 module Org
   module OriginDisplay
     class Component < ApplicationComponent
+      EXTENDED_DESCRIPTIONS = {
+        "web" => "Registered with self registration process",
+        "org reg" => "Registered by internal, organization member form",
+        "landing page" => "Registration began with incomplete registration, via organization landing page",
+        "bulk reg" => "Registered by spreadsheet import"
+      }.freeze
       def initialize(creation_description:)
         @creation_description = creation_description
       end
@@ -12,7 +18,17 @@ module Org
       end
 
       def call
-        safe_join([@creation_description, render(UI::Tooltip::Component.new(text: BikeServices::Displayer.origin_title(@creation_description)))], " ")
+        safe_join([@creation_description, render(UI::Tooltip::Component.new(text: origin_title))], " ")
+      end
+
+      private
+
+      def origin_title
+        if %w[Lightspeed Ascend].include?(@creation_description)
+          "Automatically registered by bike shop point of sale (#{@creation_description} POS)"
+        else
+          EXTENDED_DESCRIPTIONS[@creation_description] || "Registered via #{@creation_description}"
+        end
       end
     end
   end

--- a/app/components/org/origin_display/component.rb
+++ b/app/components/org/origin_display/component.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module Org
+  module OriginDisplay
+    class Component < ApplicationComponent
+      def initialize(creation_description:)
+        @creation_description = creation_description
+      end
+
+      def render?
+        @creation_description.present?
+      end
+
+      def call
+        render(UI::Tooltip::Component.new(text: BikeServices::Displayer.origin_title(@creation_description))) { @creation_description }
+      end
+    end
+  end
+end

--- a/app/components/org/search_results/bikes_table/component.html.erb
+++ b/app/components/org/search_results/bikes_table/component.html.erb
@@ -79,7 +79,7 @@
     <% table.column(label: translation(".source"), classes: "hideableColumn creation_description_cell tw:leading-none") do |bike| %>
       <% if bike.creation_description %>
         <small class="tw:text-gray-400">
-          <%= helpers.origin_display(bike.creation_description) %>
+          <%= render(Org::OriginDisplay::Component.new(creation_description: bike.creation_description)) %>
         </small>
       <% end %>
     <% end %>

--- a/app/helpers/organized_helper.rb
+++ b/app/helpers/organized_helper.rb
@@ -24,15 +24,9 @@ module OrganizedHelper
         concat(content_tag(:em, " unregistered", class: "small text-warning"))
       elsif !skip_creation && bike.creation_description.present?
         concat(", ")
-        concat(content_tag(:small, origin_display(bike.creation_description), class: "less-strong"))
+        concat(content_tag(:small, render(Org::OriginDisplay::Component.new(creation_description: bike.creation_description)), class: "less-strong"))
       end
     end
-  end
-
-  def origin_display(creation_description)
-    return "" unless creation_description.present?
-
-    content_tag(:span, creation_description, title: BikeServices::Displayer.origin_title(creation_description))
   end
 
   # Used in two places, so... putting it here. Probably is a better place somewhere else

--- a/app/services/bike_services/displayer.rb
+++ b/app/services/bike_services/displayer.rb
@@ -115,22 +115,6 @@ module BikeServices
       single_image_hash(bike.public_images.limit(1)&.first&.image_url(:large))
     end
 
-    def origin_title(creation_description)
-      return nil unless creation_description.present?
-
-      extended_description = {
-        "web" => "Registered with self registration process",
-        "org reg" => "Registered by internal, organization member form",
-        "landing page" => "Registration began with incomplete registration, via organization landing page",
-        "bulk reg" => "Registered by spreadsheet import"
-      }
-      if %w[Lightspeed Ascend].include?(creation_description)
-        "Automatically registered by bike shop point of sale (#{creation_description} POS)"
-      else
-        extended_description[creation_description] || "Registered via #{creation_description}"
-      end
-    end
-
     #
     # private below here
     #

--- a/app/views/admin/bikes/_bike_tabs.html.haml
+++ b/app/views/admin/bikes/_bike_tabs.html.haml
@@ -109,7 +109,7 @@
                     \-
                     %em
                       Via
-                      = origin_display(bike.creation_description)
+                      = render(Org::OriginDisplay::Component.new(creation_description: bike.creation_description))
                     - if bike.current_ownership&.doorkeeper_app_id.present?
                       %small.less-strong
                         oauth app

--- a/app/views/admin/bikes/_table.html.erb
+++ b/app/views/admin/bikes/_table.html.erb
@@ -131,9 +131,9 @@
           <% if bike.creation_description %>
             <span class="tw:absolute tw:right-0 tw:bottom-0 tw:text-xs tw:text-gray-400">
               <% if bike.bulk_import.present? %>
-                <%= link_to helpers.origin_display(bike.creation_description), admin_bulk_import_path(bike.bulk_import), class: "tw:text-gray-400" %>
+                <%= link_to render(Org::OriginDisplay::Component.new(creation_description: bike.creation_description)), admin_bulk_import_path(bike.bulk_import), class: "tw:text-gray-400" %>
               <% else %>
-                <%= helpers.origin_display(bike.creation_description) %>
+                <%= render(Org::OriginDisplay::Component.new(creation_description: bike.creation_description)) %>
               <% end %>
             </span>
           <% end %>

--- a/app/views/admin/bikes/_table.html.erb
+++ b/app/views/admin/bikes/_table.html.erb
@@ -130,10 +130,10 @@
 
           <% if bike.creation_description %>
             <span class="tw:absolute tw:right-0 tw:bottom-0 tw:text-xs tw:text-gray-400">
+              <%= render(Org::OriginDisplay::Component.new(creation_description: bike.creation_description)) %>
+
               <% if bike.bulk_import.present? %>
-                <%= link_to render(Org::OriginDisplay::Component.new(creation_description: bike.creation_description)), admin_bulk_import_path(bike.bulk_import), class: "tw:text-gray-400" %>
-              <% else %>
-                <%= render(Org::OriginDisplay::Component.new(creation_description: bike.creation_description)) %>
+                <%= link_to "import", admin_bulk_import_path(bike.bulk_import), class: "tw:text-gray-400" %>
               <% end %>
             </span>
           <% end %>

--- a/app/views/organized/bikes/_list.html.haml
+++ b/app/views/organized/bikes/_list.html.haml
@@ -57,7 +57,7 @@
               = bike.first_owner_email
             %small.less-strong
               - if bike.creation_description
-                = origin_display(bike.creation_description)
+                = render(Org::OriginDisplay::Component.new(creation_description: bike.creation_description))
               - unless bike.owner_email == bike.first_owner_email
                 = "(#{t('.sent_to_a_new_owner')})"
           - if current_organization.enabled?("bike_stickers")

--- a/spec/components/admin/bike_cell/component_spec.rb
+++ b/spec/components/admin/bike_cell/component_spec.rb
@@ -64,10 +64,10 @@ RSpec.describe Admin::BikeCell::Component, type: :component do
     context "with creation_description" do
       let(:bike) { FactoryBot.create(:bike_lightspeed_pos) }
 
-      it "renders origin with title" do
+      it "renders origin with tooltip" do
         expect(bike.creation_description).to eq "Lightspeed"
-        expect(component.css("small.less-strong span").text).to eq "Lightspeed"
-        expect(component.css("small.less-strong span").first["title"]).to eq "Automatically registered by bike shop point of sale (Lightspeed POS)"
+        expect(component.css("small.less-strong").text).to include("Lightspeed")
+        expect(component.css("small.less-strong [role=tooltip]").text).to eq "Automatically registered by bike shop point of sale (Lightspeed POS)"
       end
     end
   end

--- a/spec/components/org/origin_display/component_spec.rb
+++ b/spec/components/org/origin_display/component_spec.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Org::OriginDisplay::Component, type: :component do
+  let(:instance) { described_class.new(creation_description:) }
+  let(:component) { render_inline(instance) }
+
+  context "blank creation_description" do
+    let(:creation_description) { nil }
+
+    it "does not render" do
+      expect(component.to_html).to be_blank
+    end
+  end
+
+  context "with a creation_description" do
+    let(:creation_description) { Ownership.new(origin: "sticker").creation_description }
+
+    it "renders the description with the origin_title tooltip" do
+      expect(creation_description).to eq "sticker"
+      expect(component).to have_content("sticker")
+      expect(component).to have_css("[role=tooltip]", text: "Registered via sticker", visible: :all)
+    end
+  end
+end

--- a/spec/helpers/organized_helper_spec.rb
+++ b/spec/helpers/organized_helper_spec.rb
@@ -3,13 +3,13 @@ require "rails_helper"
 RSpec.describe OrganizedHelper, type: :helper do
   describe "organized bike display" do
     let(:bike) { FactoryBot.create(:bike_organized) }
-    let(:target_origin) { "<span title=\"Registered with self registration process\">web</span>" }
-    let(:target_text) do
-      "<span>#{bike.frame_colors.first} <strong>#{bike.mnfg_name}</strong>, <small class=\"less-strong\">#{target_origin}</small></span>"
-    end
+    let(:target_prefix) { "<span>#{bike.frame_colors.first} <strong>#{bike.mnfg_name}</strong>, <small class=\"less-strong\">" }
     it "renders" do
       expect(organized_bike_text).to be_nil
-      expect(organized_bike_text(bike)).to eq target_text
+      result = organized_bike_text(bike)
+      expect(result).to start_with(target_prefix)
+      expect(result).to include(">web</") # origin_display trigger text
+      expect(result).to include("Registered with self registration process") # origin_display tooltip
       expect(organized_bike_text(bike, skip_creation: true)).to eq "<span>#{bike.frame_colors.first} <strong>#{bike.mnfg_name}</strong></span>"
     end
     context "unregistered" do
@@ -30,27 +30,6 @@ RSpec.describe OrganizedHelper, type: :helper do
       it "renders with deleted" do
         expect(bike.deleted?).to be_truthy
         expect(organized_bike_text(bike)).to eq target_text
-      end
-    end
-  end
-
-  describe "origin_display" do
-    let(:target) { "<span title=\"Registration began with incomplete registration, via organization landing page\">landing page</span>" }
-    it "renders with title" do
-      expect(origin_display("landing page")).to eq target
-    end
-    context "lightspeed" do
-      let(:target) { "<span title=\"Automatically registered by bike shop point of sale (Lightspeed POS)\">Lightspeed</span>" }
-      it "renders with title" do
-        expect(origin_display("Lightspeed")).to eq target
-      end
-    end
-    context "scanned_sticker" do
-      let(:target) { "<span title=\"Registered via sticker\">sticker</span>" }
-      let(:ownership) { Ownership.new(origin: "sticker") }
-      it "renders with title" do
-        expect(ownership.creation_description).to eq "sticker"
-        expect(origin_display(ownership.creation_description)).to eq target
       end
     end
   end

--- a/spec/helpers/organized_helper_spec.rb
+++ b/spec/helpers/organized_helper_spec.rb
@@ -7,8 +7,7 @@ RSpec.describe OrganizedHelper, type: :helper do
     it "renders" do
       expect(organized_bike_text).to be_nil
       result = organized_bike_text(bike)
-      expect(result).to start_with(target_prefix)
-      expect(result).to include(">web</") # origin_display trigger text
+      expect(result).to start_with("#{target_prefix}web ") # origin_display label
       expect(result).to include("Registered with self registration process") # origin_display tooltip
       expect(organized_bike_text(bike, skip_creation: true)).to eq "<span>#{bike.frame_colors.first} <strong>#{bike.mnfg_name}</strong></span>"
     end


### PR DESCRIPTION
Extracts the `origin_display` helper into a new `Org::OriginDisplay::Component` and routes every call site through it, so the bike creation origin — label plus its explanatory title — lives in one place.

- Shows the origin title in a `UI::Tooltip` (default `?` button) beside the origin label, instead of a native `title=` attribute.
- Moves the origin-title text mapping out of `BikeServices::Displayer` (the component was its only caller) and removes the old `origin_display` helper.
