### PR TITLE
Use UI::Button purple_outline palette for RadioButtonGroup

### DIFF
--- a/app/assets/tailwind/application.css
+++ b/app/assets/tailwind/application.css
@@ -17,6 +17,12 @@
  * ancestor activates tw:dark:* utilities. */
 @custom-variant dark (&:where(.dark, .dark *));
 
+/* The selected/pressed state of a button, link or menu item, however it's flagged.
+ * Keep it the last @custom-variant: tailwind sorts custom variants in declaration
+ * order, and sorting after `dark` is what lets tw:is-active:* beat the resting,
+ * hover and dark colors it overrides without `!important`. */
+@custom-variant is-active (&:is([data-active="true"], [aria-pressed="true"], [aria-current], :active));
+
 @theme {
   --font-sans: "Open Sans", sans-serif;
   --font-header: "Montserrat", sans-serif;

--- a/app/assets/tailwind/application.css
+++ b/app/assets/tailwind/application.css
@@ -70,6 +70,15 @@
   --color-slate-800: #2f475d;
   --color-slate-900: #2c3e50; /* OG Bike Index blue-dark */
   --color-slate-950: #1d2834;
+
+  /* OG Bike Index purple accent — distinct from Tailwind's default `purple`
+     (a more violet hue still used for some badges/dark-mode tints). */
+  --color-purple-brand-50: #f7f5fc;
+  --color-purple-brand-100: #f0edfa;
+  --color-purple-brand-200: #d6d4e0;
+  --color-purple-brand-300: #9a8fc4;
+  --color-purple-brand-500: #715eb2;
+  --color-purple-brand-600: #5d4b9c;
 }
 
 @layer components {

--- a/app/assets/tailwind/application.css
+++ b/app/assets/tailwind/application.css
@@ -71,14 +71,19 @@
   --color-slate-900: #2c3e50; /* OG Bike Index blue-dark */
   --color-slate-950: #1d2834;
 
-  /* OG Bike Index purple accent — distinct from Tailwind's default `purple`
-     (a more violet hue still used for some badges/dark-mode tints). */
-  --color-purple-brand-50: #f7f5fc;
-  --color-purple-brand-100: #f0edfa;
-  --color-purple-brand-200: #d6d4e0;
-  --color-purple-brand-300: #9a8fc4;
-  --color-purple-brand-500: #715eb2;
-  --color-purple-brand-600: #5d4b9c;
+  /* OG Bike Index purple — replaces Tailwind's default `purple`. 50–600 are the
+     existing design values; 400 and 700–950 are derived to complete the ramp. */
+  --color-purple-50: #f7f5fc;
+  --color-purple-100: #f0edfa;
+  --color-purple-200: #d6d4e0;
+  --color-purple-300: #9a8fc4;
+  --color-purple-400: #8574bb;
+  --color-purple-500: #715eb2;
+  --color-purple-600: #5d4b9c;
+  --color-purple-700: #4a3c7d;
+  --color-purple-800: #3a2f62;
+  --color-purple-900: #2c244b;
+  --color-purple-950: #1c162f;
 }
 
 @layer components {

--- a/app/components/ui/button/component.rb
+++ b/app/components/ui/button/component.rb
@@ -24,13 +24,16 @@ module UI
         link: "twlink tw:p-0"
       }.freeze
 
+      # `!` important on the fill/border/text so the active color wins over the resting
+      # color regardless of Tailwind's compiled source order (arbitrary values like
+      # bg-[#715eb2] otherwise sort before named ones like bg-white and lose).
       ACTIVE_COLORS = {
-        primary: "tw:ring-2 tw:ring-blue-500/40 tw:bg-blue-700 tw:dark:bg-blue-600",
-        secondary: "tw:ring-2 tw:ring-blue-500/40 tw:bg-gray-200 tw:border-gray-400 tw:dark:bg-gray-800 tw:dark:border-gray-600",
-        error: "tw:ring-2 tw:ring-red-500/40 tw:bg-red-700 tw:dark:bg-red-600",
-        danger_outline: "tw:ring-2 tw:ring-red-500/40 tw:bg-red-100 tw:border-[#c0392b] tw:dark:bg-red-950 tw:dark:border-red-700",
-        purple: "tw:ring-2 tw:ring-[#715eb2]/40 tw:bg-[#5d4b9c]",
-        purple_outline: "tw:ring-2 tw:ring-[#715eb2]/40 tw:bg-[#715eb2] tw:text-white tw:border-[#715eb2]",
+        primary: "tw:ring-2 tw:ring-blue-500/40 tw:bg-blue-700! tw:dark:bg-blue-600!",
+        secondary: "tw:ring-2 tw:ring-blue-500/40 tw:bg-gray-200! tw:border-gray-400! tw:dark:bg-gray-800! tw:dark:border-gray-600!",
+        error: "tw:ring-2 tw:ring-red-500/40 tw:bg-red-700! tw:dark:bg-red-600!",
+        danger_outline: "tw:ring-2 tw:ring-red-500/40 tw:bg-red-100! tw:border-[#c0392b]! tw:dark:bg-red-950! tw:dark:border-red-700!",
+        purple: "tw:ring-2 tw:ring-[#715eb2]/40 tw:bg-[#5d4b9c]!",
+        purple_outline: "tw:ring-2 tw:ring-[#715eb2]/40 tw:bg-[#715eb2]! tw:text-white! tw:border-[#715eb2]!",
         link: "tw:text-blue-800 tw:dark:text-blue-300 tw:font-bold tw:underline"
       }.freeze
 

--- a/app/components/ui/button/component.rb
+++ b/app/components/ui/button/component.rb
@@ -24,27 +24,31 @@ module UI
         link: "twlink tw:p-0"
       }.freeze
 
-      # `!` important on the fill/border/text so the active color wins over the resting
-      # color: same-specificity utilities resolve by Tailwind's compiled source order,
-      # not class-attribute order, so the resting fill would otherwise bleed through.
+      # The complete color set for the persistent active: true state. build_classes
+      # emits this *instead of* COLORS (see there), so resting and active fills never
+      # coexist and no `!` important is needed to settle the cascade. link is the
+      # exception — it layers over COLORS[:link] since `twlink` isn't variant-able.
       ACTIVE_COLORS = {
-        primary: "tw:ring-2 tw:ring-blue-500/40 tw:bg-blue-700! tw:dark:bg-blue-600!",
-        secondary: "tw:ring-2 tw:ring-blue-500/40 tw:bg-gray-200! tw:border-gray-400! tw:dark:bg-gray-800! tw:dark:border-gray-600!",
-        error: "tw:ring-2 tw:ring-red-500/40 tw:bg-red-700! tw:dark:bg-red-600!",
-        danger_outline: "tw:ring-2 tw:ring-red-500/40 tw:bg-red-100! tw:border-[#c0392b]! tw:dark:bg-red-950! tw:dark:border-red-700!",
-        purple: "tw:ring-2 tw:ring-purple-500/40 tw:bg-purple-600!",
-        purple_outline: "tw:ring-2 tw:ring-purple-500/40 tw:bg-purple-500! tw:text-white! tw:border-purple-500!",
+        primary: "tw:text-white tw:bg-blue-700 tw:border tw:border-blue-600 tw:ring-2 tw:ring-blue-500/40 tw:dark:bg-blue-600 tw:dark:border-blue-500",
+        secondary: "tw:text-gray-800 tw:bg-gray-200 tw:border tw:border-gray-400 tw:ring-2 tw:ring-blue-500/40 tw:dark:text-gray-100 tw:dark:bg-gray-800 tw:dark:border-gray-600",
+        error: "tw:text-white tw:bg-red-700 tw:border tw:border-red-600 tw:ring-2 tw:ring-red-500/40 tw:dark:bg-red-600 tw:dark:border-red-500",
+        danger_outline: "tw:text-[#c0392b] tw:bg-red-100 tw:border tw:border-[#c0392b] tw:ring-2 tw:ring-red-500/40 tw:dark:text-red-400 tw:dark:bg-red-950 tw:dark:border-red-700",
+        purple: "tw:text-white tw:bg-purple-600 tw:border tw:border-purple-600 tw:ring-2 tw:ring-purple-500/40",
+        purple_outline: "tw:text-white tw:bg-purple-500 tw:border tw:border-purple-500 tw:ring-2 tw:ring-purple-500/40",
         link: "tw:text-blue-800 tw:dark:text-blue-300 tw:font-bold tw:underline"
       }.freeze
 
-      # Literal strings so Tailwind's scanner generates these aria-pressed:/active: variants.
+      # A mirror of ACTIVE_COLORS under aria-pressed:/active: — so a resting button shows
+      # the active look while pressed or toggled, without being passed active: true. Kept
+      # as literal strings so Tailwind's scanner generates the variants (see spec, which
+      # enforces the mirror). These are variants, so they win over COLORS by precedence.
       ACTIVE_PREFIXED = {
-        primary: "tw:aria-pressed:ring-2 tw:active:ring-2 tw:aria-pressed:ring-blue-500/40 tw:active:ring-blue-500/40 tw:aria-pressed:bg-blue-700 tw:active:bg-blue-700 tw:aria-pressed:dark:bg-blue-600 tw:active:dark:bg-blue-600",
-        secondary: "tw:aria-pressed:ring-2 tw:active:ring-2 tw:aria-pressed:ring-blue-500/40 tw:active:ring-blue-500/40 tw:aria-pressed:bg-gray-200 tw:active:bg-gray-200 tw:aria-pressed:border-gray-400 tw:active:border-gray-400 tw:aria-pressed:dark:bg-gray-800 tw:active:dark:bg-gray-800 tw:aria-pressed:dark:border-gray-600 tw:active:dark:border-gray-600",
-        error: "tw:aria-pressed:ring-2 tw:active:ring-2 tw:aria-pressed:ring-red-500/40 tw:active:ring-red-500/40 tw:aria-pressed:bg-red-700 tw:active:bg-red-700 tw:aria-pressed:dark:bg-red-600 tw:active:dark:bg-red-600",
-        danger_outline: "tw:aria-pressed:ring-2 tw:active:ring-2 tw:aria-pressed:ring-red-500/40 tw:active:ring-red-500/40 tw:aria-pressed:bg-red-100 tw:active:bg-red-100 tw:aria-pressed:border-[#c0392b] tw:active:border-[#c0392b] tw:aria-pressed:dark:bg-red-950 tw:active:dark:bg-red-950 tw:aria-pressed:dark:border-red-700 tw:active:dark:border-red-700",
-        purple: "tw:aria-pressed:ring-2 tw:active:ring-2 tw:aria-pressed:ring-purple-500/40 tw:active:ring-purple-500/40 tw:aria-pressed:bg-purple-600 tw:active:bg-purple-600",
-        purple_outline: "tw:aria-pressed:ring-2 tw:active:ring-2 tw:aria-pressed:ring-purple-500/40 tw:active:ring-purple-500/40 tw:aria-pressed:bg-purple-500 tw:active:bg-purple-500 tw:aria-pressed:text-white tw:active:text-white tw:aria-pressed:border-purple-500 tw:active:border-purple-500",
+        primary: "tw:aria-pressed:text-white tw:active:text-white tw:aria-pressed:bg-blue-700 tw:active:bg-blue-700 tw:aria-pressed:border tw:active:border tw:aria-pressed:border-blue-600 tw:active:border-blue-600 tw:aria-pressed:ring-2 tw:active:ring-2 tw:aria-pressed:ring-blue-500/40 tw:active:ring-blue-500/40 tw:aria-pressed:dark:bg-blue-600 tw:active:dark:bg-blue-600 tw:aria-pressed:dark:border-blue-500 tw:active:dark:border-blue-500",
+        secondary: "tw:aria-pressed:text-gray-800 tw:active:text-gray-800 tw:aria-pressed:bg-gray-200 tw:active:bg-gray-200 tw:aria-pressed:border tw:active:border tw:aria-pressed:border-gray-400 tw:active:border-gray-400 tw:aria-pressed:ring-2 tw:active:ring-2 tw:aria-pressed:ring-blue-500/40 tw:active:ring-blue-500/40 tw:aria-pressed:dark:text-gray-100 tw:active:dark:text-gray-100 tw:aria-pressed:dark:bg-gray-800 tw:active:dark:bg-gray-800 tw:aria-pressed:dark:border-gray-600 tw:active:dark:border-gray-600",
+        error: "tw:aria-pressed:text-white tw:active:text-white tw:aria-pressed:bg-red-700 tw:active:bg-red-700 tw:aria-pressed:border tw:active:border tw:aria-pressed:border-red-600 tw:active:border-red-600 tw:aria-pressed:ring-2 tw:active:ring-2 tw:aria-pressed:ring-red-500/40 tw:active:ring-red-500/40 tw:aria-pressed:dark:bg-red-600 tw:active:dark:bg-red-600 tw:aria-pressed:dark:border-red-500 tw:active:dark:border-red-500",
+        danger_outline: "tw:aria-pressed:text-[#c0392b] tw:active:text-[#c0392b] tw:aria-pressed:bg-red-100 tw:active:bg-red-100 tw:aria-pressed:border tw:active:border tw:aria-pressed:border-[#c0392b] tw:active:border-[#c0392b] tw:aria-pressed:ring-2 tw:active:ring-2 tw:aria-pressed:ring-red-500/40 tw:active:ring-red-500/40 tw:aria-pressed:dark:text-red-400 tw:active:dark:text-red-400 tw:aria-pressed:dark:bg-red-950 tw:active:dark:bg-red-950 tw:aria-pressed:dark:border-red-700 tw:active:dark:border-red-700",
+        purple: "tw:aria-pressed:text-white tw:active:text-white tw:aria-pressed:bg-purple-600 tw:active:bg-purple-600 tw:aria-pressed:border tw:active:border tw:aria-pressed:border-purple-600 tw:active:border-purple-600 tw:aria-pressed:ring-2 tw:active:ring-2 tw:aria-pressed:ring-purple-500/40 tw:active:ring-purple-500/40",
+        purple_outline: "tw:aria-pressed:text-white tw:active:text-white tw:aria-pressed:bg-purple-500 tw:active:bg-purple-500 tw:aria-pressed:border tw:active:border tw:aria-pressed:border-purple-500 tw:active:border-purple-500 tw:aria-pressed:ring-2 tw:active:ring-2 tw:aria-pressed:ring-purple-500/40 tw:active:ring-purple-500/40",
         link: "tw:aria-pressed:text-blue-800 tw:active:text-blue-800 tw:aria-pressed:dark:text-blue-300 tw:active:dark:text-blue-300 tw:aria-pressed:font-bold tw:active:font-bold tw:aria-pressed:underline tw:active:underline"
       }.freeze
 
@@ -53,13 +57,17 @@ module UI
       DISABLED_CLASSES = "tw:disabled:opacity-50 tw:disabled:cursor-not-allowed tw:disabled:pointer-events-none"
 
       def self.build_classes(color:, size:, active: false, html_class: nil)
-        classes = [BASE_CLASSES, COLORS[color], html_class]
-        unless color == :link
+        classes = [BASE_CLASSES, html_class]
+        if color == :link
+          # twlink isn't variant-able, so link layers the active delta over its resting base.
+          classes << COLORS[color]
+          classes << ACTIVE_COLORS[color] if active
+        else
           classes << SIZES[size]
           classes << "tw:focus:outline-none tw:focus:ring-3 tw:font-medium tw:no-underline"
           classes << DISABLED_CLASSES
+          classes << (active ? ACTIVE_COLORS[color] : COLORS[color])
         end
-        classes << ACTIVE_COLORS[color] if active
         classes << ACTIVE_PREFIXED[color]
         classes.compact.join(" ")
       end

--- a/app/components/ui/button/component.rb
+++ b/app/components/ui/button/component.rb
@@ -18,9 +18,9 @@ module UI
         primary: "tw:text-white tw:bg-blue-600 tw:border tw:border-blue-600 tw:hover:bg-blue-700 tw:active:bg-blue-800 tw:focus:ring-blue-500/40 tw:dark:bg-blue-500 tw:dark:border-blue-500 tw:dark:hover:bg-blue-600 tw:dark:active:bg-blue-700",
         secondary: "tw:text-gray-800 tw:bg-white tw:border tw:border-gray-300 tw:hover:bg-gray-50 tw:hover:border-gray-400 tw:active:bg-gray-100 tw:focus:ring-blue-500/40 tw:dark:bg-transparent tw:dark:text-gray-100 tw:dark:border-gray-600 tw:dark:hover:bg-gray-800",
         error: "tw:text-white tw:bg-red-600 tw:border tw:border-red-600 tw:hover:bg-red-700 tw:active:bg-red-800 tw:focus:ring-red-500/40 tw:dark:bg-red-500 tw:dark:border-red-500 tw:dark:hover:bg-red-600 tw:dark:active:bg-red-700",
-        purple: "tw:text-white tw:bg-purple-brand-500 tw:border tw:border-purple-brand-500 tw:hover:bg-purple-brand-600 tw:hover:border-purple-brand-600 tw:active:bg-purple-brand-600 tw:focus:ring-purple-brand-500/40",
+        purple: "tw:text-white tw:bg-purple-500 tw:border tw:border-purple-500 tw:hover:bg-purple-600 tw:hover:border-purple-600 tw:active:bg-purple-600 tw:focus:ring-purple-500/40",
         danger_outline: "tw:text-[#c0392b] tw:bg-white tw:border tw:border-[#f3c9c9] tw:hover:bg-red-50 tw:active:bg-red-100 tw:focus:ring-red-500/40 tw:dark:bg-transparent tw:dark:text-red-400 tw:dark:border-red-900 tw:dark:hover:bg-red-950",
-        purple_outline: "tw:text-gray-800 tw:bg-white tw:border tw:border-gray-200 tw:hover:border-purple-brand-500 tw:hover:bg-purple-brand-50 tw:focus:ring-purple-brand-500/40 tw:dark:bg-gray-800 tw:dark:text-gray-100 tw:dark:border-gray-700 tw:dark:hover:border-purple-brand-500 tw:dark:hover:bg-purple-950",
+        purple_outline: "tw:text-gray-800 tw:bg-white tw:border tw:border-gray-200 tw:hover:border-purple-500 tw:hover:bg-purple-50 tw:focus:ring-purple-500/40 tw:dark:bg-gray-800 tw:dark:text-gray-100 tw:dark:border-gray-700 tw:dark:hover:border-purple-500 tw:dark:hover:bg-purple-950",
         link: "twlink tw:p-0"
       }.freeze
 
@@ -32,8 +32,8 @@ module UI
         secondary: "tw:ring-2 tw:ring-blue-500/40 tw:bg-gray-200! tw:border-gray-400! tw:dark:bg-gray-800! tw:dark:border-gray-600!",
         error: "tw:ring-2 tw:ring-red-500/40 tw:bg-red-700! tw:dark:bg-red-600!",
         danger_outline: "tw:ring-2 tw:ring-red-500/40 tw:bg-red-100! tw:border-[#c0392b]! tw:dark:bg-red-950! tw:dark:border-red-700!",
-        purple: "tw:ring-2 tw:ring-purple-brand-500/40 tw:bg-purple-brand-600!",
-        purple_outline: "tw:ring-2 tw:ring-purple-brand-500/40 tw:bg-purple-brand-500! tw:text-white! tw:border-purple-brand-500!",
+        purple: "tw:ring-2 tw:ring-purple-500/40 tw:bg-purple-600!",
+        purple_outline: "tw:ring-2 tw:ring-purple-500/40 tw:bg-purple-500! tw:text-white! tw:border-purple-500!",
         link: "tw:text-blue-800 tw:dark:text-blue-300 tw:font-bold tw:underline"
       }.freeze
 
@@ -43,8 +43,8 @@ module UI
         secondary: "tw:aria-pressed:ring-2 tw:active:ring-2 tw:aria-pressed:ring-blue-500/40 tw:active:ring-blue-500/40 tw:aria-pressed:bg-gray-200 tw:active:bg-gray-200 tw:aria-pressed:border-gray-400 tw:active:border-gray-400 tw:aria-pressed:dark:bg-gray-800 tw:active:dark:bg-gray-800 tw:aria-pressed:dark:border-gray-600 tw:active:dark:border-gray-600",
         error: "tw:aria-pressed:ring-2 tw:active:ring-2 tw:aria-pressed:ring-red-500/40 tw:active:ring-red-500/40 tw:aria-pressed:bg-red-700 tw:active:bg-red-700 tw:aria-pressed:dark:bg-red-600 tw:active:dark:bg-red-600",
         danger_outline: "tw:aria-pressed:ring-2 tw:active:ring-2 tw:aria-pressed:ring-red-500/40 tw:active:ring-red-500/40 tw:aria-pressed:bg-red-100 tw:active:bg-red-100 tw:aria-pressed:border-[#c0392b] tw:active:border-[#c0392b] tw:aria-pressed:dark:bg-red-950 tw:active:dark:bg-red-950 tw:aria-pressed:dark:border-red-700 tw:active:dark:border-red-700",
-        purple: "tw:aria-pressed:ring-2 tw:active:ring-2 tw:aria-pressed:ring-purple-brand-500/40 tw:active:ring-purple-brand-500/40 tw:aria-pressed:bg-purple-brand-600 tw:active:bg-purple-brand-600",
-        purple_outline: "tw:aria-pressed:ring-2 tw:active:ring-2 tw:aria-pressed:ring-purple-brand-500/40 tw:active:ring-purple-brand-500/40 tw:aria-pressed:bg-purple-brand-500 tw:active:bg-purple-brand-500 tw:aria-pressed:text-white tw:active:text-white tw:aria-pressed:border-purple-brand-500 tw:active:border-purple-brand-500",
+        purple: "tw:aria-pressed:ring-2 tw:active:ring-2 tw:aria-pressed:ring-purple-500/40 tw:active:ring-purple-500/40 tw:aria-pressed:bg-purple-600 tw:active:bg-purple-600",
+        purple_outline: "tw:aria-pressed:ring-2 tw:active:ring-2 tw:aria-pressed:ring-purple-500/40 tw:active:ring-purple-500/40 tw:aria-pressed:bg-purple-500 tw:active:bg-purple-500 tw:aria-pressed:text-white tw:active:text-white tw:aria-pressed:border-purple-500 tw:active:border-purple-500",
         link: "tw:aria-pressed:text-blue-800 tw:active:text-blue-800 tw:aria-pressed:dark:text-blue-300 tw:active:dark:text-blue-300 tw:aria-pressed:font-bold tw:active:font-bold tw:aria-pressed:underline tw:active:underline"
       }.freeze
 

--- a/app/components/ui/button/component.rb
+++ b/app/components/ui/button/component.rb
@@ -18,22 +18,22 @@ module UI
         primary: "tw:text-white tw:bg-blue-600 tw:border tw:border-blue-600 tw:hover:bg-blue-700 tw:active:bg-blue-800 tw:focus:ring-blue-500/40 tw:dark:bg-blue-500 tw:dark:border-blue-500 tw:dark:hover:bg-blue-600 tw:dark:active:bg-blue-700",
         secondary: "tw:text-gray-800 tw:bg-white tw:border tw:border-gray-300 tw:hover:bg-gray-50 tw:hover:border-gray-400 tw:active:bg-gray-100 tw:focus:ring-blue-500/40 tw:dark:bg-transparent tw:dark:text-gray-100 tw:dark:border-gray-600 tw:dark:hover:bg-gray-800",
         error: "tw:text-white tw:bg-red-600 tw:border tw:border-red-600 tw:hover:bg-red-700 tw:active:bg-red-800 tw:focus:ring-red-500/40 tw:dark:bg-red-500 tw:dark:border-red-500 tw:dark:hover:bg-red-600 tw:dark:active:bg-red-700",
-        purple: "tw:text-white tw:bg-[#715eb2] tw:border tw:border-[#715eb2] tw:hover:bg-[#5d4b9c] tw:hover:border-[#5d4b9c] tw:active:bg-[#5d4b9c] tw:focus:ring-[#715eb2]/40",
+        purple: "tw:text-white tw:bg-purple-brand-500 tw:border tw:border-purple-brand-500 tw:hover:bg-purple-brand-600 tw:hover:border-purple-brand-600 tw:active:bg-purple-brand-600 tw:focus:ring-purple-brand-500/40",
         danger_outline: "tw:text-[#c0392b] tw:bg-white tw:border tw:border-[#f3c9c9] tw:hover:bg-red-50 tw:active:bg-red-100 tw:focus:ring-red-500/40 tw:dark:bg-transparent tw:dark:text-red-400 tw:dark:border-red-900 tw:dark:hover:bg-red-950",
-        purple_outline: "tw:text-gray-800 tw:bg-white tw:border tw:border-gray-200 tw:hover:border-[#715eb2] tw:hover:bg-[#f7f5fc] tw:focus:ring-[#715eb2]/40 tw:dark:bg-gray-800 tw:dark:text-gray-100 tw:dark:border-gray-700 tw:dark:hover:border-[#715eb2] tw:dark:hover:bg-purple-950",
+        purple_outline: "tw:text-gray-800 tw:bg-white tw:border tw:border-gray-200 tw:hover:border-purple-brand-500 tw:hover:bg-purple-brand-50 tw:focus:ring-purple-brand-500/40 tw:dark:bg-gray-800 tw:dark:text-gray-100 tw:dark:border-gray-700 tw:dark:hover:border-purple-brand-500 tw:dark:hover:bg-purple-950",
         link: "twlink tw:p-0"
       }.freeze
 
       # `!` important on the fill/border/text so the active color wins over the resting
-      # color regardless of Tailwind's compiled source order (arbitrary values like
-      # bg-[#715eb2] otherwise sort before named ones like bg-white and lose).
+      # color: same-specificity utilities resolve by Tailwind's compiled source order,
+      # not class-attribute order, so the resting fill would otherwise bleed through.
       ACTIVE_COLORS = {
         primary: "tw:ring-2 tw:ring-blue-500/40 tw:bg-blue-700! tw:dark:bg-blue-600!",
         secondary: "tw:ring-2 tw:ring-blue-500/40 tw:bg-gray-200! tw:border-gray-400! tw:dark:bg-gray-800! tw:dark:border-gray-600!",
         error: "tw:ring-2 tw:ring-red-500/40 tw:bg-red-700! tw:dark:bg-red-600!",
         danger_outline: "tw:ring-2 tw:ring-red-500/40 tw:bg-red-100! tw:border-[#c0392b]! tw:dark:bg-red-950! tw:dark:border-red-700!",
-        purple: "tw:ring-2 tw:ring-[#715eb2]/40 tw:bg-[#5d4b9c]!",
-        purple_outline: "tw:ring-2 tw:ring-[#715eb2]/40 tw:bg-[#715eb2]! tw:text-white! tw:border-[#715eb2]!",
+        purple: "tw:ring-2 tw:ring-purple-brand-500/40 tw:bg-purple-brand-600!",
+        purple_outline: "tw:ring-2 tw:ring-purple-brand-500/40 tw:bg-purple-brand-500! tw:text-white! tw:border-purple-brand-500!",
         link: "tw:text-blue-800 tw:dark:text-blue-300 tw:font-bold tw:underline"
       }.freeze
 
@@ -43,8 +43,8 @@ module UI
         secondary: "tw:aria-pressed:ring-2 tw:active:ring-2 tw:aria-pressed:ring-blue-500/40 tw:active:ring-blue-500/40 tw:aria-pressed:bg-gray-200 tw:active:bg-gray-200 tw:aria-pressed:border-gray-400 tw:active:border-gray-400 tw:aria-pressed:dark:bg-gray-800 tw:active:dark:bg-gray-800 tw:aria-pressed:dark:border-gray-600 tw:active:dark:border-gray-600",
         error: "tw:aria-pressed:ring-2 tw:active:ring-2 tw:aria-pressed:ring-red-500/40 tw:active:ring-red-500/40 tw:aria-pressed:bg-red-700 tw:active:bg-red-700 tw:aria-pressed:dark:bg-red-600 tw:active:dark:bg-red-600",
         danger_outline: "tw:aria-pressed:ring-2 tw:active:ring-2 tw:aria-pressed:ring-red-500/40 tw:active:ring-red-500/40 tw:aria-pressed:bg-red-100 tw:active:bg-red-100 tw:aria-pressed:border-[#c0392b] tw:active:border-[#c0392b] tw:aria-pressed:dark:bg-red-950 tw:active:dark:bg-red-950 tw:aria-pressed:dark:border-red-700 tw:active:dark:border-red-700",
-        purple: "tw:aria-pressed:ring-2 tw:active:ring-2 tw:aria-pressed:ring-[#715eb2]/40 tw:active:ring-[#715eb2]/40 tw:aria-pressed:bg-[#5d4b9c] tw:active:bg-[#5d4b9c]",
-        purple_outline: "tw:aria-pressed:ring-2 tw:active:ring-2 tw:aria-pressed:ring-[#715eb2]/40 tw:active:ring-[#715eb2]/40 tw:aria-pressed:bg-[#715eb2] tw:active:bg-[#715eb2] tw:aria-pressed:text-white tw:active:text-white tw:aria-pressed:border-[#715eb2] tw:active:border-[#715eb2]",
+        purple: "tw:aria-pressed:ring-2 tw:active:ring-2 tw:aria-pressed:ring-purple-brand-500/40 tw:active:ring-purple-brand-500/40 tw:aria-pressed:bg-purple-brand-600 tw:active:bg-purple-brand-600",
+        purple_outline: "tw:aria-pressed:ring-2 tw:active:ring-2 tw:aria-pressed:ring-purple-brand-500/40 tw:active:ring-purple-brand-500/40 tw:aria-pressed:bg-purple-brand-500 tw:active:bg-purple-brand-500 tw:aria-pressed:text-white tw:active:text-white tw:aria-pressed:border-purple-brand-500 tw:active:border-purple-brand-500",
         link: "tw:aria-pressed:text-blue-800 tw:active:text-blue-800 tw:aria-pressed:dark:text-blue-300 tw:active:dark:text-blue-300 tw:aria-pressed:font-bold tw:active:font-bold tw:aria-pressed:underline tw:active:underline"
       }.freeze
 

--- a/app/components/ui/button/component.rb
+++ b/app/components/ui/button/component.rb
@@ -15,61 +15,42 @@ module UI
       }.freeze
 
       COLORS = {
-        primary: "tw:text-white tw:bg-blue-600 tw:border tw:border-blue-600 tw:hover:bg-blue-700 tw:active:bg-blue-800 tw:focus:ring-blue-500/40 tw:dark:bg-blue-500 tw:dark:border-blue-500 tw:dark:hover:bg-blue-600 tw:dark:active:bg-blue-700",
-        secondary: "tw:text-gray-800 tw:bg-white tw:border tw:border-gray-300 tw:hover:bg-gray-50 tw:hover:border-gray-400 tw:active:bg-gray-100 tw:focus:ring-blue-500/40 tw:dark:bg-transparent tw:dark:text-gray-100 tw:dark:border-gray-600 tw:dark:hover:bg-gray-800",
-        error: "tw:text-white tw:bg-red-600 tw:border tw:border-red-600 tw:hover:bg-red-700 tw:active:bg-red-800 tw:focus:ring-red-500/40 tw:dark:bg-red-500 tw:dark:border-red-500 tw:dark:hover:bg-red-600 tw:dark:active:bg-red-700",
-        purple: "tw:text-white tw:bg-purple-500 tw:border tw:border-purple-500 tw:hover:bg-purple-600 tw:hover:border-purple-600 tw:active:bg-purple-600 tw:focus:ring-purple-500/40",
-        danger_outline: "tw:text-[#c0392b] tw:bg-white tw:border tw:border-[#f3c9c9] tw:hover:bg-red-50 tw:active:bg-red-100 tw:focus:ring-red-500/40 tw:dark:bg-transparent tw:dark:text-red-400 tw:dark:border-red-900 tw:dark:hover:bg-red-950",
+        primary: "tw:text-white tw:bg-blue-600 tw:border tw:border-blue-600 tw:hover:bg-blue-700 tw:focus:ring-blue-500/40 tw:dark:bg-blue-500 tw:dark:border-blue-500 tw:dark:hover:bg-blue-600",
+        secondary: "tw:text-gray-800 tw:bg-white tw:border tw:border-gray-300 tw:hover:bg-gray-50 tw:hover:border-gray-400 tw:focus:ring-blue-500/40 tw:dark:bg-transparent tw:dark:text-gray-100 tw:dark:border-gray-600 tw:dark:hover:bg-gray-800",
+        error: "tw:text-white tw:bg-red-600 tw:border tw:border-red-600 tw:hover:bg-red-700 tw:focus:ring-red-500/40 tw:dark:bg-red-500 tw:dark:border-red-500 tw:dark:hover:bg-red-600",
+        purple: "tw:text-white tw:bg-purple-500 tw:border tw:border-purple-500 tw:hover:bg-purple-600 tw:hover:border-purple-600 tw:focus:ring-purple-500/40",
+        danger_outline: "tw:text-[#c0392b] tw:bg-white tw:border tw:border-[#f3c9c9] tw:hover:bg-red-50 tw:focus:ring-red-500/40 tw:dark:bg-transparent tw:dark:text-red-400 tw:dark:border-red-900 tw:dark:hover:bg-red-950",
         purple_outline: "tw:text-gray-800 tw:bg-white tw:border tw:border-gray-200 tw:hover:border-purple-500 tw:hover:bg-purple-50 tw:focus:ring-purple-500/40 tw:dark:bg-gray-800 tw:dark:text-gray-100 tw:dark:border-gray-700 tw:dark:hover:border-purple-500 tw:dark:hover:bg-purple-950",
         link: "twlink tw:p-0"
       }.freeze
 
-      # The complete color set for the persistent active: true state. build_classes
-      # emits this *instead of* COLORS (see there), so resting and active fills never
-      # coexist and no `!` important is needed to settle the cascade. link is the
-      # exception — it layers over COLORS[:link] since `twlink` isn't variant-able.
+      # The active look, as a delta over COLORS — always emitted alongside it and inert
+      # until the element flags itself active (see the is-active variant in application.css,
+      # which sorts last, so these override the resting colors with no `!` important).
+      # Literal strings so Tailwind's scanner generates them; the spec enforces the prefix.
       ACTIVE_COLORS = {
-        primary: "tw:text-white tw:bg-blue-700 tw:border tw:border-blue-600 tw:ring-2 tw:ring-blue-500/40 tw:dark:bg-blue-600 tw:dark:border-blue-500",
-        secondary: "tw:text-gray-800 tw:bg-gray-200 tw:border tw:border-gray-400 tw:ring-2 tw:ring-blue-500/40 tw:dark:text-gray-100 tw:dark:bg-gray-800 tw:dark:border-gray-600",
-        error: "tw:text-white tw:bg-red-700 tw:border tw:border-red-600 tw:ring-2 tw:ring-red-500/40 tw:dark:bg-red-600 tw:dark:border-red-500",
-        danger_outline: "tw:text-[#c0392b] tw:bg-red-100 tw:border tw:border-[#c0392b] tw:ring-2 tw:ring-red-500/40 tw:dark:text-red-400 tw:dark:bg-red-950 tw:dark:border-red-700",
-        purple: "tw:text-white tw:bg-purple-600 tw:border tw:border-purple-600 tw:ring-2 tw:ring-purple-500/40",
-        purple_outline: "tw:text-white tw:bg-purple-500 tw:border tw:border-purple-500 tw:ring-2 tw:ring-purple-500/40",
-        link: "tw:text-blue-800 tw:dark:text-blue-300 tw:font-bold tw:underline"
-      }.freeze
-
-      # A mirror of ACTIVE_COLORS under aria-pressed:/active: — so a resting button shows
-      # the active look while pressed or toggled, without being passed active: true. Kept
-      # as literal strings so Tailwind's scanner generates the variants (see spec, which
-      # enforces the mirror). These are variants, so they win over COLORS by precedence.
-      ACTIVE_PREFIXED = {
-        primary: "tw:aria-pressed:text-white tw:active:text-white tw:aria-pressed:bg-blue-700 tw:active:bg-blue-700 tw:aria-pressed:border tw:active:border tw:aria-pressed:border-blue-600 tw:active:border-blue-600 tw:aria-pressed:ring-2 tw:active:ring-2 tw:aria-pressed:ring-blue-500/40 tw:active:ring-blue-500/40 tw:aria-pressed:dark:bg-blue-600 tw:active:dark:bg-blue-600 tw:aria-pressed:dark:border-blue-500 tw:active:dark:border-blue-500",
-        secondary: "tw:aria-pressed:text-gray-800 tw:active:text-gray-800 tw:aria-pressed:bg-gray-200 tw:active:bg-gray-200 tw:aria-pressed:border tw:active:border tw:aria-pressed:border-gray-400 tw:active:border-gray-400 tw:aria-pressed:ring-2 tw:active:ring-2 tw:aria-pressed:ring-blue-500/40 tw:active:ring-blue-500/40 tw:aria-pressed:dark:text-gray-100 tw:active:dark:text-gray-100 tw:aria-pressed:dark:bg-gray-800 tw:active:dark:bg-gray-800 tw:aria-pressed:dark:border-gray-600 tw:active:dark:border-gray-600",
-        error: "tw:aria-pressed:text-white tw:active:text-white tw:aria-pressed:bg-red-700 tw:active:bg-red-700 tw:aria-pressed:border tw:active:border tw:aria-pressed:border-red-600 tw:active:border-red-600 tw:aria-pressed:ring-2 tw:active:ring-2 tw:aria-pressed:ring-red-500/40 tw:active:ring-red-500/40 tw:aria-pressed:dark:bg-red-600 tw:active:dark:bg-red-600 tw:aria-pressed:dark:border-red-500 tw:active:dark:border-red-500",
-        danger_outline: "tw:aria-pressed:text-[#c0392b] tw:active:text-[#c0392b] tw:aria-pressed:bg-red-100 tw:active:bg-red-100 tw:aria-pressed:border tw:active:border tw:aria-pressed:border-[#c0392b] tw:active:border-[#c0392b] tw:aria-pressed:ring-2 tw:active:ring-2 tw:aria-pressed:ring-red-500/40 tw:active:ring-red-500/40 tw:aria-pressed:dark:text-red-400 tw:active:dark:text-red-400 tw:aria-pressed:dark:bg-red-950 tw:active:dark:bg-red-950 tw:aria-pressed:dark:border-red-700 tw:active:dark:border-red-700",
-        purple: "tw:aria-pressed:text-white tw:active:text-white tw:aria-pressed:bg-purple-600 tw:active:bg-purple-600 tw:aria-pressed:border tw:active:border tw:aria-pressed:border-purple-600 tw:active:border-purple-600 tw:aria-pressed:ring-2 tw:active:ring-2 tw:aria-pressed:ring-purple-500/40 tw:active:ring-purple-500/40",
-        purple_outline: "tw:aria-pressed:text-white tw:active:text-white tw:aria-pressed:bg-purple-500 tw:active:bg-purple-500 tw:aria-pressed:border tw:active:border tw:aria-pressed:border-purple-500 tw:active:border-purple-500 tw:aria-pressed:ring-2 tw:active:ring-2 tw:aria-pressed:ring-purple-500/40 tw:active:ring-purple-500/40",
-        link: "tw:aria-pressed:text-blue-800 tw:active:text-blue-800 tw:aria-pressed:dark:text-blue-300 tw:active:dark:text-blue-300 tw:aria-pressed:font-bold tw:active:font-bold tw:aria-pressed:underline tw:active:underline"
+        primary: "tw:is-active:bg-blue-700 tw:is-active:ring-2 tw:is-active:ring-blue-500/40 tw:is-active:dark:bg-blue-600",
+        secondary: "tw:is-active:bg-gray-200 tw:is-active:border-gray-400 tw:is-active:ring-2 tw:is-active:ring-blue-500/40 tw:is-active:dark:bg-gray-800",
+        error: "tw:is-active:bg-red-700 tw:is-active:ring-2 tw:is-active:ring-red-500/40 tw:is-active:dark:bg-red-600",
+        purple: "tw:is-active:bg-purple-600 tw:is-active:border-purple-600 tw:is-active:ring-2 tw:is-active:ring-purple-500/40",
+        danger_outline: "tw:is-active:bg-red-100 tw:is-active:border-[#c0392b] tw:is-active:ring-2 tw:is-active:ring-red-500/40 tw:is-active:dark:bg-red-950 tw:is-active:dark:border-red-700",
+        purple_outline: "tw:is-active:text-white tw:is-active:bg-purple-500 tw:is-active:border-purple-500 tw:is-active:ring-2 tw:is-active:ring-purple-500/40",
+        link: "tw:is-active:text-blue-800 tw:is-active:dark:text-blue-300 tw:is-active:font-bold tw:is-active:underline"
       }.freeze
 
       KINDS = %i[button submit]
 
       DISABLED_CLASSES = "tw:disabled:opacity-50 tw:disabled:cursor-not-allowed tw:disabled:pointer-events-none"
 
-      def self.build_classes(color:, size:, active: false, html_class: nil)
-        classes = [BASE_CLASSES, html_class]
-        if color == :link
-          # twlink isn't variant-able, so link layers the active delta over its resting base.
-          classes << COLORS[color]
-          classes << ACTIVE_COLORS[color] if active
-        else
-          classes << SIZES[size]
-          classes << "tw:focus:outline-none tw:focus:ring-3 tw:font-medium tw:no-underline"
-          classes << DISABLED_CLASSES
-          classes << (active ? ACTIVE_COLORS[color] : COLORS[color])
+      # is-active sorts after focus, so an active button's ring-2 swallows the focus ring
+      # unless focus is restated under the variant.
+      FOCUS_CLASSES = "tw:focus:outline-none tw:focus:ring-3 tw:is-active:focus:ring-3"
+
+      def self.build_classes(color:, size:, html_class: nil)
+        unless color == :link
+          extras = [SIZES[size], FOCUS_CLASSES, "tw:font-medium tw:no-underline", DISABLED_CLASSES]
         end
-        classes << ACTIVE_PREFIXED[color]
-        classes.compact.join(" ")
+        [BASE_CLASSES, html_class, *extras, COLORS[color], ACTIVE_COLORS[color]].compact.join(" ")
       end
 
       def initialize(text: nil, color: :secondary, size: :md, active: false, html_class: nil, kind: nil, disabled: false, data: {}, aria: {})
@@ -87,11 +68,11 @@ module UI
       end
 
       def call
-        content_tag(:button, @text || content, class: button_classes, type: (@kind == :submit) ? "submit" : "button", disabled: @disabled, data: @data, aria: @aria)
+        content_tag(:button, @text || content, class: button_classes, type: (@kind == :submit) ? "submit" : "button", disabled: @disabled, data: @data.merge(active: @active || nil), aria: @aria)
       end
 
       def button_classes
-        self.class.build_classes(color: @color, size: @size, active: @active, html_class: @html_class)
+        self.class.build_classes(color: @color, size: @size, html_class: @html_class)
       end
     end
   end

--- a/app/components/ui/button_link/component.rb
+++ b/app/components/ui/button_link/component.rb
@@ -19,19 +19,23 @@ module UI
       def call
         return button_to_form if @method
 
-        helpers.link_to(@text || content, @href, @html_options.merge(class: link_classes))
+        helpers.link_to(@text || content, @href, html_attributes)
       end
 
       private
 
       def button_to_form
-        helpers.button_to(@href, @html_options.merge(class: link_classes, method: @method)) do
+        helpers.button_to(@href, html_attributes.merge(method: @method)) do
           @text || content
         end
       end
 
+      def html_attributes
+        @html_options.merge(class: link_classes, data: (@html_options[:data] || {}).merge(active: @active || nil))
+      end
+
       def link_classes
-        UI::Button::Component.build_classes(color: @color, size: @size, active: @active, html_class: @html_options[:class])
+        UI::Button::Component.build_classes(color: @color, size: @size, html_class: @html_options[:class])
       end
     end
   end

--- a/app/components/ui/dropdown/component.html.erb
+++ b/app/components/ui/dropdown/component.html.erb
@@ -1,12 +1,5 @@
 <div class="tw:relative tw:inline-block" data-controller="ui--dropdown">
-  <button
-    type="button"
-    class="<%= button_classes %>"
-    id="<%= button_id %>"
-    aria-expanded="false"
-    data-action="click->ui--dropdown#toggle"
-    data-ui--dropdown-target="button"
-  >
+  <%= tag.button(**button_attributes) do %>
     <span class="tw:sr-only">Open <%= @name %> menu</span>
     <%= button_content %>
 
@@ -18,7 +11,7 @@
     >
       <%= render UI::IconChevron::Component.new(direction: :down) %>
     </span>
-  </button>
+  <% end %>
 
   <div
     class="

--- a/app/components/ui/dropdown/component.rb
+++ b/app/components/ui/dropdown/component.rb
@@ -3,15 +3,15 @@
 module UI
   module Dropdown
     class Component < ApplicationComponent
-      # Literal strings so Tailwind's scanner generates these aria-current:/active: variants.
       # Applied to the <li>; the `[&>a]` variant colors the item's link (the surface).
-      # aria-current (not aria-pressed) because aria-pressed is invalid on role="menuitem".
-      ACTIVE_PREFIXED = "tw:aria-[current]:[&>a]:bg-gray-200 tw:active:[&>a]:bg-gray-200 tw:aria-[current]:[&>a]:text-gray-900 tw:active:[&>a]:text-gray-900 tw:aria-[current]:dark:[&>a]:bg-gray-600 tw:active:dark:[&>a]:bg-gray-600 tw:aria-[current]:dark:[&>a]:text-gray-100 tw:active:dark:[&>a]:text-gray-100"
+      # The item flags itself aria-current rather than aria-pressed, which is invalid on
+      # role="menuitem" — the is-active variant (application.css) covers both.
+      ACTIVE_COLORS = "tw:is-active:[&>a]:bg-gray-200 tw:is-active:[&>a]:text-gray-900 tw:is-active:dark:[&>a]:bg-gray-600 tw:is-active:dark:[&>a]:text-gray-100"
 
       renders_one :button
       renders_many :entries, types: {
         item: lambda { |active: false, &block|
-          content_tag(:li, capture(&block), role: "menuitem", class: ACTIVE_PREFIXED, aria: {current: active || nil})
+          content_tag(:li, capture(&block), role: "menuitem", class: ACTIVE_COLORS, aria: {current: active || nil})
         },
         divider: lambda {
           content_tag(:li, "", role: "separator")
@@ -28,6 +28,16 @@ module UI
 
       private
 
+      def button_attributes
+        {
+          type: "button",
+          class: button_classes,
+          id: button_id,
+          aria: {expanded: false},
+          data: {action: "click->ui--dropdown#toggle", "ui--dropdown-target": "button", active: @active || nil}
+        }
+      end
+
       def button_content
         raw = button? ? button : @name
         (@button_color == :link) ? content_tag(:span, raw, class: "tw:underline") : raw
@@ -36,9 +46,10 @@ module UI
       def button_classes
         return @button_class if @button_class
 
-        classes = UI::Button::Component.new(color: @button_color, size: @button_size, active: @active).button_classes
+        classes = UI::Button::Component.new(color: @button_color, size: @button_size).button_classes
         if @button_color == :link
-          classes = classes.gsub("tw:underline", "").squeeze(" ").strip + " tw:px-1"
+          # button_content underlines the label span, so the trigger itself never does.
+          classes = classes.sub("tw:is-active:underline", "").squeeze(" ").strip + " tw:px-1"
         end
         classes
       end

--- a/app/components/ui/forms/radio_button_group/component.rb
+++ b/app/components/ui/forms/radio_button_group/component.rb
@@ -40,10 +40,10 @@ module UI
           tag.label(class: [
             "tw:cursor-pointer tw:select-none tw:inline-flex tw:items-center tw:mb-0! tw:px-3 tw:py-1 tw:text-sm tw:leading-snug tw:transition-colors",
             "tw:text-gray-800 tw:bg-white tw:border tw:border-gray-200 tw:dark:bg-gray-800 tw:dark:text-gray-100 tw:dark:border-gray-700",
-            "tw:hover:border-purple-brand-500 tw:hover:bg-purple-brand-50 tw:dark:hover:border-purple-brand-500 tw:dark:hover:bg-purple-950",
-            "tw:has-[:checked]:bg-purple-brand-500 tw:has-[:checked]:text-white tw:has-[:checked]:border-purple-brand-500",
-            "tw:has-[:checked]:hover:bg-purple-brand-500 tw:has-[:checked]:hover:border-purple-brand-500",
-            "tw:has-[:focus-visible]:ring-2 tw:has-[:focus-visible]:ring-purple-brand-500/40 tw:has-[:focus-visible]:ring-offset-1 tw:dark:has-[:focus-visible]:ring-offset-gray-900",
+            "tw:hover:border-purple-500 tw:hover:bg-purple-50 tw:dark:hover:border-purple-500 tw:dark:hover:bg-purple-950",
+            "tw:has-[:checked]:bg-purple-500 tw:has-[:checked]:text-white tw:has-[:checked]:border-purple-500",
+            "tw:has-[:checked]:hover:bg-purple-500 tw:has-[:checked]:hover:border-purple-500",
+            "tw:has-[:focus-visible]:ring-2 tw:has-[:focus-visible]:ring-purple-500/40 tw:has-[:focus-visible]:ring-offset-1 tw:dark:has-[:focus-visible]:ring-offset-gray-900",
             round, border_l
           ].join(" ")) do
             radio_button_tag(@name, value, checked,

--- a/app/components/ui/forms/radio_button_group/component.rb
+++ b/app/components/ui/forms/radio_button_group/component.rb
@@ -35,15 +35,15 @@ module UI
           end
           border_l = first ? "" : "tw:-ml-px"
 
+          # Mirrors UI::Button color: :purple_outline (resting + active), driving the
+          # active state off the checked radio so the two stay visually in lockstep.
           tag.label(class: [
-            "tw:cursor-pointer tw:select-none tw:inline-flex tw:items-center tw:mb-0!",
-            "tw:bg-white tw:dark:bg-gray-800 tw:border tw:border-gray-300 tw:dark:border-gray-600 tw:px-3 tw:py-1 tw:text-sm tw:leading-snug",
-            "tw:transition-colors tw:has-[:checked]:bg-gray-700 tw:has-[:checked]:text-white tw:has-[:checked]:border-gray-700",
-            "tw:dark:has-[:checked]:bg-gray-300 tw:dark:has-[:checked]:text-gray-900 tw:dark:has-[:checked]:border-gray-300",
-            "tw:hover:bg-gray-100 tw:has-[:checked]:hover:bg-gray-700",
-            "tw:dark:hover:bg-gray-700 tw:dark:has-[:checked]:hover:bg-gray-300",
-            "tw:has-[:focus-visible]:ring-2 tw:has-[:focus-visible]:ring-blue-500 tw:has-[:focus-visible]:ring-offset-1",
-            "tw:dark:has-[:focus-visible]:ring-blue-400 tw:dark:has-[:focus-visible]:ring-offset-gray-900",
+            "tw:cursor-pointer tw:select-none tw:inline-flex tw:items-center tw:mb-0! tw:px-3 tw:py-1 tw:text-sm tw:leading-snug tw:transition-colors",
+            "tw:text-gray-800 tw:bg-white tw:border tw:border-gray-200 tw:dark:bg-gray-800 tw:dark:text-gray-100 tw:dark:border-gray-700",
+            "tw:hover:border-[#715eb2] tw:hover:bg-[#f7f5fc] tw:dark:hover:border-[#715eb2] tw:dark:hover:bg-purple-950",
+            "tw:has-[:checked]:bg-[#715eb2] tw:has-[:checked]:text-white tw:has-[:checked]:border-[#715eb2]",
+            "tw:has-[:checked]:hover:bg-[#715eb2] tw:has-[:checked]:hover:border-[#715eb2]",
+            "tw:has-[:focus-visible]:ring-2 tw:has-[:focus-visible]:ring-[#715eb2]/40 tw:has-[:focus-visible]:ring-offset-1 tw:dark:has-[:focus-visible]:ring-offset-gray-900",
             round, border_l
           ].join(" ")) do
             radio_button_tag(@name, value, checked,

--- a/app/components/ui/forms/radio_button_group/component.rb
+++ b/app/components/ui/forms/radio_button_group/component.rb
@@ -40,10 +40,10 @@ module UI
           tag.label(class: [
             "tw:cursor-pointer tw:select-none tw:inline-flex tw:items-center tw:mb-0! tw:px-3 tw:py-1 tw:text-sm tw:leading-snug tw:transition-colors",
             "tw:text-gray-800 tw:bg-white tw:border tw:border-gray-200 tw:dark:bg-gray-800 tw:dark:text-gray-100 tw:dark:border-gray-700",
-            "tw:hover:border-[#715eb2] tw:hover:bg-[#f7f5fc] tw:dark:hover:border-[#715eb2] tw:dark:hover:bg-purple-950",
-            "tw:has-[:checked]:bg-[#715eb2] tw:has-[:checked]:text-white tw:has-[:checked]:border-[#715eb2]",
-            "tw:has-[:checked]:hover:bg-[#715eb2] tw:has-[:checked]:hover:border-[#715eb2]",
-            "tw:has-[:focus-visible]:ring-2 tw:has-[:focus-visible]:ring-[#715eb2]/40 tw:has-[:focus-visible]:ring-offset-1 tw:dark:has-[:focus-visible]:ring-offset-gray-900",
+            "tw:hover:border-purple-brand-500 tw:hover:bg-purple-brand-50 tw:dark:hover:border-purple-brand-500 tw:dark:hover:bg-purple-950",
+            "tw:has-[:checked]:bg-purple-brand-500 tw:has-[:checked]:text-white tw:has-[:checked]:border-purple-brand-500",
+            "tw:has-[:checked]:hover:bg-purple-brand-500 tw:has-[:checked]:hover:border-purple-brand-500",
+            "tw:has-[:focus-visible]:ring-2 tw:has-[:focus-visible]:ring-purple-brand-500/40 tw:has-[:focus-visible]:ring-offset-1 tw:dark:has-[:focus-visible]:ring-offset-gray-900",
             round, border_l
           ].join(" ")) do
             radio_button_tag(@name, value, checked,

--- a/spec/components/ui/button/component_spec.rb
+++ b/spec/components/ui/button/component_spec.rb
@@ -57,7 +57,7 @@ RSpec.describe UI::Button::Component, type: :component do
     let(:color) { :purple_outline }
 
     it "renders purple_outline styles" do
-      expect(component.to_html).to include("tw:hover:border-[#715eb2]")
+      expect(component.to_html).to include("tw:hover:border-purple-500")
     end
   end
 
@@ -149,16 +149,18 @@ RSpec.describe UI::Button::Component, type: :component do
     let(:options) { {active: true} }
     it "applies the bare active classes statically" do
       tokens = component.css("button").first["class"].split
-      expect(tokens).to include("tw:ring-2", "tw:bg-gray-200")
+      expect(tokens).to include("tw:ring-2", "tw:bg-gray-200!")
     end
   end
 
   describe "ACTIVE_PREFIXED" do
-    it "prefixes every ACTIVE_COLORS class with aria-pressed: and active: for each color" do
+    # The aria-pressed:/active: variants win by precedence, so they drop the `!`
+    # important that ACTIVE_COLORS needs for the persistent active: true state.
+    it "prefixes every ACTIVE_COLORS class (sans `!`) with aria-pressed: and active: for each color" do
       expect(described_class::ACTIVE_PREFIXED.keys).to eq(described_class::ACTIVE_COLORS.keys)
       described_class::ACTIVE_COLORS.each do |color, classes|
         expected = classes.split.flat_map do |variant|
-          base = variant.delete_prefix("tw:")
+          base = variant.delete_prefix("tw:").delete_suffix("!")
           ["tw:aria-pressed:#{base}", "tw:active:#{base}"]
         end
         expect(described_class::ACTIVE_PREFIXED[color].split).to eq(expected)

--- a/spec/components/ui/button/component_spec.rb
+++ b/spec/components/ui/button/component_spec.rb
@@ -147,20 +147,22 @@ RSpec.describe UI::Button::Component, type: :component do
 
   context "active: true" do
     let(:options) { {active: true} }
-    it "applies the bare active classes statically" do
+    it "swaps in the active color set, dropping the resting fill" do
       tokens = component.css("button").first["class"].split
-      expect(tokens).to include("tw:ring-2", "tw:bg-gray-200!")
+      expect(tokens).to include("tw:ring-2", "tw:bg-gray-200")
+      expect(tokens).not_to include("tw:bg-white")
     end
   end
 
   describe "ACTIVE_PREFIXED" do
-    # The aria-pressed:/active: variants win by precedence, so they drop the `!`
-    # important that ACTIVE_COLORS needs for the persistent active: true state.
-    it "prefixes every ACTIVE_COLORS class (sans `!`) with aria-pressed: and active: for each color" do
+    # A strict mirror of ACTIVE_COLORS under aria-pressed:/active:, so a resting button
+    # shows the active look while pressed or toggled (these variants win over COLORS by
+    # precedence). No `!` here or in ACTIVE_COLORS — the states never coexist.
+    it "prefixes every ACTIVE_COLORS class with aria-pressed: and active: for each color" do
       expect(described_class::ACTIVE_PREFIXED.keys).to eq(described_class::ACTIVE_COLORS.keys)
       described_class::ACTIVE_COLORS.each do |color, classes|
         expected = classes.split.flat_map do |variant|
-          base = variant.delete_prefix("tw:").delete_suffix("!")
+          base = variant.delete_prefix("tw:")
           ["tw:aria-pressed:#{base}", "tw:active:#{base}"]
         end
         expect(described_class::ACTIVE_PREFIXED[color].split).to eq(expected)

--- a/spec/components/ui/button/component_spec.rb
+++ b/spec/components/ui/button/component_spec.rb
@@ -101,14 +101,6 @@ RSpec.describe UI::Button::Component, type: :component do
     end
   end
 
-  context "with active state" do
-    let(:options) { {text: "Active", color: :primary, active: true} }
-
-    it "includes active ring classes" do
-      expect(component.to_html).to include("tw:ring-2")
-    end
-  end
-
   context "with submit kind" do
     let(:options) { {text: "Submit", kind: :submit} }
 
@@ -132,10 +124,15 @@ RSpec.describe UI::Button::Component, type: :component do
     end
   end
 
-  it "always applies the prefixed active classes (inert until pressed/toggled)" do
+  it "always applies the active classes (inert until data-active/pressed)" do
     tokens = component.css("button").first["class"].split
-    expect(tokens).to include("tw:aria-pressed:ring-2", "tw:active:ring-2")
-    expect(tokens).not_to include("tw:ring-2", "tw:bg-gray-200")
+    expect(tokens).to include("tw:is-active:ring-2", "tw:is-active:bg-gray-200")
+    expect(component).to have_no_css("button[data-active]")
+  end
+
+  it "keeps focus visible on an active button, whose ring would otherwise mask it" do
+    tokens = component.css("button").first["class"].split
+    expect(tokens).to include(*described_class::FOCUS_CLASSES.split)
   end
 
   context "with aria-controls" do
@@ -147,25 +144,19 @@ RSpec.describe UI::Button::Component, type: :component do
 
   context "active: true" do
     let(:options) { {active: true} }
-    it "swaps in the active color set, dropping the resting fill" do
-      tokens = component.css("button").first["class"].split
-      expect(tokens).to include("tw:ring-2", "tw:bg-gray-200")
-      expect(tokens).not_to include("tw:bg-white")
+    it "flags the button data-active, leaving the classes unchanged" do
+      expect(component).to have_css("button[data-active='true']")
+      expect(component.css("button").first["class"].split).to eq(instance.class.build_classes(color: :secondary, size: :md).split)
     end
   end
 
-  describe "ACTIVE_PREFIXED" do
-    # A strict mirror of ACTIVE_COLORS under aria-pressed:/active:, so a resting button
-    # shows the active look while pressed or toggled (these variants win over COLORS by
-    # precedence). No `!` here or in ACTIVE_COLORS — the states never coexist.
-    it "prefixes every ACTIVE_COLORS class with aria-pressed: and active: for each color" do
-      expect(described_class::ACTIVE_PREFIXED.keys).to eq(described_class::ACTIVE_COLORS.keys)
-      described_class::ACTIVE_COLORS.each do |color, classes|
-        expected = classes.split.flat_map do |variant|
-          base = variant.delete_prefix("tw:")
-          ["tw:aria-pressed:#{base}", "tw:active:#{base}"]
-        end
-        expect(described_class::ACTIVE_PREFIXED[color].split).to eq(expected)
+  describe "ACTIVE_COLORS" do
+    # Every active class is variant-prefixed, so it can never compete with the resting
+    # color it overrides — that's what lets both sets be emitted without `!` important.
+    it "covers every color, prefixed with tw:is-active:" do
+      expect(described_class::ACTIVE_COLORS.keys).to eq(described_class::COLORS.keys)
+      described_class::ACTIVE_COLORS.each_value do |classes|
+        expect(classes.split.grep_v(/\Atw:is-active:/)).to eq([])
       end
     end
   end

--- a/spec/components/ui/button/component_spec.rb
+++ b/spec/components/ui/button/component_spec.rb
@@ -101,6 +101,15 @@ RSpec.describe UI::Button::Component, type: :component do
     end
   end
 
+  context "with active state" do
+    let(:options) { {text: "Active", color: :primary, active: true} }
+
+    it "includes active ring classes" do
+      expect(component).to have_css("button[data-active='true']")
+      expect(component.to_html).to include("tw:is-active:ring-2", "tw:is-active:ring-blue-500/40")
+    end
+  end
+
   context "with submit kind" do
     let(:options) { {text: "Submit", kind: :submit} }
 
@@ -132,7 +141,7 @@ RSpec.describe UI::Button::Component, type: :component do
 
   it "keeps focus visible on an active button, whose ring would otherwise mask it" do
     tokens = component.css("button").first["class"].split
-    expect(tokens).to include(*described_class::FOCUS_CLASSES.split)
+    expect(tokens).to include("tw:focus:ring-3", "tw:is-active:focus:ring-3")
   end
 
   context "with aria-controls" do
@@ -158,6 +167,21 @@ RSpec.describe UI::Button::Component, type: :component do
       described_class::ACTIVE_COLORS.each_value do |classes|
         expect(classes.split.grep_v(/\Atw:is-active:/)).to eq([])
       end
+    end
+  end
+
+  # ACTIVE_COLORS is inert without this variant, which is what the deleted
+  # aria-pressed:/active: mirror used to spell out class by class.
+  describe "the is-active variant" do
+    let(:stylesheet) { Rails.root.join("app/assets/tailwind/application.css").read }
+
+    it "triggers on the persistent, toggled and pressed states" do
+      selectors = stylesheet[/^@custom-variant is-active \((.*)\);/, 1]
+      expect(selectors).to include('[data-active="true"]', '[aria-pressed="true"]', "[aria-current]", ":active")
+    end
+
+    it "is declared last, so it outranks the colors it overrides" do
+      expect(stylesheet.scan(/^@custom-variant (\S+)/).flatten.last).to eq("is-active")
     end
   end
 end

--- a/spec/components/ui/button_link/component_spec.rb
+++ b/spec/components/ui/button_link/component_spec.rb
@@ -23,18 +23,17 @@ RSpec.describe UI::ButtonLink::Component, type: :component do
     end
   end
 
-  it "always applies the prefixed active classes (inert until pressed/toggled)" do
+  it "always applies the active classes (inert until data-active/pressed)" do
     tokens = component.css("a").first["class"].split
-    expect(tokens).to include("tw:aria-pressed:ring-2", "tw:active:ring-2")
-    expect(tokens).not_to include("tw:ring-2", "tw:bg-gray-200")
+    expect(tokens).to include("tw:is-active:ring-2", "tw:is-active:bg-gray-200")
+    expect(component).to have_no_css("a[data-active]")
   end
 
   context "active: true" do
-    let(:options) { {text: "Active", href: "/test", active: true} }
+    let(:options) { {text: "Active", href: "/test", active: true, data: {turbo: false}} }
 
-    it "applies the bare active classes statically" do
-      tokens = component.css("a").first["class"].split
-      expect(tokens).to include("tw:ring-2", "tw:bg-gray-200")
+    it "flags the link data-active, keeping the passed data attributes" do
+      expect(component).to have_css("a[data-active='true'][data-turbo='false']")
     end
   end
 

--- a/spec/components/ui/button_link/component_spec.rb
+++ b/spec/components/ui/button_link/component_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe UI::ButtonLink::Component, type: :component do
 
     it "applies the bare active classes statically" do
       tokens = component.css("a").first["class"].split
-      expect(tokens).to include("tw:ring-2", "tw:bg-gray-200")
+      expect(tokens).to include("tw:ring-2", "tw:bg-gray-200!")
     end
   end
 

--- a/spec/components/ui/button_link/component_spec.rb
+++ b/spec/components/ui/button_link/component_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe UI::ButtonLink::Component, type: :component do
 
     it "applies the bare active classes statically" do
       tokens = component.css("a").first["class"].split
-      expect(tokens).to include("tw:ring-2", "tw:bg-gray-200!")
+      expect(tokens).to include("tw:ring-2", "tw:bg-gray-200")
     end
   end
 

--- a/spec/components/ui/forms/radio_button_group/component_spec.rb
+++ b/spec/components/ui/forms/radio_button_group/component_spec.rb
@@ -7,20 +7,17 @@ RSpec.describe UI::Forms::RadioButtonGroup::Component, type: :component do
   let(:component) { render_inline(described_class.new(name: :search_status, entries:)) }
 
   # Every purple-* color utility a class string uses, ignoring variant prefixes
-  # (hover:, dark:, has-[:checked]:, …) so the group's `has-[:checked]:bg-purple-500`
-  # compares equal to the button's `bg-purple-500`.
+  # (hover:, dark:, has-[:checked]:, is-active:, …) so the group's
+  # `has-[:checked]:bg-purple-500` compares equal to the button's `bg-purple-500`.
   def purple_tokens(class_string)
     class_string.scan(%r{(?:bg|border|text|ring)-purple-\d+(?:/\d+)?}).uniq.sort
   end
 
   it "uses the same purple palette as UI::Button's purple_outline" do
-    # The label carries resting (hover) and checked (active) purple in one class string,
-    # while the button splits them across states, so compare against both sets combined.
-    resting = UI::Button::Component.build_classes(color: :purple_outline, size: :md)
-    active = UI::Button::Component.build_classes(color: :purple_outline, size: :md, active: true)
+    button = UI::Button::Component.build_classes(color: :purple_outline, size: :md)
     label = component.css("label").first["class"]
 
     expect(purple_tokens(label)).not_to be_empty
-    expect(purple_tokens(label)).to eq(purple_tokens("#{resting} #{active}"))
+    expect(purple_tokens(label)).to eq(purple_tokens(button))
   end
 end

--- a/spec/components/ui/forms/radio_button_group/component_spec.rb
+++ b/spec/components/ui/forms/radio_button_group/component_spec.rb
@@ -14,10 +14,13 @@ RSpec.describe UI::Forms::RadioButtonGroup::Component, type: :component do
   end
 
   it "uses the same purple palette as UI::Button's purple_outline" do
-    button = UI::Button::Component.build_classes(color: :purple_outline, size: :md, active: true)
+    # The label carries resting (hover) and checked (active) purple in one class string,
+    # while the button splits them across states, so compare against both sets combined.
+    resting = UI::Button::Component.build_classes(color: :purple_outline, size: :md)
+    active = UI::Button::Component.build_classes(color: :purple_outline, size: :md, active: true)
     label = component.css("label").first["class"]
 
     expect(purple_tokens(label)).not_to be_empty
-    expect(purple_tokens(label)).to eq(purple_tokens(button))
+    expect(purple_tokens(label)).to eq(purple_tokens("#{resting} #{active}"))
   end
 end

--- a/spec/components/ui/forms/radio_button_group/component_spec.rb
+++ b/spec/components/ui/forms/radio_button_group/component_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe UI::Forms::RadioButtonGroup::Component, type: :component do
+  let(:entries) { [{value: "", label: "All"}, {value: "active", label: "Active"}] }
+  let(:component) { render_inline(described_class.new(name: :search_status, entries:)) }
+
+  # Every purple-* color utility a class string uses, ignoring variant prefixes
+  # (hover:, dark:, has-[:checked]:, …) so the group's `has-[:checked]:bg-purple-500`
+  # compares equal to the button's `bg-purple-500`.
+  def purple_tokens(class_string)
+    class_string.scan(%r{(?:bg|border|text|ring)-purple-\d+(?:/\d+)?}).uniq.sort
+  end
+
+  it "uses the same purple palette as UI::Button's purple_outline" do
+    button = UI::Button::Component.build_classes(color: :purple_outline, size: :md, active: true)
+    label = component.css("label").first["class"]
+
+    expect(purple_tokens(label)).not_to be_empty
+    expect(purple_tokens(label)).to eq(purple_tokens(button))
+  end
+end


### PR DESCRIPTION
Restyles the `UI::Forms::RadioButtonGroup` segmented control to `UI::Button`'s `purple_outline` color, makes the brand purple the theme's `purple` scale, and reworks `UI::Button`'s active state so it stops fighting the cascade.

- **RadioButtonGroup**: resting/hover use the purple_outline gray-on-white look with a purple accent; the selected segment fills solid purple (white text) via `has-[:checked]:`, focus ring in the same purple. A spec asserts its purple utilities match the ones `UI::Button` emits, so the two can't drift.
- **`purple` theme scale**: the OG Bike Index purple (`#715eb2` + shades) now defines Tailwind's `purple` (`--color-purple-50…950`), replacing the default violet so `bg-purple-*` etc. resolve to the brand hue app-wide. `UI::Button` and the radio group use these utilities instead of arbitrary hex values.
- **UI::Button active state**: `active: true` renders `data-active="true"` rather than swapping class sets, and a new `is-active` custom variant (`data-active`, `aria-pressed`, `aria-current`, `:active`) carries the active colors. It's declared last so it outranks the resting, hover and dark colors with no `!important` — a plain `data-[active=true]:` variant isn't enough, since `dark:hover:*` sorts after it and wins. That collapses two parallel color maps into one delta over `COLORS` and retires `UI::Dropdown`'s hand-doubled mirror.
  - Mousedown on `primary`/`error` now darkens one step less: the shadowed `active:bg-*` shades leave `COLORS`, replacing a tie that CSS was resolving arbitrarily (the darker shade won for blue/red, the active shade for gray).
