### PR TITLE
Guard hand-bumped fragment cache versions with a spec

### DIFF
--- a/app/components/org/search_results/bikes_table/component.rb
+++ b/app/components/org/search_results/bikes_table/component.rb
@@ -8,6 +8,10 @@ module Org
       # the search form, column-toggle settings, or pagination (e.g. a user's other
       # registrations on the show page). Pass render_sortable to enable sort links.
       class Component < ApplicationComponent
+        # UI::Table caches each row without digesting the cells rendered into it, so
+        # bump this whenever this component's or UI::Table's markup changes
+        CACHE_VERSION = "bikes_4"
+
         delegate :additional_registration_fields, :column_renames, to: :settings_component
 
         def initialize(organization:, bikes:, current_user: nil, render_sortable: false,
@@ -16,7 +20,7 @@ module Org
           @bikes = bikes
           @current_user = current_user
           @render_sortable = render_sortable
-          @cache_key = cache_key || "org-#{organization.id}-bikes_4"
+          @cache_key = cache_key || "org-#{organization.id}-#{CACHE_VERSION}"
           @sortable_search_params = sortable_search_params
           @bike_sticker = bike_sticker
           @settings_component = settings_component

--- a/app/components/page_block/footer/component.rb
+++ b/app/components/page_block/footer/component.rb
@@ -4,6 +4,8 @@ module PageBlock
   module Footer
     class Component < ApplicationComponent
       FACEBOOK_PIXEL_ID = "199066297131941"
+      # Nothing digests the cached template, so bump this whenever its markup changes
+      CACHE_VERSION = "footer_3"
 
       def initialize(current_user:, skip_facebook:, page_id:, passive_organization: nil)
         @current_user = current_user
@@ -15,7 +17,7 @@ module PageBlock
       private
 
       def cache_key
-        ["footer_3", @page_id, @current_user, @passive_organization, @skip_facebook]
+        [CACHE_VERSION, @page_id, @current_user, @passive_organization, @skip_facebook]
       end
     end
   end

--- a/app/components/registrations/show/wrapper/component.rb
+++ b/app/components/registrations/show/wrapper/component.rb
@@ -6,6 +6,10 @@ module Registrations
       # Renders the registration show page as the resolved [kind, organization]
       # perspective (e.g. [:public, nil] or [:staff, org]) and fragment-caches it.
       class Component < ApplicationComponent
+        # Nothing digests the nested components' templates, so bump this whenever
+        # their markup changes
+        CACHE_VERSION = "registrations/show-v2"
+
         def initialize(bike:, current_user:, view:, available_views:)
           @bike = bike
           @current_user = current_user
@@ -40,10 +44,9 @@ module Registrations
         # folds their versions in via #cache_version. This key can't keep cached
         # forms' CSRF tokens valid (they're session-scoped, and a user's session
         # varies across devices/logins) — the csrf-refresh controller reissues them
-        # client-side from the meta tag. Nothing digests the nested components'
-        # templates, so bump the -v2 suffix whenever their markup changes.
+        # client-side from the meta tag.
         def cache_key
-          ["registrations/show-v2", @current_user&.id,
+          [CACHE_VERSION, @current_user&.id,
             @current_user&.registration_show_toggleable?, @current_user&.feature_registration_show_legacy?,
             BikeServices::ShowViews.view_param(@view),
             @bike.cache_key_with_version, *inner_component.try(:cache_version)]

--- a/spec/components/org/search_results/bikes_table/cache_version_checkpoint.yml
+++ b/spec/components/org/search_results/bikes_table/cache_version_checkpoint.yml
@@ -1,0 +1,4 @@
+# Written by the cache_version_checkpoint shared example
+---
+cache_version: bikes_4
+files_digest: 5f0d082f99a9507382a7c9ecf1cd4a31a33a99a893bc2423b39b3d1ef0c0261d

--- a/spec/components/org/search_results/bikes_table/component_spec.rb
+++ b/spec/components/org/search_results/bikes_table/component_spec.rb
@@ -3,6 +3,10 @@
 require "rails_helper"
 
 RSpec.describe Org::SearchResults::BikesTable::Component, type: :component do
+  # UI::Table caches each row, so every component rendered into one counts too
+  it_behaves_like "cache_version_checkpoint",
+    %w[org/search_results/bikes_table ui/table org/origin_display ui/address_display]
+
   let(:instance) { described_class.new(**options) }
   let(:component) do
     with_request_url("/o/#{organization.to_param}/registrations") do

--- a/spec/components/page_block/footer/cache_version_checkpoint.yml
+++ b/spec/components/page_block/footer/cache_version_checkpoint.yml
@@ -1,0 +1,4 @@
+# Written by the cache_version_checkpoint shared example
+---
+cache_version: footer_3
+files_digest: 7c8162cff3954ef43f866fe7fc0c071afd90bfe7c02e83c5a6d3242d019531fc

--- a/spec/components/page_block/footer/component_spec.rb
+++ b/spec/components/page_block/footer/component_spec.rb
@@ -3,6 +3,8 @@
 require "rails_helper"
 
 RSpec.describe PageBlock::Footer::Component, type: :component do
+  it_behaves_like "cache_version_checkpoint"
+
   let(:instance) { described_class.new(current_user: nil, skip_facebook:, page_id: "welcome_index") }
   let(:component) { with_request_url("/") { render_inline(instance) } }
   let(:skip_facebook) { false }

--- a/spec/components/registrations/show/wrapper/cache_version_checkpoint.yml
+++ b/spec/components/registrations/show/wrapper/cache_version_checkpoint.yml
@@ -1,0 +1,4 @@
+# Written by the cache_version_checkpoint shared example
+---
+cache_version: registrations/show-v2
+files_digest: 7a6d942c2666db0bfd694810150732007efb253af2cf41c72e77697c3ac63f94

--- a/spec/components/registrations/show/wrapper/cache_version_checkpoint.yml
+++ b/spec/components/registrations/show/wrapper/cache_version_checkpoint.yml
@@ -1,4 +1,4 @@
 # Written by the cache_version_checkpoint shared example
 ---
-cache_version: registrations/show-v2
-files_digest: 7a6d942c2666db0bfd694810150732007efb253af2cf41c72e77697c3ac63f94
+cache_version: registrations/show-v3
+files_digest: 21c2a1d200b149d850a16dc303712f110eec0195f7fa5fc6a8e1b91e44a1398b

--- a/spec/components/registrations/show/wrapper/component_spec.rb
+++ b/spec/components/registrations/show/wrapper/component_spec.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Registrations::Show::Wrapper::Component, type: :component do
+  # The whole show tree renders inside this component's cache block
+  it_behaves_like "cache_version_checkpoint", %w[registrations/show]
+end

--- a/spec/support/shared_examples/cache_version_checkpoint.rb
+++ b/spec/support/shared_examples/cache_version_checkpoint.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+# Fragment caches don't digest the templates inside them, so editing that markup
+# serves stale HTML until the component's CACHE_VERSION is bumped by hand. This
+# digests the components rendered inside the cache block and fails when they change
+# without a bump, rewriting the checkpoint once the version is bumped — a run is only
+# green with the current checkpoint committed.
+#
+# Pass the component directories (relative to app/components) rendered inside the
+# cache block; defaults to the described component's own directory. Components
+# rendered by those components are missed, so the guard nags rather than proves.
+RSpec.shared_examples "cache_version_checkpoint" do |cached_component_dirs = nil|
+  let(:component_dir) { described_class.name.underscore.delete_suffix("/component") }
+  let(:component_dirs) { Array(cached_component_dirs || component_dir) }
+  let(:checkpoint_path) { Rails.root.join("spec/components", component_dir, "cache_version_checkpoint.yml") }
+  let(:checkpoint) { checkpoint_path.exist? ? YAML.safe_load_file(checkpoint_path) : {} }
+  # Previews render outside the cache block, so their markup can't go stale
+  let(:cached_files) do
+    component_dirs.flat_map { |dir| Rails.root.glob("app/components/#{dir}/**/*") }
+      .select(&:file?).reject { |file| file.to_s.match?(%r{/(component_preview\.rb|preview/)}) }.sort
+  end
+  let(:files_digest) do
+    Digest::SHA256.hexdigest(cached_files.map { |file| "#{file.relative_path_from(Rails.root)}\n#{file.read}" }.join("\n"))
+  end
+
+  it "bumps CACHE_VERSION when the cached components change" do
+    expect(cached_files.count).to be > 1 # a renamed or mistyped directory shouldn't silently pass
+    next if checkpoint["files_digest"] == files_digest
+
+    expect(described_class::CACHE_VERSION).to_not eq(checkpoint["cache_version"]),
+      "#{component_dirs.join(", ")} changed but #{described_class}::CACHE_VERSION is still " \
+      "#{described_class::CACHE_VERSION.inspect} — bump it, then re-run this spec"
+
+    checkpoint_path.write("# Written by the cache_version_checkpoint shared example\n" +
+      {"cache_version" => described_class::CACHE_VERSION, "files_digest" => files_digest}.to_yaml)
+    raise "Rewrote #{checkpoint_path.relative_path_from(Rails.root)} for #{described_class::CACHE_VERSION} — commit it"
+  end
+end


### PR DESCRIPTION
Fragment caches don't digest the templates inside them, so editing markup inside one serves stale HTML until the component's cache version is bumped by hand — and nothing caught a missed bump.

- The `cache_version_checkpoint` shared example digests the components rendered inside a cache block and fails when they change without a `CACHE_VERSION` bump, comparing against a committed `cache_version_checkpoint.yml`. Bumping the version rewrites that file and the run stays red until it's committed, so a green run means the checkpoint matches HEAD.
- Applied to the three components that fragment-cache — `Registrations::Show::Wrapper`, `PageBlock::Footer` and `Org::SearchResults::BikesTable` — each with its version literal promoted to `CACHE_VERSION`.
- Components rendered *by* the declared directories are still missed, since ViewComponent gives no transitive render graph — the guard nags rather than proves.
