### PR TITLE
Reload component sidecar translations without a server restart

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -56,7 +56,9 @@ module Bikeindex
 
     # The default locale is :en and all translations from config/locales/*.rb,yml are auto loaded.
     config.i18n.load_path += Dir[Rails.root.join("config", "locales", "**", "*.{rb,yml}").to_s]
-    config.i18n.load_path += Dir[Rails.root.join("app", "components", "**", "*.{yml}").to_s]
+    # Component sidecar translations. A reloadable path (not a static glob) so dev reloads
+    # re-scan the tree — picking up renamed/added keys and files without a server restart.
+    config.i18n.railties_load_path << config.paths.add("app/components", glob: "**/*.yml")
     config.i18n.enforce_available_locales = false
     config.i18n.default_locale = :en
     config.i18n.available_locales = %i[en es it nl nb]


### PR DESCRIPTION
Component sidecar translations (`app/components/**/*.yml`) were registered via a static boot-time `Dir[...]` glob, which is not one of Rails' i18n *reloadable* paths. So in development a renamed or added translation key wasn't re-scanned on reload — it raised `translation missing` (under `raise_on_missing_translations`) until a full server restart. This is separate from the ViewComponent preview 404 fixed in #3903.

- Register `app/components` as an i18n `railties_load_path` (a watched directory) instead of a static glob, so reloads re-scan the tree and pick up renamed/added keys and files without a restart.
- Verified by driving the real reloader: key renames and brand-new yml files now resolve on reload (new files were previously impossible to pick up), with no autoload/eager-load side effects.

Note: this is a `config/application.rb` change, so it takes one `bin/dev` restart to take effect — after which sidecar edits reload live.
