### PR TITLE
Fix admin recoveries 500 on removed StolenRecord#address

### DIFF
--- a/app/controllers/admin/recoveries_controller.rb
+++ b/app/controllers/admin/recoveries_controller.rb
@@ -7,7 +7,7 @@ module Admin
     def index
       @per_page = permitted_per_page(default: 50)
       @pagy, @recoveries = pagy(:countish, available_recoveries.reorder("stolen_records.#{sort_column} #{sort_direction}")
-        .includes(:bike), limit: @per_page, page: permitted_page)
+        .includes(:bike, :country, :region_record), limit: @per_page, page: permitted_page)
     end
 
     def show

--- a/app/views/admin/recoveries/_table.html.haml
+++ b/app/views/admin/recoveries/_table.html.haml
@@ -81,8 +81,7 @@
                   %span.text-warning
                     not owner!
           %td
-            - if recovery.address.present?
-              = recovery.city
+            = render Admin::AddressRecordCell::Component.new(address_record: recovery)
           %td.table-cell-check
             / Posted
             / = check_mark if recovery.recovery_posted

--- a/spec/requests/admin/recoveries_request_spec.rb
+++ b/spec/requests/admin/recoveries_request_spec.rb
@@ -5,10 +5,16 @@ RSpec.describe Admin::RecoveriesController, type: :request do
   include_context :request_spec_logged_in_as_superuser
 
   describe "index" do
+    let!(:stolen_record) do
+      FactoryBot.create(:stolen_record_recovered, city: "Chicago",
+        region_record: FactoryBot.create(:state_illinois))
+    end
     it "renders" do
-      get base_url
+      get "#{base_url}?search_recovery_display_status=all"
       expect(response).to be_ok
       expect(response).to render_template(:index)
+      expect(response.body).to match("Chicago")
+      expect(response.body).to match("IL")
       expect(flash).to_not be_present
       # Added in #2137 because there was an error in the scope
       get "#{base_url}?search_displayed=displayed&search_shareable=true"


### PR DESCRIPTION
Fixes the `NoMethodError: undefined method 'address' for an instance of StolenRecord` 500ing `/admin/recoveries` ([Honeybadger #133017161](https://app.honeybadger.io/projects/35931/faults/133017161)). `StolenRecord` moved from `GeocodeableLegacy` to `Geocodeable`, which doesn't define `address`, but the Location cell still guarded on it.

- Renders the shared `Admin::AddressRecordCell::Component` for that cell instead — same output as the marketplace-listings Location column, so it now shows the region/country alongside the city — and preloads `:country, :region_record` so it doesn't N+1 across the page.
- The index spec never created a recovery, so the `recoveries.each` body had never been exercised; it now creates one and asserts the location renders.
