### PR TITLE
Update UI components; add form-persist and address group

### DIFF
--- a/.claude/skills/merge-conflicts/SKILL.md
+++ b/.claude/skills/merge-conflicts/SKILL.md
@@ -15,11 +15,22 @@ allowed-tools: Bash, Read, Glob, Grep
 
 # Resolving merge conflicts
 
-This repo's target base is `origin/main`. When a branch needs to catch up with the base, or a merge/cherry-pick/pull leaves conflict markers, follow this — the goal is a clean, honest integration that a reviewer can trust and that never rewrites shared history.
+When a branch needs to catch up with its base, or a merge/cherry-pick/pull leaves conflict markers, follow this — the goal is a clean, honest integration that a reviewer can trust and that never rewrites shared history.
+
+## Determine the base branch first — don't assume `main`
+
+"Update from base", "sync with main", "this branch is behind", "merge the base in" all need a base branch to merge *from*. **Don't default to `main`.** A branch is often stacked on another feature branch, and merging `main` instead silently pulls the wrong history — the diff looks "already up to date" against `main` while the real base has commits you're missing. Resolve the base in this order:
+
+1. **A branch the user names** — "update from X" / "base is X" wins outright.
+2. **An open PR's base** — `gh pr view <branch> --json baseRefName`. Also check the base of any feature branch you recently merged into this one (`gh pr view <that-branch> --json baseRefName`); a stack's branches usually share the same base.
+3. **The upstream tracking ref**, if it names a branch other than this one's own remote mirror (`git rev-parse --abbrev-ref @{u}`).
+4. **The Conductor workspace target branch** (from the workspace/system instructions) — a default hint, *not* the last word.
+
+If 1–3 turn up nothing and the branch clearly builds on another feature branch — it was created by merging one in, was cut from `main` but layers work that lives on an unmerged branch, or the user talks about it as part of a stack — **ask which branch to update from (offer the likely candidate) rather than merging `main`.** Confirm before running the merge; a wrong base is expensive to unwind. Note that being 0-behind `main` proves nothing here — a stacked branch is normally 0-behind `main` and still far behind its real base.
 
 ## Bring a branch up to date
 
-- `git fetch origin`, then `git merge --no-edit origin/main`.
+- `git fetch origin`, then `git merge --no-edit origin/<base>` (the base resolved above, not reflexively `main`).
 - **Merge, never rebase.** Rebasing rewrites the branch's history; if the branch is already pushed, republishing it needs a force-push, and we never force-push. A merge commit keeps the real history and is always safe to push on top of.
 - If uncommitted work blocks the merge, commit that work first (it belongs to the branch anyway), then merge.
 - Already up to date → nothing to do.

--- a/app/components/org/impound_record_update_form/component.rb
+++ b/app/components/org/impound_record_update_form/component.rb
@@ -27,12 +27,14 @@ module Org
       # (blocks empty submissions).
       def form_data
         controllers = ["form-persist"]
-        actions = ["input->form-persist#save", "submit->form-persist#clear"]
+        actions = ["input->form-persist#save"]
 
         if @multi
           controllers << "table-multi-checkbox"
           actions << "submit->org--impound-update-multi#validate"
         end
+        # Clear runs after validate so a blocked (empty) multi submit keeps the draft
+        actions << "submit->form-persist#clear"
 
         {controller: controllers.join(" "), "form-persist-key-value": persist_key, action: actions.join(" ")}
       end

--- a/app/components/org/impound_record_update_form/component.rb
+++ b/app/components/org/impound_record_update_form/component.rb
@@ -22,12 +22,23 @@ module Org
         organization_impound_record_path(record_id, organization_id: @current_organization)
       end
 
-      # Multi mode: table-multi-checkbox drives select-all, and submit is
-      # validated by org--impound-update-multi (blocks empty submissions)
+      # form-persist keeps a draft of the notes/text fields across reloads. Multi
+      # mode adds table-multi-checkbox (select-all) and org--impound-update-multi
+      # (blocks empty submissions).
       def form_data
-        return {} unless @multi
+        controllers = ["form-persist"]
+        actions = ["input->form-persist#save", "submit->form-persist#clear"]
 
-        {controller: "table-multi-checkbox", action: "submit->org--impound-update-multi#validate"}
+        if @multi
+          controllers << "table-multi-checkbox"
+          actions << "submit->org--impound-update-multi#validate"
+        end
+
+        {controller: controllers.join(" "), "form-persist-key-value": persist_key, action: actions.join(" ")}
+      end
+
+      def persist_key
+        @multi ? "impound-update-multi-#{@current_organization.id}" : "impound-update-#{@impound_record.display_id}"
       end
 
       # The kind <select> change is handled by org--impound-update (field

--- a/app/components/org/impound_record_update_form/component.rb
+++ b/app/components/org/impound_record_update_form/component.rb
@@ -36,11 +36,7 @@ module Org
         # Clear runs after validate so a blocked (empty) multi submit keeps the draft
         actions << "submit->form-persist#clear"
 
-        {controller: controllers.join(" "), "form-persist-key-value": persist_key, action: actions.join(" ")}
-      end
-
-      def persist_key
-        @multi ? "impound-update-multi-#{@current_organization.id}" : "impound-update-#{@impound_record.display_id}"
+        {controller: controllers.join(" "), action: actions.join(" ")}
       end
 
       # The kind <select> change is handled by org--impound-update (field

--- a/app/components/page_block/landing_demo_modal/component.html.erb
+++ b/app/components/page_block/landing_demo_modal/component.html.erb
@@ -1,6 +1,6 @@
 <%= render(UI::Modal::Component.new(title: "Contact us for a free trial", id: @modal_id)) do |modal| %>
   <% modal.with_body do %>
-    <%= form_for @feedback, html: {data: {controller: "form-persist", "form-persist-key-value": @feedback_type, action: "input->form-persist#save submit->form-persist#clear"}} do |f| %>
+    <%= form_for @feedback, html: {data: {controller: "form-persist", action: "input->form-persist#save submit->form-persist#clear"}} do |f| %>
       <%= render(UI::Forms::Group::Component.new(form_builder: f, attribute: :name, label_text: @name_label, html_options: {required: true})) %>
       <%= render(UI::Forms::Group::Component.new(form_builder: f, attribute: :contact_name, label_text: "Name")) %>
       <%= render(UI::Forms::Group::Component.new(form_builder: f, attribute: :email, kind: :email_field, html_options: {required: true, value: @current_user&.email})) %>

--- a/app/components/page_block/landing_demo_modal/component.html.erb
+++ b/app/components/page_block/landing_demo_modal/component.html.erb
@@ -1,6 +1,6 @@
 <%= render(UI::Modal::Component.new(title: "Contact us for a free trial", id: @modal_id)) do |modal| %>
   <% modal.with_body do %>
-    <%= form_for @feedback do |f| %>
+    <%= form_for @feedback, html: {data: {controller: "form-persist", "form-persist-key-value": @feedback_type, action: "input->form-persist#save submit->form-persist#clear"}} do |f| %>
       <%= render(UI::Forms::Group::Component.new(form_builder: f, attribute: :name, label_text: @name_label, html_options: {required: true})) %>
       <%= render(UI::Forms::Group::Component.new(form_builder: f, attribute: :contact_name, label_text: "Name")) %>
       <%= render(UI::Forms::Group::Component.new(form_builder: f, attribute: :email, kind: :email_field, html_options: {required: true, value: @current_user&.email})) %>

--- a/app/components/ui/button/component.rb
+++ b/app/components/ui/button/component.rb
@@ -20,6 +20,7 @@ module UI
         error: "tw:text-white tw:bg-red-600 tw:border tw:border-red-600 tw:hover:bg-red-700 tw:active:bg-red-800 tw:focus:ring-red-500/40 tw:dark:bg-red-500 tw:dark:border-red-500 tw:dark:hover:bg-red-600 tw:dark:active:bg-red-700",
         purple: "tw:text-white tw:bg-[#715eb2] tw:border tw:border-[#715eb2] tw:hover:bg-[#5d4b9c] tw:hover:border-[#5d4b9c] tw:active:bg-[#5d4b9c] tw:focus:ring-[#715eb2]/40",
         danger_outline: "tw:text-[#c0392b] tw:bg-white tw:border tw:border-[#f3c9c9] tw:hover:bg-red-50 tw:active:bg-red-100 tw:focus:ring-red-500/40 tw:dark:bg-transparent tw:dark:text-red-400 tw:dark:border-red-900 tw:dark:hover:bg-red-950",
+        purple_outline: "tw:text-gray-800 tw:bg-white tw:border tw:border-gray-200 tw:hover:border-[#715eb2] tw:hover:bg-[#f7f5fc] tw:focus:ring-[#715eb2]/40 tw:dark:bg-gray-800 tw:dark:text-gray-100 tw:dark:border-gray-700 tw:dark:hover:border-[#715eb2] tw:dark:hover:bg-purple-950",
         link: "twlink tw:p-0"
       }.freeze
 
@@ -27,6 +28,9 @@ module UI
         primary: "tw:ring-2 tw:ring-blue-500/40 tw:bg-blue-700 tw:dark:bg-blue-600",
         secondary: "tw:ring-2 tw:ring-blue-500/40 tw:bg-gray-200 tw:border-gray-400 tw:dark:bg-gray-800 tw:dark:border-gray-600",
         error: "tw:ring-2 tw:ring-red-500/40 tw:bg-red-700 tw:dark:bg-red-600",
+        danger_outline: "tw:ring-2 tw:ring-red-500/40 tw:bg-red-100 tw:border-[#c0392b] tw:dark:bg-red-950 tw:dark:border-red-700",
+        purple: "tw:ring-2 tw:ring-[#715eb2]/40 tw:bg-[#5d4b9c]",
+        purple_outline: "tw:ring-2 tw:ring-[#715eb2]/40 tw:bg-purple-100 tw:border-[#715eb2] tw:dark:bg-purple-950 tw:dark:border-[#715eb2]",
         link: "tw:text-blue-800 tw:dark:text-blue-300 tw:font-bold tw:underline"
       }.freeze
 
@@ -35,28 +39,35 @@ module UI
         primary: "tw:aria-pressed:ring-2 tw:active:ring-2 tw:aria-pressed:ring-blue-500/40 tw:active:ring-blue-500/40 tw:aria-pressed:bg-blue-700 tw:active:bg-blue-700 tw:aria-pressed:dark:bg-blue-600 tw:active:dark:bg-blue-600",
         secondary: "tw:aria-pressed:ring-2 tw:active:ring-2 tw:aria-pressed:ring-blue-500/40 tw:active:ring-blue-500/40 tw:aria-pressed:bg-gray-200 tw:active:bg-gray-200 tw:aria-pressed:border-gray-400 tw:active:border-gray-400 tw:aria-pressed:dark:bg-gray-800 tw:active:dark:bg-gray-800 tw:aria-pressed:dark:border-gray-600 tw:active:dark:border-gray-600",
         error: "tw:aria-pressed:ring-2 tw:active:ring-2 tw:aria-pressed:ring-red-500/40 tw:active:ring-red-500/40 tw:aria-pressed:bg-red-700 tw:active:bg-red-700 tw:aria-pressed:dark:bg-red-600 tw:active:dark:bg-red-600",
+        danger_outline: "tw:aria-pressed:ring-2 tw:active:ring-2 tw:aria-pressed:ring-red-500/40 tw:active:ring-red-500/40 tw:aria-pressed:bg-red-100 tw:active:bg-red-100 tw:aria-pressed:border-[#c0392b] tw:active:border-[#c0392b] tw:aria-pressed:dark:bg-red-950 tw:active:dark:bg-red-950 tw:aria-pressed:dark:border-red-700 tw:active:dark:border-red-700",
+        purple: "tw:aria-pressed:ring-2 tw:active:ring-2 tw:aria-pressed:ring-[#715eb2]/40 tw:active:ring-[#715eb2]/40 tw:aria-pressed:bg-[#5d4b9c] tw:active:bg-[#5d4b9c]",
+        purple_outline: "tw:aria-pressed:ring-2 tw:active:ring-2 tw:aria-pressed:ring-[#715eb2]/40 tw:active:ring-[#715eb2]/40 tw:aria-pressed:bg-purple-100 tw:active:bg-purple-100 tw:aria-pressed:border-[#715eb2] tw:active:border-[#715eb2] tw:aria-pressed:dark:bg-purple-950 tw:active:dark:bg-purple-950 tw:aria-pressed:dark:border-[#715eb2] tw:active:dark:border-[#715eb2]",
         link: "tw:aria-pressed:text-blue-800 tw:active:text-blue-800 tw:aria-pressed:dark:text-blue-300 tw:active:dark:text-blue-300 tw:aria-pressed:font-bold tw:active:font-bold tw:aria-pressed:underline tw:active:underline"
       }.freeze
 
       KINDS = %i[button submit]
+
+      DISABLED_CLASSES = "tw:disabled:opacity-50 tw:disabled:cursor-not-allowed tw:disabled:pointer-events-none"
 
       def self.build_classes(color:, size:, active: false, html_class: nil)
         classes = [BASE_CLASSES, COLORS[color], html_class]
         unless color == :link
           classes << SIZES[size]
           classes << "tw:focus:outline-none tw:focus:ring-3 tw:font-medium tw:no-underline"
+          classes << DISABLED_CLASSES
         end
         classes << ACTIVE_COLORS[color] if active
         classes << ACTIVE_PREFIXED[color]
         classes.compact.join(" ")
       end
 
-      def initialize(text: nil, color: :secondary, size: :md, active: false, html_class: nil, kind: nil, data: {}, aria: {})
+      def initialize(text: nil, color: :secondary, size: :md, active: false, html_class: nil, kind: nil, disabled: false, data: {}, aria: {})
         @text = text
         @color = COLORS.key?(color) ? color : :secondary
         @kind = KINDS.include?(kind&.to_sym) ? kind.to_sym : KINDS.first
         @active = active
         @html_class = html_class
+        @disabled = disabled
         @data = data
         @aria = aria
 
@@ -65,7 +76,7 @@ module UI
       end
 
       def call
-        content_tag(:button, @text || content, class: button_classes, type: (@kind == :submit) ? "submit" : "button", data: @data, aria: @aria)
+        content_tag(:button, @text || content, class: button_classes, type: (@kind == :submit) ? "submit" : "button", disabled: @disabled, data: @data, aria: @aria)
       end
 
       def button_classes

--- a/app/components/ui/button/component_preview.rb
+++ b/app/components/ui/button/component_preview.rb
@@ -30,6 +30,15 @@ module UI
         render(UI::Button::Component.new(text: "Error Active", color: :error, active: true))
       end
 
+      # White button with a soft danger outline
+      def danger_outline
+        render(UI::Button::Component.new(text: "Mark stolen", color: :danger_outline))
+      end
+
+      def danger_outline_active
+        render(UI::Button::Component.new(text: "Danger Outline Active", color: :danger_outline, active: true))
+      end
+
       def link
         render(UI::Button::Component.new(text: "Link style", color: :link))
       end
@@ -43,9 +52,17 @@ module UI
         render(UI::Button::Component.new(text: "Purple", color: :purple))
       end
 
-      # White button with a soft danger outline
-      def danger_outline
-        render(UI::Button::Component.new(text: "Mark stolen", color: :danger_outline))
+      def purple_active
+        render(UI::Button::Component.new(text: "Purple Active", color: :purple, active: true))
+      end
+
+      # White button with a purple outline (toggles to a purple tint when active)
+      def purple_outline
+        render(UI::Button::Component.new(text: "Purple outline", color: :purple_outline))
+      end
+
+      def purple_outline_active
+        render(UI::Button::Component.new(text: "Purple Outline Active", color: :purple_outline, active: true))
       end
 
       # @!endgroup

--- a/app/components/ui/color_swatch/component.rb
+++ b/app/components/ui/color_swatch/component.rb
@@ -5,15 +5,23 @@ module UI
     # A small square showing a bike color. The display-less "cover-up" color
     # renders Color::COVER_UP_SWATCH's multicolor blend instead of a solid fill.
     class Component < ApplicationComponent
-      BASE_CLASSES = "tw:inline-block tw:h-6 tw:w-6 tw:rounded-xs tw:border tw:border-black/20 tw:align-middle"
+      # leading-[0] collapses the empty box's line-height strut so align-baseline
+      # sits its bottom on the text baseline instead of floating above it
+      BASE_CLASSES = "tw:inline-block tw:leading-[0] tw:rounded-xs tw:border tw:border-black/20"
 
-      def initialize(display: nil, name: nil)
+      SIZES = {sm: "tw:h-3 tw:w-3", md: "tw:h-6 tw:w-6"}.freeze
+
+      ALIGNS = {middle: "tw:align-middle", baseline: "tw:align-baseline"}.freeze
+
+      def initialize(display: nil, name: nil, size: :md, align: :middle)
         @display = display.presence
         @name = name.presence
+        @size = SIZES.key?(size) ? size : :md
+        @align = ALIGNS.key?(align) ? align : :middle
       end
 
       def call
-        content_tag(:span, "", class: BASE_CLASSES, style: swatch_style, title: @name)
+        content_tag(:span, "", class: "#{BASE_CLASSES} #{SIZES[@size]} #{ALIGNS[@align]}", style: swatch_style, title: @name)
       end
 
       private

--- a/app/components/ui/definition_list/row/component.rb
+++ b/app/components/ui/definition_list/row/component.rb
@@ -4,10 +4,11 @@ module UI
   module DefinitionList
     module Row
       class Component < ApplicationComponent
-        def initialize(label:, value: nil, render_with_no_value: false, full_width: false, time_localizer_settings: nil)
+        def initialize(label:, value: nil, render_with_no_value: false, no_value_text: nil, full_width: false, time_localizer_settings: nil)
           @label = label
           @value = value
           @render_with_no_value = render_with_no_value
+          @no_value_text = no_value_text
           @full_width = full_width
 
           # TODO: actually support originalTimeZone. When this is set currently, we show the timezone,
@@ -30,7 +31,7 @@ module UI
         end
 
         def no_value_content
-          translation(".no_value")
+          @no_value_text || translation(".no_value")
         end
 
         def wrapper_classes

--- a/app/components/ui/forms/address_group/component.en.yml
+++ b/app/components/ui/forms/address_group/component.en.yml
@@ -1,0 +1,13 @@
+---
+en:
+  components:
+    ui:
+      forms:
+        address_group:
+          address: Address
+          choose_country: Choose country
+          city: City
+          country: Country
+          postal_code: Postal code
+          region: Region
+          state: State

--- a/app/components/ui/forms/address_group/component.html.erb
+++ b/app/components/ui/forms/address_group/component.html.erb
@@ -1,0 +1,34 @@
+<div
+  data-controller="ui--forms--address-group"
+  data-ui--forms--address-group-us-id-value="<%= us_country_id %>"
+>
+  <%= render(UI::Forms::Group::Component.new(form_builder: @form, attribute: :street, kind: :text_field, label_text: street_label)) %>
+
+  <div class="tw:grid tw:grid-cols-2 tw:gap-x-2">
+    <%= render(UI::Forms::Group::Component.new(form_builder: @form, attribute: :city, kind: :text_field, label_text: translation(".city"))) %>
+
+    <div
+      data-ui--forms--address-group-target="state"
+      class="<%= state_hidden_class %>"
+    >
+      <%= render(UI::Forms::Group::Component.new(form_builder: @form, attribute: :region_record_id, kind: :content_block, label_text: translation(".state"))) do %>
+        <%= @form.collection_select(:region_record_id, State.united_states, :id, :name, {include_blank: true}, {class: "twinput tw:w-full"}) %>
+      <% end %>
+    </div>
+
+    <div
+      data-ui--forms--address-group-target="region"
+      class="<%= region_hidden_class %>"
+    >
+      <%= render(UI::Forms::Group::Component.new(form_builder: @form, attribute: :region_string, kind: :text_field, label_text: translation(".region"))) %>
+    </div>
+  </div>
+
+  <div class="tw:grid tw:grid-cols-2 tw:gap-x-2">
+    <%= render(UI::Forms::Group::Component.new(form_builder: @form, attribute: :postal_code, kind: :text_field, label_text: translation(".postal_code"))) %>
+
+    <%= render(UI::Forms::Group::Component.new(form_builder: @form, attribute: :country_id, kind: :content_block, label_text: translation(".country"))) do %>
+      <%= @form.select(:country_id, Country.select_options, {prompt: translation(".choose_country"), selected: selected_country_id}, {class: "twinput tw:w-full", data: {action: "change->ui--forms--address-group#toggleCountry", "ui--forms--address-group-target": "country"}}) %>
+    <% end %>
+  </div>
+</div>

--- a/app/components/ui/forms/address_group/component.rb
+++ b/app/components/ui/forms/address_group/component.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+module UI
+  module Forms
+    module AddressGroup
+      # Street/city/region/postal/country fields with a Stimulus-driven US-state
+      # vs free-text-region toggle. The form object must expose the geocodeable
+      # address attributes (street, city, region_record_id, region_string,
+      # postal_code, country_id)
+      class Component < ApplicationComponent
+        def initialize(form_builder:, street_label: nil, default_country_id: Country.united_states_id)
+          @form = form_builder
+          @street_label = street_label
+          @default_country_id = default_country_id
+        end
+
+        private
+
+        def street_label
+          @street_label || translation(".address")
+        end
+
+        def us_country_id
+          Country.united_states_id
+        end
+
+        # The object's country, falling back to the default, so the dropdown and the
+        # state/region visibility agree on load
+        def selected_country_id
+          @form.object.country_id || @default_country_id
+        end
+
+        # US shows the state select; other countries the free-text region field
+        def state_hidden_class
+          "tw:hidden" unless us_selected?
+        end
+
+        def region_hidden_class
+          "tw:hidden" if us_selected?
+        end
+
+        def us_selected?
+          selected_country_id == us_country_id
+        end
+      end
+    end
+  end
+end

--- a/app/components/ui/forms/address_group/component_preview.rb
+++ b/app/components/ui/forms/address_group/component_preview.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module UI
+  module Forms
+    module AddressGroup
+      class ComponentPreview < ApplicationComponentPreview
+        def default
+          {template: "ui/forms/address_group/component_preview/default"}
+        end
+      end
+    end
+  end
+end

--- a/app/components/ui/forms/address_group/component_preview/default.html.erb
+++ b/app/components/ui/forms/address_group/component_preview/default.html.erb
@@ -1,0 +1,3 @@
+<%= form_with(model: AddressRecord.new, url: "#", builder: BikeIndexFormBuilder) do |f| %>
+  <%= render(UI::Forms::AddressGroup::Component.new(form_builder: f)) %>
+<% end %>

--- a/app/javascript/controllers/form_persist_controller.js
+++ b/app/javascript/controllers/form_persist_controller.js
@@ -1,0 +1,76 @@
+import { Controller } from '@hotwired/stimulus'
+
+/* global localStorage, setTimeout, clearTimeout, Date, window */
+
+// Connects to data-controller="form-persist"
+// Mirrors named text fields to localStorage so a draft survives page reloads.
+// Set data-form-persist-key-value to a stable per-form key, then wire
+// data-action="input->form-persist#save submit->form-persist#clear".
+// Writes are debounced (DEBOUNCE_MS) and a restored draft is discarded once
+// older than TTL_MS.
+const DEBOUNCE_MS = 400
+const TTL_MS = 604800000 // 1 week
+
+export default class extends Controller {
+  static values = { key: String }
+
+  connect () {
+    const stored = this.read()
+    this.fields.forEach((field) => {
+      if (!field.value && stored[field.name] != null) field.value = stored[field.name]
+    })
+    // Flush a pending debounced write before the page unloads, so quickly
+    // typing then reloading doesn't drop the last keystrokes.
+    this.boundFlush = this.flush.bind(this)
+    window.addEventListener('pagehide', this.boundFlush)
+  }
+
+  disconnect () {
+    clearTimeout(this.timer)
+    window.removeEventListener('pagehide', this.boundFlush)
+  }
+
+  // Debounced so a burst of keystrokes writes once, not per character.
+  save () {
+    clearTimeout(this.timer)
+    this.timer = setTimeout(() => this.write(), DEBOUNCE_MS)
+  }
+
+  flush () {
+    if (this.timer) this.write()
+  }
+
+  clear () {
+    clearTimeout(this.timer)
+    localStorage.removeItem(this.storageKey)
+  }
+
+  write () {
+    clearTimeout(this.timer)
+    this.timer = null
+    const data = {}
+    this.fields.forEach((field) => { data[field.name] = field.value })
+    localStorage.setItem(this.storageKey, JSON.stringify({ savedAt: Date.now(), data }))
+  }
+
+  read () {
+    try {
+      const { savedAt, data } = JSON.parse(localStorage.getItem(this.storageKey)) || {}
+      if (savedAt == null || Date.now() - savedAt > TTL_MS) {
+        this.clear()
+        return {}
+      }
+      return data || {}
+    } catch {
+      return {}
+    }
+  }
+
+  get fields () {
+    return this.element.querySelectorAll('textarea, input:not([type=hidden]):not([type=submit]):not([type=button])')
+  }
+
+  get storageKey () {
+    return `form-persist:${this.keyValue}`
+  }
+}

--- a/app/javascript/controllers/form_persist_controller.js
+++ b/app/javascript/controllers/form_persist_controller.js
@@ -4,8 +4,9 @@ import { Controller } from '@hotwired/stimulus'
 
 // Connects to data-controller="form-persist"
 // Mirrors named text fields to localStorage so a draft survives page reloads.
-// Set data-form-persist-key-value to a stable per-form key, then wire
-// data-action="input->form-persist#save submit->form-persist#clear".
+// Wire data-action="input->form-persist#save submit->form-persist#clear". The
+// storage key defaults to pathname + the form's action (see derivedKey); set
+// data-form-persist-key-value only when that isn't unique per form.
 // Writes are debounced (DEBOUNCE_MS) and a restored draft is discarded once
 // older than TTL_MS.
 const DEBOUNCE_MS = 400
@@ -71,6 +72,13 @@ export default class extends Controller {
   }
 
   get storageKey () {
-    return `form-persist:${this.keyValue}`
+    return `form-persist:${this.keyValue || this.derivedKey}`
+  }
+
+  // Fallback when no key-value is set: the form's action is resource-specific and
+  // stable across reloads; pathname disambiguates forms that share an action.
+  get derivedKey () {
+    const action = this.element.getAttribute('action') || this.element.id || ''
+    return `${window.location.pathname}${action}`
   }
 }

--- a/app/javascript/controllers/org/impound_update_multi_controller.js
+++ b/app/javascript/controllers/org/impound_update_multi_controller.js
@@ -67,10 +67,10 @@ export default class extends Controller {
     } else {
       collapse('show', this.errorTarget)
       event.preventDefault()
-      // Stop the event reaching rails-ujs, which would otherwise disable the
-      // data-disable-with submit button and leave it stuck (the form never
-      // navigates away to get a fresh one).
-      event.stopPropagation()
+      // stopImmediatePropagation keeps the event from reaching rails-ujs (which
+      // would disable the data-disable-with button and leave it stuck) and from
+      // reaching form-persist#clear (which would wipe the draft on a blocked submit).
+      event.stopImmediatePropagation()
     }
   }
 

--- a/app/javascript/controllers/ui/forms/address_group_controller.js
+++ b/app/javascript/controllers/ui/forms/address_group_controller.js
@@ -1,0 +1,18 @@
+import { Controller } from '@hotwired/stimulus'
+
+// Connects to data-controller='ui--forms--address-group'
+// US addresses use a state <select>; other countries a free-text region field
+export default class extends Controller {
+  static targets = ['country', 'state', 'region']
+  static values = { usId: Number }
+
+  toggleCountry () {
+    const isUs = Number(this.countryTarget.value) === this.usIdValue
+    this.stateTarget.classList.toggle('tw:hidden', !isUs)
+    this.regionTarget.classList.toggle('tw:hidden', isUs)
+    if (!isUs) {
+      const select = this.stateTarget.querySelector('select')
+      if (select) select.value = ''
+    }
+  }
+}

--- a/app/javascript/controllers/ui/modal_controller.js
+++ b/app/javascript/controllers/ui/modal_controller.js
@@ -1,10 +1,12 @@
 import { Controller } from '@hotwired/stimulus'
 
 // Connects to data-controller="ui--modal"
+// The open state persists to the URL query (?modal_<id>=1) so the modal survives a reload.
 export default class extends Controller {
   connect () {
     this.boundOpen = this.openFromTrigger.bind(this)
     this.triggers.forEach(el => el.addEventListener('click', this.boundOpen))
+    if (this.paramInUrl) this.open()
   }
 
   disconnect () {
@@ -14,8 +16,13 @@ export default class extends Controller {
   openFromTrigger (event) {
     this.trigger = event.currentTarget
     this.trigger.classList.add('active')
+    this.open()
+  }
+
+  open () {
     this.element.showModal()
     document.body.classList.add('tw:overflow-hidden')
+    this.persist(true)
   }
 
   close () {
@@ -25,6 +32,7 @@ export default class extends Controller {
       this.trigger.classList.remove('active')
       this.trigger = null
     }
+    this.persist(false)
   }
 
   backdropClick (event) {
@@ -37,6 +45,25 @@ export default class extends Controller {
     if (event.key === 'Escape') {
       this.close()
     }
+  }
+
+  get param () {
+    return `modal_${this.element.id}`
+  }
+
+  get paramInUrl () {
+    return new URLSearchParams(window.location.search).has(this.param)
+  }
+
+  persist (open) {
+    const url = new URL(window.location)
+    if (open) {
+      url.searchParams.set(this.param, '1')
+    } else {
+      url.searchParams.delete(this.param)
+    }
+    // replaceState (not pushState) so opening doesn't stack history entries.
+    window.history.replaceState(window.history.state, '', url)
   }
 
   get triggers () {

--- a/db/seeds/seed_countries_and_states.rb
+++ b/db/seeds/seed_countries_and_states.rb
@@ -1,12 +1,27 @@
 # Country and ISO
 StatesAndCountries.countries.each do |c|
-  country = Country.create(name: c[:name], iso: c[:iso])
-  country.save
+  Country.create!(name: c[:name], iso: c[:iso])
+end
+
+# Pin the anchor country ids to the ids the Country model references
+# (Country::UNITED_STATES_ID / CANADA_ID). Auto-increment order shifts as the
+# country list grows, so swap each anchor onto its canonical id. Safe here
+# because no country_id foreign keys exist yet (states/bikes seed afterward).
+{"US" => Country::UNITED_STATES_ID, "CA" => Country::CANADA_ID}.each do |iso, target_id|
+  next if target_id.nil?
+
+  country = Country.find_by(iso:)
+  next if country.nil? || country.id == target_id
+
+  original_id = country.id
+  occupant = Country.find_by(id: target_id)
+  occupant&.update_column(:id, Country.maximum(:id) + 1)
+  country.update_column(:id, target_id)
+  occupant&.update_column(:id, original_id)
 end
 
 # US States and territories
 us_id = Country.find_by_iso("US").id
 StatesAndCountries.states.each do |s|
-  state = State.create(country_id: us_id, name: s[:name], abbreviation: s[:abbr])
-  state.save
+  State.create!(country_id: us_id, name: s[:name], abbreviation: s[:abbr])
 end

--- a/spec/components/ui/button/component_spec.rb
+++ b/spec/components/ui/button/component_spec.rb
@@ -53,12 +53,34 @@ RSpec.describe UI::Button::Component, type: :component do
     end
   end
 
+  context "with purple_outline color" do
+    let(:color) { :purple_outline }
+
+    it "renders purple_outline styles" do
+      expect(component.to_html).to include("tw:hover:border-[#715eb2]")
+    end
+  end
+
   context "with invalid color" do
     let(:color) { :invalid }
 
     it "falls back to secondary" do
       expect(component.to_html).to include("tw:bg-white")
     end
+  end
+
+  context "with disabled" do
+    let(:options) { {text: "Click", disabled: true} }
+
+    it "disables the button and applies disabled styling" do
+      expect(component).to have_css("button[disabled]")
+      tokens = component.css("button").first["class"].split
+      expect(tokens).to include(*described_class::DISABLED_CLASSES.split)
+    end
+  end
+
+  it "is not disabled by default" do
+    expect(component).to have_no_css("button[disabled]")
   end
 
   describe "sizes" do

--- a/spec/components/ui/color_swatch/component_spec.rb
+++ b/spec/components/ui/color_swatch/component_spec.rb
@@ -20,6 +20,40 @@ RSpec.describe UI::ColorSwatch::Component, type: :component do
       expect(component.to_html).to include("tw:inline-block")
       expect(component.to_html).to include("tw:rounded-xs")
     end
+
+    it "defaults to the md size, middle alignment" do
+      tokens = component.css("span").first["class"].split
+      expect(tokens).to include("tw:h-6", "tw:w-6", "tw:align-middle")
+    end
+  end
+
+  context "with size: :sm" do
+    let(:options) { {display: "#386ed2", size: :sm} }
+
+    it "renders the small size" do
+      tokens = component.css("span").first["class"].split
+      expect(tokens).to include("tw:h-3", "tw:w-3")
+      expect(tokens).to_not include("tw:h-6")
+    end
+  end
+
+  context "with align: :baseline" do
+    let(:options) { {display: "#386ed2", align: :baseline} }
+
+    it "renders baseline alignment" do
+      tokens = component.css("span").first["class"].split
+      expect(tokens).to include("tw:align-baseline")
+      expect(tokens).to_not include("tw:align-middle")
+    end
+  end
+
+  context "with invalid size and align" do
+    let(:options) { {display: "#386ed2", size: :huge, align: :top} }
+
+    it "falls back to md and middle" do
+      tokens = component.css("span").first["class"].split
+      expect(tokens).to include("tw:h-6", "tw:w-6", "tw:align-middle")
+    end
   end
 
   context "with the cover-up color" do

--- a/spec/components/ui/definition_list/row/component_spec.rb
+++ b/spec/components/ui/definition_list/row/component_spec.rb
@@ -30,6 +30,14 @@ RSpec.describe UI::DefinitionList::Row::Component, type: :component do
         expect(component).to have_text label
         expect(component).to have_text "none" # no_value_content
       end
+
+      context "with no_value_text" do
+        let(:options) { {label:, render_with_no_value: true, no_value_text: "not provided"} }
+        it "renders the custom no_value_text instead of the default" do
+          expect(component).to have_text "not provided"
+          expect(component).to_not have_text "none"
+        end
+      end
     end
   end
 

--- a/spec/components/ui/forms/address_group/component_spec.rb
+++ b/spec/components/ui/forms/address_group/component_spec.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe UI::Forms::AddressGroup::Component, type: :component do
+  let(:address_record) { AddressRecord.new }
+  let(:form_builder) do
+    BikeIndexFormBuilder.new(:address_record, address_record, ActionView::Base.new(ActionView::LookupContext.new([]), {}, nil), {})
+  end
+  let(:options) { {} }
+  let(:component) { render_inline(described_class.new(form_builder:, **options)) }
+
+  it "renders the address fields with a default street label" do
+    expect(component).to have_css("input[name='address_record[street]']")
+    expect(component).to have_css("input[name='address_record[city]']")
+    expect(component).to have_css("select[name='address_record[region_record_id]']")
+    expect(component).to have_css("input[name='address_record[region_string]']")
+    expect(component).to have_css("input[name='address_record[postal_code]']")
+    expect(component).to have_css("select[name='address_record[country_id]']")
+    expect(component).to have_css("label", text: "Address")
+  end
+
+  context "with a street_label" do
+    let(:options) { {street_label: "Address or intersection"} }
+
+    it "uses the custom street label" do
+      expect(component).to have_css("label", text: "Address or intersection")
+    end
+  end
+
+  context "with a default_country_id" do
+    let!(:country) { FactoryBot.create(:country, name: "Testland") }
+    let(:options) { {default_country_id: country.id} }
+
+    it "preselects the default country" do
+      expect(component).to have_css("select[name='address_record[country_id]'] option[value='#{country.id}'][selected]")
+    end
+
+    context "when the object already has a country" do
+      let(:other_country) { FactoryBot.create(:country, name: "Otherland") }
+      let(:address_record) { AddressRecord.new(country_id: other_country.id) }
+
+      it "keeps the object's country over the default" do
+        expect(component).to have_css("select[name='address_record[country_id]'] option[value='#{other_country.id}'][selected]")
+        expect(component).to have_no_css("option[value='#{country.id}'][selected]")
+      end
+    end
+  end
+end

--- a/spec/integration/landing_pages_lead_submission_spec.rb
+++ b/spec/integration/landing_pages_lead_submission_spec.rb
@@ -27,13 +27,29 @@ RSpec.describe "Landing page demo modals", :js, type: :system do
        contact_name: "Jane Doe", phone_number: "5551234567", title: "New School lead: Test University"}
     end
 
-    it "submits a school lead via hero button" do
+    it "submits a school lead via hero button, persisting entry across a reload" do
       visit "/for_schools"
       expect(page).to have_content("campus bike management")
       first("button[data-open-modal]").click
 
+      expect(page).to have_content("Contact us for a free trial", wait: 5)
+      fill_in "Name", with: "Jane Doe"
+      fill_in "School", with: "Test University"
+      fill_in "Phone number", with: "5551234567"
+      fill_in "Email", with: "admin@testuni.edu"
+
+      page.refresh
+
+      # have_content/have_field only match visible text, so these assert the modal
+      # reopened (URL param) with entered data restored (form-persist localStorage)
+      expect(page).to have_content("Contact us for a free trial", wait: 5)
+      expect(page).to have_field("Name", with: "Jane Doe")
+      expect(page).to have_field("School", with: "Test University")
+      expect(page).to have_field("Phone number", with: "5551234567")
+      expect(page).to have_field("Email", with: "admin@testuni.edu")
+
       expect {
-        fill_in_and_submit_demo_form(name_label: "School", name_value: "Test University", email: "admin@testuni.edu")
+        click_button "Let's chat"
         expect(page).to have_content("Thank", wait: 5)
       }.to change(Email::FeedbackNotificationJob.jobs, :count).by(1)
 


### PR DESCRIPTION
Pulls a batch of UI component updates onto main, plus a reusable form-draft persistence controller.

- **UI::Button**: new `purple_outline` color, a `disabled:` option that dims and blocks interaction, and active states for `purple`/`danger_outline` — all shown in the Lookbook preview.
- **UI::ColorSwatch** gains `size`/`align` options, **UI::DefinitionList::Row** gains a `no_value_text` override, and a **new UI::Forms::AddressGroup** renders address fields with a US-state vs free-text-region toggle.
- **form-persist** Stimulus controller drafts named text fields to `localStorage` (debounced, 1-week TTL, flush-on-unload), wired into the landing "free trial" lead modal and the impound-record update form. The storage key defaults to pathname + form action, so forms need no explicit key; a validation-blocked submit keeps the draft instead of clearing it.
- **UI::Modal** now persists its open state to the URL (`?modal_<id>=1`) so it survives a reload alongside the restored draft.
- Seed: pin the anchor country ids (US/CA) to their canonical values and switch to `create!`.
