### PR TITLE
Fix flaky org multi-search spec: gate the search button on Stimulus connect

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -338,7 +338,11 @@ jobs:
         uses: actions/upload-artifact@v7
         with:
           name: test-results-${{ env.KNAPSACK_PRO_CI_NODE_INDEX }}
-          path: tmp/rspec-${{ env.KNAPSACK_PRO_CI_NODE_INDEX }}.xml
+          # tmp/capybara holds the failure screenshots system specs write, which
+          # are usually the only evidence of what a flaky :js spec actually saw
+          path: |
+            tmp/rspec-${{ env.KNAPSACK_PRO_CI_NODE_INDEX }}.xml
+            tmp/capybara/
 
   deploy_production:
     name: "Deploy to production"

--- a/app/javascript/controllers/org/multi_search_controller.js
+++ b/app/javascript/controllers/org/multi_search_controller.js
@@ -11,7 +11,9 @@ export default class extends Controller {
     if (this.searching) return
     this.onPopState = () => this.syncFromUrl()
     window.addEventListener('popstate', this.onPopState)
-    this.syncFromUrl()
+    // Renders disabled: clicking before connect submits the form and reloads
+    this.buttonTarget.disabled = false
+    this.syncFromUrl({ preserveInput: true })
   }
 
   disconnect () {
@@ -20,7 +22,7 @@ export default class extends Controller {
 
   // Restore the form + results from the URL, on initial load and on back/forward.
   // The URL already reflects this state, so don't push another history entry.
-  syncFromUrl () {
+  syncFromUrl ({ preserveInput = false } = {}) {
     const params = new URL(window.location).searchParams
     const kind = params.get('search_kind') === 'stickers' ? 'stickers' : 'serials'
     if (this.searchKindValue !== kind) this.applyKind(kind)
@@ -29,7 +31,8 @@ export default class extends Controller {
     }
     this.syncSearchAll()
     const serialsParam = params.get('serials') || ''
-    this.textareaTarget.value = serialsParam
+    // On connect, keep anything typed while the controller was still loading
+    if (!preserveInput || serialsParam) this.textareaTarget.value = serialsParam
     const serials = this.parseSerials(serialsParam)
     if (serials.length) {
       this.search(serials, { pushHistory: false })

--- a/app/views/organized/registrations/multi_search.html.erb
+++ b/app/views/organized/registrations/multi_search.html.erb
@@ -76,11 +76,13 @@
           </span>
         </div>
 
+        <%# Searching is JS-only, so org--multi-search enables this on connect %>
         <%= render UI::Button::Component.new(
           text: button_texts[search_kind],
           color: :primary,
           size: :lg,
           kind: :submit,
+          disabled: true,
           data: {"org--multi-search-target": "button"}
         ) %>
       </div>

--- a/spec/integration/organized/registrations_search_spec.rb
+++ b/spec/integration/organized/registrations_search_spec.rb
@@ -356,13 +356,19 @@ RSpec.describe "Organized registrations search", :js, type: :system do
       ActionController::Base.cache_store = :null_store
     end
 
+    # Clicking before org--multi-search connects submits the form and reloads the
+    # page, so wait for the controller to enable the (initially disabled) button
+    def wait_for_multi_search_controller
+      expect(page).to have_button("Search serials", disabled: false, wait: 15)
+    end
+
     it "searches multiple serials, shows results, and caches rows by updated_at" do
       find("#passive_organization_submenu").click
       within(".current-organization-submenu") { click_link "Multi search" }
       expect(page).to have_current_path(/\A#{Regexp.escape(multi_serial_path)}(\?|\z)/, wait: 10)
 
       expect(page).to have_content(/multi search/i)
-      expect(page).to have_css("[data-controller~='org--multi-search']", wait: 5)
+      wait_for_multi_search_controller
 
       # Kind toggle radios should not be present without bike_stickers feature
       expect(page).not_to have_field("Serials", visible: :all)
@@ -433,6 +439,7 @@ RSpec.describe "Organized registrations search", :js, type: :system do
 
       it "toggles to sticker search and shows results" do
         visit multi_serial_path
+        wait_for_multi_search_controller
 
         # Kind toggle radios are present
         expect(page).to have_field("Serials", visible: :all)


### PR DESCRIPTION
Fixes the org multi-search integration spec, which has been failing intermittently on CI (four runs in the last day, always on the same first chip assertion).

Stimulus controllers are lazy-loaded, so `org--multi-search` connects some time after the page renders. A click before then native-submitted the JS-only form — no `action`, Turbo Drive off — which reloaded the page and restarted the search after a second module load, blowing the spec's 15s wait. Reproduced by delaying the controller module with a Playwright route.

- The submit button renders `disabled` and the controller enables it on `connect`, so it's inert until searching actually works (same pattern as the parking-notification form).
- `syncFromUrl` no longer clobbers serials typed while the controller was still loading.
- Both examples wait on the enabled button instead of the `data-controller` attribute, which only proved the markup was there.
- CI now uploads `tmp/capybara` alongside the rspec xml — the failure screenshots were the one piece of evidence missing while diagnosing this.
