### PR TITLE
Rename passwordless_user_domain to user_email_domain

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,6 +20,7 @@ Run `bin/lint` to automatically format the code. Always use `bin/lint`, don't us
 - Prefer less code, by character count (excluding whitespace and comments). Use `bin/char_count {FILE OR FOLDER}` to get the non-whitespace character count
 - prefer un-abbreviated variable names
 - Keep comments pithy — often they aren't necessary. Explain *why* for a future reader; don't narrate the change that introduced the code
+- **Service objects** (`app/services/`): a stateless service is a `module` with `extend Functionable` (see the `functionable` gem) — inputs passed as args, no instance state, private methods via `conceal` + a `# private below here` block. Reach for a `class` only when the object genuinely holds instance state across methods (e.g. a multi-step builder/updater). Don't write a stateless service as a `class` with `def self.` methods.
 
 ## Testing
 

--- a/app/controllers/admin/organizations_controller.rb
+++ b/app/controllers/admin/organizations_controller.rb
@@ -107,7 +107,7 @@ module Admin
           :name,
           :opted_into_theft_survey_2023,
           :parent_organization_id,
-          :passwordless_user_domain,
+          :user_email_domain,
           :previous_slug,
           :search_radius_miles,
           :search_radius_kilometers,

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -25,7 +25,6 @@
 #  manual_pos_kind                 :integer
 #  name                            :string(255)
 #  opted_into_theft_survey_2023    :boolean          default(FALSE)
-#  passwordless_user_domain        :string
 #  pos_kind                        :integer          default("no_pos")
 #  previous_slug                   :string
 #  regional_ids                    :jsonb
@@ -35,6 +34,7 @@
 #  show_on_map                     :boolean
 #  slug                            :string(255)      not null
 #  spam_registrations              :boolean          default(FALSE)
+#  user_email_domain               :string
 #  website                         :string(255)
 #  created_at                      :datetime         not null
 #  updated_at                      :datetime         not null
@@ -135,6 +135,7 @@ class Organization < ApplicationRecord
   validates_with OrganizationNameValidator
   validates_uniqueness_of :slug, message: "Slug error. You shouldn't see this - please contact support@bikeindex.org"
   validates_uniqueness_of :manufacturer_id, allow_blank: true
+  validate :user_email_domain_format
 
   attr_accessor :embedable_user_email, :skip_update
 
@@ -240,7 +241,7 @@ class Organization < ApplicationRecord
     end
 
     def permitted_domain_passwordless_signin
-      where.not(passwordless_user_domain: nil).with_enabled_feature_slugs("passwordless_users")
+      where.not(user_email_domain: nil).with_enabled_feature_slugs("passwordless_users")
     end
 
     def passwordless_email_matching(str)
@@ -248,7 +249,7 @@ class Organization < ApplicationRecord
       return nil unless str.present? && str.count("@") == 1 && str.match?(/.@.*\../)
 
       domain = str.split("@").last
-      permitted_domain_passwordless_signin.detect { |o| o.passwordless_user_domain == domain }
+      permitted_domain_passwordless_signin.detect { |o| o.user_email_domain == domain }
     end
 
     def example
@@ -271,7 +272,7 @@ class Organization < ApplicationRecord
   end
 
   def restrict_invitations?
-    !enabled?("passwordless_users") && !passwordless_user_domain.present?
+    !enabled?("passwordless_users") && !user_email_domain.present?
   end
 
   def sent_invitation_count
@@ -529,7 +530,7 @@ class Organization < ApplicationRecord
     self.ascend_name = nil if ascend_name.blank?
     self.is_paid = current_invoices.any? || current_parent_invoices.any?
     self.kind ||= "other" # We need to always have a kind specified - generally we catch this, but just in case...
-    self.passwordless_user_domain = EmailNormalizer.normalize(passwordless_user_domain)
+    self.user_email_domain = EmailNormalizer.normalize(user_email_domain)
     self.graduated_notification_interval = nil unless graduated_notification_interval.to_i > 0
     # For now, just use them. However - nesting organizations probably need slightly modified organization_feature slugs
     self.enabled_feature_slugs = calculated_enabled_feature_slugs.compact.sort
@@ -597,6 +598,12 @@ class Organization < ApplicationRecord
   end
 
   private
+
+  def user_email_domain_format
+    return if user_email_domain.blank?
+    errors.add(:user_email_domain, "must include a .") unless user_email_domain.include?(".")
+    errors.add(:user_email_domain, "must not include @") if user_email_domain.include?("@")
+  end
 
   def nearby_organizations_including_siblings
     return self.class.none unless regional? && search_coordinates_set?

--- a/app/views/admin/organizations/_form.html.haml
+++ b/app/views/admin/organizations/_form.html.haml
@@ -181,7 +181,7 @@
 
           - if @organization.enabled?("passwordless_users")
             .form-group
-              = f.label :passwordless_user_domain do
+              = f.label :user_email_domain do
                 %span
                 permitted domain for passwordless sign in
                 %small
@@ -189,7 +189,7 @@
               .input-group
                 .input-group-prepend
                   .input-group-text @
-                = f.text_field :passwordless_user_domain, placeholder: "something.gov", class: "form-control", disabled: !current_user.developer?
+                = f.text_field :user_email_domain, placeholder: "something.gov", class: "form-control", disabled: !current_user.developer?
               - unless current_user.developer?
                 %span.small.less-strong Ask Seth for help changing this, it's delicate
 

--- a/app/views/organized/users/index.html.haml
+++ b/app/views/organized/users/index.html.haml
@@ -19,7 +19,7 @@
         #{user_count}
       = t(".current_users")
     %p
-      = t(".permitted_domain_info_html", email_suffix: "@#{current_organization.passwordless_user_domain}", org_name: current_organization.short_name)
+      = t(".permitted_domain_info_html", email_suffix: "@#{current_organization.user_email_domain}", org_name: current_organization.short_name)
       %em.less-strong
         = t(".you_can_also")
         #{link_to t(".manually_invite_email"), new_organization_user_path(organization_id: current_organization.to_param)}.

--- a/app/views/organized/users/new.html.haml
+++ b/app/views/organized/users/new.html.haml
@@ -11,12 +11,12 @@
   - if current_organization.enabled?("passwordless_users")
     %p= t(".automatic_passwordless")
 
-    - if current_organization.passwordless_user_domain.present?
+    - if current_organization.user_email_domain.present?
       .alert.alert-info.mt-4.col-md-8.offset-md-1
         %strong
           = t(".you_have_a_permitted_domain")
         %br
-        = t(".signing_in_with_permitted_domain_html", email_suffix: "@#{current_organization.passwordless_user_domain}", org_name: current_organization.short_name)
+        = t(".signing_in_with_permitted_domain_html", email_suffix: "@#{current_organization.user_email_domain}", org_name: current_organization.short_name)
 
 = form_for @organization_role, { as: :organization_role, url: organization_users_path(organization_id: current_organization.to_param), action: 'create', html: { class: 'organized-form' } } do |f|
 

--- a/db/migrate/20260722120000_rename_passwordless_user_domain_to_user_email_domain.rb
+++ b/db/migrate/20260722120000_rename_passwordless_user_domain_to_user_email_domain.rb
@@ -1,0 +1,5 @@
+class RenamePasswordlessUserDomainToUserEmailDomain < ActiveRecord::Migration[8.0]
+  def change
+    rename_column :organizations, :passwordless_user_domain, :user_email_domain
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -2819,6 +2819,47 @@ ALTER SEQUENCE public.organization_roles_id_seq OWNED BY public.organization_rol
 
 
 --
+-- Name: organization_saml_configurations; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.organization_saml_configurations (
+    id bigint NOT NULL,
+    organization_id bigint,
+    enabled boolean DEFAULT false,
+    idp_entity_id character varying,
+    idp_sso_target_url character varying,
+    idp_slo_target_url character varying,
+    idp_cert text,
+    idp_cert_fingerprint character varying,
+    idp_cert_multi text,
+    email_attribute_name character varying,
+    name_id_format character varying,
+    created_at timestamp(6) without time zone NOT NULL,
+    updated_at timestamp(6) without time zone NOT NULL,
+    want_assertions_encrypted boolean DEFAULT false NOT NULL
+);
+
+
+--
+-- Name: organization_saml_configurations_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.organization_saml_configurations_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: organization_saml_configurations_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.organization_saml_configurations_id_seq OWNED BY public.organization_saml_configurations.id;
+
+
+--
 -- Name: organization_stolen_messages; Type: TABLE; Schema: public; Owner: -
 --
 
@@ -2894,7 +2935,7 @@ CREATE TABLE public.organizations (
     location_longitude double precision,
     regional_ids jsonb,
     manual_pos_kind integer,
-    passwordless_user_domain character varying,
+    user_email_domain character varying,
     graduated_notification_interval bigint,
     lightspeed_register_with_phone boolean DEFAULT false,
     manufacturer_id bigint,
@@ -3505,6 +3546,43 @@ CREATE SEQUENCE public.social_posts_id_seq
 --
 
 ALTER SEQUENCE public.social_posts_id_seq OWNED BY public.social_posts.id;
+
+
+--
+-- Name: sso_identities; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.sso_identities (
+    id bigint NOT NULL,
+    user_id bigint,
+    organization_id bigint,
+    provider character varying,
+    uid character varying,
+    email character varying,
+    last_sign_in_at timestamp(6) without time zone,
+    name_id_format character varying,
+    created_at timestamp(6) without time zone NOT NULL,
+    updated_at timestamp(6) without time zone NOT NULL
+);
+
+
+--
+-- Name: sso_identities_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.sso_identities_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: sso_identities_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.sso_identities_id_seq OWNED BY public.sso_identities.id;
 
 
 --
@@ -4850,6 +4928,13 @@ ALTER TABLE ONLY public.organization_roles ALTER COLUMN id SET DEFAULT nextval('
 
 
 --
+-- Name: organization_saml_configurations id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.organization_saml_configurations ALTER COLUMN id SET DEFAULT nextval('public.organization_saml_configurations_id_seq'::regclass);
+
+
+--
 -- Name: organization_stolen_messages id; Type: DEFAULT; Schema: public; Owner: -
 --
 
@@ -4959,6 +5044,13 @@ ALTER TABLE ONLY public.social_accounts ALTER COLUMN id SET DEFAULT nextval('pub
 --
 
 ALTER TABLE ONLY public.social_posts ALTER COLUMN id SET DEFAULT nextval('public.social_posts_id_seq'::regclass);
+
+
+--
+-- Name: sso_identities id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.sso_identities ALTER COLUMN id SET DEFAULT nextval('public.sso_identities_id_seq'::regclass);
 
 
 --
@@ -5678,6 +5770,14 @@ ALTER TABLE ONLY public.organization_roles
 
 
 --
+-- Name: organization_saml_configurations organization_saml_configurations_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.organization_saml_configurations
+    ADD CONSTRAINT organization_saml_configurations_pkey PRIMARY KEY (id);
+
+
+--
 -- Name: organization_stolen_messages organization_stolen_messages_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -5803,6 +5903,14 @@ ALTER TABLE ONLY public.social_accounts
 
 ALTER TABLE ONLY public.social_posts
     ADD CONSTRAINT social_posts_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: sso_identities sso_identities_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.sso_identities
+    ADD CONSTRAINT sso_identities_pkey PRIMARY KEY (id);
 
 
 --
@@ -6911,6 +7019,13 @@ CREATE INDEX index_organization_roles_on_user_id ON public.organization_roles US
 
 
 --
+-- Name: index_organization_saml_configurations_on_organization_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX index_organization_saml_configurations_on_organization_id ON public.organization_saml_configurations USING btree (organization_id);
+
+
+--
 -- Name: index_organization_stolen_messages_on_organization_id; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -7146,6 +7261,27 @@ CREATE INDEX index_social_posts_on_social_account_id ON public.social_posts USIN
 --
 
 CREATE INDEX index_social_posts_on_stolen_record_id ON public.social_posts USING btree (stolen_record_id);
+
+
+--
+-- Name: index_sso_identities_on_organization_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_sso_identities_on_organization_id ON public.sso_identities USING btree (organization_id);
+
+
+--
+-- Name: index_sso_identities_on_organization_id_and_provider_and_uid; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX index_sso_identities_on_organization_id_and_provider_and_uid ON public.sso_identities USING btree (organization_id, provider, uid);
+
+
+--
+-- Name: index_sso_identities_on_user_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_sso_identities_on_user_id ON public.sso_identities USING btree (user_id);
 
 
 --
@@ -7459,12 +7595,16 @@ ALTER TABLE ONLY public.bug_reports
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20260722120000'),
+('20260716120000'),
 ('20260713120000'),
 ('20260706180000'),
 ('20260706164500'),
 ('20260706164435'),
 ('20260628175839'),
 ('20260628175838'),
+('20260626170001'),
+('20260626170000'),
 ('20260626162049'),
 ('20260528152450'),
 ('20260525162548'),

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -2819,47 +2819,6 @@ ALTER SEQUENCE public.organization_roles_id_seq OWNED BY public.organization_rol
 
 
 --
--- Name: organization_saml_configurations; Type: TABLE; Schema: public; Owner: -
---
-
-CREATE TABLE public.organization_saml_configurations (
-    id bigint NOT NULL,
-    organization_id bigint,
-    enabled boolean DEFAULT false,
-    idp_entity_id character varying,
-    idp_sso_target_url character varying,
-    idp_slo_target_url character varying,
-    idp_cert text,
-    idp_cert_fingerprint character varying,
-    idp_cert_multi text,
-    email_attribute_name character varying,
-    name_id_format character varying,
-    created_at timestamp(6) without time zone NOT NULL,
-    updated_at timestamp(6) without time zone NOT NULL,
-    want_assertions_encrypted boolean DEFAULT false NOT NULL
-);
-
-
---
--- Name: organization_saml_configurations_id_seq; Type: SEQUENCE; Schema: public; Owner: -
---
-
-CREATE SEQUENCE public.organization_saml_configurations_id_seq
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
-
-
---
--- Name: organization_saml_configurations_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
---
-
-ALTER SEQUENCE public.organization_saml_configurations_id_seq OWNED BY public.organization_saml_configurations.id;
-
-
---
 -- Name: organization_stolen_messages; Type: TABLE; Schema: public; Owner: -
 --
 
@@ -3546,43 +3505,6 @@ CREATE SEQUENCE public.social_posts_id_seq
 --
 
 ALTER SEQUENCE public.social_posts_id_seq OWNED BY public.social_posts.id;
-
-
---
--- Name: sso_identities; Type: TABLE; Schema: public; Owner: -
---
-
-CREATE TABLE public.sso_identities (
-    id bigint NOT NULL,
-    user_id bigint,
-    organization_id bigint,
-    provider character varying,
-    uid character varying,
-    email character varying,
-    last_sign_in_at timestamp(6) without time zone,
-    name_id_format character varying,
-    created_at timestamp(6) without time zone NOT NULL,
-    updated_at timestamp(6) without time zone NOT NULL
-);
-
-
---
--- Name: sso_identities_id_seq; Type: SEQUENCE; Schema: public; Owner: -
---
-
-CREATE SEQUENCE public.sso_identities_id_seq
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
-
-
---
--- Name: sso_identities_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
---
-
-ALTER SEQUENCE public.sso_identities_id_seq OWNED BY public.sso_identities.id;
 
 
 --
@@ -4928,13 +4850,6 @@ ALTER TABLE ONLY public.organization_roles ALTER COLUMN id SET DEFAULT nextval('
 
 
 --
--- Name: organization_saml_configurations id; Type: DEFAULT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.organization_saml_configurations ALTER COLUMN id SET DEFAULT nextval('public.organization_saml_configurations_id_seq'::regclass);
-
-
---
 -- Name: organization_stolen_messages id; Type: DEFAULT; Schema: public; Owner: -
 --
 
@@ -5044,13 +4959,6 @@ ALTER TABLE ONLY public.social_accounts ALTER COLUMN id SET DEFAULT nextval('pub
 --
 
 ALTER TABLE ONLY public.social_posts ALTER COLUMN id SET DEFAULT nextval('public.social_posts_id_seq'::regclass);
-
-
---
--- Name: sso_identities id; Type: DEFAULT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.sso_identities ALTER COLUMN id SET DEFAULT nextval('public.sso_identities_id_seq'::regclass);
 
 
 --
@@ -5770,14 +5678,6 @@ ALTER TABLE ONLY public.organization_roles
 
 
 --
--- Name: organization_saml_configurations organization_saml_configurations_pkey; Type: CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.organization_saml_configurations
-    ADD CONSTRAINT organization_saml_configurations_pkey PRIMARY KEY (id);
-
-
---
 -- Name: organization_stolen_messages organization_stolen_messages_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -5903,14 +5803,6 @@ ALTER TABLE ONLY public.social_accounts
 
 ALTER TABLE ONLY public.social_posts
     ADD CONSTRAINT social_posts_pkey PRIMARY KEY (id);
-
-
---
--- Name: sso_identities sso_identities_pkey; Type: CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.sso_identities
-    ADD CONSTRAINT sso_identities_pkey PRIMARY KEY (id);
 
 
 --
@@ -7019,13 +6911,6 @@ CREATE INDEX index_organization_roles_on_user_id ON public.organization_roles US
 
 
 --
--- Name: index_organization_saml_configurations_on_organization_id; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE UNIQUE INDEX index_organization_saml_configurations_on_organization_id ON public.organization_saml_configurations USING btree (organization_id);
-
-
---
 -- Name: index_organization_stolen_messages_on_organization_id; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -7261,27 +7146,6 @@ CREATE INDEX index_social_posts_on_social_account_id ON public.social_posts USIN
 --
 
 CREATE INDEX index_social_posts_on_stolen_record_id ON public.social_posts USING btree (stolen_record_id);
-
-
---
--- Name: index_sso_identities_on_organization_id; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX index_sso_identities_on_organization_id ON public.sso_identities USING btree (organization_id);
-
-
---
--- Name: index_sso_identities_on_organization_id_and_provider_and_uid; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE UNIQUE INDEX index_sso_identities_on_organization_id_and_provider_and_uid ON public.sso_identities USING btree (organization_id, provider, uid);
-
-
---
--- Name: index_sso_identities_on_user_id; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX index_sso_identities_on_user_id ON public.sso_identities USING btree (user_id);
 
 
 --
@@ -7603,8 +7467,6 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20260706164435'),
 ('20260628175839'),
 ('20260628175838'),
-('20260626170001'),
-('20260626170000'),
 ('20260626162049'),
 ('20260528152450'),
 ('20260525162548'),

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -215,7 +215,7 @@ RSpec.describe UsersController, type: :controller do
         end
       end
       context "with auto passwordless users" do
-        let!(:organization) { FactoryBot.create(:organization_with_organization_features, enabled_feature_slugs: ["passwordless_users"], passwordless_user_domain: "ladot.online", available_invitation_count: 1) }
+        let!(:organization) { FactoryBot.create(:organization_with_organization_features, enabled_feature_slugs: ["passwordless_users"], user_email_domain: "ladot.online", available_invitation_count: 1) }
         let(:email) { "example@ladot.online" }
         it "Does not create a organization_role or automatically confirm the user" do
           expect(session[:passive_organization_id]).to be_blank
@@ -361,7 +361,7 @@ RSpec.describe UsersController, type: :controller do
       end
 
       context "with auto_passwordless organization" do
-        let!(:organization) { FactoryBot.create(:organization_with_organization_features, enabled_feature_slugs: ["passwordless_users"], passwordless_user_domain: "ladot.online", available_invitation_count: 1) }
+        let!(:organization) { FactoryBot.create(:organization_with_organization_features, enabled_feature_slugs: ["passwordless_users"], user_email_domain: "ladot.online", available_invitation_count: 1) }
         let(:user) { FactoryBot.create(:user, email: email) }
         let(:email) { "something@ladot.com" }
 

--- a/spec/jobs/callback_job/after_user_create_job_spec.rb
+++ b/spec/jobs/callback_job/after_user_create_job_spec.rb
@@ -209,7 +209,7 @@ RSpec.describe CallbackJob::AfterUserCreateJob, type: :job do
   end
 
   context "organization with auto passwordless users" do
-    let!(:organization) { FactoryBot.create(:organization_with_organization_features, enabled_feature_slugs: ["passwordless_users"], passwordless_user_domain: "city.gov", available_invitation_count: 1) }
+    let!(:organization) { FactoryBot.create(:organization_with_organization_features, enabled_feature_slugs: ["passwordless_users"], user_email_domain: "city.gov", available_invitation_count: 1) }
     let(:user) { FactoryBot.create(:user, email: email) }
     let(:email) { "example@somethingcity.gov" }
     it "does not become member for non-matching domain" do

--- a/spec/models/organization_spec.rb
+++ b/spec/models/organization_spec.rb
@@ -463,8 +463,8 @@ RSpec.describe Organization, type: :model do
     it "is truthy" do
       expect(Organization.new.restrict_invitations?).to be_truthy
     end
-    context "passwordless_users with passwordless_user_domain" do
-      let(:organization) { FactoryBot.create(:organization_with_organization_features, enabled_feature_slugs: ["passwordless_users"], passwordless_user_domain: "example.gov") }
+    context "passwordless_users with user_email_domain" do
+      let(:organization) { FactoryBot.create(:organization_with_organization_features, enabled_feature_slugs: ["passwordless_users"], user_email_domain: "example.gov") }
       it "is falsey" do
         expect(organization.restrict_invitations?).to be_falsey
         expect(Organization.permitted_domain_passwordless_signin.pluck(:id)).to eq([organization.id])

--- a/spec/requests/admin/organizations_request_spec.rb
+++ b/spec/requests/admin/organizations_request_spec.rb
@@ -222,11 +222,14 @@ RSpec.describe Admin::OrganizationsController, type: :request do
         expect(organization.reload.manufacturer_id).to be_blank
       end
     end
-    context "update passwordless_user_domain" do
-      it "updates (only blocking non-developers in frontend because whateves)" do
-        put "#{base_url}/#{organization.to_param}", params: {organization: {passwordless_user_domain: "@bikeindex.org"}}
-        organization.reload
-        expect(organization.passwordless_user_domain).to eq "@bikeindex.org"
+    context "update user_email_domain" do
+      it "updates a valid domain and rejects values with an @ or without a ." do
+        put "#{base_url}/#{organization.to_param}", params: {organization: {user_email_domain: "bikeindex.org"}}
+        expect(organization.reload.user_email_domain).to eq "bikeindex.org"
+        put "#{base_url}/#{organization.to_param}", params: {organization: {user_email_domain: "@bikeindex.org"}}
+        expect(organization.reload.user_email_domain).to eq "bikeindex.org" # unchanged - invalid
+        put "#{base_url}/#{organization.to_param}", params: {organization: {user_email_domain: "bikeindexorg"}}
+        expect(organization.reload.user_email_domain).to eq "bikeindex.org" # unchanged - invalid
       end
     end
     context "updating graduated notifications" do
@@ -289,7 +292,7 @@ RSpec.describe Admin::OrganizationsController, type: :request do
           name: "other namE",
           search_radius_miles: 1222.2,
           graduated_notification_interval_days: 4444,
-          passwordless_user_domain: "stuff.com"
+          user_email_domain: "stuff.com"
         }
       end
       it "updates the organization attributes" do

--- a/spec/requests/organized/users_request_spec.rb
+++ b/spec/requests/organized/users_request_spec.rb
@@ -212,7 +212,7 @@ RSpec.describe Organized::UsersController, type: :request do
         end
       end
       context "restrict_invitations? is false" do
-        let(:current_organization) { FactoryBot.create(:organization_with_organization_features, enabled_feature_slugs: ["passwordless_users"], passwordless_user_domain: "example.gov", available_invitation_count: 1) }
+        let(:current_organization) { FactoryBot.create(:organization_with_organization_features, enabled_feature_slugs: ["passwordless_users"], user_email_domain: "example.gov", available_invitation_count: 1) }
         it "just creates the user" do
           Sidekiq::Testing.inline! do
             ActionMailer::Base.deliveries = []
@@ -260,7 +260,7 @@ RSpec.describe Organized::UsersController, type: :request do
             end
           end
           context "restrict_invitations? is false" do
-            let(:current_organization) { FactoryBot.create(:organization_with_organization_features, enabled_feature_slugs: ["passwordless_users"], passwordless_user_domain: "example.gov", available_invitation_count: 1) }
+            let(:current_organization) { FactoryBot.create(:organization_with_organization_features, enabled_feature_slugs: ["passwordless_users"], user_email_domain: "example.gov", available_invitation_count: 1) }
             it "creates organization_roles" do
               Sidekiq::Testing.inline! do
                 ActionMailer::Base.deliveries = []

--- a/spec/requests/sessions_request_spec.rb
+++ b/spec/requests/sessions_request_spec.rb
@@ -58,7 +58,7 @@ RSpec.describe SessionsController, type: :request do
     context "passwordless organization domain" do
       let!(:organization) do
         FactoryBot.create(:organization_with_organization_features,
-          enabled_feature_slugs: ["passwordless_users"], passwordless_user_domain: "party.edu")
+          enabled_feature_slugs: ["passwordless_users"], user_email_domain: "party.edu")
       end
       it "renders the magic-link step for the org domain (even with no account yet)" do
         identify("newperson@party.edu")
@@ -118,12 +118,12 @@ RSpec.describe SessionsController, type: :request do
       end
     end
     context "passwordless email" do
-      let!(:current_organization) { FactoryBot.create(:organization_with_organization_features, enabled_feature_slugs: ["passwordless_users"], passwordless_user_domain: "party.edu", available_invitation_count: 1) }
+      let!(:current_organization) { FactoryBot.create(:organization_with_organization_features, enabled_feature_slugs: ["passwordless_users"], user_email_domain: "party.edu", available_invitation_count: 1) }
       it "autogenerates" do
         ActionMailer::Base.deliveries = []
         Sidekiq::Job.clear_all
         Sidekiq::Testing.inline! do
-          # Just throw this in here because we don't have anywhere else that tests signup with passwordless_user_domain present...
+          # Just throw this in here because we don't have anywhere else that tests signup with user_email_domain present...
           expect { post "/session/create_magic_link", params: {email: "somethingcool@ party.edu"} }.to_not change(User, :count)
           expect(current_organization.organization_roles.count).to eq 0
           expect {


### PR DESCRIPTION
Renames the `passwordless_user_domain` organization column to `user_email_domain`. The column drives passwordless-signin email routing today and SAML SSO routing on the upcoming SSO branch, so the generic name reflects its dual role. Split out of #3758 so the rename can land on its own.

- Adds a format validation — the domain must include a `.` and must not include an `@`.
- Documents the `functionable` service-object convention in `AGENTS.md` (stateless services are modules; classes are reserved for stateful objects).
