### PR TITLE
Assert multi-search chip state by content, not badge color class

### DIFF
--- a/spec/integration/organized/registrations_search_spec.rb
+++ b/spec/integration/organized/registrations_search_spec.rb
@@ -378,7 +378,7 @@ RSpec.describe "Organized registrations search", :js, type: :system do
       click_button "Search serials"
 
       # Chips update with results
-      expect(page).to have_css("#chip_2.tw\\:bg-gray-100", wait: 15)
+      expect(page).to have_css("#chip_2", text: "no matches", wait: 15)
 
       # Results sorted by chip order, empty results removed
       expect(page).to have_css(".multi-search-serial-result", count: 2)
@@ -465,12 +465,12 @@ RSpec.describe "Organized registrations search", :js, type: :system do
         find("textarea#serials").set("STKR200, STKR100, STKR300")
         click_button "Search stickers"
 
-        # Chips for unclaimed and non-org stickers show gray (no bikes)
-        expect(page).to have_css("#chip_1.tw\\:bg-gray-100", wait: 15)
-        expect(page).to have_css("#chip_2.tw\\:bg-gray-100")
+        # Unclaimed and non-org stickers have no bikes
+        expect(page).to have_css("#chip_1", text: "no matches", wait: 15)
+        expect(page).to have_css("#chip_2", text: "no matches")
 
         # Only claimed org sticker has a bike result
-        expect(page).to have_css("#chip_0.tw\\:bg-green-50")
+        expect(page).to have_css("#chip_0 a[href='#result_0']")
 
         # Switch back to serials
         choose "Serials", allow_label_click: true, visible: :all


### PR DESCRIPTION
`registrations_search_spec` pinned the multi-search chips by their Tailwind color class (`tw:bg-gray-100`, `tw:bg-green-50`). Retuning `UI::Badge`'s palette makes those selectors silently stop matching, so the spec burns its full 15s wait and fails against a perfectly rendered page — which reads as a flake rather than a stale assertion. The base branch of #3957 hit exactly that: it updated the chip *component* spec's color literal and missed this one.

- Chips now assert what they mean — a miss renders "no matches", a hit renders an anchor to its result.
- The `text:` filter is load-bearing: `renderPlaceholderChips` creates `#chip_N` synchronously, so a bare id selector would match the spinner and drop the synchronization barrier.
- The palette stays pinned in the chip and badge component specs, where a retune fails fast with a string diff instead of a 15s timeout against a correct page.

Worth a look: `multi_search.html.erb` exports `successClass`/`grayClass` into the Stimulus controller, which never reads either — the same palette-leaking-out-of-`UI::Badge` pattern, but I left it for its own change.
