### PR TITLE
Pass org_role instead of a staff boolean to the registration show wrappers

### DIFF
--- a/app/components/org/parking_notification_details/component.html.erb
+++ b/app/components/org/parking_notification_details/component.html.erb
@@ -74,7 +74,7 @@
             <% else %>
               the user
             <% end %>
-            <% if display_dev_info? %>
+            <% if helpers.display_dev_info? %>
               <br>
               <small class="only-dev-visible">
                 <span class="less-strong">developer info:</span>
@@ -121,7 +121,7 @@
           From GPS
         <% end %>
 
-        <% if display_dev_info? %>
+        <% if helpers.display_dev_info? %>
           <small class="only-dev-visible ml-2">
             <span class="less-strong">developer info:</span>
             <%= @parking_notification.to_coordinates %>

--- a/app/components/org/parking_notification_details/component.rb
+++ b/app/components/org/parking_notification_details/component.rb
@@ -16,11 +16,6 @@ module Org
       def passed_bike
         @bike || @parking_notification.bike
       end
-
-      # A ControllerHelpers method, absent from the Lookbook preview view context
-      def display_dev_info?
-        helpers.respond_to?(:display_dev_info?) && helpers.display_dev_info?
-      end
     end
   end
 end

--- a/app/components/registrations/show/org_admin/component.html.erb
+++ b/app/components/registrations/show/org_admin/component.html.erb
@@ -7,7 +7,7 @@
   <div class="tw:flex tw:flex-wrap tw:items-start tw:justify-between tw:gap-4">
     <div>
       <div class="tw:mb-2 tw:flex tw:flex-wrap tw:items-center tw:gap-2">
-        <%= render(Registrations::Show::ViewSwitcher::Component.new(bike: @bike, current_view: [org_role, @organization], available_views: @available_views, label: @organization.short_name, color: org_chip_color, solid: false, role_label: role_label, current_user: @current_user)) %>
+        <%= render(Registrations::Show::ViewSwitcher::Component.new(bike: @bike, current_view: [@org_role, @organization], available_views: @available_views, label: @organization.short_name, color: org_chip_color, solid: false, role_label: role_label, current_user: @current_user)) %>
       </div>
 
       <h1 class="tw:text-2xl tw:font-bold"><%= title %></h1>
@@ -26,7 +26,7 @@
     </div>
   </div>
 
-  <%= render(Registrations::Show::OrgTopActions::Wrapper::Component.new(bike: @bike, organization: @organization, org_role:)) %>
+  <%= render(Registrations::Show::OrgTopActions::Wrapper::Component.new(bike: @bike, organization: @organization, org_role: @org_role)) %>
 
   <%#
     On mobile the column wrappers collapse (tw:contents) so every card is a

--- a/app/components/registrations/show/org_admin/component.html.erb
+++ b/app/components/registrations/show/org_admin/component.html.erb
@@ -7,7 +7,7 @@
   <div class="tw:flex tw:flex-wrap tw:items-start tw:justify-between tw:gap-4">
     <div>
       <div class="tw:mb-2 tw:flex tw:flex-wrap tw:items-center tw:gap-2">
-        <%= render(Registrations::Show::ViewSwitcher::Component.new(bike: @bike, current_view: [staff? ? :staff : :limited, @organization], available_views: @available_views, label: @organization.short_name, color: org_chip_color, solid: false, role_label: role_label, current_user: @current_user)) %>
+        <%= render(Registrations::Show::ViewSwitcher::Component.new(bike: @bike, current_view: [org_role, @organization], available_views: @available_views, label: @organization.short_name, color: org_chip_color, solid: false, role_label: role_label, current_user: @current_user)) %>
       </div>
 
       <h1 class="tw:text-2xl tw:font-bold"><%= title %></h1>
@@ -26,7 +26,7 @@
     </div>
   </div>
 
-  <%= render(Registrations::Show::OrgTopActions::Wrapper::Component.new(bike: @bike, organization: @organization, staff: staff?)) %>
+  <%= render(Registrations::Show::OrgTopActions::Wrapper::Component.new(bike: @bike, organization: @organization, org_role:)) %>
 
   <%#
     On mobile the column wrappers collapse (tw:contents) so every card is a

--- a/app/components/registrations/show/org_admin/component.rb
+++ b/app/components/registrations/show/org_admin/component.rb
@@ -10,9 +10,9 @@ module Registrations
         # Registration fields shown with the owner rather than in registration info
         OWNER_ACCESS_REG_FIELDS = %w[reg_address reg_organization_affiliation reg_student_id].freeze
 
-        # org_role: overrides the computed role so a superadmin can view the org
-        # panel as staff or as limited (view_as)
-        def initialize(bike:, current_user:, organization:, available_views: [], org_role: nil)
+        # org_role is the role this panel renders as - a superadmin can view any
+        # organization as :staff or as :limited (view_as)
+        def initialize(bike:, current_user:, organization:, org_role:, available_views: [])
           @bike = bike
           @current_user = current_user
           @organization = organization
@@ -39,12 +39,8 @@ module Registrations
           render(UI::DefinitionList::Row::Component.new(label:, value:, render_with_no_value: true, no_value_text: "-"), &block)
         end
 
-        def org_role
-          @org_role ||= BikeServices::ShowViews.role_for(@current_user, @organization)
-        end
-
         def staff?
-          org_role == :staff
+          @org_role == :staff
         end
 
         def organization_registered?

--- a/app/components/registrations/show/org_admin/component.rb
+++ b/app/components/registrations/show/org_admin/component.rb
@@ -10,14 +10,14 @@ module Registrations
         # Registration fields shown with the owner rather than in registration info
         OWNER_ACCESS_REG_FIELDS = %w[reg_address reg_organization_affiliation reg_student_id].freeze
 
-        # staff: overrides the computed role so a superadmin can view the org
+        # org_role: overrides the computed role so a superadmin can view the org
         # panel as staff or as limited (view_as)
-        def initialize(bike:, current_user:, organization:, available_views: [], staff: nil)
+        def initialize(bike:, current_user:, organization:, available_views: [], org_role: nil)
           @bike = bike
           @current_user = current_user
           @organization = organization
           @available_views = available_views
-          @force_staff = staff
+          @org_role = org_role
         end
 
         def render?
@@ -39,10 +39,12 @@ module Registrations
           render(UI::DefinitionList::Row::Component.new(label:, value:, render_with_no_value: true, no_value_text: "-"), &block)
         end
 
-        def staff?
-          return @force_staff unless @force_staff.nil?
+        def org_role
+          @org_role ||= BikeServices::ShowViews.role_for(@current_user, @organization)
+        end
 
-          @current_user.member_bike_edit_of?(@organization)
+        def staff?
+          org_role == :staff
         end
 
         def organization_registered?

--- a/app/components/registrations/show/org_top_actions/wrapper/component.rb
+++ b/app/components/registrations/show/org_top_actions/wrapper/component.rb
@@ -17,13 +17,17 @@ module Registrations
             amber: ["tw:bg-[#fff8e1]", "tw:text-[#caa11a]"]
           }.freeze
 
-          def initialize(bike:, organization:, staff:)
+          def initialize(bike:, organization:, org_role:)
             @bike = bike
             @organization = organization
-            @staff = staff
+            @org_role = org_role
           end
 
           private
+
+          def staff?
+            @org_role == :staff
+          end
 
           # A grid rather than the button's default flex, so the two layouts can share
           # one DOM order: below sm the subtitle sits beside the icon with the title
@@ -78,11 +82,11 @@ module Registrations
 
           # Staff create an impound before it's impounded, and update it after
           def show_create_impound?
-            show_impound? && @staff && !impounded?
+            show_impound? && staff? && !impounded?
           end
 
           def show_update_impound?
-            show_impound? && @staff && impounded?
+            show_impound? && staff? && impounded?
           end
 
           def show_parking_notifications?

--- a/app/components/registrations/show/org_top_actions/wrapper/component_preview.rb
+++ b/app/components/registrations/show/org_top_actions/wrapper/component_preview.rb
@@ -22,13 +22,13 @@ module Registrations
               "Impounded" => component(preview_bike(:status_impounded)),
               "Unregistered parking notification" => component(preview_bike(:unregistered_parking_notification)),
               "With parking notification" => component(bike_with_parking_notification),
-              "Limited (non-staff) member" => component(preview_bike(:status_with_owner), staff: false),
+              "Limited (non-staff) member" => component(preview_bike(:status_with_owner), org_role: :limited),
               "No features" => component(preview_bike(:status_with_owner), organization: ::Organization.new(short_name: "Preview", enabled_feature_slugs: []))
             }
           end
 
-          def component(bike, staff: true, organization: lookbook_organization)
-            Component.new(bike:, organization:, staff:)
+          def component(bike, org_role: :staff, organization: lookbook_organization)
+            Component.new(bike:, organization:, org_role:)
           end
 
           def preview_bike(status)

--- a/app/components/registrations/show/wrapper/component.rb
+++ b/app/components/registrations/show/wrapper/component.rb
@@ -26,7 +26,7 @@ module Registrations
             kind, organization = @view
             if organization
               OrgAdmin::Component.new(bike: @bike, current_user: @current_user, organization:,
-                staff: kind == :staff, available_views: @available_views)
+                org_role: kind, available_views: @available_views)
             else
               Consumer::Component.new(bike: @bike, current_user: @current_user, owner: kind == :owner,
                 show_for_sale: @bike.is_for_sale?, available_views: @available_views)

--- a/app/controllers/component_previews_controller.rb
+++ b/app/controllers/component_previews_controller.rb
@@ -1,0 +1,6 @@
+# Previews render through the app's controller, so components can call the
+# ControllerHelpers helper methods (display_dev_info?, current_user, ...) that
+# they rely on everywhere else
+class ComponentPreviewsController < ApplicationController
+  include ViewComponent::PreviewActions
+end

--- a/app/services/bike_services/show_views.rb
+++ b/app/services/bike_services/show_views.rb
@@ -32,11 +32,6 @@ module BikeServices
       [:public, nil]
     end
 
-    # An org member's role: :staff when they can edit bikes, else :limited.
-    def role_for(current_user, organization)
-      current_user.member_bike_edit_of?(organization) ? :staff : :limited
-    end
-
     #
     # private below here
     #
@@ -47,6 +42,11 @@ module BikeServices
         roles = current_user.superuser? ? %i[staff limited] : [role_for(current_user, org)]
         roles.map { |role| [role, org] }
       end
+    end
+
+    # An org member's role: :staff when they can edit bikes, else :limited.
+    def role_for(current_user, organization)
+      current_user.member_bike_edit_of?(organization) ? :staff : :limited
     end
 
     def viewable_organizations(bike:, current_user:, organization:, preview_organization: nil)
@@ -63,6 +63,6 @@ module BikeServices
       orgs.compact.uniq.select { |org| current_user.authorized?(org) }
     end
 
-    conceal :organization_views, :viewable_organizations
+    conceal :organization_views, :viewable_organizations, :role_for
   end
 end

--- a/app/services/bike_services/show_views.rb
+++ b/app/services/bike_services/show_views.rb
@@ -32,6 +32,11 @@ module BikeServices
       [:public, nil]
     end
 
+    # An org member's role: :staff when they can edit bikes, else :limited.
+    def role_for(current_user, organization)
+      current_user.member_bike_edit_of?(organization) ? :staff : :limited
+    end
+
     #
     # private below here
     #
@@ -42,11 +47,6 @@ module BikeServices
         roles = current_user.superuser? ? %i[staff limited] : [role_for(current_user, org)]
         roles.map { |role| [role, org] }
       end
-    end
-
-    # An org member's role: :staff when they can edit bikes, else :limited.
-    def role_for(current_user, organization)
-      current_user.member_bike_edit_of?(organization) ? :staff : :limited
     end
 
     def viewable_organizations(bike:, current_user:, organization:, preview_organization: nil)
@@ -63,6 +63,6 @@ module BikeServices
       orgs.compact.uniq.select { |org| current_user.authorized?(org) }
     end
 
-    conceal :organization_views, :viewable_organizations, :role_for
+    conceal :organization_views, :viewable_organizations
   end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -82,6 +82,7 @@ module Bikeindex
     # Enable instrumentation for ViewComponents (used by rack-mini-profiler)
     config.view_component.instrumentation_enabled = true
     config.view_component.default_preview_layout = "component_preview"
+    config.view_component.previews.controller = "ComponentPreviewsController"
     # This is ugly but necessary, see github.com/ViewComponent/view_component/issues/1064
     initializer "app_assets", after: "importmap.assets" do
       Rails.application.config.assets.paths << Rails.root.join("app")

--- a/config/application.rb
+++ b/config/application.rb
@@ -81,7 +81,6 @@ module Bikeindex
 
     # Enable instrumentation for ViewComponents (used by rack-mini-profiler)
     config.view_component.instrumentation_enabled = true
-    config.view_component.default_preview_layout = "component_preview"
     config.view_component.previews.controller = "ComponentPreviewsController"
     # This is ugly but necessary, see github.com/ViewComponent/view_component/issues/1064
     initializer "app_assets", after: "importmap.assets" do

--- a/spec/components/registrations/show/org_admin/component_spec.rb
+++ b/spec/components/registrations/show/org_admin/component_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Registrations::Show::OrgAdmin::Component, type: :component do
   # don't touch the bike still expire the cached panel when they change
   describe "#cache_version" do
     def cache_version
-      described_class.new(bike: bike.reload, current_user:, organization:).cache_version
+      described_class.new(bike: bike.reload, current_user:, organization:, org_role: :staff).cache_version
     end
 
     it "changes when an organization note is added" do
@@ -30,7 +30,7 @@ RSpec.describe Registrations::Show::OrgAdmin::Component, type: :component do
     let!(:other_bike) { FactoryBot.create(:bike_organized, :with_ownership_claimed, creation_organization: organization, user: bike.user) }
 
     it "renders the column-toggle settings inside the card" do
-      render_inline(described_class.new(bike: bike.reload, current_user:, organization:))
+      render_inline(described_class.new(bike: bike.reload, current_user:, organization:, org_role: :staff))
 
       expect(page).to have_css("[data-controller~='org--search-column-toggle']")
       expect(page).to have_text("Visible columns")

--- a/spec/components/registrations/show/org_top_actions/wrapper/component_spec.rb
+++ b/spec/components/registrations/show/org_top_actions/wrapper/component_spec.rb
@@ -58,20 +58,20 @@ RSpec.describe Registrations::Show::OrgTopActions::Wrapper::Component, type: :co
     end
   end
 
-  context "when stolen, without unstolen_notifications" do
-    let(:enabled_feature_slugs) { %w[impound_bikes parking_notifications] }
-    let(:bike) { Bike.new(status: :status_stolen, cycle_type: "bike", current_stolen_record: StolenRecord.new) }
-
-    it "renders the message action" do
-      expect(action_panels).to eq(%w[message impound parking notifications_show])
-    end
-  end
-
-  context "when with owner, without unstolen_notifications" do
+  context "without unstolen_notifications" do
     let(:enabled_feature_slugs) { %w[impound_bikes parking_notifications] }
 
     it "renders no message action" do
       expect(action_panels).to eq(%w[impound parking notifications_show])
+    end
+
+    context "and stolen" do
+      let(:bike) { Bike.new(status: :status_stolen, cycle_type: "bike", current_stolen_record: StolenRecord.new) }
+
+      # A stolen bike's owner is messageable without the feature
+      it "renders the message action" do
+        expect(action_panels).to eq(%w[message impound parking notifications_show])
+      end
     end
   end
 end

--- a/spec/components/registrations/show/org_top_actions/wrapper/component_spec.rb
+++ b/spec/components/registrations/show/org_top_actions/wrapper/component_spec.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Registrations::Show::OrgTopActions::Wrapper::Component, type: :component do
+  let(:enabled_feature_slugs) { %w[unstolen_notifications impound_bikes parking_notifications] }
+  let(:organization) { FactoryBot.create(:organization_with_organization_features, enabled_feature_slugs:) }
+  let(:status) { :status_with_owner }
+  let(:bike) { Bike.new(status:, cycle_type: "bike") }
+  let(:org_role) { :staff }
+
+  # The action buttons, named by the panel each one opens
+  def action_panels
+    render_inline(described_class.new(bike:, organization:, org_role:))
+    page.all("[data-registrations--show--action-panels-target='trigger']").map { |trigger| trigger["data-panel-name"] }
+  end
+
+  it "renders every action" do
+    expect(action_panels).to eq(%w[message impound parking notifications_show])
+    expect(page).to have_button("Message Owner")
+    expect(page).to have_button("Impound", exact: true)
+    expect(page).to have_button("New Parking Notification")
+    expect(page).to have_button("View Notifications")
+  end
+
+  context "when limited" do
+    let(:org_role) { :limited }
+
+    it "renders everything but impound" do
+      expect(action_panels).to eq(%w[message parking notifications_show])
+    end
+  end
+
+  context "when the organization has no features" do
+    let(:organization) { FactoryBot.create(:organization) }
+
+    it "renders no actions" do
+      expect(action_panels).to eq([])
+    end
+  end
+
+  context "when impounded" do
+    let(:status) { :status_impounded }
+
+    # The owner isn't messageable, and there's no point filing a parking
+    # notification against a bike that's already impounded
+    it "renders the impound update" do
+      expect(action_panels).to eq(%w[impound_update notifications_show])
+      expect(page).to have_button("Update Impound Record")
+    end
+
+    context "and limited" do
+      let(:org_role) { :limited }
+
+      it "renders no impound update" do
+        expect(action_panels).to eq(%w[notifications_show])
+      end
+    end
+  end
+
+  context "when stolen, without unstolen_notifications" do
+    let(:enabled_feature_slugs) { %w[impound_bikes parking_notifications] }
+    let(:bike) { Bike.new(status: :status_stolen, cycle_type: "bike", current_stolen_record: StolenRecord.new) }
+
+    it "renders the message action" do
+      expect(action_panels).to eq(%w[message impound parking notifications_show])
+    end
+  end
+
+  context "when with owner, without unstolen_notifications" do
+    let(:enabled_feature_slugs) { %w[impound_bikes parking_notifications] }
+
+    it "renders no message action" do
+      expect(action_panels).to eq(%w[impound parking notifications_show])
+    end
+  end
+end

--- a/spec/components/registrations/show/org_top_actions/wrapper/component_system_spec.rb
+++ b/spec/components/registrations/show/org_top_actions/wrapper/component_system_spec.rb
@@ -15,12 +15,6 @@ RSpec.describe Registrations::Show::OrgTopActions::Wrapper::Component, :js, type
   it "opens one panel at a time, keeping the open panel in the URL" do
     visit preview_path
 
-    within(scenario("Limited (non-staff) member")) do
-      expect(page).to have_button("View Notifications")
-      # Impounding is staff-only
-      expect(page).to have_no_button("Impound", exact: true)
-    end
-
     owner_section = scenario("With owner")
 
     within(owner_section) do

--- a/spec/components/registrations/show/org_top_actions/wrapper/component_system_spec.rb
+++ b/spec/components/registrations/show/org_top_actions/wrapper/component_system_spec.rb
@@ -51,13 +51,5 @@ RSpec.describe Registrations::Show::OrgTopActions::Wrapper::Component, :js, type
     end
 
     expect(page).to have_no_current_path(/panel=/, url: true)
-
-    # A shared link reopens the named panel without a click
-    visit "#{preview_path}?panel=message"
-
-    within(scenario("With owner")) do
-      expect(page).to have_button("Send message")
-      expect(page).to have_css("button[aria-pressed='true']", text: "Message Owner")
-    end
   end
 end

--- a/spec/components/registrations/show/org_top_actions/wrapper/component_system_spec.rb
+++ b/spec/components/registrations/show/org_top_actions/wrapper/component_system_spec.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Registrations::Show::OrgTopActions::Wrapper::Component, :js, type: :system do
+  let(:preview_path) { "/rails/view_components/registrations/show/org_top_actions/wrapper/component/default" }
+  # The preview renders against the seeded brakebills org, so every feature-gated action shows
+  let!(:organization) { FactoryBot.create(:organization_brakebills) }
+
+  # The preview stacks a section per scenario, each its own accordion
+  def scenario(label)
+    find("section", text: label)
+  end
+
+  it "opens one panel at a time, keeping the open panel in the URL" do
+    visit preview_path
+
+    within(scenario("Limited (non-staff) member")) do
+      expect(page).to have_button("View Notifications")
+      # Impounding is staff-only
+      expect(page).to have_no_button("Impound", exact: true)
+    end
+
+    owner_section = scenario("With owner")
+
+    within(owner_section) do
+      expect(page).to have_button("Message Owner")
+      expect(page).to have_button("New Parking Notification")
+      # Panels start closed
+      expect(page).to have_no_button("Send message")
+
+      click_button "Message Owner"
+
+      expect(page).to have_button("Send message")
+      expect(page).to have_css("button[aria-pressed='true']", text: "Message Owner")
+    end
+
+    expect(page).to have_current_path(/panel=message/, url: true)
+    expect_axe_clean
+
+    within(owner_section) do
+      # Opening another panel closes the message panel
+      click_button "View Notifications"
+
+      expect(page).to have_content("No parking notifications for this bike")
+      expect(page).to have_no_button("Send message")
+      expect(page).to have_css("button[aria-pressed='false']", text: "Message Owner")
+    end
+
+    expect(page).to have_current_path(/panel=notifications_show/, url: true)
+
+    within(owner_section) do
+      # Clicking the open panel's trigger closes it
+      click_button "View Notifications"
+
+      expect(page).to have_no_content("No parking notifications for this bike")
+    end
+
+    expect(page).to have_no_current_path(/panel=/, url: true)
+
+    # A shared link reopens the named panel without a click
+    visit "#{preview_path}?panel=message"
+
+    within(scenario("With owner")) do
+      expect(page).to have_button("Send message")
+      expect(page).to have_css("button[aria-pressed='true']", text: "Message Owner")
+    end
+  end
+end

--- a/spec/requests/component_previews_request_spec.rb
+++ b/spec/requests/component_previews_request_spec.rb
@@ -7,8 +7,8 @@ RSpec.describe "ComponentPreviews", type: :request do
   let(:organization) { FactoryBot.create(:organization_brakebills) }
   let!(:parking_notification) { FactoryBot.create(:parking_notification, organization:) }
 
-  # Previews go through ComponentPreviewsController so components can call the
-  # ControllerHelpers methods they use everywhere else (here: display_dev_info?)
+  # ParkingNotificationDetails calls display_dev_info?, so it's the canary for
+  # previews rendering through a controller with the helper methods
   it "renders a preview of a component that uses the controller helpers" do
     get "/rails/view_components/registrations/show/org_top_actions/wrapper/component/default"
 

--- a/spec/requests/component_previews_request_spec.rb
+++ b/spec/requests/component_previews_request_spec.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "ComponentPreviews", type: :request do
+  # The preview renders against the seeded brakebills org
+  let(:organization) { FactoryBot.create(:organization_brakebills) }
+  let!(:parking_notification) { FactoryBot.create(:parking_notification, organization:) }
+
+  # Previews go through ComponentPreviewsController so components can call the
+  # ControllerHelpers methods they use everywhere else (here: display_dev_info?)
+  it "renders a preview of a component that uses the controller helpers" do
+    get "/rails/view_components/registrations/show/org_top_actions/wrapper/component/default"
+
+    expect(response.status).to eq 200
+    expect(response.body).to match("Notification#")
+  end
+end


### PR DESCRIPTION
`Registrations::Show::Wrapper` already resolves the viewer's perspective as a `[kind, organization]` pair, so it now hands the role symbol down (`org_role: :staff | :limited`) instead of flattening it to a `staff:` boolean at the top and rebuilding `[staff? ? :staff : :limited, org]` for the view switcher further down. `OrgAdmin` and `OrgTopActions::Wrapper` each derive their own `staff?` from it.

- Adds specs for `OrgTopActions::Wrapper`: which action buttons render per role, bike status and org features, plus a system spec for the accordion — one panel open at a time, and the open panel round-tripping through the `?panel=` param.
- Previews render through `ComponentPreviewsController` (`ApplicationController` + `ViewComponent::PreviewActions`) rather than ViewComponent's bare `Rails::ApplicationController`, so components can call `ControllerHelpers` helper methods in Lookbook — dropping the `respond_to?(:display_dev_info?)` guard `Org::ParkingNotificationDetails` carried for previews.
- Removes `config.view_component.default_preview_layout`, ViewComponent 3 config that 4.x doesn't read (the preview layout comes from `ApplicationComponentPreview`).
