### PR TITLE
UI::Forms::Combobox renders no label - wrap it in UI::Forms::Group

### DIFF
--- a/.claude/skills/frontend-conventions/SKILL.md
+++ b/.claude/skills/frontend-conventions/SKILL.md
@@ -54,6 +54,10 @@ The same instinct applies beyond buttons: **check `app/components/ui/` before ha
 
 **Every `UI::Tooltip` uses the default `?` button trigger** unless the user explicitly says otherwise — never pass a label as the tooltip's trigger content. See `app/components/ui/tooltip/`.
 
+## Form fields: the label comes from `UI::Forms::Group`
+
+**A `UI::Forms::*` field renders no label of its own** — wrap it in a `UI::Forms::Group` with `kind: :content_block`, passing `form_builder:` when there is one. Holds for `Combobox`, `Select`, and `TextEditor`. See `app/components/ui/forms/group/component_preview/` and `app/components/ui/forms/combobox/component_preview/`.
+
 ## Typeaheads: always `UI::Forms::Combobox`
 
 **Every typeahead / autocomplete / combobox goes through `UI::Forms::Combobox::Component`** — never a new Stimulus controller that fetches matches and renders its own menu. See `app/components/ui/forms/combobox/` (component + `component_preview.rb`) and `spec/components/ui/forms/combobox` for how to invoke it.

--- a/.claude/skills/frontend-conventions/SKILL.md
+++ b/.claude/skills/frontend-conventions/SKILL.md
@@ -56,7 +56,7 @@ The same instinct applies beyond buttons: **check `app/components/ui/` before ha
 
 ## Form fields: the label comes from `UI::Forms::Group`
 
-**A `UI::Forms::*` field renders no label of its own** — wrap it in a `UI::Forms::Group` with `kind: :content_block`, passing `form_builder:` when there is one. Holds for `Combobox`, `Select`, and `TextEditor`. See `app/components/ui/forms/group/component_preview/` and `app/components/ui/forms/combobox/component_preview/`.
+**A `UI::Forms::*` field renders no label of its own** — wrap it in a `UI::Forms::Group` with `kind: :content_block`, passing `form_builder:` when there is one. Holds for `Combobox`, `Select`, and `TextEditor`. A visually hidden label is the exception — `Group`'s label always carries a required/optional suffix, so use a bare `label_tag` with `twlabel tw:sr-only`, the way `Search::Form` does. See `app/components/ui/forms/group/component_preview/` and `app/components/ui/forms/combobox/component_preview/`.
 
 ## Typeaheads: always `UI::Forms::Combobox`
 

--- a/.claude/skills/frontend-conventions/SKILL.md
+++ b/.claude/skills/frontend-conventions/SKILL.md
@@ -56,7 +56,7 @@ The same instinct applies beyond buttons: **check `app/components/ui/` before ha
 
 ## Form fields: the label comes from `UI::Forms::Group`
 
-**A `UI::Forms::*` field renders no label of its own** — wrap it in a `UI::Forms::Group` with `kind: :content_block`, passing `form_builder:` when there is one. Holds for `Combobox`, `Select`, and `TextEditor`. A visually hidden label is the exception — `Group`'s label always carries a required/optional suffix, so use a bare `label_tag` with `twlabel tw:sr-only`, the way `Search::Form` does. See `app/components/ui/forms/group/component_preview/` and `app/components/ui/forms/combobox/component_preview/`.
+**A `UI::Forms::*` field renders no label of its own** — render it inside a `UI::Forms::Group` block, passing `form_builder:` when there is one. Holds for `Combobox`, `Select`, and `TextEditor`. A visually hidden label is the exception — `Group`'s label always carries a required/optional suffix, so use a bare `label_tag` with `twlabel tw:sr-only`, the way `Search::Form` does. See `app/components/ui/forms/group/component_preview/` and `app/components/ui/forms/combobox/component_preview/`.
 
 ## Typeaheads: always `UI::Forms::Combobox`
 

--- a/app/components/org/search/form/component.html.erb
+++ b/app/components/org/search/form/component.html.erb
@@ -56,7 +56,7 @@
       </div>
 
       <div class="tw:w-20">
-        <%= render UI::Button::Component.new(color: :primary, kind: :submit, html_class: "tw:w-full tw:h-full tw:justify-center#{" tw:disabled:cursor-wait" if turbo?}") do %>
+        <%= render UI::Button::Component.new(color: :primary, kind: :submit, html_class: "tw:w-full tw:h-full#{" tw:disabled:cursor-wait" if turbo?}") do %>
           <%= helpers.inline_svg_tag "icons/searcher.svg",
           id: "search-button",
           class: "tw:text-white",

--- a/app/components/registrations/show/consumer/component.html.erb
+++ b/app/components/registrations/show/consumer/component.html.erb
@@ -47,11 +47,11 @@
         <% if @owner %>
           <%= edit_bike_button %>
           <% if show_marketplace_button? %>
-            <%= render(UI::ButtonLink::Component.new(href: edit_bike_path(@bike, edit_template: "marketplace"), text: translation(".sell_on_marketplace"), color: :primary, size: :lg, class: "tw:justify-center tw:text-center tw:py-2.5!")) %>
+            <%= render(UI::ButtonLink::Component.new(href: edit_bike_path(@bike, edit_template: "marketplace"), text: translation(".sell_on_marketplace"), color: :primary, size: :lg, class: "tw:text-center tw:py-2.5!")) %>
           <% end %>
           <%= render(Registrations::Show::Share::Component.new(text: translation(".share_my_page"), url: bike_url(@bike))) %>
           <% if @bike.status_with_owner? %>
-            <%= render(UI::ButtonLink::Component.new(href: edit_bike_path(@bike, edit_template: "report_stolen"), text: translation(".mark_stolen"), color: :danger_outline, class: "tw:justify-center tw:text-center tw:py-2.5!")) %>
+            <%= render(UI::ButtonLink::Component.new(href: edit_bike_path(@bike, edit_template: "report_stolen"), text: translation(".mark_stolen"), color: :danger_outline, class: "tw:text-center tw:py-2.5!")) %>
           <% end %>
         <% else %>
           <%= render(Registrations::Show::Share::Component.new(text: translation(".share"), url: bike_url(@bike))) %>

--- a/app/components/registrations/show/consumer/component.rb
+++ b/app/components/registrations/show/consumer/component.rb
@@ -51,7 +51,7 @@ module Registrations
         # Half-width next to "Sell on Marketplace" when it shows, full-width otherwise
         def edit_bike_button
           render(UI::ButtonLink::Component.new(href: edit_bike_path(@bike, edit_template: @bike.default_edit_template),
-            text: translation(".edit_this_bike", bike_type: @bike.type), color: :purple, size: :lg, class: "tw:justify-center tw:text-center tw:py-2.5!"))
+            text: translation(".edit_this_bike", bike_type: @bike.type), color: :purple, size: :lg, class: "tw:text-center tw:py-2.5!"))
         end
       end
     end

--- a/app/components/registrations/show/share/component.rb
+++ b/app/components/registrations/show/share/component.rb
@@ -12,7 +12,7 @@ module Registrations
 
         def call
           render UI::Button::Component.new(color: :secondary, size: :md,
-            html_class: "tw:w-full tw:justify-center tw:py-2.5!",
+            html_class: "tw:w-full tw:py-2.5!",
             data: {controller: "registrations--show--share",
                    "registrations--show--share-url-value": @url,
                    action: "registrations--show--share#share"}) do

--- a/app/components/search/form/component.html.erb
+++ b/app/components/search/form/component.html.erb
@@ -37,15 +37,16 @@
           >
             <% if render_primary_activity_field? %>
               <div class="tw:w-full tw:md:max-w-xl">
+                <%= label_tag :primary_activity,
+                translation(".search_for_primary_activity"),
+                class: "twlabel tw:sr-only" %>
+
                 <%= render(::UI::Forms::Combobox::Component.new(
                   name: :primary_activity,
-                  id: "primary_activity",
                   options: primary_activity_combobox_options,
                   value: @interpreted_params[:primary_activity],
                   include_blank: true,
                   placeholder: translation(".search_for_primary_activity"),
-                  label: translation(".search_for_primary_activity"),
-                  label_class: "tw:sr-only",
                 )) %>
               </div>
             <% end %>

--- a/app/components/search/form/component.html.erb
+++ b/app/components/search/form/component.html.erb
@@ -47,6 +47,7 @@
                   value: @interpreted_params[:primary_activity],
                   include_blank: true,
                   placeholder: translation(".search_for_primary_activity"),
+                  dialog_label: translation(".search_for_primary_activity"),
                 )) %>
               </div>
             <% end %>

--- a/app/components/search/form/component.html.erb
+++ b/app/components/search/form/component.html.erb
@@ -37,17 +37,15 @@
           >
             <% if render_primary_activity_field? %>
               <div class="tw:w-full tw:md:max-w-xl">
-                <%= label_tag :primary_activity,
-                translation(".search_for_primary_activity"),
-                class: "twlabel tw:sr-only" %>
+                <%= label_tag :primary_activity, primary_activity_label, class: "twlabel tw:sr-only" %>
 
                 <%= render(::UI::Forms::Combobox::Component.new(
                   name: :primary_activity,
                   options: primary_activity_combobox_options,
                   value: @interpreted_params[:primary_activity],
                   include_blank: true,
-                  placeholder: translation(".search_for_primary_activity"),
-                  dialog_label: translation(".search_for_primary_activity"),
+                  placeholder: primary_activity_label,
+                  dialog_label: primary_activity_label,
                 )) %>
               </div>
             <% end %>

--- a/app/components/search/form/component.html.erb
+++ b/app/components/search/form/component.html.erb
@@ -88,7 +88,7 @@
       </div>
 
       <div class="tw:w-20">
-        <%= render UI::Button::Component.new(color: :primary, kind: :submit, html_class: "tw:w-full tw:h-full tw:justify-center tw:disabled:cursor-wait") do %>
+        <%= render UI::Button::Component.new(color: :primary, kind: :submit, html_class: "tw:w-full tw:h-full tw:disabled:cursor-wait") do %>
           <%= helpers.inline_svg_tag "icons/searcher.svg",
             id: "search-button",
             class: "tw:text-white",

--- a/app/components/search/form/component.rb
+++ b/app/components/search/form/component.rb
@@ -80,6 +80,11 @@ module Search
       def primary_activity_combobox_options
         PrimaryActivity.by_priority.map { |pa| {display: pa.display_name_search, value: pa.id} }
       end
+
+      # Doubles as the visually hidden label, the placeholder and the mobile dialog's label
+      def primary_activity_label
+        translation(".search_for_primary_activity")
+      end
     end
   end
 end

--- a/app/components/ui/button/component.rb
+++ b/app/components/ui/button/component.rb
@@ -6,7 +6,7 @@ module UI
     # submits a request to a URL (button_to), use UI::ButtonLink instead — it reuses
     # this component's build_classes, so the two stay visually in lockstep.
     class Component < ApplicationComponent
-      BASE_CLASSES = "tw:inline-flex tw:items-center tw:gap-1.5 tw:rounded-lg tw:cursor-pointer tw:transition-colors"
+      BASE_CLASSES = "tw:inline-flex tw:items-center tw:justify-center tw:gap-1.5 tw:rounded-lg tw:cursor-pointer tw:transition-colors"
 
       SIZES = {
         sm: "tw:px-2.5 tw:py-1 tw:text-xs",

--- a/app/components/ui/forms/address_group/component.html.erb
+++ b/app/components/ui/forms/address_group/component.html.erb
@@ -11,7 +11,7 @@
       data-ui--forms--address-group-target="state"
       class="<%= state_hidden_class %>"
     >
-      <%= render(UI::Forms::Group::Component.new(form_builder: @form, attribute: :region_record_id, kind: :content_block, label_text: translation(".state"))) do %>
+      <%= render(UI::Forms::Group::Component.new(form_builder: @form, attribute: :region_record_id, label_text: translation(".state"))) do %>
         <%= @form.collection_select(:region_record_id, State.united_states, :id, :name, {include_blank: true}, {class: "twinput tw:w-full"}) %>
       <% end %>
     </div>
@@ -27,7 +27,7 @@
   <div class="tw:grid tw:grid-cols-2 tw:gap-x-2">
     <%= render(UI::Forms::Group::Component.new(form_builder: @form, attribute: :postal_code, kind: :text_field, label_text: translation(".postal_code"))) %>
 
-    <%= render(UI::Forms::Group::Component.new(form_builder: @form, attribute: :country_id, kind: :content_block, label_text: translation(".country"))) do %>
+    <%= render(UI::Forms::Group::Component.new(form_builder: @form, attribute: :country_id, label_text: translation(".country"))) do %>
       <%= @form.select(:country_id, Country.select_options, {prompt: translation(".choose_country"), selected: selected_country_id}, {class: "twinput tw:w-full", data: {action: "change->ui--forms--address-group#toggleCountry", "ui--forms--address-group-target": "country"}}) %>
     <% end %>
   </div>

--- a/app/components/ui/forms/combobox/component.rb
+++ b/app/components/ui/forms/combobox/component.rb
@@ -10,8 +10,7 @@ module UI
       #   - hashes:  [{display: "Trek", value: "1"}, ...]
       #   - records: any object with a public #to_combobox_display method
       #
-      # It renders no label -- wrap it in a UI::Forms::Group (kind: :content_block)
-      # to get one.
+      # It renders no label -- wrap it in a UI::Forms::Group block to get one.
       #
       # Any other keyword (id:, value:, open:, free_text:, autocomplete:,
       # placeholder:, etc.) is forwarded to `hw_combobox_tag`.

--- a/app/components/ui/forms/combobox/component.rb
+++ b/app/components/ui/forms/combobox/component.rb
@@ -11,8 +11,7 @@ module UI
       #   - records: any object with a public #to_combobox_display method
       #
       # It renders no label -- wrap it in a UI::Forms::Group (kind: :content_block)
-      # to get one. Pass `dialog_label:` when the Group's label isn't the humanized
-      # name, since the mobile dialog covers the page.
+      # to get one.
       #
       # Any other keyword (id:, value:, open:, free_text:, autocomplete:,
       # placeholder:, etc.) is forwarded to `hw_combobox_tag`.
@@ -30,10 +29,11 @@ module UI
         private
 
         # id: without a form builder the gem ids the input with a uuid, which a Group
-        # label's `for` can't target. dialog_label: names the input inside the full
-        # screen dialog the gem opens on mobile, which hides the Group's label.
+        # label's `for` can't target. dialog_label: names the input in the full screen
+        # dialog the gem opens on mobile, which hides the Group's label -- pass it
+        # explicitly when that label isn't the humanized name.
         def defaults
-          {dialog_label: @name.to_s.humanize, **(@combobox_options[:form] ? {} : {id: @name})}
+          {dialog_label: @name.to_s.humanize, id: (@name unless @combobox_options[:form])}.compact
         end
       end
     end

--- a/app/components/ui/forms/combobox/component.rb
+++ b/app/components/ui/forms/combobox/component.rb
@@ -11,7 +11,8 @@ module UI
       #   - records: any object with a public #to_combobox_display method
       #
       # It renders no label -- wrap it in a UI::Forms::Group (kind: :content_block)
-      # to get one.
+      # to get one. Pass `dialog_label:` when the Group's label isn't the humanized
+      # name, since the mobile dialog covers the page.
       #
       # Any other keyword (id:, value:, open:, free_text:, autocomplete:,
       # placeholder:, etc.) is forwarded to `hw_combobox_tag`.
@@ -23,15 +24,16 @@ module UI
         end
 
         def call
-          helpers.hw_combobox_tag(@name, @options_or_src, **default_id, **@combobox_options)
+          helpers.hw_combobox_tag(@name, @options_or_src, **defaults, **@combobox_options)
         end
 
         private
 
-        # Without a form builder the gem ids the input with a uuid, which a Group
-        # label's `for` can't target -- fall back to the name.
-        def default_id
-          @combobox_options[:form] ? {} : {id: @name}
+        # id: without a form builder the gem ids the input with a uuid, which a Group
+        # label's `for` can't target. dialog_label: names the input inside the full
+        # screen dialog the gem opens on mobile, which hides the Group's label.
+        def defaults
+          {dialog_label: @name.to_s.humanize, **(@combobox_options[:form] ? {} : {id: @name})}
         end
       end
     end

--- a/app/components/ui/forms/combobox/component.rb
+++ b/app/components/ui/forms/combobox/component.rb
@@ -10,20 +10,28 @@ module UI
       #   - hashes:  [{display: "Trek", value: "1"}, ...]
       #   - records: any object with a public #to_combobox_display method
       #
-      # Any other keyword (label:, id:, value:, open:, free_text:, autocomplete:,
+      # It renders no label -- wrap it in a UI::Forms::Group (kind: :content_block)
+      # to get one.
+      #
+      # Any other keyword (id:, value:, open:, free_text:, autocomplete:,
       # placeholder:, etc.) is forwarded to `hw_combobox_tag`.
       class Component < ApplicationComponent
-        def initialize(name:, options: [], src: nil, label_class: nil, **combobox_options)
+        def initialize(name:, options: [], src: nil, **combobox_options)
           @name = name
           @options_or_src = src || options
-          @label_class = label_class
           @combobox_options = combobox_options
         end
 
         def call
-          helpers.hw_combobox_tag(@name, @options_or_src, **@combobox_options) do |combobox|
-            combobox.customize_label(class: @label_class) if @label_class
-          end
+          helpers.hw_combobox_tag(@name, @options_or_src, **default_id, **@combobox_options)
+        end
+
+        private
+
+        # Without a form builder the gem ids the input with a uuid, which a Group
+        # label's `for` can't target -- fall back to the name.
+        def default_id
+          @combobox_options[:form] ? {} : {id: @name}
         end
       end
     end

--- a/app/components/ui/forms/combobox/component_preview.rb
+++ b/app/components/ui/forms/combobox/component_preview.rb
@@ -6,47 +6,29 @@ module UI
       class ComponentPreview < ApplicationComponentPreview
         # @!group Variants
 
-        # Plain string options
+        # Plain string options, labeled by a UI::Forms::Group
         def default
-          render(UI::Forms::Combobox::Component.new(
-            name: "manufacturer",
-            label: "Manufacturer",
-            options: %w[Trek Giant Specialized Cannondale Surly Bianchi]
-          ))
+          {template: "ui/forms/combobox/component_preview/default"}
         end
 
         # Hash options with separate display and submitted value
         def with_values
-          render(UI::Forms::Combobox::Component.new(
-            name: "color",
-            label: "Color",
-            options: [
-              {display: "Black", value: "1"},
-              {display: "Blue", value: "2"},
-              {display: "Red", value: "3"}
-            ]
-          ))
+          {template: "ui/forms/combobox/component_preview/with_values"}
         end
 
         # Pre-selected value, listbox open on load
         def preselected
-          render(UI::Forms::Combobox::Component.new(
-            name: "manufacturer",
-            label: "Manufacturer",
-            value: "Surly",
-            open: true,
-            options: %w[Trek Giant Specialized Cannondale Surly Bianchi]
-          ))
+          {template: "ui/forms/combobox/component_preview/preselected"}
         end
 
         # Allows submitting a value that is not in the options list
         def free_text
-          render(UI::Forms::Combobox::Component.new(
-            name: "manufacturer",
-            label: "Manufacturer (or type your own)",
-            free_text: true,
-            options: %w[Trek Giant Specialized Cannondale Surly Bianchi]
-          ))
+          {template: "ui/forms/combobox/component_preview/free_text"}
+        end
+
+        # Inside a form, where the form builder ids the input and labels it
+        def form_builder
+          {template: "ui/forms/combobox/component_preview/form_builder"}
         end
 
         # @!endgroup

--- a/app/components/ui/forms/combobox/component_preview.rb
+++ b/app/components/ui/forms/combobox/component_preview.rb
@@ -26,11 +26,6 @@ module UI
           {template: "ui/forms/combobox/component_preview/free_text"}
         end
 
-        # Inside a form, where the form builder ids the input and labels it
-        def form_builder
-          {template: "ui/forms/combobox/component_preview/form_builder"}
-        end
-
         # @!endgroup
       end
     end

--- a/app/components/ui/forms/combobox/component_preview/default.html.erb
+++ b/app/components/ui/forms/combobox/component_preview/default.html.erb
@@ -1,0 +1,3 @@
+<%= render(UI::Forms::Group::Component.new(attribute: :manufacturer, kind: :content_block)) do %>
+  <%= render(UI::Forms::Combobox::Component.new(name: :manufacturer, options: %w[Trek Giant Specialized Cannondale Surly Bianchi])) %>
+<% end %>

--- a/app/components/ui/forms/combobox/component_preview/default.html.erb
+++ b/app/components/ui/forms/combobox/component_preview/default.html.erb
@@ -1,3 +1,3 @@
-<%= render(UI::Forms::Group::Component.new(attribute: :manufacturer, kind: :content_block)) do %>
-  <%= render(UI::Forms::Combobox::Component.new(name: :manufacturer, options: %w[Trek Giant Specialized Cannondale Surly Bianchi])) %>
+<%= render(UI::Forms::Group::Component.new(attribute: :cycle_type, kind: :content_block)) do %>
+  <%= render(UI::Forms::Combobox::Component.new(name: :cycle_type, options: CycleType.select_options.map(&:first))) %>
 <% end %>

--- a/app/components/ui/forms/combobox/component_preview/default.html.erb
+++ b/app/components/ui/forms/combobox/component_preview/default.html.erb
@@ -1,3 +1,3 @@
-<%= render(UI::Forms::Group::Component.new(attribute: :cycle_type, kind: :content_block)) do %>
+<%= render(UI::Forms::Group::Component.new(attribute: :cycle_type)) do %>
   <%= render(UI::Forms::Combobox::Component.new(name: :cycle_type, options: CycleType.select_options.map(&:first))) %>
 <% end %>

--- a/app/components/ui/forms/combobox/component_preview/form_builder.html.erb
+++ b/app/components/ui/forms/combobox/component_preview/form_builder.html.erb
@@ -1,0 +1,6 @@
+<%= form_with(url: "#", builder: BikeIndexFormBuilder) do |f| %>
+  <%= render(UI::Forms::Group::Component.new(form_builder: f, attribute: :manufacturer, kind: :content_block)) do %>
+    <%= render(UI::Forms::Combobox::Component.new(name: :manufacturer, form: f,
+      options: %w[Trek Giant Specialized Cannondale Surly Bianchi])) %>
+  <% end %>
+<% end %>

--- a/app/components/ui/forms/combobox/component_preview/form_builder.html.erb
+++ b/app/components/ui/forms/combobox/component_preview/form_builder.html.erb
@@ -1,6 +1,0 @@
-<%= form_with(url: "#", builder: BikeIndexFormBuilder) do |f| %>
-  <%= render(UI::Forms::Group::Component.new(form_builder: f, attribute: :manufacturer, kind: :content_block)) do %>
-    <%= render(UI::Forms::Combobox::Component.new(name: :manufacturer, form: f,
-      options: %w[Trek Giant Specialized Cannondale Surly Bianchi])) %>
-  <% end %>
-<% end %>

--- a/app/components/ui/forms/combobox/component_preview/free_text.html.erb
+++ b/app/components/ui/forms/combobox/component_preview/free_text.html.erb
@@ -1,0 +1,5 @@
+<%= render(UI::Forms::Group::Component.new(attribute: :manufacturer, kind: :content_block,
+  label_text: "Manufacturer (or type your own)")) do %>
+  <%= render(UI::Forms::Combobox::Component.new(name: :manufacturer, free_text: true,
+    options: %w[Trek Giant Specialized Cannondale Surly Bianchi])) %>
+<% end %>

--- a/app/components/ui/forms/combobox/component_preview/free_text.html.erb
+++ b/app/components/ui/forms/combobox/component_preview/free_text.html.erb
@@ -1,4 +1,4 @@
-<%= render(UI::Forms::Group::Component.new(attribute: :primary_activity, kind: :content_block,
+<%= render(UI::Forms::Group::Component.new(attribute: :primary_activity,
   label_text: "Primary activity (or type your own)")) do %>
   <%= render(UI::Forms::Combobox::Component.new(name: :primary_activity, free_text: true,
     options: PrimaryActivity.family.alphabetized.pluck(:name))) %>

--- a/app/components/ui/forms/combobox/component_preview/free_text.html.erb
+++ b/app/components/ui/forms/combobox/component_preview/free_text.html.erb
@@ -1,5 +1,5 @@
-<%= render(UI::Forms::Group::Component.new(attribute: :manufacturer, kind: :content_block,
-  label_text: "Manufacturer (or type your own)")) do %>
-  <%= render(UI::Forms::Combobox::Component.new(name: :manufacturer, free_text: true,
-    options: %w[Trek Giant Specialized Cannondale Surly Bianchi])) %>
+<%= render(UI::Forms::Group::Component.new(attribute: :primary_activity, kind: :content_block,
+  label_text: "Primary activity (or type your own)")) do %>
+  <%= render(UI::Forms::Combobox::Component.new(name: :primary_activity, free_text: true,
+    options: PrimaryActivity.family.alphabetized.pluck(:name))) %>
 <% end %>

--- a/app/components/ui/forms/combobox/component_preview/preselected.html.erb
+++ b/app/components/ui/forms/combobox/component_preview/preselected.html.erb
@@ -1,0 +1,4 @@
+<%= render(UI::Forms::Group::Component.new(attribute: :manufacturer, kind: :content_block, required: true)) do %>
+  <%= render(UI::Forms::Combobox::Component.new(name: :manufacturer, value: "Surly", open: true, required: true,
+    options: %w[Trek Giant Specialized Cannondale Surly Bianchi])) %>
+<% end %>

--- a/app/components/ui/forms/combobox/component_preview/preselected.html.erb
+++ b/app/components/ui/forms/combobox/component_preview/preselected.html.erb
@@ -1,4 +1,4 @@
-<%= render(UI::Forms::Group::Component.new(attribute: :primary_activity_id, kind: :content_block, required: true)) do %>
+<%= render(UI::Forms::Group::Component.new(attribute: :primary_activity_id, required: true)) do %>
   <%= render(UI::Forms::Combobox::Component.new(name: :primary_activity_id, open: true, required: true,
     value: PrimaryActivity.family.by_priority.first&.id,
     options: PrimaryActivity.family.alphabetized.pluck(:name, :id))) %>

--- a/app/components/ui/forms/combobox/component_preview/preselected.html.erb
+++ b/app/components/ui/forms/combobox/component_preview/preselected.html.erb
@@ -1,4 +1,5 @@
-<%= render(UI::Forms::Group::Component.new(attribute: :manufacturer, kind: :content_block, required: true)) do %>
-  <%= render(UI::Forms::Combobox::Component.new(name: :manufacturer, value: "Surly", open: true, required: true,
-    options: %w[Trek Giant Specialized Cannondale Surly Bianchi])) %>
+<%= render(UI::Forms::Group::Component.new(attribute: :primary_activity_id, kind: :content_block, required: true)) do %>
+  <%= render(UI::Forms::Combobox::Component.new(name: :primary_activity_id, open: true, required: true,
+    value: PrimaryActivity.family.by_priority.first&.id,
+    options: PrimaryActivity.family.alphabetized.pluck(:name, :id))) %>
 <% end %>

--- a/app/components/ui/forms/combobox/component_preview/with_values.html.erb
+++ b/app/components/ui/forms/combobox/component_preview/with_values.html.erb
@@ -1,4 +1,4 @@
-<%= render(UI::Forms::Group::Component.new(attribute: :wheel_size_id, kind: :content_block)) do %>
+<%= render(UI::Forms::Group::Component.new(attribute: :wheel_size_id)) do %>
   <%= render(UI::Forms::Combobox::Component.new(name: :wheel_size_id,
     options: WheelSize.commonness.first(6).map { |wheel_size| {display: wheel_size.select_value, value: wheel_size.id} })) %>
 <% end %>

--- a/app/components/ui/forms/combobox/component_preview/with_values.html.erb
+++ b/app/components/ui/forms/combobox/component_preview/with_values.html.erb
@@ -1,0 +1,7 @@
+<%= render(UI::Forms::Group::Component.new(attribute: :color, kind: :content_block)) do %>
+  <%= render(UI::Forms::Combobox::Component.new(name: :color, options: [
+    {display: "Black", value: "1"},
+    {display: "Blue", value: "2"},
+    {display: "Red", value: "3"}
+  ])) %>
+<% end %>

--- a/app/components/ui/forms/combobox/component_preview/with_values.html.erb
+++ b/app/components/ui/forms/combobox/component_preview/with_values.html.erb
@@ -1,7 +1,4 @@
-<%= render(UI::Forms::Group::Component.new(attribute: :color, kind: :content_block)) do %>
-  <%= render(UI::Forms::Combobox::Component.new(name: :color, options: [
-    {display: "Black", value: "1"},
-    {display: "Blue", value: "2"},
-    {display: "Red", value: "3"}
-  ])) %>
+<%= render(UI::Forms::Group::Component.new(attribute: :wheel_size_id, kind: :content_block)) do %>
+  <%= render(UI::Forms::Combobox::Component.new(name: :wheel_size_id,
+    options: WheelSize.commonness.first(6).map { |wheel_size| {display: wheel_size.select_value, value: wheel_size.id} })) %>
 <% end %>

--- a/app/components/ui/forms/combobox_manufacturer/component.rb
+++ b/app/components/ui/forms/combobox_manufacturer/component.rb
@@ -7,9 +7,8 @@ module UI
       #
       # Defaults `name` to :manufacturer_id and the options to every manufacturer;
       # pass `frame_maker: true` to limit the list to frame makers, or a `manufacturers`
-      # relation to set it explicitly. Every other keyword (form:, label:, value:,
-      # required:, include_blank:, placeholder:, etc.) is forwarded to
-      # UI::Forms::Combobox::Component.
+      # relation to set it explicitly. Every other keyword (form:, value:, required:,
+      # include_blank:, placeholder:, etc.) is forwarded to UI::Forms::Combobox::Component.
       class Component < ApplicationComponent
         def initialize(name: :manufacturer_id, frame_maker: false, manufacturers: nil, **combobox_options)
           @name = name
@@ -20,7 +19,6 @@ module UI
         def call
           render UI::Forms::Combobox::Component.new(
             name: @name,
-            label: Manufacturer.model_name.human,
             options: @manufacturers.pluck(:name, :id),
             **@combobox_options
           )

--- a/app/components/ui/forms/combobox_manufacturer/component_preview.rb
+++ b/app/components/ui/forms/combobox_manufacturer/component_preview.rb
@@ -6,9 +6,9 @@ module UI
       class ComponentPreview < ApplicationComponentPreview
         # @!group Variants
 
-        # Every manufacturer, keyed to :manufacturer_id
+        # Every manufacturer, keyed to :manufacturer_id, labeled by a UI::Forms::Group
         def default
-          render(UI::Forms::ComboboxManufacturer::Component.new)
+          {template: "ui/forms/combobox_manufacturer/component_preview/default"}
         end
 
         # Limited to frame makers
@@ -16,12 +16,9 @@ module UI
           render(UI::Forms::ComboboxManufacturer::Component.new(frame_maker: true))
         end
 
-        # Pre-selected value, custom label
+        # Pre-selected value
         def preselected
-          render(UI::Forms::ComboboxManufacturer::Component.new(
-            label: "Frame manufacturer",
-            value: Manufacturer.frame_makers.first&.id
-          ))
+          render(UI::Forms::ComboboxManufacturer::Component.new(value: Manufacturer.frame_makers.first&.id))
         end
 
         # @!endgroup

--- a/app/components/ui/forms/combobox_manufacturer/component_preview/default.html.erb
+++ b/app/components/ui/forms/combobox_manufacturer/component_preview/default.html.erb
@@ -1,0 +1,4 @@
+<%= render(UI::Forms::Group::Component.new(attribute: :manufacturer_id, kind: :content_block,
+  label_text: Manufacturer.model_name.human)) do %>
+  <%= render(UI::Forms::ComboboxManufacturer::Component.new) %>
+<% end %>

--- a/app/components/ui/forms/combobox_manufacturer/component_preview/default.html.erb
+++ b/app/components/ui/forms/combobox_manufacturer/component_preview/default.html.erb
@@ -1,4 +1,4 @@
-<%= render(UI::Forms::Group::Component.new(attribute: :manufacturer_id, kind: :content_block,
+<%= render(UI::Forms::Group::Component.new(attribute: :manufacturer_id,
   label_text: Manufacturer.model_name.human)) do %>
   <%= render(UI::Forms::ComboboxManufacturer::Component.new) %>
 <% end %>

--- a/app/components/ui/forms/group/component.html.erb
+++ b/app/components/ui/forms/group/component.html.erb
@@ -1,5 +1,5 @@
 <div class="<%= @wrapper_class %>">
-  <%= @form_builder.label @attribute, label_content, class: "twlabel" %>
+  <%= label_markup %>
 
   <% unless @kind == :content_block %>
     <%= render(UI::Forms::Input::Component.new(form_builder: @form_builder, attribute: @attribute, kind: @kind, required: required?, html_options: @html_options)) %>

--- a/app/components/ui/forms/group/component.html.erb
+++ b/app/components/ui/forms/group/component.html.erb
@@ -1,9 +1,9 @@
 <div class="<%= @wrapper_class %>">
   <%= label_markup %>
 
-  <% unless @kind == :content_block %>
+  <% if content? %>
+    <%= content %>
+  <% else %>
     <%= render(UI::Forms::Input::Component.new(form_builder: @form_builder, attribute: @attribute, kind: @kind, required: required?, html_options: @html_options)) %>
   <% end %>
-
-  <%= content if content? %>
 </div>

--- a/app/components/ui/forms/group/component.rb
+++ b/app/components/ui/forms/group/component.rb
@@ -4,11 +4,15 @@ module UI
   module Forms
     module Group
       class Component < ApplicationComponent
-        def initialize(form_builder:, attribute:, kind: :text_field, label_text: nil, required: false,
+        # Without a form_builder (a form_tag form) the label points at whatever the
+        # content block renders with the attribute's id.
+        def initialize(attribute:, form_builder: nil, kind: :text_field, label_text: nil, required: false,
           wrapper_class: "tw:mb-4", html_options: {})
+          @kind = kind.to_sym
+          raise ArgumentError, "pass form_builder, or kind: :content_block" if form_builder.nil? && @kind != :content_block
+
           @form_builder = form_builder
           @attribute = attribute
-          @kind = kind.to_sym
           @label_text = label_text || attribute.to_s.humanize
           @required = required
           @wrapper_class = wrapper_class
@@ -16,6 +20,14 @@ module UI
         end
 
         private
+
+        def label_markup
+          if @form_builder
+            @form_builder.label(@attribute, label_content, class: "twlabel")
+          else
+            label_tag(@attribute, label_content, class: "twlabel")
+          end
+        end
 
         # The label carries a required "*" or an "optional" badge, keyed off required?.
         def label_content

--- a/app/components/ui/forms/group/component.rb
+++ b/app/components/ui/forms/group/component.rb
@@ -4,19 +4,23 @@ module UI
   module Forms
     module Group
       class Component < ApplicationComponent
-        # Without a form_builder (a form_tag form) the label points at whatever the
-        # content block renders with the attribute's id.
+        # Pass a block (a UI::Forms::Combobox, Select, TextEditor...) and it renders in
+        # place of the input -- `kind` is then unused. Without a form_builder that block
+        # is the only valid shape: the label falls back to label_tag, so it points at
+        # whatever the block renders with the attribute's id.
         def initialize(attribute:, form_builder: nil, kind: :text_field, label_text: nil, required: false,
           wrapper_class: "tw:mb-4", html_options: {})
-          @kind = kind.to_sym
-          raise ArgumentError, "pass form_builder, or kind: :content_block" if form_builder.nil? && @kind != :content_block
-
           @form_builder = form_builder
           @attribute = attribute
+          @kind = kind.to_sym
           @label_text = label_text || attribute.to_s.humanize
           @required = required
           @wrapper_class = wrapper_class
           @html_options = html_options
+        end
+
+        def before_render
+          raise ArgumentError, "pass form_builder, or a content block" if @form_builder.nil? && !content?
         end
 
         private

--- a/app/components/ui/forms/group/component_preview.rb
+++ b/app/components/ui/forms/group/component_preview.rb
@@ -25,6 +25,10 @@ module UI
           {template: "ui/forms/group/component_preview/select"}
         end
 
+        def combobox
+          {template: "ui/forms/group/component_preview/combobox"}
+        end
+
         def radio_button_group
           {template: "ui/forms/group/component_preview/radio_button_group"}
         end

--- a/app/components/ui/forms/group/component_preview/combobox.html.erb
+++ b/app/components/ui/forms/group/component_preview/combobox.html.erb
@@ -1,6 +1,6 @@
-<%# kind: :content_block renders the label, then yields to a content block -- here a combobox. %>
+<%# A content block renders in place of the input -- here a combobox. %>
 <%= form_with(url: "#", builder: BikeIndexFormBuilder) do |f| %>
-  <%= render(UI::Forms::Group::Component.new(form_builder: f, attribute: :cycle_type, kind: :content_block, required: true)) do %>
+  <%= render(UI::Forms::Group::Component.new(form_builder: f, attribute: :cycle_type, required: true)) do %>
     <%= render(UI::Forms::Combobox::Component.new(name: :cycle_type, form: f, required: true,
       include_blank: true, placeholder: "Choose a cycle type",
       options: CycleType.select_options)) %>

--- a/app/components/ui/forms/group/component_preview/combobox.html.erb
+++ b/app/components/ui/forms/group/component_preview/combobox.html.erb
@@ -1,0 +1,8 @@
+<%# kind: :content_block renders the label, then yields to a content block -- here a combobox. %>
+<%= form_with(url: "#", builder: BikeIndexFormBuilder) do |f| %>
+  <%= render(UI::Forms::Group::Component.new(form_builder: f, attribute: :manufacturer, kind: :content_block, required: true)) do %>
+    <%= render(UI::Forms::Combobox::Component.new(name: :manufacturer, form: f, required: true,
+      include_blank: true, placeholder: "Choose a manufacturer",
+      options: %w[Trek Giant Specialized Cannondale Surly Bianchi])) %>
+  <% end %>
+<% end %>

--- a/app/components/ui/forms/group/component_preview/combobox.html.erb
+++ b/app/components/ui/forms/group/component_preview/combobox.html.erb
@@ -1,8 +1,8 @@
 <%# kind: :content_block renders the label, then yields to a content block -- here a combobox. %>
 <%= form_with(url: "#", builder: BikeIndexFormBuilder) do |f| %>
-  <%= render(UI::Forms::Group::Component.new(form_builder: f, attribute: :manufacturer, kind: :content_block, required: true)) do %>
-    <%= render(UI::Forms::Combobox::Component.new(name: :manufacturer, form: f, required: true,
-      include_blank: true, placeholder: "Choose a manufacturer",
-      options: %w[Trek Giant Specialized Cannondale Surly Bianchi])) %>
+  <%= render(UI::Forms::Group::Component.new(form_builder: f, attribute: :cycle_type, kind: :content_block, required: true)) do %>
+    <%= render(UI::Forms::Combobox::Component.new(name: :cycle_type, form: f, required: true,
+      include_blank: true, placeholder: "Choose a cycle type",
+      options: CycleType.select_options)) %>
   <% end %>
 <% end %>

--- a/app/components/ui/forms/group/component_preview/content_block.html.erb
+++ b/app/components/ui/forms/group/component_preview/content_block.html.erb
@@ -1,6 +1,6 @@
-<%# kind: :content_block renders the label, then yields to a content block -- here a Lexxy text editor. %>
+<%# A content block renders in place of the input -- here a Lexxy text editor. %>
 <%= form_with(model: OrganizationFeature.new(description: "<p>A rich-text description</p>"), url: "#", builder: BikeIndexFormBuilder) do |f| %>
-  <%= render(UI::Forms::Group::Component.new(form_builder: f, attribute: :description, kind: :content_block)) do %>
+  <%= render(UI::Forms::Group::Component.new(form_builder: f, attribute: :description)) do %>
     <%= render(UI::Forms::TextEditor::Component.new(form_builder: f, attribute: :description, standalone: false)) %>
   <% end %>
 <% end %>

--- a/app/components/ui/forms/group/component_preview/file_upload.html.erb
+++ b/app/components/ui/forms/group/component_preview/file_upload.html.erb
@@ -1,6 +1,6 @@
-<%# kind: :content_block renders the label, then yields to a content block -- here a file upload input. %>
+<%# A content block renders in place of the input -- here a file upload input. %>
 <%= form_with(url: "#", builder: BikeIndexFormBuilder) do |f| %>
-  <%= render(UI::Forms::Group::Component.new(form_builder: f, attribute: :avatar, kind: :content_block)) do %>
+  <%= render(UI::Forms::Group::Component.new(form_builder: f, attribute: :avatar)) do %>
     <%= render(UI::Forms::FileUpload::Component.new(form_builder: f, attribute: :avatar, accept: "image/*")) %>
   <% end %>
 <% end %>

--- a/app/components/ui/forms/group/component_preview/radio_button_group.html.erb
+++ b/app/components/ui/forms/group/component_preview/radio_button_group.html.erb
@@ -1,6 +1,6 @@
-<%# kind: :content_block renders the label, then yields to a content block -- here a radio button group. %>
+<%# A content block renders in place of the input -- here a radio button group. %>
 <%= form_with(url: "#", builder: BikeIndexFormBuilder) do |f| %>
-  <%= render(UI::Forms::Group::Component.new(form_builder: f, attribute: :frame_size, kind: :content_block)) do %>
+  <%= render(UI::Forms::Group::Component.new(form_builder: f, attribute: :frame_size)) do %>
     <%= render(UI::Forms::RadioButtonGroup::Component.new(name: :frame_size, selected: "m", full_width: true,
       entries: %w[xs s m l xl].map { |size| {value: size, label: size.upcase} })) %>
   <% end %>

--- a/app/components/ui/forms/group/component_preview/select.html.erb
+++ b/app/components/ui/forms/group/component_preview/select.html.erb
@@ -1,6 +1,6 @@
-<%# kind: :content_block renders the label, then yields to a content block -- here a select. %>
+<%# A content block renders in place of the input -- here a select. %>
 <%= form_with(url: "#", builder: BikeIndexFormBuilder) do |f| %>
-  <%= render(UI::Forms::Group::Component.new(form_builder: f, attribute: :frame_material, kind: :content_block)) do %>
+  <%= render(UI::Forms::Group::Component.new(form_builder: f, attribute: :frame_material)) do %>
     <%= render(UI::Forms::Select::Component.new(form_builder: f, attribute: :frame_material,
       option_tags: [["Aluminum", "aluminum"], ["Steel", "steel"], ["Carbon", "carbon"]],
       options: {include_blank: "Choose a material"})) %>

--- a/app/components/ui/forms/select/component.rb
+++ b/app/components/ui/forms/select/component.rb
@@ -5,7 +5,7 @@ module UI
     module Select
       # A twinput-styled select. Rails' `select` takes its option tags and options as
       # positional arguments, so it doesn't fit UI::Forms::Input's kind contract —
-      # pair this with UI::Forms::Group (kind: :content_block) for a label.
+      # pair this with a UI::Forms::Group block for a label.
       #
       # option_tags and options are named for select_tag: options carries Rails'
       # selected:/include_blank:/prompt:.

--- a/app/components/ui/forms/text_editor/component.rb
+++ b/app/components/ui/forms/text_editor/component.rb
@@ -3,7 +3,7 @@
 module UI
   module Forms
     module TextEditor
-      # Bare Lexxy editor; pair with UI::Forms::Group (kind: :content_block, standalone: false) for a label.
+      # Bare Lexxy editor; pair with a UI::Forms::Group block (and standalone: false) for a label.
       # Carries data-controller="lexxy", which loads the editor JS and stylesheet on demand.
       class Component < ApplicationComponent
         SIZE = %i[default single_line].freeze

--- a/app/views/admin/bike_stickers/new.html.haml
+++ b/app/views/admin/bike_stickers/new.html.haml
@@ -55,8 +55,8 @@
 
   .row.mt-4
     .col-md-6.col-lg-3
-      .form-group
-        = render UI::Forms::Combobox::Component.new(name: :organization_id, form: f, label: BikeStickerBatch.human_attribute_name(:organization_id), placeholder: "Choose organization", required: true, include_blank: true, options: @organizations.pluck(:name, :id))
+      = render(UI::Forms::Group::Component.new(form_builder: f, attribute: :organization_id, kind: :content_block, label_text: BikeStickerBatch.human_attribute_name(:organization_id), required: true)) do
+        = render UI::Forms::Combobox::Component.new(name: :organization_id, form: f, placeholder: "Choose organization", required: true, include_blank: true, options: @organizations.pluck(:name, :id))
     .col-md-6.col-lg-9
       .form-group
         = f.label :notes, "Notes"

--- a/app/views/admin/bike_stickers/new.html.haml
+++ b/app/views/admin/bike_stickers/new.html.haml
@@ -55,7 +55,7 @@
 
   .row.mt-4
     .col-md-6.col-lg-3
-      = render(UI::Forms::Group::Component.new(form_builder: f, attribute: :organization_id, kind: :content_block, label_text: BikeStickerBatch.human_attribute_name(:organization_id), required: true)) do
+      = render(UI::Forms::Group::Component.new(form_builder: f, attribute: :organization_id, label_text: BikeStickerBatch.human_attribute_name(:organization_id), required: true)) do
         = render UI::Forms::Combobox::Component.new(name: :organization_id, form: f, placeholder: "Choose organization", required: true, include_blank: true, options: @organizations.pluck(:name, :id))
     .col-md-6.col-lg-9
       .form-group

--- a/app/views/admin/bike_stickers/reassign.html.haml
+++ b/app/views/admin/bike_stickers/reassign.html.haml
@@ -29,7 +29,7 @@
             - if @bike_sticker1.present?
               .col-12
                 - opt_vals = BikeStickerBatch.includes(:organization).order(id: :desc).map { |b| ["##{b.id} - #{b.organization&.short_name} - #{b.notes}", b.id] }
-                = render(UI::Forms::Group::Component.new(attribute: :search_bike_sticker_batch_id, kind: :content_block, label_text: "Sticker Batch")) do
+                = render(UI::Forms::Group::Component.new(attribute: :search_bike_sticker_batch_id, label_text: "Sticker Batch")) do
                   = render UI::Forms::Combobox::Component.new(name: :search_bike_sticker_batch_id, dialog_label: "Sticker Batch", placeholder: "Select batch", value: @bike_sticker_batch&.id, include_blank: true, options: opt_vals)
             .col-sm-6
               .form-group
@@ -41,7 +41,7 @@
                 = text_field_tag :search_sticker2, params[:search_sticker2], class: "form-control"
             .col-12
               - org_opt_vals = Organization.approved.name_ordered.pluck(:name, :id)
-              = render(UI::Forms::Group::Component.new(attribute: :organization_id, kind: :content_block, label_text: "Organization to assign stickers to")) do
+              = render(UI::Forms::Group::Component.new(attribute: :organization_id, label_text: "Organization to assign stickers to")) do
                 = render UI::Forms::Combobox::Component.new(name: :organization_id, placeholder: "Select organization", value: current_organization&.id, include_blank: true, options: org_opt_vals)
           .form-group.mt-2
             = submit_tag 'Select', name: 'select', class: 'btn btn-primary ml-2'

--- a/app/views/admin/bike_stickers/reassign.html.haml
+++ b/app/views/admin/bike_stickers/reassign.html.haml
@@ -30,7 +30,7 @@
               .col-12
                 - opt_vals = BikeStickerBatch.includes(:organization).order(id: :desc).map { |b| ["##{b.id} - #{b.organization&.short_name} - #{b.notes}", b.id] }
                 = render(UI::Forms::Group::Component.new(attribute: :search_bike_sticker_batch_id, kind: :content_block, label_text: "Sticker Batch")) do
-                  = render UI::Forms::Combobox::Component.new(name: :search_bike_sticker_batch_id, placeholder: "Select batch", value: @bike_sticker_batch&.id, include_blank: true, options: opt_vals)
+                  = render UI::Forms::Combobox::Component.new(name: :search_bike_sticker_batch_id, dialog_label: "Sticker Batch", placeholder: "Select batch", value: @bike_sticker_batch&.id, include_blank: true, options: opt_vals)
             .col-sm-6
               .form-group
                 = label_tag :search_sticker1, "Starting Sticker code"

--- a/app/views/admin/bike_stickers/reassign.html.haml
+++ b/app/views/admin/bike_stickers/reassign.html.haml
@@ -28,9 +28,9 @@
           .row.mt-4
             - if @bike_sticker1.present?
               .col-12
-                .form-group
-                  - opt_vals = BikeStickerBatch.includes(:organization).order(id: :desc).map { |b| ["##{b.id} - #{b.organization&.short_name} - #{b.notes}", b.id] }
-                  = render UI::Forms::Combobox::Component.new(name: :search_bike_sticker_batch_id, label: "Sticker Batch", placeholder: "Select batch", value: @bike_sticker_batch&.id, include_blank: true, options: opt_vals)
+                - opt_vals = BikeStickerBatch.includes(:organization).order(id: :desc).map { |b| ["##{b.id} - #{b.organization&.short_name} - #{b.notes}", b.id] }
+                = render(UI::Forms::Group::Component.new(attribute: :search_bike_sticker_batch_id, kind: :content_block, label_text: "Sticker Batch")) do
+                  = render UI::Forms::Combobox::Component.new(name: :search_bike_sticker_batch_id, placeholder: "Select batch", value: @bike_sticker_batch&.id, include_blank: true, options: opt_vals)
             .col-sm-6
               .form-group
                 = label_tag :search_sticker1, "Starting Sticker code"
@@ -40,9 +40,9 @@
                 = label_tag :search_sticker2, "Ending Sticker code"
                 = text_field_tag :search_sticker2, params[:search_sticker2], class: "form-control"
             .col-12
-              .form-group
-                - org_opt_vals = Organization.approved.name_ordered.pluck(:name, :id)
-                = render UI::Forms::Combobox::Component.new(name: :organization_id, label: "Organization to assign stickers to", placeholder: "Select organization", value: current_organization&.id, include_blank: true, options: org_opt_vals)
+              - org_opt_vals = Organization.approved.name_ordered.pluck(:name, :id)
+              = render(UI::Forms::Group::Component.new(attribute: :organization_id, kind: :content_block, label_text: "Organization to assign stickers to")) do
+                = render UI::Forms::Combobox::Component.new(name: :organization_id, placeholder: "Select organization", value: current_organization&.id, include_blank: true, options: org_opt_vals)
           .form-group.mt-2
             = submit_tag 'Select', name: 'select', class: 'btn btn-primary ml-2'
 

--- a/app/views/admin/bikes/edit.html.haml
+++ b/app/views/admin/bikes/edit.html.haml
@@ -104,7 +104,7 @@
                 %p.d-none
                   = Country.united_states_id
             = render(UI::Forms::Group::Component.new(form_builder: s, attribute: :region_record_id, kind: :content_block, label_text: "State", wrapper_class: "form-group col-6")) do
-              = render UI::Forms::Combobox::Component.new(name: :region_record_id, form: s, placeholder: "State", include_blank: true, options: State.united_states.pluck(:name, :id))
+              = render UI::Forms::Combobox::Component.new(name: :region_record_id, form: s, dialog_label: "State", placeholder: "State", include_blank: true, options: State.united_states.pluck(:name, :id))
           .form-group
             = label :street, "Intersection or address"
             = s.text_field :street, placeholder: "Intersection or address", class: "form-control"

--- a/app/views/admin/bikes/edit.html.haml
+++ b/app/views/admin/bikes/edit.html.haml
@@ -15,9 +15,9 @@
 
   .row
     .col-md-4.col-lg-3
-      .form-group
+      = render(UI::Forms::Group::Component.new(form_builder: f, attribute: :cycle_type, kind: :content_block, label_text: "Cycle type", required: true)) do
         -# cycle_type is an integer-backed enum: pass enum *labels* as option values and an explicit value: to override hotwire_combobox's enum branch (which would emit cycle_type_before_type_cast)
-        = render UI::Forms::Combobox::Component.new(name: :cycle_type, form: f, value: @bike.cycle_type, label: "Cycle type", required: true, options: CycleType.select_options)
+        = render UI::Forms::Combobox::Component.new(name: :cycle_type, form: f, value: @bike.cycle_type, required: true, options: CycleType.select_options)
     .col-6.col-md-4.col-lg-5
       .form-group
         = f.label :serial_number
@@ -31,12 +31,12 @@
         = f.label :made_without_serial
   .row
     .col-6.col-md-4.col-lg-3
-      .form-group
-        - manufacturer_label = capture do
-          Manufacturer
-          %em.small
-            = link_to "mfg bikes", admin_bikes_path(search_manufacturer: @bike.mnfg_name), class: "less-strong"
-        = render UI::Forms::ComboboxManufacturer::Component.new(frame_maker: true, form: f, label: manufacturer_label, required: true)
+      - manufacturer_label = capture do
+        Manufacturer
+        %em.small
+          = link_to "mfg bikes", admin_bikes_path(search_manufacturer: @bike.mnfg_name), class: "less-strong"
+      = render(UI::Forms::Group::Component.new(form_builder: f, attribute: :manufacturer_id, kind: :content_block, label_text: manufacturer_label, required: true)) do
+        = render UI::Forms::ComboboxManufacturer::Component.new(frame_maker: true, form: f, required: true)
     .col-6.col-md-4.col-lg-3
       .form-group
         = f.label :manufacturer_other do
@@ -52,8 +52,8 @@
         = f.label :year
         = f.text_field :year, class: "form-control"
     .col-6.col-md-4.col-lg-3
-      .form-group
-        = render UI::Forms::Combobox::Component.new(name: :primary_frame_color_id, form: f, label: Bike.human_attribute_name(:primary_frame_color_id), placeholder: "Choose color", required: true, include_blank: true, options: Color.all.pluck(:name, :id))
+      = render(UI::Forms::Group::Component.new(form_builder: f, attribute: :primary_frame_color_id, kind: :content_block, label_text: Bike.human_attribute_name(:primary_frame_color_id), required: true)) do
+        = render UI::Forms::Combobox::Component.new(name: :primary_frame_color_id, form: f, placeholder: "Choose color", required: true, include_blank: true, options: Color.all.pluck(:name, :id))
     .col-md-4.col-lg-3
       .form-group
         = f.label :frame_model
@@ -78,8 +78,8 @@
         = f.email_field :owner_email, required: true, class: "form-control"
     - if @organizations.present?
       .col-md-4.col-lg-3
-        .form-group
-          = render UI::Forms::Combobox::Component.new(name: :creation_organization_id, form: f, label: Bike.human_attribute_name(:creation_organization_id), placeholder: "Choose organization", include_blank: true, options: @organizations.pluck(:name, :id))
+        = render(UI::Forms::Group::Component.new(form_builder: f, attribute: :creation_organization_id, kind: :content_block, label_text: Bike.human_attribute_name(:creation_organization_id))) do
+          = render UI::Forms::Combobox::Component.new(name: :creation_organization_id, form: f, placeholder: "Choose organization", include_blank: true, options: @organizations.pluck(:name, :id))
       .col-md-4.col-lg-3
         .form-group.fancy-select.unfancy
           = f.label :bike_organization_ids, 'Current orgs'
@@ -99,11 +99,12 @@
           .row
             #stolen-bike-location.form-group.col-6
               #country_select_container
-                = render UI::Forms::Combobox::Component.new(name: :country_id, form: s, label: "Country", placeholder: "Choose country", include_blank: true, options: Country.select_options)
+                = render(UI::Forms::Group::Component.new(form_builder: s, attribute: :country_id, kind: :content_block, label_text: "Country", wrapper_class: "")) do
+                  = render UI::Forms::Combobox::Component.new(name: :country_id, form: s, placeholder: "Choose country", include_blank: true, options: Country.select_options)
                 %p.d-none
                   = Country.united_states_id
-            .form-group.col-6
-              = render UI::Forms::Combobox::Component.new(name: :region_record_id, form: s, label: "State", placeholder: "State", include_blank: true, options: State.united_states.pluck(:name, :id))
+            = render(UI::Forms::Group::Component.new(form_builder: s, attribute: :region_record_id, kind: :content_block, label_text: "State", wrapper_class: "form-group col-6")) do
+              = render UI::Forms::Combobox::Component.new(name: :region_record_id, form: s, placeholder: "State", include_blank: true, options: State.united_states.pluck(:name, :id))
           .form-group
             = label :street, "Intersection or address"
             = s.text_field :street, placeholder: "Intersection or address", class: "form-control"

--- a/app/views/admin/bikes/edit.html.haml
+++ b/app/views/admin/bikes/edit.html.haml
@@ -15,7 +15,7 @@
 
   .row
     .col-md-4.col-lg-3
-      = render(UI::Forms::Group::Component.new(form_builder: f, attribute: :cycle_type, kind: :content_block, label_text: "Cycle type", required: true)) do
+      = render(UI::Forms::Group::Component.new(form_builder: f, attribute: :cycle_type, label_text: "Cycle type", required: true)) do
         -# cycle_type is an integer-backed enum: pass enum *labels* as option values and an explicit value: to override hotwire_combobox's enum branch (which would emit cycle_type_before_type_cast)
         = render UI::Forms::Combobox::Component.new(name: :cycle_type, form: f, value: @bike.cycle_type, required: true, options: CycleType.select_options)
     .col-6.col-md-4.col-lg-5
@@ -35,7 +35,7 @@
         Manufacturer
         %em.small
           = link_to "mfg bikes", admin_bikes_path(search_manufacturer: @bike.mnfg_name), class: "less-strong"
-      = render(UI::Forms::Group::Component.new(form_builder: f, attribute: :manufacturer_id, kind: :content_block, label_text: manufacturer_label, required: true)) do
+      = render(UI::Forms::Group::Component.new(form_builder: f, attribute: :manufacturer_id, label_text: manufacturer_label, required: true)) do
         = render UI::Forms::ComboboxManufacturer::Component.new(frame_maker: true, form: f, required: true)
     .col-6.col-md-4.col-lg-3
       .form-group
@@ -52,7 +52,7 @@
         = f.label :year
         = f.text_field :year, class: "form-control"
     .col-6.col-md-4.col-lg-3
-      = render(UI::Forms::Group::Component.new(form_builder: f, attribute: :primary_frame_color_id, kind: :content_block, label_text: Bike.human_attribute_name(:primary_frame_color_id), required: true)) do
+      = render(UI::Forms::Group::Component.new(form_builder: f, attribute: :primary_frame_color_id, label_text: Bike.human_attribute_name(:primary_frame_color_id), required: true)) do
         = render UI::Forms::Combobox::Component.new(name: :primary_frame_color_id, form: f, placeholder: "Choose color", required: true, include_blank: true, options: Color.all.pluck(:name, :id))
     .col-md-4.col-lg-3
       .form-group
@@ -78,7 +78,7 @@
         = f.email_field :owner_email, required: true, class: "form-control"
     - if @organizations.present?
       .col-md-4.col-lg-3
-        = render(UI::Forms::Group::Component.new(form_builder: f, attribute: :creation_organization_id, kind: :content_block, label_text: Bike.human_attribute_name(:creation_organization_id))) do
+        = render(UI::Forms::Group::Component.new(form_builder: f, attribute: :creation_organization_id, label_text: Bike.human_attribute_name(:creation_organization_id))) do
           = render UI::Forms::Combobox::Component.new(name: :creation_organization_id, form: f, placeholder: "Choose organization", include_blank: true, options: @organizations.pluck(:name, :id))
       .col-md-4.col-lg-3
         .form-group.fancy-select.unfancy
@@ -99,11 +99,11 @@
           .row
             #stolen-bike-location.form-group.col-6
               #country_select_container
-                = render(UI::Forms::Group::Component.new(form_builder: s, attribute: :country_id, kind: :content_block, label_text: "Country", wrapper_class: "")) do
+                = render(UI::Forms::Group::Component.new(form_builder: s, attribute: :country_id, label_text: "Country", wrapper_class: "")) do
                   = render UI::Forms::Combobox::Component.new(name: :country_id, form: s, placeholder: "Choose country", include_blank: true, options: Country.select_options)
                 %p.d-none
                   = Country.united_states_id
-            = render(UI::Forms::Group::Component.new(form_builder: s, attribute: :region_record_id, kind: :content_block, label_text: "State", wrapper_class: "form-group col-6")) do
+            = render(UI::Forms::Group::Component.new(form_builder: s, attribute: :region_record_id, label_text: "State", wrapper_class: "form-group col-6")) do
               = render UI::Forms::Combobox::Component.new(name: :region_record_id, form: s, dialog_label: "State", placeholder: "State", include_blank: true, options: State.united_states.pluck(:name, :id))
           .form-group
             = label :street, "Intersection or address"

--- a/app/views/admin/bikes/missing_manufacturer.html.haml
+++ b/app/views/admin/bikes/missing_manufacturer.html.haml
@@ -46,7 +46,8 @@
 = form_tag update_manufacturers_admin_bikes_path, data: {controller: "table-multi-checkbox"} do
   .row
     .col-md-4
-      = render UI::Forms::ComboboxManufacturer::Component.new(frame_maker: true, placeholder: "Choose manufacturer", include_blank: true)
+      = render(UI::Forms::Group::Component.new(attribute: :manufacturer_id, kind: :content_block, label_text: Manufacturer.model_name.human)) do
+        = render UI::Forms::ComboboxManufacturer::Component.new(frame_maker: true, placeholder: "Choose manufacturer", include_blank: true)
     .col-md-2
       = submit_tag 'Update selected', class: 'btn btn-primary'
 

--- a/app/views/admin/bikes/missing_manufacturer.html.haml
+++ b/app/views/admin/bikes/missing_manufacturer.html.haml
@@ -46,7 +46,7 @@
 = form_tag update_manufacturers_admin_bikes_path, data: {controller: "table-multi-checkbox"} do
   .row
     .col-md-4
-      = render(UI::Forms::Group::Component.new(attribute: :manufacturer_id, kind: :content_block, label_text: Manufacturer.model_name.human)) do
+      = render(UI::Forms::Group::Component.new(attribute: :manufacturer_id, label_text: Manufacturer.model_name.human)) do
         = render UI::Forms::ComboboxManufacturer::Component.new(frame_maker: true, placeholder: "Choose manufacturer", include_blank: true)
     .col-md-2
       = submit_tag 'Update selected', class: 'btn btn-primary'

--- a/app/views/admin/bug_reports/index.html.erb
+++ b/app/views/admin/bug_reports/index.html.erb
@@ -61,7 +61,9 @@
   <%= form_tag assign_tags_admin_bug_reports_path, method: :post, data: {controller: "table-multi-checkbox"} do %>
     <div class="row align-items-end">
       <div class="col-md-4">
-        <%= render UI::Forms::Combobox::Component.new(name: :tags, label: "Tag to assign", free_text: true, options: searchable_tags, placeholder: "Select or create a tag") %>
+        <%= render(UI::Forms::Group::Component.new(attribute: :tags, kind: :content_block, label_text: "Tag to assign")) do %>
+          <%= render UI::Forms::Combobox::Component.new(name: :tags, free_text: true, options: searchable_tags, placeholder: "Select or create a tag") %>
+        <% end %>
       </div>
 
       <div class="col-md-2">

--- a/app/views/admin/bug_reports/index.html.erb
+++ b/app/views/admin/bug_reports/index.html.erb
@@ -61,7 +61,7 @@
   <%= form_tag assign_tags_admin_bug_reports_path, method: :post, data: {controller: "table-multi-checkbox"} do %>
     <div class="row align-items-end">
       <div class="col-md-4">
-        <%= render(UI::Forms::Group::Component.new(attribute: :tags, kind: :content_block, label_text: "Tag to assign")) do %>
+        <%= render(UI::Forms::Group::Component.new(attribute: :tags, label_text: "Tag to assign")) do %>
           <%= render UI::Forms::Combobox::Component.new(name: :tags, free_text: true, options: searchable_tags, placeholder: "Select or create a tag") %>
         <% end %>
       </div>

--- a/app/views/admin/bulk_imports/new.html.haml
+++ b/app/views/admin/bulk_imports/new.html.haml
@@ -7,8 +7,8 @@
     = form_for [:admin, @bulk_import] do |f|
       = render(UI::Alerts::ObjectError::Component.new(object: @bulk_import))
 
-      .form-group
-        = render UI::Forms::Combobox::Component.new(name: :organization_id, form: f, label: BulkImport.human_attribute_name(:organization_id), placeholder: "Choose organization", required: true, include_blank: true, options: Organization.all.pluck(:name, :id))
+      = render(UI::Forms::Group::Component.new(form_builder: f, attribute: :organization_id, kind: :content_block, label_text: BulkImport.human_attribute_name(:organization_id), required: true)) do
+        = render UI::Forms::Combobox::Component.new(name: :organization_id, form: f, placeholder: "Choose organization", required: true, include_blank: true, options: Organization.all.pluck(:name, :id))
       .form-group
         .input-group
           .custom-file

--- a/app/views/admin/bulk_imports/new.html.haml
+++ b/app/views/admin/bulk_imports/new.html.haml
@@ -7,7 +7,7 @@
     = form_for [:admin, @bulk_import] do |f|
       = render(UI::Alerts::ObjectError::Component.new(object: @bulk_import))
 
-      = render(UI::Forms::Group::Component.new(form_builder: f, attribute: :organization_id, kind: :content_block, label_text: BulkImport.human_attribute_name(:organization_id), required: true)) do
+      = render(UI::Forms::Group::Component.new(form_builder: f, attribute: :organization_id, label_text: BulkImport.human_attribute_name(:organization_id), required: true)) do
         = render UI::Forms::Combobox::Component.new(name: :organization_id, form: f, placeholder: "Choose organization", required: true, include_blank: true, options: Organization.all.pluck(:name, :id))
       .form-group
         .input-group

--- a/app/views/admin/mail_snippets/_form.html.erb
+++ b/app/views/admin/mail_snippets/_form.html.erb
@@ -37,17 +37,17 @@
 
 <% def select_display(kind); "#{MailSnippet.kind_humanized(kind)} - in #{MailSnippet.organization_email_for(kind)} emails" end %>
 
-<%= render(UI::Forms::Group::Component.new(form_builder: f, attribute: :kind, kind: :content_block, label_text: MailSnippet.human_attribute_name(:kind), required: true)) do %>
+<%= render(UI::Forms::Group::Component.new(form_builder: f, attribute: :kind, label_text: MailSnippet.human_attribute_name(:kind), required: true)) do %>
   <%# kind is an integer-backed enum: options/value must be the enum *labels* — kind= rejects the integer-as-string a form submits, and an explicit value: overrides hotwire_combobox's enum branch (which would emit kind_before_type_cast) %>
   <%= render UI::Forms::Combobox::Component.new(name: :kind, form: f, value: @mail_snippet.kind, required: true, options: MailSnippet.kinds.map { |kind| {display: select_display(kind), value: kind} }) %>
 <% end %>
 
 <% if @mail_snippet.kind == "stolen_notification_oauth" %>
-  <%= render(UI::Forms::Group::Component.new(form_builder: f, attribute: :doorkeeper_app_id, kind: :content_block, label_text: MailSnippet.human_attribute_name(:doorkeeper_app_id))) do %>
+  <%= render(UI::Forms::Group::Component.new(form_builder: f, attribute: :doorkeeper_app_id, label_text: MailSnippet.human_attribute_name(:doorkeeper_app_id))) do %>
     <%= render UI::Forms::Combobox::Component.new(name: :doorkeeper_app_id, form: f, placeholder: "Choose Doorkeeper App", options: Doorkeeper::Application.where(can_send_stolen_notifications: true).map { |app| {display: app.name, value: app.id} }) %>
   <% end %>
 <% else %>
-  <%= render(UI::Forms::Group::Component.new(form_builder: f, attribute: :organization_id, kind: :content_block, label_text: MailSnippet.human_attribute_name(:organization_id))) do %>
+  <%= render(UI::Forms::Group::Component.new(form_builder: f, attribute: :organization_id, label_text: MailSnippet.human_attribute_name(:organization_id))) do %>
     <%= render UI::Forms::Combobox::Component.new(name: :organization_id, form: f, placeholder: "Choose organization", options: @organizations.map { |org| {display: org.name, value: org.id} }) %>
   <% end %>
 <% end %>

--- a/app/views/admin/mail_snippets/_form.html.erb
+++ b/app/views/admin/mail_snippets/_form.html.erb
@@ -37,19 +37,19 @@
 
 <% def select_display(kind); "#{MailSnippet.kind_humanized(kind)} - in #{MailSnippet.organization_email_for(kind)} emails" end %>
 
-<div class="form-group">
+<%= render(UI::Forms::Group::Component.new(form_builder: f, attribute: :kind, kind: :content_block, label_text: MailSnippet.human_attribute_name(:kind), required: true)) do %>
   <%# kind is an integer-backed enum: options/value must be the enum *labels* — kind= rejects the integer-as-string a form submits, and an explicit value: overrides hotwire_combobox's enum branch (which would emit kind_before_type_cast) %>
-  <%= render UI::Forms::Combobox::Component.new(name: :kind, form: f, value: @mail_snippet.kind, label: MailSnippet.human_attribute_name(:kind), required: true, options: MailSnippet.kinds.map { |kind| {display: select_display(kind), value: kind} }) %>
-</div>
+  <%= render UI::Forms::Combobox::Component.new(name: :kind, form: f, value: @mail_snippet.kind, required: true, options: MailSnippet.kinds.map { |kind| {display: select_display(kind), value: kind} }) %>
+<% end %>
 
 <% if @mail_snippet.kind == "stolen_notification_oauth" %>
-  <div class="form-group">
-    <%= render UI::Forms::Combobox::Component.new(name: :doorkeeper_app_id, form: f, label: MailSnippet.human_attribute_name(:doorkeeper_app_id), placeholder: "Choose Doorkeeper App", options: Doorkeeper::Application.where(can_send_stolen_notifications: true).map { |app| {display: app.name, value: app.id} }) %>
-  </div>
+  <%= render(UI::Forms::Group::Component.new(form_builder: f, attribute: :doorkeeper_app_id, kind: :content_block, label_text: MailSnippet.human_attribute_name(:doorkeeper_app_id))) do %>
+    <%= render UI::Forms::Combobox::Component.new(name: :doorkeeper_app_id, form: f, placeholder: "Choose Doorkeeper App", options: Doorkeeper::Application.where(can_send_stolen_notifications: true).map { |app| {display: app.name, value: app.id} }) %>
+  <% end %>
 <% else %>
-  <div class="form-group">
-    <%= render UI::Forms::Combobox::Component.new(name: :organization_id, form: f, label: MailSnippet.human_attribute_name(:organization_id), placeholder: "Choose organization", options: @organizations.map { |org| {display: org.name, value: org.id} }) %>
-  </div>
+  <%= render(UI::Forms::Group::Component.new(form_builder: f, attribute: :organization_id, kind: :content_block, label_text: MailSnippet.human_attribute_name(:organization_id))) do %>
+    <%= render UI::Forms::Combobox::Component.new(name: :organization_id, form: f, placeholder: "Choose organization", options: @organizations.map { |org| {display: org.name, value: org.id} }) %>
+  <% end %>
 <% end %>
 
 <%= render(UI::Forms::Group::Component.new(form_builder: f, attribute: :subject)) %>

--- a/app/views/admin/organization_roles/_form.html.haml
+++ b/app/views/admin/organization_roles/_form.html.haml
@@ -9,8 +9,8 @@
     = form_for [:admin, @organization_role] do |f|
       = render(UI::Alerts::ObjectError::Component.new(object: @organization_role))
 
-      .form-group
-        = render UI::Forms::Combobox::Component.new(name: :organization_id, form: f, label: OrganizationRole.human_attribute_name(:organization), placeholder: "Please select an organization", required: true, include_blank: true, options: @organizations.pluck(:name, :id))
+      = render(UI::Forms::Group::Component.new(form_builder: f, attribute: :organization_id, kind: :content_block, label_text: OrganizationRole.human_attribute_name(:organization), required: true)) do
+        = render UI::Forms::Combobox::Component.new(name: :organization_id, form: f, placeholder: "Please select an organization", required: true, include_blank: true, options: @organizations.pluck(:name, :id))
 
       .form-group
         = f.label :invited_email

--- a/app/views/admin/organization_roles/_form.html.haml
+++ b/app/views/admin/organization_roles/_form.html.haml
@@ -9,7 +9,7 @@
     = form_for [:admin, @organization_role] do |f|
       = render(UI::Alerts::ObjectError::Component.new(object: @organization_role))
 
-      = render(UI::Forms::Group::Component.new(form_builder: f, attribute: :organization_id, kind: :content_block, label_text: OrganizationRole.human_attribute_name(:organization), required: true)) do
+      = render(UI::Forms::Group::Component.new(form_builder: f, attribute: :organization_id, label_text: OrganizationRole.human_attribute_name(:organization), required: true)) do
         = render UI::Forms::Combobox::Component.new(name: :organization_id, form: f, placeholder: "Please select an organization", required: true, include_blank: true, options: @organizations.pluck(:name, :id))
 
       .form-group

--- a/app/views/admin/organizations/_form.html.haml
+++ b/app/views/admin/organizations/_form.html.haml
@@ -93,13 +93,13 @@
       = f.label :direct_unclaimed_notifications do
         Send emails directly to unclaimed bike owners
         %small.less-strong don't require org to forward
-    .form-group
-      - parent_org_label = capture do
-        Parent organization
-        %small.less-strong
-          %strong.text-danger (probably) do not add parents!
-          Parents must be part of the same organization
-      = render UI::Forms::Combobox::Component.new(name: :parent_organization_id, form: f, label: parent_org_label, placeholder: "Choose organization", include_blank: true, options: Organization.with_enabled_feature_slugs("child_organizations").pluck(:name, :id), data: {"admin--organization-form-target": "ambassadorField"})
+    - parent_org_label = capture do
+      Parent organization
+      %small.less-strong
+        %strong.text-danger (probably) do not add parents!
+        Parents must be part of the same organization
+    = render(UI::Forms::Group::Component.new(form_builder: f, attribute: :parent_organization_id, kind: :content_block, label_text: parent_org_label, wrapper_class: "form-group")) do
+      = render UI::Forms::Combobox::Component.new(name: :parent_organization_id, form: f, placeholder: "Choose organization", include_blank: true, options: Organization.with_enabled_feature_slugs("child_organizations").pluck(:name, :id), data: {"admin--organization-form-target": "ambassadorField"})
       %small
         %strong Use the "regional" feature instead.
         %em To add regional organizations rather than child/parent relationships, enable it through a paid invoice for the organization. All organizations with a location in the same area will automatically be associated.
@@ -122,11 +122,11 @@
     - if @organization.id.present?
       - emails = @organization.users.pluck(:email)
       - emails << ENV['AUTO_ORG_MEMBER'] unless emails.any?
-      .form-group
-        - embedable_label = capture do
-          Auto user email
-          %small.less-strong embed registration email
-        = render UI::Forms::Combobox::Component.new(name: :embedable_user_email, form: f, label: embedable_label, placeholder: "Select email", value: @embedable_email, include_blank: true, options: emails)
+      - embedable_label = capture do
+        Auto user email
+        %small.less-strong embed registration email
+      = render(UI::Forms::Group::Component.new(form_builder: f, attribute: :embedable_user_email, kind: :content_block, label_text: embedable_label, wrapper_class: "form-group")) do
+        = render UI::Forms::Combobox::Component.new(name: :embedable_user_email, form: f, placeholder: "Select email", value: @embedable_email, include_blank: true, options: emails)
         %small.less-strong
           - if @organization.organization_roles.count == 0
             You can use #{ENV['AUTO_ORG_MEMBER']} if
@@ -140,8 +140,8 @@
             if checked, we will start email their customers theft surveys
 
     - if @organization.official_manufacturer?
-      .form-group
-        = render UI::Forms::ComboboxManufacturer::Component.new(frame_maker: true, form: f, label: Organization.human_attribute_name(:manufacturer), required: true)
+      = render(UI::Forms::Group::Component.new(form_builder: f, attribute: :manufacturer_id, kind: :content_block, label_text: Organization.human_attribute_name(:manufacturer), required: true, wrapper_class: "form-group")) do
+        = render UI::Forms::ComboboxManufacturer::Component.new(frame_maker: true, form: f, required: true)
         %small
           %strong This organization has <code>Official manufacturer organization</code> enabled.
           Select a manufacturer to give them manufacturer access.

--- a/app/views/admin/organizations/_form.html.haml
+++ b/app/views/admin/organizations/_form.html.haml
@@ -98,7 +98,7 @@
       %small.less-strong
         %strong.text-danger (probably) do not add parents!
         Parents must be part of the same organization
-    = render(UI::Forms::Group::Component.new(form_builder: f, attribute: :parent_organization_id, kind: :content_block, label_text: parent_org_label, wrapper_class: "form-group")) do
+    = render(UI::Forms::Group::Component.new(form_builder: f, attribute: :parent_organization_id, label_text: parent_org_label, wrapper_class: "form-group")) do
       = render UI::Forms::Combobox::Component.new(name: :parent_organization_id, form: f, placeholder: "Choose organization", include_blank: true, options: Organization.with_enabled_feature_slugs("child_organizations").pluck(:name, :id), data: {"admin--organization-form-target": "ambassadorField"})
       %small
         %strong Use the "regional" feature instead.
@@ -125,7 +125,7 @@
       - embedable_label = capture do
         Auto user email
         %small.less-strong embed registration email
-      = render(UI::Forms::Group::Component.new(form_builder: f, attribute: :embedable_user_email, kind: :content_block, label_text: embedable_label, wrapper_class: "form-group")) do
+      = render(UI::Forms::Group::Component.new(form_builder: f, attribute: :embedable_user_email, label_text: embedable_label, wrapper_class: "form-group")) do
         = render UI::Forms::Combobox::Component.new(name: :embedable_user_email, form: f, placeholder: "Select email", value: @embedable_email, include_blank: true, options: emails)
         %small.less-strong
           - if @organization.organization_roles.count == 0
@@ -140,7 +140,7 @@
             if checked, we will start email their customers theft surveys
 
     - if @organization.official_manufacturer?
-      = render(UI::Forms::Group::Component.new(form_builder: f, attribute: :manufacturer_id, kind: :content_block, label_text: Organization.human_attribute_name(:manufacturer), required: true, wrapper_class: "form-group")) do
+      = render(UI::Forms::Group::Component.new(form_builder: f, attribute: :manufacturer_id, label_text: Organization.human_attribute_name(:manufacturer), required: true, wrapper_class: "form-group")) do
         = render UI::Forms::ComboboxManufacturer::Component.new(frame_maker: true, form: f, required: true)
         %small
           %strong This organization has <code>Official manufacturer organization</code> enabled.

--- a/app/views/admin/payments/edit.html.haml
+++ b/app/views/admin/payments/edit.html.haml
@@ -24,7 +24,7 @@
 
         .row
           .col-lg-6
-            = render(UI::Forms::Group::Component.new(form_builder: f, attribute: :organization_id, kind: :content_block, label_text: Payment.human_attribute_name(:organization_id))) do
+            = render(UI::Forms::Group::Component.new(form_builder: f, attribute: :organization_id, label_text: Payment.human_attribute_name(:organization_id))) do
               = render UI::Forms::Combobox::Component.new(name: :organization_id, form: f, placeholder: "Choose organization", include_blank: true, options: Organization.approved.pluck(:name, :id))
           .col-lg-6
             .form-group

--- a/app/views/admin/payments/edit.html.haml
+++ b/app/views/admin/payments/edit.html.haml
@@ -24,8 +24,8 @@
 
         .row
           .col-lg-6
-            .form-group
-              = render UI::Forms::Combobox::Component.new(name: :organization_id, form: f, label: Payment.human_attribute_name(:organization_id), placeholder: "Choose organization", include_blank: true, options: Organization.approved.pluck(:name, :id))
+            = render(UI::Forms::Group::Component.new(form_builder: f, attribute: :organization_id, kind: :content_block, label_text: Payment.human_attribute_name(:organization_id))) do
+              = render UI::Forms::Combobox::Component.new(name: :organization_id, form: f, placeholder: "Choose organization", include_blank: true, options: Organization.approved.pluck(:name, :id))
           .col-lg-6
             .form-group
               = f.label :invoice_id, "Invoice #"

--- a/app/views/admin/payments/new.html.haml
+++ b/app/views/admin/payments/new.html.haml
@@ -6,9 +6,9 @@
 
   .row
     .col-md-6
-      .form-group
+      = render(UI::Forms::Group::Component.new(form_builder: f, attribute: :payment_method, kind: :content_block, label_text: Payment.human_attribute_name(:payment_method))) do
         -# payment_method is an integer-backed enum: pass enum *labels* as option values and an explicit value: to override hotwire_combobox's enum branch (which would emit payment_method_before_type_cast)
-        = render UI::Forms::Combobox::Component.new(name: :payment_method, form: f, value: @payment.payment_method, label: Payment.human_attribute_name(:payment_method), options: Payment.admin_creatable_payment_methods.map { |m| [m.humanize, m] })
+        = render UI::Forms::Combobox::Component.new(name: :payment_method, form: f, value: @payment.payment_method, options: Payment.admin_creatable_payment_methods.map { |m| [m.humanize, m] })
     .col-md-6
       .form-group
         - f.object.created_at = Binxtils::TimeParser.round(f.object.created_at || Time.current)
@@ -26,8 +26,8 @@
         = f.label :email, "Email of user who created payment"
         = f.email_field :email, class: "form-control"
     .col-md-6
-      .form-group
-        = render UI::Forms::Combobox::Component.new(name: :organization_id, form: f, label: Payment.human_attribute_name(:organization_id), placeholder: "Choose organization", include_blank: true, options: Organization.all.pluck(:name, :id))
+      = render(UI::Forms::Group::Component.new(form_builder: f, attribute: :organization_id, kind: :content_block, label_text: Payment.human_attribute_name(:organization_id))) do
+        = render UI::Forms::Combobox::Component.new(name: :organization_id, form: f, placeholder: "Choose organization", include_blank: true, options: Organization.all.pluck(:name, :id))
     .col-md-6
       .form-group
         = f.label :referral_source, class: "control-label"

--- a/app/views/admin/payments/new.html.haml
+++ b/app/views/admin/payments/new.html.haml
@@ -6,7 +6,7 @@
 
   .row
     .col-md-6
-      = render(UI::Forms::Group::Component.new(form_builder: f, attribute: :payment_method, kind: :content_block, label_text: Payment.human_attribute_name(:payment_method))) do
+      = render(UI::Forms::Group::Component.new(form_builder: f, attribute: :payment_method, label_text: Payment.human_attribute_name(:payment_method))) do
         -# payment_method is an integer-backed enum: pass enum *labels* as option values and an explicit value: to override hotwire_combobox's enum branch (which would emit payment_method_before_type_cast)
         = render UI::Forms::Combobox::Component.new(name: :payment_method, form: f, value: @payment.payment_method, options: Payment.admin_creatable_payment_methods.map { |m| [m.humanize, m] })
     .col-md-6
@@ -26,7 +26,7 @@
         = f.label :email, "Email of user who created payment"
         = f.email_field :email, class: "form-control"
     .col-md-6
-      = render(UI::Forms::Group::Component.new(form_builder: f, attribute: :organization_id, kind: :content_block, label_text: Payment.human_attribute_name(:organization_id))) do
+      = render(UI::Forms::Group::Component.new(form_builder: f, attribute: :organization_id, label_text: Payment.human_attribute_name(:organization_id))) do
         = render UI::Forms::Combobox::Component.new(name: :organization_id, form: f, placeholder: "Choose organization", include_blank: true, options: Organization.all.pluck(:name, :id))
     .col-md-6
       .form-group

--- a/app/views/admin/social_posts/new.html.haml
+++ b/app/views/admin/social_posts/new.html.haml
@@ -21,7 +21,7 @@
               Account
               %small.less-strong
                 will send the original post
-            = render(UI::Forms::Group::Component.new(form_builder: f, attribute: :social_account_id, kind: :content_block, label_text: account_label, wrapper_class: "form-group")) do
+            = render(UI::Forms::Group::Component.new(form_builder: f, attribute: :social_account_id, label_text: account_label, wrapper_class: "form-group")) do
               = render UI::Forms::Combobox::Component.new(name: :social_account_id, form: f, placeholder: "Choose  ", include_blank: true, options: SocialAccount.all.pluck(:screen_name, :id))
             .form-group.avatar-upload
               = f.label :image, 'Post photo', class: 'control-label'

--- a/app/views/admin/social_posts/new.html.haml
+++ b/app/views/admin/social_posts/new.html.haml
@@ -17,19 +17,19 @@
       .card-body
         .row
           .col-md-6
-            .form-group
-              - account_label = capture do
-                Account
-                %small.less-strong
-                  will send the original post
-              = render UI::Forms::Combobox::Component.new(name: :social_account_id, form: f, label: account_label, placeholder: "Choose  ", include_blank: true, options: SocialAccount.all.pluck(:screen_name, :id))
-              .form-group.avatar-upload
-                = f.label :image, 'Post photo', class: 'control-label'
-                .avatar-img
-                  .input-group
-                    .custom-file
-                    = f.label :image, "Post Image", class: "custom-file-label"
-                    = f.file_field :image, class: "custom-file-input", accept: ImageUploader.permitted_extensions.join(",")
+            - account_label = capture do
+              Account
+              %small.less-strong
+                will send the original post
+            = render(UI::Forms::Group::Component.new(form_builder: f, attribute: :social_account_id, kind: :content_block, label_text: account_label, wrapper_class: "form-group")) do
+              = render UI::Forms::Combobox::Component.new(name: :social_account_id, form: f, placeholder: "Choose  ", include_blank: true, options: SocialAccount.all.pluck(:screen_name, :id))
+            .form-group.avatar-upload
+              = f.label :image, 'Post photo', class: 'control-label'
+              .avatar-img
+                .input-group
+                  .custom-file
+                  = f.label :image, "Post Image", class: "custom-file-label"
+                  = f.file_field :image, class: "custom-file-input", accept: ImageUploader.permitted_extensions.join(",")
           .col-md-6
             .form-group#characterCounterField
               = f.label :body do

--- a/spec/components/ui/forms/combobox/component_spec.rb
+++ b/spec/components/ui/forms/combobox/component_spec.rb
@@ -17,6 +17,11 @@ RSpec.describe UI::Forms::Combobox::Component, type: :component do
     expect(component).to have_css("[role='option'][data-value='Trek']", text: "Trek", visible: :all)
   end
 
+  it "renders no label of its own, and ids the input with the name so a Group label can target it" do
+    expect(component).to_not have_css("label", visible: :all, text: /\S/)
+    expect(component).to have_css("input[role='combobox'][id='manufacturer']")
+  end
+
   context "with hash options" do
     let(:combobox_options) { [{display: "Black", value: "1"}, {display: "Blue", value: "2"}] }
 
@@ -26,13 +31,27 @@ RSpec.describe UI::Forms::Combobox::Component, type: :component do
     end
   end
 
-  context "with a label and a preselected value" do
-    let(:extra) { {label: "Manufacturer", value: "Surly"} }
+  context "with a preselected value" do
+    let(:extra) { {value: "Surly"} }
 
-    it "renders the label and prefills the value" do
-      expect(component).to have_css("label", text: "Manufacturer")
+    it "prefills the value" do
       expect(component).to have_css("[data-hw-combobox-prefilled-display-value='Surly']")
       expect(component).to have_css("input[type='hidden'][value='Surly']", visible: :all)
+    end
+  end
+
+  context "with a form builder" do
+    let(:component) do
+      render_in_view_context do
+        form_for Bike.new, url: "#", builder: BikeIndexFormBuilder do |f|
+          render(UI::Forms::Combobox::Component.new(name: :manufacturer, form: f, options: %w[Trek Giant Surly]))
+        end
+      end
+    end
+
+    it "leaves the input id to the form builder, matching a Group label's for" do
+      expect(component).to have_css("input[role='combobox'][id='bike_manufacturer']")
+      expect(component).to have_css("input[type='hidden'][name='bike[manufacturer]']", visible: :all)
     end
   end
 

--- a/spec/components/ui/forms/combobox/component_spec.rb
+++ b/spec/components/ui/forms/combobox/component_spec.rb
@@ -5,38 +5,51 @@ require "rails_helper"
 RSpec.describe UI::Forms::Combobox::Component, type: :component do
   let(:instance) { described_class.new(**options) }
   let(:component) { render_inline(instance) }
-  let(:options) { {name: "manufacturer", options: combobox_options}.merge(extra) }
-  let(:combobox_options) { %w[Trek Giant Surly] }
+  let(:options) { {name: "cycle_type", options: combobox_options}.merge(extra) }
+  let(:combobox_options) { %w[Bike Tandem Unicycle] }
   let(:extra) { {} }
 
   it "renders an accessible combobox wired to the hw-combobox controller" do
     expect(component).to have_css("fieldset.hw-combobox[data-controller='hw-combobox']")
     expect(component).to have_css("input[role='combobox']")
-    expect(component).to have_css("input[type='hidden'][name='manufacturer']", visible: :all)
+    expect(component).to have_css("input[type='hidden'][name='cycle_type']", visible: :all)
     expect(component).to have_css("[role='option']", count: 3, visible: :all)
-    expect(component).to have_css("[role='option'][data-value='Trek']", text: "Trek", visible: :all)
+    expect(component).to have_css("[role='option'][data-value='Tandem']", text: "Tandem", visible: :all)
   end
 
   it "renders no label of its own, and ids the input with the name so a Group label can target it" do
-    expect(component).to_not have_css("label", visible: :all, text: /\S/)
-    expect(component).to have_css("input[role='combobox'][id='manufacturer']")
+    expect(component).to_not have_css("label.hw-combobox__label", visible: :all, text: /\S/)
+    expect(component).to have_css("input[role='combobox'][id='cycle_type']")
+  end
+
+  it "labels the mobile dialog's input, which a Group label can't reach" do
+    expect(component).to have_css("label.hw-combobox__dialog__label[for='cycle_type-hw-dialog-combobox']",
+      text: "Cycle type", visible: :all)
+  end
+
+  context "with a dialog_label" do
+    let(:extra) { {dialog_label: "Kind of cycle"} }
+
+    it "overrides the humanized name" do
+      expect(component).to have_css("label.hw-combobox__dialog__label", text: "Kind of cycle", visible: :all)
+    end
   end
 
   context "with hash options" do
-    let(:combobox_options) { [{display: "Black", value: "1"}, {display: "Blue", value: "2"}] }
+    let(:combobox_options) { [{display: "[622] 700c", value: "1"}, {display: "[559] 26in", value: "2"}] }
 
     it "renders the display text with the underlying value" do
-      expect(component).to have_css("[role='option'][data-value='1']", text: "Black", visible: :all)
-      expect(component).to have_css("[role='option'][data-value='2']", text: "Blue", visible: :all)
+      expect(component).to have_css("[role='option'][data-value='1']", text: "[622] 700c", visible: :all)
+      expect(component).to have_css("[role='option'][data-value='2']", text: "[559] 26in", visible: :all)
     end
   end
 
   context "with a preselected value" do
-    let(:extra) { {value: "Surly"} }
+    let(:extra) { {value: "Unicycle"} }
 
     it "prefills the value" do
-      expect(component).to have_css("[data-hw-combobox-prefilled-display-value='Surly']")
-      expect(component).to have_css("input[type='hidden'][value='Surly']", visible: :all)
+      expect(component).to have_css("[data-hw-combobox-prefilled-display-value='Unicycle']")
+      expect(component).to have_css("input[type='hidden'][value='Unicycle']", visible: :all)
     end
   end
 
@@ -44,24 +57,24 @@ RSpec.describe UI::Forms::Combobox::Component, type: :component do
     let(:component) do
       render_in_view_context do
         form_for Bike.new, url: "#", builder: BikeIndexFormBuilder do |f|
-          render(UI::Forms::Combobox::Component.new(name: :manufacturer, form: f, options: %w[Trek Giant Surly]))
+          render(UI::Forms::Combobox::Component.new(name: :primary_activity_id, form: f, options: %w[Road Gravel]))
         end
       end
     end
 
     it "leaves the input id to the form builder, matching a Group label's for" do
-      expect(component).to have_css("input[role='combobox'][id='bike_manufacturer']")
-      expect(component).to have_css("input[type='hidden'][name='bike[manufacturer]']", visible: :all)
+      expect(component).to have_css("input[role='combobox'][id='bike_primary_activity_id']")
+      expect(component).to have_css("input[type='hidden'][name='bike[primary_activity_id]']", visible: :all)
     end
   end
 
   context "with src for async loading" do
-    let(:options) { {name: "manufacturer", src: "/manufacturers"} }
+    let(:options) { {name: "primary_activity", src: "/primary_activities"} }
 
     it "renders an async endpoint instead of inline options" do
       html = component.to_html
       expect(html).to include("data-hw-combobox-async-src-value")
-      expect(html).to include("/manufacturers")
+      expect(html).to include("/primary_activities")
       expect(component).not_to have_css("[role='option']", visible: :all)
     end
   end

--- a/spec/components/ui/forms/combobox/component_system_spec.rb
+++ b/spec/components/ui/forms/combobox/component_system_spec.rb
@@ -12,29 +12,29 @@ RSpec.describe UI::Forms::Combobox::Component, :js, type: :system do
     expect_axe_clean
 
     # Opens the listbox on click
-    find_field("Manufacturer").click
+    find_field("Cycle type").click
 
     expect(page).to have_css('[aria-expanded="true"]')
-    expect(page).to have_css('[role="option"]', count: 6)
+    expect(page).to have_css('[role="option"]', count: CycleType.slugs.count)
     expect_axe_clean
 
     # Filters the options as you type
-    fill_in "Manufacturer", with: "an"
+    fill_in "Cycle type", with: "cargo"
 
-    expect(page).to have_css('[role="option"]', text: "Giant")
-    expect(page).to have_css('[role="option"]', text: "Cannondale")
-    expect(page).not_to have_css('[role="option"]', text: "Trek")
+    expect(page).to have_css('[role="option"]', text: "Cargo Bike (front storage)")
+    expect(page).to have_css('[role="option"]', text: "Cargo Tricycle (trike with rear storage)")
+    expect(page).not_to have_css('[role="option"]', text: "Unicycle")
 
     # Selecting an option closes the listbox and fills the visible input
     # and the hidden field that carries the form value
-    find('[role="option"]', text: "Cannondale").click
+    find('[role="option"]', text: "Cargo Bike (front storage)").click
 
     expect(page).to have_css('[aria-expanded="false"]')
-    expect(find_field("Manufacturer").value).to eq "Cannondale"
-    expect(find("input[name='manufacturer']", visible: :hidden).value).to eq "Cannondale"
+    expect(find_field("Cycle type").value).to eq "Cargo Bike (front storage)"
+    expect(find("input[name='cycle_type']", visible: :hidden).value).to eq "Cargo Bike (front storage)"
 
     # Reopen, then close with the Escape key
-    find_field("Manufacturer").click
+    find_field("Cycle type").click
 
     expect(page).to have_css('[aria-expanded="true"]')
 

--- a/spec/components/ui/forms/combobox_manufacturer/component_spec.rb
+++ b/spec/components/ui/forms/combobox_manufacturer/component_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe UI::Forms::ComboboxManufacturer::Component, type: :component do
 
   it "renders a manufacturer_id combobox of every manufacturer" do
     expect(component).to have_css("input[type='hidden'][name='manufacturer_id']", visible: :all)
-    expect(component).to_not have_css("label", visible: :all, text: /\S/)
+    expect(component).to_not have_css("label.hw-combobox__label", visible: :all, text: /\S/)
     expect(component).to have_css("[role='option'][data-value='#{frame_maker.id}']", text: "Surly", visible: :all)
     expect(component).to have_css("[role='option'][data-value='#{component_maker.id}']", text: "Shimano", visible: :all)
   end

--- a/spec/components/ui/forms/combobox_manufacturer/component_spec.rb
+++ b/spec/components/ui/forms/combobox_manufacturer/component_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe UI::Forms::ComboboxManufacturer::Component, type: :component do
 
   it "renders a manufacturer_id combobox of every manufacturer" do
     expect(component).to have_css("input[type='hidden'][name='manufacturer_id']", visible: :all)
-    expect(component).to have_css("label", text: "Manufacturer")
+    expect(component).to_not have_css("label", visible: :all, text: /\S/)
     expect(component).to have_css("[role='option'][data-value='#{frame_maker.id}']", text: "Surly", visible: :all)
     expect(component).to have_css("[role='option'][data-value='#{component_maker.id}']", text: "Shimano", visible: :all)
   end
@@ -35,11 +35,10 @@ RSpec.describe UI::Forms::ComboboxManufacturer::Component, type: :component do
   end
 
   context "with forwarded options" do
-    let(:options) { {name: :cmp_manufacturer_id, label: "Frame manufacturer", value: frame_maker.id} }
+    let(:options) { {name: :cmp_manufacturer_id, value: frame_maker.id} }
 
-    it "forwards name, label, and value to the combobox" do
+    it "forwards name and value to the combobox" do
       expect(component).to have_css("input[type='hidden'][name='cmp_manufacturer_id']", visible: :all)
-      expect(component).to have_css("label", text: "Frame manufacturer")
       expect(component).to have_css("[data-hw-combobox-prefilled-display-value='Surly']")
     end
   end

--- a/spec/components/ui/forms/group/component_spec.rb
+++ b/spec/components/ui/forms/group/component_spec.rb
@@ -87,15 +87,15 @@ RSpec.describe UI::Forms::Group::Component, type: :component do
   context "when content_block wrapping a combobox, without a form_builder" do
     let(:component) do
       render_in_view_context do
-        render(UI::Forms::Group::Component.new(attribute: :manufacturer, kind: :content_block)) do
-          render(UI::Forms::Combobox::Component.new(name: :manufacturer, options: %w[Trek Surly]))
+        render(UI::Forms::Group::Component.new(attribute: :cycle_type, kind: :content_block)) do
+          render(UI::Forms::Combobox::Component.new(name: :cycle_type, options: %w[Bike Tandem]))
         end
       end
     end
 
     it "labels the combobox by its name" do
-      expect(component).to have_css("label[for='manufacturer']", text: "Manufacturer")
-      expect(component).to have_css("input[role='combobox'][id='manufacturer']")
+      expect(component).to have_css("label[for='cycle_type']", text: "Cycle type")
+      expect(component).to have_css("input[role='combobox'][id='cycle_type']")
     end
   end
 

--- a/spec/components/ui/forms/group/component_spec.rb
+++ b/spec/components/ui/forms/group/component_spec.rb
@@ -84,6 +84,21 @@ RSpec.describe UI::Forms::Group::Component, type: :component do
     end
   end
 
+  context "when content_block wrapping a combobox, without a form_builder" do
+    let(:component) do
+      render_in_view_context do
+        render(UI::Forms::Group::Component.new(attribute: :manufacturer, kind: :content_block)) do
+          render(UI::Forms::Combobox::Component.new(name: :manufacturer, options: %w[Trek Surly]))
+        end
+      end
+    end
+
+    it "labels the combobox by its name" do
+      expect(component).to have_css("label[for='manufacturer']", text: "Manufacturer")
+      expect(component).to have_css("input[role='combobox'][id='manufacturer']")
+    end
+  end
+
   context "when content_block" do
     let(:kind) { :content_block }
     let(:component) do

--- a/spec/components/ui/forms/group/component_spec.rb
+++ b/spec/components/ui/forms/group/component_spec.rb
@@ -64,11 +64,11 @@ RSpec.describe UI::Forms::Group::Component, type: :component do
     end
   end
 
-  context "when content_block wrapping a select" do
+  context "when a content block wraps a select" do
     let(:component) do
       render_in_view_context do
         form_for User.new, url: "#", method: :patch, builder: BikeIndexFormBuilder do |f|
-          render(UI::Forms::Group::Component.new(form_builder: f, attribute: :name, kind: :content_block)) do
+          render(UI::Forms::Group::Component.new(form_builder: f, attribute: :name)) do
             render(UI::Forms::Select::Component.new(form_builder: f, attribute: :name,
               option_tags: [["Red", "1"], ["Blue", "2"]], options: {selected: "2"}))
           end
@@ -84,10 +84,10 @@ RSpec.describe UI::Forms::Group::Component, type: :component do
     end
   end
 
-  context "when content_block wrapping a combobox, without a form_builder" do
+  context "when a content block wraps a combobox, without a form_builder" do
     let(:component) do
       render_in_view_context do
-        render(UI::Forms::Group::Component.new(attribute: :cycle_type, kind: :content_block)) do
+        render(UI::Forms::Group::Component.new(attribute: :cycle_type)) do
           render(UI::Forms::Combobox::Component.new(name: :cycle_type, options: %w[Bike Tandem]))
         end
       end
@@ -99,10 +99,9 @@ RSpec.describe UI::Forms::Group::Component, type: :component do
     end
   end
 
-  context "when content_block" do
-    let(:kind) { :content_block }
+  context "when given a content block" do
     let(:component) do
-      render_inline(described_class.new(form_builder:, attribute:, kind:, label_text:)) do
+      render_inline(described_class.new(form_builder:, attribute:, label_text:)) do
         "<my-field></my-field>".html_safe
       end
     end
@@ -113,6 +112,11 @@ RSpec.describe UI::Forms::Group::Component, type: :component do
       expect(component).to_not have_css("input")
       expect(component).to_not have_css("textarea")
     end
+  end
+
+  it "raises without a form_builder or a content block, since there'd be no field to render" do
+    expect { render_inline(described_class.new(attribute: :name)) }
+      .to raise_error(ArgumentError, /form_builder/)
   end
 
   # The gap to the field lives on .twlabel rather than on either side, so it

--- a/spec/requests/admin/bikes_request_spec.rb
+++ b/spec/requests/admin/bikes_request_spec.rb
@@ -41,6 +41,16 @@ RSpec.describe Admin::BikesController, type: :request do
     end
   end
 
+  describe "missing_manufacturer" do
+    let!(:bike) { FactoryBot.create(:bike, :with_ownership, manufacturer: Manufacturer.other, manufacturer_other: "Cool Bikes") }
+    it "renders" do
+      get "#{base_url}/missing_manufacturer"
+      expect(response.code).to eq("200")
+      expect(response).to render_template("missing_manufacturer")
+      expect(assigns(:bikes).pluck(:id)).to eq([bike.id])
+    end
+  end
+
   describe "edit" do
     let(:bike) { FactoryBot.create(:stolen_bike) }
     let(:stolen_record) { bike.current_stolen_record }

--- a/spec/requests/api/v3/bikes_request_spec.rb
+++ b/spec/requests/api/v3/bikes_request_spec.rb
@@ -115,8 +115,11 @@ RSpec.describe "Bikes API V3", type: :request do
     describe "short_id" do
       # The short_id "/" is a real path separator here (e.g. /api/v3/bikes/r/35); the "_" and
       # "-" separators (see ShortId.decode) are accepted equivalents.
+      # Pin the id: ShortId.encode only stays decimal below 1296 (see its spec)
+      let(:bike) { FactoryBot.create(:bike, id: 35) }
+
       it "finds the bike from its short_id (r/ and r_)" do
-        expect(bike.short_id).to eq "r/#{bike.id}"
+        expect(bike.short_id).to eq "r/35"
         [bike.short_id, bike.short_id.tr("/", "_")].each do |short_id|
           get "/api/v3/bikes/#{short_id}", params: {format: :json}
           expect(response.code).to eq("200")

--- a/spec/vcr_cassettes/MembershipsController-create-no_user.yml
+++ b/spec/vcr_cassettes/MembershipsController-create-no_user.yml
@@ -10,7 +10,7 @@ http_interactions:
       User-Agent:
       - Stripe/v1 RubyBindings/13.4.1
       Idempotency-Key:
-      - af4f1fa6-3c57-4710-927a-aa2e5eebb9f2
+      - b8eaa4f8-15fe-4d11-9bc5-0709aaca6140
       Stripe-Version:
       - 2025-01-27.acacia
       Content-Type:
@@ -27,7 +27,7 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Mon, 25 May 2026 21:41:15 GMT
+      - Mon, 27 Jul 2026 22:14:07 GMT
       Content-Type:
       - application/json
       Content-Length:
@@ -50,21 +50,18 @@ http_interactions:
       Content-Security-Policy:
       - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
         img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
-        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=RbMA1-0SZkS6or-1RnBMcLscYOE4CuGYRqoYGdaVh-_HrWt8dN1eEX6yLWhuk2SLFN2GJ4H-ObUbR0nO;
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=_MQuyLtvv0xWRshV6jvqY9MhexKTROjf3uEwIq72oxM6zcBivWTkQXcWGkQPEKOMlnT3ZLxgKulCAAy6;
         report-to csp
       Idempotency-Key:
-      - af4f1fa6-3c57-4710-927a-aa2e5eebb9f2
+      - b8eaa4f8-15fe-4d11-9bc5-0709aaca6140
       Original-Request:
-      - req_zKnaaX0RM6D4jz
+      - req_v0xZ1xtinmNKoy
       Report-To:
-      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=RbMA1-0SZkS6or-1RnBMcLscYOE4CuGYRqoYGdaVh-_HrWt8dN1eEX6yLWhuk2SLFN2GJ4H-ObUbR0nO&t=1"}],"include_subdomains":true}'
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=_MQuyLtvv0xWRshV6jvqY9MhexKTROjf3uEwIq72oxM6zcBivWTkQXcWGkQPEKOMlnT3ZLxgKulCAAy6&t=1"}],"include_subdomains":true}'
       Reporting-Endpoints:
-      - csp="https://q.stripe.com/csp-report-v2?q=RbMA1-0SZkS6or-1RnBMcLscYOE4CuGYRqoYGdaVh-_HrWt8dN1eEX6yLWhuk2SLFN2GJ4H-ObUbR0nO&t=1"
+      - csp="https://q.stripe.com/csp-report-v2?q=_MQuyLtvv0xWRshV6jvqY9MhexKTROjf3uEwIq72oxM6zcBivWTkQXcWGkQPEKOMlnT3ZLxgKulCAAy6&t=1"
       Request-Id:
-      - req_zKnaaX0RM6D4jz
-      Stripe-Notice:
-      - You are using an outdated API version (2025-01-27.acacia). We recommend upgrading
-        to the latest API version, 2026-04-22.dahlia. See https://docs.stripe.com/upgrades
+      - req_v0xZ1xtinmNKoy
       Stripe-Should-Retry:
       - 'false'
       Stripe-Version:
@@ -83,7 +80,7 @@ http_interactions:
       encoding: UTF-8
       string: |-
         {
-          "id": "cs_test_a1OlHzxcDrxSruKFC7Io3lVJfBmdupgIOO0WYVOSdxtIB0mP8iEtbEOoiP",
+          "id": "cs_test_a1AKMkXYqWUSCYCLQAmeBHpFhOvhjS4cnpndRXmm3kbxF5tTtQdi5EePCd",
           "object": "checkout.session",
           "adaptive_pricing": {
             "enabled": true
@@ -117,7 +114,7 @@ http_interactions:
           "collected_information": null,
           "consent": null,
           "consent_collection": null,
-          "created": 1779745274,
+          "created": 1785190447,
           "currency": "usd",
           "currency_conversion": null,
           "custom_fields": [],
@@ -133,7 +130,7 @@ http_interactions:
           "customer_details": null,
           "customer_email": null,
           "discounts": [],
-          "expires_at": 1779831674,
+          "expires_at": 1785276847,
           "integration_identifier": null,
           "invoice": null,
           "invoice_creation": null,
@@ -189,8 +186,8 @@ http_interactions:
             "amount_tax": 0
           },
           "ui_mode": "hosted",
-          "url": "https://checkout.stripe.com/c/pay/cs_test_a1OlHzxcDrxSruKFC7Io3lVJfBmdupgIOO0WYVOSdxtIB0mP8iEtbEOoiP#fidnandhYHdWcXxpYCc%2FJ2FgY2RwaXEnKSdicGRmZGhqaWBTZHdsZGtxJz8nZmprcXdqaScpJ2R1bE5gfCc%2FJ3VuWnFgdnFaX09BbE1nX0lWR2ZkUVxvNXY3RG0yaEtgJyknY3dqaFZgd3Ngdyc%2FcXdwYCknZ2RmbmJ3anBrYUZqaWp3Jz8nJmNjY2NjYycpJ2lkfGpwcVF8dWAnPyd2bGtiaWBabHFgaCcpJ2BrZGdpYFVpZGZgbWppYWB3dic%2FcXdwYHgl",
+          "url": "https://checkout.stripe.com/c/pay/cs_test_a1AKMkXYqWUSCYCLQAmeBHpFhOvhjS4cnpndRXmm3kbxF5tTtQdi5EePCd#fidnandhYHdWcXxpYCc%2FJ2FgY2RwaXEnKSdicGRmZGhqaWBTZHdsZGtxJz8nZmprcXdqaScpJ2R1bE5gfCc%2FJ3VuWnFgdnFaX09BbE1nX0lWR2ZkUVxvNXY3RG0yaEtgJyknY3dqaFZgd3Ngdyc%2FcXdwYCknZ2RmbmJ3anBrYUZqaWp3Jz8nJmNjY2NjYycpJ2lkfGpwcVF8dWAnPyd2bGtiaWBabHFgaCcpJ2BrZGdpYFVpZGZgbWppYWB3dic%2FcXdwYHgl",
           "wallet_options": null
         }
-  recorded_at: Mon, 25 May 2026 21:41:15 GMT
+  recorded_at: Mon, 27 Jul 2026 22:14:07 GMT
 recorded_with: VCR 6.4.0

--- a/spec/vcr_cassettes/MembershipsController-create-success.yml
+++ b/spec/vcr_cassettes/MembershipsController-create-success.yml
@@ -5,14 +5,14 @@ http_interactions:
     uri: https://api.stripe.com/v1/checkout/sessions
     body:
       encoding: UTF-8
-      string: success_url=http%3A%2F%2Ftest.host%2Fmembership%2Fsuccess%3Fsession_id%3D%7BCHECKOUT_SESSION_ID%7D&cancel_url=http%3A%2F%2Ftest.host%2Fmembership%2Fnew&mode=subscription&line_items[0][quantity]=1&line_items[0][price]=price_0Qs5p2m0T0GBfX0vhLrGLAAi&customer_email=user6s%40bikeindex.org
+      string: success_url=http%3A%2F%2Ftest.host%2Fmembership%2Fsuccess%3Fsession_id%3D%7BCHECKOUT_SESSION_ID%7D&cancel_url=http%3A%2F%2Ftest.host%2Fmembership%2Fnew&mode=subscription&line_items[0][quantity]=1&line_items[0][price]=price_0Qs5p2m0T0GBfX0vhLrGLAAi&customer_email=user1062s%40bikeindex.org
     headers:
       User-Agent:
       - Stripe/v1 RubyBindings/13.4.1
       X-Stripe-Client-Telemetry:
-      - '{"last_request_metrics":{"request_id":"req_zKnaaX0RM6D4jz","request_duration_ms":389}}'
+      - '{"last_request_metrics":{"request_id":"req_v0xZ1xtinmNKoy","request_duration_ms":511}}'
       Idempotency-Key:
-      - d69af04d-6ceb-48dc-bf60-124789a9e821
+      - 9b8e46f0-8f76-4676-a1fc-b9b408ffe680
       Stripe-Version:
       - 2025-01-27.acacia
       Content-Type:
@@ -29,11 +29,11 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Mon, 25 May 2026 21:41:15 GMT
+      - Mon, 27 Jul 2026 22:14:08 GMT
       Content-Type:
       - application/json
       Content-Length:
-      - '3768'
+      - '3774'
       Connection:
       - keep-alive
       Access-Control-Allow-Credentials:
@@ -52,21 +52,18 @@ http_interactions:
       Content-Security-Policy:
       - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
         img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
-        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=RbMA1-0SZkS6or-1RnBMcLscYOE4CuGYRqoYGdaVh-_HrWt8dN1eEX6yLWhuk2SLFN2GJ4H-ObUbR0nO;
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=Fliex2wMi2DNYh6k7CDngJ94k7c5tjXOfx8XF5B8JG71-tzBt_-a2i4AGQoaxDdMdCym-4Vfi1GlExEu;
         report-to csp
       Idempotency-Key:
-      - d69af04d-6ceb-48dc-bf60-124789a9e821
+      - 9b8e46f0-8f76-4676-a1fc-b9b408ffe680
       Original-Request:
-      - req_jTSfujFAgSCAIY
+      - req_wsN7m6JWKXyMIB
       Report-To:
-      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=RbMA1-0SZkS6or-1RnBMcLscYOE4CuGYRqoYGdaVh-_HrWt8dN1eEX6yLWhuk2SLFN2GJ4H-ObUbR0nO&t=1"}],"include_subdomains":true}'
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=Fliex2wMi2DNYh6k7CDngJ94k7c5tjXOfx8XF5B8JG71-tzBt_-a2i4AGQoaxDdMdCym-4Vfi1GlExEu&t=1"}],"include_subdomains":true}'
       Reporting-Endpoints:
-      - csp="https://q.stripe.com/csp-report-v2?q=RbMA1-0SZkS6or-1RnBMcLscYOE4CuGYRqoYGdaVh-_HrWt8dN1eEX6yLWhuk2SLFN2GJ4H-ObUbR0nO&t=1"
+      - csp="https://q.stripe.com/csp-report-v2?q=Fliex2wMi2DNYh6k7CDngJ94k7c5tjXOfx8XF5B8JG71-tzBt_-a2i4AGQoaxDdMdCym-4Vfi1GlExEu&t=1"
       Request-Id:
-      - req_jTSfujFAgSCAIY
-      Stripe-Notice:
-      - You are using an outdated API version (2025-01-27.acacia). We recommend upgrading
-        to the latest API version, 2026-04-22.dahlia. See https://docs.stripe.com/upgrades
+      - req_wsN7m6JWKXyMIB
       Stripe-Should-Retry:
       - 'false'
       Stripe-Version:
@@ -85,7 +82,7 @@ http_interactions:
       encoding: UTF-8
       string: |-
         {
-          "id": "cs_test_a1pGPZfWdT50n9APibQ6PngYGzGW3j4CixuBVxcTmhUWyXA7gZ5F47Uawl",
+          "id": "cs_test_a1Q6DgwhYAiazizLFSuz02aGx8JevqaQG8tmoWTR0vDU3E6QUFwMtV2qHS",
           "object": "checkout.session",
           "adaptive_pricing": {
             "enabled": true
@@ -123,7 +120,7 @@ http_interactions:
           },
           "consent": null,
           "consent_collection": null,
-          "created": 1779745275,
+          "created": 1785190448,
           "currency": "usd",
           "currency_conversion": null,
           "custom_fields": [],
@@ -139,16 +136,16 @@ http_interactions:
           "customer_details": {
             "address": null,
             "business_name": null,
-            "email": "user6s@bikeindex.org",
+            "email": "user1062s@bikeindex.org",
             "individual_name": null,
             "name": null,
             "phone": null,
             "tax_exempt": "none",
             "tax_ids": null
           },
-          "customer_email": "user6s@bikeindex.org",
+          "customer_email": "user1062s@bikeindex.org",
           "discounts": [],
-          "expires_at": 1779831675,
+          "expires_at": 1785276847,
           "integration_identifier": null,
           "invoice": null,
           "invoice_creation": null,
@@ -204,8 +201,8 @@ http_interactions:
             "amount_tax": 0
           },
           "ui_mode": "hosted",
-          "url": "https://checkout.stripe.com/c/pay/cs_test_a1pGPZfWdT50n9APibQ6PngYGzGW3j4CixuBVxcTmhUWyXA7gZ5F47Uawl#fidnandhYHdWcXxpYCc%2FJ2FgY2RwaXEnKSdicGRmZGhqaWBTZHdsZGtxJz8nZmprcXdqaScpJ2R1bE5gfCc%2FJ3VuWnFgdnFaX09BbE1nX0lWR2ZkUVxvNXY3RG0yaEtgJyknY3dqaFZgd3Ngdyc%2FcXdwYCknZ2RmbmJ3anBrYUZqaWp3Jz8nJmNjY2NjYycpJ2lkfGpwcVF8dWAnPyd2bGtiaWBabHFgaCcpJ2BrZGdpYFVpZGZgbWppYWB3dic%2FcXdwYHgl",
+          "url": "https://checkout.stripe.com/c/pay/cs_test_a1Q6DgwhYAiazizLFSuz02aGx8JevqaQG8tmoWTR0vDU3E6QUFwMtV2qHS#fidnandhYHdWcXxpYCc%2FJ2FgY2RwaXEnKSdicGRmZGhqaWBTZHdsZGtxJz8nZmprcXdqaScpJ2R1bE5gfCc%2FJ3VuWnFgdnFaX09BbE1nX0lWR2ZkUVxvNXY3RG0yaEtgJyknY3dqaFZgd3Ngdyc%2FcXdwYCknZ2RmbmJ3anBrYUZqaWp3Jz8nJmNjY2NjYycpJ2lkfGpwcVF8dWAnPyd2bGtiaWBabHFgaCcpJ2BrZGdpYFVpZGZgbWppYWB3dic%2FcXdwYHgl",
           "wallet_options": null
         }
-  recorded_at: Mon, 25 May 2026 21:41:15 GMT
+  recorded_at: Mon, 27 Jul 2026 22:14:08 GMT
 recorded_with: VCR 6.4.0

--- a/spec/vcr_cassettes/MembershipsController-create-yearly-success.yml
+++ b/spec/vcr_cassettes/MembershipsController-create-yearly-success.yml
@@ -5,14 +5,14 @@ http_interactions:
     uri: https://api.stripe.com/v1/checkout/sessions
     body:
       encoding: UTF-8
-      string: success_url=http%3A%2F%2Ftest.host%2Fmembership%2Fsuccess%3Fsession_id%3D%7BCHECKOUT_SESSION_ID%7D&cancel_url=http%3A%2F%2Ftest.host%2Fmembership%2Fnew&mode=subscription&line_items[0][quantity]=1&line_items[0][price]=price_0Qs5rim0T0GBfX0vE7Q7cyoG&customer_email=user7s%40bikeindex.org
+      string: success_url=http%3A%2F%2Ftest.host%2Fmembership%2Fsuccess%3Fsession_id%3D%7BCHECKOUT_SESSION_ID%7D&cancel_url=http%3A%2F%2Ftest.host%2Fmembership%2Fnew&mode=subscription&line_items[0][quantity]=1&line_items[0][price]=price_0Qs5rim0T0GBfX0vE7Q7cyoG&customer_email=user1064s%40bikeindex.org
     headers:
       User-Agent:
       - Stripe/v1 RubyBindings/13.4.1
       X-Stripe-Client-Telemetry:
-      - '{"last_request_metrics":{"request_id":"req_jTSfujFAgSCAIY","request_duration_ms":382}}'
+      - '{"last_request_metrics":{"request_id":"req_wsN7m6JWKXyMIB","request_duration_ms":0}}'
       Idempotency-Key:
-      - '081beac7-9d5f-48b2-9cc9-48e1f8e3d57d'
+      - c1421718-168c-4671-957c-d4c48a5f290a
       Stripe-Version:
       - 2025-01-27.acacia
       Content-Type:
@@ -29,11 +29,11 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Mon, 25 May 2026 21:41:16 GMT
+      - Mon, 27 Jul 2026 22:14:08 GMT
       Content-Type:
       - application/json
       Content-Length:
-      - '3770'
+      - '3776'
       Connection:
       - keep-alive
       Access-Control-Allow-Credentials:
@@ -52,21 +52,18 @@ http_interactions:
       Content-Security-Policy:
       - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
         img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
-        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=RbMA1-0SZkS6or-1RnBMcLscYOE4CuGYRqoYGdaVh-_HrWt8dN1eEX6yLWhuk2SLFN2GJ4H-ObUbR0nO;
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=0eyum-mFuSLFkA5XnLx1zPYVOWj9Ant6pKBtOXY-VwB0PCC7U7TXW4Kn5lmwoXD2ubO3b7KFfplJlKSe;
         report-to csp
       Idempotency-Key:
-      - '081beac7-9d5f-48b2-9cc9-48e1f8e3d57d'
+      - c1421718-168c-4671-957c-d4c48a5f290a
       Original-Request:
-      - req_7gFGUWgWba6olc
+      - req_UsoGrAC8NYCUqB
       Report-To:
-      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=RbMA1-0SZkS6or-1RnBMcLscYOE4CuGYRqoYGdaVh-_HrWt8dN1eEX6yLWhuk2SLFN2GJ4H-ObUbR0nO&t=1"}],"include_subdomains":true}'
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=0eyum-mFuSLFkA5XnLx1zPYVOWj9Ant6pKBtOXY-VwB0PCC7U7TXW4Kn5lmwoXD2ubO3b7KFfplJlKSe&t=1"}],"include_subdomains":true}'
       Reporting-Endpoints:
-      - csp="https://q.stripe.com/csp-report-v2?q=RbMA1-0SZkS6or-1RnBMcLscYOE4CuGYRqoYGdaVh-_HrWt8dN1eEX6yLWhuk2SLFN2GJ4H-ObUbR0nO&t=1"
+      - csp="https://q.stripe.com/csp-report-v2?q=0eyum-mFuSLFkA5XnLx1zPYVOWj9Ant6pKBtOXY-VwB0PCC7U7TXW4Kn5lmwoXD2ubO3b7KFfplJlKSe&t=1"
       Request-Id:
-      - req_7gFGUWgWba6olc
-      Stripe-Notice:
-      - You are using an outdated API version (2025-01-27.acacia). We recommend upgrading
-        to the latest API version, 2026-04-22.dahlia. See https://docs.stripe.com/upgrades
+      - req_UsoGrAC8NYCUqB
       Stripe-Should-Retry:
       - 'false'
       Stripe-Version:
@@ -85,7 +82,7 @@ http_interactions:
       encoding: UTF-8
       string: |-
         {
-          "id": "cs_test_a1BH7pRTxvRUAiG4oY9Xndiu0lJGXKQoKyNUrwmNlVaN3fJrA96wVrnn5l",
+          "id": "cs_test_a1ZVz6cdAUqcILpLVLAwL5a8Zmelu4SizalhtgArFNuPDfZo8qvVtfXFtf",
           "object": "checkout.session",
           "adaptive_pricing": {
             "enabled": true
@@ -123,7 +120,7 @@ http_interactions:
           },
           "consent": null,
           "consent_collection": null,
-          "created": 1779745276,
+          "created": 1785190448,
           "currency": "usd",
           "currency_conversion": null,
           "custom_fields": [],
@@ -139,16 +136,16 @@ http_interactions:
           "customer_details": {
             "address": null,
             "business_name": null,
-            "email": "user7s@bikeindex.org",
+            "email": "user1064s@bikeindex.org",
             "individual_name": null,
             "name": null,
             "phone": null,
             "tax_exempt": "none",
             "tax_ids": null
           },
-          "customer_email": "user7s@bikeindex.org",
+          "customer_email": "user1064s@bikeindex.org",
           "discounts": [],
-          "expires_at": 1779831676,
+          "expires_at": 1785276848,
           "integration_identifier": null,
           "invoice": null,
           "invoice_creation": null,
@@ -204,8 +201,8 @@ http_interactions:
             "amount_tax": 0
           },
           "ui_mode": "hosted",
-          "url": "https://checkout.stripe.com/c/pay/cs_test_a1BH7pRTxvRUAiG4oY9Xndiu0lJGXKQoKyNUrwmNlVaN3fJrA96wVrnn5l#fidnandhYHdWcXxpYCc%2FJ2FgY2RwaXEnKSdicGRmZGhqaWBTZHdsZGtxJz8nZmprcXdqaScpJ2R1bE5gfCc%2FJ3VuWnFgdnFaX09BbE1nX0lWR2ZkUVxvNXY3RG0yaEtgJyknY3dqaFZgd3Ngdyc%2FcXdwYCknZ2RmbmJ3anBrYUZqaWp3Jz8nJmNjY2NjYycpJ2lkfGpwcVF8dWAnPyd2bGtiaWBabHFgaCcpJ2BrZGdpYFVpZGZgbWppYWB3dic%2FcXdwYHgl",
+          "url": "https://checkout.stripe.com/c/pay/cs_test_a1ZVz6cdAUqcILpLVLAwL5a8Zmelu4SizalhtgArFNuPDfZo8qvVtfXFtf#fidnandhYHdWcXxpYCc%2FJ2FgY2RwaXEnKSdicGRmZGhqaWBTZHdsZGtxJz8nZmprcXdqaScpJ2R1bE5gfCc%2FJ3VuWnFgdnFaX09BbE1nX0lWR2ZkUVxvNXY3RG0yaEtgJyknY3dqaFZgd3Ngdyc%2FcXdwYCknZ2RmbmJ3anBrYUZqaWp3Jz8nJmNjY2NjYycpJ2lkfGpwcVF8dWAnPyd2bGtiaWBabHFgaCcpJ2BrZGdpYFVpZGZgbWppYWB3dic%2FcXdwYHgl",
           "wallet_options": null
         }
-  recorded_at: Mon, 25 May 2026 21:41:16 GMT
+  recorded_at: Mon, 27 Jul 2026 22:14:08 GMT
 recorded_with: VCR 6.4.0

--- a/spec/vcr_cassettes/MembershipsController-edit-success.yml
+++ b/spec/vcr_cassettes/MembershipsController-edit-success.yml
@@ -10,105 +10,6 @@ http_interactions:
       User-Agent:
       - Stripe/v1 RubyBindings/13.4.1
       X-Stripe-Client-Telemetry:
-      - '{"last_request_metrics":{"request_id":"req_jTSfujFAgSCAIY","request_duration_ms":0}}'
-      Idempotency-Key:
-      - 66f654f2-1ef9-4985-bf38-a9d3c11244ce
-      Stripe-Version:
-      - 2025-01-27.acacia
-      Content-Type:
-      - application/x-www-form-urlencoded
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Server:
-      - nginx
-      Date:
-      - Mon, 25 May 2026 21:41:16 GMT
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '491'
-      Connection:
-      - keep-alive
-      Access-Control-Allow-Credentials:
-      - 'true'
-      Access-Control-Allow-Methods:
-      - GET, HEAD, PUT, PATCH, POST, DELETE
-      Access-Control-Allow-Origin:
-      - "*"
-      Access-Control-Expose-Headers:
-      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
-        X-Stripe-Privileged-Session-Required
-      Access-Control-Max-Age:
-      - '300'
-      Cache-Control:
-      - no-cache, no-store
-      Content-Security-Policy:
-      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
-        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
-        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=qVjYUJF-3-NgrS96W522iTOaxcBGuLsP3uaAgproCPodndTFD70B06o3e18TeK2OtP-0WhkIsmBwh-BQ;
-        report-to csp
-      Idempotency-Key:
-      - 66f654f2-1ef9-4985-bf38-a9d3c11244ce
-      Original-Request:
-      - req_BkFPOS6C8DMEzJ
-      Report-To:
-      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=qVjYUJF-3-NgrS96W522iTOaxcBGuLsP3uaAgproCPodndTFD70B06o3e18TeK2OtP-0WhkIsmBwh-BQ&t=1"}],"include_subdomains":true}'
-      Reporting-Endpoints:
-      - csp="https://q.stripe.com/csp-report-v2?q=qVjYUJF-3-NgrS96W522iTOaxcBGuLsP3uaAgproCPodndTFD70B06o3e18TeK2OtP-0WhkIsmBwh-BQ&t=1"
-      Request-Id:
-      - req_BkFPOS6C8DMEzJ
-      Stripe-Notice:
-      - You are using an outdated API version (2025-01-27.acacia). We recommend upgrading
-        to the latest API version, 2026-04-22.dahlia. See https://docs.stripe.com/upgrades
-      Stripe-Should-Retry:
-      - 'false'
-      Stripe-Version:
-      - 2025-01-27.acacia
-      Vary:
-      - Origin
-      X-Stripe-Priority-Routing-Enabled:
-      - 'true'
-      X-Stripe-Routing-Context-Priority-Tier:
-      - api-testmode
-      X-Wc:
-      - 3c3
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains; preload
-    body:
-      encoding: UTF-8
-      string: |-
-        {
-          "id": "bps_0Tb6FMm0T0GBfX0vSPcdKDDv",
-          "object": "billing_portal.session",
-          "configuration": "bpc_0QvSOWm0T0GBfX0vQCpYBJv1",
-          "created": 1779745276,
-          "customer": "cus_RohIc4uZhMPzxN",
-          "customer_account": null,
-          "flow": null,
-          "livemode": false,
-          "locale": null,
-          "on_behalf_of": null,
-          "return_url": "http://test.host/my_account",
-          "url": "https://billing.stripe.com/p/session/test_YWNjdF8yS3NubTBUMEdCZlgwdnlQVUl4RSxfVWFHbWptcVpmcDZ3c3lnOEJDMjBLWFdRR0RzcDNKdg0100vI5gAcea"
-        }
-  recorded_at: Mon, 25 May 2026 21:41:16 GMT
-- request:
-    method: post
-    uri: https://api.stripe.com/v1/billing_portal/sessions
-    body:
-      encoding: UTF-8
-      string: customer=cus_RohIc4uZhMPzxN&return_url=http%3A%2F%2Ftest.host%2Fmy_account
-    headers:
-      User-Agent:
-      - Stripe/v1 RubyBindings/13.4.1
-      X-Stripe-Client-Telemetry:
       - '{"last_request_metrics":{"request_id":"req_7gFGUWgWba6olc","request_duration_ms":0}}'
       Idempotency-Key:
       - f1b28333-5a4a-4edd-bc2f-b8f21f33a214
@@ -198,4 +99,100 @@ http_interactions:
           "url": "https://billing.stripe.com/p/session/test_YWNjdF8yS3NubTBUMEdCZlgwdnlQVUl4RSxfVWsxM3hEckV4TDhVZmZ0eVJlZ1RZM3cwYVQ0WFJzRQ010074JpLsoS"
         }
   recorded_at: Sat, 20 Jun 2026 22:05:27 GMT
+- request:
+    method: post
+    uri: https://api.stripe.com/v1/billing_portal/sessions
+    body:
+      encoding: UTF-8
+      string: customer=cus_RohIc4uZhMPzxN&return_url=http%3A%2F%2Ftest.host%2Fmy_account
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/13.4.1
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_UsoGrAC8NYCUqB","request_duration_ms":439}}'
+      Idempotency-Key:
+      - 94046a90-66ab-4c22-af58-312a10e12406
+      Stripe-Version:
+      - 2025-01-27.acacia
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Mon, 27 Jul 2026 22:14:09 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '491'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=0eyum-mFuSLFkA5XnLx1zPYVOWj9Ant6pKBtOXY-VwB0PCC7U7TXW4Kn5lmwoXD2ubO3b7KFfplJlKSe;
+        report-to csp
+      Idempotency-Key:
+      - 94046a90-66ab-4c22-af58-312a10e12406
+      Original-Request:
+      - req_rZZKLRDFawpOUt
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=0eyum-mFuSLFkA5XnLx1zPYVOWj9Ant6pKBtOXY-VwB0PCC7U7TXW4Kn5lmwoXD2ubO3b7KFfplJlKSe&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=0eyum-mFuSLFkA5XnLx1zPYVOWj9Ant6pKBtOXY-VwB0PCC7U7TXW4Kn5lmwoXD2ubO3b7KFfplJlKSe&t=1"
+      Request-Id:
+      - req_rZZKLRDFawpOUt
+      Stripe-Should-Retry:
+      - 'false'
+      Stripe-Version:
+      - 2025-01-27.acacia
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "bps_0Txwmim0T0GBfX0v6Lfv6FB2",
+          "object": "billing_portal.session",
+          "configuration": "bpc_0QvSOWm0T0GBfX0vQCpYBJv1",
+          "created": 1785190448,
+          "customer": "cus_RohIc4uZhMPzxN",
+          "customer_account": null,
+          "flow": null,
+          "livemode": false,
+          "locale": null,
+          "on_behalf_of": null,
+          "return_url": "http://test.host/my_account",
+          "url": "https://billing.stripe.com/p/session/test_YWNjdF8yS3NubTBUMEdCZlgwdnlQVUl4RSxfVXhzWFA1VmluTzZVR09uUXRGMTdMZndRN1ViVWFkZQ0100C9FlsVy2"
+        }
+  recorded_at: Mon, 27 Jul 2026 22:14:09 GMT
 recorded_with: VCR 6.4.0

--- a/spec/vcr_cassettes/payments_controller-below-stripe-minimum.yml
+++ b/spec/vcr_cassettes/payments_controller-below-stripe-minimum.yml
@@ -9,8 +9,10 @@ http_interactions:
     headers:
       User-Agent:
       - Stripe/v1 RubyBindings/13.4.1
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_AJUZNa35aBoD7n","request_duration_ms":257}}'
       Idempotency-Key:
-      - 9cd1debd-0f5e-4759-a37a-fdbd250ea32f
+      - 10770e7b-9db2-4259-8e19-03de30003ff9
       Stripe-Version:
       - 2025-01-27.acacia
       Content-Type:
@@ -27,7 +29,7 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Tue, 28 Apr 2026 15:32:21 GMT
+      - Mon, 27 Jul 2026 22:15:48 GMT
       Content-Type:
       - application/json
       Content-Length:
@@ -50,17 +52,18 @@ http_interactions:
       Content-Security-Policy:
       - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
         img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
-        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=rt7f3NaRRjEvZ-f7Gkff6305Gq_GOR5m6TOCNO47ZY_iJWix4iWOZ-gigiSOrCgRskfObuB9tAo0rXGL
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=RSo8Fh-Oxgaepd33JOlm_awlX79qslsr9ajrnadxSvrw4HPWN1_g3vxzyH38WmKIHgXVoULwizC5b27O;
+        report-to csp
       Idempotency-Key:
-      - 9cd1debd-0f5e-4759-a37a-fdbd250ea32f
+      - 10770e7b-9db2-4259-8e19-03de30003ff9
       Original-Request:
-      - req_c2PSUJCFgRm2an
+      - req_vyl1GRAb42lV9I
       Report-To:
-      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=rt7f3NaRRjEvZ-f7Gkff6305Gq_GOR5m6TOCNO47ZY_iJWix4iWOZ-gigiSOrCgRskfObuB9tAo0rXGL&t=1"}],"include_subdomains":true}'
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=RSo8Fh-Oxgaepd33JOlm_awlX79qslsr9ajrnadxSvrw4HPWN1_g3vxzyH38WmKIHgXVoULwizC5b27O&t=1"}],"include_subdomains":true}'
       Reporting-Endpoints:
-      - csp="https://q.stripe.com/csp-report-v2?q=rt7f3NaRRjEvZ-f7Gkff6305Gq_GOR5m6TOCNO47ZY_iJWix4iWOZ-gigiSOrCgRskfObuB9tAo0rXGL&t=1"
+      - csp="https://q.stripe.com/csp-report-v2?q=RSo8Fh-Oxgaepd33JOlm_awlX79qslsr9ajrnadxSvrw4HPWN1_g3vxzyH38WmKIHgXVoULwizC5b27O&t=1"
       Request-Id:
-      - req_c2PSUJCFgRm2an
+      - req_vyl1GRAb42lV9I
       Stripe-Should-Retry:
       - 'false'
       Stripe-Version:
@@ -82,10 +85,10 @@ http_interactions:
           "error": {
             "code": "amount_too_small",
             "doc_url": "https://stripe.com/docs/error-codes/amount-too-small",
-            "message": "The Checkout Session's total amount due must add up to at least $0.50 usd",
-            "request_log_url": "https://dashboard.stripe.com/acct_2Ksnm0T0GBfX0vyPUIxE/test/workbench/logs?object=req_c2PSUJCFgRm2an",
+            "message": "The Checkout Session's total amount due must add up to at least $0.50 USD",
+            "request_log_url": "https://dashboard.stripe.com/acct_2Ksnm0T0GBfX0vyPUIxE/test/workbench/logs?object=req_vyl1GRAb42lV9I",
             "type": "invalid_request_error"
           }
         }
-  recorded_at: Tue, 28 Apr 2026 15:32:21 GMT
+  recorded_at: Mon, 27 Jul 2026 22:15:48 GMT
 recorded_with: VCR 6.4.0

--- a/spec/vcr_cassettes/payments_controller-donation-customer.yml
+++ b/spec/vcr_cassettes/payments_controller-donation-customer.yml
@@ -294,9 +294,9 @@ http_interactions:
       User-Agent:
       - Stripe/v1 RubyBindings/13.4.1
       X-Stripe-Client-Telemetry:
-      - '{"last_request_metrics":{"request_id":"req_Rpp6C8buPFBNa9","request_duration_ms":375}}'
+      - '{"last_request_metrics":{"request_id":"req_ngfDcNyk5buLa5","request_duration_ms":480}}'
       Idempotency-Key:
-      - 4a949fde-5f05-4b5d-b15f-4c443b890f1c
+      - aaffd357-345d-439c-82b8-7d45d12364b7
       Stripe-Version:
       - 2025-01-27.acacia
       Content-Type:
@@ -313,11 +313,11 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Mon, 27 Jul 2026 22:15:48 GMT
+      - Mon, 27 Jul 2026 22:25:18 GMT
       Content-Type:
       - application/json
       Content-Length:
-      - '3996'
+      - '4000'
       Connection:
       - keep-alive
       Access-Control-Allow-Credentials:
@@ -336,18 +336,18 @@ http_interactions:
       Content-Security-Policy:
       - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
         img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
-        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=RSo8Fh-Oxgaepd33JOlm_awlX79qslsr9ajrnadxSvrw4HPWN1_g3vxzyH38WmKIHgXVoULwizC5b27O;
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=gkOGnvJdwwE-WDUBnG_GioSaOZP9fXb8SWnL0cruxhODm5ejqnqZ8DlOlAGvF9of2Pi1M8Y2KKuHbbne;
         report-to csp
       Idempotency-Key:
-      - 4a949fde-5f05-4b5d-b15f-4c443b890f1c
+      - aaffd357-345d-439c-82b8-7d45d12364b7
       Original-Request:
-      - req_AJUZNa35aBoD7n
+      - req_LmV01MOgttgJg4
       Report-To:
-      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=RSo8Fh-Oxgaepd33JOlm_awlX79qslsr9ajrnadxSvrw4HPWN1_g3vxzyH38WmKIHgXVoULwizC5b27O&t=1"}],"include_subdomains":true}'
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=gkOGnvJdwwE-WDUBnG_GioSaOZP9fXb8SWnL0cruxhODm5ejqnqZ8DlOlAGvF9of2Pi1M8Y2KKuHbbne&t=1"}],"include_subdomains":true}'
       Reporting-Endpoints:
-      - csp="https://q.stripe.com/csp-report-v2?q=RSo8Fh-Oxgaepd33JOlm_awlX79qslsr9ajrnadxSvrw4HPWN1_g3vxzyH38WmKIHgXVoULwizC5b27O&t=1"
+      - csp="https://q.stripe.com/csp-report-v2?q=gkOGnvJdwwE-WDUBnG_GioSaOZP9fXb8SWnL0cruxhODm5ejqnqZ8DlOlAGvF9of2Pi1M8Y2KKuHbbne&t=1"
       Request-Id:
-      - req_AJUZNa35aBoD7n
+      - req_LmV01MOgttgJg4
       Stripe-Should-Retry:
       - 'false'
       Stripe-Version:
@@ -366,7 +366,7 @@ http_interactions:
       encoding: UTF-8
       string: |-
         {
-          "id": "cs_test_a1h1YVSSDuCCecKqK6J2cYqZUm3vA4NhdMle35KmTTTawodJnk59RkPVMl",
+          "id": "cs_test_a1yIOVPBB6QMufTXKJXtlENuXBnfGnbBmWtVy3LevdUmNvHJIMrQiQlXNx",
           "object": "checkout.session",
           "adaptive_pricing": {
             "enabled": true
@@ -390,7 +390,7 @@ http_interactions:
             "font_family": "default",
             "icon": {
               "type": "url",
-              "url": "https://d1wqzb5bdbcre6.cloudfront.net/b4482d0007d24b441c7905466ea522c2ee3dcc6a8eff7f58350343a828cf242e/68747470733a2f2f73332e616d617a6f6e6177732e636f6d2f7374726970652d75706c6f6164732f616363745f324b736e6d3054304742665830767950554978456d65726368616e742d69636f6e2d3436393534342d42696b65496e6465784c6f676f2e706e67/6d65726368616e745f69643d616363745f324b736e6d30543047426658307679505549784526636c69656e743d5041594d454e545f50414745"
+              "url": "https://stripe-camo.global.ssl.fastly.net/b4482d0007d24b441c7905466ea522c2ee3dcc6a8eff7f58350343a828cf242e/68747470733a2f2f73332e616d617a6f6e6177732e636f6d2f7374726970652d75706c6f6164732f616363745f324b736e6d3054304742665830767950554978456d65726368616e742d69636f6e2d3436393534342d42696b65496e6465784c6f676f2e706e67/6d65726368616e745f69643d616363745f324b736e6d30543047426658307679505549784526636c69656e743d5041594d454e545f50414745"
             },
             "logo": null
           },
@@ -404,7 +404,7 @@ http_interactions:
           },
           "consent": null,
           "consent_collection": null,
-          "created": 1785190548,
+          "created": 1785191118,
           "currency": "usd",
           "currency_conversion": null,
           "custom_fields": [],
@@ -429,7 +429,7 @@ http_interactions:
           },
           "customer_email": null,
           "discounts": [],
-          "expires_at": 1785276948,
+          "expires_at": 1785277518,
           "integration_identifier": null,
           "invoice": null,
           "invoice_creation": {
@@ -496,8 +496,8 @@ http_interactions:
             "amount_tax": 0
           },
           "ui_mode": "hosted",
-          "url": "https://checkout.stripe.com/c/pay/cs_test_a1h1YVSSDuCCecKqK6J2cYqZUm3vA4NhdMle35KmTTTawodJnk59RkPVMl#fidnandhYHdWcXxpYCc%2FJ2FgY2RwaXEnKSdicGRmZGhqaWBTZHdsZGtxJz8nZmprcXdqaScpJ2R1bE5gfCc%2FJ3VuWnFgdnFaX09BbE1nX0lWR2ZkUVxvNXY3RG0yaEtgJyknY3dqaFZgd3Ngdyc%2FcXdwYCknZ2RmbmJ3anBrYUZqaWp3Jz8nJmNjY2NjYycpJ2lkfGpwcVF8dWAnPyd2bGtiaWBabHFgaCcpJ2BrZGdpYFVpZGZgbWppYWB3dic%2FcXdwYHgl",
+          "url": "https://checkout.stripe.com/c/pay/cs_test_a1yIOVPBB6QMufTXKJXtlENuXBnfGnbBmWtVy3LevdUmNvHJIMrQiQlXNx#fidnandhYHdWcXxpYCc%2FJ2FgY2RwaXEnKSdicGRmZGhqaWBTZHdsZGtxJz8nZmprcXdqaScpJ2R1bE5gfCc%2FJ3VuWnFgdnFaX09BbE1nX0lWR2ZkUVxvNXY3RG0yaEtgJyknY3dqaFZgd3Ngdyc%2FcXdwYCknZ2RmbmJ3anBrYUZqaWp3Jz8nJmNjY2NjYycpJ2lkfGpwcVF8dWAnPyd2bGtiaWBabHFgaCcpJ2BrZGdpYFVpZGZgbWppYWB3dic%2FcXdwYHgl",
           "wallet_options": null
         }
-  recorded_at: Mon, 27 Jul 2026 22:15:48 GMT
+  recorded_at: Mon, 27 Jul 2026 22:25:18 GMT
 recorded_with: VCR 6.4.0

--- a/spec/vcr_cassettes/payments_controller-donation-customer.yml
+++ b/spec/vcr_cassettes/payments_controller-donation-customer.yml
@@ -294,9 +294,9 @@ http_interactions:
       User-Agent:
       - Stripe/v1 RubyBindings/13.4.1
       X-Stripe-Client-Telemetry:
-      - '{"last_request_metrics":{"request_id":"req_DvEgH7eR5j0Bmv","request_duration_ms":450}}'
+      - '{"last_request_metrics":{"request_id":"req_Rpp6C8buPFBNa9","request_duration_ms":375}}'
       Idempotency-Key:
-      - d2dea014-b70c-4e26-a216-828bd855a8e5
+      - 4a949fde-5f05-4b5d-b15f-4c443b890f1c
       Stripe-Version:
       - 2025-01-27.acacia
       Content-Type:
@@ -313,11 +313,11 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Sat, 20 Jun 2026 22:05:05 GMT
+      - Mon, 27 Jul 2026 22:15:48 GMT
       Content-Type:
       - application/json
-      Transfer-Encoding:
-      - chunked
+      Content-Length:
+      - '3996'
       Connection:
       - keep-alive
       Access-Control-Allow-Credentials:
@@ -336,21 +336,18 @@ http_interactions:
       Content-Security-Policy:
       - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
         img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
-        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=KdjiuHlHSlIkqdA5U7o2sgSXV2qHQfI0JDvZZC10baVstyrl0ptHQ0MCIFMqSGjZnBJkfy56z7nfi59M;
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=RSo8Fh-Oxgaepd33JOlm_awlX79qslsr9ajrnadxSvrw4HPWN1_g3vxzyH38WmKIHgXVoULwizC5b27O;
         report-to csp
       Idempotency-Key:
-      - d2dea014-b70c-4e26-a216-828bd855a8e5
+      - 4a949fde-5f05-4b5d-b15f-4c443b890f1c
       Original-Request:
-      - req_qQ4KNit4RFO2BX
+      - req_AJUZNa35aBoD7n
       Report-To:
-      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=KdjiuHlHSlIkqdA5U7o2sgSXV2qHQfI0JDvZZC10baVstyrl0ptHQ0MCIFMqSGjZnBJkfy56z7nfi59M&t=1"}],"include_subdomains":true}'
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=RSo8Fh-Oxgaepd33JOlm_awlX79qslsr9ajrnadxSvrw4HPWN1_g3vxzyH38WmKIHgXVoULwizC5b27O&t=1"}],"include_subdomains":true}'
       Reporting-Endpoints:
-      - csp="https://q.stripe.com/csp-report-v2?q=KdjiuHlHSlIkqdA5U7o2sgSXV2qHQfI0JDvZZC10baVstyrl0ptHQ0MCIFMqSGjZnBJkfy56z7nfi59M&t=1"
+      - csp="https://q.stripe.com/csp-report-v2?q=RSo8Fh-Oxgaepd33JOlm_awlX79qslsr9ajrnadxSvrw4HPWN1_g3vxzyH38WmKIHgXVoULwizC5b27O&t=1"
       Request-Id:
-      - req_qQ4KNit4RFO2BX
-      Stripe-Notice:
-      - You are using an outdated API version (2025-01-27.acacia). We recommend upgrading
-        to the latest API version, 2026-05-27.dahlia. See https://docs.stripe.com/upgrades
+      - req_AJUZNa35aBoD7n
       Stripe-Should-Retry:
       - 'false'
       Stripe-Version:
@@ -369,7 +366,7 @@ http_interactions:
       encoding: UTF-8
       string: |-
         {
-          "id": "cs_test_a1SrYzqNdHTDGZxjMsv0WCc8PDs5jPrOZpTVEg2TlUZpeO2LIhKFo2cvey",
+          "id": "cs_test_a1h1YVSSDuCCecKqK6J2cYqZUm3vA4NhdMle35KmTTTawodJnk59RkPVMl",
           "object": "checkout.session",
           "adaptive_pricing": {
             "enabled": true
@@ -407,7 +404,7 @@ http_interactions:
           },
           "consent": null,
           "consent_collection": null,
-          "created": 1781993105,
+          "created": 1785190548,
           "currency": "usd",
           "currency_conversion": null,
           "custom_fields": [],
@@ -432,7 +429,7 @@ http_interactions:
           },
           "customer_email": null,
           "discounts": [],
-          "expires_at": 1782079504,
+          "expires_at": 1785276948,
           "integration_identifier": null,
           "invoice": null,
           "invoice_creation": {
@@ -499,8 +496,8 @@ http_interactions:
             "amount_tax": 0
           },
           "ui_mode": "hosted",
-          "url": "https://checkout.stripe.com/c/pay/cs_test_a1SrYzqNdHTDGZxjMsv0WCc8PDs5jPrOZpTVEg2TlUZpeO2LIhKFo2cvey#fidnandhYHdWcXxpYCc%2FJ2FgY2RwaXEnKSdicGRmZGhqaWBTZHdsZGtxJz8nZmprcXdqaScpJ2R1bE5gfCc%2FJ3VuWnFgdnFaX09BbE1nX0lWR2ZkUVxvNXY3RG0yaEtgJyknY3dqaFZgd3Ngdyc%2FcXdwYCknZ2RmbmJ3anBrYUZqaWp3Jz8nJmNjY2NjYycpJ2lkfGpwcVF8dWAnPyd2bGtiaWBabHFgaCcpJ2BrZGdpYFVpZGZgbWppYWB3dic%2FcXdwYHgl",
+          "url": "https://checkout.stripe.com/c/pay/cs_test_a1h1YVSSDuCCecKqK6J2cYqZUm3vA4NhdMle35KmTTTawodJnk59RkPVMl#fidnandhYHdWcXxpYCc%2FJ2FgY2RwaXEnKSdicGRmZGhqaWBTZHdsZGtxJz8nZmprcXdqaScpJ2R1bE5gfCc%2FJ3VuWnFgdnFaX09BbE1nX0lWR2ZkUVxvNXY3RG0yaEtgJyknY3dqaFZgd3Ngdyc%2FcXdwYCknZ2RmbmJ3anBrYUZqaWp3Jz8nJmNjY2NjYycpJ2lkfGpwcVF8dWAnPyd2bGtiaWBabHFgaCcpJ2BrZGdpYFVpZGZgbWppYWB3dic%2FcXdwYHgl",
           "wallet_options": null
         }
-  recorded_at: Sat, 20 Jun 2026 22:05:05 GMT
+  recorded_at: Mon, 27 Jul 2026 22:15:48 GMT
 recorded_with: VCR 6.4.0

--- a/spec/vcr_cassettes/payments_controller-donation.yml
+++ b/spec/vcr_cassettes/payments_controller-donation.yml
@@ -174,14 +174,12 @@ http_interactions:
     uri: https://api.stripe.com/v1/checkout/sessions
     body:
       encoding: UTF-8
-      string: submit_type=donate&line_items[0][price_data][unit_amount]=4000&line_items[0][price_data][currency]=MXN&line_items[0][price_data][product_data][name]=Donation&line_items[0][price_data][product_data][images][0]=https%3A%2F%2Ffiles.bikeindex.org%2Fuploads%2FPu%2F151203%2Freg_hance.jpg&line_items[0][quantity]=1&mode=payment&success_url=http%3A%2F%2Ftest.host%2Fpayments%2Fsuccess%3Fsession_id%3D%7BCHECKOUT_SESSION_ID%7D&cancel_url=http%3A%2F%2Ftest.host%2Fpayments%2Fnew&customer_email=user3313s%40bikeindex.org
+      string: submit_type=donate&line_items[0][price_data][unit_amount]=4000&line_items[0][price_data][currency]=MXN&line_items[0][price_data][product_data][name]=Donation&line_items[0][price_data][product_data][images][0]=https%3A%2F%2Ffiles.bikeindex.org%2Fuploads%2FPu%2F151203%2Freg_hance.jpg&line_items[0][quantity]=1&mode=payment&success_url=http%3A%2F%2Ftest.host%2Fpayments%2Fsuccess%3Fsession_id%3D%7BCHECKOUT_SESSION_ID%7D&cancel_url=http%3A%2F%2Ftest.host%2Fpayments%2Fnew&customer_email=user89s%40bikeindex.org
     headers:
       User-Agent:
       - Stripe/v1 RubyBindings/13.4.1
-      X-Stripe-Client-Telemetry:
-      - '{"last_request_metrics":{"request_id":"req_MUlgTes1WDja7o","request_duration_ms":273}}'
       Idempotency-Key:
-      - a9eaca46-b1b2-4842-a4f8-6d6ef9fad002
+      - 0e851e59-c4fa-408d-8680-ff891f317816
       Stripe-Version:
       - 2025-01-27.acacia
       Content-Type:
@@ -198,11 +196,11 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Mon, 27 Jul 2026 22:15:47 GMT
+      - Mon, 27 Jul 2026 22:25:17 GMT
       Content-Type:
       - application/json
       Content-Length:
-      - '3869'
+      - '3865'
       Connection:
       - keep-alive
       Access-Control-Allow-Credentials:
@@ -221,18 +219,18 @@ http_interactions:
       Content-Security-Policy:
       - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
         img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
-        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=RSo8Fh-Oxgaepd33JOlm_awlX79qslsr9ajrnadxSvrw4HPWN1_g3vxzyH38WmKIHgXVoULwizC5b27O;
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=gkOGnvJdwwE-WDUBnG_GioSaOZP9fXb8SWnL0cruxhODm5ejqnqZ8DlOlAGvF9of2Pi1M8Y2KKuHbbne;
         report-to csp
       Idempotency-Key:
-      - a9eaca46-b1b2-4842-a4f8-6d6ef9fad002
+      - 0e851e59-c4fa-408d-8680-ff891f317816
       Original-Request:
-      - req_Rpp6C8buPFBNa9
+      - req_ngfDcNyk5buLa5
       Report-To:
-      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=RSo8Fh-Oxgaepd33JOlm_awlX79qslsr9ajrnadxSvrw4HPWN1_g3vxzyH38WmKIHgXVoULwizC5b27O&t=1"}],"include_subdomains":true}'
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=gkOGnvJdwwE-WDUBnG_GioSaOZP9fXb8SWnL0cruxhODm5ejqnqZ8DlOlAGvF9of2Pi1M8Y2KKuHbbne&t=1"}],"include_subdomains":true}'
       Reporting-Endpoints:
-      - csp="https://q.stripe.com/csp-report-v2?q=RSo8Fh-Oxgaepd33JOlm_awlX79qslsr9ajrnadxSvrw4HPWN1_g3vxzyH38WmKIHgXVoULwizC5b27O&t=1"
+      - csp="https://q.stripe.com/csp-report-v2?q=gkOGnvJdwwE-WDUBnG_GioSaOZP9fXb8SWnL0cruxhODm5ejqnqZ8DlOlAGvF9of2Pi1M8Y2KKuHbbne&t=1"
       Request-Id:
-      - req_Rpp6C8buPFBNa9
+      - req_ngfDcNyk5buLa5
       Stripe-Should-Retry:
       - 'false'
       Stripe-Version:
@@ -251,7 +249,7 @@ http_interactions:
       encoding: UTF-8
       string: |-
         {
-          "id": "cs_test_a1yorEbpdEP0YnrxMdA94ruiM6v6L3ZAbGo9ax6LFanoqQZrgZgzgQrIgN",
+          "id": "cs_test_a1LXSM3WfUPrYzmpGZsYCVsjQkKcpfzNoQaxegtCi8e8vkV2V61C6pwSl0",
           "object": "checkout.session",
           "adaptive_pricing": {
             "enabled": true
@@ -289,7 +287,7 @@ http_interactions:
           },
           "consent": null,
           "consent_collection": null,
-          "created": 1785190547,
+          "created": 1785191117,
           "currency": "mxn",
           "currency_conversion": null,
           "custom_fields": [],
@@ -305,16 +303,16 @@ http_interactions:
           "customer_details": {
             "address": null,
             "business_name": null,
-            "email": "user3313s@bikeindex.org",
+            "email": "user89s@bikeindex.org",
             "individual_name": null,
             "name": null,
             "phone": null,
             "tax_exempt": "none",
             "tax_ids": null
           },
-          "customer_email": "user3313s@bikeindex.org",
+          "customer_email": "user89s@bikeindex.org",
           "discounts": [],
-          "expires_at": 1785276947,
+          "expires_at": 1785277517,
           "integration_identifier": null,
           "invoice": null,
           "invoice_creation": {
@@ -374,8 +372,8 @@ http_interactions:
             "amount_tax": 0
           },
           "ui_mode": "hosted",
-          "url": "https://checkout.stripe.com/c/pay/cs_test_a1yorEbpdEP0YnrxMdA94ruiM6v6L3ZAbGo9ax6LFanoqQZrgZgzgQrIgN#fidnandhYHdWcXxpYCc%2FJ2FgY2RwaXEnKSdicGRmZGhqaWBTZHdsZGtxJz8nZmprcXdqaScpJ2R1bE5gfCc%2FJ3VuWnFgdnFaX09BbE1nX0lWR2ZkUVxvNXY3RG0yaEtgJyknY3dqaFZgd3Ngdyc%2FcXdwYCknZ2RmbmJ3anBrYUZqaWp3Jz8nJmNjY2NjYycpJ2lkfGpwcVF8dWAnPyd2bGtiaWBabHFgaCcpJ2BrZGdpYFVpZGZgbWppYWB3dic%2FcXdwYHgl",
+          "url": "https://checkout.stripe.com/c/pay/cs_test_a1LXSM3WfUPrYzmpGZsYCVsjQkKcpfzNoQaxegtCi8e8vkV2V61C6pwSl0#fidnandhYHdWcXxpYCc%2FJ2FgY2RwaXEnKSdicGRmZGhqaWBTZHdsZGtxJz8nZmprcXdqaScpJ2R1bE5gfCc%2FJ3VuWnFgdnFaX09BbE1nX0lWR2ZkUVxvNXY3RG0yaEtgJyknY3dqaFZgd3Ngdyc%2FcXdwYCknZ2RmbmJ3anBrYUZqaWp3Jz8nJmNjY2NjYycpJ2lkfGpwcVF8dWAnPyd2bGtiaWBabHFgaCcpJ2BrZGdpYFVpZGZgbWppYWB3dic%2FcXdwYHgl",
           "wallet_options": null
         }
-  recorded_at: Mon, 27 Jul 2026 22:15:47 GMT
+  recorded_at: Mon, 27 Jul 2026 22:25:17 GMT
 recorded_with: VCR 6.4.0

--- a/spec/vcr_cassettes/payments_controller-donation.yml
+++ b/spec/vcr_cassettes/payments_controller-donation.yml
@@ -174,14 +174,14 @@ http_interactions:
     uri: https://api.stripe.com/v1/checkout/sessions
     body:
       encoding: UTF-8
-      string: submit_type=donate&line_items[0][price_data][unit_amount]=4000&line_items[0][price_data][currency]=MXN&line_items[0][price_data][product_data][name]=Donation&line_items[0][price_data][product_data][images][0]=https%3A%2F%2Ffiles.bikeindex.org%2Fuploads%2FPu%2F151203%2Freg_hance.jpg&line_items[0][quantity]=1&mode=payment&success_url=http%3A%2F%2Ftest.host%2Fpayments%2Fsuccess%3Fsession_id%3D%7BCHECKOUT_SESSION_ID%7D&cancel_url=http%3A%2F%2Ftest.host%2Fpayments%2Fnew&customer_email=user149s%40bikeindex.org
+      string: submit_type=donate&line_items[0][price_data][unit_amount]=4000&line_items[0][price_data][currency]=MXN&line_items[0][price_data][product_data][name]=Donation&line_items[0][price_data][product_data][images][0]=https%3A%2F%2Ffiles.bikeindex.org%2Fuploads%2FPu%2F151203%2Freg_hance.jpg&line_items[0][quantity]=1&mode=payment&success_url=http%3A%2F%2Ftest.host%2Fpayments%2Fsuccess%3Fsession_id%3D%7BCHECKOUT_SESSION_ID%7D&cancel_url=http%3A%2F%2Ftest.host%2Fpayments%2Fnew&customer_email=user3313s%40bikeindex.org
     headers:
       User-Agent:
       - Stripe/v1 RubyBindings/13.4.1
       X-Stripe-Client-Telemetry:
-      - '{"last_request_metrics":{"request_id":"req_wbOb1o6EJnJjsC","request_duration_ms":4}}'
+      - '{"last_request_metrics":{"request_id":"req_MUlgTes1WDja7o","request_duration_ms":273}}'
       Idempotency-Key:
-      - 96df3d8f-306f-4330-aca4-0eafd4027d4e
+      - a9eaca46-b1b2-4842-a4f8-6d6ef9fad002
       Stripe-Version:
       - 2025-01-27.acacia
       Content-Type:
@@ -198,11 +198,11 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Sat, 20 Jun 2026 22:05:04 GMT
+      - Mon, 27 Jul 2026 22:15:47 GMT
       Content-Type:
       - application/json
-      Transfer-Encoding:
-      - chunked
+      Content-Length:
+      - '3869'
       Connection:
       - keep-alive
       Access-Control-Allow-Credentials:
@@ -221,21 +221,18 @@ http_interactions:
       Content-Security-Policy:
       - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
         img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
-        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=KdjiuHlHSlIkqdA5U7o2sgSXV2qHQfI0JDvZZC10baVstyrl0ptHQ0MCIFMqSGjZnBJkfy56z7nfi59M;
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=RSo8Fh-Oxgaepd33JOlm_awlX79qslsr9ajrnadxSvrw4HPWN1_g3vxzyH38WmKIHgXVoULwizC5b27O;
         report-to csp
       Idempotency-Key:
-      - 96df3d8f-306f-4330-aca4-0eafd4027d4e
+      - a9eaca46-b1b2-4842-a4f8-6d6ef9fad002
       Original-Request:
-      - req_DvEgH7eR5j0Bmv
+      - req_Rpp6C8buPFBNa9
       Report-To:
-      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=KdjiuHlHSlIkqdA5U7o2sgSXV2qHQfI0JDvZZC10baVstyrl0ptHQ0MCIFMqSGjZnBJkfy56z7nfi59M&t=1"}],"include_subdomains":true}'
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=RSo8Fh-Oxgaepd33JOlm_awlX79qslsr9ajrnadxSvrw4HPWN1_g3vxzyH38WmKIHgXVoULwizC5b27O&t=1"}],"include_subdomains":true}'
       Reporting-Endpoints:
-      - csp="https://q.stripe.com/csp-report-v2?q=KdjiuHlHSlIkqdA5U7o2sgSXV2qHQfI0JDvZZC10baVstyrl0ptHQ0MCIFMqSGjZnBJkfy56z7nfi59M&t=1"
+      - csp="https://q.stripe.com/csp-report-v2?q=RSo8Fh-Oxgaepd33JOlm_awlX79qslsr9ajrnadxSvrw4HPWN1_g3vxzyH38WmKIHgXVoULwizC5b27O&t=1"
       Request-Id:
-      - req_DvEgH7eR5j0Bmv
-      Stripe-Notice:
-      - You are using an outdated API version (2025-01-27.acacia). We recommend upgrading
-        to the latest API version, 2026-05-27.dahlia. See https://docs.stripe.com/upgrades
+      - req_Rpp6C8buPFBNa9
       Stripe-Should-Retry:
       - 'false'
       Stripe-Version:
@@ -254,7 +251,7 @@ http_interactions:
       encoding: UTF-8
       string: |-
         {
-          "id": "cs_test_a1WCJH3R1HpmBcyjs48r65pB83l0wEtYTSIioQrrFi2AETVqK3ZyXgePT3",
+          "id": "cs_test_a1yorEbpdEP0YnrxMdA94ruiM6v6L3ZAbGo9ax6LFanoqQZrgZgzgQrIgN",
           "object": "checkout.session",
           "adaptive_pricing": {
             "enabled": true
@@ -292,7 +289,7 @@ http_interactions:
           },
           "consent": null,
           "consent_collection": null,
-          "created": 1781993104,
+          "created": 1785190547,
           "currency": "mxn",
           "currency_conversion": null,
           "custom_fields": [],
@@ -308,16 +305,16 @@ http_interactions:
           "customer_details": {
             "address": null,
             "business_name": null,
-            "email": "user149s@bikeindex.org",
+            "email": "user3313s@bikeindex.org",
             "individual_name": null,
             "name": null,
             "phone": null,
             "tax_exempt": "none",
             "tax_ids": null
           },
-          "customer_email": "user149s@bikeindex.org",
+          "customer_email": "user3313s@bikeindex.org",
           "discounts": [],
-          "expires_at": 1782079504,
+          "expires_at": 1785276947,
           "integration_identifier": null,
           "invoice": null,
           "invoice_creation": {
@@ -377,8 +374,8 @@ http_interactions:
             "amount_tax": 0
           },
           "ui_mode": "hosted",
-          "url": "https://checkout.stripe.com/c/pay/cs_test_a1WCJH3R1HpmBcyjs48r65pB83l0wEtYTSIioQrrFi2AETVqK3ZyXgePT3#fidnandhYHdWcXxpYCc%2FJ2FgY2RwaXEnKSdicGRmZGhqaWBTZHdsZGtxJz8nZmprcXdqaScpJ2R1bE5gfCc%2FJ3VuWnFgdnFaX09BbE1nX0lWR2ZkUVxvNXY3RG0yaEtgJyknY3dqaFZgd3Ngdyc%2FcXdwYCknZ2RmbmJ3anBrYUZqaWp3Jz8nJmNjY2NjYycpJ2lkfGpwcVF8dWAnPyd2bGtiaWBabHFgaCcpJ2BrZGdpYFVpZGZgbWppYWB3dic%2FcXdwYHgl",
+          "url": "https://checkout.stripe.com/c/pay/cs_test_a1yorEbpdEP0YnrxMdA94ruiM6v6L3ZAbGo9ax6LFanoqQZrgZgzgQrIgN#fidnandhYHdWcXxpYCc%2FJ2FgY2RwaXEnKSdicGRmZGhqaWBTZHdsZGtxJz8nZmprcXdqaScpJ2R1bE5gfCc%2FJ3VuWnFgdnFaX09BbE1nX0lWR2ZkUVxvNXY3RG0yaEtgJyknY3dqaFZgd3Ngdyc%2FcXdwYCknZ2RmbmJ3anBrYUZqaWp3Jz8nJmNjY2NjYycpJ2lkfGpwcVF8dWAnPyd2bGtiaWBabHFgaCcpJ2BrZGdpYFVpZGZgbWppYWB3dic%2FcXdwYHgl",
           "wallet_options": null
         }
-  recorded_at: Sat, 20 Jun 2026 22:05:04 GMT
+  recorded_at: Mon, 27 Jul 2026 22:15:47 GMT
 recorded_with: VCR 6.4.0

--- a/spec/vcr_cassettes/payments_controller-onetime-nouser.yml
+++ b/spec/vcr_cassettes/payments_controller-onetime-nouser.yml
@@ -9,8 +9,10 @@ http_interactions:
     headers:
       User-Agent:
       - Stripe/v1 RubyBindings/13.4.1
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_48DAyRVveX0xhj","request_duration_ms":114}}'
       Idempotency-Key:
-      - 6b01dcc1-8492-4a72-8a36-8d2b6ba17778
+      - 30e6a20d-eabb-4e7c-9cdb-d72272f40c84
       Stripe-Version:
       - 2025-01-27.acacia
       Content-Type:
@@ -27,11 +29,11 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Tue, 28 Apr 2026 15:32:59 GMT
+      - Mon, 27 Jul 2026 22:15:47 GMT
       Content-Type:
       - application/json
       Content-Length:
-      - '3573'
+      - '3577'
       Connection:
       - keep-alive
       Access-Control-Allow-Credentials:
@@ -50,17 +52,18 @@ http_interactions:
       Content-Security-Policy:
       - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
         img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
-        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=aTjASQ5rN63L65omajFv6M2qyGhtkKopwLc0phq2r39EQddFwhP1ytKmzCeR0wlwmy4DilAUj85EVGrP
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=RSo8Fh-Oxgaepd33JOlm_awlX79qslsr9ajrnadxSvrw4HPWN1_g3vxzyH38WmKIHgXVoULwizC5b27O;
+        report-to csp
       Idempotency-Key:
-      - 6b01dcc1-8492-4a72-8a36-8d2b6ba17778
+      - 30e6a20d-eabb-4e7c-9cdb-d72272f40c84
       Original-Request:
-      - req_wbOb1o6EJnJjsC
+      - req_MUlgTes1WDja7o
       Report-To:
-      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=aTjASQ5rN63L65omajFv6M2qyGhtkKopwLc0phq2r39EQddFwhP1ytKmzCeR0wlwmy4DilAUj85EVGrP&t=1"}],"include_subdomains":true}'
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=RSo8Fh-Oxgaepd33JOlm_awlX79qslsr9ajrnadxSvrw4HPWN1_g3vxzyH38WmKIHgXVoULwizC5b27O&t=1"}],"include_subdomains":true}'
       Reporting-Endpoints:
-      - csp="https://q.stripe.com/csp-report-v2?q=aTjASQ5rN63L65omajFv6M2qyGhtkKopwLc0phq2r39EQddFwhP1ytKmzCeR0wlwmy4DilAUj85EVGrP&t=1"
+      - csp="https://q.stripe.com/csp-report-v2?q=RSo8Fh-Oxgaepd33JOlm_awlX79qslsr9ajrnadxSvrw4HPWN1_g3vxzyH38WmKIHgXVoULwizC5b27O&t=1"
       Request-Id:
-      - req_wbOb1o6EJnJjsC
+      - req_MUlgTes1WDja7o
       Stripe-Should-Retry:
       - 'false'
       Stripe-Version:
@@ -79,7 +82,7 @@ http_interactions:
       encoding: UTF-8
       string: |-
         {
-          "id": "cs_test_a1yxkCSwichSFf34QyYfdd40nd2pm4VxjXFdTNlrHM0qL5RF7ccIZZtnEV",
+          "id": "cs_test_a14nJIyHqVJNPqD57TYohiYe1wFcsSYucMGOt2WC1urPTW9BcEbf8jD7Mk",
           "object": "checkout.session",
           "adaptive_pricing": {
             "enabled": true
@@ -103,7 +106,7 @@ http_interactions:
             "font_family": "default",
             "icon": {
               "type": "url",
-              "url": "https://d1wqzb5bdbcre6.cloudfront.net/b4482d0007d24b441c7905466ea522c2ee3dcc6a8eff7f58350343a828cf242e/68747470733a2f2f73332e616d617a6f6e6177732e636f6d2f7374726970652d75706c6f6164732f616363745f324b736e6d3054304742665830767950554978456d65726368616e742d69636f6e2d3436393534342d42696b65496e6465784c6f676f2e706e67/6d65726368616e745f69643d616363745f324b736e6d30543047426658307679505549784526636c69656e743d5041594d454e545f50414745"
+              "url": "https://stripe-camo.global.ssl.fastly.net/b4482d0007d24b441c7905466ea522c2ee3dcc6a8eff7f58350343a828cf242e/68747470733a2f2f73332e616d617a6f6e6177732e636f6d2f7374726970652d75706c6f6164732f616363745f324b736e6d3054304742665830767950554978456d65726368616e742d69636f6e2d3436393534342d42696b65496e6465784c6f676f2e706e67/6d65726368616e745f69643d616363745f324b736e6d30543047426658307679505549784526636c69656e743d5041594d454e545f50414745"
             },
             "logo": null
           },
@@ -113,7 +116,7 @@ http_interactions:
           "collected_information": null,
           "consent": null,
           "consent_collection": null,
-          "created": 1777390379,
+          "created": 1785190547,
           "currency": "usd",
           "currency_conversion": null,
           "custom_fields": [],
@@ -129,7 +132,7 @@ http_interactions:
           "customer_details": null,
           "customer_email": null,
           "discounts": [],
-          "expires_at": 1777476779,
+          "expires_at": 1785276947,
           "integration_identifier": null,
           "invoice": null,
           "invoice_creation": {
@@ -190,8 +193,8 @@ http_interactions:
             "amount_tax": 0
           },
           "ui_mode": "hosted",
-          "url": "https://checkout.stripe.com/c/pay/cs_test_a1yxkCSwichSFf34QyYfdd40nd2pm4VxjXFdTNlrHM0qL5RF7ccIZZtnEV#fidnandhYHdWcXxpYCc%2FJ2FgY2RwaXEnKSdicGRmZGhqaWBTZHdsZGtxJz8nZmprcXdqaScpJ2R1bE5gfCc%2FJ3VuWnFgdnFaX09BbE1nX0lWR2ZkUVxvNXY3RG0yaEtgJyknY3dqaFZgd3Ngdyc%2FcXdwYCknZ2RmbmJ3anBrYUZqaWp3Jz8nJmNjY2NjYycpJ2lkfGpwcVF8dWAnPyd2bGtiaWBabHFgaCcpJ2BrZGdpYFVpZGZgbWppYWB3dic%2FcXdwYHgl",
+          "url": "https://checkout.stripe.com/c/pay/cs_test_a14nJIyHqVJNPqD57TYohiYe1wFcsSYucMGOt2WC1urPTW9BcEbf8jD7Mk#fidnandhYHdWcXxpYCc%2FJ2FgY2RwaXEnKSdicGRmZGhqaWBTZHdsZGtxJz8nZmprcXdqaScpJ2R1bE5gfCc%2FJ3VuWnFgdnFaX09BbE1nX0lWR2ZkUVxvNXY3RG0yaEtgJyknY3dqaFZgd3Ngdyc%2FcXdwYCknZ2RmbmJ3anBrYUZqaWp3Jz8nJmNjY2NjYycpJ2lkfGpwcVF8dWAnPyd2bGtiaWBabHFgaCcpJ2BrZGdpYFVpZGZgbWppYWB3dic%2FcXdwYHgl",
           "wallet_options": null
         }
-  recorded_at: Tue, 28 Apr 2026 15:32:59 GMT
+  recorded_at: Mon, 27 Jul 2026 22:15:47 GMT
 recorded_with: VCR 6.4.0

--- a/spec/vcr_cassettes/payments_controller-success-customer.yml
+++ b/spec/vcr_cassettes/payments_controller-success-customer.yml
@@ -10,175 +10,6 @@ http_interactions:
       User-Agent:
       - Stripe/v1 RubyBindings/13.4.1
       X-Stripe-Client-Telemetry:
-      - '{"last_request_metrics":{"request_id":"req_dxUME1skuy559U","request_duration_ms":162}}'
-      Stripe-Version:
-      - 2025-01-27.acacia
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Server:
-      - nginx
-      Date:
-      - Fri, 03 Apr 2026 13:12:53 GMT
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '2573'
-      Connection:
-      - keep-alive
-      Access-Control-Allow-Credentials:
-      - 'true'
-      Access-Control-Allow-Methods:
-      - GET, HEAD, PUT, PATCH, POST, DELETE
-      Access-Control-Allow-Origin:
-      - "*"
-      Access-Control-Expose-Headers:
-      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
-        X-Stripe-Privileged-Session-Required
-      Access-Control-Max-Age:
-      - '300'
-      Cache-Control:
-      - no-cache, no-store
-      Content-Security-Policy:
-      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
-        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
-        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=WTQQIC7f6vIyzn7htHAPST8rxzNrQDi0jfT0af-AWX9NIR9d9lajbxNZveeLW3huoyik9FNHc_9WBScd
-      Request-Id:
-      - req_VwgO1gLjhBEhZz
-      Stripe-Version:
-      - 2025-01-27.acacia
-      Vary:
-      - Origin
-      X-Stripe-Priority-Routing-Enabled:
-      - 'true'
-      X-Stripe-Routing-Context-Priority-Tier:
-      - api-testmode
-      X-Wc:
-      - 3c3
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains; preload
-    body:
-      encoding: UTF-8
-      string: |-
-        {
-          "id": "cs_test_a1OjyvijhWCbD9a9qWzUfM7UisfeWgROJx7tEF8Nc92PCP1uR1vjmXngCa",
-          "object": "checkout.session",
-          "adaptive_pricing": null,
-          "after_expiration": null,
-          "allow_promotion_codes": null,
-          "amount_subtotal": 500000,
-          "amount_total": 500000,
-          "automatic_tax": {
-            "enabled": false,
-            "liability": null,
-            "provider": null,
-            "status": null
-          },
-          "billing_address_collection": null,
-          "cancel_url": "http://localhost:3001/payments/new",
-          "client_reference_id": null,
-          "client_secret": null,
-          "collected_information": {
-            "business_name": null,
-            "individual_name": null,
-            "shipping_details": null
-          },
-          "consent": null,
-          "consent_collection": null,
-          "created": 1625254985,
-          "currency": "usd",
-          "currency_conversion": null,
-          "custom_fields": [],
-          "custom_text": {
-            "after_submit": null,
-            "shipping_address": null,
-            "submit": null,
-            "terms_of_service_acceptance": null
-          },
-          "customer": "cus_JmR9ccDp8JD2Mo",
-          "customer_account": null,
-          "customer_creation": null,
-          "customer_details": {
-            "address": null,
-            "business_name": null,
-            "email": "testly@bikeindex.org",
-            "individual_name": null,
-            "name": null,
-            "phone": null,
-            "tax_exempt": "none",
-            "tax_ids": []
-          },
-          "customer_email": null,
-          "discounts": [],
-          "expires_at": 1625341385,
-          "integration_identifier": null,
-          "invoice": null,
-          "invoice_creation": null,
-          "livemode": false,
-          "locale": null,
-          "metadata": {},
-          "mode": "payment",
-          "origin_context": null,
-          "payment_intent": "pi_0J8sGTm0T0GBfX0v4QU0tTnn",
-          "payment_link": null,
-          "payment_method_collection": null,
-          "payment_method_configuration_details": null,
-          "payment_method_options": {
-            "card": {
-              "request_three_d_secure": "automatic"
-            }
-          },
-          "payment_method_types": [
-            "card"
-          ],
-          "payment_status": "paid",
-          "permissions": null,
-          "phone_number_collection": {
-            "enabled": false
-          },
-          "recovered_from": null,
-          "saved_payment_method_options": {
-            "allow_redisplay_filters": [
-              "always"
-            ],
-            "payment_method_remove": "disabled",
-            "payment_method_save": null
-          },
-          "setup_intent": null,
-          "shipping_address_collection": null,
-          "shipping_cost": null,
-          "shipping_details": null,
-          "shipping_options": [],
-          "status": "complete",
-          "submit_type": "pay",
-          "subscription": null,
-          "success_url": "http://localhost:3001/payments/success?session_id={CHECKOUT_SESSION_ID}",
-          "total_details": {
-            "amount_discount": 0,
-            "amount_shipping": 0,
-            "amount_tax": 0
-          },
-          "ui_mode": "hosted",
-          "url": null,
-          "wallet_options": null
-        }
-  recorded_at: Fri, 03 Apr 2026 13:12:53 GMT
-- request:
-    method: get
-    uri: https://api.stripe.com/v1/checkout/sessions/cs_test_a1OjyvijhWCbD9a9qWzUfM7UisfeWgROJx7tEF8Nc92PCP1uR1vjmXngCa
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - Stripe/v1 RubyBindings/13.4.1
-      X-Stripe-Client-Telemetry:
       - '{"last_request_metrics":{"request_id":"req_h3eNSCingOznig","request_duration_ms":194}}'
       Stripe-Version:
       - 2025-01-27.acacia
@@ -347,4 +178,179 @@ http_interactions:
           "wallet_options": null
         }
   recorded_at: Sat, 20 Jun 2026 22:05:05 GMT
+- request:
+    method: get
+    uri: https://api.stripe.com/v1/checkout/sessions/cs_test_a1OjyvijhWCbD9a9qWzUfM7UisfeWgROJx7tEF8Nc92PCP1uR1vjmXngCa
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/13.4.1
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_uDWu440Opxpgmh","request_duration_ms":202}}'
+      Stripe-Version:
+      - 2025-01-27.acacia
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Mon, 27 Jul 2026 22:15:47 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '2601'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=RSo8Fh-Oxgaepd33JOlm_awlX79qslsr9ajrnadxSvrw4HPWN1_g3vxzyH38WmKIHgXVoULwizC5b27O;
+        report-to csp
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=RSo8Fh-Oxgaepd33JOlm_awlX79qslsr9ajrnadxSvrw4HPWN1_g3vxzyH38WmKIHgXVoULwizC5b27O&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=RSo8Fh-Oxgaepd33JOlm_awlX79qslsr9ajrnadxSvrw4HPWN1_g3vxzyH38WmKIHgXVoULwizC5b27O&t=1"
+      Request-Id:
+      - req_48DAyRVveX0xhj
+      Stripe-Version:
+      - 2025-01-27.acacia
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "cs_test_a1OjyvijhWCbD9a9qWzUfM7UisfeWgROJx7tEF8Nc92PCP1uR1vjmXngCa",
+          "object": "checkout.session",
+          "adaptive_pricing": null,
+          "after_expiration": null,
+          "allow_promotion_codes": null,
+          "amount_subtotal": 500000,
+          "amount_total": 500000,
+          "automatic_tax": {
+            "enabled": false,
+            "liability": null,
+            "provider": null,
+            "status": null
+          },
+          "billing_address_collection": null,
+          "cancel_url": "http://localhost:3001/payments/new",
+          "client_reference_id": null,
+          "client_secret": null,
+          "collected_information": {
+            "business_name": null,
+            "individual_name": null,
+            "shipping_details": null
+          },
+          "consent": null,
+          "consent_collection": null,
+          "created": 1625254985,
+          "currency": "usd",
+          "currency_conversion": null,
+          "custom_fields": [],
+          "custom_text": {
+            "after_submit": null,
+            "shipping_address": null,
+            "submit": null,
+            "terms_of_service_acceptance": null
+          },
+          "customer": "cus_JmR9ccDp8JD2Mo",
+          "customer_account": null,
+          "customer_creation": null,
+          "customer_details": {
+            "address": null,
+            "business_name": null,
+            "email": "testly@bikeindex.org",
+            "individual_name": null,
+            "name": null,
+            "phone": null,
+            "tax_exempt": "none",
+            "tax_ids": []
+          },
+          "customer_email": null,
+          "discounts": [],
+          "expires_at": 1625341385,
+          "integration_identifier": null,
+          "invoice": null,
+          "invoice_creation": null,
+          "livemode": false,
+          "locale": null,
+          "managed_payments": null,
+          "metadata": {},
+          "mode": "payment",
+          "origin_context": null,
+          "payment_intent": "pi_0J8sGTm0T0GBfX0v4QU0tTnn",
+          "payment_link": null,
+          "payment_method_collection": null,
+          "payment_method_configuration_details": null,
+          "payment_method_options": {
+            "card": {
+              "request_three_d_secure": "automatic"
+            }
+          },
+          "payment_method_types": [
+            "card"
+          ],
+          "payment_status": "paid",
+          "permissions": null,
+          "phone_number_collection": {
+            "enabled": false
+          },
+          "recovered_from": null,
+          "saved_payment_method_options": {
+            "allow_redisplay_filters": [
+              "always"
+            ],
+            "payment_method_remove": "disabled",
+            "payment_method_save": null
+          },
+          "setup_intent": null,
+          "shipping_address_collection": null,
+          "shipping_cost": null,
+          "shipping_details": null,
+          "shipping_options": [],
+          "status": "complete",
+          "submit_type": "pay",
+          "subscription": null,
+          "success_url": "http://localhost:3001/payments/success?session_id={CHECKOUT_SESSION_ID}",
+          "total_details": {
+            "amount_discount": 0,
+            "amount_shipping": 0,
+            "amount_tax": 0
+          },
+          "ui_mode": "hosted",
+          "url": null,
+          "wallet_options": null
+        }
+  recorded_at: Mon, 27 Jul 2026 22:15:47 GMT
 recorded_with: VCR 6.4.0

--- a/spec/vcr_cassettes/payments_controller-success.yml
+++ b/spec/vcr_cassettes/payments_controller-success.yml
@@ -9,175 +9,6 @@ http_interactions:
     headers:
       User-Agent:
       - Stripe/v1 RubyBindings/13.4.1
-      X-Stripe-Client-Telemetry:
-      - '{"last_request_metrics":{"request_id":"req_8fckReS621fkw2","request_duration_ms":420}}'
-      Stripe-Version:
-      - 2025-01-27.acacia
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Server:
-      - nginx
-      Date:
-      - Fri, 03 Apr 2026 13:12:53 GMT
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '2570'
-      Connection:
-      - keep-alive
-      Access-Control-Allow-Credentials:
-      - 'true'
-      Access-Control-Allow-Methods:
-      - GET, HEAD, PUT, PATCH, POST, DELETE
-      Access-Control-Allow-Origin:
-      - "*"
-      Access-Control-Expose-Headers:
-      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
-        X-Stripe-Privileged-Session-Required
-      Access-Control-Max-Age:
-      - '300'
-      Cache-Control:
-      - no-cache, no-store
-      Content-Security-Policy:
-      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
-        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
-        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=WTQQIC7f6vIyzn7htHAPST8rxzNrQDi0jfT0af-AWX9NIR9d9lajbxNZveeLW3huoyik9FNHc_9WBScd
-      Request-Id:
-      - req_dxUME1skuy559U
-      Stripe-Version:
-      - 2025-01-27.acacia
-      Vary:
-      - Origin
-      X-Stripe-Priority-Routing-Enabled:
-      - 'true'
-      X-Stripe-Routing-Context-Priority-Tier:
-      - api-testmode
-      X-Wc:
-      - 3c3
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains; preload
-    body:
-      encoding: UTF-8
-      string: |-
-        {
-          "id": "cs_test_a17wYrWqVcrfgLkOnthsa6r4STYqidDh3gTU8pkUqgGepDZSprYeoT8VxV",
-          "object": "checkout.session",
-          "adaptive_pricing": null,
-          "after_expiration": null,
-          "allow_promotion_codes": null,
-          "amount_subtotal": 5000,
-          "amount_total": 5000,
-          "automatic_tax": {
-            "enabled": false,
-            "liability": null,
-            "provider": null,
-            "status": null
-          },
-          "billing_address_collection": null,
-          "cancel_url": "http://localhost:3001/payments/new",
-          "client_reference_id": null,
-          "client_secret": null,
-          "collected_information": {
-            "business_name": null,
-            "individual_name": null,
-            "shipping_details": null
-          },
-          "consent": null,
-          "consent_collection": null,
-          "created": 1625248467,
-          "currency": "usd",
-          "currency_conversion": null,
-          "custom_fields": [],
-          "custom_text": {
-            "after_submit": null,
-            "shipping_address": null,
-            "submit": null,
-            "terms_of_service_acceptance": null
-          },
-          "customer": "cus_JmPqQDidyY7LDB",
-          "customer_account": null,
-          "customer_creation": null,
-          "customer_details": {
-            "address": null,
-            "business_name": null,
-            "email": "seth@bikeindex.org",
-            "individual_name": null,
-            "name": null,
-            "phone": null,
-            "tax_exempt": "none",
-            "tax_ids": []
-          },
-          "customer_email": null,
-          "discounts": [],
-          "expires_at": 1625334867,
-          "integration_identifier": null,
-          "invoice": null,
-          "invoice_creation": null,
-          "livemode": false,
-          "locale": null,
-          "metadata": {},
-          "mode": "payment",
-          "origin_context": null,
-          "payment_intent": "pi_0J8qZLm0T0GBfX0v6J8Q3YjN",
-          "payment_link": null,
-          "payment_method_collection": null,
-          "payment_method_configuration_details": null,
-          "payment_method_options": {
-            "card": {
-              "request_three_d_secure": "automatic"
-            }
-          },
-          "payment_method_types": [
-            "card"
-          ],
-          "payment_status": "paid",
-          "permissions": null,
-          "phone_number_collection": {
-            "enabled": false
-          },
-          "recovered_from": null,
-          "saved_payment_method_options": {
-            "allow_redisplay_filters": [
-              "always"
-            ],
-            "payment_method_remove": "disabled",
-            "payment_method_save": null
-          },
-          "setup_intent": null,
-          "shipping_address_collection": null,
-          "shipping_cost": null,
-          "shipping_details": null,
-          "shipping_options": [],
-          "status": "complete",
-          "submit_type": "donate",
-          "subscription": null,
-          "success_url": "http://localhost:3001/payments/success?session_id={CHECKOUT_SESSION_ID}",
-          "total_details": {
-            "amount_discount": 0,
-            "amount_shipping": 0,
-            "amount_tax": 0
-          },
-          "ui_mode": "hosted",
-          "url": null,
-          "wallet_options": null
-        }
-  recorded_at: Fri, 03 Apr 2026 13:12:53 GMT
-- request:
-    method: get
-    uri: https://api.stripe.com/v1/checkout/sessions/cs_test_a17wYrWqVcrfgLkOnthsa6r4STYqidDh3gTU8pkUqgGepDZSprYeoT8VxV
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - Stripe/v1 RubyBindings/13.4.1
       Stripe-Version:
       - 2025-01-27.acacia
       Accept-Encoding:
@@ -345,4 +176,179 @@ http_interactions:
           "wallet_options": null
         }
   recorded_at: Sat, 20 Jun 2026 22:05:05 GMT
+- request:
+    method: get
+    uri: https://api.stripe.com/v1/checkout/sessions/cs_test_a17wYrWqVcrfgLkOnthsa6r4STYqidDh3gTU8pkUqgGepDZSprYeoT8VxV
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Stripe/v1 RubyBindings/13.4.1
+      X-Stripe-Client-Telemetry:
+      - '{"last_request_metrics":{"request_id":"req_DvIE6mselKbVyA","request_duration_ms":1}}'
+      Stripe-Version:
+      - 2025-01-27.acacia
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Mon, 27 Jul 2026 22:15:46 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '2598'
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Expose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Max-Age:
+      - '300'
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=RSo8Fh-Oxgaepd33JOlm_awlX79qslsr9ajrnadxSvrw4HPWN1_g3vxzyH38WmKIHgXVoULwizC5b27O;
+        report-to csp
+      Report-To:
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=RSo8Fh-Oxgaepd33JOlm_awlX79qslsr9ajrnadxSvrw4HPWN1_g3vxzyH38WmKIHgXVoULwizC5b27O&t=1"}],"include_subdomains":true}'
+      Reporting-Endpoints:
+      - csp="https://q.stripe.com/csp-report-v2?q=RSo8Fh-Oxgaepd33JOlm_awlX79qslsr9ajrnadxSvrw4HPWN1_g3vxzyH38WmKIHgXVoULwizC5b27O&t=1"
+      Request-Id:
+      - req_uDWu440Opxpgmh
+      Stripe-Version:
+      - 2025-01-27.acacia
+      Vary:
+      - Origin
+      X-Stripe-Priority-Routing-Enabled:
+      - 'true'
+      X-Stripe-Routing-Context-Priority-Tier:
+      - api-testmode
+      X-Wc:
+      - 3c3
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains; preload
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "id": "cs_test_a17wYrWqVcrfgLkOnthsa6r4STYqidDh3gTU8pkUqgGepDZSprYeoT8VxV",
+          "object": "checkout.session",
+          "adaptive_pricing": null,
+          "after_expiration": null,
+          "allow_promotion_codes": null,
+          "amount_subtotal": 5000,
+          "amount_total": 5000,
+          "automatic_tax": {
+            "enabled": false,
+            "liability": null,
+            "provider": null,
+            "status": null
+          },
+          "billing_address_collection": null,
+          "cancel_url": "http://localhost:3001/payments/new",
+          "client_reference_id": null,
+          "client_secret": null,
+          "collected_information": {
+            "business_name": null,
+            "individual_name": null,
+            "shipping_details": null
+          },
+          "consent": null,
+          "consent_collection": null,
+          "created": 1625248467,
+          "currency": "usd",
+          "currency_conversion": null,
+          "custom_fields": [],
+          "custom_text": {
+            "after_submit": null,
+            "shipping_address": null,
+            "submit": null,
+            "terms_of_service_acceptance": null
+          },
+          "customer": "cus_JmPqQDidyY7LDB",
+          "customer_account": null,
+          "customer_creation": null,
+          "customer_details": {
+            "address": null,
+            "business_name": null,
+            "email": "seth@bikeindex.org",
+            "individual_name": null,
+            "name": null,
+            "phone": null,
+            "tax_exempt": "none",
+            "tax_ids": []
+          },
+          "customer_email": null,
+          "discounts": [],
+          "expires_at": 1625334867,
+          "integration_identifier": null,
+          "invoice": null,
+          "invoice_creation": null,
+          "livemode": false,
+          "locale": null,
+          "managed_payments": null,
+          "metadata": {},
+          "mode": "payment",
+          "origin_context": null,
+          "payment_intent": "pi_0J8qZLm0T0GBfX0v6J8Q3YjN",
+          "payment_link": null,
+          "payment_method_collection": null,
+          "payment_method_configuration_details": null,
+          "payment_method_options": {
+            "card": {
+              "request_three_d_secure": "automatic"
+            }
+          },
+          "payment_method_types": [
+            "card"
+          ],
+          "payment_status": "paid",
+          "permissions": null,
+          "phone_number_collection": {
+            "enabled": false
+          },
+          "recovered_from": null,
+          "saved_payment_method_options": {
+            "allow_redisplay_filters": [
+              "always"
+            ],
+            "payment_method_remove": "disabled",
+            "payment_method_save": null
+          },
+          "setup_intent": null,
+          "shipping_address_collection": null,
+          "shipping_cost": null,
+          "shipping_details": null,
+          "shipping_options": [],
+          "status": "complete",
+          "submit_type": "donate",
+          "subscription": null,
+          "success_url": "http://localhost:3001/payments/success?session_id={CHECKOUT_SESSION_ID}",
+          "total_details": {
+            "amount_discount": 0,
+            "amount_shipping": 0,
+            "amount_tax": 0
+          },
+          "ui_mode": "hosted",
+          "url": null,
+          "wallet_options": null
+        }
+  recorded_at: Mon, 27 Jul 2026 22:15:46 GMT
 recorded_with: VCR 6.4.0


### PR DESCRIPTION
The combobox styled its own label through the hotwire_combobox gem, so it was the one form field whose label skipped `twlabel` and the required / optional marker every other field gets from `UI::Forms::Group`.

- `label:`/`label_class:` are gone from `Combobox` and `ComboboxManufacturer`; every call site renders the field inside a `Group` block, the same pairing `Select` and `TextEditor` already document — previewed at `ui/forms/group/component/combobox`. The search bar is the exception: `Group` always appends a required / optional suffix, so its visually-hidden label stays a plain `label_tag`, matching the serial and price fields beside it.
- `Group` takes an optional `form_builder:` — without one it labels via `label_tag`, for the admin `form_tag` forms that have no builder. The combobox ids its input with its name in that case, so the label's `for` finds it, and it names the gem's mobile dialog the same way — that dialog covers the page below 640px, so the Group's label can't reach it.
- `Group` now infers "render the block instead of an input" from the block itself, so `kind: :content_block` is gone from all ~30 call sites (including the pre-existing `Select`/`TextEditor`/`AddressGroup` ones).
- Combobox previews moved off manufacturers, which are `ComboboxManufacturer`'s job, onto cycle types, primary activities and wheel sizes.
- Also carries `tw:justify-center` into `UI::Button::BASE_CLASSES` from sethherr/new-registration-flow (0a79c1778), with the per-call-site patches it makes redundant removed.

