### PR TITLE
Fix the flaky search-form localStorage assertion

### DIFF
--- a/spec/components/search/form/component_system_spec.rb
+++ b/spec/components/search/form/component_system_spec.rb
@@ -70,14 +70,15 @@ RSpec.describe Search::Form::Component, :js, type: :system do
     end
 
     # kind_select_fields_controller writes these on turbo:submit-end, which fires
-    # after the URL changes; it namespaces the keys inside a component preview
+    # after the URL changes; it namespaces the keys inside a component preview.
+    # Raise Capybara's error, not RSpec's: synchronize rescues StandardError, and
+    # an RSpec expectation failure descends from Exception, so it would never retry.
     def expect_localstorage_location(location:, distance:)
       expected = {"preview-searchLocation" => location, "preview-searchDistance" => distance}
-      deadline = Time.current + 5
-      stored = local_storage
-      until expected.keys.all? { |key| stored[key] } || Time.current > deadline
-        sleep 0.1
-        stored = local_storage
+      stored = page.document.synchronize(5) do
+        local_storage.tap do |storage|
+          raise Capybara::ExpectationNotMet unless expected.keys.all? { |key| storage[key] }
+        end
       end
       expect(stored).to match_hash_indifferently(expected)
     end

--- a/spec/components/search/form/component_system_spec.rb
+++ b/spec/components/search/form/component_system_spec.rb
@@ -56,8 +56,8 @@ RSpec.describe Search::Form::Component, :js, type: :system do
       end
     end
 
-    def expect_localstorage_location(location:, distance:)
-      local_storage = page.evaluate_script(<<~JS)
+    def local_storage
+      page.evaluate_script(<<~JS)
         (() => {
           let storage = {};
           for (let i = 0; i < localStorage.length; i++) {
@@ -67,11 +67,19 @@ RSpec.describe Search::Form::Component, :js, type: :system do
           return storage;
         })()
       JS
+    end
 
-      location_key = local_storage.find { |k, _| k.match?(/location/i) }&.first
-      distance_key = local_storage.find { |k, _| k.match?(/distance/i) }&.first
-      # pp local_storage
-      expect(local_storage).to match_hash_indifferently({location_key => location, distance_key => distance})
+    # kind_select_fields_controller writes these on turbo:submit-end, which fires
+    # after the URL changes; it namespaces the keys inside a component preview
+    def expect_localstorage_location(location:, distance:)
+      expected = {"preview-searchLocation" => location, "preview-searchDistance" => distance}
+      deadline = Time.current + 5
+      stored = local_storage
+      until expected.keys.all? { |key| stored[key] } || Time.current > deadline
+        sleep 0.1
+        stored = local_storage
+      end
+      expect(stored).to match_hash_indifferently(expected)
     end
 
     it "submits after selecting a color" do


### PR DESCRIPTION
`EverythingCombobox submits after selecting a color` fails intermittently on CI (most recently [run 30164381310](https://github.com/bikeindex/bike_index/actions/runs/30164381310), which exhausted both `:flaky` retries).

- `kind_select_fields_controller` writes the location to localStorage on `turbo:submit-end`, which fires *after* the URL changes — so reading it immediately after `have_current_path` raced the write and sometimes saw an empty store. It now retries through `page.document.synchronize` until the keys land.
- The assertion derived its expected keys *from the actual storage*, so an empty read compared `{nil => "251"}` against `{}` and reported `Expected keys: [] to equal: [nil]` — which says nothing about what went wrong. The keys are named now, so a real failure prints a diff of what localStorage actually held.

`synchronize` has to raise `Capybara::ExpectationNotMet` rather than letting an RSpec matcher fail inside the block: it rescues `StandardError`, and `RSpec::Expectations::ExpectationNotMetError` descends from `Exception` — so the tidier-looking `synchronize(errors: [RSpec::Expectations::ExpectationNotMetError])` retries nothing and leaves the race in place while still passing.

Keeping the `:flaky` tag: it covers the whole `describe`, and the combobox autocomplete in that block has its own async waits (`wait: 30`) plus a separate documented Playwright quirk around Enter, neither of which this touches.
