### PR TITLE
Move form Stimulus controllers under ui/forms

### DIFF
--- a/app/components/org/location_address_fields/component.html.erb
+++ b/app/components/org/location_address_fields/component.html.erb
@@ -1,7 +1,7 @@
 <div
   class="form-group address-group"
-  data-controller="form--legacy-form-well--address-record"
-  data-form--legacy-form-well--address-record-us-id-value="<%= Country.united_states_id %>"
+  data-controller="ui--forms--legacy-form-well--address-record"
+  data-ui--forms--legacy-form-well--address-record-us-id-value="<%= Country.united_states_id %>"
 >
   <% if @show_label %>
     <%= @builder.label :street, translation(:address) %>
@@ -20,7 +20,7 @@
         { include_blank: true, prompt: translation(".state") },
         {
           :class => "form-control tw:mt-2! #{initial_state_class}",
-          "data-form--legacy-form-well--address-record-target" => "state",
+          "data-ui--forms--legacy-form-well--address-record-target" => "state",
         },
       ) %>
 
@@ -28,7 +28,7 @@
         :region_string,
         :placeholder => translation(".region"),
         :class => "form-control tw:mt-2! #{initial_region_class}",
-        "data-form--legacy-form-well--address-record-target" => "region",
+        "data-ui--forms--legacy-form-well--address-record-target" => "region",
       ) %>
     </div>
 
@@ -45,7 +45,7 @@
         { prompt: translation(".choose_country"), required: true },
         {
           :class => "form-control tw:mt-2!",
-          "data-form--legacy-form-well--address-record-target" => "country",
+          "data-ui--forms--legacy-form-well--address-record-target" => "country",
         }
       ) %>
     </div>

--- a/app/components/registrations/show/component_list/component.html.erb
+++ b/app/components/registrations/show/component_list/component.html.erb
@@ -1,6 +1,6 @@
-<details data-controller="details" <% unless @collapsed %>  open<% end %>>
+<details data-controller="ui--details" <% unless @collapsed %>  open<% end %>>
   <summary
-    data-action="click->details#toggle"
+    data-action="click->ui--details#toggle"
     class="
       tw:flex tw:cursor-pointer tw:list-none tw:items-center
       tw:justify-between tw:gap-3 tw:rounded-sm tw:border tw:border-gray-200
@@ -35,7 +35,7 @@
   </summary>
 
   <div
-    data-details-target="content"
+    data-ui--details-target="content"
     class="tw:flex tw:flex-col tw:gap-6 tw:pt-6 <%= "tw:hidden!" if @collapsed %>"
   >
     <% grouped_rows.each do |cgroup, rows| %>

--- a/app/components/registrations/show/wrapper/component.rb
+++ b/app/components/registrations/show/wrapper/component.rb
@@ -8,7 +8,7 @@ module Registrations
       class Component < ApplicationComponent
         # Nothing digests the nested components' templates, so bump this whenever
         # their markup changes
-        CACHE_VERSION = "registrations/show-v4"
+        CACHE_VERSION = "registrations/show-v5"
 
         def initialize(bike:, current_user:, view:, available_views:, bike_sticker: nil)
           @bike = bike

--- a/app/components/ui/button/component.rb
+++ b/app/components/ui/button/component.rb
@@ -82,7 +82,7 @@ module UI
         data = @data.merge(active: @active || nil)
         return data unless @spinner
 
-        data.merge(controller: [data[:controller], "ui--buttons--submit-spinner"].compact.join(" "))
+        data.merge(controller: [data[:controller], "ui--button--submit-spinner"].compact.join(" "))
       end
 
       # Hidden until the submit-spinner controller reveals it on form submit;
@@ -91,7 +91,7 @@ module UI
         return unless @spinner
 
         content_tag(:span, render(UI::LoadingSpinner::Component.new(size: :sm, color_class: nil)),
-          class: "tw:hidden", data: {"ui--buttons--submit-spinner-target": "spinner"})
+          class: "tw:hidden", data: {"ui--button--submit-spinner-target": "spinner"})
       end
     end
   end

--- a/app/components/ui/details/component_preview/with_animation.html.erb
+++ b/app/components/ui/details/component_preview/with_animation.html.erb
@@ -1,6 +1,6 @@
-<details data-controller="details" class="tw:max-w-md">
+<details data-controller="ui--details" class="tw:max-w-md">
   <summary
-    data-action="click->details#toggle"
+    data-action="click->ui--details#toggle"
     class="
       tw:flex tw:cursor-pointer tw:list-none tw:items-center
       tw:justify-between tw:gap-3 tw:rounded-sm tw:border tw:border-gray-200
@@ -11,7 +11,7 @@
     <%= render UI::IconChevron::Component.new(html_class: "tw:transition-transform tw:[details[open]_&]:rotate-90") %>
   </summary>
 
-  <div data-details-target="content" class="tw:hidden! tw:pt-3">
+  <div data-ui--details-target="content" class="tw:hidden! tw:pt-3">
     <p class="tw:mb-0">
       Native &lt;details&gt; body, animated open/closed by the details
       controller.

--- a/app/components/ui/forms/file_upload/component.html.erb
+++ b/app/components/ui/forms/file_upload/component.html.erb
@@ -1,8 +1,8 @@
 <%# drop is bound to the root, not the frame, so dropping on the button works too. %>
 <div
-  data-controller="form--file-upload"
-  data-form--file-upload-placeholder-value="<%= @placeholder %>"
-  data-action="drop->form--file-upload#drop dragover@document->form--file-upload#dragOver dragleave@document->form--file-upload#endDrag drop@document->form--file-upload#endDrag"
+  data-controller="ui--forms--file-upload"
+  data-ui--forms--file-upload-placeholder-value="<%= @placeholder %>"
+  data-action="drop->ui--forms--file-upload#drop dragover@document->ui--forms--file-upload#dragOver dragleave@document->ui--forms--file-upload#endDrag drop@document->ui--forms--file-upload#endDrag"
 >
   <%#
     The drop target frames the preview and controls; its border is transparent until a drag
@@ -19,8 +19,8 @@
       tw:dark:data-[dragging=true]:border-gray-600
       tw:dark:data-[over=true]:bg-blue-950
     "
-    data-form--file-upload-target="dropZone"
-    data-action="dragenter->form--file-upload#highlightDropZone dragleave->form--file-upload#unhighlightDropZone"
+    data-ui--forms--file-upload-target="dropZone"
+    data-action="dragenter->ui--forms--file-upload#highlightDropZone dragleave->ui--forms--file-upload#unhighlightDropZone"
   >
     <% if @attachment_url %>
       <%# block so the controls start a new line, w-fit so the link doesn't stretch past the image %>
@@ -33,13 +33,13 @@
       <%= @form_builder.file_field(@attribute, @html_options) %>
 
       <%# Stimulus has no default event for a label, so name click explicitly. %>
-      <%= @form_builder.label @attribute, label_content, class: @label_classes, data: {action: "click->form--file-upload#chooseFile"} %>
+      <%= @form_builder.label @attribute, label_content, class: @label_classes, data: {action: "click->ui--forms--file-upload#chooseFile"} %>
 
       <% if @camera %>
         <%# `capture` only reaches a camera on touch devices; a fine pointer would just reopen the file picker. %>
         <%= render UI::Button::Component.new(
               html_class: "tw:whitespace-nowrap tw:pointer-fine:hidden",
-              data: {action: "form--file-upload#takePicture"}
+              data: {action: "ui--forms--file-upload#takePicture"}
             ) do %>
           <%# hidden from AT: the button's own text already names it %>
           <%= helpers.inline_svg_tag("icons/camera.svg", class: "tw:h-4 tw:w-4", aria_hidden: true) %>
@@ -49,7 +49,7 @@
 
       <span
         class="tw:min-w-0 tw:truncate tw:text-gray-500 tw:dark:text-gray-400"
-        data-form--file-upload-target="filename"
+        data-ui--forms--file-upload-target="filename"
       >
         <%= @placeholder %>
       </span>

--- a/app/components/ui/forms/file_upload/component.rb
+++ b/app/components/ui/forms/file_upload/component.rb
@@ -24,7 +24,7 @@ module UI
           @html_options = {
             class: "tw:peer tw:sr-only",
             accept: accept_list.join(",").presence,
-            data: {"form--file-upload-target": "input", action: "form--file-upload#display"}
+            data: {"ui--forms--file-upload-target": "input", action: "ui--forms--file-upload#display"}
           }.merge(html_options)
 
           # Style the label as a UI::Button; the focus ring is driven by the peer (sr-only) input.

--- a/app/components/ui/forms/legacy_form_well/address_record/component.html.erb
+++ b/app/components/ui/forms/legacy_form_well/address_record/component.html.erb
@@ -1,7 +1,7 @@
 <div
   class="<%= @wrapper_class %>"
-  data-controller="form--legacy-form-well--address-record"
-  data-form--legacy-form-well--address-record-us-id-value="<%= Country.united_states_id %>"
+  data-controller="ui--forms--legacy-form-well--address-record"
+  data-ui--forms--legacy-form-well--address-record-us-id-value="<%= Country.united_states_id %>"
 >
   <%# TODO: make fancy select - requires updating the stimulus controller to trigger on Selectize change %>
   <div class="form-group row">
@@ -10,7 +10,7 @@
     <div
       class="form-well-input <%= non_static_field_class %>"
       data-usid="<%= Country.united_states_id %>"
-      data-form--legacy-form-well--address-record-with-default-target="nonStaticFields"
+      data-ui--forms--legacy-form-well--address-record-with-default-target="nonStaticFields"
     >
       <%= @builder.select(
         :country_id,
@@ -18,7 +18,7 @@
         { prompt: translation(".choose_country"), required: country_required? },
         {
           :class => "form-control",
-          "data-form--legacy-form-well--address-record-target" => "country",
+          "data-ui--forms--legacy-form-well--address-record-target" => "country",
         },
       ) %>
     </div>
@@ -26,7 +26,7 @@
     <% if @static_fields %>
       <p
         class="form-well-input-static tw:py-0!"
-        data-form--legacy-form-well--address-record-with-default-target="staticFields"
+        data-ui--forms--legacy-form-well--address-record-with-default-target="staticFields"
       >
         <%= @builder.object.country_name %>
       </p>
@@ -39,7 +39,7 @@
 
       <div
         class="form-well-input pb-0 <%= non_static_field_class %>"
-        data-form--legacy-form-well--address-record-with-default-target="nonStaticFields"
+        data-ui--forms--legacy-form-well--address-record-with-default-target="nonStaticFields"
       >
         <%= @builder.text_field :street,
                             placeholder: street_placeholder,
@@ -62,14 +62,14 @@
       <% if @static_fields %>
         <p
           class="form-well-input-static tw:py-0!"
-          data-form--legacy-form-well--address-record-with-default-target="staticFields"
+          data-ui--forms--legacy-form-well--address-record-with-default-target="staticFields"
         >
           <%= @builder.object.street %>
         </p>
         <% if @street_2 %>
           <p
             class="form-well-input-static tw:py-0!"
-            data-form--legacy-form-well--address-record-with-default-target="staticFields"
+            data-ui--forms--legacy-form-well--address-record-with-default-target="staticFields"
           >
             <%= @builder.object.street_2 %>
           </p>
@@ -87,7 +87,7 @@
 
     <div
       class="form-well-input <%= non_static_field_class %>"
-      data-form--legacy-form-well--address-record-with-default-target="nonStaticFields"
+      data-ui--forms--legacy-form-well--address-record-with-default-target="nonStaticFields"
     >
       <%= @builder.text_field :city,
                           placeholder: translation(".city"),
@@ -97,7 +97,7 @@
     <% if @static_fields %>
       <p
         class="form-well-input-static tw:py-0!"
-        data-form--legacy-form-well--address-record-with-default-target="staticFields"
+        data-ui--forms--legacy-form-well--address-record-with-default-target="staticFields"
       >
         <%= @builder.object.city %>, <%= @builder.object.region %>,
         <%= @builder.object.postal_code %>
@@ -108,7 +108,7 @@
   <%# NOTE: The below rows are hidden when static (and rendered above), to fix a spacing issue %>
   <div
     class="form-group row <%= non_static_field_class %>"
-    data-form--legacy-form-well--address-record-with-default-target="nonStaticFields"
+    data-ui--forms--legacy-form-well--address-record-with-default-target="nonStaticFields"
   >
     <label class="form-well-label"></label>
 
@@ -121,7 +121,7 @@
         { include_blank: true, prompt: translation(".state") },
         {
           :class => "form-control #{initial_state_class}",
-          "data-form--legacy-form-well--address-record-target" => "state",
+          "data-ui--forms--legacy-form-well--address-record-target" => "state",
         },
       ) %>
 
@@ -129,20 +129,20 @@
         :region_string,
         :placeholder => translation(".region"),
         :class => "form-control #{initial_region_class}",
-        "data-form--legacy-form-well--address-record-target" => "region",
+        "data-ui--forms--legacy-form-well--address-record-target" => "region",
       ) %>
     </div>
   </div>
 
   <div
     class="form-group row <%= non_static_field_class %>"
-    data-form--legacy-form-well--address-record-with-default-target="nonStaticFields"
+    data-ui--forms--legacy-form-well--address-record-with-default-target="nonStaticFields"
   >
     <label class="form-well-label"></label>
 
     <div
       class="form-well-input <%= non_static_field_class %>"
-      data-form--legacy-form-well--address-record-with-default-target="nonStaticFields"
+      data-ui--forms--legacy-form-well--address-record-with-default-target="nonStaticFields"
     >
       <%= @builder.text_field :postal_code,
                           placeholder: translation(".postal_code"),

--- a/app/components/ui/forms/legacy_form_well/address_record_with_default/component.html.erb
+++ b/app/components/ui/forms/legacy_form_well/address_record_with_default/component.html.erb
@@ -1,6 +1,6 @@
 <div
   class="related-fields"
-  data-controller="form--legacy-form-well--address-record-with-default"
+  data-controller="ui--forms--legacy-form-well--address-record-with-default"
 >
   <%= render(
     UI::Forms::LegacyFormWell::AddressRecord::Component.new(
@@ -18,12 +18,8 @@
       <div class="form-well-input form-well-input-checks">
         <label>
           <%= @builder.check_box :user_account_address,
-                             {
-                               "data-action" =>
-                                 "change->form--legacy-form-well--address-record-with-default#toggleUseAccount",
-                               "data-form--legacy-form-well--address-record-with-default-target" =>
-                                 "useAccountCheckbox",
-                             } %>
+                data: {action: "change->ui--forms--legacy-form-well--address-record-with-default#toggleUseAccount",
+                       "ui--forms--legacy-form-well--address-record-with-default-target": "useAccountCheckbox"} %>
           
           <span class="tw:cursor-pointer"><%= translation(".use_account_address") %></span>
           (<%= link_to translation(".edit_my_account_path"), edit_my_account_path %>)

--- a/app/components/ui/forms/text_editor/component.rb
+++ b/app/components/ui/forms/text_editor/component.rb
@@ -4,7 +4,7 @@ module UI
   module Forms
     module TextEditor
       # Bare Lexxy editor; pair with UI::Forms::Group (kind: :content_block, standalone: false) for a label.
-      # Carries data-controller="lexxy", which loads the editor JS and stylesheet on demand.
+      # Carries data-controller="ui--forms--text-editor", which loads the editor JS and stylesheet on demand.
       class Component < ApplicationComponent
         SIZE = %i[default single_line].freeze
 
@@ -42,7 +42,8 @@ module UI
         end
 
         def asset_data
-          {controller: "lexxy", action: "click->lexxy#focusEditor", lexxy_stylesheet_value: helpers.stylesheet_path("lexxy")}
+          {controller: "ui--forms--text-editor", action: "click->ui--forms--text-editor#focusEditor",
+           "ui--forms--text-editor-stylesheet-value": helpers.stylesheet_path("lexxy")}
         end
 
         def editor_class

--- a/app/components/ui/forms/text_editor/component_preview/default.html.erb
+++ b/app/components/ui/forms/text_editor/component_preview/default.html.erb
@@ -1,4 +1,4 @@
-<%# The editor carries data-controller="lexxy", which loads the JS bundle and stylesheet itself. %>
+<%# The editor carries data-controller="ui--forms--text-editor", which loads the JS bundle and stylesheet itself. %>
 <%= form_with(model: OrganizationFeature.new(description: "<p>A rich-text description</p>"), url: "#", builder: BikeIndexFormBuilder) do |f| %>
   <%= render(UI::Forms::TextEditor::Component.new(form_builder: f, attribute: :description, size: local_assigns.fetch(:size, :default), toolbar_buttons: local_assigns.fetch(:toolbar_buttons, nil))) %>
 <% end %>

--- a/app/javascript/controllers/ui/button/submit_spinner_controller.js
+++ b/app/javascript/controllers/ui/button/submit_spinner_controller.js
@@ -1,6 +1,6 @@
 import { Controller } from '@hotwired/stimulus'
 
-// Connects to data-controller="ui--buttons--submit-spinner" (on a submit button - rendered
+// Connects to data-controller="ui--button--submit-spinner" (on a submit button - rendered
 // by UI::Button spinner: true). Once the button's form actually submits
 // (native validation has passed), disables the button and reveals its spinner.
 export default class extends Controller {

--- a/app/javascript/controllers/ui/details_controller.js
+++ b/app/javascript/controllers/ui/details_controller.js
@@ -1,7 +1,7 @@
 import { Controller } from '@hotwired/stimulus'
 import { collapse } from 'utils/collapse_utils'
 
-// Connects to data-controller='details'
+// Connects to data-controller='ui--details'
 // Animates a native <details> open/close via collapse_utils while keeping its
 // `open` attribute (and the CSS keyed off it) in sync. Closing stays open until
 // the animation finishes, otherwise the browser hides the content instantly.

--- a/app/javascript/controllers/ui/forms/file_upload_controller.js
+++ b/app/javascript/controllers/ui/forms/file_upload_controller.js
@@ -1,6 +1,6 @@
 import { Controller } from '@hotwired/stimulus'
 
-// Connects to data-controller='form--file-upload'
+// Connects to data-controller='ui--forms--file-upload'
 // Shows the selected filename (or a count for multiple files) in the field, and
 // frames the controls as a drop target while a file is dragged over the page.
 export default class extends Controller {

--- a/app/javascript/controllers/ui/forms/legacy_form_well/address_record_controller.js
+++ b/app/javascript/controllers/ui/forms/legacy_form_well/address_record_controller.js
@@ -1,7 +1,7 @@
 import { Controller } from '@hotwired/stimulus'
 import { collapse } from 'utils/collapse_utils'
 
-// Connects to data-controller='form--legacy-form-well--address-record'
+// Connects to data-controller='ui--forms--legacy-form-well--address-record'
 export default class extends Controller {
   static targets = ['country', 'state', 'region']
   static values = { usId: String }

--- a/app/javascript/controllers/ui/forms/legacy_form_well/address_record_with_default_controller.js
+++ b/app/javascript/controllers/ui/forms/legacy_form_well/address_record_with_default_controller.js
@@ -1,7 +1,7 @@
 import { Controller } from '@hotwired/stimulus'
 import { collapse } from 'utils/collapse_utils'
 
-// Connects to data-controller='form--legacy-form-well--address-record-with-default'
+// Connects to data-controller='ui--forms--legacy-form-well--address-record-with-default'
 export default class extends Controller {
   static targets = ['useAccountCheckbox', 'staticFields', 'nonStaticFields']
 

--- a/app/javascript/controllers/ui/forms/text_editor_controller.js
+++ b/app/javascript/controllers/ui/forms/text_editor_controller.js
@@ -1,6 +1,6 @@
 import { Controller } from '@hotwired/stimulus'
 
-// Connects to data-controller='lexxy'
+// Connects to data-controller='ui--forms--text-editor'
 // Lazily loads the Lexxy editor bundle and its gem stylesheet only on pages that use it (both are
 // large / gem-served). Importing the module registers the <lexxy-editor> custom element, upgrading
 // every editor on the page; the stylesheet is injected once (deduped by href) so the editor works

--- a/app/views/admin/recoveries/edit.html.erb
+++ b/app/views/admin/recoveries/edit.html.erb
@@ -67,9 +67,9 @@
 
 <p>Only edit if you want to change what is stored about this recovery.</p>
 
-<details data-controller="details">
+<details data-controller="ui--details">
   <summary
-    data-action="click->details#toggle"
+    data-action="click->ui--details#toggle"
     class="
       gray-link tw:cursor-pointer tw:list-none
       tw:[&::-webkit-details-marker]:hidden
@@ -78,7 +78,7 @@
     show edit form
   </summary>
 
-  <div data-details-target="content" class="tw:hidden!">
+  <div data-ui--details-target="content" class="tw:hidden!">
     <hr class="mt-5 mb-4">
 
     <%= form_for([:admin, @recovery], url: { action: "update", controller: "recoveries" }, html: { class: "form form-horizontal" }) do |f| %>

--- a/app/views/organized/exports/show.html.erb
+++ b/app/views/organized/exports/show.html.erb
@@ -76,9 +76,9 @@
           <% bike_ids = @export.exported_bike_ids %>
 
           <% if bike_ids.present? %>
-            <details data-controller="details">
+            <details data-controller="ui--details">
               <summary
-                data-action="click->details#toggle"
+                data-action="click->ui--details#toggle"
                 class="
                   small less-strong tw:cursor-pointer tw:list-none
                   tw:[&::-webkit-details-marker]:hidden
@@ -94,7 +94,7 @@
               </summary>
 
               <ul
-                data-details-target="content"
+                data-ui--details-target="content"
                 class="exported-link-list tw:hidden!"
               >
                 <% bike_ids.each_with_index do |id, i| %>

--- a/spec/components/registrations/show/wrapper/cache_version_checkpoint.yml
+++ b/spec/components/registrations/show/wrapper/cache_version_checkpoint.yml
@@ -1,4 +1,4 @@
 # Written by the cache_version_checkpoint shared example
 ---
-cache_version: registrations/show-v4
-files_digest: 731acd9d3f99dafb1fbfc8cb824a388081b9cda022b9a01ffff425ce05c77f49
+cache_version: registrations/show-v5
+files_digest: 6356ed4f1355e2f4cf2a0e32882be34b8f8e03da502491596f98698787280540

--- a/spec/components/ui/button/component_spec.rb
+++ b/spec/components/ui/button/component_spec.rb
@@ -38,8 +38,8 @@ RSpec.describe UI::Button::Component, type: :component do
     let(:options) { {text:, kind: :submit, spinner: true} }
 
     it "renders a self-wired hidden spinner that inherits the button's text color" do
-      expect(component).to have_css("button[data-controller='ui--buttons--submit-spinner']")
-      expect(component).to have_css("span.tw\\:hidden[data-ui--buttons--submit-spinner-target='spinner'] svg", visible: :all)
+      expect(component).to have_css("button[data-controller='ui--button--submit-spinner']")
+      expect(component).to have_css("span.tw\\:hidden[data-ui--button--submit-spinner-target='spinner'] svg", visible: :all)
       expect(component.css("svg").first["class"]).to_not include("tw:text-slate-400")
       expect(component).to have_text("Click me")
     end

--- a/spec/components/ui/details/component_system_spec.rb
+++ b/spec/components/ui/details/component_system_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe "details controller", :js, type: :system do
+RSpec.describe "ui--details controller", :js, type: :system do
   let(:preview_path) { "/rails/view_components/ui/details/component/with_animation" }
 
   it "toggles the native <details> open/closed and animates the content" do
@@ -14,7 +14,7 @@ RSpec.describe "details controller", :js, type: :system do
 
     find("summary").click
 
-    # details#toggle opens the native element and animates the content in.
+    # ui--details#toggle opens the native element and animates the content in.
     expect(page).to have_content("Native <details> body")
     expect(page).to have_css("details[open]")
 

--- a/spec/components/ui/forms/file_upload/component_spec.rb
+++ b/spec/components/ui/forms/file_upload/component_spec.rb
@@ -13,17 +13,17 @@ RSpec.describe UI::Forms::FileUpload::Component, type: :component do
 
   it "renders the input, both labels and the drop frame -- but no camera or thumbnail" do
     expect(component).to have_css("input#user_avatar[type='file'][name='user[avatar]']")
-    expect(component).to have_css("[data-controller='form--file-upload']")
-    expect(component).to have_css("[data-form--file-upload-target='input']")
-    expect(component).to have_css("[data-form--file-upload-target='filename']", text: "No file chosen")
-    expect(component).to have_css("label[data-action='click->form--file-upload#chooseFile']")
+    expect(component).to have_css("[data-controller='ui--forms--file-upload']")
+    expect(component).to have_css("[data-ui--forms--file-upload-target='input']")
+    expect(component).to have_css("[data-ui--forms--file-upload-target='filename']", text: "No file chosen")
+    expect(component).to have_css("label[data-action='click->ui--forms--file-upload#chooseFile']")
     # both wordings ship, and the pointer media query picks one (see the system spec)
     expect(component).to have_css("label span", text: "Click or drop to choose file")
     expect(component).to have_css("label span", text: "Choose file")
     # the frame is always rendered -- only its border reacts to a drag
-    expect(component).to have_css("[data-form--file-upload-target='dropZone'].tw\\:border-transparent")
+    expect(component).to have_css("[data-ui--forms--file-upload-target='dropZone'].tw\\:border-transparent")
     # nothing accepted, so nothing to photograph; nothing attached, so nothing to preview
-    expect(component).to have_no_css("button[data-action='form--file-upload#takePicture']")
+    expect(component).to have_no_css("button[data-action='ui--forms--file-upload#takePicture']")
     expect(component).to have_no_css("img")
   end
 
@@ -75,7 +75,7 @@ RSpec.describe UI::Forms::FileUpload::Component, type: :component do
       let(:options) { {accept: ImageUploader.permitted_extensions} }
 
       it "renders a camera button with the camera icon" do
-        expect(component).to have_css("button[data-action='form--file-upload#takePicture']", text: "Take picture")
+        expect(component).to have_css("button[data-action='ui--forms--file-upload#takePicture']", text: "Take picture")
         # decorative -- the button text is what names it
         expect(component).to have_css("button svg[aria-hidden='true']")
       end
@@ -85,7 +85,7 @@ RSpec.describe UI::Forms::FileUpload::Component, type: :component do
       let(:options) { {accept: PdfUploader.permitted_extensions} }
 
       it "renders no camera button" do
-        expect(component).to have_no_css("button[data-action='form--file-upload#takePicture']")
+        expect(component).to have_no_css("button[data-action='ui--forms--file-upload#takePicture']")
       end
     end
 
@@ -93,7 +93,7 @@ RSpec.describe UI::Forms::FileUpload::Component, type: :component do
       let(:options) { {accept: ".csv", camera: true} }
 
       it "renders a camera button" do
-        expect(component).to have_css("button[data-action='form--file-upload#takePicture']", text: "Take picture")
+        expect(component).to have_css("button[data-action='ui--forms--file-upload#takePicture']", text: "Take picture")
       end
     end
 
@@ -101,7 +101,7 @@ RSpec.describe UI::Forms::FileUpload::Component, type: :component do
       let(:options) { {accept: "image/*", camera: false} }
 
       it "renders no camera button" do
-        expect(component).to have_no_css("button[data-action='form--file-upload#takePicture']")
+        expect(component).to have_no_css("button[data-action='ui--forms--file-upload#takePicture']")
       end
     end
   end

--- a/spec/components/ui/forms/file_upload/component_system_spec.rb
+++ b/spec/components/ui/forms/file_upload/component_system_spec.rb
@@ -4,7 +4,7 @@ require "rails_helper"
 
 RSpec.describe UI::Forms::FileUpload::Component, :js, type: :system do
   let(:base_path) { "/rails/view_components/ui/forms/file_upload/component/" }
-  let(:drop_frame) { "[data-form--file-upload-target='dropZone']" }
+  let(:drop_frame) { "[data-ui--forms--file-upload-target='dropZone']" }
   # Dragging a file has no Capybara equivalent -- the drag source is the OS, not the
   # page -- so the events carry a hand-built DataTransfer, per Playwright's docs.
   let(:start_drag) do
@@ -18,14 +18,14 @@ RSpec.describe UI::Forms::FileUpload::Component, :js, type: :system do
   it "takes a file from the picker or a drag, and adapts its labels to the pointer" do
     visit("#{base_path}default")
 
-    expect(page).to have_css("[data-form--file-upload-target='filename']", text: "No file chosen")
+    expect(page).to have_css("[data-ui--forms--file-upload-target='filename']", text: "No file chosen")
     # a fine pointer can click and drop, and the frame is idle until something is dragged
     expect(page).to have_css("label", text: "Click or drop to choose file")
     expect(page).to have_no_css("#{drop_frame}[data-dragging]")
 
     attach_file("file", Rails.root.join("spec/fixtures/bike.jpg").to_s, make_visible: true)
 
-    expect(page).to have_css("[data-form--file-upload-target='filename']", text: "bike.jpg")
+    expect(page).to have_css("[data-ui--forms--file-upload-target='filename']", text: "bike.jpg")
 
     # dragging text rather than a file leaves the frame alone
     page.execute_script(<<~JS)
@@ -62,11 +62,11 @@ RSpec.describe UI::Forms::FileUpload::Component, :js, type: :system do
     # Two files into a single-file input -- only the first should land.
     page.execute_script(<<~JS)
       window.fileTransfer.items.add(new File(["y"], "second.jpg", {type: "image/jpeg"}))
-      document.querySelector("[data-controller='form--file-upload'] label")
+      document.querySelector("[data-controller='ui--forms--file-upload'] label")
         .dispatchEvent(new DragEvent("drop", {bubbles: true, dataTransfer: window.fileTransfer}))
     JS
 
-    expect(page).to have_css("[data-form--file-upload-target='filename']", text: "dropped.jpg")
+    expect(page).to have_css("[data-ui--forms--file-upload-target='filename']", text: "dropped.jpg")
     expect(page).to have_no_css("#{drop_frame}[data-dragging]")
     # rendered, but the media query keeps it from a mouse
     expect(page).to have_button("Take picture", visible: :hidden)

--- a/spec/components/ui/forms/legacy_form_well/address_record_with_default/component_spec.rb
+++ b/spec/components/ui/forms/legacy_form_well/address_record_with_default/component_spec.rb
@@ -52,6 +52,10 @@ RSpec.describe UI::Forms::LegacyFormWell::AddressRecordWithDefault::Component, t
 
       expect(component).to have_text("Use account address")
       expect(component).to have_checked_field("bike[current_marketplace_listing_attributes][address_record_attributes][user_account_address]")
+
+      # A mistyped identifier silently no-ops in Stimulus, so assert the wiring
+      expect(component).to have_css("input[data-action='change->ui--forms--legacy-form-well--address-record-with-default#toggleUseAccount']" \
+        "[data-ui--forms--legacy-form-well--address-record-with-default-target='useAccountCheckbox']", visible: :all)
     end
   end
 end

--- a/spec/components/ui/forms/text_editor/component_spec.rb
+++ b/spec/components/ui/forms/text_editor/component_spec.rb
@@ -22,9 +22,9 @@ RSpec.describe UI::Forms::TextEditor::Component, type: :component do
     expect(component).to_not have_css("lexxy-editor.lexxy-editor--compact")
   end
 
-  it "adds the lexxy controller and stylesheet value by default" do
+  it "adds the controller and stylesheet value by default" do
     expect(rendered_component(record))
-      .to have_css("lexxy-editor[data-controller='lexxy'][data-lexxy-stylesheet-value*='lexxy']")
+      .to have_css("lexxy-editor[data-controller='ui--forms--text-editor'][data-ui--forms--text-editor-stylesheet-value*='lexxy']")
   end
 
   it "derives the standalone editor's accessible name from the attribute (Lexxy copies aria-label onto the box)" do

--- a/spec/integration/organized/manage_spec.rb
+++ b/spec/integration/organized/manage_spec.rb
@@ -23,10 +23,10 @@ RSpec.describe "Organized manage", :js, type: :system do
     fill_in "Website", with: "https://example.com"
     check "Send emails directly to unclaimed bike owners."
 
-    expect(page).to have_css("[data-form--file-upload-target='filename']", text: "No file chosen")
+    expect(page).to have_css("[data-ui--forms--file-upload-target='filename']", text: "No file chosen")
     attach_file("organization[avatar]", Rails.root.join("spec/fixtures/bike.jpg").to_s, make_visible: true)
     # the UI::Forms::FileUpload Stimulus controller reflects the chosen file in the field
-    expect(page).to have_css("[data-form--file-upload-target='filename']", text: "bike.jpg")
+    expect(page).to have_css("[data-ui--forms--file-upload-target='filename']", text: "bike.jpg")
 
     within("form.organized-form") { click_button "Update" }
 

--- a/spec/integration/organized/registration_sequences_spec.rb
+++ b/spec/integration/organized/registration_sequences_spec.rb
@@ -49,7 +49,7 @@ RSpec.describe "Organized registration sequences", :js, type: :system do
     attach_file "registration_sequence_page[image]",
       Rails.root.join("spec/fixtures/bike.jpg").to_s, make_visible: true
     # the UI::Forms::FileUpload Stimulus controller reflects the chosen file
-    expect(page).to have_css("[data-form--file-upload-target='filename']", text: "bike.jpg")
+    expect(page).to have_css("[data-ui--forms--file-upload-target='filename']", text: "bike.jpg")
 
     click_button "Save page"
 


### PR DESCRIPTION
Stimulus derives a controller's identifier from its file path, so the JS for the `UI::Forms::*` components sat under `controllers/form/` while the components lived in `app/components/ui/forms/` — the two namespaces didn't line up, and `lexxy_controller` sat at the root with a vendor name rather than the component's.

- `controllers/form/*` and `controllers/lexxy_controller.js` move to `controllers/ui/forms/*`, with lexxy renamed `text_editor_controller` to match `UI::Forms::TextEditor`. The rest is the mechanical identifier rename that forces (`form--file-upload` → `ui--forms--file-upload`, `lexxy` → `ui--forms--text-editor`, and so on) across the components, previews and specs.
- `AddressRecordWithDefault`'s checkbox switches to the nested `data:` hash so the longer identifier still fits on a line, and gains an assertion on its `data-action`/target wiring — a mistyped identifier is a silent no-op in Stimulus, and nothing outside the system spec covered it.

No pins to update: `pin_all_from "app/javascript/controllers"` recurses, and `lazyLoadControllersFrom` derives the module path from the identifier.

The other root controllers worth relocating — `collapse`, `details`, `sortable`, `strip_inputs`, `form_persist` — are deliberately left for a follow-up; `collapse` alone touches ~38 files.
