### PR TITLE
Fix the radio group's checked ring and hovered right border

### DIFF
--- a/app/components/ui/forms/radio_button_group/component.rb
+++ b/app/components/ui/forms/radio_button_group/component.rb
@@ -43,6 +43,8 @@ module UI
             "tw:hover:border-purple-500 tw:hover:bg-purple-50 tw:dark:hover:border-purple-500 tw:dark:hover:bg-purple-950",
             "tw:has-[:checked]:bg-purple-500 tw:has-[:checked]:text-white tw:has-[:checked]:border-purple-500",
             "tw:has-[:checked]:hover:bg-purple-500 tw:has-[:checked]:hover:border-purple-500",
+            # relative/z-10 keeps the ring above the neighboring labels, which overlap it by a pixel
+            "tw:has-[:checked]:ring-2 tw:has-[:checked]:ring-purple-500/40 tw:has-[:checked]:relative tw:has-[:checked]:z-10",
             "tw:has-[:focus-visible]:ring-2 tw:has-[:focus-visible]:ring-purple-500/40 tw:has-[:focus-visible]:ring-offset-1 tw:dark:has-[:focus-visible]:ring-offset-gray-900",
             round, border_l
           ].join(" ")) do

--- a/app/components/ui/forms/radio_button_group/component.rb
+++ b/app/components/ui/forms/radio_button_group/component.rb
@@ -37,15 +37,18 @@ module UI
 
           # Mirrors UI::Button color: :purple_outline (resting + active), driving the
           # active state off the checked radio so the two stay visually in lockstep.
+          #
+          # Segments overlap by a pixel, so a later sibling paints over its neighbor's
+          # right border and ring. The z-index ladder decides who wins that pixel:
+          # pointer/keyboard focus outranks the checked segment, which outranks the rest.
           tag.label(class: [
-            "tw:cursor-pointer tw:select-none tw:inline-flex tw:items-center tw:mb-0! tw:px-3 tw:py-1 tw:text-sm tw:leading-snug tw:transition-colors",
+            "tw:relative tw:cursor-pointer tw:select-none tw:inline-flex tw:items-center tw:mb-0! tw:px-3 tw:py-1 tw:text-sm tw:leading-snug tw:transition-colors",
             "tw:text-gray-800 tw:bg-white tw:border tw:border-gray-200 tw:dark:bg-gray-800 tw:dark:text-gray-100 tw:dark:border-gray-700",
-            "tw:hover:border-purple-500 tw:hover:bg-purple-50 tw:dark:hover:border-purple-500 tw:dark:hover:bg-purple-950",
+            "tw:hover:border-purple-500 tw:hover:bg-purple-50 tw:hover:z-20 tw:dark:hover:border-purple-500 tw:dark:hover:bg-purple-950",
             "tw:has-[:checked]:bg-purple-500 tw:has-[:checked]:text-white tw:has-[:checked]:border-purple-500",
             "tw:has-[:checked]:hover:bg-purple-500 tw:has-[:checked]:hover:border-purple-500",
-            # relative/z-10 keeps the ring above the neighboring labels, which overlap it by a pixel
-            "tw:has-[:checked]:ring-2 tw:has-[:checked]:ring-purple-500/40 tw:has-[:checked]:relative tw:has-[:checked]:z-10",
-            "tw:has-[:focus-visible]:ring-2 tw:has-[:focus-visible]:ring-purple-500/40 tw:has-[:focus-visible]:ring-offset-1 tw:dark:has-[:focus-visible]:ring-offset-gray-900",
+            "tw:has-[:checked]:ring-2 tw:has-[:checked]:ring-purple-500/40 tw:has-[:checked]:z-10",
+            "tw:has-[:focus-visible]:ring-2 tw:has-[:focus-visible]:ring-purple-500/40 tw:has-[:focus-visible]:ring-offset-1 tw:has-[:focus-visible]:z-20 tw:dark:has-[:focus-visible]:ring-offset-gray-900",
             round, border_l
           ].join(" ")) do
             radio_button_tag(@name, value, checked,

--- a/app/components/ui/forms/radio_button_group/component.rb
+++ b/app/components/ui/forms/radio_button_group/component.rb
@@ -37,10 +37,8 @@ module UI
 
           # Mirrors UI::Button color: :purple_outline (resting + active), driving the
           # active state off the checked radio so the two stay visually in lockstep.
-          #
-          # Segments overlap by a pixel, so a later sibling paints over its neighbor's
-          # right border and ring. The z-index ladder decides who wins that pixel:
-          # pointer/keyboard focus outranks the checked segment, which outranks the rest.
+          # Segments overlap by a pixel; z-index breaks the tie for it: hover/focus,
+          # then checked, then the rest.
           tag.label(class: [
             "tw:relative tw:cursor-pointer tw:select-none tw:inline-flex tw:items-center tw:mb-0! tw:px-3 tw:py-1 tw:text-sm tw:leading-snug tw:transition-colors",
             "tw:text-gray-800 tw:bg-white tw:border tw:border-gray-200 tw:dark:bg-gray-800 tw:dark:text-gray-100 tw:dark:border-gray-700",

--- a/app/components/ui/forms/radio_button_group/component_preview.rb
+++ b/app/components/ui/forms/radio_button_group/component_preview.rb
@@ -18,7 +18,7 @@ module UI
 
         def with_html_labels
           render(UI::Forms::RadioButtonGroup::Component.new(
-            name: :search_status,
+            name: :search_impounded,
             entries: [
               {value: "", label: "All"},
               {value: "not_impounded", label: "only <strong>not</strong> impounded"},

--- a/spec/components/ui/forms/radio_button_group/component_spec.rb
+++ b/spec/components/ui/forms/radio_button_group/component_spec.rb
@@ -5,6 +5,8 @@ require "rails_helper"
 RSpec.describe UI::Forms::RadioButtonGroup::Component, type: :component do
   let(:entries) { [{value: "", label: "All"}, {value: "active", label: "Active"}] }
   let(:component) { render_inline(described_class.new(name: :search_status, entries:)) }
+  let(:label) { component.css("label").first["class"] }
+  let(:button) { UI::Button::Component.build_classes(color: :purple_outline, size: :md) }
 
   # Every purple-* color utility a class string uses, ignoring variant prefixes
   # (hover:, dark:, has-[:checked]:, is-active:, …) so the group's
@@ -13,11 +15,20 @@ RSpec.describe UI::Forms::RadioButtonGroup::Component, type: :component do
     class_string.scan(%r{(?:bg|border|text|ring)-purple-\d+(?:/\d+)?}).uniq.sort
   end
 
-  it "uses the same purple palette as UI::Button's purple_outline" do
-    button = UI::Button::Component.build_classes(color: :purple_outline, size: :md)
-    label = component.css("label").first["class"]
+  # The utilities a class string applies under a single variant, e.g. "is-active" or
+  # "has-[:checked]" — `tw:is-active:bg-purple-500` and
+  # `tw:has-[:checked]:bg-purple-500` both reduce to `bg-purple-500`.
+  def utilities_for(class_string, variant)
+    class_string.split.filter_map { it[/\Atw:#{Regexp.escape(variant)}:([^:]+)\z/, 1] }.sort
+  end
 
+  it "uses the same purple palette as UI::Button's purple_outline" do
     expect(purple_tokens(label)).not_to be_empty
     expect(purple_tokens(label)).to eq(purple_tokens(button))
+  end
+
+  it "applies the button's active utilities when checked" do
+    expect(utilities_for(button, "is-active")).not_to be_empty
+    expect(utilities_for(label, "has-[:checked]")).to include(*utilities_for(button, "is-active"))
   end
 end

--- a/spec/components/ui/forms/radio_button_group/component_spec.rb
+++ b/spec/components/ui/forms/radio_button_group/component_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe UI::Forms::RadioButtonGroup::Component, type: :component do
   let(:component) { render_inline(described_class.new(name: :search_status, entries:)) }
   let(:label) { component.css("label").first["class"] }
   let(:button) { UI::Button::Component.build_classes(color: :purple_outline, size: :md) }
+  let(:button_active) { UI::Button::Component::ACTIVE_COLORS[:purple_outline] }
 
   # Every purple-* color utility a class string uses, ignoring variant prefixes
   # (hover:, dark:, has-[:checked]:, is-active:, …) so the group's
@@ -15,11 +16,11 @@ RSpec.describe UI::Forms::RadioButtonGroup::Component, type: :component do
     class_string.scan(%r{(?:bg|border|text|ring)-purple-\d+(?:/\d+)?}).uniq.sort
   end
 
-  # The utilities a class string applies under a single variant, e.g. "is-active" or
-  # "has-[:checked]" — `tw:is-active:bg-purple-500` and
+  # What a class string applies under the given variant, with any deeper variant kept
+  # so it still has to match: `tw:is-active:bg-purple-500` and
   # `tw:has-[:checked]:bg-purple-500` both reduce to `bg-purple-500`.
   def utilities_for(class_string, variant)
-    class_string.split.filter_map { it[/\Atw:#{Regexp.escape(variant)}:([^:]+)\z/, 1] }.sort
+    class_string.split.filter_map { it[/\Atw:#{Regexp.escape(variant)}:(.+)\z/, 1] }.sort
   end
 
   it "uses the same purple palette as UI::Button's purple_outline" do
@@ -28,7 +29,7 @@ RSpec.describe UI::Forms::RadioButtonGroup::Component, type: :component do
   end
 
   it "applies the button's active utilities when checked" do
-    expect(utilities_for(button, "is-active")).not_to be_empty
-    expect(utilities_for(label, "has-[:checked]")).to include(*utilities_for(button, "is-active"))
+    expect(utilities_for(button_active, "is-active")).not_to be_empty
+    expect(utilities_for(label, "has-[:checked]")).to include(*utilities_for(button_active, "is-active"))
   end
 end


### PR DESCRIPTION
`UI::Forms::RadioButtonGroup` restates `UI::Button`'s `purple_outline` palette under a `has-[:checked]:` variant, since its active state is driven by a checked radio rather than the `is-active` data attribute. It restated everything except the ring, so the checked segment read flatter than an active `purple_outline` button.

Fixing that surfaced a second problem: segments overlap by `-ml-px`, and every label was statically positioned, so a later sibling painted over its neighbor's right border and ring. That's why a hovered segment's right border stayed gray, and it clipped the focus ring the same way.

- The checked label now carries `ring-2 ring-purple-500/40`, matching `ACTIVE_COLORS[:purple_outline]`.
- Every label is `relative`, with a z-index ladder deciding who owns the shared pixel: hover/focus over checked over resting. Hover wins over checked deliberately — the state under the pointer should be the one drawn whole.
- The `with_html_labels` preview gets its own radio name; Lookbook's Examples page renders every scenario into one DOM, so sharing `search_status` made it and `default` a single radio group.
- The lockstep spec compares the label's `has-[:checked]:` utilities against `ACTIVE_COLORS[:purple_outline]`, so a color added to the button has to reach the group or the spec fails.

The stacking fix isn't covered by a spec — it's paint order, which only a pixel diff would catch. See the screenshots comment.
