### PR TITLE
Move IpSpoofAttackFilter to config/initializers

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -16,8 +16,6 @@ require "action_view/railtie"
 require "sprockets/railtie"
 # require "rails/test_unit/railtie"
 
-require_relative "../lib/ip_spoof_attack_filter"
-
 # Require the gems listed in Gemfile, including any gems
 # you've limited to :test, :development, or :production.
 Bundler.require(*Rails.groups)
@@ -64,9 +62,6 @@ module Bikeindex
     config.i18n.available_locales = %i[en es it nl nb]
     config.i18n.fallbacks = {"en-US": :en, "en-GB": :en}
 
-    # Must sit below DebugExceptions/ShowExceptions: those rescue the raised IpSpoofAttackError
-    # and render it as a 500 before it can reach this filter. Above them it never fires.
-    config.middleware.insert_after ActionDispatch::DebugExceptions, IpSpoofAttackFilter
     config.middleware.use Rack::Deflater
     config.middleware.insert 0, Rack::UTF8Sanitizer
 

--- a/config/initializers/ip_spoof_attack_filter.rb
+++ b/config/initializers/ip_spoof_attack_filter.rb
@@ -18,3 +18,7 @@ class IpSpoofAttackFilter
     [403, {"content-type" => "text/plain"}, ["Forbidden"]]
   end
 end
+
+# Must sit below DebugExceptions/ShowExceptions: those rescue the raised IpSpoofAttackError
+# and render it as a 500 before it can reach this filter. Above them it never fires.
+Rails.application.config.middleware.insert_after ActionDispatch::DebugExceptions, IpSpoofAttackFilter


### PR DESCRIPTION
Move `IpSpoofAttackFilter` out of `lib/` and into a self-contained `config/initializers/ip_spoof_attack_filter.rb` that both defines the class and inserts it into the middleware stack.

- Collapses the previous three coordinated pieces (class in `lib/`, `require_relative` in `application.rb`, and the `insert_after` call inside the config block) into one file.
- No behavior change — the class body and the `insert_after ActionDispatch::DebugExceptions` placement are unchanged.
