### PR TITLE
Reverse-geocode the parking-notification pin server-side

### DIFF
--- a/app/components/registrations/show/org_top_actions/parking_notification_form/component.html.erb
+++ b/app/components/registrations/show/org_top_actions/parking_notification_form/component.html.erb
@@ -5,7 +5,6 @@
   data-registrations--show--parking-notification-form-notification-heading-value="<%= translation(".create_parking_notification") %>"
   data-registrations--show--parking-notification-form-impound-heading-value="<%= translation(".impound_this_bike_type", bike_type: @bike.type) %>"
   data-registrations--show--parking-notification-form-default-kind-value="<%= new_parking_notification.kind %>"
-  data-registrations--show--parking-notification-form-mapbox-key-value="<%= ENV["MAPBOX_MAPPING"] %>"
   data-registrations--show--parking-notification-form-org-latitude-value="<%= org_map_coordinates[:latitude] %>"
   data-registrations--show--parking-notification-form-org-longitude-value="<%= org_map_coordinates[:longitude] %>"
   data-action="registrations--show--action-panels:shown->registrations--show--parking-notification-form#applyMode"

--- a/app/controllers/reverse_geocode_controller.rb
+++ b/app/controllers/reverse_geocode_controller.rb
@@ -1,0 +1,32 @@
+# Reverse-geocodes a coordinate into AddressRecord's assignable attributes, so a map
+# pin prefills an address form from the provider the server itself geocodes with.
+# Session-authenticated, so it stays out of the public /api namespace — and not named
+# GeocodeController, which makes Rails include the GeocodeHelper service as a view helper
+class ReverseGeocodeController < ApplicationController
+  def index
+    return render(json: {error: "Unauthorized"}, status: :unauthorized) if current_user.blank?
+
+    coordinates = permitted_coordinates
+    return render(json: {error: "Invalid coordinates"}, status: :bad_request) if coordinates.blank?
+
+    render json: address_fields(GeocodeHelper.assignable_address_hash_for(**coordinates, new_attrs: true))
+  end
+
+  private
+
+  # Rounded so a pin restored from the URL (which keeps 6 places) shares a Geocoder
+  # cache key with the raw map centre it came from — 5 places is ~1m
+  def permitted_coordinates
+    latitude, longitude = %i[latitude longitude].map { Float(params[it], exception: false)&.round(5) }
+    {latitude:, longitude:} if latitude&.between?(-90, 90) && longitude&.between?(-180, 180)
+  end
+
+  # Resolving the region here (rather than shipping the state code) mirrors
+  # Geocodeable#assign_region_record: exactly one of the two region fields is set
+  def address_fields(address)
+    region_record_id = State.friendly_find(address[:region_string], country_id: address[:country_id])&.id
+
+    address.slice(*Geocodeable::ADDRESS_ATTRS)
+      .merge(region_record_id:, region_string: (address[:region_string] unless region_record_id))
+  end
+end

--- a/app/javascript/controllers/registrations/show/parking_notification_form_controller.js
+++ b/app/javascript/controllers/registrations/show/parking_notification_form_controller.js
@@ -12,7 +12,7 @@ import { ExpandControl, groundRadiusStops, loadMapLibre, MAPS_STYLE_URL, OSM_ATT
 // onto the form, and keeps the pin + zoom in the URL so a reload restores them.
 // Moving the map moves the pin. "Enter address manually" reveals the
 // UI::Forms::AddressGroup fields instead. Tiles come from our self-hosted MapLibre
-// basemap; the mapboxKey is only for reverse-geocoding the pin.
+// basemap.
 const DEFAULT_ZOOM = 15.5
 
 // The device's own position, so a dragged pin can be judged against where the
@@ -38,7 +38,6 @@ export default class extends Controller {
     notificationHeading: String,
     impoundHeading: String,
     defaultKind: String,
-    mapboxKey: String,
     orgLatitude: Number,
     orgLongitude: Number
   }
@@ -305,34 +304,20 @@ export default class extends Controller {
 
   // Split the pin's coordinates into address parts, to seed the manual-entry
   // fields. Marked before the request so toggling modes doesn't re-ask for a
-  // spot we've already looked up
+  // spot we've already looked up. Our endpoint resolves the country and region the
+  // way the server does, so what we prefill is what a save would store
   async reverseGeocode () {
-    if (!this.mapboxKeyValue) return
     this.geocodedFor = this.pinKey
+    // What the fields hold now — anything typed while we wait is theirs, not ours to replace
+    const replaceable = new Map([...this.addressGroupTarget.querySelectorAll('[name]')].map((field) => [field, field.value]))
     try {
-      const url = `https://api.mapbox.com/geocoding/v5/mapbox.places/${this.pinLongitude},${this.pinLatitude}.json?access_token=${this.mapboxKeyValue}&types=address&limit=1`
-      const response = await window.fetch(url)
+      const url = `/reverse_geocode?latitude=${this.pinLatitude}&longitude=${this.pinLongitude}`
+      // Accept json so a rack-attack 429 comes back as json rather than plain text
+      const response = await window.fetch(url, { headers: { Accept: 'application/json' } })
       if (!response.ok) return
-      const feature = (await response.json()).features?.[0]
-      if (!feature) return
-      this.geocodedAddress = this.addressFromFeature(feature)
-      // The pin has moved since the fields were seeded, so whatever they hold
-      // describes the old spot — replace it
-      this.fillAddress({ overwrite: true })
+      this.geocodedAddress = await response.json()
+      this.fillAddress(replaceable)
     } catch { /* leave the fields for them to fill in */ }
-  }
-
-  // Split a Mapbox feature into street/city/region/postal/country parts
-  addressFromFeature (feature) {
-    const context = feature.context || []
-    const part = (prefix) => context.find((entry) => entry.id.startsWith(`${prefix}.`))?.text
-    return {
-      street: [feature.address, feature.text].filter(Boolean).join(' '),
-      city: part('place') || part('locality'),
-      region: part('region'),
-      postalCode: part('postcode'),
-      country: part('country')
-    }
   }
 
   enterManually () {
@@ -349,46 +334,27 @@ export default class extends Controller {
     return this.locationModeTargets.some((radio) => radio.value === 'entered' && radio.checked)
   }
 
-  // Write the located place into the AddressGroup fields. Without `overwrite` it
-  // only fills blanks, so it can't clobber what they typed. Fields are reached by
-  // name (not targets) to stay decoupled from AddressGroup.
-  fillAddress ({ overwrite = false } = {}) {
+  addressField (attribute) {
+    return this.addressGroupTarget.querySelector(`[name$='[${attribute}]']`)
+  }
+
+  // Write the located place into the AddressGroup fields, which the endpoint names
+  // its response after. A blank field is always filled; a field with something in it
+  // only when `replaceable` says it still holds what the geocode was asked against.
+  fillAddress (replaceable = new Map()) {
     const address = this.geocodedAddress
     if (!address) return
-    this.setField('street', address.street, overwrite)
-    this.setField('city', address.city, overwrite)
-    this.setField('postal_code', address.postalCode, overwrite)
-    this.selectCountry(address.country, overwrite)
-    this.selectRegion(address.region, overwrite)
-  }
-
-  setField (attribute, value, overwrite) {
-    if (!value) return
-    const field = this.element.querySelector(`[name$='[${attribute}]']`)
-    if (field && (overwrite || !field.value)) field.value = value
-  }
-
-  // Match the country by name and let AddressGroup toggle the state/region field
-  selectCountry (name, overwrite) {
-    if (!name) return
-    const select = this.element.querySelector("select[name$='[country_id]']")
-    if (!select || (select.value && !overwrite)) return
-    const option = [...select.options].find((entry) => entry.text === name)
-    if (!option) return
-    select.value = option.value
-    select.dispatchEvent(new Event('change', { bubbles: true }))
-  }
-
-  // A matching US state fills the select; otherwise the free-text region field
-  selectRegion (name, overwrite) {
-    if (!name) return
-    const stateSelect = this.element.querySelector("select[name$='[region_record_id]']")
-    const stateOption = stateSelect && [...stateSelect.options].find((entry) => entry.text === name)
-    if (stateOption) {
-      if (overwrite || !stateSelect.value) stateSelect.value = stateOption.value
-    } else {
-      this.setField('region_string', name, overwrite)
-    }
+    const country = this.addressField('country_id')
+    const countryBefore = country?.value
+    Object.entries(address).forEach(([attribute, value]) => {
+      const field = this.addressField(attribute)
+      if (!field || !value) return
+      if (field.value && field.value !== replaceable.get(field)) return
+      field.value = value
+    })
+    // Let AddressGroup swap the state select for the free-text region field. Only on
+    // an actual change — it clears the state select for a non-US country
+    if (country && country.value !== countryBefore) country.dispatchEvent(new Event('change', { bubbles: true }))
   }
 
   // Manual entry requires the street and city; the map pin doesn't

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -405,6 +405,8 @@ Rails.application.routes.draw do
   get "strava_search", to: "strava_search#index"
   post "strava_search/token", to: "strava_search#create_token", as: :strava_search_token
 
+  get "reverse_geocode", to: "reverse_geocode#index", defaults: {format: "json"}
+
   mount Lookbook::Engine, at: "/lookbook"
 
   get "/400", to: "errors#bad_request", via: :all

--- a/spec/components/registrations/show/org_top_actions/parking_notification_form/component_system_spec.rb
+++ b/spec/components/registrations/show/org_top_actions/parking_notification_form/component_system_spec.rb
@@ -11,35 +11,22 @@ RSpec.describe Registrations::Show::OrgTopActions::ParkingNotificationForm::Comp
   let(:organization) { FactoryBot.create(:organization) }
   let!(:bike) { FactoryBot.create(:bike_organized, creation_organization: organization) }
 
-  # Coordinates the mocked device reports (SF Bay) and the address Mapbox returns
+  # Coordinates the mocked device reports (SF Bay) and the address /reverse_geocode returns
   let(:latitude) { "37.8698" }
   let(:longitude) { "-122.2585" }
   # A resolved pin is mirrored into the URL — there is no on-page location readout
   let(:located_url) { /map_lat=37\.8698.*map_lng=-122\.2585.*map_zoom=15\.50/ }
-  let(:geocode_feature) do
-    {
-      address: "2363a",
-      text: "Bryant Street",
-      context: [
-        {id: "postcode.1", text: "94110"},
-        {id: "place.1", text: "San Francisco"},
-        {id: "region.1", text: "California"},
-        {id: "country.1", text: "United States"}
-      ]
-    }
+  let(:country) { Country.united_states }
+  let!(:state) { FactoryBot.create(:state_california) }
+  # How long the stubbed endpoint takes to answer
+  let(:geocode_delay) { 0 }
+  let(:geocode_address) do
+    {street: "2363a Bryant Street", city: "San Francisco", postal_code: "94110",
+     region_record_id: state.id, region_string: nil, country_id: country.id}
   end
-  # Mapbox answers a pin anywhere else with a different address, so the two can be told apart
-  let(:moved_feature) do
-    geocode_feature.merge(
-      address: "1200",
-      text: "Valencia Street",
-      context: [
-        {id: "postcode.1", text: "94612"},
-        {id: "place.1", text: "Oakland"},
-        {id: "region.1", text: "California"},
-        {id: "country.1", text: "United States"}
-      ]
-    )
+  # A pin anywhere else resolves to a different address, so the two can be told apart
+  let(:moved_address) do
+    geocode_address.merge(street: "1200 Valencia Street", city: "Oakland", postal_code: "94612")
   end
 
   def coordinate(field)
@@ -189,16 +176,16 @@ RSpec.describe Registrations::Show::OrgTopActions::ParkingNotificationForm::Comp
   # No visit here — the driver boots its page on demand, so the routes and
   # permissions install against a blank page and every example visits its own URL
   before do
-    stub_const("ENV", ENV.to_hash.merge("MAPBOX_MAPPING" => "pk.test-token"))
     move_device_to(latitude: latitude.to_f, longitude: longitude.to_f, accuracy: 20)
     # capture for the cross-thread route handler
-    feature, moved, device_longitude = geocode_feature, moved_feature, longitude
+    address, moved, device_longitude, delay = geocode_address, moved_address, longitude, geocode_delay
     page.driver.with_playwright_page do |playwright_page|
       context = playwright_page.context
       context.grant_permissions(["geolocation"])
-      # Stub Mapbox reverse-geocode so the address resolves without the network
-      context.route("https://api.mapbox.com/geocoding/**", proc { |route, request|
-        route.fulfill(status: 200, json: {features: [request.url.include?("/#{device_longitude},") ? feature : moved]})
+      # Stub our reverse-geocode endpoint so the address resolves without hitting Google
+      context.route("**/reverse_geocode?**", proc { |route, request|
+        sleep delay
+        route.fulfill(status: 200, json: request.url.include?("longitude=#{device_longitude}") ? address : moved)
       })
       # Serve an empty MapLibre style so the map builds without fetching basemap tiles
       context.route("#{maps_host}/**", proc { |route, _request|
@@ -229,7 +216,9 @@ RSpec.describe Registrations::Show::OrgTopActions::ParkingNotificationForm::Comp
     expect(page).to have_field("Address or intersection", with: "2363a Bryant Street")
     expect(page).to have_field("City", with: "San Francisco")
     expect(page).to have_field("Postal code", with: "94110")
-    expect(address_field("region_string")).to eq("California")
+    # The endpoint hands back ids, so the selects are set directly rather than matched by label
+    expect(address_field("region_record_id")).to eq(state.id.to_s)
+    expect(address_field("country_id")).to eq(country.id.to_s)
     expect(coordinate("use_entered_address")).to eq("true")
     expect_axe_clean
 
@@ -264,6 +253,23 @@ RSpec.describe Registrations::Show::OrgTopActions::ParkingNotificationForm::Comp
 
     expect(page).to have_field("Optional message to send to the owner", with: "Blocking the bike lane")
     expect(address_field("internal_notes")).to eq("Third report this week")
+  end
+
+  # The response can land after they've started typing
+  context "when the geocode is slow to answer" do
+    let(:geocode_delay) { 2 }
+
+    it "fills the blanks but leaves the field they typed into while it was in flight" do
+      visit "#{preview_path}?panel=parking"
+
+      expect(page).to have_current_path(located_url, url: true, wait: 10)
+
+      find("label", text: "Enter address manually").click
+      fill_in "Address or intersection", with: "NE corner of 24th & Bryant"
+
+      expect(page).to have_field("City", with: "San Francisco", wait: 10)
+      expect(page).to have_field("Address or intersection", with: "NE corner of 24th & Bryant")
+    end
   end
 
   # The ?panel=parking load path auto-opens the panel on connect, so geolocation

--- a/spec/requests/reverse_geocode_request_spec.rb
+++ b/spec/requests/reverse_geocode_request_spec.rb
@@ -1,0 +1,59 @@
+require "rails_helper"
+
+RSpec.describe "ReverseGeocode", type: :request do
+  describe "index" do
+    let(:base_url) { "/reverse_geocode" }
+    let(:latitude) { 42.84901970000 }
+    let(:longitude) { -106.30153410000 }
+
+    context "not logged in" do
+      it "responds unauthorized" do
+        get base_url, params: {latitude:, longitude:}
+        expect(response.code).to eq("401")
+      end
+    end
+
+    context "logged in" do
+      include_context :request_spec_logged_in_as_user
+      include_context :geocoder_real
+      let(:vcr_config) { {match_requests_on: [:path], re_record_interval: 4.months} }
+      let(:country) { Country.united_states }
+      let!(:state) { FactoryBot.create(:state, name: "Wyoming", abbreviation: "WY", country:) }
+      let(:target) do
+        {street: "1740 East 2nd Street", city: "Casper", postal_code: "82601",
+         country_id: country.id, region_record_id: state.id, region_string: nil}
+      end
+
+      def get_geocode
+        VCR.use_cassette("geohelper-reverse_geocode", vcr_config) do
+          get base_url, params: {latitude:, longitude:}
+        end
+      end
+
+      it "returns the address fields, with the region resolved to a state" do
+        get_geocode
+        expect(response.code).to eq("200")
+        expect(json_result).to match_hash_indifferently target
+      end
+
+      context "with coordinates it can't use" do
+        it "responds bad_request" do
+          [{}, {latitude: "here", longitude: "there"}, {latitude: 91, longitude:}].each do |coordinates|
+            get base_url, params: coordinates
+            expect(response.code).to eq("400")
+          end
+        end
+      end
+
+      context "with an unrecognized region" do
+        let!(:state) { FactoryBot.create(:state_california) }
+
+        it "returns region_string rather than a state" do
+          get_geocode
+          expect(json_result["region_record_id"]).to be_nil
+          expect(json_result["region_string"]).to eq "WY"
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
The parking-notification map pin resolved its address through `api.mapbox.com` from the browser, while `ParkingNotification` re-geocodes with Google on save — so the address prefilled into the manual-entry fields wasn't necessarily the one that got stored, and the Mapbox token was rendered into the DOM.

- `GET /reverse_geocode` wraps `GeocodeHelper.assignable_address_hash_for` and returns `Geocodeable::ADDRESS_ATTRS` with the region resolved to a `region_record_id`, so the country and state selects are set by id instead of matched against option text. That drops `addressFromFeature`, `selectCountry` and `selectRegion` from the Stimulus controller.
- The response now only replaces a field that still holds what it did when the request went out — a server round trip is a hop slower than calling a provider directly, which widens the window where the fill lands on top of what someone has started typing.
- Deliberately outside `namespace :api`: that namespace is public+CORS or OAuth-token, and its rack-attack bucket (150/30s) is too generous for something proxying paid geocoding. It's `ReverseGeocodeController` rather than `GeocodeController` because Rails auto-includes a same-named helper, and `GeocodeHelper` is a `Functionable` module that can't be included.
- `MAPBOX_MAPPING` stays — `bikes/_stolen_map` still uses it.
