### PR TITLE
Hide review-app topbar in screenshots

### DIFF
--- a/.claude/skills/frontend-screenshots/SKILL.md
+++ b/.claude/skills/frontend-screenshots/SKILL.md
@@ -61,12 +61,13 @@ Two viewports — resize once each, then walk every URL:
 1. `browser_resize` 1440×900 → for each URL: navigate → settle → hide the footer → `browser_take_screenshot` (`fullPage: true`) to `...-desktop.png`.
 2. `browser_resize` 390×844 → same loop → `...-mobile.png`.
 
-**Full page, minus the footer, no `target:` arg.** Capture the whole page (`fullPage: true`) so nothing below the fold is cut off, but hide the site footer first — it's identical on every page and just pads every capture. After each navigation (hiding doesn't persist across page loads), run:
+**Full page, minus the footer and review-app banner, no `target:` arg.** Capture the whole page (`fullPage: true`) so nothing below the fold is cut off, but first hide the site footer (identical on every page, just padding) and the `#review-app-banner` topbar (dev/review-app-only chrome that isn't part of the real page). After each navigation (hiding doesn't persist across page loads), run:
 
 ```js
 browser_evaluate: () => {
   document.querySelector('.primary-footer, footer, [role="contentinfo"]')?.style.setProperty('display', 'none');
-  return document.body.scrollHeight; // content height with the footer gone
+  document.getElementById('review-app-banner')?.style.setProperty('display', 'none');
+  return document.body.scrollHeight; // content height with the footer + banner gone
 }
 ```
 

--- a/app/components/page_block/review_app_banner/component.html.erb
+++ b/app/components/page_block/review_app_banner/component.html.erb
@@ -3,7 +3,10 @@
   letter_opener tooltip renders over it instead of behind when it flips down.
 %>
 
-<div class="tw:relative tw:z-[1040] tw:border-b tw:px-4 tw:py-2 tw:text-center tw:font-semibold tw:text-black <%= banner_accent_class %>">
+<div
+  id="review-app-banner"
+  class="tw:relative tw:z-[1040] tw:border-b tw:px-4 tw:py-2 tw:text-center tw:font-semibold tw:text-black <%= banner_accent_class %>"
+>
   <%# Hide the "Review app" label on small screens — the PR title carries the context there; "Sandbox" has no title, so it stays %>
   <span class="<%= "tw:hidden tw:sm:inline" if @pr_number %>">
     <%= banner_label %>


### PR DESCRIPTION
Screenshots captured via the `frontend-screenshots` skill were including the dev/review-app topbar banner, which isn't part of the real page.

- Add a stable `#review-app-banner` id to the banner component so it can be targeted reliably.
- Hide `#review-app-banner` (alongside the footer) in the skill's per-navigation capture step, so captures start at the actual page content.
