### PR TITLE
Route all inbound email to bug reports

### DIFF
--- a/app/mailboxes/application_mailbox.rb
+++ b/app/mailboxes/application_mailbox.rb
@@ -1,3 +1,5 @@
 class ApplicationMailbox < ActionMailbox::Base
-  routing(/(?:bugs|contact)@/i => :bug_reports)
+  # Anything Postmark forwards to our inbound address (support@, contact@, bugs@, ...) is a
+  # support message - capture it for admin triage rather than raising RoutingError and retrying
+  routing all: :bug_reports
 end

--- a/spec/mailboxes/bug_reports_mailbox_spec.rb
+++ b/spec/mailboxes/bug_reports_mailbox_spec.rb
@@ -58,13 +58,15 @@ RSpec.describe BugReportsMailbox do
     end
   end
 
-  context "not addressed to bugs@" do
-    it "does not route to a bug report" do
-      inbound_email = create_inbound_email_from_mail(
-        from: user.email, to: "somewhere-else@bikeindex.org", subject: "Hi", body: "Hello"
-      )
-      expect { inbound_email.route }.to raise_error(ActionMailbox::Router::RoutingError)
-      expect(BugReport.count).to eq 0
+  context "addressed to another address" do
+    it "still routes to a bug report" do
+      expect do
+        receive_inbound_email_from_mail(
+          from: user.email, to: "support@bikeindex.org", subject: "Hi", body: "Hello"
+        )
+      end.to change(BugReport, :count).by 1
+
+      expect(BugReport.last).to have_attributes(email: user.email, user_id: user.id, subject: "Hi")
     end
   end
 end


### PR DESCRIPTION
Any inbound email Postmark forwarded to us that wasn't addressed to `bugs@` or `contact@` — most notably `support@`, the primary support address — matched no mailbox route, raised `ActionMailbox::Router::RoutingError`, and retried 25× in Sidekiq (Honeybadger [#132525441](https://app.honeybadger.io/projects/35931/faults/132525441)).

- Route all inbound email to `bug_reports` for admin triage instead of only `bugs@`/`contact@`. Anything Postmark forwards to our inbound address was intentionally sent to a Bike Index address, so it's captured rather than dropped or errored.