### PR TITLE
Set the passive_organization when viewing a registration as an organization

### DIFF
--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -12,7 +12,11 @@ class RegistrationsController < ApplicationController
     available_views = BikeServices::ShowViews.available(bike: @bike, current_user:,
       organization: current_organization || passive_organization, preview_organization: requested_view&.last)
 
-    render(Registrations::Show::Wrapper::Component.new(bike: @bike, current_user:, view: current_view(available_views, requested_view),
+    view = current_view(available_views, requested_view)
+    # So the view_as organization sticks on the next request
+    set_passive_organization(view.last) if view.last
+
+    render(Registrations::Show::Wrapper::Component.new(bike: @bike, current_user:, view:,
       available_views:), layout: "application")
   end
 

--- a/spec/requests/registrations/show_request_spec.rb
+++ b/spec/requests/registrations/show_request_spec.rb
@@ -414,6 +414,25 @@ RSpec.describe "RegistrationsController#show", type: :request do
       end
     end
 
+    context "view_as another organization" do
+      let(:current_user) { FactoryBot.create(:organization_admin, organization:) }
+      let(:other_organization) { FactoryBot.create(:organization) }
+      let!(:organization_role) { FactoryBot.create(:organization_role_claimed, organization: other_organization, user: current_user) }
+
+      it "sets the passive_organization, so the organization sticks on the next request" do
+        # Which organization is default_organization isn't ordered, so put one in the session
+        get "#{base_url}/#{bike.id}", params: {organization_id: organization.to_param}
+        expect(session[:passive_organization_id]).to eq organization.id
+
+        get "#{base_url}/#{bike.id}", params: {view_as: "#{other_organization.to_param}.staff"}
+        expect(whitespace_normalized_body_text).to match("Viewing as #{other_organization.short_name} staff")
+        expect(session[:passive_organization_id]).to eq other_organization.id
+
+        get "#{base_url}/#{bike.id}"
+        expect(whitespace_normalized_body_text).to match("Viewing as #{other_organization.short_name} staff")
+      end
+    end
+
     context "superuser view_as options" do
       let(:current_user) { FactoryBot.create(:superuser) }
       let!(:brakebills) { FactoryBot.create(:organization, name: "Brakebills") }


### PR DESCRIPTION
Viewing a registration as an organization (`?view_as=<org-slug>.staff`) now writes that organization into `passive_organization`, so it sticks for the rest of the site instead of resetting on the next page.

- Only organization perspectives set it — `view_as=public` and `view_as=owner` leave the session org alone, and `organization_id=false` is still how you clear it.
- It keys off the *resolved* view rather than the raw param, so a `view_as` the viewer isn't permitted falls back and can't write an org into their session.

Worth a look: superusers are `authorized?` for every organization, so previewing one from the view switcher switches their session org too — happy to scope that to non-preview views if you'd rather it not stick.
