### PR TITLE
Refine org-admin registration show: unregistered bikes and stickers

### DIFF
--- a/app/components/registrations/show/org_admin/component.en.yml
+++ b/app/components/registrations/show/org_admin/component.en.yml
@@ -6,6 +6,7 @@ en:
         org_admin:
           about_this_bike: About this %{bike_type}
           active: Active
+          assign_sticker: Assign sticker
           audit: E-Vehicle Audit
           avery_exportable: Avery Exportable
           claimed: Claimed
@@ -20,6 +21,7 @@ en:
           is_false: 'false'
           is_true: 'true'
           know_something_about_this_bike_type: Know something about this %{bike_type}?
+          link_sticker: Link sticker
           link_url: Link url
           message_owner: Message owner
           message_owner_sub: via Bike Index
@@ -61,7 +63,11 @@ en:
           send_message: Send message
           showing_recent: Showing the %{count} most recent
           sticker: Sticker
-          unregistered_owner: This %{bike_type} is not registered to a user. It was added to track parking notifications.
+          sticker_claimed: claimed
+          sticker_code: Sticker code
+          unregistered_owner: >-
+            This %{bike_type} is not registered to a user. It was added to track parking
+            notifications.
           view_all_registrations: view all →
           view_notifications: View notifications
           view_notifications_sub: Parking activity

--- a/app/components/registrations/show/org_admin/component.en.yml
+++ b/app/components/registrations/show/org_admin/component.en.yml
@@ -61,6 +61,7 @@ en:
           send_message: Send message
           showing_recent: Showing the %{count} most recent
           sticker: Sticker
+          unregistered_owner: This %{bike_type} is not registered to a user. It was added to track parking notifications.
           view_all_registrations: view all →
           view_notifications: View notifications
           view_notifications_sub: Parking activity

--- a/app/components/registrations/show/org_admin/component.html.erb
+++ b/app/components/registrations/show/org_admin/component.html.erb
@@ -19,7 +19,7 @@
       </p>
 
       <div class="tw:mt-2 tw:flex tw:flex-wrap tw:gap-2">
-        <% if @bike.claimed? %>
+        <% if @bike.claimed? && !@bike.unregistered_parking_notification? %>
           <%= render(UI::Badge::Component.new(text: translation(".claimed"), color: :notice, indicator: true)) %>
         <% end %>
 
@@ -350,9 +350,11 @@
               <%= info_row(translation(".organization_registered"), @bike.creation_organization&.name) %>
             <% end %>
 
-            <%= info_row(translation(".claimed")) do %>
-              <% if @bike.claimed? %>
-                <%= render(UI::Time::Component.new(time: current_ownership.claimed_at)) %>
+            <% unless @bike.unregistered_parking_notification? %>
+              <%= info_row(translation(".claimed")) do %>
+                <% if @bike.claimed? %>
+                  <%= render(UI::Time::Component.new(time: current_ownership.claimed_at)) %>
+                <% end %>
               <% end %>
             <% end %>
 

--- a/app/components/registrations/show/org_admin/component.html.erb
+++ b/app/components/registrations/show/org_admin/component.html.erb
@@ -346,7 +346,30 @@
 
             <% if @organization.enabled?("bike_stickers") %>
               <%= info_row(translation(".sticker")) do %>
-                <%= safe_join(bike_stickers.map { |bike_sticker| sticker_link(bike_sticker) }, ", ") %>
+                <div class="tw:flex tw:flex-col tw:items-end tw:gap-0.5">
+                  <% bike_stickers.each do |bike_sticker| %>
+                    <span>
+                      <%= sticker_link(bike_sticker) %>
+
+                      <% if bike_sticker.claimed_at.present? %>
+                        <span class="tw:text-xs tw:opacity-65">
+                          <%= translation(".sticker_claimed") %>
+                          <%= render(UI::Time::Component.new(time: bike_sticker.claimed_at)) %>
+                        </span>
+                      <% end %>
+                    </span>
+                  <% end %>
+
+                  <% if staff? %>
+                    <button
+                      type="button"
+                      data-open-modal="link-sticker-modal"
+                      class="twlink tw:cursor-pointer tw:text-xs"
+                    >
+                      <%= translation(".link_sticker") %>
+                    </button>
+                  <% end %>
+                </div>
               <% end %>
             <% end %>
 
@@ -441,6 +464,23 @@
           ·
           <%= link_to translation(".view_all_registrations"), other_registrations_search_path, class: "twlink", data: {turbo_frame: "_top"} %>
         </p>
+      <% end %>
+    <% end %>
+  <% end %>
+
+  <% if staff? && @organization.enabled?("bike_stickers") %>
+    <%= render(UI::Modal::Component.new(id: "link-sticker-modal", title: translation(".link_sticker"))) do |modal| %>
+      <% modal.with_body do %>
+        <%= form_with model: BikeSticker.new, url: organization_sticker_path(id: "code", organization_id: @organization.to_param), method: :put, class: "tw:flex tw:flex-col tw:gap-3" do |form| %>
+          <%= form.hidden_field :bike_id, value: @bike.id %>
+
+          <div>
+            <%= form.label :code, translation(".sticker_code"), class: "twlabel" %>
+            <%= form.text_field :code, required: true, class: "twinput" %>
+          </div>
+
+          <%= render(UI::Button::Component.new(text: translation(".assign_sticker"), color: :purple, kind: :submit)) %>
+        <% end %>
       <% end %>
     <% end %>
   <% end %>

--- a/app/components/registrations/show/org_admin/component.html.erb
+++ b/app/components/registrations/show/org_admin/component.html.erb
@@ -234,45 +234,49 @@
         </h2>
 
         <div class="tw:mt-3">
-          <%= render(UI::DefinitionList::Container::Component.new(term: :right_align)) do %>
-            <%= info_row(translation(".owner_name"), @bike.owner_name) %>
+          <% if @bike.unregistered_parking_notification? %>
+            <p class="tw:text-sm tw:opacity-65">
+              <%= translation(".unregistered_owner", bike_type: @bike.type) %>
+            </p>
+          <% else %>
+            <%= render(UI::DefinitionList::Container::Component.new(term: :right_align)) do %>
+              <%= info_row(translation(".owner_name"), @bike.owner_name) %>
 
-            <% if show_contact? %>
-              <%= info_row(translation(".owner_email")) do %>
-                <% if @bike.owner_email.present? %>
-                  <%= link_to(@bike.owner_email, "mailto:#{@bike.owner_email}", class: "twlink") %>
+              <% if show_contact? %>
+                <%= info_row(translation(".owner_email")) do %>
+                  <% if @bike.owner_email.present? %>
+                    <%= link_to(@bike.owner_email, "mailto:#{@bike.owner_email}", class: "twlink") %>
+                  <% end %>
                 <% end %>
-              <% end %>
-              <%= info_row(translation(".owner_phone")) { helpers.phone_link(owner_phone, class: "twlink tw:font-mono") } %>
-              <% owner_reg_field_rows.each do |label, value| %>
-                <%= info_row(label, value) %>
+                <%= info_row(translation(".owner_phone")) { helpers.phone_link(owner_phone, class: "twlink tw:font-mono") } %>
+                <% owner_reg_field_rows.each do |label, value| %>
+                  <%= info_row(label, value) %>
+                <% end %>
               <% end %>
             <% end %>
           <% end %>
         </div>
 
-        <% if show_contact? %>
-          <% if staff? %>
-            <div
-              class="
-                tw:mt-3 tw:flex tw:items-center tw:justify-between tw:gap-3
-                tw:rounded-lg tw:bg-purple-50 tw:p-3 tw:dark:bg-purple-950
-              "
-            >
-              <div class="tw:min-w-0">
-                <p class="tw:text-sm tw:font-bold">
-                  <%= translation(".org_can_edit", org_name: @organization.short_name, bike_type: @bike.type) %>
-                </p>
+        <% if staff? && (@bike.unregistered_parking_notification? || show_contact?) %>
+          <div
+            class="
+              tw:mt-3 tw:flex tw:items-center tw:justify-between tw:gap-3
+              tw:rounded-lg tw:bg-purple-50 tw:p-3 tw:dark:bg-purple-950
+            "
+          >
+            <div class="tw:min-w-0">
+              <p class="tw:text-sm tw:font-bold">
+                <%= translation(".org_can_edit", org_name: @organization.short_name, bike_type: @bike.type) %>
+              </p>
 
-                <p class="tw:mt-1 tw:text-xs tw:opacity-65">
-                  <%= translation(".org_can_edit_sub", bike_type: @bike.type) %>
-                </p>
-              </div>
-
-              <%= render(UI::ButtonLink::Component.new(href: edit_access_path, text: translation(".edit"), color: :secondary, size: :sm, class: "tw:flex-none")) %>
+              <p class="tw:mt-1 tw:text-xs tw:opacity-65">
+                <%= translation(".org_can_edit_sub", bike_type: @bike.type) %>
+              </p>
             </div>
-          <% end %>
-        <% else %>
+
+            <%= render(UI::ButtonLink::Component.new(href: edit_access_path, text: translation(".edit"), color: :secondary, size: :sm, class: "tw:flex-none")) %>
+          </div>
+        <% elsif !show_contact? && !@bike.unregistered_parking_notification? %>
           <div
             class="
               tw:mt-3 tw:rounded-lg tw:border tw:border-dashed

--- a/app/components/registrations/show/org_admin/component.html.erb
+++ b/app/components/registrations/show/org_admin/component.html.erb
@@ -19,7 +19,7 @@
       </p>
 
       <div class="tw:mt-2 tw:flex tw:flex-wrap tw:gap-2">
-        <% if @bike.claimed? && !@bike.unregistered_parking_notification? %>
+        <% if @bike.claimed? && !unregistered? %>
           <%= render(UI::Badge::Component.new(text: translation(".claimed"), color: :notice, indicator: true)) %>
         <% end %>
 
@@ -234,7 +234,7 @@
         </h2>
 
         <div class="tw:mt-3">
-          <% if @bike.unregistered_parking_notification? %>
+          <% if unregistered? %>
             <p class="tw:text-sm tw:opacity-65">
               <%= translation(".unregistered_owner", bike_type: @bike.type) %>
             </p>
@@ -257,7 +257,7 @@
           <% end %>
         </div>
 
-        <% if staff? && (@bike.unregistered_parking_notification? || show_contact?) %>
+        <% if staff? && (unregistered? || show_contact?) %>
           <div
             class="
               tw:mt-3 tw:flex tw:items-center tw:justify-between tw:gap-3
@@ -276,7 +276,7 @@
 
             <%= render(UI::ButtonLink::Component.new(href: edit_access_path, text: translation(".edit"), color: :secondary, size: :sm, class: "tw:flex-none")) %>
           </div>
-        <% elsif !show_contact? && !@bike.unregistered_parking_notification? %>
+        <% elsif !show_contact? && !unregistered? %>
           <div
             class="
               tw:mt-3 tw:rounded-lg tw:border tw:border-dashed
@@ -361,13 +361,7 @@
                   <% end %>
 
                   <% if staff? %>
-                    <button
-                      type="button"
-                      data-open-modal="link-sticker-modal"
-                      class="twlink tw:cursor-pointer tw:text-xs"
-                    >
-                      <%= translation(".link_sticker") %>
-                    </button>
+                    <%= render(UI::Button::Component.new(text: translation(".link_sticker"), color: :link, html_class: "tw:text-xs", data: {open_modal: "link-sticker-modal"})) %>
                   <% end %>
                 </div>
               <% end %>
@@ -377,7 +371,7 @@
               <%= info_row(translation(".organization_registered"), @bike.creation_organization&.name) %>
             <% end %>
 
-            <% unless @bike.unregistered_parking_notification? %>
+            <% unless unregistered? %>
               <%= info_row(translation(".claimed")) do %>
                 <% if @bike.claimed? %>
                   <%= render(UI::Time::Component.new(time: current_ownership.claimed_at)) %>

--- a/app/components/registrations/show/org_admin/component.rb
+++ b/app/components/registrations/show/org_admin/component.rb
@@ -66,6 +66,10 @@ module Registrations
           @organization_registered = @bike.organized?(@organization)
         end
 
+        def unregistered?
+          @bike.unregistered_parking_notification?
+        end
+
         # Owner contact + law-enforcement data is only shown to full staff on a bike
         # registered with their organization
         def show_contact?
@@ -137,7 +141,7 @@ module Registrations
 
         # Org-owned stickers link to their edit page; others show the code as text
         def sticker_link(bike_sticker)
-          return bike_sticker.pretty_code unless bike_sticker.organization == @organization
+          return bike_sticker.pretty_code unless bike_sticker.organization_id == @organization.id
 
           link_to(bike_sticker.pretty_code, edit_organization_sticker_path(id: bike_sticker.code, organization_id: @organization.to_param), class: "twlink")
         end

--- a/app/components/registrations/show/status/component.en.yml
+++ b/app/components/registrations/show/status/component.en.yml
@@ -8,3 +8,4 @@ en:
           impounded: Impounded
           not_stolen: Not stolen
           stolen: Stolen
+          unregistered: Unregistered

--- a/app/components/registrations/show/status/component.rb
+++ b/app/components/registrations/show/status/component.rb
@@ -22,6 +22,8 @@ module Registrations
             translation(".found")
           elsif @bike.status_impounded?
             translation(".impounded")
+          elsif @bike.unregistered_parking_notification?
+            translation(".unregistered")
           else
             translation(".not_stolen")
           end
@@ -29,7 +31,7 @@ module Registrations
 
         def color
           return :error if @bike.status_stolen?
-          return :warning if @bike.status_impounded?
+          return :warning if @bike.status_impounded? || @bike.unregistered_parking_notification?
 
           :success
         end

--- a/app/components/ui/color_swatch/component.rb
+++ b/app/components/ui/color_swatch/component.rb
@@ -5,7 +5,9 @@ module UI
     # A small square showing a bike color. The display-less "cover-up" color
     # renders Color::COVER_UP_SWATCH's multicolor blend instead of a solid fill.
     class Component < ApplicationComponent
-      BASE_CLASSES = "tw:inline-block tw:rounded-xs tw:border tw:border-black/20"
+      # leading-[0] collapses the empty box's line-height strut so align-baseline
+      # sits its bottom on the text baseline instead of floating above it
+      BASE_CLASSES = "tw:inline-block tw:leading-[0] tw:rounded-xs tw:border tw:border-black/20"
 
       SIZES = {sm: "tw:h-3 tw:w-3", md: "tw:h-6 tw:w-6"}.freeze
 

--- a/spec/components/registrations/show/status/component_spec.rb
+++ b/spec/components/registrations/show/status/component_spec.rb
@@ -19,6 +19,15 @@ RSpec.describe Registrations::Show::Status::Component, type: :component do
     end
   end
 
+  context "unregistered" do
+    let(:bike) { FactoryBot.create(:bike, status: "unregistered_parking_notification") }
+    it "shows unregistered in a warning (yellow) badge" do
+      render_inline(component)
+      expect(page).to have_text("Unregistered")
+      expect(page).to have_css("span.tw\\:text-amber-700")
+    end
+  end
+
   # Impounded and found (an impounded bike with a "found" impound record) need an
   # organization + impound record to set the status; those are covered end-to-end
   # in spec/requests/registrations/show_request_spec.rb.

--- a/spec/requests/registrations/show_request_spec.rb
+++ b/spec/requests/registrations/show_request_spec.rb
@@ -150,6 +150,9 @@ RSpec.describe "RegistrationsController#show", type: :request do
           expect(body).to match("Unregistered")
           expect(body).to_not match("Not stolen")
           expect(body).to_not match("Claimed")
+          # Owner & access shows the parking-notification explanation, no owner rows
+          expect(body).to match("not registered to a user. It was added to track parking notifications")
+          expect(body).to_not match(bike.owner_email)
         end
       end
     end

--- a/spec/requests/registrations/show_request_spec.rb
+++ b/spec/requests/registrations/show_request_spec.rb
@@ -155,6 +155,20 @@ RSpec.describe "RegistrationsController#show", type: :request do
           expect(body).to_not match(bike.owner_email)
         end
       end
+
+      context "with a bike sticker" do
+        let(:organization) { FactoryBot.create(:organization_with_organization_features, enabled_feature_slugs: ["bike_stickers"]) }
+        let!(:bike_sticker) { FactoryBot.create(:bike_sticker_claimed, organization:, bike:) }
+        it "shows the sticker with its claimed time and an always-present link-sticker action" do
+          get "#{base_url}/#{bike.id}"
+          body = whitespace_normalized_body_text
+          expect(body).to match(bike_sticker.pretty_code)
+          expect(body).to match("claimed")
+          expect(body).to match("Link sticker")
+          # The link-sticker modal posts to the org sticker update endpoint
+          expect(response.body).to include(organization_sticker_path(id: "code", organization_id: organization.to_param))
+        end
+      end
     end
 
     context "with organization registration fields" do

--- a/spec/requests/registrations/show_request_spec.rb
+++ b/spec/requests/registrations/show_request_spec.rb
@@ -140,6 +140,18 @@ RSpec.describe "RegistrationsController#show", type: :request do
           expect(body).to_not match("Not stolen")
         end
       end
+
+      context "unregistered bike" do
+        let(:bike) { FactoryBot.create(:bike_organized, :with_ownership_claimed, creation_organization: organization, status: "unregistered_parking_notification").reload }
+        it "shows the unregistered status and no claim, even though claimed" do
+          expect(bike.claimed?).to be_truthy
+          get "#{base_url}/#{bike.id}"
+          body = whitespace_normalized_body_text
+          expect(body).to match("Unregistered")
+          expect(body).to_not match("Not stolen")
+          expect(body).to_not match("Claimed")
+        end
+      end
     end
 
     context "with organization registration fields" do


### PR DESCRIPTION
Improves how unregistered (parking-notification) bikes present in the registration show redesign, refines the org-admin sticker row, plus a shared swatch-alignment fix.

- The status badge now reads "Unregistered" in yellow on both the public/owner and org-admin views (was a green "Not stolen").
- The org-admin panel no longer shows the "Claimed" badge or claimed-date row for these bikes (they're technically `claimed?` but shouldn't display as such).
- The org-admin Owner & access panel shows a plain explanation ("This {bike_type} is not registered to a user. It was added to track parking notifications.") instead of owner rows — ungated by contact permission — keeping only the can-edit box for staff.
- The sticker row now shows each sticker's claimed time and always offers a "Link sticker" action (a `UI::Modal` with the assign-sticker form), mirroring `Org::BikeAccessPanel`.
- Baseline-align the color swatch: its empty box's line-height strut made `align-baseline` float the swatch above the text, so `leading-[0]` collapses the strut and drops its bottom onto the baseline.
