### PR TITLE
Seed member user with member@brakebills.edu

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -34,7 +34,7 @@ _Bike Index also requires some additional libraries. We recommend installing the
 Follow [the Getting Started guide](docs/getting-started.markdown) for a complete set up. Or if you're familiar with developing Ruby on Rails applications start with these steps and a local Postgresql installation:
 
 - `bin/setup` sets up the application and seeds test organizations, bikes and users:
-  - Four test user accounts: admin@bikeindex.org, dev@bikeindex.org (developer), member@bikeindex.org, user@bikeindex.org (all have password `pleaseplease12`)
+  - Four test user accounts: admin@bikeindex.org, dev@bikeindex.org (developer), member@brakebills.edu, user@bikeindex.org (all have password `pleaseplease12`)
   - Gives user@bikeindex.org 50 bikes
   - Give test organization Brakebills all organization features and some test parking notifications
 

--- a/db/seeds/seed_organization_bikes_and_associations.rb
+++ b/db/seeds/seed_organization_bikes_and_associations.rb
@@ -1,6 +1,6 @@
 # Seed parking notifications and impound records around San Francisco for the Brakebills organization
 brakebills = Organization.find_by_name("Brakebills")
-member = User.find_by_email("member@bikeindex.org")
+member = User.find_by_email("member@brakebills.edu")
 user = User.find_by_email("user@bikeindex.org")
 
 raise "missing Brakebills org, test users, or manufacturers" if member.blank? || user.blank? || Manufacturer.none?

--- a/db/seeds/seed_organizations.rb
+++ b/db/seeds/seed_organizations.rb
@@ -70,7 +70,7 @@ brakebills = Organization.find_by_name("Brakebills") || Organization.create!(nam
 brakebills_invoice = Invoice.create(organization: brakebills, amount_due: 0, start_at: Time.current - 1.hour, is_endless: true)
 brakebills_feature_ids = feature_ids - [official_manufacturer_feature_id, skip_ownership_email_feature_id, avery_export_feature_id]
 brakebills_invoice.update(organization_feature_ids: brakebills_feature_ids)
-OrganizationRole.create(organization_id: brakebills.id, user_id: User.find_by_email("member@bikeindex.org").id, role: "member")
+OrganizationRole.create(organization_id: brakebills.id, user_id: User.find_by_email("member@brakebills.edu").id, role: "member")
 
 # Logo (rasterized from db/seeds/images/brakebills.svg — CarrierWave rejects SVG)
 if brakebills.avatar.blank?

--- a/db/seeds/seed_organized_emails.rb
+++ b/db/seeds/seed_organized_emails.rb
@@ -4,7 +4,7 @@
 # so we need at least one of each kind tied to Brakebills.
 
 brakebills = Organization.find_by_name("Brakebills")
-member = User.find_by_email("member@bikeindex.org")
+member = User.find_by_email("member@brakebills.edu")
 user = User.find_by_email("user@bikeindex.org")
 
 raise "missing Brakebills org or test users" if brakebills.blank? || member.blank? || user.blank?

--- a/db/seeds/seed_test_users.rb
+++ b/db/seeds/seed_test_users.rb
@@ -4,7 +4,7 @@
 user_attrs = {
   admin: {name: "Admin User", email: "admin@bikeindex.org", password: "pleaseplease12", password_confirmation: "pleaseplease12", terms_of_service: true, vendor_terms_of_service: true, when_vendor_terms_of_service: Time.current},
   dev: {name: "Dev User", email: "dev@bikeindex.org", password: "pleaseplease12", password_confirmation: "pleaseplease12", terms_of_service: true, vendor_terms_of_service: true, when_vendor_terms_of_service: Time.current, developer: true},
-  member: {name: "Member User", email: "member@bikeindex.org", password: "pleaseplease12", password_confirmation: "pleaseplease12", terms_of_service: true, vendor_terms_of_service: true, when_vendor_terms_of_service: Time.current},
+  member: {name: "Member User", email: "member@brakebills.edu", password: "pleaseplease12", password_confirmation: "pleaseplease12", terms_of_service: true, vendor_terms_of_service: true, when_vendor_terms_of_service: Time.current},
   user: {name: "Test User", email: "user@bikeindex.org", password: "pleaseplease12", password_confirmation: "pleaseplease12", terms_of_service: true},
   api_accessor: {name: "Api Accessor", email: "api@bikeindex.org", password: "pleaseplease12", password_confirmation: "pleaseplease12", terms_of_service: true},
   example_user: {name: "Example User", email: "example_user@bikeindex.org", password: "pleaseplease12", password_confirmation: "pleaseplease12", terms_of_service: true}


### PR DESCRIPTION
Change the seeded "Member User" from `member@bikeindex.org` to `member@brakebills.edu`, matching the Brakebills test organization it belongs to.

- Updates the four seed files that reference the member account (user definition, org role, organized emails, org bikes/associations).
- Updates the test-account list in the README to match.
