### PR TITLE
Fix the stolen-with-reports TSV join after the region_record rename

### DIFF
--- a/app/services/spreadsheets/tsv_creator.rb
+++ b/app/services/spreadsheets/tsv_creator.rb
@@ -99,7 +99,7 @@ module Spreadsheets
       out_file = File.join(Rails.root, filename)
       output = File.open(out_file, "w")
       output.puts stolen_with_reports_header
-      stolen_records.joins(:bike, :state).merge(Bike.with_known_serial).find_each do |sr|
+      stolen_records.joins(:bike, :region_record).merge(Bike.with_known_serial).find_each do |sr|
         next unless sr.police_report_number.present?
 
         row = sr.tsv_row(false, with_stolen_locations: true)

--- a/spec/services/spreadsheets/tsv_creator_spec.rb
+++ b/spec/services/spreadsheets/tsv_creator_spec.rb
@@ -24,6 +24,24 @@ RSpec.describe Spreadsheets::TsvCreator do
     end
   end
 
+  describe "create_stolen_with_reports" do
+    let!(:stolen_record) do
+      FactoryBot.create(:stolen_record, :in_nyc, approved: true,
+        police_report_number: "XXX999", police_report_department: "New York")
+    end
+
+    it "creates a tsv of the records with a region_record" do
+      # In approveds_with_reports, but Amsterdam has no region_record
+      FactoryBot.create(:stolen_record, :in_amsterdam, approved: true,
+        police_report_number: "YYY888", police_report_department: "Amsterdam")
+      expect_any_instance_of(TsvUploader).to receive(:store!)
+      expect_any_instance_of(TsvUploader).to receive(:current_path) { "some-file.tsv" }
+      output = instance.create_stolen_with_reports
+      expect(File.read(output))
+        .to eq("#{instance.stolen_with_reports_header}#{stolen_record.tsv_row(false, with_stolen_locations: true)}")
+    end
+  end
+
   describe "create_daily_tsvs" do
     it "calls create_stolen and create_stolen_with_reports with scoped query" do
       stolen_record = FactoryBot.create(:stolen_record, current: true, tsved_at: nil)


### PR DESCRIPTION
The daily `Spreadsheets::TsvCreatorJob` has been raising `ActiveRecord::ConfigurationError` since #3352 renamed `StolenRecord`'s `state` association to `region_record` — `create_stolen_with_reports` still joined `:state`. ([Honeybadger](https://app.honeybadger.io/projects/35931/faults/132982306))

- `joins(:bike, :region_record)` is the same INNER JOIN under the association's new name, so the export still covers exactly the records with a state. Grepping turned up no other stragglers.
- `create_stolen_with_reports` gets its own spec — the `create_daily_tsvs` one stubs it out, which is how the broken query shipped.

Worth a look: `region` now falls back to `region_string` when there's no `region_record`, so a record whose state didn't resolve to a `State` renders a `StolenState` everywhere else in the app but is still dropped from this feed. I kept the pre-#3352 behavior; happy to widen it to `region_record_id IS NOT NULL OR region_string IS NOT NULL` if that's the intent.
