### PR TITLE
Add the scanned sticker block to the registration show redesign

### DIFF
--- a/.claude/skills/frontend-conventions/SKILL.md
+++ b/.claude/skills/frontend-conventions/SKILL.md
@@ -50,7 +50,7 @@ The `bin/dev` command handles building and updating Tailwind and JS.
 
 The same instinct applies beyond buttons: **check `app/components/ui/` and `app/components/atom/` before hand-rolling any UI primitive** (dropdowns → `UI::Dropdown`, tooltips → `UI::Tooltip`, form fields → `UI::Forms::*`, badges, modals, pagination, tables…). If a component exists for the pattern, use it; if it almost fits, extend it rather than forking its markup inline.
 
-`UI::*` is domain-agnostic presentation. `Atom::*` renders a single Bike Index value in its canonical form — see `app/components/atom/` (`Atom::Serial`, `Atom::Sticker`, `Atom::ShortId`). New code renders a serial with `Atom::Serial::Component`, not `BikeHelper#render_serial_display`.
+`Atom::*` (`app/components/atom/`) holds the small value-rendering components — `Atom::Serial`, `Atom::Sticker`, `Atom::ShortId`. Everything else is `UI::*`; older value renderers like `UI::AddressDisplay` predate the split and stay put. Render a serial with `Atom::Serial::Component`, not `BikeHelper#render_serial_display`.
 
 ## Tooltips: default `?` button trigger
 

--- a/.claude/skills/frontend-conventions/SKILL.md
+++ b/.claude/skills/frontend-conventions/SKILL.md
@@ -48,7 +48,9 @@ The `bin/dev` command handles building and updating Tailwind and JS.
 - A link styled as a button: `UI::ButtonLink::Component.new(href:, text:, color:, size:)` — same palette, renders an `<a>`.
 - A standalone action button (POST/DELETE/etc. to a URL) — a link that performs an action: pass `method:` to `ButtonLink` and it renders `button_to` for you (`render UI::ButtonLink::Component.new(text: "Delete", color: :error, href: bike_path(@bike), method: :delete)`), so don't hand-roll a `button_to` or wrap a submit button in a bare form. Extra `html_options` flow through: pass `params:` for a POST that carries params (they render as hidden fields — no manual `form_with`/`hidden_field_tag` needed), and `form: {onsubmit: …}` for a confirm on the wrapping form.
 
-The same instinct applies beyond buttons: **check `app/components/ui/` before hand-rolling any UI primitive** (dropdowns → `UI::Dropdown`, tooltips → `UI::Tooltip`, form fields → `UI::Forms::*`, badges, modals, pagination, tables…). If a `UI::*` component exists for the pattern, use it; if it almost fits, extend it rather than forking its markup inline.
+The same instinct applies beyond buttons: **check `app/components/ui/` and `app/components/atom/` before hand-rolling any UI primitive** (dropdowns → `UI::Dropdown`, tooltips → `UI::Tooltip`, form fields → `UI::Forms::*`, badges, modals, pagination, tables…). If a component exists for the pattern, use it; if it almost fits, extend it rather than forking its markup inline.
+
+`UI::*` is domain-agnostic presentation. `Atom::*` renders a single Bike Index value in its canonical form — see `app/components/atom/` (`Atom::Serial`, `Atom::Sticker`, `Atom::ShortId`). New code renders a serial with `Atom::Serial::Component`, not `BikeHelper#render_serial_display`.
 
 ## Tooltips: default `?` button trigger
 

--- a/app/assets/images/icons/qr-code.svg
+++ b/app/assets/images/icons/qr-code.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" viewBox="0 0 16 16">
+  <path fill-rule="evenodd" d="M1 1h6v6H1zm1 1v4h4V2z"/>
+  <path d="M3 3h2v2H3z"/>
+  <path fill-rule="evenodd" d="M9 1h6v6H9zm1 1v4h4V2z"/>
+  <path d="M11 3h2v2h-2z"/>
+  <path fill-rule="evenodd" d="M1 9h6v6H1zm1 1v4h4v-4z"/>
+  <path d="M3 11h2v2H3zM9 9h2v2H9zM13 9h2v2h-2zM11 11h2v2h-2zM9 13h2v2H9zM13 13h2v2h-2z"/>
+</svg>

--- a/app/components/atom/serial/component.en.yml
+++ b/app/components/atom/serial/component.en.yml
@@ -1,0 +1,10 @@
+---
+en:
+  components:
+    atom:
+      serial:
+        hidden: hidden
+        hidden_because_status: because %{bike_type} is %{status}
+        hidden_for_unauthorized_users: hidden for unauthorized users
+        made_without_serial: made without serial
+        unknown: unknown

--- a/app/components/atom/serial/component.rb
+++ b/app/components/atom/serial/component.rb
@@ -6,11 +6,8 @@ module Atom
     # absent serial renders that word in place of the number, and a hidden serial
     # is followed by why it's hidden unless skip_explanation.
     class Component < ApplicationComponent
-      BASE_CLASSES = "tw:font-mono tw:p-0 tw:bg-transparent tw:text-inherit tw:rounded-none"
       # What serial_display returns in place of a number
       PLACEHOLDERS = ["hidden", "unknown", "made without serial"].freeze
-      # BikeHelper#render_serial_display renders serials everywhere else, so borrow its keys
-      TRANSLATION_SCOPE = %i[helpers bike_helper].freeze
 
       def initialize(bike:, user: nil, skip_explanation: false)
         @bike = bike
@@ -23,7 +20,9 @@ module Atom
       end
 
       def call
-        safe_join([serial_block, explanation].compact, " ")
+        return serial_block unless explanation?
+
+        safe_join([serial_block, " ", explanation])
       end
 
       private
@@ -37,22 +36,23 @@ module Atom
       end
 
       def serial_block
-        return content_tag(:span, translation(serial.downcase.tr(" ", "_"), scope: TRANSLATION_SCOPE), class: "tw:opacity-65") if placeholder?
+        return content_tag(:span, serial, class: "serial-span") unless placeholder?
 
-        content_tag(:code, serial, class: BASE_CLASSES)
+        content_tag(:span, translation(".#{serial.downcase.tr(" ", "_")}"), class: "less-strong")
+      end
+
+      def explanation?
+        @bike.serial_hidden? && !@skip_explanation
       end
 
       def explanation
-        return unless @bike.serial_hidden? && !@skip_explanation
-
-        content_tag(:em, explanation_text, class: "tw:text-sm tw:opacity-65")
+        content_tag(:em, explanation_text, class: "small less-less-strong")
       end
 
       def explanation_text
-        return translation(:hidden_for_unauthorized_users, scope: TRANSLATION_SCOPE) if @bike.authorized?(@user)
+        return translation(".hidden_for_unauthorized_users") if @bike.authorized?(@user)
 
-        translation(:hidden_because_status, bike_type: @bike.type,
-          status: @bike.status_humanized_translated, scope: TRANSLATION_SCOPE)
+        translation(".hidden_because_status", bike_type: @bike.type, status: @bike.status_humanized_translated)
       end
     end
   end

--- a/app/components/atom/serial/component.rb
+++ b/app/components/atom/serial/component.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+module Atom
+  module Serial
+    # Renders a bike's serial as seen by the given user. A hidden, unknown or
+    # absent serial renders that word in place of the number, and a hidden serial
+    # is followed by why it's hidden unless skip_explanation.
+    class Component < ApplicationComponent
+      BASE_CLASSES = "tw:font-mono tw:p-0 tw:bg-transparent tw:text-inherit tw:rounded-none"
+      # Serials the model reports in words rather than as a number
+      UNSET = ["hidden", "unknown", "made without serial"].freeze
+      # Shared with BikeHelper#render_serial_display, which renders this outside the redesign
+      TRANSLATION_SCOPE = %i[helpers bike_helper].freeze
+
+      def initialize(bike:, user: nil, skip_explanation: false)
+        @bike = bike
+        @user = user
+        @skip_explanation = skip_explanation
+      end
+
+      def render?
+        serial.present?
+      end
+
+      def call
+        safe_join([serial_block, explanation].compact, " ")
+      end
+
+      private
+
+      def serial
+        @serial ||= @bike.serial_display(@user)
+      end
+
+      def unset?
+        UNSET.include?(serial.downcase)
+      end
+
+      def serial_block
+        return content_tag(:span, translation(serial.downcase.tr(" ", "_"), scope: TRANSLATION_SCOPE), class: "tw:opacity-65") if unset?
+
+        content_tag(:code, serial, class: BASE_CLASSES)
+      end
+
+      def explanation
+        return unless @bike.serial_hidden? && !@skip_explanation
+
+        content_tag(:em, explanation_text, class: "tw:text-sm tw:opacity-65")
+      end
+
+      def explanation_text
+        return translation(:hidden_for_unauthorized_users, scope: TRANSLATION_SCOPE) if @bike.authorized?(@user)
+
+        translation(:hidden_because_status, bike_type: @bike.type,
+          status: @bike.status_humanized_translated, scope: TRANSLATION_SCOPE)
+      end
+    end
+  end
+end

--- a/app/components/atom/serial/component.rb
+++ b/app/components/atom/serial/component.rb
@@ -7,9 +7,9 @@ module Atom
     # is followed by why it's hidden unless skip_explanation.
     class Component < ApplicationComponent
       BASE_CLASSES = "tw:font-mono tw:p-0 tw:bg-transparent tw:text-inherit tw:rounded-none"
-      # Serials the model reports in words rather than as a number
-      UNSET = ["hidden", "unknown", "made without serial"].freeze
-      # Shared with BikeHelper#render_serial_display, which renders this outside the redesign
+      # What serial_display returns in place of a number
+      PLACEHOLDERS = ["hidden", "unknown", "made without serial"].freeze
+      # BikeHelper#render_serial_display renders serials everywhere else, so borrow its keys
       TRANSLATION_SCOPE = %i[helpers bike_helper].freeze
 
       def initialize(bike:, user: nil, skip_explanation: false)
@@ -32,12 +32,12 @@ module Atom
         @serial ||= @bike.serial_display(@user)
       end
 
-      def unset?
-        UNSET.include?(serial.downcase)
+      def placeholder?
+        PLACEHOLDERS.include?(serial.downcase)
       end
 
       def serial_block
-        return content_tag(:span, translation(serial.downcase.tr(" ", "_"), scope: TRANSLATION_SCOPE), class: "tw:opacity-65") if unset?
+        return content_tag(:span, translation(serial.downcase.tr(" ", "_"), scope: TRANSLATION_SCOPE), class: "tw:opacity-65") if placeholder?
 
         content_tag(:code, serial, class: BASE_CLASSES)
       end

--- a/app/components/atom/serial/component_preview.rb
+++ b/app/components/atom/serial/component_preview.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+module Atom
+  module Serial
+    # Every serial state, rendered against in-memory bikes so nothing is written
+    # to the database. The hidden states need a viewer who can see the serial, so
+    # they pass lookbook_user (a superuser).
+    # @label Serial
+    class ComponentPreview < ApplicationComponentPreview
+      # @!group Variants
+      # @param serial text "Serial to render"
+      def default(serial: "FFF333")
+        render(Atom::Serial::Component.new(bike: preview_bike(serial_number: serial)))
+      end
+
+      # @label unknown serial
+      def unknown
+        render(Atom::Serial::Component.new(bike: preview_bike(serial_number: "unknown")))
+      end
+
+      # @label made without a serial
+      def made_without_serial
+        bike = preview_bike(serial_number: "made_without_serial", made_without_serial: true)
+        render(Atom::Serial::Component.new(bike:))
+      end
+
+      # @label hidden, with the reason why
+      def hidden
+        render(Atom::Serial::Component.new(bike: hidden_bike))
+      end
+
+      # @label hidden, reason skipped
+      def hidden_skip_explanation
+        render(Atom::Serial::Component.new(bike: hidden_bike, skip_explanation: true))
+      end
+
+      # @label hidden, shown to a viewer who may see it
+      def hidden_authorized
+        render(Atom::Serial::Component.new(bike: hidden_bike, user: lookbook_user))
+      end
+
+      # @label hidden, shown to a viewer who may see it, reason skipped
+      def hidden_authorized_skip_explanation
+        render(Atom::Serial::Component.new(bike: hidden_bike, user: lookbook_user, skip_explanation: true))
+      end
+
+      # @label no serial (renders nothing)
+      def blank
+        render(Atom::Serial::Component.new(bike: ::Bike.new))
+      end
+      # @!endgroup
+
+      private
+
+      def preview_bike(**attributes)
+        ::Bike.new(cycle_type: :bike, **attributes)
+      end
+
+      # Impounded is what makes a serial hidden - tandem so the reason reads distinctly
+      def hidden_bike
+        preview_bike(serial_number: "FFF333", cycle_type: :tandem, status: :status_impounded)
+      end
+    end
+  end
+end

--- a/app/components/atom/short_id/component.rb
+++ b/app/components/atom/short_id/component.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-module UI
+module Atom
   module ShortId
     # Renders a record's short_id (see ShortIdable) as a monospace code block.
     # Pass a record that responds to short_id, or a raw short_id string.

--- a/app/components/atom/short_id/component_preview.rb
+++ b/app/components/atom/short_id/component_preview.rb
@@ -1,23 +1,23 @@
 # frozen_string_literal: true
 
-module UI
+module Atom
   module ShortId
     # @label Short ID
     class ComponentPreview < ApplicationComponentPreview
       # @!group Variants
       # @param id text "ID to render"
       def default(id: "r/21J-HW")
-        render(UI::ShortId::Component.new(short_id: id))
+        render(Atom::ShortId::Component.new(short_id: id))
       end
 
       # @label short (decimal) id
       def decimal
-        render(UI::ShortId::Component.new(short_id: "r/36"))
+        render(Atom::ShortId::Component.new(short_id: "r/36"))
       end
 
       # @label with extra classes appended
       def with_html_class
-        render(UI::ShortId::Component.new(short_id: "r/21J-HW", html_class: "tw:text-base"))
+        render(Atom::ShortId::Component.new(short_id: "r/21J-HW", html_class: "tw:text-base"))
       end
       # @!endgroup
     end

--- a/app/components/atom/sticker/component.rb
+++ b/app/components/atom/sticker/component.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+module Atom
+  module Sticker
+    # Renders a bike sticker's code as a monospace code block. Pass a BikeSticker,
+    # or a raw pretty_code string; url links the code.
+    class Component < ApplicationComponent
+      BASE_CLASSES = "tw:font-mono tw:text-sm tw:font-semibold tw:p-0 tw:bg-transparent tw:text-inherit tw:rounded-none"
+
+      def initialize(bike_sticker: nil, pretty_code: nil, url: nil, html_class: nil)
+        @pretty_code = pretty_code || bike_sticker&.pretty_code
+        @url = url
+        @html_class = html_class
+      end
+
+      def render?
+        @pretty_code.present?
+      end
+
+      def call
+        return code_block if @url.blank?
+
+        link_to(code_block, @url, class: "twlink")
+      end
+
+      private
+
+      def code_block
+        content_tag(:code, @pretty_code, class: [BASE_CLASSES, @html_class].compact.join(" "))
+      end
+    end
+  end
+end

--- a/app/components/atom/sticker/component.rb
+++ b/app/components/atom/sticker/component.rb
@@ -5,12 +5,11 @@ module Atom
     # Renders a bike sticker's code as a monospace code block. Pass a BikeSticker,
     # or a raw pretty_code string; url links the code.
     class Component < ApplicationComponent
-      BASE_CLASSES = "tw:font-mono tw:text-sm tw:font-semibold tw:p-0 tw:bg-transparent tw:text-inherit tw:rounded-none"
+      BASE_CLASSES = "#{ShortId::Component::BASE_CLASSES} tw:font-semibold"
 
-      def initialize(bike_sticker: nil, pretty_code: nil, url: nil, html_class: nil)
+      def initialize(bike_sticker: nil, pretty_code: nil, url: nil)
         @pretty_code = pretty_code || bike_sticker&.pretty_code
         @url = url
-        @html_class = html_class
       end
 
       def render?
@@ -26,7 +25,7 @@ module Atom
       private
 
       def code_block
-        content_tag(:code, @pretty_code, class: [BASE_CLASSES, @html_class].compact.join(" "))
+        content_tag(:code, @pretty_code, class: BASE_CLASSES)
       end
     end
   end

--- a/app/components/atom/sticker/component_preview.rb
+++ b/app/components/atom/sticker/component_preview.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module Atom
+  module Sticker
+    # @label Sticker
+    class ComponentPreview < ApplicationComponentPreview
+      # @!group Variants
+      # @param code text "Sticker code to render"
+      def default(code: "BR 000 1")
+        render(Atom::Sticker::Component.new(pretty_code: code))
+      end
+
+      # @label linked to the sticker's edit page
+      def with_url
+        render(Atom::Sticker::Component.new(pretty_code: "BR 000 1", url: "#"))
+      end
+      # @!endgroup
+    end
+  end
+end

--- a/app/components/registrations/show/bike_details/component.html.erb
+++ b/app/components/registrations/show/bike_details/component.html.erb
@@ -5,7 +5,7 @@
 
   <div class="tw:mt-3">
     <%= render(UI::DefinitionList::Container::Component.new(term: :below)) do %>
-      <%= render(UI::DefinitionList::Row::Component.new(label: translation(".serial"))) { render_serial_display(@bike, @serial_user, skip_explanation: @skip_serial_explanation) } %>
+      <%= render(UI::DefinitionList::Row::Component.new(label: translation(".serial"))) { render(Atom::Serial::Component.new(bike: @bike, user: @serial_user, skip_explanation: @skip_serial_explanation)) } %>
       <%= render(UI::DefinitionList::Row::Component.new(label: translation(".other_serial"), value: @bike.extra_registration_number)) %>
       <%= render(UI::DefinitionList::Row::Component.new(label: translation(".vehicle_type"), value: vehicle_type)) %>
       <%= render(UI::DefinitionList::Row::Component.new(label: translation(".manufacturer"), value: manufacturer_name)) %>

--- a/app/components/registrations/show/bike_details/component.rb
+++ b/app/components/registrations/show/bike_details/component.rb
@@ -6,8 +6,6 @@ module Registrations
       # The "Bike details" spec-sheet card. The serial is rendered for the given
       # user, so the public view passes nil to keep a hidden serial hidden.
       class Component < ApplicationComponent
-        include BikeHelper
-
         def initialize(bike:, serial_user: nil, skip_serial_explanation: false)
           @bike = bike
           @serial_user = serial_user

--- a/app/components/registrations/show/bike_index_card/component.html.erb
+++ b/app/components/registrations/show/bike_index_card/component.html.erb
@@ -9,7 +9,7 @@
 
       <%= render(UI::DefinitionList::Row::Component.new(label: translation(".frame_material"), value: @bike.frame_material_name)) %>
       <%= render(UI::DefinitionList::Row::Component.new(label: translation(".activity"), value: activity_name)) %>
-      <%= render(UI::DefinitionList::Row::Component.new(label: translation(".id"))) { render(UI::ShortId::Component.new(record: @bike)) } %>
+      <%= render(UI::DefinitionList::Row::Component.new(label: translation(".id"))) { render(Atom::ShortId::Component.new(record: @bike)) } %>
       <%= render(UI::DefinitionList::Row::Component.new(label: translation(".registered_since"))) { render(UI::Time::Component.new(time: @bike.created_at)) } %>
     <% end %>
   </div>

--- a/app/components/registrations/show/consumer/component.html.erb
+++ b/app/components/registrations/show/consumer/component.html.erb
@@ -4,8 +4,6 @@
     tw:gap-6 tw:px-2 tw:min-[992px]:-mt-[60px]
   "
 >
-  <%= render(Registrations::Show::ScannedSticker::Component.new(bike: @bike, bike_sticker: @bike_sticker, current_user: @current_user)) %>
-
   <div class="tw:grid tw:gap-6 tw:lg:grid-cols-3">
     <div class="tw:lg:col-span-2">
       <div
@@ -42,6 +40,8 @@
 
         <%= render(Registrations::Show::Status::Component.new(bike: @bike)) %>
       </div>
+
+      <%= render(Registrations::Show::ScannedSticker::Component.new(bike: @bike, bike_sticker: @bike_sticker, current_user: @current_user)) %>
 
       <%= render(Registrations::Show::BikeIndexCard::Component.new(bike: @bike, term: :right_align)) %>
 

--- a/app/components/registrations/show/consumer/component.html.erb
+++ b/app/components/registrations/show/consumer/component.html.erb
@@ -4,6 +4,8 @@
     tw:gap-6 tw:px-2 tw:min-[992px]:-mt-[60px]
   "
 >
+  <%= render(Registrations::Show::ScannedSticker::Component.new(bike: @bike, bike_sticker: @bike_sticker, current_user: @current_user)) %>
+
   <div class="tw:grid tw:gap-6 tw:lg:grid-cols-3">
     <div class="tw:lg:col-span-2">
       <div

--- a/app/components/registrations/show/consumer/component.rb
+++ b/app/components/registrations/show/consumer/component.rb
@@ -8,11 +8,12 @@ module Registrations
 
         # owner: overrides the computed ownership so the wrapper can force the
         # public or owner perspective (view_as)
-        def initialize(bike:, current_user:, show_for_sale: false, owner: nil, available_views: [])
+        def initialize(bike:, current_user:, show_for_sale: false, owner: nil, available_views: [], bike_sticker: nil)
           @bike = bike
           @current_user = current_user
           @show_for_sale = show_for_sale
           @available_views = available_views
+          @bike_sticker = bike_sticker
           @owner = owner.nil? ? (@current_user.present? && @bike.owner == @current_user) : owner
         end
 

--- a/app/components/registrations/show/org_admin/component.html.erb
+++ b/app/components/registrations/show/org_admin/component.html.erb
@@ -4,8 +4,6 @@
     tw:px-2
   "
 >
-  <%= render(Registrations::Show::ScannedSticker::Component.new(bike: @bike, bike_sticker: @bike_sticker, current_user: @current_user)) %>
-
   <div class="tw:flex tw:flex-wrap tw:items-start tw:justify-between tw:gap-4">
     <div>
       <div class="tw:mb-2 tw:flex tw:flex-wrap tw:items-center tw:gap-2">
@@ -27,6 +25,8 @@
       </div>
     </div>
   </div>
+
+  <%= render(Registrations::Show::ScannedSticker::Component.new(bike: @bike, bike_sticker: @bike_sticker, current_user: @current_user)) %>
 
   <%= render(Registrations::Show::OrgTopActions::Wrapper::Component.new(bike: @bike, organization: @organization, org_role: @org_role)) %>
 

--- a/app/components/registrations/show/org_admin/component.html.erb
+++ b/app/components/registrations/show/org_admin/component.html.erb
@@ -4,6 +4,8 @@
     tw:px-2
   "
 >
+  <%= render(Registrations::Show::ScannedSticker::Component.new(bike: @bike, bike_sticker: @bike_sticker, current_user: @current_user)) %>
+
   <div class="tw:flex tw:flex-wrap tw:items-start tw:justify-between tw:gap-4">
     <div>
       <div class="tw:mb-2 tw:flex tw:flex-wrap tw:items-center tw:gap-2">

--- a/app/components/registrations/show/org_admin/component.rb
+++ b/app/components/registrations/show/org_admin/component.rb
@@ -114,9 +114,11 @@ module Registrations
 
         # Org-owned stickers link to their edit page; others show the code as text
         def sticker_link(bike_sticker)
-          return bike_sticker.pretty_code unless bike_sticker.organization_id == @organization.id
+          url = if bike_sticker.organization_id == @organization.id
+            edit_organization_sticker_path(id: bike_sticker.code, organization_id: @organization.to_param)
+          end
 
-          link_to(bike_sticker.pretty_code, edit_organization_sticker_path(id: bike_sticker.code, organization_id: @organization.to_param), class: "twlink")
+          render(Atom::Sticker::Component.new(bike_sticker:, url:))
         end
 
         def model_audit

--- a/app/components/registrations/show/org_admin/component.rb
+++ b/app/components/registrations/show/org_admin/component.rb
@@ -12,11 +12,12 @@ module Registrations
 
         # org_role is the role this panel renders as - a superadmin can view any
         # organization as :staff or as :limited (view_as)
-        def initialize(bike:, current_user:, organization:, org_role:, available_views: [])
+        def initialize(bike:, current_user:, organization:, org_role:, available_views: [], bike_sticker: nil)
           @bike = bike
           @current_user = current_user
           @organization = organization
           @available_views = available_views
+          @bike_sticker = bike_sticker
           @org_role = org_role
         end
 

--- a/app/components/registrations/show/scanned_sticker/component.en.yml
+++ b/app/components/registrations/show/scanned_sticker/component.en.yml
@@ -1,0 +1,14 @@
+---
+en:
+  components:
+    registrations:
+      show:
+        scanned_sticker:
+          change_the_bike_sticker_linked_to: Change the bike it links to
+          is_this_linked_to_incorrect_bike: Is this sticker linked to the incorrect
+            bike?
+          switch_to_new_bike_id: Switch to a new bike ID
+          update: Update
+          you_scanned_this_sticker_html: >-
+            You scanned the sticker <strong>%{pretty_code}</strong>, which is assigned
+            to this %{bike_type}.

--- a/app/components/registrations/show/scanned_sticker/component.en.yml
+++ b/app/components/registrations/show/scanned_sticker/component.en.yml
@@ -4,10 +4,10 @@ en:
     registrations:
       show:
         scanned_sticker:
-          change_the_bike_sticker_linked_to: Change the bike it links to
+          change_the_bike_sticker_linked_to: Change the %{bike_type} it links to
           is_this_linked_to_incorrect_bike: Is this sticker linked to the incorrect
-            bike?
-          switch_to_new_bike_id: Switch to a new bike ID
+            %{bike_type}?
+          switch_to_new_bike_id: Switch to a new %{bike_type} ID
           update: Update
           you_scanned_this_sticker_html: >-
             You scanned the sticker <strong>%{pretty_code}</strong>, which is assigned

--- a/app/components/registrations/show/scanned_sticker/component.en.yml
+++ b/app/components/registrations/show/scanned_sticker/component.en.yml
@@ -9,6 +9,5 @@ en:
             %{bike_type}?
           switch_to_new_bike_id: Switch to a new %{bike_type} ID
           update: Update
-          you_scanned_this_sticker_html: >-
-            You scanned <strong>%{pretty_code}</strong>, which is assigned to this
-            %{bike_type}.
+          you_scanned_this_sticker_html: You scanned %{sticker}, which is assigned
+            to this %{bike_type}.

--- a/app/components/registrations/show/scanned_sticker/component.en.yml
+++ b/app/components/registrations/show/scanned_sticker/component.en.yml
@@ -10,5 +10,5 @@ en:
           switch_to_new_bike_id: Switch to a new %{bike_type} ID
           update: Update
           you_scanned_this_sticker_html: >-
-            You scanned the sticker <strong>%{pretty_code}</strong>, which is assigned
-            to this %{bike_type}.
+            You scanned <strong>%{pretty_code}</strong>, which is assigned to this
+            %{bike_type}.

--- a/app/components/registrations/show/scanned_sticker/component.html.erb
+++ b/app/components/registrations/show/scanned_sticker/component.html.erb
@@ -1,6 +1,6 @@
 <%= render(UI::Alert::Component.new(kind: :success, margin_classes: "", icon: qr_icon)) do %>
   <p>
-    <%= translation(".you_scanned_this_sticker_html", pretty_code: @bike_sticker.pretty_code, bike_type: @bike.type) %>
+    <%= translation(".you_scanned_this_sticker_html", sticker: render(Atom::Sticker::Component.new(bike_sticker: @bike_sticker)), bike_type: @bike.type) %>
   </p>
 
   <% if relinkable? %>

--- a/app/components/registrations/show/scanned_sticker/component.html.erb
+++ b/app/components/registrations/show/scanned_sticker/component.html.erb
@@ -1,0 +1,29 @@
+<%= render(UI::Alert::Component.new(kind: :success, margin_classes: "")) do %>
+  <p>
+    <%= translation(".you_scanned_this_sticker_html", pretty_code: @bike_sticker.pretty_code, bike_type: @bike.type) %>
+  </p>
+
+  <% if relinkable? %>
+    <div data-controller="collapse" class="tw:mt-2 tw:text-sm">
+      <%= translation(".is_this_linked_to_incorrect_bike") %>
+
+      <%= render(UI::Button::Component.new(
+        text: translation(".change_the_bike_sticker_linked_to"),
+        color: :link,
+        aria: {expanded: false},
+        data: {"collapse-target": "trigger", action: "collapse#toggle"}
+      )) %>
+
+      <div data-collapse-target="content" class="tw:hidden">
+        <%= form_with(url: update_sticker_path, method: :put, class: "tw:mt-3 tw:max-w-lg", data: {controller: "csrf-refresh"}) do |form| %>
+          <%= form.label :bike_id, translation(".switch_to_new_bike_id"), class: "twlabel" %>
+          <%= form.text_field :bike_id, placeholder: bike_url(@bike), class: "twinput tw:w-full" %>
+
+          <div class="tw:mt-2">
+            <%= render(UI::Button::Component.new(text: translation(".update"), color: :purple, kind: :submit)) %>
+          </div>
+        <% end %>
+      </div>
+    </div>
+  <% end %>
+<% end %>

--- a/app/components/registrations/show/scanned_sticker/component.html.erb
+++ b/app/components/registrations/show/scanned_sticker/component.html.erb
@@ -17,7 +17,7 @@
       <div data-collapse-target="content" class="tw:hidden">
         <%= form_with(url: update_sticker_path, method: :put, class: "tw:mt-3 tw:max-w-lg", data: {controller: "csrf-refresh"}) do |form| %>
           <%= form.label :bike_id, translation(".switch_to_new_bike_id"), class: "twlabel" %>
-          <%= form.text_field :bike_id, placeholder: bike_url(@bike), class: "twinput tw:w-full" %>
+          <%= form.text_field :bike_id, placeholder: bike_url(1234), class: "twinput tw:w-full" %>
 
           <div class="tw:mt-2">
             <%= render(UI::Button::Component.new(text: translation(".update"), color: :purple, kind: :submit)) %>

--- a/app/components/registrations/show/scanned_sticker/component.html.erb
+++ b/app/components/registrations/show/scanned_sticker/component.html.erb
@@ -5,10 +5,10 @@
 
   <% if relinkable? %>
     <div data-controller="collapse" class="tw:mt-2 tw:text-sm">
-      <%= translation(".is_this_linked_to_incorrect_bike") %>
+      <%= translation(".is_this_linked_to_incorrect_bike", bike_type: @bike.type) %>
 
       <%= render(UI::Button::Component.new(
-        text: translation(".change_the_bike_sticker_linked_to"),
+        text: translation(".change_the_bike_sticker_linked_to", bike_type: @bike.type),
         color: :link,
         aria: {expanded: false},
         data: {"collapse-target": "trigger", action: "collapse#toggle"}
@@ -16,7 +16,7 @@
 
       <div data-collapse-target="content" class="tw:hidden">
         <%= form_with(url: update_sticker_path, method: :put, class: "tw:mt-3 tw:max-w-lg", data: {controller: "csrf-refresh"}) do |form| %>
-          <%= form.label :bike_id, translation(".switch_to_new_bike_id"), class: "twlabel" %>
+          <%= form.label :bike_id, translation(".switch_to_new_bike_id", bike_type: @bike.type), class: "twlabel" %>
           <%= form.text_field :bike_id, placeholder: bike_url(1234), class: "twinput tw:w-full" %>
 
           <div class="tw:mt-2">

--- a/app/components/registrations/show/scanned_sticker/component.html.erb
+++ b/app/components/registrations/show/scanned_sticker/component.html.erb
@@ -1,4 +1,4 @@
-<%= render(UI::Alert::Component.new(kind: :success, margin_classes: "")) do %>
+<%= render(UI::Alert::Component.new(kind: :success, margin_classes: "", icon: qr_icon)) do %>
   <p>
     <%= translation(".you_scanned_this_sticker_html", pretty_code: @bike_sticker.pretty_code, bike_type: @bike.type) %>
   </p>

--- a/app/components/registrations/show/scanned_sticker/component.rb
+++ b/app/components/registrations/show/scanned_sticker/component.rb
@@ -25,6 +25,10 @@ module Registrations
         def update_sticker_path
           bike_sticker_path(id: @bike_sticker.code, organization_id: @bike_sticker.organization_id)
         end
+
+        def qr_icon
+          helpers.inline_svg_tag("icons/qr-code.svg", class: "tw:h-4 tw:w-4", aria_hidden: true)
+        end
       end
     end
   end

--- a/app/components/registrations/show/scanned_sticker/component.rb
+++ b/app/components/registrations/show/scanned_sticker/component.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+module Registrations
+  module Show
+    module ScannedSticker
+      # Shown when the viewer arrived by scanning a sticker (?scanned_id), with a
+      # re-link form for viewers who are allowed to reassign the sticker
+      class Component < ApplicationComponent
+        def initialize(bike:, bike_sticker: nil, current_user: nil)
+          @bike = bike
+          @bike_sticker = bike_sticker
+          @current_user = current_user
+        end
+
+        def render?
+          @bike_sticker.present?
+        end
+
+        private
+
+        def relinkable?
+          @current_user&.authorized?(@bike_sticker)
+        end
+
+        def update_sticker_path
+          bike_sticker_path(id: @bike_sticker.code, organization_id: @bike_sticker.organization_id)
+        end
+      end
+    end
+  end
+end

--- a/app/components/registrations/show/wrapper/component.rb
+++ b/app/components/registrations/show/wrapper/component.rb
@@ -6,11 +6,12 @@ module Registrations
       # Renders the registration show page as the resolved [kind, organization]
       # perspective (e.g. [:public, nil] or [:staff, org]) and fragment-caches it.
       class Component < ApplicationComponent
-        def initialize(bike:, current_user:, view:, available_views:)
+        def initialize(bike:, current_user:, view:, available_views:, bike_sticker: nil)
           @bike = bike
           @current_user = current_user
           @view = view
           @available_views = available_views
+          @bike_sticker = bike_sticker
         end
 
         def call
@@ -26,10 +27,10 @@ module Registrations
             kind, organization = @view
             if organization
               OrgAdmin::Component.new(bike: @bike, current_user: @current_user, organization:,
-                org_role: kind, available_views: @available_views)
+                org_role: kind, available_views: @available_views, bike_sticker: @bike_sticker)
             else
               Consumer::Component.new(bike: @bike, current_user: @current_user, owner: kind == :owner,
-                show_for_sale: @bike.is_for_sale?, available_views: @available_views)
+                show_for_sale: @bike.is_for_sale?, available_views: @available_views, bike_sticker: @bike_sticker)
             end
           end
         end
@@ -41,11 +42,11 @@ module Registrations
         # forms' CSRF tokens valid (they're session-scoped, and a user's session
         # varies across devices/logins) — the csrf-refresh controller reissues them
         # client-side from the meta tag. Nothing digests the nested components'
-        # templates, so bump the -v2 suffix whenever their markup changes.
+        # templates, so bump the -v3 suffix whenever their markup changes.
         def cache_key
-          ["registrations/show-v2", @current_user&.id,
+          ["registrations/show-v3", @current_user&.id,
             @current_user&.registration_show_toggleable?, @current_user&.feature_registration_show_legacy?,
-            BikeServices::ShowViews.view_param(@view),
+            BikeServices::ShowViews.view_param(@view), @bike_sticker&.id,
             @bike.cache_key_with_version, *inner_component.try(:cache_version)]
         end
       end

--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -16,8 +16,11 @@ class RegistrationsController < ApplicationController
     # So the view_as organization sticks on the next request
     set_passive_organization(view.last) if view.last
 
+    bike_sticker = BikeSticker.lookup_with_fallback(params[:scanned_id],
+      organization_id: params[:organization_id], user: current_user)
+
     render(Registrations::Show::Wrapper::Component.new(bike: @bike, current_user:, view:,
-      available_views:), layout: "application")
+      available_views:, bike_sticker:), layout: "application")
   end
 
   # The redesign has no edit view of its own; edit still lives on the bike

--- a/app/javascript/controllers/collapse_controller.js
+++ b/app/javascript/controllers/collapse_controller.js
@@ -4,7 +4,8 @@ import { collapse } from 'utils/collapse_utils'
 // Connects to data-controller='collapse'
 // Animates [data-collapse-target=content] open/closed. Optionally rotates a
 // [data-collapse-target=chevron] and keeps [data-collapse-target=trigger]'s
-// aria-expanded in sync. With data-collapse-param-value set, the open state
+// aria-expanded and data-active (the is-active variant) in sync. With
+// data-collapse-param-value set, the open state
 // persists to the URL query (?param=1) so it survives reloads and navigation.
 export default class extends Controller {
   static targets = ['content', 'chevron', 'trigger']
@@ -39,7 +40,10 @@ export default class extends Controller {
   setExpanded (expanding, duration) {
     collapse(expanding ? 'show' : 'hide', this.contentTargets, duration)
     this.chevronTargets.forEach((chevron) => chevron.classList.toggle('tw:rotate-90', expanding))
-    this.triggerTargets.forEach((trigger) => trigger.setAttribute('aria-expanded', String(expanding)))
+    this.triggerTargets.forEach((trigger) => {
+      trigger.setAttribute('aria-expanded', String(expanding))
+      trigger.dataset.active = String(expanding)
+    })
     this.persist(expanding)
   }
 

--- a/spec/components/atom/serial/component_spec.rb
+++ b/spec/components/atom/serial/component_spec.rb
@@ -2,49 +2,48 @@
 
 require "rails_helper"
 
+# The rendered HTML matches BikeHelper#render_serial_display exactly - this replaces
+# that helper in the redesign, so the assertions mirror spec/helpers/bike_helper_spec
 RSpec.describe Atom::Serial::Component, type: :component do
   let(:instance) { described_class.new(bike:, **options) }
   let(:component) { render_inline(instance) }
   let(:options) { {} }
   let(:bike) { FactoryBot.create(:bike, serial_number: "FFF333") }
 
-  it "renders the serial in a monospace code block" do
-    expect(component).to have_css("code", text: "FFF333")
-    expect(component.to_html).to include("tw:font-mono")
+  it "renders the serial" do
+    expect(component.to_html.strip).to eq '<span class="serial-span">FFF333</span>'
   end
 
   context "serial unknown" do
     let(:bike) { FactoryBot.create(:bike, serial_number: "unknown") }
 
-    it "renders the word rather than a code block" do
-      expect(component).to have_css("span", text: "unknown")
-      expect(component).to have_no_css("code")
+    it "renders the word rather than the number" do
+      expect(component.to_html.strip).to eq '<span class="less-strong">unknown</span>'
     end
   end
 
   context "made without serial" do
     let(:bike) { FactoryBot.create(:bike, made_without_serial: true) }
 
-    it "renders the made-without-serial text" do
-      expect(component).to have_text("made without serial")
+    it "renders made without serial" do
+      expect(component.to_html.strip).to eq '<span class="less-strong">made without serial</span>'
     end
   end
 
   context "hidden serial" do
+    let(:bike) { FactoryBot.create(:bike, serial_number: "FFF333", cycle_type: :tandem) }
     before { bike.status = "status_impounded" }
 
     it "hides the serial and explains why" do
-      expect(component).to have_no_text("FFF333")
-      expect(component).to have_text("hidden")
-      expect(component).to have_css("em", text: "because bike is impounded")
+      expect(component.to_html.strip)
+        .to eq '<span class="less-strong">hidden</span> <em class="small less-less-strong">because tandem is impounded</em>'
     end
 
     context "with skip_explanation" do
       let(:options) { {skip_explanation: true} }
 
       it "hides the serial without the explanation" do
-        expect(component).to have_no_text("FFF333")
-        expect(component).to have_no_css("em")
+        expect(component.to_html.strip).to eq '<span class="less-strong">hidden</span>'
       end
     end
 
@@ -52,9 +51,25 @@ RSpec.describe Atom::Serial::Component, type: :component do
       let(:options) { {user: FactoryBot.create(:superuser)} }
 
       it "shows the serial with the unauthorized-users note" do
-        expect(component).to have_css("code", text: "FFF333")
-        expect(component).to have_css("em", text: "hidden for unauthorized users")
+        expect(component.to_html.strip)
+          .to eq '<span class="serial-span">FFF333</span> <em class="small less-less-strong">hidden for unauthorized users</em>'
       end
+
+      context "with skip_explanation" do
+        let(:options) { {user: FactoryBot.create(:superuser), skip_explanation: true} }
+
+        it "shows the serial alone" do
+          expect(component.to_html.strip).to eq '<span class="serial-span">FFF333</span>'
+        end
+      end
+    end
+  end
+
+  context "no serial" do
+    let(:bike) { Bike.new }
+
+    it "renders nothing" do
+      expect(component.to_html).to be_blank
     end
   end
 end

--- a/spec/components/atom/serial/component_spec.rb
+++ b/spec/components/atom/serial/component_spec.rb
@@ -56,7 +56,7 @@ RSpec.describe Atom::Serial::Component, type: :component do
       end
 
       context "with skip_explanation" do
-        let(:options) { {user: FactoryBot.create(:superuser), skip_explanation: true} }
+        let(:options) { super().merge(skip_explanation: true) }
 
         it "shows the serial alone" do
           expect(component.to_html.strip).to eq '<span class="serial-span">FFF333</span>'

--- a/spec/components/atom/serial/component_spec.rb
+++ b/spec/components/atom/serial/component_spec.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Atom::Serial::Component, type: :component do
+  let(:instance) { described_class.new(bike:, **options) }
+  let(:component) { render_inline(instance) }
+  let(:options) { {} }
+  let(:bike) { FactoryBot.create(:bike, serial_number: "FFF333") }
+
+  it "renders the serial in a monospace code block" do
+    expect(component).to have_css("code", text: "FFF333")
+    expect(component.to_html).to include("tw:font-mono")
+  end
+
+  context "serial unknown" do
+    let(:bike) { FactoryBot.create(:bike, serial_number: "unknown") }
+
+    it "renders the word rather than a code block" do
+      expect(component).to have_css("span", text: "unknown")
+      expect(component).to have_no_css("code")
+    end
+  end
+
+  context "made without serial" do
+    let(:bike) { FactoryBot.create(:bike, made_without_serial: true) }
+
+    it "renders the made-without-serial text" do
+      expect(component).to have_text("made without serial")
+    end
+  end
+
+  context "hidden serial" do
+    before { bike.status = "status_impounded" }
+
+    it "hides the serial and explains why" do
+      expect(component).to have_no_text("FFF333")
+      expect(component).to have_text("hidden")
+      expect(component).to have_css("em", text: "because bike is impounded")
+    end
+
+    context "with skip_explanation" do
+      let(:options) { {skip_explanation: true} }
+
+      it "hides the serial without the explanation" do
+        expect(component).to have_no_text("FFF333")
+        expect(component).to have_no_css("em")
+      end
+    end
+
+    context "for a user who may see it" do
+      let(:options) { {user: FactoryBot.create(:superuser)} }
+
+      it "shows the serial with the unauthorized-users note" do
+        expect(component).to have_css("code", text: "FFF333")
+        expect(component).to have_css("em", text: "hidden for unauthorized users")
+      end
+    end
+  end
+end

--- a/spec/components/atom/short_id/component_spec.rb
+++ b/spec/components/atom/short_id/component_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe UI::ShortId::Component, type: :component do
+RSpec.describe Atom::ShortId::Component, type: :component do
   let(:instance) { described_class.new(**options) }
   let(:component) { render_inline(instance) }
   let(:options) { {short_id: "r/21J-HW"} }

--- a/spec/components/atom/sticker/component_spec.rb
+++ b/spec/components/atom/sticker/component_spec.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Atom::Sticker::Component, type: :component do
+  let(:instance) { described_class.new(**options) }
+  let(:component) { render_inline(instance) }
+  let(:options) { {pretty_code: "BR 000 1"} }
+
+  it "renders the code in a monospace code block" do
+    expect(component).to have_css("code", text: "BR 000 1")
+    expect(component.to_html).to include("tw:font-mono")
+    expect(component).to have_no_css("a")
+  end
+
+  context "with a bike_sticker" do
+    let(:bike_sticker) { FactoryBot.create(:bike_sticker, code: "BR1") }
+    let(:options) { {bike_sticker:} }
+
+    it "renders the sticker's pretty_code" do
+      expect(component).to have_css("code", text: bike_sticker.pretty_code)
+    end
+  end
+
+  context "with a url" do
+    let(:options) { {pretty_code: "BR 000 1", url: "/o/brakebills/stickers/BR1/edit"} }
+
+    it "links the code" do
+      expect(component).to have_css("a[href='/o/brakebills/stickers/BR1/edit'] code", text: "BR 000 1")
+    end
+  end
+
+  context "with a blank code" do
+    let(:options) { {bike_sticker: nil} }
+
+    it "renders nothing" do
+      expect(component.to_html).to be_blank
+    end
+  end
+end

--- a/spec/components/registrations/show/scanned_sticker/component_spec.rb
+++ b/spec/components/registrations/show/scanned_sticker/component_spec.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Registrations::Show::ScannedSticker::Component, type: :component do
+  let(:component) { described_class.new(bike:, bike_sticker:, current_user:) }
+  let(:bike) { FactoryBot.create(:bike, :with_ownership_claimed) }
+  let(:bike_sticker) { FactoryBot.create(:bike_sticker_claimed, bike:, user: bike.owner) }
+  let(:current_user) { bike.owner }
+
+  context "viewer who can't update the sticker" do
+    let(:current_user) { nil }
+
+    it "shows the scanned sticker without the re-link form" do
+      render_inline(component)
+      expect(page).to have_text("You scanned the sticker")
+      expect(page).to have_text(bike_sticker.pretty_code)
+      expect(page).to_not have_button("Change the bike it links to")
+    end
+  end
+
+  context "viewer authorized for the sticker" do
+    it "includes the form to re-link the sticker" do
+      render_inline(component)
+      expect(page).to have_button("Change the bike it links to")
+      expect(page).to have_css("form[action='/bike_stickers/#{bike_sticker.code}'] input[name='bike_id']", visible: :all)
+      expect(page).to have_button("Update")
+    end
+  end
+
+  context "no sticker" do
+    let(:bike_sticker) { nil }
+
+    it "does not render" do
+      render_inline(component)
+      expect(page.native.text).to be_blank
+    end
+  end
+end

--- a/spec/components/registrations/show/scanned_sticker/component_spec.rb
+++ b/spec/components/registrations/show/scanned_sticker/component_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Registrations::Show::ScannedSticker::Component, type: :component 
 
     it "shows the scanned sticker without the re-link form" do
       render_inline(component)
-      expect(page).to have_text("You scanned the sticker")
+      expect(page).to have_text("You scanned")
       expect(page).to have_text(bike_sticker.pretty_code)
       expect(page).to_not have_button("Change the bike it links to")
     end

--- a/spec/components/ui/collapse/component_system_spec.rb
+++ b/spec/components/ui/collapse/component_system_spec.rb
@@ -14,22 +14,22 @@ RSpec.describe "collapse controller", :js, type: :system do
     click_button("Toggle details")
 
     # collapse#show reveals the body, writes ?details=1 via history.replaceState,
-    # and flips the trigger's aria-expanded.
+    # and flips the trigger's aria-expanded and data-active.
     expect(page).to have_content("Persisted panel body")
     expect(page).to have_current_path(/details=1/, url: true)
-    expect(page).to have_css("button[aria-expanded='true']", text: "Toggle details")
+    expect(page).to have_css("button[aria-expanded='true'][data-active='true']", text: "Toggle details")
 
     expect_axe_clean
 
-    # Reloading with the param restores the open state (and aria-expanded) without a click.
+    # Reloading with the param restores the open state (and the trigger's flags) without a click.
     visit "#{preview_path}?details=1"
     expect(page).to have_content("Persisted panel body")
-    expect(page).to have_css("button[aria-expanded='true']", text: "Toggle details")
+    expect(page).to have_css("button[aria-expanded='true'][data-active='true']", text: "Toggle details")
 
     # Collapsing again removes the param.
     click_button("Toggle details")
     expect(page).to have_no_content("Persisted panel body")
     expect(page).not_to have_current_path(/details=1/, url: true)
-    expect(page).to have_css("button[aria-expanded='false']", text: "Toggle details")
+    expect(page).to have_css("button[aria-expanded='false'][data-active='false']", text: "Toggle details")
   end
 end

--- a/spec/requests/registrations/show_request_spec.rb
+++ b/spec/requests/registrations/show_request_spec.rb
@@ -100,12 +100,12 @@ RSpec.describe "RegistrationsController#show", type: :request do
       let!(:bike_sticker) { FactoryBot.create(:bike_sticker_claimed, bike:, user: current_user) }
       it "renders the scanned sticker with the re-link form, only with scanned_id" do
         get "#{base_url}/#{bike.id}"
-        expect(whitespace_normalized_body_text).to_not match("You scanned the sticker")
+        expect(whitespace_normalized_body_text).to_not match("You scanned")
 
         get "#{base_url}/#{bike.id}", params: {scanned_id: bike_sticker.code}
         expect(response.status).to eq(200)
         body = whitespace_normalized_body_text
-        expect(body).to match("You scanned the sticker")
+        expect(body).to match("You scanned")
         expect(body).to match(bike_sticker.pretty_code)
         expect(body).to match("Change the bike it links to")
         expect(response.body).to match(bike_sticker_path(id: bike_sticker.code))

--- a/spec/requests/registrations/show_request_spec.rb
+++ b/spec/requests/registrations/show_request_spec.rb
@@ -95,6 +95,22 @@ RSpec.describe "RegistrationsController#show", type: :request do
         expect(body).to match("3025551234")
       end
     end
+
+    context "arrived by scanning a sticker" do
+      let!(:bike_sticker) { FactoryBot.create(:bike_sticker_claimed, bike:, user: current_user) }
+      it "renders the scanned sticker with the re-link form, only with scanned_id" do
+        get "#{base_url}/#{bike.id}"
+        expect(whitespace_normalized_body_text).to_not match("You scanned the sticker")
+
+        get "#{base_url}/#{bike.id}", params: {scanned_id: bike_sticker.code}
+        expect(response.status).to eq(200)
+        body = whitespace_normalized_body_text
+        expect(body).to match("You scanned the sticker")
+        expect(body).to match(bike_sticker.pretty_code)
+        expect(body).to match("Change the bike it links to")
+        expect(response.body).to match(bike_sticker_path(id: bike_sticker.code))
+      end
+    end
   end
 
   context "anonymous viewer of an ownerless bike" do


### PR DESCRIPTION
The redesigned registration show components never read `scanned_id`, so arriving from a sticker scan lost the "you scanned this sticker" block that `bikes/show` has had. `Registrations::Show::ScannedSticker::Component` ports it: the alert naming the code, plus the collapsed re-link form for viewers `authorized?` for the sticker.

- `RegistrationsController#show` resolves `?scanned_id` with `BikeSticker.lookup_with_fallback`, matching `BikesController#show`. It returns nil on blank input before touching the database, so unscanned page loads cost nothing and need no `present?` guard.
- The banner renders inside `Consumer` and `OrgAdmin` rather than above them in `Wrapper` — `Consumer`'s container carries a negative top margin that would overlap anything emitted before it. That puts it inside the fragment cache, so the sticker id joins the cache key.
- New `Atom::` namespace for the small value-rendering components: `Atom::Sticker`, `Atom::Serial` (its own translations and markup, byte-identical to `BikeHelper#render_serial_display` so the two can diverge later), and `UI::ShortId` moved across.
- `collapse#toggle` syncs `data-active` alongside `aria-expanded`, so a `UI::Button` trigger keeps its `is-active` styling while the panel is open.
