### PR TITLE
Drop the combobox wrapper_class argument

### DIFF
--- a/app/components/ui/forms/combobox/component.rb
+++ b/app/components/ui/forms/combobox/component.rb
@@ -18,8 +18,8 @@ module UI
       #   - :inline  one line, the muted part following the display text
       #   - :stacked a muted line below the display text, on a taller input
       #
-      # It always renders inside a wrapper div, so the markup doesn't shift when
-      # rich_display is toggled -- wrap it yourself for the parent's layout.
+      # It always renders inside a wrapper div, so the combobox sits at the same
+      # depth either way -- add your own wrapper for the parent's layout.
       #
       # Any other keyword (id:, value:, open:, free_text:, autocomplete:,
       # placeholder:, etc.) is forwarded to `hw_combobox_tag`.
@@ -39,7 +39,7 @@ module UI
         end
 
         def call
-          tag.div(class: "tw:relative", data: wrapper_data) do
+          tag.div(**wrapper_attrs) do
             safe_join([combobox, overlay].compact)
           end
         end
@@ -53,10 +53,12 @@ module UI
           end
         end
 
-        # The wrapper always renders, so toggling rich_display doesn't move the
-        # combobox in its parent's layout -- but only it pays for the controller
-        def wrapper_data
-          {controller: ("ui--forms--combobox-display" if @rich_display)}.compact
+        # Only a rich display needs the controller, or the positioning context
+        # the overlay is placed against
+        def wrapper_attrs
+          return {} unless @rich_display
+
+          {class: "tw:relative", data: {controller: "ui--forms--combobox-display"}}
         end
 
         def overlay

--- a/app/components/ui/forms/combobox/component.rb
+++ b/app/components/ui/forms/combobox/component.rb
@@ -17,8 +17,9 @@ module UI
       # ui/forms/combobox_display_controller.js.
       #   - :inline  one line, the muted part following the display text
       #   - :stacked a muted line below the display text, on a taller input
-      # wrapper_class: goes on the wrapper the combobox always renders in, for
-      # the parent's layout (e.g. "tw:flex-1").
+      #
+      # It always renders inside a wrapper div, so the markup doesn't shift when
+      # rich_display is toggled -- wrap it yourself for the parent's layout.
       #
       # Any other keyword (id:, value:, open:, free_text:, autocomplete:,
       # placeholder:, etc.) is forwarded to `hw_combobox_tag`.
@@ -30,16 +31,15 @@ module UI
         STACKED_OVERLAY_CLASSES = "tw:flex tw:flex-col tw:justify-center tw:overflow-hidden"
         STACKED_INPUT_CLASSES = "tw:min-h-13"
 
-        def initialize(name:, options: [], src: nil, rich_display: nil, wrapper_class: nil, **combobox_options)
+        def initialize(name:, options: [], src: nil, rich_display: nil, **combobox_options)
           @name = name
           @options_or_src = src || options
           @rich_display = RICH_DISPLAYS.detect { |display| display.to_s == rich_display.to_s }
-          @wrapper_class = wrapper_class
           @combobox_options = combobox_options
         end
 
         def call
-          tag.div(class: ["tw:relative", @wrapper_class], data: wrapper_data) do
+          tag.div(class: "tw:relative", data: wrapper_data) do
             safe_join([combobox, overlay].compact)
           end
         end

--- a/spec/components/ui/forms/combobox/component_spec.rb
+++ b/spec/components/ui/forms/combobox/component_spec.rb
@@ -36,7 +36,9 @@ RSpec.describe UI::Forms::Combobox::Component, type: :component do
   end
 
   it "wraps the combobox without paying for the display controller" do
-    expect(component).to have_css("div.tw\\:relative fieldset.hw-combobox")
+    expect(component).to have_css("div > fieldset.hw-combobox")
+    # No overlay to position against, so no positioning context either
+    expect(component).to_not have_css("div.tw\\:relative")
     expect(component).to_not have_css("[data-controller='ui--forms--combobox-display']")
     expect(component).to_not have_css("[data-ui--forms--combobox-display-target='overlay']", visible: :all)
   end

--- a/spec/components/ui/forms/combobox/component_spec.rb
+++ b/spec/components/ui/forms/combobox/component_spec.rb
@@ -41,22 +41,6 @@ RSpec.describe UI::Forms::Combobox::Component, type: :component do
     expect(component).to_not have_css("[data-ui--forms--combobox-display-target='overlay']", visible: :all)
   end
 
-  context "with a wrapper_class" do
-    let(:extra) { {wrapper_class: "tw:flex-1"} }
-
-    it "puts it on the wrapper, whether or not there's a rich display" do
-      expect(component).to have_css("div.tw\\:relative.tw\\:flex-1 fieldset.hw-combobox")
-    end
-
-    context "with rich_display" do
-      let(:extra) { {wrapper_class: "tw:flex-1", rich_display: :stacked} }
-
-      it "puts it on the same wrapper the display controller uses" do
-        expect(component).to have_css("div.tw\\:relative.tw\\:flex-1[data-controller='ui--forms--combobox-display']")
-      end
-    end
-  end
-
   context "with rich_display: :inline" do
     let(:extra) { {rich_display: :inline} }
 


### PR DESCRIPTION
Follows #3980, which gave `UI::Forms::Combobox` a `wrapper_class:` argument alongside the wrapper it now always renders. The argument never picked up a caller, and it only existed so a caller could reach through the component to the div — one it can just as easily wrap itself.

- Drops `wrapper_class:`. The register flow's flex-row combobox wraps itself instead.
- The wrapper's `tw:relative` moves behind `rich_display:` too. It exists so the overlay has something to position against, and the overlay only renders for a rich display — the other ~25 comboboxes were carrying a containing block for absolutely-positioned descendants that nothing asked for. The div itself still always renders, so the combobox sits at the same depth either way.
