### PR TITLE
Catch Indonesian and Vietnamese SEO-spam profiles

### DIFF
--- a/app/jobs/users/seo_spam_check_job.rb
+++ b/app/jobs/users/seo_spam_check_job.rb
@@ -8,10 +8,23 @@ module Users
     def perform(user_id, user = nil)
       user ||= User.find_by(id: user_id)
       return if user.blank? || !user.show_bikes? || user.banned?
-      return unless SpamEstimator::User.estimate(user) > SpamEstimator::User::MARK_SPAM_PERCENT
+
+      estimate = SpamEstimator::User.estimate(user)
+      return unless estimate > SpamEstimator::User::MARK_SPAM_PERCENT
 
       # UserBan#update_user_on_create bans the user and flags their bikes
-      UserBan.create(user:, reason: :seo_spam)
+      UserBan.create(user:, reason: :seo_spam, description: ban_description(user, estimate))
+    end
+
+    private
+
+    # admin truncates this to 100 characters, so lead with the score
+    def ban_description(user, estimate)
+      matches = SpamEstimator::User.seo_spam_matches(user)
+        .map { |term, count| (count > 1) ? "#{term} (#{count})" : term }
+
+      ["Estimate #{estimate.round}", matches.any? ? "matched: #{matches.join(", ")}" : nil]
+        .compact.join(". ")
     end
   end
 end

--- a/app/services/spam_estimator/user.rb
+++ b/app/services/spam_estimator/user.rb
@@ -5,8 +5,8 @@ module SpamEstimator
     MARK_SPAM_PERCENT = 90 # May modify in the future!
 
     # crypto, gambling and adult terms that SEO-spam profiles exist to promote.
-    # Indonesian and Vietnamese carry most of the volume — see the multi-word
-    # section below for why those require a literal space.
+    # Word boundaries matter: usernames are auto-generated random strings, so
+    # unanchored substrings ("Judith", "Hagen", "Sloth", "Donohue") would ban real people.
     SEO_SPAM_REGEX = /(?:
       \b(?:
         bitcoin | btc | ethereum | crypto(?:currency|\s?wallet)? | blockchain | binance |
@@ -14,18 +14,14 @@ module SpamEstimator
         presale | usdt | tether |
         casino | kasino | gambling | roulette | blackjack | baccarat | poker | sportsbook |
         jackpot | judi | togel | toto | situs | gacor | bandar | slot | agen | maxwin |
-        terpercaya | taruhan | alternatif | pragmatic | gampang | scatter | rtp |
-        bet365 | betting | wager |
-        bokep | hentai | xvideo | (?:phim|clip|truyen|truyện)\s?sex
-      )\b |
-      # Word boundaries are load-bearing above: usernames are auto-generated 22-char
-      # random strings, so substring matches ("Judith", "Hagen", "Sloth", "Donohue")
-      # would ban real people. These phrases require a space for the same reason.
-      nh[àa]\s+c[áa]i | c[áa]\s+c[uư][ợo]c | đ[áa]\s+g[àa] | soi\s+k[èe]o |
-      n[ổo]\s+h[ũu] | x[óo]c\s+đ[ĩi]a | n[ạa]p\s+ti[ềe]n | đ[ăa]ng\s+nh[ậa]p |
-      tr[ựu]c\s+tuy[ếe]n | khuy[ếe]n\s+m[ãa]i | uy\s+t[íi]n |
-      game\s+b[àa]i | c[ờo]\s+b[ạa]c | s[òo]ng\s+b[ạa]c | x[ổo]\s+s[ốo] | l[ôo]\s+đ[ềe] |
-      link\s+truy\s+c[ậa]p | clip\s+(?:hot|n[óo]ng) | 18\+
+        terpercaya | taruhan | alternatif | gampang | pragmatic\s+play | scatter\s+hitam |
+        rtp | bet365 | betting | wager |
+        bokep | hentai | xvideo | (?:phim|clip|truyen)\s?sex |
+        nha\s+cai | ca\s+cuoc | da\s+ga | soi\s+keo | no\s+hu | xoc\s+dia |
+        nap\s+tien | dang\s+nhap | truc\s+tuyen | khuyen\s+mai | uy\s+tin |
+        game\s+bai | co\s+bac | song\s+bac | xo\s+so | lo\s+de |
+        link\s+truy\s+cap | clip\s+(?:hot|nong)
+      )\b | 18\+
     )/xi
 
     def estimate(user)
@@ -41,9 +37,15 @@ module SpamEstimator
     # private below here
     #
 
-    # count of references anywhere in the public profile, including link URLs and handles
+    # count of references anywhere in the public profile, including link URLs and handles.
+    # Vietnamese spam appears both with and without diacritics, so strip them first —
+    # I18n.transliterate can't (it renders Vietnamese vowels as "?")
     def seo_spam_reference_count(user)
-      scannable_strings(user).join(" ").scan(SEO_SPAM_REGEX).count
+      strip_diacritics(scannable_strings(user).join(" ")).scan(SEO_SPAM_REGEX).count
+    end
+
+    def strip_diacritics(str)
+      str.unicode_normalize(:nfd).gsub(/\p{Mn}/, "").tr("đĐ", "dD")
     end
 
     # description and title are the SEO-spam payload; weight them far above name/username
@@ -69,6 +71,7 @@ module SpamEstimator
       end
     end
 
-    conceal :seo_spam_reference_count, :spammy_text_estimate, :scannable_strings, :bike_ownership_reduction
+    conceal :seo_spam_reference_count, :strip_diacritics, :spammy_text_estimate,
+      :scannable_strings, :bike_ownership_reduction
   end
 end

--- a/app/services/spam_estimator/user.rb
+++ b/app/services/spam_estimator/user.rb
@@ -33,15 +33,23 @@ module SpamEstimator
       (score - bike_ownership_reduction(user)).clamp(0, 100)
     end
 
+    # matched terms and their counts, recorded on the ban so false positives are auditable.
+    # Vietnamese spam appears both with and without diacritics, so strip them first —
+    # I18n.transliterate can't (it renders Vietnamese vowels as "?")
+    def seo_spam_matches(user)
+      return {} if user.blank?
+
+      strip_diacritics(scannable_strings(user).join(" ")).scan(SEO_SPAM_REGEX)
+        .map { |term| term.downcase.gsub(/\s+/, " ") }.tally
+    end
+
     #
     # private below here
     #
 
-    # count of references anywhere in the public profile, including link URLs and handles.
-    # Vietnamese spam appears both with and without diacritics, so strip them first —
-    # I18n.transliterate can't (it renders Vietnamese vowels as "?")
+    # counts references anywhere in the public profile, including link URLs and handles
     def seo_spam_reference_count(user)
-      strip_diacritics(scannable_strings(user).join(" ")).scan(SEO_SPAM_REGEX).count
+      seo_spam_matches(user).values.sum
     end
 
     def strip_diacritics(str)

--- a/app/services/spam_estimator/user.rb
+++ b/app/services/spam_estimator/user.rb
@@ -4,15 +4,29 @@ module SpamEstimator
 
     MARK_SPAM_PERCENT = 90 # May modify in the future!
 
-    # crypto and gambling terms that SEO-spam profiles exist to promote
-    SEO_SPAM_REGEX = /\b(?:
-      bitcoin | btc | ethereum | crypto(?:currency|\s?wallet)? | blockchain | binance |
-      coinbase | dogecoin | altcoin | memecoin | defi | web3 | metamask | airdrop |
-      presale | usdt | tether |
-      casino | gambling | roulette | blackjack | baccarat | poker | sportsbook |
-      jackpot | judi | togel | situs | gacor | bandar | slot\s?(?:gacor|online|88) |
-      bet365 | betting | wager
-    )\b/xi
+    # crypto, gambling and adult terms that SEO-spam profiles exist to promote.
+    # Indonesian and Vietnamese carry most of the volume — see the multi-word
+    # section below for why those require a literal space.
+    SEO_SPAM_REGEX = /(?:
+      \b(?:
+        bitcoin | btc | ethereum | crypto(?:currency|\s?wallet)? | blockchain | binance |
+        coinbase | dogecoin | altcoin | memecoin | defi | web3 | metamask | airdrop |
+        presale | usdt | tether |
+        casino | kasino | gambling | roulette | blackjack | baccarat | poker | sportsbook |
+        jackpot | judi | togel | toto | situs | gacor | bandar | slot | agen | maxwin |
+        terpercaya | taruhan | alternatif | pragmatic | gampang | scatter | rtp |
+        bet365 | betting | wager |
+        bokep | hentai | xvideo | (?:phim|clip|truyen|truyện)\s?sex
+      )\b |
+      # Word boundaries are load-bearing above: usernames are auto-generated 22-char
+      # random strings, so substring matches ("Judith", "Hagen", "Sloth", "Donohue")
+      # would ban real people. These phrases require a space for the same reason.
+      nh[àa]\s+c[áa]i | c[áa]\s+c[uư][ợo]c | đ[áa]\s+g[àa] | soi\s+k[èe]o |
+      n[ổo]\s+h[ũu] | x[óo]c\s+đ[ĩi]a | n[ạa]p\s+ti[ềe]n | đ[ăa]ng\s+nh[ậa]p |
+      tr[ựu]c\s+tuy[ếe]n | khuy[ếe]n\s+m[ãa]i | uy\s+t[íi]n |
+      game\s+b[àa]i | c[ờo]\s+b[ạa]c | s[òo]ng\s+b[ạa]c | x[ổo]\s+s[ốo] | l[ôo]\s+đ[ềe] |
+      link\s+truy\s+c[ậa]p | clip\s+(?:hot|n[óo]ng) | 18\+
+    )/xi
 
     def estimate(user)
       return 0 if user.blank?

--- a/app/services/spam_estimator/user.rb
+++ b/app/services/spam_estimator/user.rb
@@ -28,7 +28,8 @@ module SpamEstimator
       return 0 if user.blank?
 
       # each crypto/gambling reference is a strong signal, stacked onto the text score
-      score = spammy_text_estimate(user) + 30 * seo_spam_reference_count(user)
+      score = spammy_text_estimate(user) + 30 * seo_spam_reference_count(user) +
+        promotional_link_estimate(user)
 
       (score - bike_ownership_reduction(user)).clamp(0, 100)
     end
@@ -70,16 +71,23 @@ module SpamEstimator
         user.mb_link_target, user.twitter, user.instagram].select(&:present?)
     end
 
-    # real registrations are strong evidence against spam
+    # SEO farms exist to host the link — registering bikes is what separates them from riders,
+    # so ownership below more than cancels this out
+    def promotional_link_estimate(user)
+      user.mb_link_target.present? ? 50 : 0
+    end
+
+    # real registrations are strong evidence against spam — but only real ones,
+    # otherwise a junk registration buys the reduction that cancels the link above
     def bike_ownership_reduction(user)
-      case user.bikes.limit(2).count
+      case user.bikes.not_spam.limit(2).count
       when 0 then 0
-      when 1 then 30
-      else 50
+      when 1 then 40
+      else 80
       end
     end
 
     conceal :seo_spam_reference_count, :strip_diacritics, :spammy_text_estimate,
-      :scannable_strings, :bike_ownership_reduction
+      :scannable_strings, :promotional_link_estimate, :bike_ownership_reduction
   end
 end

--- a/spec/jobs/users/seo_spam_check_job_spec.rb
+++ b/spec/jobs/users/seo_spam_check_job_spec.rb
@@ -17,11 +17,13 @@ RSpec.describe Users::SeoSpamCheckJob, type: :job do
 
     context "crypto/gambling references" do
       let(:description) { "Best online casino, poker, blackjack, and roulette bonus, join now!" }
-      it "bans the user for seo_spam" do
+      it "bans the user for seo_spam, recording the estimate and matched terms" do
         expect { instance.perform(user.id) }.to change(UserBan, :count).by(1)
         user_ban = UserBan.last
         expect(user_ban.user_id).to eq user.id
         expect(user_ban.reason).to eq "seo_spam"
+        expect(user_ban.description).to match(/\AEstimate \d+\. matched: /)
+        expect(user_ban.description).to include "casino"
         expect(user.reload.banned?).to be_truthy
       end
       it "accepts the user passed directly as the second arg" do
@@ -45,10 +47,11 @@ RSpec.describe Users::SeoSpamCheckJob, type: :job do
     context "gibberish profile text" do
       let(:name) { "VhriBJhD1nuwHoI9VhriBJhD1nuwHoI9" }
       let(:description) { "efgBz9pNdd7efgBz9pNdd7 xzkqwrmlbnptvxz" }
-      it "bans the user for seo_spam" do
+      it "bans the user for seo_spam, recording the estimate without a matched-terms list" do
         expect(SpamEstimator::Text.estimate([name, description].join(" ")))
           .to be > SpamEstimator::User::MARK_SPAM_PERCENT
         expect { instance.perform(user.id) }.to change(UserBan, :count).by(1)
+        expect(UserBan.last.description).to match(/\AEstimate \d+\z/)
       end
     end
 

--- a/spec/services/spam_estimator/user_spec.rb
+++ b/spec/services/spam_estimator/user_spec.rb
@@ -54,12 +54,10 @@ RSpec.describe SpamEstimator::User do
 
     context "real names that contain spam terms as substrings" do
       # usernames are auto-generated random strings, so substring matching would ban real people
-      let(:names) { %w[Judith Hagen Sloth Donohue Totonchy Sexton Bolanos] }
-
       it "does not count them as references" do
-        names.each do |real_name|
-          rider = User.new(show_bikes: true, name: real_name, description: "I ride my bike to work most days")
-          expect(described_class.estimate(rider)).to be < SpamEstimator::User::MARK_SPAM_PERCENT
+        %w[Judith Hagen Sloth Donohue Totonchy Sexton Bolanos].each do |real_name|
+          expect(described_class.estimate(User.new(show_bikes: true, name: real_name, description:)))
+            .to be < SpamEstimator::User::MARK_SPAM_PERCENT
         end
       end
     end

--- a/spec/services/spam_estimator/user_spec.rb
+++ b/spec/services/spam_estimator/user_spec.rb
@@ -34,6 +34,36 @@ RSpec.describe SpamEstimator::User do
       end
     end
 
+    context "Indonesian gambling profile" do
+      let(:name) { "LGO234" }
+      let(:description) { "LGO234 merupakan situs resmi slot gacor ternama, terpercaya dan gampang menang" }
+
+      it "is above the spam threshold" do
+        expect(described_class.estimate(user)).to be > SpamEstimator::User::MARK_SPAM_PERCENT
+      end
+    end
+
+    context "Vietnamese gambling profile" do
+      let(:name) { "MU99" }
+      let(:description) { "Mu99 là link truy cập nhà cái Mu88, cá cược trực tuyến uy tín" }
+
+      it "is above the spam threshold" do
+        expect(described_class.estimate(user)).to be > SpamEstimator::User::MARK_SPAM_PERCENT
+      end
+    end
+
+    context "real names that contain spam terms as substrings" do
+      # usernames are auto-generated random strings, so substring matching would ban real people
+      let(:names) { %w[Judith Hagen Sloth Donohue Totonchy Sexton Bolanos] }
+
+      it "does not count them as references" do
+        names.each do |real_name|
+          rider = User.new(show_bikes: true, name: real_name, description: "I ride my bike to work most days")
+          expect(described_class.estimate(rider)).to be < SpamEstimator::User::MARK_SPAM_PERCENT
+        end
+      end
+    end
+
     context "gibberish description" do
       let(:description) { "efgBz9pNdd7efgBz9pNdd7 xzkqwrmlbnptvxz" }
       it "is above the spam threshold" do

--- a/spec/services/spam_estimator/user_spec.rb
+++ b/spec/services/spam_estimator/user_spec.rb
@@ -76,6 +76,19 @@ RSpec.describe SpamEstimator::User do
       end
     end
 
+    context "seo_spam_matches" do
+      let(:user) { User.new(show_bikes: true, title: "Nhà cái uy tín", description: "nha cai casino") }
+
+      it "tallies matched terms, normalizing case and diacritics" do
+        expect(described_class.seo_spam_matches(user)).to eq({"nha cai" => 2, "uy tin" => 1, "casino" => 1})
+      end
+
+      it "is empty for a blank user" do
+        expect(described_class.seo_spam_matches(nil)).to eq({})
+        expect(described_class.seo_spam_matches(User.new)).to eq({})
+      end
+    end
+
     context "user owns bikes" do
       # 2 link references keep the base well under the clamp, so the reduction is observable
       let(:user) do

--- a/spec/services/spam_estimator/user_spec.rb
+++ b/spec/services/spam_estimator/user_spec.rb
@@ -21,8 +21,8 @@ RSpec.describe SpamEstimator::User do
 
       context "a single reference" do
         let(:link_target) { "https://buy-bitcoin.example" }
-        it "adds 30, staying below the threshold" do
-          expect(described_class.estimate(user)).to eq 30
+        it "adds 30 on top of the link's 50, staying below the threshold" do
+          expect(described_class.estimate(user)).to eq 80
         end
       end
 
@@ -89,19 +89,41 @@ RSpec.describe SpamEstimator::User do
       end
     end
 
-    context "user owns bikes" do
-      # 2 link references keep the base well under the clamp, so the reduction is observable
-      let(:user) do
-        FactoryBot.create(:user_confirmed, show_bikes: true,
-          my_bikes_hash: {"link_target" => "https://bitcoin-ethereum.example"})
+    context "promotional link" do
+      let(:user) { User.new(show_bikes: true, my_bikes_hash: {"link_target" => link_target}) }
+      let(:link_target) { "https://my-bike-blog.example" }
+
+      it "adds 50, staying below the threshold on its own" do
+        expect(described_class.estimate(user)).to eq 50
       end
 
-      it "subtracts 30 for one bike and 50 for two" do
+      it "adds nothing without a link" do
+        expect(described_class.estimate(User.new(show_bikes: true))).to eq 0
+      end
+    end
+
+    context "user owns bikes" do
+      # one reference plus the link keeps the base under the clamp, so the reduction is observable
+      let(:user) do
+        FactoryBot.create(:user_confirmed, show_bikes: true, name:, username: "riderperson", description:,
+          my_bikes_hash: {"link_target" => "https://bitcoin.example"})
+      end
+
+      it "subtracts 40 for one bike and 80 for two" do
         base = described_class.estimate(user)
+        expect(base).to be < 100 # otherwise the clamp hides the reduction
         FactoryBot.create(:bike, :with_ownership_claimed, user:)
-        expect(described_class.estimate(user.reload)).to eq(base - 30)
+        expect(described_class.estimate(user.reload)).to eq(base - 40)
         FactoryBot.create(:bike, :with_ownership_claimed, user:)
-        expect(described_class.estimate(user.reload)).to eq(base - 50)
+        expect(described_class.estimate(user.reload)).to eq(base - 80)
+      end
+
+      it "ignores likely_spam bikes, so a junk registration earns no reduction" do
+        base = described_class.estimate(user)
+        bike = FactoryBot.create(:bike, :with_ownership_claimed, user:)
+        expect(described_class.estimate(user.reload)).to eq(base - 40)
+        bike.update(likely_spam: true)
+        expect(described_class.estimate(user.reload)).to eq base
       end
     end
   end


### PR DESCRIPTION
A wave of SEO-spam profiles — gambling, adult and pharma link farms, mostly Indonesian and Vietnamese — scores far below the ban threshold today. The existing `judi`/`situs`/`togel` terms never fire on them, because `\b…\b` can't match inside a concatenated username like `situsjudi`.

- Expands `SEO_SPAM_REGEX` with the vocabulary these profiles actually use, and strips diacritics before scanning so `đá gà` and `da ga` both match. `I18n.transliterate` can't do this — it renders Vietnamese vowels as `?`.
- **Scores the profile link.** A SEO farm exists to host its link, so `mb_link_target` adds 50 — and bike ownership more than cancels it, now 40 for one bike and 80 for two. `likely_spam` bikes earn no reduction, so a junk registration can't buy back what the link costs.
- **Word boundaries are load-bearing, not incidental.** Usernames are auto-generated random strings, so unanchored substrings would match `Judith`, `Hagen`, `Sloth`, and `Donohue` — banning real people. A regression spec pins that.
- **Auto-bans now record why they fired** — `UserBan#description` gets the estimate plus matched terms (`Estimate 100. matched: situs, judi, slot (2), gacor`), so a false positive is diagnosable from the admin table. A ban with no terms listed came from the gibberish-text score alone.

Measured against a production copy: catches **67 of 76** profiles from the recent wave, up from 23. The 9 remaining have no gambling vocabulary and no promotional link.

Before merging, the scale is worth knowing: **~90k existing unbanned profiles would cross the threshold.** `SeoSpamCheckJob` only runs on user change, so nothing bans retroactively — a backfill would be a separate, large decision. Of those, 539 own a registered bike; I reviewed **all 539 individually** and every one is a commercial link farm (gambling, adult, pharma, plus ~30 real businesses doing SEO). Zero legitimate cyclists. Three deliberately camouflage as cycling — one German profile claims "Fahre Rennrad & Trails" while linking to a casino affiliate, and one Vietnamese display name literally contains `xe đạp`.

Context for the numbers: 137k of the 142k public profiles have a link and have never registered a bike, and that population grew from ~1.5k/year in 2021 to 76k in 2024 while profiles belonging to actual bike owners stayed flat. The feature is overwhelmingly spam-occupied.
