### PR TITLE
Keep primary_replica_structure.sql in sync on schema dump

### DIFF
--- a/db/primary_replica_structure.sql
+++ b/db/primary_replica_structure.sql
@@ -37,9 +37,107 @@ CREATE EXTENSION IF NOT EXISTS pg_stat_statements WITH SCHEMA public;
 COMMENT ON EXTENSION pg_stat_statements IS 'track planning and execution statistics of all SQL statements executed';
 
 
+--
+-- Name: pg_trgm; Type: EXTENSION; Schema: -; Owner: -
+--
+
+CREATE EXTENSION IF NOT EXISTS pg_trgm WITH SCHEMA public;
+
+
+--
+-- Name: EXTENSION pg_trgm; Type: COMMENT; Schema: -; Owner: -
+--
+
+COMMENT ON EXTENSION pg_trgm IS 'text similarity measurement and index searching based on trigrams';
+
+
+--
+-- Name: bikes_search_vector_update(); Type: FUNCTION; Schema: public; Owner: -
+--
+
+CREATE FUNCTION public.bikes_search_vector_update() RETURNS trigger
+    LANGUAGE plpgsql
+    AS $$
+BEGIN
+  NEW.search_vector :=
+    setweight(to_tsvector('simple', coalesce(NEW.serial_number, '')), 'A') ||
+    setweight(to_tsvector('simple', coalesce(NEW.cached_data, '')), 'B') ||
+    setweight(to_tsvector('simple', coalesce(NEW.all_description, '')), 'C');
+  RETURN NEW;
+END
+$$;
+
+
 SET default_tablespace = '';
 
 SET default_table_access_method = heap;
+
+--
+-- Name: action_mailbox_inbound_emails; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.action_mailbox_inbound_emails (
+    id bigint NOT NULL,
+    status integer DEFAULT 0 NOT NULL,
+    message_id character varying NOT NULL,
+    message_checksum character varying NOT NULL,
+    created_at timestamp(6) without time zone NOT NULL,
+    updated_at timestamp(6) without time zone NOT NULL
+);
+
+
+--
+-- Name: action_mailbox_inbound_emails_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.action_mailbox_inbound_emails_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: action_mailbox_inbound_emails_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.action_mailbox_inbound_emails_id_seq OWNED BY public.action_mailbox_inbound_emails.id;
+
+
+--
+-- Name: action_text_rich_texts; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.action_text_rich_texts (
+    id bigint NOT NULL,
+    name character varying NOT NULL,
+    body text,
+    record_type character varying NOT NULL,
+    record_id bigint NOT NULL,
+    created_at timestamp(6) without time zone NOT NULL,
+    updated_at timestamp(6) without time zone NOT NULL
+);
+
+
+--
+-- Name: action_text_rich_texts_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.action_text_rich_texts_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: action_text_rich_texts_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.action_text_rich_texts_id_seq OWNED BY public.action_text_rich_texts.id;
+
 
 --
 -- Name: active_storage_attachments; Type: TABLE; Schema: public; Owner: -
@@ -374,6 +472,40 @@ ALTER SEQUENCE public.b_params_id_seq OWNED BY public.b_params.id;
 
 
 --
+-- Name: bike_organization_notes; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.bike_organization_notes (
+    id bigint NOT NULL,
+    body text,
+    user_id bigint NOT NULL,
+    created_at timestamp(6) without time zone NOT NULL,
+    updated_at timestamp(6) without time zone NOT NULL,
+    bike_id bigint NOT NULL,
+    organization_id bigint NOT NULL
+);
+
+
+--
+-- Name: bike_organization_notes_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.bike_organization_notes_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: bike_organization_notes_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.bike_organization_notes_id_seq OWNED BY public.bike_organization_notes.id;
+
+
+--
 -- Name: bike_organizations; Type: TABLE; Schema: public; Owner: -
 --
 
@@ -611,7 +743,6 @@ CREATE TABLE public.bikes (
     created_at timestamp without time zone NOT NULL,
     updated_at timestamp without time zone NOT NULL,
     manufacturer_other character varying(255),
-    zipcode character varying(255),
     cached_data text,
     description text,
     owner_email text,
@@ -635,7 +766,6 @@ CREATE TABLE public.bikes (
     pdf character varying(255),
     paint_id integer,
     example boolean DEFAULT false NOT NULL,
-    country_id integer,
     serial_normalized character varying(255),
     stock_photo_url character varying(255),
     current_stolen_record_id integer,
@@ -652,12 +782,9 @@ CREATE TABLE public.bikes (
     cycle_type integer DEFAULT 0,
     propulsion_type integer DEFAULT 0,
     deleted_at timestamp without time zone,
-    city character varying,
     latitude double precision,
     longitude double precision,
     status integer DEFAULT 0,
-    street character varying,
-    state_id bigint,
     address_set_manually boolean DEFAULT false,
     is_phone boolean DEFAULT false,
     current_impound_record_id bigint,
@@ -669,9 +796,9 @@ CREATE TABLE public.bikes (
     likely_spam boolean DEFAULT false,
     serial_segments_migrated_at timestamp without time zone,
     model_audit_id bigint,
-    neighborhood character varying,
     primary_activity_id bigint,
-    address_record_id bigint
+    address_record_id bigint,
+    search_vector tsvector
 );
 
 
@@ -772,6 +899,48 @@ CREATE SEQUENCE public.blogs_id_seq
 --
 
 ALTER SEQUENCE public.blogs_id_seq OWNED BY public.blogs.id;
+
+
+--
+-- Name: bug_reports; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.bug_reports (
+    id bigint NOT NULL,
+    user_id bigint,
+    email text,
+    subject text,
+    body text,
+    is_member boolean DEFAULT false NOT NULL,
+    is_paid_organization boolean DEFAULT false NOT NULL,
+    is_paid_organization_staff boolean DEFAULT false NOT NULL,
+    github_pull_request integer,
+    tags text[] DEFAULT '{}'::text[] NOT NULL,
+    created_at timestamp(6) without time zone NOT NULL,
+    updated_at timestamp(6) without time zone NOT NULL,
+    received_at timestamp(6) without time zone,
+    from_name text,
+    inbound_email_id bigint
+);
+
+
+--
+-- Name: bug_reports_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.bug_reports_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: bug_reports_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.bug_reports_id_seq OWNED BY public.bug_reports.id;
 
 
 --
@@ -1217,7 +1386,8 @@ CREATE TABLE public.exports (
     rows integer,
     options jsonb DEFAULT '{}'::jsonb,
     created_at timestamp without time zone NOT NULL,
-    updated_at timestamp without time zone NOT NULL
+    updated_at timestamp without time zone NOT NULL,
+    deleted_at timestamp(6) without time zone
 );
 
 
@@ -1478,7 +1648,6 @@ CREATE TABLE public.graduated_notifications (
     marked_remaining_at timestamp without time zone,
     status integer DEFAULT 0,
     email character varying,
-    delivery_status character varying,
     created_at timestamp without time zone NOT NULL,
     updated_at timestamp without time zone NOT NULL,
     not_most_recent boolean DEFAULT false,
@@ -1711,7 +1880,8 @@ CREATE TABLE public.impound_records (
     display_id_prefix character varying,
     impounded_description text,
     unregistered_bike boolean DEFAULT false,
-    address_record_id bigint
+    address_record_id bigint,
+    impounded_from_address_record_id bigint
 );
 
 
@@ -1732,40 +1902,6 @@ CREATE SEQUENCE public.impound_records_id_seq
 --
 
 ALTER SEQUENCE public.impound_records_id_seq OWNED BY public.impound_records.id;
-
-
---
--- Name: integrations; Type: TABLE; Schema: public; Owner: -
---
-
-CREATE TABLE public.integrations (
-    id integer NOT NULL,
-    user_id integer,
-    access_token text,
-    provider_name character varying(255),
-    information text,
-    created_at timestamp without time zone NOT NULL,
-    updated_at timestamp without time zone NOT NULL
-);
-
-
---
--- Name: integrations_id_seq; Type: SEQUENCE; Schema: public; Owner: -
---
-
-CREATE SEQUENCE public.integrations_id_seq
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
-
-
---
--- Name: integrations_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
---
-
-ALTER SEQUENCE public.integrations_id_seq OWNED BY public.integrations.id;
 
 
 --
@@ -2004,22 +2140,12 @@ ALTER SEQUENCE public.locks_id_seq OWNED BY public.locks.id;
 CREATE TABLE public.mail_snippets (
     id integer NOT NULL,
     is_enabled boolean DEFAULT false NOT NULL,
-    is_location_triggered boolean DEFAULT false NOT NULL,
     body text,
-    latitude double precision,
-    longitude double precision,
-    proximity_radius integer,
     created_at timestamp without time zone NOT NULL,
     updated_at timestamp without time zone NOT NULL,
     organization_id integer,
     kind integer DEFAULT 0,
-    street character varying,
-    city character varying,
-    zipcode character varying,
-    state_id bigint,
-    country_id bigint,
     subject text,
-    neighborhood character varying,
     doorkeeper_app_id bigint
 );
 
@@ -2183,7 +2309,8 @@ CREATE TABLE public.marketplace_listings (
     updated_at timestamp(6) without time zone NOT NULL,
     price_negotiable boolean DEFAULT false,
     description text,
-    sale_id bigint
+    sale_id bigint,
+    seller_member boolean DEFAULT false NOT NULL
 );
 
 
@@ -2907,15 +3034,13 @@ CREATE TABLE public.parking_notifications (
     accuracy double precision,
     created_at timestamp without time zone NOT NULL,
     updated_at timestamp without time zone NOT NULL,
-    zipcode character varying,
+    postal_code character varying,
     city character varying,
     neighborhood character varying,
-    hide_address boolean DEFAULT false,
     country_id bigint,
-    state_id bigint,
+    region_record_id bigint,
     message text,
     location_from_address boolean DEFAULT false,
-    delivery_status character varying,
     unregistered_bike boolean DEFAULT false,
     status integer DEFAULT 0,
     resolved_at timestamp without time zone,
@@ -2924,7 +3049,8 @@ CREATE TABLE public.parking_notifications (
     retrieved_by_id bigint,
     image text,
     image_processing boolean DEFAULT false NOT NULL,
-    repeat_number integer
+    repeat_number integer,
+    region_string character varying
 );
 
 
@@ -3168,6 +3294,74 @@ CREATE SEQUENCE public.recovery_displays_id_seq
 --
 
 ALTER SEQUENCE public.recovery_displays_id_seq OWNED BY public.recovery_displays.id;
+
+
+--
+-- Name: registration_sequence_pages; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.registration_sequence_pages (
+    id bigint NOT NULL,
+    registration_sequence_id bigint NOT NULL,
+    title character varying,
+    subtitle text,
+    body text,
+    listing_order integer,
+    created_at timestamp(6) without time zone NOT NULL,
+    updated_at timestamp(6) without time zone NOT NULL
+);
+
+
+--
+-- Name: registration_sequence_pages_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.registration_sequence_pages_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: registration_sequence_pages_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.registration_sequence_pages_id_seq OWNED BY public.registration_sequence_pages.id;
+
+
+--
+-- Name: registration_sequences; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.registration_sequences (
+    id bigint NOT NULL,
+    organization_id bigint,
+    start_at timestamp(6) without time zone,
+    end_at timestamp(6) without time zone,
+    created_at timestamp(6) without time zone NOT NULL,
+    updated_at timestamp(6) without time zone NOT NULL
+);
+
+
+--
+-- Name: registration_sequences_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.registration_sequences_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: registration_sequences_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.registration_sequences_id_seq OWNED BY public.registration_sequences.id;
 
 
 --
@@ -3505,6 +3699,137 @@ CREATE SEQUENCE public.stolen_records_id_seq
 --
 
 ALTER SEQUENCE public.stolen_records_id_seq OWNED BY public.stolen_records.id;
+
+
+--
+-- Name: strava_activities; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.strava_activities (
+    id bigint NOT NULL,
+    strava_integration_id bigint NOT NULL,
+    strava_id character varying NOT NULL,
+    title character varying,
+    description text,
+    distance_meters double precision,
+    moving_time_seconds integer,
+    total_elevation_gain_meters double precision,
+    sport_type character varying,
+    private boolean DEFAULT false,
+    kudos_count integer,
+    gear_id character varying,
+    photos jsonb,
+    segment_locations jsonb,
+    activity_type character varying,
+    start_date timestamp(6) without time zone,
+    timezone character varying,
+    created_at timestamp(6) without time zone NOT NULL,
+    updated_at timestamp(6) without time zone NOT NULL,
+    average_speed double precision,
+    suffer_score double precision,
+    strava_data jsonb,
+    enriched_at timestamp(6) without time zone
+);
+
+
+--
+-- Name: strava_activities_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.strava_activities_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: strava_activities_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.strava_activities_id_seq OWNED BY public.strava_activities.id;
+
+
+--
+-- Name: strava_gears; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.strava_gears (
+    id bigint NOT NULL,
+    strava_integration_id bigint NOT NULL,
+    item_type character varying,
+    item_id bigint,
+    strava_id character varying NOT NULL,
+    name character varying,
+    gear_type integer,
+    total_distance_kilometers integer,
+    strava_data jsonb,
+    last_updated_from_strava_at timestamp(6) without time zone,
+    created_at timestamp(6) without time zone NOT NULL,
+    updated_at timestamp(6) without time zone NOT NULL
+);
+
+
+--
+-- Name: strava_gears_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.strava_gears_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: strava_gears_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.strava_gears_id_seq OWNED BY public.strava_gears.id;
+
+
+--
+-- Name: strava_integrations; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.strava_integrations (
+    id bigint NOT NULL,
+    user_id bigint NOT NULL,
+    access_token text NOT NULL,
+    refresh_token text NOT NULL,
+    token_expires_at timestamp(6) without time zone,
+    strava_permissions character varying,
+    strava_id character varying,
+    athlete_activity_count integer,
+    activities_downloaded_count integer DEFAULT 0 NOT NULL,
+    status integer DEFAULT 0 NOT NULL,
+    last_updated_activities_at timestamp(6) without time zone,
+    deleted_at timestamp(6) without time zone,
+    created_at timestamp(6) without time zone NOT NULL,
+    updated_at timestamp(6) without time zone NOT NULL,
+    strava_data jsonb
+);
+
+
+--
+-- Name: strava_integrations_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.strava_integrations_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: strava_integrations_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.strava_integrations_id_seq OWNED BY public.strava_integrations.id;
 
 
 --
@@ -3927,7 +4252,6 @@ CREATE TABLE public.users (
     email character varying(255),
     password text,
     last_login_at timestamp without time zone,
-    superuser boolean DEFAULT false NOT NULL,
     token_for_password_reset text,
     created_at timestamp without time zone NOT NULL,
     updated_at timestamp without time zone NOT NULL,
@@ -4029,6 +4353,20 @@ ALTER SEQUENCE public.wheel_sizes_id_seq OWNED BY public.wheel_sizes.id;
 
 
 --
+-- Name: action_mailbox_inbound_emails id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.action_mailbox_inbound_emails ALTER COLUMN id SET DEFAULT nextval('public.action_mailbox_inbound_emails_id_seq'::regclass);
+
+
+--
+-- Name: action_text_rich_texts id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.action_text_rich_texts ALTER COLUMN id SET DEFAULT nextval('public.action_text_rich_texts_id_seq'::regclass);
+
+
+--
 -- Name: active_storage_attachments id; Type: DEFAULT; Schema: public; Owner: -
 --
 
@@ -4092,6 +4430,13 @@ ALTER TABLE ONLY public.b_params ALTER COLUMN id SET DEFAULT nextval('public.b_p
 
 
 --
+-- Name: bike_organization_notes id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.bike_organization_notes ALTER COLUMN id SET DEFAULT nextval('public.bike_organization_notes_id_seq'::regclass);
+
+
+--
 -- Name: bike_organizations id; Type: DEFAULT; Schema: public; Owner: -
 --
 
@@ -4145,6 +4490,13 @@ ALTER TABLE ONLY public.blog_content_tags ALTER COLUMN id SET DEFAULT nextval('p
 --
 
 ALTER TABLE ONLY public.blogs ALTER COLUMN id SET DEFAULT nextval('public.blogs_id_seq'::regclass);
+
+
+--
+-- Name: bug_reports id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.bug_reports ALTER COLUMN id SET DEFAULT nextval('public.bug_reports_id_seq'::regclass);
 
 
 --
@@ -4327,13 +4679,6 @@ ALTER TABLE ONLY public.impound_record_updates ALTER COLUMN id SET DEFAULT nextv
 --
 
 ALTER TABLE ONLY public.impound_records ALTER COLUMN id SET DEFAULT nextval('public.impound_records_id_seq'::regclass);
-
-
---
--- Name: integrations id; Type: DEFAULT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.integrations ALTER COLUMN id SET DEFAULT nextval('public.integrations_id_seq'::regclass);
 
 
 --
@@ -4582,6 +4927,20 @@ ALTER TABLE ONLY public.recovery_displays ALTER COLUMN id SET DEFAULT nextval('p
 
 
 --
+-- Name: registration_sequence_pages id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.registration_sequence_pages ALTER COLUMN id SET DEFAULT nextval('public.registration_sequence_pages_id_seq'::regclass);
+
+
+--
+-- Name: registration_sequences id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.registration_sequences ALTER COLUMN id SET DEFAULT nextval('public.registration_sequences_id_seq'::regclass);
+
+
+--
 -- Name: sales id; Type: DEFAULT; Schema: public; Owner: -
 --
 
@@ -4628,6 +4987,27 @@ ALTER TABLE ONLY public.stolen_notifications ALTER COLUMN id SET DEFAULT nextval
 --
 
 ALTER TABLE ONLY public.stolen_records ALTER COLUMN id SET DEFAULT nextval('public.stolen_records_id_seq'::regclass);
+
+
+--
+-- Name: strava_activities id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.strava_activities ALTER COLUMN id SET DEFAULT nextval('public.strava_activities_id_seq'::regclass);
+
+
+--
+-- Name: strava_gears id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.strava_gears ALTER COLUMN id SET DEFAULT nextval('public.strava_gears_id_seq'::regclass);
+
+
+--
+-- Name: strava_integrations id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.strava_integrations ALTER COLUMN id SET DEFAULT nextval('public.strava_integrations_id_seq'::regclass);
 
 
 --
@@ -4722,6 +5102,22 @@ ALTER TABLE ONLY public.wheel_sizes ALTER COLUMN id SET DEFAULT nextval('public.
 
 
 --
+-- Name: action_mailbox_inbound_emails action_mailbox_inbound_emails_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.action_mailbox_inbound_emails
+    ADD CONSTRAINT action_mailbox_inbound_emails_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: action_text_rich_texts action_text_rich_texts_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.action_text_rich_texts
+    ADD CONSTRAINT action_text_rich_texts_pkey PRIMARY KEY (id);
+
+
+--
 -- Name: active_storage_attachments active_storage_attachments_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -4802,6 +5198,14 @@ ALTER TABLE ONLY public.b_params
 
 
 --
+-- Name: bike_organization_notes bike_organization_notes_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.bike_organization_notes
+    ADD CONSTRAINT bike_organization_notes_pkey PRIMARY KEY (id);
+
+
+--
 -- Name: bike_organizations bike_organizations_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -4863,6 +5267,14 @@ ALTER TABLE ONLY public.blog_content_tags
 
 ALTER TABLE ONLY public.blogs
     ADD CONSTRAINT blogs_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: bug_reports bug_reports_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.bug_reports
+    ADD CONSTRAINT bug_reports_pkey PRIMARY KEY (id);
 
 
 --
@@ -5071,14 +5483,6 @@ ALTER TABLE ONLY public.impound_record_updates
 
 ALTER TABLE ONLY public.impound_records
     ADD CONSTRAINT impound_records_pkey PRIMARY KEY (id);
-
-
---
--- Name: integrations integrations_pkey; Type: CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.integrations
-    ADD CONSTRAINT integrations_pkey PRIMARY KEY (id);
 
 
 --
@@ -5362,6 +5766,22 @@ ALTER TABLE ONLY public.recovery_displays
 
 
 --
+-- Name: registration_sequence_pages registration_sequence_pages_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.registration_sequence_pages
+    ADD CONSTRAINT registration_sequence_pages_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: registration_sequences registration_sequences_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.registration_sequences
+    ADD CONSTRAINT registration_sequences_pkey PRIMARY KEY (id);
+
+
+--
 -- Name: sales sales_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -5415,6 +5835,30 @@ ALTER TABLE ONLY public.stolen_bike_listings
 
 ALTER TABLE ONLY public.stolen_notifications
     ADD CONSTRAINT stolen_notifications_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: strava_activities strava_activities_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.strava_activities
+    ADD CONSTRAINT strava_activities_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: strava_gears strava_gears_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.strava_gears
+    ADD CONSTRAINT strava_gears_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: strava_integrations strava_integrations_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.strava_integrations
+    ADD CONSTRAINT strava_integrations_pkey PRIMARY KEY (id);
 
 
 --
@@ -5522,6 +5966,20 @@ ALTER TABLE ONLY public.wheel_sizes
 
 
 --
+-- Name: index_action_mailbox_inbound_emails_uniqueness; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX index_action_mailbox_inbound_emails_uniqueness ON public.action_mailbox_inbound_emails USING btree (message_id, message_checksum);
+
+
+--
+-- Name: index_action_text_rich_texts_uniqueness; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX index_action_text_rich_texts_uniqueness ON public.action_text_rich_texts USING btree (record_type, record_id, name);
+
+
+--
 -- Name: index_active_storage_attachments_on_blob_id; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -5571,13 +6029,6 @@ CREATE INDEX index_address_records_on_organization_id ON public.address_records 
 
 
 --
--- Name: index_address_records_on_region_record_id; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX index_address_records_on_region_record_id ON public.address_records USING btree (region_record_id);
-
-
---
 -- Name: index_address_records_on_user_id; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -5592,17 +6043,38 @@ CREATE INDEX index_alert_images_on_stolen_record_id ON public.alert_images USING
 
 
 --
--- Name: index_ambassador_task_assignments_on_ambassador_task_id; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX index_ambassador_task_assignments_on_ambassador_task_id ON public.ambassador_task_assignments USING btree (ambassador_task_id);
-
-
---
 -- Name: index_ambassador_tasks_on_title; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE UNIQUE INDEX index_ambassador_tasks_on_title ON public.ambassador_tasks USING btree (title);
+
+
+--
+-- Name: index_b_params_on_bike_owner_email_trgm; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_b_params_on_bike_owner_email_trgm ON public.b_params USING gin ((((params -> 'bike'::text) ->> 'owner_email'::text)) public.gin_trgm_ops);
+
+
+--
+-- Name: index_b_params_on_created_bike_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_b_params_on_created_bike_id ON public.b_params USING btree (created_bike_id);
+
+
+--
+-- Name: index_b_params_on_email_trgm; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_b_params_on_email_trgm ON public.b_params USING gin (email public.gin_trgm_ops) WHERE (created_bike_id IS NULL);
+
+
+--
+-- Name: index_b_params_on_id_token; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_b_params_on_id_token ON public.b_params USING btree (id_token);
 
 
 --
@@ -5613,6 +6085,13 @@ CREATE INDEX index_b_params_on_organization_id ON public.b_params USING btree (o
 
 
 --
+-- Name: index_bike_organization_notes_on_bike_id_and_organization_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX index_bike_organization_notes_on_bike_id_and_organization_id ON public.bike_organization_notes USING btree (bike_id, organization_id);
+
+
+--
 -- Name: index_bike_organizations_on_bike_id; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -5620,31 +6099,10 @@ CREATE INDEX index_bike_organizations_on_bike_id ON public.bike_organizations US
 
 
 --
--- Name: index_bike_organizations_on_deleted_at; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX index_bike_organizations_on_deleted_at ON public.bike_organizations USING btree (deleted_at);
-
-
---
 -- Name: index_bike_organizations_on_organization_id; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX index_bike_organizations_on_organization_id ON public.bike_organizations USING btree (organization_id);
-
-
---
--- Name: index_bike_sticker_batches_on_organization_id; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX index_bike_sticker_batches_on_organization_id ON public.bike_sticker_batches USING btree (organization_id);
-
-
---
--- Name: index_bike_sticker_batches_on_user_id; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX index_bike_sticker_batches_on_user_id ON public.bike_sticker_batches USING btree (user_id);
 
 
 --
@@ -5704,31 +6162,10 @@ CREATE INDEX index_bike_stickers_on_bike_sticker_batch_id ON public.bike_sticker
 
 
 --
--- Name: index_bike_stickers_on_secondary_organization_id; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX index_bike_stickers_on_secondary_organization_id ON public.bike_stickers USING btree (secondary_organization_id);
-
-
---
 -- Name: index_bike_versions_on_bike_id; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX index_bike_versions_on_bike_id ON public.bike_versions USING btree (bike_id);
-
-
---
--- Name: index_bike_versions_on_front_gear_type_id; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX index_bike_versions_on_front_gear_type_id ON public.bike_versions USING btree (front_gear_type_id);
-
-
---
--- Name: index_bike_versions_on_front_wheel_size_id; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX index_bike_versions_on_front_wheel_size_id ON public.bike_versions USING btree (front_wheel_size_id);
 
 
 --
@@ -5746,13 +6183,6 @@ CREATE INDEX index_bike_versions_on_owner_id ON public.bike_versions USING btree
 
 
 --
--- Name: index_bike_versions_on_paint_id; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX index_bike_versions_on_paint_id ON public.bike_versions USING btree (paint_id);
-
-
---
 -- Name: index_bike_versions_on_primary_activity_id; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -5760,45 +6190,10 @@ CREATE INDEX index_bike_versions_on_primary_activity_id ON public.bike_versions 
 
 
 --
--- Name: index_bike_versions_on_primary_frame_color_id; Type: INDEX; Schema: public; Owner: -
+-- Name: index_bikes_current_listing_order; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_bike_versions_on_primary_frame_color_id ON public.bike_versions USING btree (primary_frame_color_id);
-
-
---
--- Name: index_bike_versions_on_rear_gear_type_id; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX index_bike_versions_on_rear_gear_type_id ON public.bike_versions USING btree (rear_gear_type_id);
-
-
---
--- Name: index_bike_versions_on_rear_wheel_size_id; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX index_bike_versions_on_rear_wheel_size_id ON public.bike_versions USING btree (rear_wheel_size_id);
-
-
---
--- Name: index_bike_versions_on_secondary_frame_color_id; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX index_bike_versions_on_secondary_frame_color_id ON public.bike_versions USING btree (secondary_frame_color_id);
-
-
---
--- Name: index_bike_versions_on_tertiary_frame_color_id; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX index_bike_versions_on_tertiary_frame_color_id ON public.bike_versions USING btree (tertiary_frame_color_id);
-
-
---
--- Name: index_bikes_on_address_record_id; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX index_bikes_on_address_record_id ON public.bikes USING btree (address_record_id) WHERE (address_record_id IS NOT NULL);
+CREATE INDEX index_bikes_current_listing_order ON public.bikes USING btree (listing_order DESC) WHERE ((example = false) AND (user_hidden = false) AND (likely_spam = false) AND (deleted_at IS NULL));
 
 
 --
@@ -5806,13 +6201,6 @@ CREATE INDEX index_bikes_on_address_record_id ON public.bikes USING btree (addre
 --
 
 CREATE INDEX index_bikes_on_creation_organization_id ON public.bikes USING btree (creation_organization_id) WHERE (creation_organization_id IS NOT NULL);
-
-
---
--- Name: index_bikes_on_current_impound_record_id; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX index_bikes_on_current_impound_record_id ON public.bikes USING btree (current_impound_record_id) WHERE (current_impound_record_id IS NOT NULL);
 
 
 --
@@ -5858,6 +6246,20 @@ CREATE INDEX index_bikes_on_listing_order ON public.bikes USING btree (listing_o
 
 
 --
+-- Name: index_bikes_on_lower_frame_model; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_bikes_on_lower_frame_model ON public.bikes USING btree ("left"(lower(frame_model), 255));
+
+
+--
+-- Name: index_bikes_on_lower_mnfg_name; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_bikes_on_lower_mnfg_name ON public.bikes USING btree (lower((mnfg_name)::text));
+
+
+--
 -- Name: index_bikes_on_manufacturer_id; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -5872,10 +6274,10 @@ CREATE INDEX index_bikes_on_model_audit_id ON public.bikes USING btree (model_au
 
 
 --
--- Name: index_bikes_on_paint_id; Type: INDEX; Schema: public; Owner: -
+-- Name: index_bikes_on_owner_email_trgm; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_bikes_on_paint_id ON public.bikes USING btree (paint_id) WHERE (paint_id IS NOT NULL);
+CREATE INDEX index_bikes_on_owner_email_trgm ON public.bikes USING gin (owner_email public.gin_trgm_ops);
 
 
 --
@@ -5893,6 +6295,13 @@ CREATE INDEX index_bikes_on_primary_frame_color_id ON public.bikes USING btree (
 
 
 --
+-- Name: index_bikes_on_search_vector; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_bikes_on_search_vector ON public.bikes USING gin (search_vector);
+
+
+--
 -- Name: index_bikes_on_secondary_frame_color_id; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -5900,10 +6309,17 @@ CREATE INDEX index_bikes_on_secondary_frame_color_id ON public.bikes USING btree
 
 
 --
--- Name: index_bikes_on_state_id; Type: INDEX; Schema: public; Owner: -
+-- Name: index_bikes_on_serial_normalized_no_space_trgm; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_bikes_on_state_id ON public.bikes USING btree (state_id);
+CREATE INDEX index_bikes_on_serial_normalized_no_space_trgm ON public.bikes USING gin (serial_normalized_no_space public.gin_trgm_ops) WHERE ((example = false) AND (user_hidden = false) AND (likely_spam = false) AND (deleted_at IS NULL));
+
+
+--
+-- Name: index_bikes_on_serial_normalized_tsvector; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_bikes_on_serial_normalized_tsvector ON public.bikes USING gin (to_tsvector('simple'::regconfig, (serial_normalized)::text)) WHERE ((example = false) AND (user_hidden = false) AND (likely_spam = false) AND (deleted_at IS NULL));
 
 
 --
@@ -5942,6 +6358,27 @@ CREATE INDEX index_blog_content_tags_on_content_tag_id ON public.blog_content_ta
 
 
 --
+-- Name: index_bug_reports_on_inbound_email_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_bug_reports_on_inbound_email_id ON public.bug_reports USING btree (inbound_email_id);
+
+
+--
+-- Name: index_bug_reports_on_tags; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_bug_reports_on_tags ON public.bug_reports USING gin (tags);
+
+
+--
+-- Name: index_bug_reports_on_user_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_bug_reports_on_user_id ON public.bug_reports USING btree (user_id);
+
+
+--
 -- Name: index_components_on_bike_id; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -5963,6 +6400,13 @@ CREATE INDEX index_components_on_manufacturer_id ON public.components USING btre
 
 
 --
+-- Name: index_customer_contacts_on_bike_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_customer_contacts_on_bike_id ON public.customer_contacts USING btree (bike_id);
+
+
+--
 -- Name: index_email_bans_on_user_id; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -5970,10 +6414,17 @@ CREATE INDEX index_email_bans_on_user_id ON public.email_bans USING btree (user_
 
 
 --
--- Name: index_email_domains_on_creator_id; Type: INDEX; Schema: public; Owner: -
+-- Name: index_email_domains_on_domain_trgm; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_email_domains_on_creator_id ON public.email_domains USING btree (creator_id);
+CREATE INDEX index_email_domains_on_domain_trgm ON public.email_domains USING gin (domain public.gin_trgm_ops);
+
+
+--
+-- Name: index_email_domains_on_domain_unique; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX index_email_domains_on_domain_unique ON public.email_domains USING btree (domain) WHERE (deleted_at IS NULL);
 
 
 --
@@ -5988,13 +6439,6 @@ CREATE UNIQUE INDEX index_exchange_rates_on_from_and_to ON public.exchange_rates
 --
 
 CREATE INDEX index_exports_on_organization_id ON public.exports USING btree (organization_id);
-
-
---
--- Name: index_exports_on_user_id; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX index_exports_on_user_id ON public.exports USING btree (user_id);
 
 
 --
@@ -6023,13 +6467,6 @@ CREATE INDEX index_external_registry_bikes_on_serial_normalized ON public.extern
 --
 
 CREATE INDEX index_external_registry_bikes_on_type ON public.external_registry_bikes USING btree (type);
-
-
---
--- Name: index_external_registry_credentials_on_type; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX index_external_registry_credentials_on_type ON public.external_registry_credentials USING btree (type);
 
 
 --
@@ -6065,20 +6502,6 @@ CREATE UNIQUE INDEX index_flipper_gates_on_feature_key_and_key_and_value ON publ
 --
 
 CREATE INDEX index_graduated_notifications_on_bike_id ON public.graduated_notifications USING btree (bike_id);
-
-
---
--- Name: index_graduated_notifications_on_bike_organization_id; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX index_graduated_notifications_on_bike_organization_id ON public.graduated_notifications USING btree (bike_organization_id);
-
-
---
--- Name: index_graduated_notifications_on_marked_remaining_by_id; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX index_graduated_notifications_on_marked_remaining_by_id ON public.graduated_notifications USING btree (marked_remaining_by_id);
 
 
 --
@@ -6166,13 +6589,6 @@ CREATE INDEX index_impound_claims_on_user_id ON public.impound_claims USING btre
 
 
 --
--- Name: index_impound_configurations_on_organization_id; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX index_impound_configurations_on_organization_id ON public.impound_configurations USING btree (organization_id);
-
-
---
 -- Name: index_impound_record_updates_on_impound_claim_id; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -6187,20 +6603,6 @@ CREATE INDEX index_impound_record_updates_on_impound_record_id ON public.impound
 
 
 --
--- Name: index_impound_record_updates_on_location_id; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX index_impound_record_updates_on_location_id ON public.impound_record_updates USING btree (location_id);
-
-
---
--- Name: index_impound_record_updates_on_user_id; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX index_impound_record_updates_on_user_id ON public.impound_record_updates USING btree (user_id);
-
-
---
 -- Name: index_impound_records_on_address_record_id; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -6212,6 +6614,13 @@ CREATE INDEX index_impound_records_on_address_record_id ON public.impound_record
 --
 
 CREATE INDEX index_impound_records_on_bike_id ON public.impound_records USING btree (bike_id);
+
+
+--
+-- Name: index_impound_records_on_impounded_from_address_record_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_impound_records_on_impounded_from_address_record_id ON public.impound_records USING btree (impounded_from_address_record_id) WHERE (impounded_from_address_record_id IS NOT NULL);
 
 
 --
@@ -6233,13 +6642,6 @@ CREATE INDEX index_impound_records_on_organization_id ON public.impound_records 
 --
 
 CREATE INDEX index_impound_records_on_user_id ON public.impound_records USING btree (user_id);
-
-
---
--- Name: index_integrations_on_user_id; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX index_integrations_on_user_id ON public.integrations USING btree (user_id);
 
 
 --
@@ -6285,34 +6687,6 @@ CREATE INDEX index_locks_on_user_id ON public.locks USING btree (user_id);
 
 
 --
--- Name: index_mail_snippets_on_country_id; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX index_mail_snippets_on_country_id ON public.mail_snippets USING btree (country_id);
-
-
---
--- Name: index_mail_snippets_on_doorkeeper_app_id; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX index_mail_snippets_on_doorkeeper_app_id ON public.mail_snippets USING btree (doorkeeper_app_id);
-
-
---
--- Name: index_mail_snippets_on_organization_id; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX index_mail_snippets_on_organization_id ON public.mail_snippets USING btree (organization_id);
-
-
---
--- Name: index_mail_snippets_on_state_id; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX index_mail_snippets_on_state_id ON public.mail_snippets USING btree (state_id);
-
-
---
 -- Name: index_mailchimp_data_on_user_id; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -6341,17 +6715,17 @@ CREATE INDEX index_marketplace_listings_on_item ON public.marketplace_listings U
 
 
 --
--- Name: index_marketplace_listings_on_sale_id; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX index_marketplace_listings_on_sale_id ON public.marketplace_listings USING btree (sale_id);
-
-
---
 -- Name: index_marketplace_listings_on_seller_id; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX index_marketplace_listings_on_seller_id ON public.marketplace_listings USING btree (seller_id);
+
+
+--
+-- Name: index_marketplace_listings_on_seller_member; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_marketplace_listings_on_seller_member ON public.marketplace_listings USING btree (seller_member) WHERE seller_member;
 
 
 --
@@ -6383,13 +6757,6 @@ CREATE INDEX index_marketplace_messages_on_sender_id ON public.marketplace_messa
 
 
 --
--- Name: index_memberships_on_creator_id; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX index_memberships_on_creator_id ON public.memberships USING btree (creator_id);
-
-
---
 -- Name: index_memberships_on_user_id; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -6397,24 +6764,10 @@ CREATE INDEX index_memberships_on_user_id ON public.memberships USING btree (use
 
 
 --
--- Name: index_model_attestations_on_model_audit_id; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX index_model_attestations_on_model_audit_id ON public.model_attestations USING btree (model_audit_id);
-
-
---
 -- Name: index_model_attestations_on_organization_id; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX index_model_attestations_on_organization_id ON public.model_attestations USING btree (organization_id);
-
-
---
--- Name: index_model_attestations_on_user_id; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX index_model_attestations_on_user_id ON public.model_attestations USING btree (user_id);
 
 
 --
@@ -6439,10 +6792,24 @@ CREATE INDEX index_normalized_serial_segments_on_duplicate_bike_group_id ON publ
 
 
 --
+-- Name: index_normalized_serial_segments_on_segment; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_normalized_serial_segments_on_segment ON public.normalized_serial_segments USING btree (segment);
+
+
+--
 -- Name: index_notifications_on_bike_id; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX index_notifications_on_bike_id ON public.notifications USING btree (bike_id);
+
+
+--
+-- Name: index_notifications_on_message_channel_target_trgm; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_notifications_on_message_channel_target_trgm ON public.notifications USING gin (message_channel_target public.gin_trgm_ops);
 
 
 --
@@ -6502,13 +6869,6 @@ CREATE UNIQUE INDEX index_oauth_applications_on_uid ON public.oauth_applications
 
 
 --
--- Name: index_organization_manufacturers_on_manufacturer_id; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX index_organization_manufacturers_on_manufacturer_id ON public.organization_manufacturers USING btree (manufacturer_id);
-
-
---
 -- Name: index_organization_manufacturers_on_organization_id; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -6555,13 +6915,6 @@ CREATE INDEX index_organization_roles_on_user_id ON public.organization_roles US
 --
 
 CREATE INDEX index_organization_stolen_messages_on_organization_id ON public.organization_stolen_messages USING btree (organization_id);
-
-
---
--- Name: index_organization_stolen_messages_on_updator_id; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX index_organization_stolen_messages_on_updator_id ON public.organization_stolen_messages USING btree (updator_id);
 
 
 --
@@ -6628,13 +6981,6 @@ CREATE INDEX index_ownerships_on_doorkeeper_app_id ON public.ownerships USING bt
 
 
 --
--- Name: index_ownerships_on_impound_record_id; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX index_ownerships_on_impound_record_id ON public.ownerships USING btree (impound_record_id);
-
-
---
 -- Name: index_ownerships_on_organization_id; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -6663,13 +7009,6 @@ CREATE INDEX index_parking_notifications_on_bike_id ON public.parking_notificati
 
 
 --
--- Name: index_parking_notifications_on_country_id; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX index_parking_notifications_on_country_id ON public.parking_notifications USING btree (country_id);
-
-
---
 -- Name: index_parking_notifications_on_impound_record_id; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -6688,20 +7027,6 @@ CREATE INDEX index_parking_notifications_on_initial_record_id ON public.parking_
 --
 
 CREATE INDEX index_parking_notifications_on_organization_id ON public.parking_notifications USING btree (organization_id);
-
-
---
--- Name: index_parking_notifications_on_retrieved_by_id; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX index_parking_notifications_on_retrieved_by_id ON public.parking_notifications USING btree (retrieved_by_id);
-
-
---
--- Name: index_parking_notifications_on_state_id; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX index_parking_notifications_on_state_id ON public.parking_notifications USING btree (state_id);
 
 
 --
@@ -6761,45 +7086,38 @@ CREATE INDEX index_recovery_displays_on_stolen_record_id ON public.recovery_disp
 
 
 --
--- Name: index_sales_on_item; Type: INDEX; Schema: public; Owner: -
+-- Name: index_registration_sequence_pages_on_registration_sequence_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_sales_on_item ON public.sales USING btree (item_type, item_id);
-
-
---
--- Name: index_sales_on_marketplace_message_id; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX index_sales_on_marketplace_message_id ON public.sales USING btree (marketplace_message_id);
+CREATE INDEX index_registration_sequence_pages_on_registration_sequence_id ON public.registration_sequence_pages USING btree (registration_sequence_id);
 
 
 --
--- Name: index_sales_on_ownership_id; Type: INDEX; Schema: public; Owner: -
+-- Name: index_registration_sequences_on_organization_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_sales_on_ownership_id ON public.sales USING btree (ownership_id);
-
-
---
--- Name: index_sales_on_seller_id; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX index_sales_on_seller_id ON public.sales USING btree (seller_id);
+CREATE INDEX index_registration_sequences_on_organization_id ON public.registration_sequences USING btree (organization_id);
 
 
 --
--- Name: index_social_accounts_on_country_id; Type: INDEX; Schema: public; Owner: -
+-- Name: index_registration_sequences_one_active_per_org; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_social_accounts_on_country_id ON public.social_accounts USING btree (country_id);
+CREATE UNIQUE INDEX index_registration_sequences_one_active_per_org ON public.registration_sequences USING btree (organization_id) WHERE ((start_at IS NOT NULL) AND (end_at IS NULL));
 
 
 --
--- Name: index_social_accounts_on_latitude_and_longitude; Type: INDEX; Schema: public; Owner: -
+-- Name: index_registration_sequences_one_draft_per_org; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_social_accounts_on_latitude_and_longitude ON public.social_accounts USING btree (latitude, longitude);
+CREATE UNIQUE INDEX index_registration_sequences_one_draft_per_org ON public.registration_sequences USING btree (organization_id) WHERE ((start_at IS NULL) AND (organization_id IS NOT NULL));
+
+
+--
+-- Name: index_registration_sequences_single_template; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX index_registration_sequences_single_template ON public.registration_sequences USING btree (((organization_id IS NULL))) WHERE (organization_id IS NULL);
 
 
 --
@@ -6807,13 +7125,6 @@ CREATE INDEX index_social_accounts_on_latitude_and_longitude ON public.social_ac
 --
 
 CREATE INDEX index_social_accounts_on_screen_name ON public.social_accounts USING btree (screen_name);
-
-
---
--- Name: index_social_accounts_on_state_id; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX index_social_accounts_on_state_id ON public.social_accounts USING btree (state_id);
 
 
 --
@@ -6838,62 +7149,6 @@ CREATE INDEX index_social_posts_on_stolen_record_id ON public.social_posts USING
 
 
 --
--- Name: index_states_on_country_id; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX index_states_on_country_id ON public.states USING btree (country_id);
-
-
---
--- Name: index_stolen_bike_listings_on_bike_id; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX index_stolen_bike_listings_on_bike_id ON public.stolen_bike_listings USING btree (bike_id);
-
-
---
--- Name: index_stolen_bike_listings_on_initial_listing_id; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX index_stolen_bike_listings_on_initial_listing_id ON public.stolen_bike_listings USING btree (initial_listing_id);
-
-
---
--- Name: index_stolen_bike_listings_on_manufacturer_id; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX index_stolen_bike_listings_on_manufacturer_id ON public.stolen_bike_listings USING btree (manufacturer_id);
-
-
---
--- Name: index_stolen_bike_listings_on_primary_frame_color_id; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX index_stolen_bike_listings_on_primary_frame_color_id ON public.stolen_bike_listings USING btree (primary_frame_color_id);
-
-
---
--- Name: index_stolen_bike_listings_on_secondary_frame_color_id; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX index_stolen_bike_listings_on_secondary_frame_color_id ON public.stolen_bike_listings USING btree (secondary_frame_color_id);
-
-
---
--- Name: index_stolen_bike_listings_on_tertiary_frame_color_id; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX index_stolen_bike_listings_on_tertiary_frame_color_id ON public.stolen_bike_listings USING btree (tertiary_frame_color_id);
-
-
---
--- Name: index_stolen_notifications_on_doorkeeper_app_id; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX index_stolen_notifications_on_doorkeeper_app_id ON public.stolen_notifications USING btree (doorkeeper_app_id);
-
-
---
 -- Name: index_stolen_records_on_bike_id; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -6908,17 +7163,31 @@ CREATE INDEX index_stolen_records_on_latitude_and_longitude ON public.stolen_rec
 
 
 --
--- Name: index_stolen_records_on_organization_stolen_message_id; Type: INDEX; Schema: public; Owner: -
+-- Name: index_strava_activities_on_strava_integration_id_and_strava_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_stolen_records_on_organization_stolen_message_id ON public.stolen_records USING btree (organization_stolen_message_id);
+CREATE UNIQUE INDEX index_strava_activities_on_strava_integration_id_and_strava_id ON public.strava_activities USING btree (strava_integration_id, strava_id);
 
 
 --
--- Name: index_stolen_records_on_recovering_user_id; Type: INDEX; Schema: public; Owner: -
+-- Name: index_strava_gears_on_item_type_and_item_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_stolen_records_on_recovering_user_id ON public.stolen_records USING btree (recovering_user_id);
+CREATE UNIQUE INDEX index_strava_gears_on_item_type_and_item_id ON public.strava_gears USING btree (item_type, item_id) WHERE (item_id IS NOT NULL);
+
+
+--
+-- Name: index_strava_gears_on_strava_integration_id_and_strava_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX index_strava_gears_on_strava_integration_id_and_strava_id ON public.strava_gears USING btree (strava_integration_id, strava_id);
+
+
+--
+-- Name: index_strava_integrations_on_user_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX index_strava_integrations_on_user_id ON public.strava_integrations USING btree (user_id) WHERE (deleted_at IS NULL);
 
 
 --
@@ -6926,13 +7195,6 @@ CREATE INDEX index_stolen_records_on_recovering_user_id ON public.stolen_records
 --
 
 CREATE INDEX index_stripe_subscriptions_on_membership_id ON public.stripe_subscriptions USING btree (membership_id);
-
-
---
--- Name: index_stripe_subscriptions_on_stripe_price_stripe_id; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX index_stripe_subscriptions_on_stripe_price_stripe_id ON public.stripe_subscriptions USING btree (stripe_price_stripe_id);
 
 
 --
@@ -6992,13 +7254,6 @@ CREATE INDEX index_user_alerts_on_bike_id ON public.user_alerts USING btree (bik
 
 
 --
--- Name: index_user_alerts_on_organization_id; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX index_user_alerts_on_organization_id ON public.user_alerts USING btree (organization_id);
-
-
---
 -- Name: index_user_alerts_on_theft_alert_id; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -7020,17 +7275,17 @@ CREATE INDEX index_user_alerts_on_user_phone_id ON public.user_alerts USING btre
 
 
 --
--- Name: index_user_bans_on_creator_id; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX index_user_bans_on_creator_id ON public.user_bans USING btree (creator_id);
-
-
---
 -- Name: index_user_bans_on_user_id; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX index_user_bans_on_user_id ON public.user_bans USING btree (user_id);
+
+
+--
+-- Name: index_user_emails_on_email_confirmed; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_user_emails_on_email_confirmed ON public.user_emails USING btree (email) WHERE (confirmation_token IS NULL);
 
 
 --
@@ -7069,17 +7324,17 @@ CREATE INDEX index_users_on_address_record_id ON public.users USING btree (addre
 
 
 --
--- Name: index_users_on_auth_token; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX index_users_on_auth_token ON public.users USING btree (auth_token);
-
-
---
 -- Name: index_users_on_email; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX index_users_on_email ON public.users USING btree (email) WHERE (deleted_at IS NULL);
+
+
+--
+-- Name: index_users_on_email_trgm; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_users_on_email_trgm ON public.users USING gin (email public.gin_trgm_ops) WHERE (deleted_at IS NULL);
 
 
 --
@@ -7108,6 +7363,13 @@ CREATE UNIQUE INDEX unique_assignment_to_ambassador ON public.ambassador_task_as
 --
 
 CREATE UNIQUE INDEX unique_schema_migrations ON public.schema_migrations USING btree (version);
+
+
+--
+-- Name: bikes bikes_search_vector_trigger; Type: TRIGGER; Schema: public; Owner: -
+--
+
+CREATE TRIGGER bikes_search_vector_trigger BEFORE INSERT OR UPDATE OF serial_number, cached_data, all_description ON public.bikes FOR EACH ROW EXECUTE FUNCTION public.bikes_search_vector_update();
 
 
 --
@@ -7183,12 +7445,60 @@ ALTER TABLE ONLY public.ambassador_task_assignments
 
 
 --
+-- Name: bug_reports fk_rails_fd37ef25f8; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.bug_reports
+    ADD CONSTRAINT fk_rails_fd37ef25f8 FOREIGN KEY (inbound_email_id) REFERENCES public.action_mailbox_inbound_emails(id) ON DELETE SET NULL;
+
+
+--
 -- PostgreSQL database dump complete
 --
 
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20260713120000'),
+('20260706180000'),
+('20260706164500'),
+('20260706164435'),
+('20260628175839'),
+('20260628175838'),
+('20260626162049'),
+('20260528152450'),
+('20260525162548'),
+('20260518093158'),
+('20260514182008'),
+('20260514085900'),
+('20260430122735'),
+('20260428142526'),
+('20260428000001'),
+('20260425103043'),
+('20260425000001'),
+('20260424000002'),
+('20260424000001'),
+('20260412183446'),
+('20260401211310'),
+('20260331160943'),
+('20260319153927'),
+('20260318211638'),
+('20260310045539'),
+('20260310031750'),
+('20260308002919'),
+('20260305025122'),
+('20260304181710'),
+('20260220053202'),
+('20260219190342'),
+('20260218010402'),
+('20260217170639'),
+('20260214163159'),
+('20260209164044'),
+('20260209164043'),
+('20260209164042'),
+('20260209032356'),
+('20260209031725'),
+('20260206174653'),
 ('20260205050421'),
 ('20260204180206'),
 ('20260204054435'),

--- a/db/primary_replica_structure.sql
+++ b/db/primary_replica_structure.sql
@@ -2894,7 +2894,7 @@ CREATE TABLE public.organizations (
     location_longitude double precision,
     regional_ids jsonb,
     manual_pos_kind integer,
-    passwordless_user_domain character varying,
+    user_email_domain character varying,
     graduated_notification_interval bigint,
     lightspeed_register_with_phone boolean DEFAULT false,
     manufacturer_id bigint,
@@ -7459,6 +7459,8 @@ ALTER TABLE ONLY public.bug_reports
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20260722120000'),
+('20260716120000'),
 ('20260713120000'),
 ('20260706180000'),
 ('20260706164500'),

--- a/lib/tasks/schema_dump.rake
+++ b/lib/tasks/schema_dump.rake
@@ -13,4 +13,9 @@ Rake::Task["db:schema:dump"].enhance do
     }.join
     File.write(file, cleaned) if cleaned != content
   end
+
+  # primary_replica is a replica of the primary database (same physical database
+  # everywhere), so its schema always matches structure.sql. Rails skips replica
+  # configs when dumping, which left this file to rot — mirror it so it can't drift.
+  File.write("db/primary_replica_structure.sql", File.read("db/structure.sql"))
 end


### PR DESCRIPTION
`db/primary_replica_structure.sql` had gone stale — last regenerated in #3083 — because Rails skips replica configs when dumping the schema, so nothing kept it current. The `primary_replica` connection is a replica of the primary database (the same physical database in every environment), so its schema is always identical to `structure.sql`.

- Enhance the existing `db:schema:dump` post-processing to mirror `structure.sql` into `primary_replica_structure.sql`, so it re-syncs on every dump — including after `db:migrate`.
- Regenerate the committed file, which had drifted far from the real schema.
