### PR TITLE
Dev review banner: link the branch's PR, flag a missing superuser

### DIFF
--- a/.claude/skills/frontend-conventions/SKILL.md
+++ b/.claude/skills/frontend-conventions/SKILL.md
@@ -5,7 +5,7 @@ description: >-
   the standard `twinput`/`twlabel`/`twlink` form/link classes, the
   `number_display` helper for numbers, the UI component library rule
   (every button is `UI::Button`/`UI::ButtonLink`, every
-  typeahead/autocomplete is `Form::Combobox`, never hand-rolled
+  typeahead/autocomplete is `UI::Forms::Combobox`, never hand-rolled
   markup), ViewComponent rules (keyword arguments, instance variables,
   `helpers.` prefix in templates), and `UI::Time::Component` for every
   date/time. Trigger
@@ -48,15 +48,15 @@ The `bin/dev` command handles building and updating Tailwind and JS.
 - A link styled as a button: `UI::ButtonLink::Component.new(href:, text:, color:, size:)` — same palette, renders an `<a>`.
 - A standalone action button (POST/DELETE/etc. to a URL) — a link that performs an action: pass `method:` to `ButtonLink` and it renders `button_to` for you (`render UI::ButtonLink::Component.new(text: "Delete", color: :error, href: bike_path(@bike), method: :delete)`), so don't hand-roll a `button_to` or wrap a submit button in a bare form. Extra `html_options` flow through: pass `params:` for a POST that carries params (they render as hidden fields — no manual `form_with`/`hidden_field_tag` needed), and `form: {onsubmit: …}` for a confirm on the wrapping form.
 
-The same instinct applies beyond buttons: **check `app/components/ui/` and `app/components/form/` before hand-rolling any UI primitive** (dropdowns → `UI::Dropdown`, tooltips → `UI::Tooltip`, badges, modals, pagination, tables…). If a `UI::*`/`Form::*` component exists for the pattern, use it; if it almost fits, extend it rather than forking its markup inline.
+The same instinct applies beyond buttons: **check `app/components/ui/` before hand-rolling any UI primitive** (dropdowns → `UI::Dropdown`, tooltips → `UI::Tooltip`, form fields → `UI::Forms::*`, badges, modals, pagination, tables…). If a `UI::*` component exists for the pattern, use it; if it almost fits, extend it rather than forking its markup inline.
 
 ## Tooltips: default `?` button trigger
 
 **Every `UI::Tooltip` uses the default `?` button trigger** unless the user explicitly says otherwise — never pass a label as the tooltip's trigger content. See `app/components/ui/tooltip/`.
 
-## Typeaheads: always `Form::Combobox`
+## Typeaheads: always `UI::Forms::Combobox`
 
-**Every typeahead / autocomplete / combobox goes through `Form::Combobox::Component`** — never a new Stimulus controller that fetches matches and renders its own menu. See `app/components/form/combobox/` (component + `component_preview.rb`) and `spec/components/form/combobox` for how to invoke it.
+**Every typeahead / autocomplete / combobox goes through `UI::Forms::Combobox::Component`** — never a new Stimulus controller that fetches matches and renders its own menu. See `app/components/ui/forms/combobox/` (component + `component_preview.rb`) and `spec/components/ui/forms/combobox` for how to invoke it.
 
 ## Showing and hiding elements: always use the collapse helpers
 

--- a/.claude/skills/pr/SKILL.md
+++ b/.claude/skills/pr/SKILL.md
@@ -88,4 +88,15 @@ Push the branch: `git push -u origin HEAD`. Don't report the local branch name d
 
 Always pass the body via `--body-file` (not inline `--body`) to preserve formatting.
 
+### 3.5. Point the local dev banner at the PR
+
+Only when `.workspace_id` exists at the repo root (a Conductor workspace) — on both step 3 paths, since a retitled PR needs `REVIEW_APP_PR_TITLE` refreshed just as much as a new one. Upsert the PR's current number and title into `.env.development`; never Read or Edit that file, it holds live API tokens:
+
+```bash
+sed -i '' '/^REVIEW_APP_PR_\(NUMBER\|TITLE\)=/d' .env.development
+gh pr view --json number,title --jq '"REVIEW_APP_PR_NUMBER=\(.number)\nREVIEW_APP_PR_TITLE=\(.title|tojson)"' >> .env.development
+```
+
+`.env.*` is gitignored, so this stays local. `app/views/layouts/application.html.erb` passes both into the dev banner, and dotenv reads the file only at boot — mention in the final report that `bin/dev` needs a restart to pick them up; never restart it yourself.
+
 **If `FRONTEND=false`, stop here and return the PR URL.** If `FRONTEND=true`, read `references/screenshots.md` and follow it to capture before/after screenshots and post them as a PR comment (it uses `$EXISTING_PR`/`$PR_NUMBER` from the steps above). Screenshot tooling never blocks the PR — if it fails, return the PR URL and report the failure.

--- a/.claude/skills/pr/SKILL.md
+++ b/.claude/skills/pr/SKILL.md
@@ -88,15 +88,4 @@ Push the branch: `git push -u origin HEAD`. Don't report the local branch name d
 
 Always pass the body via `--body-file` (not inline `--body`) to preserve formatting.
 
-### 3.5. Point the local dev banner at the PR
-
-Only when `.workspace_id` exists at the repo root (a Conductor workspace) — on both step 3 paths, since a retitled PR needs `REVIEW_APP_PR_TITLE` refreshed just as much as a new one. Upsert the PR's current number and title into `.env.development`; never Read or Edit that file, it holds live API tokens:
-
-```bash
-sed -i '' '/^REVIEW_APP_PR_\(NUMBER\|TITLE\)=/d' .env.development
-gh pr view --json number,title --jq '"REVIEW_APP_PR_NUMBER=\(.number)\nREVIEW_APP_PR_TITLE=\(.title|tojson)"' >> .env.development
-```
-
-`.env.*` is gitignored, so this stays local. `app/views/layouts/application.html.erb` passes both into the dev banner, and dotenv reads the file only at boot — mention in the final report that `bin/dev` needs a restart to pick them up; never restart it yourself.
-
 **If `FRONTEND=false`, stop here and return the PR URL.** If `FRONTEND=true`, read `references/screenshots.md` and follow it to capture before/after screenshots and post them as a PR comment (it uses `$EXISTING_PR`/`$PR_NUMBER` from the steps above). Screenshot tooling never blocks the PR — if it fails, return the PR URL and report the failure.

--- a/app/components/page_block/review_app_banner/component.en.yml
+++ b/app/components/page_block/review_app_banner/component.en.yml
@@ -10,6 +10,7 @@ en:
         label_sandbox: Sandbox
         letter_opener_link: email outbox
         letter_opener_tooltip: View the email sent by this review app
+        no_superadmin: no superuser (can't signin)
         pr_link: 'PR #%{number}'
         superadmin_button: sign in as superadmin
         superadmin_signed_in: signed in as superadmin

--- a/app/components/page_block/review_app_banner/component.html.erb
+++ b/app/components/page_block/review_app_banner/component.html.erb
@@ -54,5 +54,10 @@
       <%= hidden_field_tag :return_to, @return_to if @return_to.present? %>
       <%= render UI::Button::Component.new(text: translation(".superadmin_button"), kind: :submit, size: :sm) %>
     <% end %>
+  <% else %>
+    &middot;
+    <span class="tw:font-normal tw:text-black/60 tw:italic">
+      <%= translation(".no_superadmin") %>
+    </span>
   <% end %>
 </div>

--- a/app/components/page_block/review_app_banner/component.rb
+++ b/app/components/page_block/review_app_banner/component.rb
@@ -8,10 +8,6 @@ module PageBlock
     # server), `ENV["REVIEW_APP_PR_NUMBER"]`, and `ENV["REVIEW_APP_PR_TITLE"]`;
     # the component renders only when `review_app` is present.
     class Component < ApplicationComponent
-      # Set NO_REVIEW_TOPBAR=true to suppress the banner everywhere it would
-      # otherwise show (dev, review apps, sandbox)
-      NO_REVIEW_TOPBAR = ENV["NO_REVIEW_TOPBAR"] == "true"
-
       def initialize(review_app:, pr_number: nil, pr_title: nil, commit: nil, current_user: nil, return_to: nil)
         @review_app = review_app
         @pr_number = pr_number
@@ -22,8 +18,6 @@ module PageBlock
       end
 
       def render?
-        return false if NO_REVIEW_TOPBAR
-
         @review_app.present?
       end
 

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -60,7 +60,8 @@
       <%= t(".skip_to_main_content") %>
     </a>
 
-    <% unless Rails.env.production? %>
+    <%# NO_REVIEW_TOPBAR=true suppresses the banner everywhere it would otherwise show (dev, review apps, sandbox) %>
+    <% unless Rails.env.production? || ENV["NO_REVIEW_TOPBAR"] == "true" %>
       <%= render(PageBlock::ReviewAppBanner::Component.new(review_app: ENV["REVIEW_APP"] || (Rails.env.development? && "development"), pr_number: ENV["REVIEW_APP_PR_NUMBER"], pr_title: ENV["REVIEW_APP_PR_TITLE"], commit: ENV["REVIEW_APP_COMMIT"], current_user:, return_to: request.fullpath)) %>
     <% end %>
 

--- a/bin/dev
+++ b/bin/dev
@@ -11,8 +11,7 @@ eval "$(ruby bin/env --export)"
 echo "Starting server on http://localhost:$DEV_PORT"
 echo
 
-# Point the review banner at this branch's PR. Empty (banner shows no link) when
-# there's no PR or no gh.
+# Point the review banner at this branch's PR
 if [ -f .workspace_id ] && [ "$NO_REVIEW_TOPBAR" != "true" ] &&
   ! grep -qs "^NO_REVIEW_TOPBAR=true" .env.development; then
   eval "$(gh pr view --json number,title --jq '@sh "export REVIEW_APP_PR_NUMBER=\(.number) REVIEW_APP_PR_TITLE=\(.title)"' 2>/dev/null)"

--- a/bin/dev
+++ b/bin/dev
@@ -11,6 +11,13 @@ eval "$(ruby bin/env --export)"
 echo "Starting server on http://localhost:$DEV_PORT"
 echo
 
+# Point the review banner at this branch's PR. Empty (banner shows no link) when
+# there's no PR or no gh.
+if [ -f .workspace_id ] && [ "$NO_REVIEW_TOPBAR" != "true" ] &&
+  ! grep -qs "^NO_REVIEW_TOPBAR=true" .env.development; then
+  eval "$(gh pr view --json number,title --jq '@sh "export REVIEW_APP_PR_NUMBER=\(.number) REVIEW_APP_PR_TITLE=\(.title)"' 2>/dev/null)"
+fi
+
 # Pass --strava to start the strava_search Vite dev server
 FOREMAN_ARGS="-f Procfile.dev"
 if [[ " $* " == *" --strava "* ]]; then

--- a/spec/components/page_block/review_app_banner/component_spec.rb
+++ b/spec/components/page_block/review_app_banner/component_spec.rb
@@ -26,12 +26,6 @@ RSpec.describe PageBlock::ReviewAppBanner::Component, type: :component do
     expect(component.css("form[action='/session/sign_in_with_magic_link'] button").text).to eq("sign in as superadmin")
   end
 
-  it "suppresses every topbar when NO_REVIEW_TOPBAR is set" do
-    stub_const("#{described_class}::NO_REVIEW_TOPBAR", true)
-    expect(described_class.new(review_app: "development").render?).to be_falsey
-    expect(described_class.new(review_app: "1").render?).to be_falsey
-  end
-
   context "when review_app is present" do
     let(:component) { render_inline(described_class.new(review_app: "1", pr_number:, pr_title:, commit:, current_user:, return_to:)) }
     let(:pr_number) { nil }
@@ -56,8 +50,9 @@ RSpec.describe PageBlock::ReviewAppBanner::Component, type: :component do
       expect(disclaimer[:class].to_s).to include("tw:hidden")
     end
 
-    it "doesn't render the superadmin button when there is no superadmin" do
+    it "says signing in isn't possible when there is no superadmin" do
       expect(component.css("form[action='/session/sign_in_with_magic_link']")).to be_empty
+      expect(component.text).to include("no superuser (can't signin)")
     end
 
     context "with a superadmin" do

--- a/spec/requests/landing_pages_request_spec.rb
+++ b/spec/requests/landing_pages_request_spec.rb
@@ -45,6 +45,18 @@ RSpec.describe LandingPagesController, type: :request do
     end
   end
 
+  describe "review app banner" do
+    it "renders the banner, and suppresses it with NO_REVIEW_TOPBAR" do
+      stub_const("ENV", ENV.to_hash.merge("REVIEW_APP" => "1"))
+      get "/for_bike_shops"
+      expect(response.body).to include("review-app-banner")
+
+      stub_const("ENV", ENV.to_hash.merge("REVIEW_APP" => "1", "NO_REVIEW_TOPBAR" => "true"))
+      get "/for_bike_shops"
+      expect(response.body).not_to include("review-app-banner")
+    end
+  end
+
   describe "organization show" do
     let(:title) { response.body[/<title[^>]*>([^<]*)/, 1] }
     let!(:organization) { FactoryBot.create(:organization, short_name: "University") }


### PR DESCRIPTION
The dev server renders the review-app banner, but with no PR number or title it can't link anywhere. `bin/dev` now exports both from `gh pr view` for the current branch.

- Skipped outside a workspace checkout (no `.workspace_id`) and when `NO_REVIEW_TOPBAR=true` in the shell or `.env.development`; silently no-ops when the branch has no PR or `gh` isn't installed.
- Exports rather than writing `.env.development`, so nothing goes stale when the PR closes and `bin/setup` can't clobber it by re-copying `.env.conductor_dev`.
- The banner says "no superuser (can't signin)" where the sign-in button goes when the database has no superuser, rather than rendering nothing — which read as a broken button.
- `NO_REVIEW_TOPBAR` moves from the component to the application layout, alongside the other `ENV` reads.
