### PR TITLE
Scrub API error messages so 500s reach Honeybadger

### DIFF
--- a/app/controllers/api/base.rb
+++ b/app/controllers/api/base.rb
@@ -79,15 +79,15 @@ module API
 
     def self.respond_to_error(e)
       logger.error e unless Rails.env.test? # Breaks tests...
-      eclass = e.class.to_s
-      message = "OAuth error: #{e}" if /APIAuthorization::Errors/.match?(eclass)
-      opts = {error: message || e.message}
-      status_code = status_code_for(e, eclass)
-      if Rails.env.production?
-        Honeybadger.notify(e) if status_code > 450 # Only notify in production for 500s
-      else
-        opts[:trace] = e.backtrace[0, 10]
-      end
+      # Exception messages can carry invalid UTF-8 (scanner probe URLs, malformed
+      # params). Scrub before matching or serializing — an unscrubbed bad byte
+      # raises here and suppresses the Honeybadger notify below, leaving a bare 500.
+      message = e.message.to_s.dup.force_encoding(Encoding::UTF_8).scrub
+      status_code = status_code_for(e, message)
+      Honeybadger.notify(e) if Rails.env.production? && status_code > 450 # Only notify for 500s
+      message = "OAuth error: #{message}" if /APIAuthorization::Errors/.match?(e.class.to_s)
+      opts = {error: message}
+      opts[:trace] = e.backtrace[0, 10] unless Rails.env.production?
       Rack::Response.new(opts.to_json, status_code, {
         "Content-Type" => "application/json",
         "Access-Control-Allow-Origin" => "*",
@@ -95,17 +95,18 @@ module API
       })
     end
 
-    def self.status_code_for(error, eclass)
+    def self.status_code_for(error, message)
+      eclass = error.class.to_s
       if /OAuthUnauthorizedError/.match?(eclass)
         401
       elsif /OAuthForbiddenError/.match?(eclass)
         403
-      elsif (eclass =~ /RecordNotFound/) || (error.message =~ /unable to find/i)
+      elsif eclass.match?(/RecordNotFound/) || message.match?(/unable to find/i)
         404
       elsif error.is_a?(Rack::BadRequest) # malformed request body (e.g. empty multipart)
         400
       else
-        (error.respond_to? :status) && error.status || 500
+        (error.respond_to?(:status) && error.status) || 500
       end
     end
   end

--- a/spec/requests/api/base_request_spec.rb
+++ b/spec/requests/api/base_request_spec.rb
@@ -1,51 +1,27 @@
 require "rails_helper"
 
-# Regression coverage for the API error handler. Exception messages routinely
-# carry invalid UTF-8 — enum errors interpolate the raw param value
-# ("'\xC3(' is not a valid frame_material"), scanners send probe bytes. An
-# unscrubbed bad byte used to crash respond_to_error, producing a bare 500 with
-# no JSON body and — worse — suppressing the Honeybadger notify, so API 500s
-# went unreported.
+# The one API error-handler behavior the endpoint request specs don't exercise:
+# an exception whose message carries invalid UTF-8 (enum errors interpolate the
+# raw param value — "'\xC3(' is not a valid frame_material" — and scanners send
+# probe bytes). The bad byte used to crash respond_to_error, yielding a bare 500
+# with no JSON body and no Honeybadger notify. Status mapping, the {"error": …}
+# envelope, and CORS headers are covered by the v2/v3 request specs.
 RSpec.describe API::Base do
-  let(:invalid_utf8) { "'\xC3\x28' is not a valid frame_material".dup.force_encoding(Encoding::UTF_8) }
-  # respond_to_error reads e.backtrace, so exercise real raised exceptions
-  def raised(klass, message)
-    raise klass, message
-  rescue => e
-    e
-  end
-
-  describe ".status_code_for" do
-    it "maps by class and message" do
-      expect(described_class.status_code_for(ActiveRecord::RecordNotFound.new, "missing")).to eq 404
-      expect(described_class.status_code_for(StandardError.new, "Unable to find endpoint")).to eq 404
-      expect(described_class.status_code_for(StandardError.new, "boom")).to eq 500
+  describe ".respond_to_error with an invalid-UTF-8 message" do
+    let(:invalid_utf8) { "'\xC3\x28' is not a valid frame_material".dup.force_encoding(Encoding::UTF_8) }
+    # respond_to_error reads e.backtrace, so raise the exception for real
+    let(:error) do
+      raise StandardError, invalid_utf8
+    rescue => e
+      e
     end
-  end
 
-  describe ".respond_to_error" do
-    it "returns a JSON error response with CORS headers" do
-      response = described_class.respond_to_error(raised(StandardError, "boom"))
+    it "scrubs the bad bytes instead of crashing" do
+      expect(invalid_utf8).not_to be_valid_encoding
+      response = nil
+      expect { response = described_class.respond_to_error(error) }.not_to raise_error
       expect(response.status).to eq 500
-      expect(response.headers["Access-Control-Allow-Origin"]).to eq "*"
-      expect(JSON.parse(response.body.first)["error"]).to eq "boom"
-    end
-
-    it "maps a not-found message to 404" do
-      response = described_class.respond_to_error(raised(StandardError, "Unable to find endpoint"))
-      expect(response.status).to eq 404
-    end
-
-    context "with an invalid-UTF-8 message" do
-      it "scrubs the bad bytes instead of crashing" do
-        expect(invalid_utf8).not_to be_valid_encoding
-        response = nil
-        expect { response = described_class.respond_to_error(raised(StandardError, invalid_utf8)) }
-          .not_to raise_error
-        expect(response.status).to eq 500
-        body = JSON.parse(response.body.first)
-        expect(body["error"]).to include "is not a valid frame_material"
-      end
+      expect(JSON.parse(response.body.first)["error"]).to include "is not a valid frame_material"
     end
   end
 end

--- a/spec/requests/api/base_request_spec.rb
+++ b/spec/requests/api/base_request_spec.rb
@@ -1,0 +1,51 @@
+require "rails_helper"
+
+# Regression coverage for the API error handler. Exception messages routinely
+# carry invalid UTF-8 — enum errors interpolate the raw param value
+# ("'\xC3(' is not a valid frame_material"), scanners send probe bytes. An
+# unscrubbed bad byte used to crash respond_to_error, producing a bare 500 with
+# no JSON body and — worse — suppressing the Honeybadger notify, so API 500s
+# went unreported.
+RSpec.describe API::Base do
+  let(:invalid_utf8) { "'\xC3\x28' is not a valid frame_material".dup.force_encoding(Encoding::UTF_8) }
+  # respond_to_error reads e.backtrace, so exercise real raised exceptions
+  def raised(klass, message)
+    raise klass, message
+  rescue => e
+    e
+  end
+
+  describe ".status_code_for" do
+    it "maps by class and message" do
+      expect(described_class.status_code_for(ActiveRecord::RecordNotFound.new, "missing")).to eq 404
+      expect(described_class.status_code_for(StandardError.new, "Unable to find endpoint")).to eq 404
+      expect(described_class.status_code_for(StandardError.new, "boom")).to eq 500
+    end
+  end
+
+  describe ".respond_to_error" do
+    it "returns a JSON error response with CORS headers" do
+      response = described_class.respond_to_error(raised(StandardError, "boom"))
+      expect(response.status).to eq 500
+      expect(response.headers["Access-Control-Allow-Origin"]).to eq "*"
+      expect(JSON.parse(response.body.first)["error"]).to eq "boom"
+    end
+
+    it "maps a not-found message to 404" do
+      response = described_class.respond_to_error(raised(StandardError, "Unable to find endpoint"))
+      expect(response.status).to eq 404
+    end
+
+    context "with an invalid-UTF-8 message" do
+      it "scrubs the bad bytes instead of crashing" do
+        expect(invalid_utf8).not_to be_valid_encoding
+        response = nil
+        expect { response = described_class.respond_to_error(raised(StandardError, invalid_utf8)) }
+          .not_to raise_error
+        expect(response.status).to eq 500
+        body = JSON.parse(response.body.first)
+        expect(body["error"]).to include "is not a valid frame_material"
+      end
+    end
+  end
+end


### PR DESCRIPTION
Restore Honeybadger visibility for API 500s. Exception messages routinely carry invalid UTF-8 — scanner probe URLs, and enum errors that interpolate the raw param value (`'…' is not a valid frame_material`). That bad byte raised inside `status_code_for`'s regex match and `opts.to_json`, crashing `respond_to_error` itself: the exception escaped as a bare Rack 500 with no JSON body, the wrong status (404/400/401 never mapped), and — since the notify sat on the line *after* the crash — no Honeybadger report. That's why API 500s appeared in the logs but nowhere in the error pipeline.

- Scrub the message once before matching or serializing, reusing the `csp_reports_controller` idiom (`.dup.force_encoding(UTF_8).scrub`).
- Compute the status and fire the Honeybadger notify before building the response body, so a formatting failure can no longer suppress the report.
- Add a regression test for the invalid-UTF-8 message path (crash → scrubbed 500 with a valid JSON body).
