### PR TITLE
Seed the bike_show_redesign flags enabled for the admin user

### DIFF
--- a/db/seeds/seed_test_users.rb
+++ b/db/seeds/seed_test_users.rb
@@ -20,4 +20,8 @@ end
 admin = User.find_by(email: "admin@bikeindex.org")
 SuperuserAbility.create!(user: admin)
 
+# Actor gates, not the :superusers group — the in-app toggle disables per-actor
+Flipper.enable_actor(:bike_show_redesign, admin)
+Flipper.enable_actor(:bike_show_redesign_toggle, admin)
+
 puts "Users added successfully\n"


### PR DESCRIPTION
The `bike_show_redesign` flags are seeded off, so trying the redesign locally means flipping them by hand in a console. This enables both for the seeded `admin@bikeindex.org` superuser.

- Uses actor gates rather than the `:superusers` group registered in `config/initializers/flipper.rb` — `MyAccountsController#toggle_show_redesign` flips the flag with `Flipper.disable_actor`, which a group gate would silently override, leaving the in-app toggle looking broken.
- Only the admin user gets the flags; the other seeded users stay on the legacy bike show page.
