### PR TITLE
Retry hotwire_combobox option clicks that detach mid-click

### DIFF
--- a/spec/components/search/form/component_system_spec.rb
+++ b/spec/components/search/form/component_system_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe Search::Form::Component, :js, type: :system do
     def combobox_select(query, option_text)
       type_into(".hw-combobox__input", query)
       expect(page).to have_css(".hw-combobox__option", text: option_text, wait: 30)
-      find(".hw-combobox__option", text: option_text, match: :first).click
+      click_combobox_option(option_text)
     end
 
     def expect_count(kind_scope, value = :greater_than_zero)

--- a/spec/integration/organized/graduated_notifications_search_spec.rb
+++ b/spec/integration/organized/graduated_notifications_search_spec.rb
@@ -66,7 +66,7 @@ RSpec.describe "Organized graduated notifications search", :js, type: :system do
     expect(page).to have_css(".hw-combobox", count: 1, wait: 10)
     type_into(".hw-combobox__input", "Black")
     expect(page).to have_css(".hw-combobox__option", text: "Black", wait: 10)
-    find(".hw-combobox__option", text: "Black", match: :first).click
+    click_combobox_option("Black")
     find("#search-button").click
 
     expect(page).to have_current_path(/query_items/, wait: 10)

--- a/spec/integration/registration/search_spec.rb
+++ b/spec/integration/registration/search_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe "Bike search", :js, type: :system do
   def search_color_and_submit(color)
     type_into(".hw-combobox__input", color)
     expect(page).to have_css(".hw-combobox__option", text: "that are", wait: 5)
-    find(".hw-combobox__option", text: color, match: :first).click
+    click_combobox_option(color)
     find("#search-button").click
   end
 

--- a/spec/integration/search_marketplace_spec.rb
+++ b/spec/integration/search_marketplace_spec.rb
@@ -80,7 +80,7 @@ RSpec.describe "Marketplace infinite scroll", :js, type: :system do
   def search_primary_activity(display_name)
     type_into("#primary_activity", display_name)
     expect(page).to have_css(".hw-combobox__option", text: display_name, wait: 5)
-    find(".hw-combobox__option", text: display_name, match: :first).click
+    click_combobox_option(display_name)
     find("#search-button").click
   end
 
@@ -134,7 +134,7 @@ RSpec.describe "Marketplace infinite scroll", :js, type: :system do
       type_into(".hw-combobox__input", "Yuba")
       # Wait for the combobox autocomplete to load
       expect(page).to have_css(".hw-combobox__option", text: "Listings made by Yuba", wait: 5)
-      find(".hw-combobox__option", text: "Listings made by Yuba", match: :first).click
+      click_combobox_option("Listings made by Yuba")
     end
     find("#search-button").click
     # Should load new results

--- a/spec/support/system_spec_helpers.rb
+++ b/spec/support/system_spec_helpers.rb
@@ -52,11 +52,25 @@ module SystemSpecHelpers
   # so the raw Playwright::Error escapes. Re-find and re-fill on detach, which is
   # what Capybara does for the wrapped actions.
   def fill_in(*args, **options, &block)
-    attempts = 0
+    retry_on_detach { super }
+  end
+
+  # Click an async hotwire_combobox option, re-finding it if a later async
+  # response re-renders the listbox and detaches the node between find and click.
+  def click_combobox_option(text)
+    retry_on_detach { find(".hw-combobox__option", text:, match: :first).click }
+  end
+
+  private
+
+  # Retry a Playwright action when the node detaches mid-action -- the raw
+  # Playwright::Error that Capybara's own retry doesn't rescue on this driver.
+  def retry_on_detach(attempts: 3)
+    tries = 0
     begin
-      super
+      yield
     rescue Playwright::Error => e
-      raise unless e.message.include?("not attached to the DOM") && (attempts += 1) <= 3
+      raise unless e.message.include?("not attached to the DOM") && (tries += 1) <= attempts
       sleep 0.1
       retry
     end


### PR DESCRIPTION
Fixes a flaky `:js` system failure where clicking an async hotwire_combobox option raised `Playwright::Error: Element is not attached to the DOM`. The combobox loads options over a server round-trip per keystroke, so a late response re-renders the listbox and detaches the node that `find(...)` resolved before `.click` runs — the same detach the existing `fill_in` override already retries, but which the `find(...).click` path didn't cover.

- Add a shared `retry_on_detach` helper and a `click_combobox_option` built on it, and route the `fill_in` override through the same helper.
- Apply `click_combobox_option` at every async-combobox click site (organized graduated notifications, registration, marketplace, and the search form component spec).
