### PR TITLE
Restore the search button on narrow phone widths

### DIFF
--- a/app/components/org/search/form/component.html.erb
+++ b/app/components/org/search/form/component.html.erb
@@ -55,7 +55,7 @@
         </div>
       </div>
 
-      <div class="tw:w-20">
+      <div class="tw:w-20 tw:shrink-0">
         <%= render UI::Button::Component.new(color: :primary, kind: :submit, html_class: "tw:w-full tw:h-full#{" tw:disabled:cursor-wait" if turbo?}") do %>
           <%= helpers.inline_svg_tag "icons/searcher.svg",
           id: "search-button",

--- a/app/components/org/search/form/component.html.erb
+++ b/app/components/org/search/form/component.html.erb
@@ -55,6 +55,7 @@
         </div>
       </div>
 
+      <%# shrink-0: the fields column would otherwise squeeze this to a sliver on phones %>
       <div class="tw:w-20 tw:shrink-0">
         <%= render UI::Button::Component.new(color: :primary, kind: :submit, html_class: "tw:w-full tw:h-full#{" tw:disabled:cursor-wait" if turbo?}") do %>
           <%= helpers.inline_svg_tag "icons/searcher.svg",

--- a/app/components/org/search/settings/component.html.erb
+++ b/app/components/org/search/settings/component.html.erb
@@ -125,7 +125,7 @@
 </div>
 
 <div class="tw:mt-2 tw:flex tw:items-center tw:justify-end tw:gap-4">
-  <%= render(UI::Button::Component.new(color: :primary, size: :sm, aria: {pressed: settings_default_open?}, data: {action: "click->org--search#toggleSettings", "org--search-target": "settingsButton"})) do %>
+  <%= render(UI::Button::Component.new(color: :primary, size: :sm, active: settings_default_open?, aria: {expanded: settings_default_open?}, data: {action: "click->org--search#toggleSettings", "org--search-target": "settingsButton"})) do %>
     <%= translation(".settings") %>
     <%= helpers.inline_svg_tag "icons/settings_slider.svg", class: "tw:inline", alt: "settings icon" %>
   <% end %>

--- a/app/components/registrations/show/wrapper/component.rb
+++ b/app/components/registrations/show/wrapper/component.rb
@@ -8,7 +8,7 @@ module Registrations
       class Component < ApplicationComponent
         # Nothing digests the nested components' templates, so bump this whenever
         # their markup changes
-        CACHE_VERSION = "registrations/show-v3"
+        CACHE_VERSION = "registrations/show-v4"
 
         def initialize(bike:, current_user:, view:, available_views:, bike_sticker: nil)
           @bike = bike

--- a/app/components/search/form/component.html.erb
+++ b/app/components/search/form/component.html.erb
@@ -86,11 +86,7 @@
         <% end %>
       </div>
 
-      <%#
-        shrink-0: the fields column's min-content exceeds narrow phone widths, which
-        otherwise squeezes the button (and the icon inside it) down to a sliver
-      %>
-
+      <%# shrink-0: the fields column would otherwise squeeze this to a sliver on phones %>
       <div class="tw:w-20 tw:shrink-0">
         <%= render UI::Button::Component.new(color: :primary, kind: :submit, html_class: "tw:w-full tw:h-full tw:disabled:cursor-wait") do %>
           <%= helpers.inline_svg_tag "icons/searcher.svg",

--- a/app/components/search/form/component.html.erb
+++ b/app/components/search/form/component.html.erb
@@ -66,7 +66,7 @@
                 <%= number_field_tag :price_min_amount,
                 @price_min_amount,
                 placeholder: translation(".min"),
-                class: "twinput tw:min-w-20 fieldResetsCounts" %>
+                class: "twinput tw:min-w-16 fieldResetsCounts" %>
 
                 <span class="tw:mr-1 tw:ml-2 tw:block tw:min-w-6 tw:py-1.5">
                   &ndash; <%= @currency_sym %>
@@ -79,14 +79,19 @@
                 <%= number_field_tag :price_max_amount,
                 @price_max_amount,
                 placeholder: translation(".max"),
-                class: "twinput tw:min-w-20 fieldResetsCounts" %>
+                class: "twinput tw:min-w-16 fieldResetsCounts" %>
               </span>
             <% end %>
           </div>
         <% end %>
       </div>
 
-      <div class="tw:w-20">
+      <%#
+        shrink-0: the fields column's min-content exceeds narrow phone widths, which
+        otherwise squeezes the button (and the icon inside it) down to a sliver
+      %>
+
+      <div class="tw:w-20 tw:shrink-0">
         <%= render UI::Button::Component.new(color: :primary, kind: :submit, html_class: "tw:w-full tw:h-full tw:disabled:cursor-wait") do %>
           <%= helpers.inline_svg_tag "icons/searcher.svg",
             id: "search-button",

--- a/app/components/ui/button/component.rb
+++ b/app/components/ui/button/component.rb
@@ -69,7 +69,7 @@ module UI
       end
 
       def call
-        content_tag(:button, button_content, class: button_classes, type: (@kind == :submit) ? "submit" : "button", disabled: @disabled, data: button_data, aria: @aria)
+        content_tag(:button, safe_join([spinner_span, @text || content].compact), class: button_classes, type: (@kind == :submit) ? "submit" : "button", disabled: @disabled, data: button_data, aria: @aria)
       end
 
       def button_classes
@@ -85,14 +85,13 @@ module UI
         data.merge(controller: [data[:controller], "ui--buttons--submit-spinner"].compact.join(" "))
       end
 
-      def button_content
-        return @text || content unless @spinner
+      # Hidden until the submit-spinner controller reveals it on form submit;
+      # no color_class so the svg spins in the button's own text color.
+      def spinner_span
+        return unless @spinner
 
-        # Hidden until the submit-spinner controller reveals it on form submit;
-        # no color_class so the svg spins in the button's own text color.
-        spinner = content_tag(:span, render(UI::LoadingSpinner::Component.new(size: :sm, color_class: "")),
+        content_tag(:span, render(UI::LoadingSpinner::Component.new(size: :sm, color_class: nil)),
           class: "tw:hidden", data: {"ui--buttons--submit-spinner-target": "spinner"})
-        safe_join([spinner, @text || content])
       end
     end
   end

--- a/app/components/ui/button/component.rb
+++ b/app/components/ui/button/component.rb
@@ -53,13 +53,14 @@ module UI
         [BASE_CLASSES, html_class, *extras, COLORS[color], ACTIVE_COLORS[color]].compact.join(" ")
       end
 
-      def initialize(text: nil, color: :secondary, size: :md, active: false, html_class: nil, kind: nil, disabled: false, data: {}, aria: {})
+      def initialize(text: nil, color: :secondary, size: :md, active: false, html_class: nil, kind: nil, disabled: false, spinner: false, data: {}, aria: {})
         @text = text
         @color = COLORS.key?(color) ? color : :secondary
         @kind = KINDS.include?(kind&.to_sym) ? kind.to_sym : KINDS.first
         @active = active
         @html_class = html_class
         @disabled = disabled
+        @spinner = spinner
         @data = data
         @aria = aria
 
@@ -68,11 +69,30 @@ module UI
       end
 
       def call
-        content_tag(:button, @text || content, class: button_classes, type: (@kind == :submit) ? "submit" : "button", disabled: @disabled, data: @data.merge(active: @active || nil), aria: @aria)
+        content_tag(:button, button_content, class: button_classes, type: (@kind == :submit) ? "submit" : "button", disabled: @disabled, data: button_data, aria: @aria)
       end
 
       def button_classes
         self.class.build_classes(color: @color, size: @size, html_class: @html_class)
+      end
+
+      private
+
+      def button_data
+        data = @data.merge(active: @active || nil)
+        return data unless @spinner
+
+        data.merge(controller: [data[:controller], "ui--buttons--submit-spinner"].compact.join(" "))
+      end
+
+      def button_content
+        return @text || content unless @spinner
+
+        # Hidden until the submit-spinner controller reveals it on form submit;
+        # no color_class so the svg spins in the button's own text color.
+        spinner = content_tag(:span, render(UI::LoadingSpinner::Component.new(size: :sm, color_class: "")),
+          class: "tw:hidden", data: {"ui--buttons--submit-spinner-target": "spinner"})
+        safe_join([spinner, @text || content])
       end
     end
   end

--- a/app/components/ui/button/component_preview.rb
+++ b/app/components/ui/button/component_preview.rb
@@ -3,13 +3,14 @@
 module UI
   module Button
     class ComponentPreview < ApplicationComponentPreview
-      # @!group Colors
-      # Shown disabled with the spinner revealed, as the submit-spinner controller leaves it mid-submit
+      # The mid-submit state: disabled, with the spinner span force-shown (the
+      # controller reveals it on a real submit)
       def submitting
         render(UI::Button::Component.new(text: "Next", color: :primary, kind: :submit,
           spinner: true, disabled: true, html_class: "tw:[&_span]:inline-flex!"))
       end
 
+      # @!group Colors
       def primary
         render(UI::Button::Component.new(text: "Primary", color: :primary))
       end

--- a/app/components/ui/button/component_preview.rb
+++ b/app/components/ui/button/component_preview.rb
@@ -4,6 +4,12 @@ module UI
   module Button
     class ComponentPreview < ApplicationComponentPreview
       # @!group Colors
+      # Shown disabled with the spinner revealed, as the submit-spinner controller leaves it mid-submit
+      def submitting
+        render(UI::Button::Component.new(text: "Next", color: :primary, kind: :submit,
+          spinner: true, disabled: true, html_class: "tw:[&_span]:inline-flex!"))
+      end
+
       def primary
         render(UI::Button::Component.new(text: "Primary", color: :primary))
       end

--- a/app/components/ui/loading_spinner/component.rb
+++ b/app/components/ui/loading_spinner/component.rb
@@ -8,7 +8,7 @@ module UI
         md: "tw:h-15 tw:w-15"
       }.freeze
 
-      # color_class: "" leaves the svg inheriting currentColor from its surroundings
+      # A nil color_class leaves the svg inheriting currentColor from its surroundings
       def initialize(text: nil, size: :md, color_class: "tw:text-slate-400 tw:dark:text-blue-800")
         @text = text
         @size = SIZES.key?(size) ? size : :md

--- a/app/components/ui/loading_spinner/component.rb
+++ b/app/components/ui/loading_spinner/component.rb
@@ -8,9 +8,11 @@ module UI
         md: "tw:h-15 tw:w-15"
       }.freeze
 
-      def initialize(text: nil, size: :md)
+      # color_class: "" leaves the svg inheriting currentColor from its surroundings
+      def initialize(text: nil, size: :md, color_class: "tw:text-slate-400 tw:dark:text-blue-800")
         @text = text
         @size = SIZES.key?(size) ? size : :md
+        @color_class = color_class
       end
 
       def call
@@ -30,7 +32,7 @@ module UI
       private
 
       def spinner_svg
-        classes = "tw:animate-spin tw:text-slate-400 tw:dark:text-blue-800 #{SIZES[@size]}"
+        classes = ["tw:animate-spin", @color_class.presence, SIZES[@size]].compact.join(" ")
         classes = "tw:inline #{classes}" if inline?
         classes = "tw:mx-auto tw:mt-4 #{classes}" unless inline?
 

--- a/app/javascript/controllers/org/search_controller.js
+++ b/app/javascript/controllers/org/search_controller.js
@@ -10,7 +10,7 @@ export default class extends Controller {
   connect () {
     if (localStorage.getItem('orgRegistrationSettingsOpen') === 'true') {
       collapse('show', this.settingsTarget, 0)
-      if (this.hasSettingsButtonTarget) this.settingsButtonTarget.setAttribute('aria-pressed', 'true')
+      this.setSettingsButtonState(true)
     }
     this.initNotesSearch()
     document.addEventListener('turbo:frame-render', this.handleFrameRender)
@@ -29,7 +29,14 @@ export default class extends Controller {
       this.settingsTarget.classList.contains('tw:hidden')
     collapse('toggle', this.settingsTarget)
     localStorage.setItem('orgRegistrationSettingsOpen', wasHidden ? 'true' : 'false')
-    if (this.hasSettingsButtonTarget) this.settingsButtonTarget.setAttribute('aria-pressed', String(wasHidden))
+    this.setSettingsButtonState(wasHidden)
+  }
+
+  // data-active drives UI::Button's active styling, aria-expanded the disclosure semantics
+  setSettingsButtonState (open) {
+    if (!this.hasSettingsButtonTarget) return
+    this.settingsButtonTarget.dataset.active = String(open)
+    this.settingsButtonTarget.setAttribute('aria-expanded', String(open))
   }
 
   initNotesSearch () {

--- a/app/javascript/controllers/registrations/show/action_panels_controller.js
+++ b/app/javascript/controllers/registrations/show/action_panels_controller.js
@@ -33,9 +33,9 @@ export default class extends Controller {
     })
     this.triggerTargets.forEach((trigger) => {
       const active = String(trigger.dataset.panelName === name)
-      // aria-expanded for disclosure semantics, aria-pressed drives active styling
+      // aria-expanded for disclosure semantics, data-active drives UI::Button's styling
       trigger.setAttribute('aria-expanded', active)
-      trigger.setAttribute('aria-pressed', active)
+      trigger.dataset.active = active
     })
     this.openName = name
     this.persist(name)

--- a/app/javascript/controllers/ui/buttons/submit_spinner_controller.js
+++ b/app/javascript/controllers/ui/buttons/submit_spinner_controller.js
@@ -1,0 +1,30 @@
+import { Controller } from '@hotwired/stimulus'
+import { collapse } from 'utils/collapse_utils'
+
+// Connects to data-controller="ui--buttons--submit-spinner" (on a submit button - rendered
+// by UI::Button spinner: true). Once the button's form actually submits
+// (native validation has passed), disables the button and reveals its spinner.
+export default class extends Controller {
+  static targets = ['spinner']
+
+  connect () {
+    this.boundStart = this.start.bind(this)
+    this.element.form?.addEventListener('submit', this.boundStart)
+    // A cached back/forward restore would otherwise show the submitted state
+    if (this.element.dataset.submitted) {
+      delete this.element.dataset.submitted
+      this.element.disabled = false
+      this.spinnerTargets.forEach(spinner => collapse('hide', spinner, 0))
+    }
+  }
+
+  disconnect () {
+    this.element.form?.removeEventListener('submit', this.boundStart)
+  }
+
+  start () {
+    this.element.dataset.submitted = 'true'
+    this.element.disabled = true
+    this.spinnerTargets.forEach(spinner => collapse('show', spinner, 0))
+  }
+}

--- a/app/javascript/controllers/ui/buttons/submit_spinner_controller.js
+++ b/app/javascript/controllers/ui/buttons/submit_spinner_controller.js
@@ -1,5 +1,4 @@
 import { Controller } from '@hotwired/stimulus'
-import { collapse } from 'utils/collapse_utils'
 
 // Connects to data-controller="ui--buttons--submit-spinner" (on a submit button - rendered
 // by UI::Button spinner: true). Once the button's form actually submits
@@ -8,23 +7,25 @@ export default class extends Controller {
   static targets = ['spinner']
 
   connect () {
-    this.boundStart = this.start.bind(this)
-    this.element.form?.addEventListener('submit', this.boundStart)
+    // Cached, because a detached button's .form is null - disconnect couldn't find it to unsubscribe
+    this.form = this.element.form
+    this.form?.addEventListener('submit', this.start)
     // A cached back/forward restore would otherwise show the submitted state
     if (this.element.dataset.submitted) {
       delete this.element.dataset.submitted
       this.element.disabled = false
-      this.spinnerTargets.forEach(spinner => collapse('hide', spinner, 0))
+      this.spinnerTarget.classList.add('tw:hidden')
     }
   }
 
   disconnect () {
-    this.element.form?.removeEventListener('submit', this.boundStart)
+    this.form?.removeEventListener('submit', this.start)
+    this.form = null
   }
 
-  start () {
+  start = () => {
     this.element.dataset.submitted = 'true'
     this.element.disabled = true
-    this.spinnerTargets.forEach(spinner => collapse('show', spinner, 0))
+    this.spinnerTarget.classList.remove('tw:hidden')
   }
 }

--- a/app/javascript/controllers/ui/modal_controller.js
+++ b/app/javascript/controllers/ui/modal_controller.js
@@ -15,7 +15,8 @@ export default class extends Controller {
 
   openFromTrigger (event) {
     this.trigger = event.currentTarget
-    this.trigger.classList.add('active')
+    // data-active, not an `active` class: that's what the is-active variant matches
+    this.trigger.dataset.active = 'true'
     this.open()
   }
 
@@ -29,7 +30,7 @@ export default class extends Controller {
     this.element.close()
     document.body.classList.remove('tw:overflow-hidden')
     if (this.trigger) {
-      this.trigger.classList.remove('active')
+      delete this.trigger.dataset.active
       this.trigger = null
     }
     this.persist(false)

--- a/spec/components/registrations/show/org_top_actions/wrapper/component_system_spec.rb
+++ b/spec/components/registrations/show/org_top_actions/wrapper/component_system_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe Registrations::Show::OrgTopActions::Wrapper::Component, :js, type
       click_button "Message Owner"
 
       expect(page).to have_button("Send message")
-      expect(page).to have_css("button[aria-pressed='true']", text: "Message Owner")
+      expect(page).to have_css("button[data-active='true']", text: "Message Owner")
     end
 
     expect(page).to have_current_path(/panel=message/, url: true)
@@ -38,7 +38,7 @@ RSpec.describe Registrations::Show::OrgTopActions::Wrapper::Component, :js, type
 
       expect(page).to have_content("No parking notifications for this bike")
       expect(page).to have_no_button("Send message")
-      expect(page).to have_css("button[aria-pressed='false']", text: "Message Owner")
+      expect(page).to have_css("button[data-active='false']", text: "Message Owner")
     end
 
     expect(page).to have_current_path(/panel=notifications_show/, url: true)

--- a/spec/components/registrations/show/wrapper/cache_version_checkpoint.yml
+++ b/spec/components/registrations/show/wrapper/cache_version_checkpoint.yml
@@ -1,4 +1,4 @@
 # Written by the cache_version_checkpoint shared example
 ---
-cache_version: registrations/show-v3
-files_digest: 21c2a1d200b149d850a16dc303712f110eec0195f7fa5fc6a8e1b91e44a1398b
+cache_version: registrations/show-v4
+files_digest: 731acd9d3f99dafb1fbfc8cb824a388081b9cda022b9a01ffff425ce05c77f49

--- a/spec/components/ui/button/component_spec.rb
+++ b/spec/components/ui/button/component_spec.rb
@@ -34,6 +34,17 @@ RSpec.describe UI::Button::Component, type: :component do
     end
   end
 
+  context "with spinner" do
+    let(:options) { {text:, kind: :submit, spinner: true} }
+
+    it "renders a self-wired hidden spinner that inherits the button's text color" do
+      expect(component).to have_css("button[data-controller='ui--buttons--submit-spinner']")
+      expect(component).to have_css("span.tw\\:hidden[data-ui--buttons--submit-spinner-target='spinner'] svg", visible: :all)
+      expect(component.css("svg").first["class"]).to_not include("tw:text-slate-400")
+      expect(component).to have_text("Click me")
+    end
+  end
+
   context "with link color" do
     let(:color) { :link }
 

--- a/spec/integration/organized/registrations_search_spec.rb
+++ b/spec/integration/organized/registrations_search_spec.rb
@@ -50,6 +50,7 @@ RSpec.describe "Organized registrations search", :js, type: :system do
 
   def expect_settings_open
     expect(find(settings_selector, visible: :all)["class"]).not_to include("tw:hidden!")
+    expect(page).to have_css("[data-org--search-target='settingsButton'][data-active='true']")
   end
 
   def open_settings_if_not


### PR DESCRIPTION
The search submit button collapsed on narrow phones. Its `tw:w-20` wrapper is a flex item with the default `flex-shrink: 1`, so on `/search/marketplace` the fields column's min-content took its space back out of the button — and because `icons/searcher.svg` carries only a `viewBox`, the icon shrank with it: 80px/54px became 47px/21px at 375px and 39px/13px at 320px.

- `tw:shrink-0` pins the button on both search forms. That alone overflows the row, so the price inputs drop to `tw:min-w-16`, putting the column's min-content under what's available at 320px — they still render wider than the floor there, and desktop is untouched.
- `UI::Button` takes `spinner: true`, carried over from `sethherr/new-registration-flow`: it attaches a controller that disables the button and reveals a spinner once its form really submits. Not wired to a caller yet — it's only safe on forms that navigate, since it resets on reconnect, which rules out both search forms (they target a sibling turbo frame).
- Active state is flagged with `data-active` everywhere now, replacing `aria-pressed` on the org search settings and action-panel triggers and a `classList.add('active')` on modal triggers — that last one matched nothing in the `is-active` variant, so `UI::Button` modal triggers had no active styling at all.
- Unrelated, and needed to get CI green: `95b8f6e05` changed cached `registrations/show` markup without bumping `CACHE_VERSION`, so the checkpoint spec added in #3966 fails on `main` and the fragment cache is serving pre-centering HTML. Bumped to v4.
