### PR TITLE
Display "Unregistered Parking Notification" origin label

### DIFF
--- a/app/components/org/origin_display/component.rb
+++ b/app/components/org/origin_display/component.rb
@@ -18,17 +18,29 @@ module Org
       end
 
       def call
-        safe_join([@creation_description, render(UI::Tooltip::Component.new(text: origin_title))], " ")
+        safe_join([label, render(UI::Tooltip::Component.new(text: origin_title))], " ")
       end
 
       private
 
+      def label
+        return "Unregistered Parking Notification" if unregistered_parking_notification?
+
+        @creation_description
+      end
+
       def origin_title
         if %w[Lightspeed Ascend].include?(@creation_description)
           "Automatically registered by bike shop point of sale (#{@creation_description} POS)"
+        elsif unregistered_parking_notification?
+          "Registered via the Unregistered Parking Notification flow"
         else
           EXTENDED_DESCRIPTIONS[@creation_description] || "Registered via #{@creation_description}"
         end
+      end
+
+      def unregistered_parking_notification?
+        @creation_description == "creator unregistered parking notification"
       end
     end
   end

--- a/spec/components/org/origin_display/component_spec.rb
+++ b/spec/components/org/origin_display/component_spec.rb
@@ -23,4 +23,14 @@ RSpec.describe Org::OriginDisplay::Component, type: :component do
       expect(component).to have_css("[role=tooltip]", text: "Registered via sticker", visible: :all)
     end
   end
+
+  context "with an unregistered parking notification" do
+    let(:creation_description) { Ownership.new(origin: "creator_unregistered_parking_notification").creation_description }
+
+    it "renders the humanized label with the flow tooltip" do
+      expect(creation_description).to eq "creator unregistered parking notification"
+      expect(component).to have_content("Unregistered Parking Notification")
+      expect(component).to have_css("[role=tooltip]", text: "Registered via the Unregistered Parking Notification flow", visible: :all)
+    end
+  end
 end


### PR DESCRIPTION
Follows up on #3904, which introduced `Org::OriginDisplay::Component`.

- Renders bikes registered through the unregistered parking notification flow as **"Unregistered Parking Notification"** with a tooltip reading "Registered via the Unregistered Parking Notification flow", rather than the raw humanized origin ("creator unregistered parking notification").

Heads up: the origin's `Ownership#creation_description` mapping (`ownership.rb:192`) is dead code — it checks the origin key `unregistered_parking_notification`, but the real enum key is `creator_unregistered_parking_notification`, so it never fires and the value falls through to the titleized fallback. This PR handles the display in the component; the model line is worth fixing separately (it also affects the org export's `registration_method` column and the admin ownerships table).
