### PR TITLE
Autocomplete the manufacturer combobox, with free text for unknown manufacturers

### DIFF
--- a/app/components/ui/forms/combobox_manufacturer/component.en.yml
+++ b/app/components/ui/forms/combobox_manufacturer/component.en.yml
@@ -1,0 +1,7 @@
+---
+en:
+  components:
+    ui:
+      forms:
+        combobox_manufacturer:
+          placeholder: Start typing e.g. %{name}

--- a/app/components/ui/forms/combobox_manufacturer/component.rb
+++ b/app/components/ui/forms/combobox_manufacturer/component.rb
@@ -5,25 +5,56 @@ module UI
     module ComboboxManufacturer
       # UI::Forms::Combobox preconfigured for picking a Manufacturer.
       #
-      # Defaults `name` to :manufacturer_id and the options to every manufacturer;
-      # pass `frame_maker: true` to limit the list to frame makers, or a `manufacturers`
-      # relation to set it explicitly. Every other keyword (form:, label:, value:,
-      # required:, include_blank:, placeholder:, etc.) is forwarded to
-      # UI::Forms::Combobox::Component.
+      # Defaults `name` to :manufacturer_id, autocompleting against the Autocomplete
+      # index (Search::ComboboxController#manufacturers) rather than rendering every
+      # manufacturer; pass `frame_maker: true` to limit it to manufacturers that make
+      # frames. Every other keyword (form:, label:, value:, required:, placeholder:,
+      # etc.) is forwarded to UI::Forms::Combobox::Component.
+      #
+      # A manufacturer that isn't in the index is entered as free text through the
+      # "Unknown manufacturer" option, which BParam resolves to Manufacturer.other plus
+      # manufacturer_other. Pass `no_manufacturer_other: true` where only an indexed
+      # manufacturer is acceptable.
       class Component < ApplicationComponent
-        def initialize(name: :manufacturer_id, frame_maker: false, manufacturers: nil, **combobox_options)
+        def initialize(name: :manufacturer_id, frame_maker: false, no_manufacturer_other: false, **combobox_options)
           @name = name
-          @manufacturers = manufacturers || (frame_maker ? Manufacturer.frame_makers : Manufacturer.all)
+          @frame_maker = frame_maker
+          @no_manufacturer_other = no_manufacturer_other
           @combobox_options = combobox_options
         end
 
         def call
-          render UI::Forms::Combobox::Component.new(
+          render UI::Forms::Combobox::Component.new(**combobox_arguments)
+        end
+
+        private
+
+        def combobox_arguments
+          {
             name: @name,
             label: Manufacturer.model_name.human,
-            options: @manufacturers.pluck(:name, :id),
-            **@combobox_options
-          )
+            src: search_combobox_manufacturers_path(frame_maker: @frame_maker.presence,
+              no_manufacturer_other: @no_manufacturer_other.presence),
+            **free_text_options,
+            **@combobox_options,
+            **manufacturer_other_options
+          }
+        end
+
+        def free_text_options
+          @no_manufacturer_other ? {} : {free_text: true}
+        end
+
+        # An async combobox displays its initial value via the form object's
+        # manufacturer. Manufacturer.other displays as "Other", so replace the form with
+        # its field name and the free text, which the combobox displays as-is.
+        def manufacturer_other_options
+          return {} if @no_manufacturer_other
+
+          form = @combobox_options[:form]
+          return {} unless form&.object.try(:manufacturer)&.other?
+
+          {form: nil, name: form.field_name(@name), id: form.field_id(@name), value: form.object.manufacturer_other}
         end
       end
     end

--- a/app/components/ui/forms/combobox_manufacturer/component.rb
+++ b/app/components/ui/forms/combobox_manufacturer/component.rb
@@ -16,6 +16,10 @@ module UI
       # manufacturer_other. Pass `no_manufacturer_other: true` where only an indexed
       # manufacturer is acceptable.
       class Component < ApplicationComponent
+        # One is sampled for the placeholder, to show what the field autocompletes
+        PLACEHOLDER_NAMES = ["Trek", "Specialized", "Giant Bikes", "Rad Power Bikes", "Cannondale",
+          "Lectric eBikes", "Aventón", "Canyon", "Orbea"].freeze
+
         def initialize(name: :manufacturer_id, frame_maker: false, no_manufacturer_other: false, **combobox_options)
           @name = name
           @frame_maker = frame_maker
@@ -37,6 +41,7 @@ module UI
               no_manufacturer_other: @no_manufacturer_other.presence),
             **free_text_options,
             **@combobox_options,
+            placeholder: translation(".placeholder", name: PLACEHOLDER_NAMES.sample),
             **manufacturer_other_options
           }
         end

--- a/app/components/ui/forms/combobox_manufacturer/component.rb
+++ b/app/components/ui/forms/combobox_manufacturer/component.rb
@@ -8,9 +8,9 @@ module UI
       # Defaults `name` to :manufacturer_id, autocompleting against the Autocomplete
       # index (Search::ComboboxController#manufacturers) rather than rendering every
       # manufacturer; pass `frame_maker: true` to limit it to manufacturers that make
-      # frames. Every other keyword (form:, value:, required:, etc.) is forwarded to
-      # UI::Forms::Combobox::Component, which renders no label -- wrap it in a
-      # UI::Forms::Group block to get one.
+      # frames. Every other keyword except `placeholder:` (form:, value:, required:,
+      # etc.) is forwarded to UI::Forms::Combobox::Component, which renders no label --
+      # wrap it in a UI::Forms::Group block to get one.
       #
       # A manufacturer that isn't in the index is entered as free text through the
       # "Unknown manufacturer" option, which BParam resolves to Manufacturer.other plus
@@ -34,20 +34,21 @@ module UI
 
         private
 
+        # placeholder comes after the caller's options: every manufacturer field reads
+        # the same, so it isn't overridable
         def combobox_arguments
           {
             name: @name,
-            src: search_combobox_manufacturers_path(frame_maker: @frame_maker.presence,
-              no_manufacturer_other: @no_manufacturer_other.presence),
-            **free_text_options,
+            src: search_combobox_manufacturers_path(**src_params),
+            free_text: !@no_manufacturer_other,
             **@combobox_options,
             placeholder: translation(".placeholder", name: PLACEHOLDER_NAMES.sample),
             **manufacturer_other_options
           }
         end
 
-        def free_text_options
-          @no_manufacturer_other ? {} : {free_text: true}
+        def src_params
+          {frame_maker: @frame_maker, no_manufacturer_other: @no_manufacturer_other}.select { |_, value| value }
         end
 
         # An async combobox displays its initial value via the form object's

--- a/app/components/ui/forms/combobox_manufacturer/component_preview.rb
+++ b/app/components/ui/forms/combobox_manufacturer/component_preview.rb
@@ -6,25 +6,45 @@ module UI
       class ComponentPreview < ApplicationComponentPreview
         # @!group Variants
 
-        # Every manufacturer, keyed to :manufacturer_id
+        # Autocompletes every manufacturer, keyed to :manufacturer_id. A manufacturer
+        # that isn't indexed is entered through the "Unknown manufacturer" option
         def default
           render(UI::Forms::ComboboxManufacturer::Component.new)
         end
 
-        # Limited to frame makers
+        # Limited to manufacturers that make frames
         def frame_makers
           render(UI::Forms::ComboboxManufacturer::Component.new(frame_maker: true))
         end
 
-        # Pre-selected value, custom label
+        # Only an indexed manufacturer is selectable
+        def no_manufacturer_other
+          render(UI::Forms::ComboboxManufacturer::Component.new(no_manufacturer_other: true))
+        end
+
+        # Pre-selected manufacturer, custom label
         def preselected
           render(UI::Forms::ComboboxManufacturer::Component.new(
             label: "Frame manufacturer",
-            value: Manufacturer.frame_makers.first&.id
+            form: bike_form(Bike.new(manufacturer: Manufacturer.frame_makers.first))
+          ))
+        end
+
+        # How a record with Manufacturer.other renders - its manufacturer_other is
+        # displayed, since Manufacturer.other isn't selectable
+        def unknown_manufacturer
+          render(UI::Forms::ComboboxManufacturer::Component.new(
+            form: bike_form(Bike.new(manufacturer: Manufacturer.other, manufacturer_other: "Bikes by Seth"))
           ))
         end
 
         # @!endgroup
+
+        private
+
+        def bike_form(bike)
+          ActionView::Helpers::FormBuilder.new("bike", bike, template, {})
+        end
       end
     end
   end

--- a/app/components/ui/forms/combobox_manufacturer/component_preview.rb
+++ b/app/components/ui/forms/combobox_manufacturer/component_preview.rb
@@ -15,12 +15,13 @@ module UI
 
         # Limited to manufacturers that make frames
         def frame_makers
-          render(UI::Forms::ComboboxManufacturer::Component.new(frame_maker: true))
+          render(UI::Forms::ComboboxManufacturer::Component.new(frame_maker: true, id: "frame_makers_manufacturer_id"))
         end
 
         # Only an indexed manufacturer is selectable
         def no_manufacturer_other
-          render(UI::Forms::ComboboxManufacturer::Component.new(no_manufacturer_other: true))
+          render(UI::Forms::ComboboxManufacturer::Component.new(no_manufacturer_other: true,
+            id: "no_manufacturer_other_manufacturer_id"))
         end
 
         # Pre-selected manufacturer
@@ -42,8 +43,8 @@ module UI
 
         private
 
-        # The combobox ids come from the form's object name, so each variant needs its
-        # own - they render together on the group page
+        # The variants render together on the group page, so each needs its own ids -
+        # which the combobox derives from the field name, or the form's object name
         def bike_form(object_name, bike)
           ActionView::Helpers::FormBuilder.new(object_name, bike, template, {})
         end

--- a/app/components/ui/forms/combobox_manufacturer/component_preview.rb
+++ b/app/components/ui/forms/combobox_manufacturer/component_preview.rb
@@ -26,7 +26,7 @@ module UI
         def preselected
           render(UI::Forms::ComboboxManufacturer::Component.new(
             label: "Frame manufacturer",
-            form: bike_form(Bike.new(manufacturer: Manufacturer.frame_makers.first))
+            form: bike_form("preselected_bike", Bike.new(manufacturer: Manufacturer.frame_makers.first))
           ))
         end
 
@@ -34,7 +34,7 @@ module UI
         # displayed, since Manufacturer.other isn't selectable
         def unknown_manufacturer
           render(UI::Forms::ComboboxManufacturer::Component.new(
-            form: bike_form(Bike.new(manufacturer: Manufacturer.other, manufacturer_other: "Bikes by Seth"))
+            form: bike_form("unknown_bike", Bike.new(manufacturer: Manufacturer.other, manufacturer_other: "Bikes by Seth"))
           ))
         end
 
@@ -42,8 +42,10 @@ module UI
 
         private
 
-        def bike_form(bike)
-          ActionView::Helpers::FormBuilder.new("bike", bike, template, {})
+        # The combobox ids come from the form's object name, so each variant needs its
+        # own - they render together on the group page
+        def bike_form(object_name, bike)
+          ActionView::Helpers::FormBuilder.new(object_name, bike, template, {})
         end
       end
     end

--- a/app/components/ui/forms/combobox_manufacturer/component_preview.rb
+++ b/app/components/ui/forms/combobox_manufacturer/component_preview.rb
@@ -46,7 +46,7 @@ module UI
         # The variants render together on the group page, so each needs its own ids -
         # which the combobox derives from the field name, or the form's object name
         def bike_form(object_name, bike)
-          ActionView::Helpers::FormBuilder.new(object_name, bike, template, {})
+          BikeIndexFormBuilder.new(object_name, bike, template, {})
         end
       end
     end

--- a/app/components/ui/forms/combobox_manufacturer_options/component.en.yml
+++ b/app/components/ui/forms/combobox_manufacturer_options/component.en.yml
@@ -1,0 +1,7 @@
+---
+en:
+  components:
+    ui:
+      forms:
+        combobox_manufacturer_options:
+          unknown_manufacturer: Unknown manufacturer

--- a/app/components/ui/forms/combobox_manufacturer_options/component.rb
+++ b/app/components/ui/forms/combobox_manufacturer_options/component.rb
@@ -8,8 +8,6 @@ module UI
       # synthetic "Unknown manufacturer" option that free text is entered through.
       # Sibling to the form control; this is the turbo-stream response backing it.
       class Component < ApplicationComponent
-        UNKNOWN_OPTION_ID = "hw_unknown_manufacturer_option"
-
         def initialize(matches:, next_page:, q: nil, no_manufacturer_other: false)
           @matches = matches
           @next_page = next_page
@@ -33,7 +31,10 @@ module UI
 
         # Manufacturer.other is never selectable - it's what free text resolves to
         def manufacturer_matches
-          @manufacturer_matches ||= @matches.reject { |match| match["id"] == Manufacturer.other.id }
+          @manufacturer_matches ||= begin
+            other_id = Manufacturer.other.id
+            @matches.reject { |match| match["id"] == other_id }
+          end
         end
 
         def unknown_manufacturer?
@@ -48,7 +49,7 @@ module UI
             tag.span(@q)
           ])
 
-          {id: UNKNOWN_OPTION_ID, value: @q, display: @q, content:}
+          {id: "hw_unknown_manufacturer_option", value: @q, display: @q, content:}
         end
       end
     end

--- a/app/components/ui/forms/combobox_manufacturer_options/component.rb
+++ b/app/components/ui/forms/combobox_manufacturer_options/component.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+module UI
+  module Forms
+    module ComboboxManufacturerOptions
+      # The async options for UI::Forms::ComboboxManufacturer::Component - autocomplete
+      # matches (ordered by manufacturer priority, then alphabetically), plus the
+      # synthetic "Unknown manufacturer" option that free text is entered through.
+      # Sibling to the form control; this is the turbo-stream response backing it.
+      class Component < ApplicationComponent
+        UNKNOWN_OPTION_ID = "hw_unknown_manufacturer_option"
+
+        def initialize(matches:, next_page:, q: nil, no_manufacturer_other: false)
+          @matches = matches
+          @next_page = next_page
+          @q = q.presence
+          @no_manufacturer_other = no_manufacturer_other
+        end
+
+        def call
+          helpers.hw_async_combobox_options(option_data, next_page: @next_page)
+        end
+
+        private
+
+        def option_data
+          data = manufacturer_matches.map do |match|
+            {id: "manufacturer_#{match["id"]}", value: match["id"], display: match["text"]}
+          end
+          data << unknown_manufacturer_option if unknown_manufacturer?
+          data
+        end
+
+        # Manufacturer.other is never selectable - it's what free text resolves to
+        def manufacturer_matches
+          @manufacturer_matches ||= @matches.reject { |match| match["id"] == Manufacturer.other.id }
+        end
+
+        def unknown_manufacturer?
+          return false if @no_manufacturer_other || @q.blank? || !helpers.hw_first_page?
+
+          manufacturer_matches.none? { |match| match["text"].casecmp?(@q) }
+        end
+
+        def unknown_manufacturer_option
+          content = safe_join([
+            tag.span(translation(".unknown_manufacturer"), class: "tw:text-gray-500 tw:dark:text-gray-400"), " ",
+            tag.span(@q)
+          ])
+
+          {id: UNKNOWN_OPTION_ID, value: @q, display: @q, content:}
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/admin/bikes_controller.rb
+++ b/app/controllers/admin/bikes_controller.rb
@@ -139,6 +139,19 @@ module Admin
 
     def permitted_parameters
       params.require(:bike).permit(BikeServices::Creator.old_attr_accessible + [bike_organization_ids: []])
+        .merge(manufacturer_parameters)
+    end
+
+    # The manufacturer combobox submits the name of a manufacturer that isn't listed,
+    # which becomes Manufacturer.other plus manufacturer_other (matching BParam)
+    def manufacturer_parameters
+      manufacturer_param = params.dig(:bike, :manufacturer_id)
+      return {} if manufacturer_param.blank?
+
+      manufacturer = Manufacturer.friendly_find(manufacturer_param)
+      return {"manufacturer_id" => manufacturer.id, "manufacturer_other" => nil} if manufacturer.present?
+
+      {"manufacturer_id" => Manufacturer.other.id, "manufacturer_other" => manufacturer_param}
     end
 
     def destroy_bike

--- a/app/controllers/search/combobox_controller.rb
+++ b/app/controllers/search/combobox_controller.rb
@@ -1,12 +1,14 @@
 # frozen_string_literal: true
 
 module Search
-  # Backs the search query items combobox (Search::EverythingCombobox::Component):
-  # autocomplete options and the selection chips, both rendered for hotwire_combobox.
+  # Backs the comboboxes that autocomplete from the Autocomplete index: the search
+  # query items (Search::EverythingCombobox::Component) - options and selection chips -
+  # and the manufacturer picker (UI::Forms::ComboboxManufacturer::Component).
   class ComboboxController < ApplicationController
     PER_PAGE = 15
+    MANUFACTURER_CATEGORIES = %w[cmp_mnfg frame_mnfg].freeze
 
-    # Both actions only ever render turbo_stream
+    # Every action only ever renders turbo_stream
     before_action { request.format = :turbo_stream }
 
     def options
@@ -19,6 +21,20 @@ module Search
           search_obj_name: params[:search_obj_name].presence || "Registrations",
           next_page:,
           q: params[:q]
+        )
+      )
+    end
+
+    def manufacturers
+      matches = Autocomplete::Matcher.search(manufacturer_params)
+      next_page = (matches.length >= PER_PAGE) ? current_page + 1 : nil
+
+      render turbo_stream: view_context.render(
+        UI::Forms::ComboboxManufacturerOptions::Component.new(
+          matches:,
+          next_page:,
+          q: params[:q],
+          no_manufacturer_other: Binxtils::InputNormalizer.boolean(params[:no_manufacturer_other])
         )
       )
     end
@@ -40,6 +56,13 @@ module Search
 
     def autocomplete_params
       params.permit(:q, :page, :categories, :cache).merge(per_page: PER_PAGE)
+    end
+
+    # frame_maker limits the categories to manufacturers that make frames
+    def manufacturer_params
+      categories = Binxtils::InputNormalizer.boolean(params[:frame_maker]) ? %w[frame_mnfg] : MANUFACTURER_CATEGORIES
+
+      params.permit(:q, :page, :cache).merge(per_page: PER_PAGE, categories:)
     end
 
     def current_page

--- a/app/controllers/search/combobox_controller.rb
+++ b/app/controllers/search/combobox_controller.rb
@@ -6,20 +6,18 @@ module Search
   # and the manufacturer picker (UI::Forms::ComboboxManufacturer::Component).
   class ComboboxController < ApplicationController
     PER_PAGE = 15
-    MANUFACTURER_CATEGORIES = %w[cmp_mnfg frame_mnfg].freeze
 
     # Every action only ever renders turbo_stream
     before_action { request.format = :turbo_stream }
 
     def options
       matches = Autocomplete::Matcher.search(autocomplete_params)
-      next_page = (matches.length >= PER_PAGE) ? current_page + 1 : nil
 
       render turbo_stream: view_context.render(
         Search::EverythingComboboxOptions::Component.new(
           matches:,
           search_obj_name: params[:search_obj_name].presence || "Registrations",
-          next_page:,
+          next_page: next_page_for(matches),
           q: params[:q]
         )
       )
@@ -27,12 +25,11 @@ module Search
 
     def manufacturers
       matches = Autocomplete::Matcher.search(manufacturer_params)
-      next_page = (matches.length >= PER_PAGE) ? current_page + 1 : nil
 
       render turbo_stream: view_context.render(
         UI::Forms::ComboboxManufacturerOptions::Component.new(
           matches:,
-          next_page:,
+          next_page: next_page_for(matches),
           q: params[:q],
           no_manufacturer_other: Binxtils::InputNormalizer.boolean(params[:no_manufacturer_other])
         )
@@ -60,9 +57,13 @@ module Search
 
     # frame_maker limits the categories to manufacturers that make frames
     def manufacturer_params
-      categories = Binxtils::InputNormalizer.boolean(params[:frame_maker]) ? %w[frame_mnfg] : MANUFACTURER_CATEGORIES
+      categories = Binxtils::InputNormalizer.boolean(params[:frame_maker]) ? %w[frame_mnfg] : %w[cmp_mnfg frame_mnfg]
 
-      params.permit(:q, :page, :cache).merge(per_page: PER_PAGE, categories:)
+      autocomplete_params.merge(categories:)
+    end
+
+    def next_page_for(matches)
+      (matches.length >= PER_PAGE) ? current_page + 1 : nil
     end
 
     def current_page

--- a/app/javascript/controllers/admin/bike_manufacturer_controller.js
+++ b/app/javascript/controllers/admin/bike_manufacturer_controller.js
@@ -1,0 +1,14 @@
+import { Controller } from '@hotwired/stimulus'
+
+// Connects to data-controller='admin--bike-manufacturer'
+//
+// Shows the warning under the manufacturer combobox while the selected manufacturer
+// is free text - an indexed manufacturer submits its id, the "Unknown manufacturer"
+// option submits what was typed.
+export default class extends Controller {
+  static targets = ['warning']
+
+  toggleWarning ({ detail: { value } }) {
+    this.warningTarget.hidden = value === '' || /^\d+$/.test(value)
+  }
+}

--- a/app/javascript/controllers/admin/bike_manufacturer_controller.js
+++ b/app/javascript/controllers/admin/bike_manufacturer_controller.js
@@ -8,7 +8,8 @@ import { Controller } from '@hotwired/stimulus'
 export default class extends Controller {
   static targets = ['warning']
 
+  // Digits are an id, matching how Manufacturer.friendly_find reads the submitted value
   toggleWarning ({ detail: { value } }) {
-    this.warningTarget.hidden = value === '' || /^\d+$/.test(value)
+    this.warningTarget.hidden = /^\d*$/.test(value)
   }
 }

--- a/app/models/manufacturer.rb
+++ b/app/models/manufacturer.rb
@@ -103,6 +103,11 @@ class Manufacturer < ApplicationRecord
     slug
   end
 
+  # How an async combobox displays an already selected manufacturer
+  def to_combobox_display
+    name
+  end
+
   def official_organization
     @official_organization ||= Organization.find_by_manufacturer_id(id)
   end

--- a/app/views/admin/bikes/edit.html.haml
+++ b/app/views/admin/bikes/edit.html.haml
@@ -1,7 +1,5 @@
 = render partial: "/admin/bikes/bike_tabs", locals: { bike: @bike, active_tab: "bikes-edit" }
 
-.d-none{ data: { url: ENV['BASE_URL'] } }
-
 .admin-subnav.midpage-subnav
   .col-4.col-md-6
     %h1
@@ -31,22 +29,14 @@
         = f.label :made_without_serial
   .row
     .col-6.col-md-4.col-lg-3
-      .form-group
+      .form-group{ data: { controller: "admin--bike-manufacturer", action: "hw-combobox:preselection->admin--bike-manufacturer#toggleWarning" } }
         - manufacturer_label = capture do
           Manufacturer
           %em.small
             = link_to "mfg bikes", admin_bikes_path(search_manufacturer: @bike.mnfg_name), class: "less-strong"
         = render UI::Forms::ComboboxManufacturer::Component.new(frame_maker: true, form: f, label: manufacturer_label, required: true)
-    .col-6.col-md-4.col-lg-3
-      .form-group
-        = f.label :manufacturer_other do
-          %span.d-none.d-sm-inline
-            Other mnfg
-          %small.less-strong
-            %span.d-none.d-xl-inline
-              Only necessary
-            if Manufacturer <em>Other</em>
-        = f.text_field :manufacturer_other, class: "form-control"
+        %small{class: UI::Alert::Component::TEXT_CLASSES[:warning], hidden: !@bike.manufacturer&.other?, data: { "admin--bike-manufacturer-target": "warning" }}
+          Manufacturer is <em>Other</em>, this isn't a listed manufacturer
     .col-6.col-md-4.col-lg-3
       .form-group
         = f.label :year
@@ -98,10 +88,7 @@
         .col-md-4
           .row
             #stolen-bike-location.form-group.col-6
-              #country_select_container
-                = render UI::Forms::Combobox::Component.new(name: :country_id, form: s, label: "Country", placeholder: "Choose country", include_blank: true, options: Country.select_options)
-                %p.d-none
-                  = Country.united_states_id
+              = render UI::Forms::Combobox::Component.new(name: :country_id, form: s, label: "Country", placeholder: "Choose country", include_blank: true, options: Country.select_options)
             .form-group.col-6
               = render UI::Forms::Combobox::Component.new(name: :region_record_id, form: s, label: "State", placeholder: "State", include_blank: true, options: State.united_states.pluck(:name, :id))
           .form-group

--- a/app/views/admin/bikes/missing_manufacturer.html.haml
+++ b/app/views/admin/bikes/missing_manufacturer.html.haml
@@ -46,7 +46,7 @@
 = form_tag update_manufacturers_admin_bikes_path, data: {controller: "table-multi-checkbox"} do
   .row
     .col-md-4
-      = render UI::Forms::ComboboxManufacturer::Component.new(frame_maker: true, placeholder: "Choose manufacturer", include_blank: true)
+      = render UI::Forms::ComboboxManufacturer::Component.new(frame_maker: true, no_manufacturer_other: true, placeholder: "Choose manufacturer")
     .col-md-2
       = submit_tag 'Update selected', class: 'btn btn-primary'
 

--- a/app/views/admin/bikes/missing_manufacturer.html.haml
+++ b/app/views/admin/bikes/missing_manufacturer.html.haml
@@ -46,7 +46,7 @@
 = form_tag update_manufacturers_admin_bikes_path, data: {controller: "table-multi-checkbox"} do
   .row
     .col-md-4
-      = render UI::Forms::ComboboxManufacturer::Component.new(frame_maker: true, no_manufacturer_other: true, placeholder: "Choose manufacturer")
+      = render UI::Forms::ComboboxManufacturer::Component.new(frame_maker: true, no_manufacturer_other: true)
     .col-md-2
       = submit_tag 'Update selected', class: 'btn btn-primary'
 

--- a/app/views/admin/organizations/_form.html.haml
+++ b/app/views/admin/organizations/_form.html.haml
@@ -141,7 +141,7 @@
 
     - if @organization.official_manufacturer?
       .form-group
-        = render UI::Forms::ComboboxManufacturer::Component.new(frame_maker: true, form: f, label: Organization.human_attribute_name(:manufacturer), required: true)
+        = render UI::Forms::ComboboxManufacturer::Component.new(frame_maker: true, no_manufacturer_other: true, form: f, label: Organization.human_attribute_name(:manufacturer), required: true)
         %small
           %strong This organization has <code>Official manufacturer organization</code> enabled.
           Select a manufacturer to give them manufacturer access.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -167,6 +167,8 @@ Rails.application.routes.draw do
     # Autocomplete + selection chips for the search query items combobox
     get "combobox/options", to: "combobox#options", as: :combobox_options
     post "combobox/chips", to: "combobox#chips", as: :combobox_chips
+    # Autocomplete for the manufacturer combobox (UI::Forms::ComboboxManufacturer)
+    get "combobox/manufacturers", to: "combobox#manufacturers", as: :combobox_manufacturers
     resources :registrations, only: %i[index] do
       collection do
         get :similar_serials

--- a/spec/components/ui/forms/combobox_manufacturer/component_spec.rb
+++ b/spec/components/ui/forms/combobox_manufacturer/component_spec.rb
@@ -6,41 +6,64 @@ RSpec.describe UI::Forms::ComboboxManufacturer::Component, type: :component do
   let(:instance) { described_class.new(**options) }
   let(:component) { render_inline(instance) }
   let(:options) { {} }
-  let!(:frame_maker) { FactoryBot.create(:manufacturer, name: "Surly", frame_maker: true) }
-  let!(:component_maker) { FactoryBot.create(:manufacturer, name: "Shimano", frame_maker: false) }
+  let(:async_src) { component.css("[data-hw-combobox-async-src-value]").first["data-hw-combobox-async-src-value"] }
 
-  it "renders a manufacturer_id combobox of every manufacturer" do
+  it "renders a manufacturer_id combobox that autocompletes every manufacturer, accepting free text" do
     expect(component).to have_css("input[type='hidden'][name='manufacturer_id']", visible: :all)
     expect(component).to have_css("label", text: "Manufacturer")
-    expect(component).to have_css("[role='option'][data-value='#{frame_maker.id}']", text: "Surly", visible: :all)
-    expect(component).to have_css("[role='option'][data-value='#{component_maker.id}']", text: "Shimano", visible: :all)
+    expect(component).to have_css("[data-hw-combobox-name-when-new-value='manufacturer_id']")
+    expect(async_src).to start_with "/search/combobox/manufacturers"
+    expect(async_src).to_not include "frame_maker"
+    expect(async_src).to_not include "no_manufacturer_other"
   end
 
   context "with frame_maker: true" do
     let(:options) { {frame_maker: true} }
 
-    it "renders only frame makers" do
-      expect(component).to have_css("[role='option'][data-value='#{frame_maker.id}']", text: "Surly", visible: :all)
-      expect(component).not_to have_css("[role='option']", text: "Shimano", visible: :all)
+    it "limits the autocomplete to frame makers" do
+      expect(async_src).to include "frame_maker=true"
     end
   end
 
-  context "with a custom manufacturers relation" do
-    let(:options) { {manufacturers: Manufacturer.frame_makers} }
+  context "with no_manufacturer_other: true" do
+    let(:options) { {no_manufacturer_other: true} }
 
-    it "renders the given manufacturers" do
-      expect(component).to have_css("[role='option']", text: "Surly", visible: :all)
-      expect(component).not_to have_css("[role='option']", text: "Shimano", visible: :all)
+    it "renders without free text" do
+      expect(async_src).to include "no_manufacturer_other=true"
+      expect(component).to_not have_css("[data-hw-combobox-name-when-new-value]")
+    end
+  end
+
+  context "with a form" do
+    let(:bike) { Bike.new(manufacturer:, manufacturer_other:) }
+    let(:manufacturer) { FactoryBot.create(:manufacturer, name: "Surly") }
+    let(:manufacturer_other) { nil }
+    let(:form) { ActionView::Helpers::FormBuilder.new("bike", bike, vc_test_controller.view_context, {}) }
+    let(:options) { {form:} }
+
+    it "renders the manufacturer's name and id" do
+      expect(component).to have_css("input[type='hidden'][name='bike[manufacturer_id]'][value='#{manufacturer.id}']", visible: :all)
+      expect(component).to have_css("[data-hw-combobox-prefilled-display-value='Surly']")
+    end
+
+    context "with Manufacturer.other" do
+      let(:manufacturer) { Manufacturer.other }
+      let(:manufacturer_other) { "Bikes by Seth" }
+
+      it "renders manufacturer_other, since Manufacturer.other isn't selectable" do
+        expect(component).to have_css("input[type='hidden'][name='bike[manufacturer_id]'][value='Bikes by Seth']", visible: :all)
+        expect(component).to have_css("[data-hw-combobox-prefilled-display-value='Bikes by Seth']")
+      end
     end
   end
 
   context "with forwarded options" do
-    let(:options) { {name: :cmp_manufacturer_id, label: "Frame manufacturer", value: frame_maker.id} }
+    let(:options) { {name: :cmp_manufacturer_id, label: "Frame manufacturer", placeholder: "Choose"} }
 
-    it "forwards name, label, and value to the combobox" do
+    it "forwards name, label, and placeholder to the combobox" do
       expect(component).to have_css("input[type='hidden'][name='cmp_manufacturer_id']", visible: :all)
       expect(component).to have_css("label", text: "Frame manufacturer")
-      expect(component).to have_css("[data-hw-combobox-prefilled-display-value='Surly']")
+      expect(component).to have_css("input[placeholder='Choose']")
     end
   end
 end

--- a/spec/components/ui/forms/combobox_manufacturer/component_spec.rb
+++ b/spec/components/ui/forms/combobox_manufacturer/component_spec.rb
@@ -11,6 +11,8 @@ RSpec.describe UI::Forms::ComboboxManufacturer::Component, type: :component do
   it "renders a manufacturer_id combobox that autocompletes every manufacturer, accepting free text" do
     expect(component).to have_css("input[type='hidden'][name='manufacturer_id']", visible: :all)
     expect(component).to have_css("label", text: "Manufacturer")
+    placeholder = component.css("input[role='combobox']").first["placeholder"]
+    expect(described_class::PLACEHOLDER_NAMES).to include placeholder.delete_prefix("Start typing e.g. ")
     expect(component).to have_css("[data-hw-combobox-name-when-new-value='manufacturer_id']")
     expect(async_src).to start_with "/search/combobox/manufacturers"
     expect(async_src).to_not include "frame_maker"
@@ -60,10 +62,10 @@ RSpec.describe UI::Forms::ComboboxManufacturer::Component, type: :component do
   context "with forwarded options" do
     let(:options) { {name: :cmp_manufacturer_id, label: "Frame manufacturer", placeholder: "Choose"} }
 
-    it "forwards name, label, and placeholder to the combobox" do
+    it "forwards name and label, but keeps its own placeholder" do
       expect(component).to have_css("input[type='hidden'][name='cmp_manufacturer_id']", visible: :all)
       expect(component).to have_css("label", text: "Frame manufacturer")
-      expect(component).to have_css("input[placeholder='Choose']")
+      expect(component).to_not have_css("input[placeholder='Choose']")
     end
   end
 end

--- a/spec/components/ui/forms/combobox_manufacturer/component_spec.rb
+++ b/spec/components/ui/forms/combobox_manufacturer/component_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe UI::Forms::ComboboxManufacturer::Component, type: :component do
     let(:bike) { Bike.new(manufacturer:, manufacturer_other:) }
     let(:manufacturer) { FactoryBot.create(:manufacturer, name: "Surly") }
     let(:manufacturer_other) { nil }
-    let(:form) { ActionView::Helpers::FormBuilder.new("bike", bike, vc_test_controller.view_context, {}) }
+    let(:form) { BikeIndexFormBuilder.new("bike", bike, vc_test_controller.view_context, {}) }
     let(:options) { {form:} }
 
     it "renders the manufacturer's name and id" do

--- a/spec/components/ui/forms/combobox_manufacturer/component_system_spec.rb
+++ b/spec/components/ui/forms/combobox_manufacturer/component_system_spec.rb
@@ -30,34 +30,24 @@ RSpec.describe UI::Forms::ComboboxManufacturer::Component, :js, type: :system do
 
     # An unindexed manufacturer is entered through the unknown option
     type_into(find_field("Manufacturer"), "Bikes by Seth")
-    find('[role="option"]', text: "Unknown manufacturer Bikes by Seth").click
+    click_combobox_option("Unknown manufacturer Bikes by Seth")
 
     expect(page).to have_css('[aria-expanded="false"]')
     expect(find_field("Manufacturer").value).to eq "Bikes by Seth"
     expect(hidden_field.value).to eq "Bikes by Seth"
-  end
 
-  context "with no_manufacturer_other" do
-    # This preview renders the bare component, which has no label of its own
-    let(:combobox) { find("input[role='combobox']") }
+    # With no_manufacturer_other, free text isn't offered or kept. This preview
+    # renders the bare component, which has no label of its own
+    visit "/rails/view_components/ui/forms/combobox_manufacturer/component/no_manufacturer_other"
 
-    it "only selects an indexed manufacturer" do
-      visit "/rails/view_components/ui/forms/combobox_manufacturer/component/no_manufacturer_other"
+    expect(page).to have_css('[aria-expanded="false"]', wait: 10)
 
-      expect(page).to have_css('[aria-expanded="false"]', wait: 10)
+    type_into(find("input[role='combobox']"), "Bikes by Seth")
 
-      type_into(combobox, "sur")
+    expect(page).to_not have_css('[role="option"]')
 
-      expect(page).to have_css('[role="option"]', text: "Surly")
-      expect(page).to_not have_css('[role="option"]', text: "Unknown manufacturer")
+    send_keys(:enter)
 
-      type_into(combobox, "Bikes by Seth")
-
-      expect(page).to_not have_css('[role="option"]')
-
-      send_keys(:enter)
-
-      expect(hidden_field.value).to be_blank
-    end
+    expect(hidden_field.value).to be_blank
   end
 end

--- a/spec/components/ui/forms/combobox_manufacturer/component_system_spec.rb
+++ b/spec/components/ui/forms/combobox_manufacturer/component_system_spec.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe UI::Forms::ComboboxManufacturer::Component, :js, type: :system do
+  let!(:manufacturer) { FactoryBot.create(:manufacturer, name: "Surly", frame_maker: true) }
+  let(:hidden_field) { find("input[name='manufacturer_id']", visible: :hidden) }
+  # Matcher results are cached in redis for 10 minutes, which outlives the example
+  before { Autocomplete::Loader.clear_redis && Autocomplete::Loader.load_all(%w[Manufacturer]) }
+
+  it "selects an indexed manufacturer, and enters an unindexed one as free text" do
+    visit "/rails/view_components/ui/forms/combobox_manufacturer/component/default"
+
+    # `aria-expanded` is set by the combobox Stimulus controller on connect, not
+    # in the server-rendered HTML -- wait out the first JS connect on slow CI.
+    expect(page).to have_css('[aria-expanded="false"]', wait: 10)
+
+    type_into(find_field("Manufacturer"), "sur")
+
+    expect(page).to have_css('[role="option"]', text: "Surly")
+    expect(page).to have_css('[role="option"]', text: "Unknown manufacturer")
+    expect(page).to_not have_css('[role="option"]', text: "Other")
+
+    # The typed text autocompletes to the manufacturer, which is selected on close
+    send_keys(:enter)
+
+    expect(page).to have_css('[aria-expanded="false"]')
+    expect(find_field("Manufacturer").value).to eq "Surly"
+    expect(hidden_field.value).to eq manufacturer.id.to_s
+
+    # An unindexed manufacturer is entered through the unknown option
+    type_into(find_field("Manufacturer"), "Bikes by Seth")
+    find('[role="option"]', text: "Unknown manufacturer Bikes by Seth").click
+
+    expect(page).to have_css('[aria-expanded="false"]')
+    expect(find_field("Manufacturer").value).to eq "Bikes by Seth"
+    expect(hidden_field.value).to eq "Bikes by Seth"
+  end
+
+  context "with no_manufacturer_other" do
+    it "only selects an indexed manufacturer" do
+      visit "/rails/view_components/ui/forms/combobox_manufacturer/component/no_manufacturer_other"
+
+      expect(page).to have_css('[aria-expanded="false"]', wait: 10)
+
+      type_into(find_field("Manufacturer"), "sur")
+
+      expect(page).to have_css('[role="option"]', text: "Surly")
+      expect(page).to_not have_css('[role="option"]', text: "Unknown manufacturer")
+
+      type_into(find_field("Manufacturer"), "Bikes by Seth")
+
+      expect(page).to_not have_css('[role="option"]')
+
+      send_keys(:enter)
+
+      expect(hidden_field.value).to be_blank
+    end
+  end
+end

--- a/spec/requests/admin/bikes_request_spec.rb
+++ b/spec/requests/admin/bikes_request_spec.rb
@@ -44,6 +44,8 @@ RSpec.describe Admin::BikesController, type: :request do
   describe "edit" do
     let(:bike) { FactoryBot.create(:stolen_bike) }
     let(:stolen_record) { bike.current_stolen_record }
+    # Stimulus unhides it when free text is entered
+    let(:manufacturer_warning) { Nokogiri::HTML(response.body).at_css("[data-admin--bike-manufacturer-target='warning']") }
     context "standard" do
       it "renders" do
         get "#{base_url}/#{FactoryBot.create(:bike).id}/edit"
@@ -51,6 +53,17 @@ RSpec.describe Admin::BikesController, type: :request do
         expect(response).to render_template("edit")
         expect(flash).to_not be_present
         expect(assigns(:page_id)).to eq "admin_bikes_edit"
+        expect(manufacturer_warning.key?("hidden")).to be_truthy
+      end
+    end
+    context "with an unknown manufacturer" do
+      let(:bike) { FactoryBot.create(:bike, manufacturer: Manufacturer.other, manufacturer_other: "Bikes by Seth") }
+      it "renders the manufacturer combobox with the free text, and warns that the manufacturer is other" do
+        get "#{base_url}/#{bike.id}/edit"
+        expect(response.code).to eq("200")
+        expect(response.body).to match(/data-hw-combobox-prefilled-display-value="Bikes by Seth"/)
+        expect(manufacturer_warning.text.strip).to match(/Manufacturer is Other/)
+        expect(manufacturer_warning.key?("hidden")).to be_falsey
       end
     end
     context "with recovery" do
@@ -148,6 +161,33 @@ RSpec.describe Admin::BikesController, type: :request do
         expect(ActionMailer::Base.deliveries.count).to eq 0
       end
     end
+    context "manufacturer" do
+      let(:manufacturer) { FactoryBot.create(:manufacturer, name: "Surly") }
+
+      it "assigns a manufacturer that isn't listed to Manufacturer.other" do
+        put "#{base_url}/#{bike.id}", params: {bike: {manufacturer_id: "Bikes by Seth"}}
+        expect(flash[:success]).to be_present
+        bike.reload
+        expect(bike.manufacturer_id).to eq Manufacturer.other.id
+        expect(bike.manufacturer_other).to eq "Bikes by Seth"
+        expect(bike.mnfg_name).to eq "Bikes by Seth"
+      end
+
+      context "with an unknown manufacturer" do
+        let(:bike) { FactoryBot.create(:bike, :with_ownership, manufacturer: Manufacturer.other, manufacturer_other: "Bikes by Seth") }
+
+        it "removes manufacturer_other when a listed manufacturer is selected" do
+          expect(bike.reload.mnfg_name).to eq "Bikes by Seth"
+          put "#{base_url}/#{bike.id}", params: {bike: {manufacturer_id: manufacturer.id.to_s}}
+          expect(flash[:success]).to be_present
+          bike.reload
+          expect(bike.manufacturer_id).to eq manufacturer.id
+          expect(bike.manufacturer_other).to be_nil
+          expect(bike.mnfg_name).to eq "Surly"
+        end
+      end
+    end
+
     context "made without serial" do
       let(:bike) { FactoryBot.create(:bike, serial_number: "og serial") }
       it "makes it made without serial" do

--- a/spec/requests/search/combobox_request_spec.rb
+++ b/spec/requests/search/combobox_request_spec.rb
@@ -71,6 +71,77 @@ RSpec.describe Search::ComboboxController, type: :request do
     end
   end
 
+  describe "manufacturers" do
+    let!(:trek) { FactoryBot.create(:manufacturer, name: "Trek", frame_maker: true) }
+    let!(:trek_components) { FactoryBot.create(:manufacturer, name: "Trek Parts", frame_maker: false) }
+    let!(:avantrek) { FactoryBot.create(:manufacturer, name: "AVANTREK", frame_maker: true) }
+    # Matcher results are cached in redis for 10 minutes, which outlives the example
+    before { Autocomplete::Loader.clear_redis && Autocomplete::Loader.load_all(%w[Manufacturer]) }
+
+    it "renders the matching manufacturers, plus the unknown manufacturer synthetic" do
+      get "/search/combobox/manufacturers", params: {q: "tre", for_id: "test"}, as: :turbo_stream
+
+      expect(response.code).to eq("200")
+      expect(response.body).to include("data-value=\"#{trek.id}\"")
+      expect(response.body).to include("data-value=\"#{trek_components.id}\"")
+      # AVANTREK isn't a match - the autocomplete index matches on word prefixes
+      expect(response.body).to_not include("data-value=\"#{avantrek.id}\"")
+      # Manufacturer.other is never selectable
+      expect(response.body).to_not include("data-value=\"#{Manufacturer.other.id}\"")
+      expect(response.body).to include("Unknown manufacturer")
+      expect(response.body).to include("hw_unknown_manufacturer_option")
+    end
+
+    context "with matches of differing priority" do
+      let!(:bike) { FactoryBot.create(:bike, manufacturer: trek_components) }
+
+      before do
+        # bike creation doesn't trigger Manufacturer#before_save, so update to
+        # recompute calculated_priority with the new b_count
+        Manufacturer.find(trek_components.id).update(updated_at: Time.current)
+        Autocomplete::Loader.load_all(%w[Manufacturer])
+      end
+
+      it "orders by priority, then alphabetically" do
+        expect(Manufacturer.find(trek_components.id).priority).to be > trek.reload.priority
+
+        get "/search/combobox/manufacturers", params: {q: "tre", for_id: "test"}, as: :turbo_stream
+
+        expect(response.body.index("data-value=\"#{trek_components.id}\""))
+          .to be < response.body.index("data-value=\"#{trek.id}\"")
+      end
+    end
+
+    context "with frame_maker" do
+      it "only renders frame makers" do
+        get "/search/combobox/manufacturers", params: {q: "tre", frame_maker: "true", for_id: "test"}, as: :turbo_stream
+
+        expect(response.body).to include("data-value=\"#{trek.id}\"")
+        expect(response.body).to_not include("data-value=\"#{trek_components.id}\"")
+      end
+    end
+
+    context "with no_manufacturer_other" do
+      it "doesn't render the unknown manufacturer synthetic" do
+        get "/search/combobox/manufacturers",
+          params: {q: "nonesuch", no_manufacturer_other: "true", for_id: "test"}, as: :turbo_stream
+
+        expect(response.code).to eq("200")
+        expect(response.body).to_not include("Unknown manufacturer")
+      end
+    end
+
+    context "with an exact match" do
+      it "doesn't render the unknown manufacturer synthetic" do
+        get "/search/combobox/manufacturers", params: {q: "tre", for_id: "test"}, as: :turbo_stream
+        expect(response.body).to include("hw_unknown_manufacturer_option")
+
+        get "/search/combobox/manufacturers", params: {q: "Trek", for_id: "test"}, as: :turbo_stream
+        expect(response.body).to_not include("hw_unknown_manufacturer_option")
+      end
+    end
+  end
+
   describe "chips" do
     let!(:color) { FactoryBot.create(:color, name: "Burgundy") }
     let!(:manufacturer) { FactoryBot.create(:manufacturer, name: "Cool Bikes") }

--- a/spec/requests/search/combobox_request_spec.rb
+++ b/spec/requests/search/combobox_request_spec.rb
@@ -90,6 +90,9 @@ RSpec.describe Search::ComboboxController, type: :request do
       expect(response.body).to_not include("data-value=\"#{Manufacturer.other.id}\"")
       expect(response.body).to include("Unknown manufacturer")
       expect(response.body).to include("hw_unknown_manufacturer_option")
+      # Matches of equal priority are alphabetical
+      expect(response.body.index("data-value=\"#{trek.id}\""))
+        .to be < response.body.index("data-value=\"#{trek_components.id}\"")
     end
 
     context "with matches of differing priority" do
@@ -102,7 +105,7 @@ RSpec.describe Search::ComboboxController, type: :request do
         Autocomplete::Loader.load_all(%w[Manufacturer])
       end
 
-      it "orders by priority, then alphabetically" do
+      it "orders by priority" do
         expect(Manufacturer.find(trek_components.id).priority).to be > trek.reload.priority
 
         get "/search/combobox/manufacturers", params: {q: "tre", for_id: "test"}, as: :turbo_stream


### PR DESCRIPTION
The manufacturer combobox rendered every manufacturer into the page — 448kb of html on `admin/bikes/edit` — and offered `Manufacturer.other` as a pickable option. It now autocompletes against the Autocomplete index through `Search::ComboboxController#manufacturers`, which orders matches by manufacturer priority then alphabetically, so "trek" lands Trek above Trek Parts.

- A manufacturer that isn't indexed is entered through the "Unknown manufacturer" option — the manufacturer field's version of the search bar's "Search for" — which `BParam` (and now `Admin::BikesController`) resolves to `Manufacturer.other` plus `manufacturer_other`. Pass `no_manufacturer_other: true` where only an indexed manufacturer is acceptable, as the organization form and bulk manufacturer assignment do.
- Because the index matches on word prefixes rather than substrings, "trek" no longer matches AVANTREK at all. Manufacturers reach the index through `ScheduledAutocompleteCheckJob`, so a brand new one isn't pickable until that runs.
- Admin bike edit drops its `manufacturer_other` field for a warning under the combobox, which appears as soon as free text is entered. Also removes two dead hooks from that view: the `BASE_URL` div and `#country_select_container`, whose JS went away in b62edbf78.
