### PR TITLE
Show the review-app topbar title in the Lookbook navbar

### DIFF
--- a/app/components/page_block/review_app_banner/component.rb
+++ b/app/components/page_block/review_app_banner/component.rb
@@ -3,11 +3,21 @@
 module PageBlock
   module ReviewAppBanner
     # Banner shown across the top of every page on review-app and local dev
-    # deploys, so there's no chance of confusing them with production. Callers
-    # pass `ENV["REVIEW_APP"]` (or the string "development" for the local dev
-    # server), `ENV["REVIEW_APP_PR_NUMBER"]`, and `ENV["REVIEW_APP_PR_TITLE"]`;
-    # the component renders only when `review_app` is present.
+    # deploys, so there's no chance of confusing them with production. Deploys
+    # build it with `.from_env`; the component renders only when `review_app` is
+    # present, so previews can pass one explicitly.
     class Component < ApplicationComponent
+      # `review_app` is nil — so nothing renders — in production and when
+      # NO_REVIEW_TOPBAR=true. The Lookbook navbar is scoped through here too
+      # (config/initializers/lookbook.rb)
+      def self.from_env(current_user: nil, return_to: nil)
+        review_app = ENV["REVIEW_APP"] || (Rails.env.development? && "development")
+        review_app = nil if Rails.env.production? || ENV["NO_REVIEW_TOPBAR"] == "true"
+
+        new(review_app:, pr_number: ENV["REVIEW_APP_PR_NUMBER"], pr_title: ENV["REVIEW_APP_PR_TITLE"],
+          commit: ENV["REVIEW_APP_COMMIT"], current_user:, return_to:)
+      end
+
       def initialize(review_app:, pr_number: nil, pr_title: nil, commit: nil, current_user: nil, return_to: nil)
         @review_app = review_app
         @pr_number = pr_number
@@ -19,6 +29,14 @@ module PageBlock
 
       def render?
         @review_app.present?
+      end
+
+      # Plain-text title, also shown in the Lookbook navbar (config/initializers/lookbook.rb)
+      def topbar_title
+        return nil unless render?
+        return banner_label if @pr_number.blank?
+
+        "#{banner_label} · #{pr_link_text}"
       end
 
       private

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -60,10 +60,7 @@
       <%= t(".skip_to_main_content") %>
     </a>
 
-    <%# NO_REVIEW_TOPBAR=true suppresses the banner everywhere it would otherwise show (dev, review apps, sandbox) %>
-    <% unless Rails.env.production? || ENV["NO_REVIEW_TOPBAR"] == "true" %>
-      <%= render(PageBlock::ReviewAppBanner::Component.new(review_app: ENV["REVIEW_APP"] || (Rails.env.development? && "development"), pr_number: ENV["REVIEW_APP_PR_NUMBER"], pr_title: ENV["REVIEW_APP_PR_TITLE"], commit: ENV["REVIEW_APP_COMMIT"], current_user:, return_to: request.fullpath)) %>
-    <% end %>
+    <%= render(PageBlock::ReviewAppBanner::Component.from_env(current_user:, return_to: request.fullpath)) %>
 
     <%# Cache navbar to speed stuff up, on per-user, per-page %>
     <% cache(["main_navbar5", page_id, current_user_or_unconfirmed_user, passive_organization]) do %>

--- a/config/initializers/lookbook.rb
+++ b/config/initializers/lookbook.rb
@@ -6,6 +6,14 @@ Lookbook.configure do |config|
   config.preview_paths = ["#{Rails.root}/app/components/"]
 end
 
+# Append the review-app topbar's title to the navbar, so a Lookbook tab is
+# identifiable as dev/sandbox/a PR. after_initialize because component
+# translations aren't on the I18n load path while initializers run.
+Rails.application.config.after_initialize do
+  title = PageBlock::ReviewAppBanner::Component.from_env.topbar_title
+  Lookbook.config.project_name = ["Bike Index", title].compact.join(" · ")
+end
+
 # Fix preview breakage during development code reloading. Both patches re-resolve
 # preview classes through the autoloader after Zeitwerk unloads constants on reload.
 if Rails.env.development?

--- a/spec/components/page_block/review_app_banner/component_spec.rb
+++ b/spec/components/page_block/review_app_banner/component_spec.rb
@@ -6,10 +6,38 @@ RSpec.describe PageBlock::ReviewAppBanner::Component, type: :component do
   it "doesn't render when review_app is blank" do
     expect(described_class.new(review_app: nil).render?).to be_falsey
     expect(described_class.new(review_app: "").render?).to be_falsey
+    expect(described_class.new(review_app: nil).topbar_title).to be_nil
+  end
+
+  describe ".from_env" do
+    it "doesn't render without REVIEW_APP outside of development" do
+      expect(described_class.from_env.render?).to be_falsey
+    end
+
+    context "with the review app env" do
+      let(:review_app_env) do
+        {"REVIEW_APP" => "1", "REVIEW_APP_PR_NUMBER" => "1234", "REVIEW_APP_PR_TITLE" => "Add Promoted section",
+         "REVIEW_APP_COMMIT" => "a1b2c3d"}
+      end
+
+      before { stub_const("ENV", ENV.to_hash.merge(review_app_env)) }
+
+      it "reads the deploy's PR from the env" do
+        expect(described_class.from_env.topbar_title).to eq "Review app · Add Promoted section"
+      end
+
+      it "doesn't render with NO_REVIEW_TOPBAR" do
+        stub_const("ENV", ENV.to_hash.merge(review_app_env, "NO_REVIEW_TOPBAR" => "true"))
+        expect(described_class.from_env.render?).to be_falsey
+        expect(described_class.from_env.topbar_title).to be_nil
+      end
+    end
   end
 
   it "renders a purple development banner for the local dev server" do
-    component = render_inline(described_class.new(review_app: "development"))
+    banner = described_class.new(review_app: "development")
+    component = render_inline(banner)
+    expect(banner.topbar_title).to eq "Development"
     expect(component.text).to include("Development")
     expect(component.text).not_to include("Sandbox")
     expect(component.css("a[href='/letter_opener']")).to be_present
@@ -27,7 +55,8 @@ RSpec.describe PageBlock::ReviewAppBanner::Component, type: :component do
   end
 
   context "when review_app is present" do
-    let(:component) { render_inline(described_class.new(review_app: "1", pr_number:, pr_title:, commit:, current_user:, return_to:)) }
+    let(:banner) { described_class.new(review_app: "1", pr_number:, pr_title:, commit:, current_user:, return_to:) }
+    let(:component) { render_inline(banner) }
     let(:pr_number) { nil }
     let(:pr_title) { nil }
     let(:commit) { nil }
@@ -36,6 +65,7 @@ RSpec.describe PageBlock::ReviewAppBanner::Component, type: :component do
 
     it "renders the sandbox label and disclaimer" do
       # No pr_number is the persistent sandbox deploy, not a per-PR review app
+      expect(banner.topbar_title).to eq "Sandbox"
       expect(component.text).to include("Sandbox")
       expect(component.text).not_to include("Review app")
       expect(component.text).to include("data is ephemeral")
@@ -148,6 +178,7 @@ RSpec.describe PageBlock::ReviewAppBanner::Component, type: :component do
       end
 
       it "shows the review app label instead of the sandbox label, hidden on small screens" do
+        expect(banner.topbar_title).to eq "Review app · PR #1234"
         expect(component.text).to include("Review app")
         expect(component.text).not_to include("Sandbox")
         # The PR title carries the context on small screens, so the label hides
@@ -159,6 +190,7 @@ RSpec.describe PageBlock::ReviewAppBanner::Component, type: :component do
         let(:pr_title) { "Add Promoted section" }
 
         it "uses the title as the PR link text" do
+          expect(banner.topbar_title).to eq "Review app · Add Promoted section"
           link = component.css("a[href^='https://github.com']").first
           expect(link[:href]).to eq("https://github.com/bikeindex/bike_index/pull/1234")
           expect(link.text.strip).to eq("Add Promoted section")


### PR DESCRIPTION
Lookbook's header read "Bikeindex" on every deploy, so a preview tab gave no hint which one it belonged to. It now carries the review-app topbar's title — `Bike Index · Development`, `Bike Index · Sandbox`, or `Bike Index · Review app · <PR title>` — scoped the same way the topbar is, so production and `NO_REVIEW_TOPBAR=true` leave it at "Bike Index".

- `ReviewAppBanner::Component.from_env` now owns the ENV reading and the suppression rule the layout spelled out inline, since the navbar needed the same wiring. It returns a component whose `review_app` is nil when suppressed, so `render?` does the hiding and previews can still pass a `review_app` explicitly.
- `topbar_title` composes the banner's existing label and PR-link text, so the two can't drift.
- The navbar is set from `after_initialize` — component translations aren't on the I18n load path yet while initializers run — and assigns rather than appends, so it doesn't depend on that hook running exactly once.
