### PR TITLE
Keep the stolen/impounded map circle over a fixed ground area

### DIFF
--- a/app/components/registrations/show/map/component.html.erb
+++ b/app/components/registrations/show/map/component.html.erb
@@ -3,7 +3,7 @@
   data-registrations--show--map-style-url-value="<%= MAPS_STYLE_URL %>"
   data-registrations--show--map-latitude-value="<%= @latitude %>"
   data-registrations--show--map-longitude-value="<%= @longitude %>"
-  data-registrations--show--map-radius-base-value="<%= radius_base %>"
+  data-registrations--show--map-radius-meters-value="<%= radius_meters %>"
   data-registrations--show--map-point-value="<%= @point %>"
   class="
     tw:relative tw:mt-3 tw:mb-4 tw:h-80 tw:w-full tw:overflow-hidden

--- a/app/components/registrations/show/map/component.rb
+++ b/app/components/registrations/show/map/component.rb
@@ -20,9 +20,10 @@ module Registrations
 
         private
 
-        # The circle grows faster with zoom when the exact address is public
-        def radius_base
-          @precise ? 2 : 1.15
+        # Non-precise coordinates are rounded to Bike::PUBLIC_COORD_LENGTH decimals,
+        # so the circle has to be wide enough to hide where in that square they fell
+        def radius_meters
+          @precise ? 250 : 1000
         end
       end
     end

--- a/app/javascript/controllers/registrations/show/map_controller.js
+++ b/app/javascript/controllers/registrations/show/map_controller.js
@@ -1,17 +1,9 @@
 import { Controller } from '@hotwired/stimulus'
+import { loadMapLibre, OSM_ATTRIBUTION } from 'utils/maplibre'
 
 // Connects to data-controller='registrations--show--map'
-// Lazy-loads MapLibre GL + the PMTiles protocol and renders a map centered on
-// the coordinates, marking them with a dot (point) or a translucent red circle
-// (approximate area).
-const MAPLIBRE_VERSION = '4.7.1'
-const PMTILES_VERSION = '3.2.1'
-const MAPLIBRE_JS = `https://cdn.jsdelivr.net/npm/maplibre-gl@${MAPLIBRE_VERSION}/dist/maplibre-gl.js`
-const MAPLIBRE_CSS = `https://cdn.jsdelivr.net/npm/maplibre-gl@${MAPLIBRE_VERSION}/dist/maplibre-gl.css`
-const PMTILES_JS = `https://cdn.jsdelivr.net/npm/pmtiles@${PMTILES_VERSION}/dist/pmtiles.js`
-
-// OpenStreetMap's ODbL license requires crediting contributors on the map
-const ATTRIBUTION = '© OpenStreetMap contributors'
+// Renders a map centered on the coordinates, marking them with a dot (point) or
+// a translucent red circle (approximate area).
 
 // A fixed dot marking the exact spot
 const POINT_PAINT = {
@@ -22,12 +14,23 @@ const POINT_PAINT = {
   'circle-stroke-color': 'white'
 }
 
-// A translucent circle approximating the area; grows with zoom
-const CIRCLE_PAINT = (radiusBase) => ({
-  'circle-radius': { stops: [[5, 5], [16, 240]], base: radiusBase },
-  'circle-color': 'red',
-  'circle-opacity': 0.4
-})
+// Web Mercator meters per pixel at zoom 0 on the equator (MapLibre uses 512px tiles)
+const METERS_PER_PIXEL_Z0 = 40075016.686 / 512
+
+// A translucent circle covering the approximate area. circle-radius is in screen
+// pixels, so it has to double every zoom level to keep covering the same ground.
+const CIRCLE_PAINT = (radiusMeters, latitude) => {
+  const pixelsAtZoom0 = radiusMeters / (METERS_PER_PIXEL_Z0 * Math.cos(latitude * Math.PI / 180))
+  return {
+    'circle-radius': [
+      'interpolate', ['exponential', 2], ['zoom'],
+      0, pixelsAtZoom0,
+      22, pixelsAtZoom0 * 2 ** 22
+    ],
+    'circle-color': 'red',
+    'circle-opacity': 0.4
+  }
+}
 
 export default class extends Controller {
   static targets = ['canvas', 'unavailable']
@@ -35,7 +38,7 @@ export default class extends Controller {
     styleUrl: String,
     latitude: Number,
     longitude: Number,
-    radiusBase: { type: Number, default: 1.15 },
+    radiusMeters: Number,
     point: Boolean
   }
 
@@ -75,7 +78,7 @@ export default class extends Controller {
       center,
       zoom: 13,
       maxZoom: 16,
-      attributionControl: { customAttribution: ATTRIBUTION }
+      attributionControl: { customAttribution: OSM_ATTRIBUTION }
     })
 
     this.map.on('load', () => {
@@ -87,45 +90,8 @@ export default class extends Controller {
         id: 'location',
         type: 'circle',
         source: 'location',
-        paint: this.pointValue ? POINT_PAINT : CIRCLE_PAINT(this.radiusBaseValue)
+        paint: this.pointValue ? POINT_PAINT : CIRCLE_PAINT(this.radiusMetersValue, this.latitudeValue)
       })
     })
   }
-}
-
-// Load MapLibre GL + the PMTiles protocol once, shared across controller instances.
-let mapLibrePromise
-function loadMapLibre () {
-  if (window.maplibregl) return Promise.resolve(window.maplibregl)
-  if (mapLibrePromise) return mapLibrePromise
-
-  mapLibrePromise = (async () => {
-    if (!document.querySelector(`link[href="${MAPLIBRE_CSS}"]`)) {
-      const link = document.createElement('link')
-      link.rel = 'stylesheet'
-      link.href = MAPLIBRE_CSS
-      document.head.appendChild(link)
-    }
-    await Promise.all([loadScript(MAPLIBRE_JS), loadScript(PMTILES_JS)])
-
-    const { maplibregl, pmtiles } = window
-    // Teach MapLibre to read pmtiles:// sources (the single-file vector tiles)
-    maplibregl.addProtocol('pmtiles', new pmtiles.Protocol().tile)
-    return maplibregl
-  })()
-  return mapLibrePromise
-}
-
-function loadScript (src) {
-  return new Promise((resolve, reject) => {
-    if (document.querySelector(`script[src="${src}"]`)) {
-      resolve()
-      return
-    }
-    const script = document.createElement('script')
-    script.src = src
-    script.onload = resolve
-    script.onerror = reject
-    document.head.appendChild(script)
-  })
 }

--- a/app/javascript/utils/maplibre.js
+++ b/app/javascript/utils/maplibre.js
@@ -1,0 +1,47 @@
+// Loads MapLibre GL + the PMTiles protocol from the CDN once, sharing the promise
+// across every controller instance that renders our self-hosted basemap.
+const MAPLIBRE_VERSION = '4.7.1'
+const PMTILES_VERSION = '3.2.1'
+const MAPLIBRE_JS = `https://cdn.jsdelivr.net/npm/maplibre-gl@${MAPLIBRE_VERSION}/dist/maplibre-gl.js`
+const MAPLIBRE_CSS = `https://cdn.jsdelivr.net/npm/maplibre-gl@${MAPLIBRE_VERSION}/dist/maplibre-gl.css`
+const PMTILES_JS = `https://cdn.jsdelivr.net/npm/pmtiles@${PMTILES_VERSION}/dist/pmtiles.js`
+
+// OpenStreetMap's ODbL license requires crediting contributors on the map
+export const OSM_ATTRIBUTION = '© OpenStreetMap contributors'
+
+let mapLibrePromise
+
+export function loadMapLibre () {
+  if (window.maplibregl) return Promise.resolve(window.maplibregl)
+  if (mapLibrePromise) return mapLibrePromise
+
+  mapLibrePromise = (async () => {
+    if (!document.querySelector(`link[href="${MAPLIBRE_CSS}"]`)) {
+      const link = document.createElement('link')
+      link.rel = 'stylesheet'
+      link.href = MAPLIBRE_CSS
+      document.head.appendChild(link)
+    }
+    await Promise.all([loadScript(MAPLIBRE_JS), loadScript(PMTILES_JS)])
+
+    const { maplibregl, pmtiles } = window
+    // Teach MapLibre to read pmtiles:// sources (the single-file vector tiles)
+    maplibregl.addProtocol('pmtiles', new pmtiles.Protocol().tile)
+    return maplibregl
+  })()
+  return mapLibrePromise
+}
+
+function loadScript (src) {
+  return new Promise((resolve, reject) => {
+    if (document.querySelector(`script[src="${src}"]`)) {
+      resolve()
+      return
+    }
+    const script = document.createElement('script')
+    script.src = src
+    script.onload = resolve
+    script.onerror = reject
+    document.head.appendChild(script)
+  })
+}

--- a/spec/components/registrations/show/map/component_spec.rb
+++ b/spec/components/registrations/show/map/component_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Registrations::Show::Map::Component, type: :component do
     expect(node["data-registrations--show--map-style-url-value"]).to eq "https://maps.example.com/style.json"
     expect(node["data-registrations--show--map-latitude-value"]).to eq "40.7"
     expect(node["data-registrations--show--map-longitude-value"]).to eq "-73.9"
-    expect(node["data-registrations--show--map-radius-base-value"]).to eq "1.15"
+    expect(node["data-registrations--show--map-radius-meters-value"]).to eq "1000"
     expect(node["data-registrations--show--map-point-value"]).to eq "false"
     expect(node).to have_css("[data-registrations--show--map-target='canvas']")
     # Shown by the controller when MapLibre/WebGL is unavailable
@@ -20,9 +20,9 @@ RSpec.describe Registrations::Show::Map::Component, type: :component do
 
   context "precise (exact address public)" do
     let(:options) { {latitude: 40.7, longitude: -73.9, precise: true} }
-    it "uses a larger radius base" do
+    it "uses a tighter radius" do
       render_inline(component)
-      expect(page.find("div[data-controller='registrations--show--map']")["data-registrations--show--map-radius-base-value"]).to eq "2"
+      expect(page.find("div[data-controller='registrations--show--map']")["data-registrations--show--map-radius-meters-value"]).to eq "250"
     end
   end
 


### PR DESCRIPTION
The translucent circle on the stolen/impounded map covered *more* ground the further you zoomed out — implying less location precision than the data actually has. `circle-radius` is in screen pixels, and the old curve (`stops: [[5, 5], [16, 240]]`, base 1.15) grew it 48× across 11 zoom levels while the map scale changed 2048×.

- The pixel radius is now derived from a real ground radius and interpolated base-2, so it doubles every zoom level and pins to a fixed footprint. The opaque `radiusBase` curve constant becomes `radiusMeters` (1000m when coordinates are rounded to `Bike::PUBLIC_COORD_LENGTH`, 250m when the exact address is public).
- Radii are picked to match the old on-screen size at the default zoom 13, so the initial view is unchanged — only zooming behaves differently.
- Extracts the MapLibre + PMTiles CDN loader into `utils/maplibre`, byte-identical to the copy on `sethherr/parking-notification-map-pin` so the two converge on merge.

Scoped to the `bike_show_redesign` component. The legacy Mapbox path (`stolen_map_controller.js:67`, still what unflagged users see) carries the same inverted scaling and is left for a follow-up.
