### PR TITLE
Reap unattached blobs, and stamp alert images in binx_data

### DIFF
--- a/app/jobs/backfills/stolen_alert_blob_binx_data_job.rb
+++ b/app/jobs/backfills/stolen_alert_blob_binx_data_job.rb
@@ -2,7 +2,7 @@
 
 module Backfills
   # Stamp the alert images minted before Images::StolenProcessor set binx_data, so
-  # CleanUnattachedBlobsJob's filename fallback can go.
+  # CleanUnattachedBlobsJob's filename fallback and StolenRecord's metadata fallback can go.
   class StolenAlertBlobBinxDataJob < ApplicationJob
     include Sidekiq::IterableJob
 
@@ -11,6 +11,7 @@ module Backfills
     # StolenProcessor names them "stolen-<stolen_record_id>-<template>.jpeg" - anything else
     # matching the ILIKE is a file a user named, and stamping it would exempt it from the reaper
     FILENAME_MATCHER = /\Astolen-(\d+)-/
+    MIGRATED_KEYS = %w[image_id removed].freeze
 
     def build_enumerator(cursor:)
       active_record_records_enumerator(blobs, cursor:)
@@ -22,7 +23,8 @@ module Backfills
       stolen_record_id = blob.filename.to_s[FILENAME_MATCHER, 1]
       return if stolen_record_id.blank?
 
-      blob.update_columns(binx_data: {"stolen_record_id" => stolen_record_id.to_i})
+      migrated = blob.metadata.slice(*MIGRATED_KEYS)
+      blob.update_columns(binx_data: {"stolen_record_id" => stolen_record_id.to_i}.merge(migrated))
     end
 
     private

--- a/app/jobs/backfills/stolen_alert_blob_binx_data_job.rb
+++ b/app/jobs/backfills/stolen_alert_blob_binx_data_job.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+module Backfills
+  # Stamp the alert images minted before Images::StolenProcessor set binx_data, so
+  # CleanUnattachedBlobsJob's filename fallback can go.
+  class StolenAlertBlobBinxDataJob < ApplicationJob
+    include Sidekiq::IterableJob
+
+    sidekiq_options queue: "low_priority", retry: false
+
+    # StolenProcessor names them "stolen-<stolen_record_id>-<template>.jpeg" - anything else
+    # matching the ILIKE is a file a user named, and stamping it would exempt it from the reaper
+    FILENAME_MATCHER = /\Astolen-(\d+)-/
+
+    def build_enumerator(cursor:)
+      active_record_records_enumerator(blobs, cursor:)
+    end
+
+    # Stamped rows drop out of the relation, but the cursor moves forward by id, so a resumed
+    # run doesn't skip anything
+    def each_iteration(blob)
+      stolen_record_id = blob.filename.to_s[FILENAME_MATCHER, 1]
+      return if stolen_record_id.blank?
+
+      blob.update_columns(binx_data: {"stolen_record_id" => stolen_record_id.to_i})
+    end
+
+    private
+
+    def blobs
+      ActiveStorage::Blob.where(binx_data: nil).where("filename ILIKE ?", "stolen-%")
+    end
+  end
+end

--- a/app/jobs/bike_jobs/remove_orphaned_images_job.rb
+++ b/app/jobs/bike_jobs/remove_orphaned_images_job.rb
@@ -19,8 +19,12 @@ module BikeJobs
         1.week.ago..1.day.ago
       end
 
+      # The stamp is what exempts a blob from CleanUnattachedBlobsJob, so it has to be what
+      # collects it here too - a stamp without a matching filename would leak forever. The
+      # filename covers whatever Backfills::StolenAlertBlobBinxDataJob hasn't stamped
       def blobs_for(stolen_record_id)
-        ActiveStorage::Blob.where("filename ILIKE ?", "stolen-#{stolen_record_id}-%")
+        ActiveStorage::Blob.where("binx_data->>'stolen_record_id' = ? OR filename ILIKE ?",
+          stolen_record_id.to_s, "stolen-#{stolen_record_id}-%")
           .where("created_at < ?", check_period.last)
       end
     end

--- a/app/jobs/clean_unattached_blobs_job.rb
+++ b/app/jobs/clean_unattached_blobs_job.rb
@@ -22,8 +22,8 @@ class CleanUnattachedBlobsJob < ScheduledJob
 
   # Alert images are unattached on purpose - StolenRecord attaches them with dependent: false
   # so links to a superseded one keep resolving. BikeJobs::RemoveOrphanedImagesJob owns those
-  # and knows when they're safe to drop. The filename match covers the alerts created before
-  # StolenProcessor stamped them, and can go once none are left.
+  # and knows when they're safe to drop. The filename match covers whatever
+  # Backfills::StolenAlertBlobBinxDataJob hasn't stamped, and can go once it has run.
   def blobs
     ActiveStorage::Blob.unattached.where(created_at: ...self.class.clean_before)
       .where("binx_data->>'stolen_record_id' IS NULL")

--- a/app/jobs/clean_unattached_blobs_job.rb
+++ b/app/jobs/clean_unattached_blobs_job.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+# A blob is uploaded before the record that references it is saved, so a form the user
+# abandons after picking a file leaves a blob nothing will ever attach.
+class CleanUnattachedBlobsJob < ScheduledJob
+  prepend ScheduledJobRecorder
+
+  BATCH_SIZE = 1000 # Bounds a run; the rest keeps until tomorrow
+
+  def self.frequency
+    25.hours
+  end
+
+  # Nothing here is urgent, and a blob can legitimately wait on a confirmation email
+  def self.clean_before
+    Time.current - 30.days
+  end
+
+  def perform
+    blobs.each { it.purge_later }
+  end
+
+  # Alert images are unattached on purpose - StolenRecord attaches them with dependent: false
+  # so links to a superseded one keep resolving. BikeJobs::RemoveOrphanedImagesJob owns those
+  # and knows when they're safe to drop. The filename match covers the alerts created before
+  # StolenProcessor stamped them, and can go once none are left.
+  def blobs
+    ActiveStorage::Blob.unattached.where(created_at: ...self.class.clean_before)
+      .where("binx_data->>'stolen_record_id' IS NULL")
+      .where.not("filename ILIKE ?", "stolen-%").limit(BATCH_SIZE)
+  end
+end

--- a/app/jobs/scheduled_job_runner.rb
+++ b/app/jobs/scheduled_job_runner.rb
@@ -41,6 +41,7 @@ class ScheduledJobRunner < ScheduledJob
       BikeJobs::UpdateTheftAlertFacebookJob,
       CleanBParamsJob,
       CleanBulkImportJob,
+      CleanUnattachedBlobsJob,
       CreateGraduatedNotificationJob,
       CreateStolenGeojsonJob,
       CreateUserAlertNotificationJob,

--- a/app/models/stolen_record.rb
+++ b/app/models/stolen_record.rb
@@ -203,13 +203,13 @@ class StolenRecord < ApplicationRecord
     end
   end
 
-  # In Images::StolenProcessor we set metadata["removed"] when we remove an image
+  # Images::StolenProcessor marks the blob removed when the image it rendered from is gone
   def images_attached?
-    image_four_by_five&.attached? && image_four_by_five.blob&.metadata&.dig("removed") != true
+    image_four_by_five&.attached? && alert_blob_data("removed") != true
   end
 
   def images_attached_id
-    image_four_by_five&.blob&.metadata&.dig("image_id")
+    alert_blob_data("image_id")
   end
 
   def should_be_geocoded? = skip_geocoding.blank?
@@ -393,6 +393,13 @@ class StolenRecord < ApplicationRecord
   end
 
   private
+
+  # metadata is where these lived before binx_data, and where they stay until
+  # Backfills::StolenAlertBlobBinxDataJob has run - so binx_data wins key by key
+  def alert_blob_data(key)
+    blob = image_four_by_five&.blob
+    blob&.metadata.to_h.merge(blob&.binx_data.to_h)[key]
+  end
 
   # The read replica can't make database changes, but can enqueue the worker - which will make the changes
   def enqueue_worker(location_changed = false)

--- a/app/services/images/stolen_processor.rb
+++ b/app/services/images/stolen_processor.rb
@@ -84,29 +84,26 @@ module Images
       stolen_record.image_four_by_five.blob.created_at > images_updated
     end
 
+    # stolen_record_id is what marks these as ours to keep - a superseded alert stays
+    # unattached on purpose (dependent: false), and CleanUnattachedBlobsJob reads the stamp
+    # rather than reaping it
     def attach_images(stolen_record, image, location_text)
-      four_by_five = ActiveStorage::Blob.create_and_upload!(
-        io: generate_alert(template: :four_by_five, image:, location_text:),
-        filename: "stolen-#{stolen_record.id}-four_by_five.jpeg"
-      )
-      four_by_five.analyze
-
-      square = ActiveStorage::Blob.create_and_upload!(
-        io: generate_alert(template: :square, image:, location_text:),
-        filename: "stolen-#{stolen_record.id}-square.jpeg"
-      )
-      square.analyze
-
-      opengraph = ActiveStorage::Blob.create_and_upload!(
-        io: generate_alert(template: :opengraph, image:, location_text:),
-        filename: "stolen-#{stolen_record.id}-opengraph.jpeg"
-      )
-      opengraph.analyze
+      four_by_five = create_alert_blob(stolen_record, :four_by_five, image, location_text)
+      square = create_alert_blob(stolen_record, :square, image, location_text)
+      opengraph = create_alert_blob(stolen_record, :opengraph, image, location_text)
 
       stolen_record.image_square.attach(square)
       stolen_record.image_opengraph.attach(opengraph)
       # Attach 4 by five last, it's what sets images_attached?
       stolen_record.image_four_by_five.attach(four_by_five)
+    end
+
+    # create_and_upload! takes explicit keywords, so the stamp is a second write
+    def create_alert_blob(stolen_record, template, image, location_text)
+      ActiveStorage::Blob.create_and_upload!(
+        io: generate_alert(template:, image:, location_text:),
+        filename: "stolen-#{stolen_record.id}-#{template}.jpeg"
+      ).tap { it.update!(binx_data: {"stolen_record_id" => stolen_record.id}) }.tap(&:analyze)
     end
 
     def generate_alert(template:, image:, location_text:, convert: "jpeg")
@@ -223,8 +220,8 @@ module Images
         .gsub("'", "\\'")
     end
 
-    conceal :image_and_id, :use_stolen_images_override_id?, :attach_images, :generate_alert,
-      :template_path, :topbar_path, :bike_image_dimensions_for, :bike_image_offset,
+    conceal :image_and_id, :use_stolen_images_override_id?, :attach_images, :create_alert_blob,
+      :generate_alert, :template_path, :topbar_path, :bike_image_dimensions_for, :bike_image_offset,
       :caption_overlay, :font, :fc_list_output, :fc_list_has?, :stolen_record_location
   end
 end

--- a/app/services/images/stolen_processor.rb
+++ b/app/services/images/stolen_processor.rb
@@ -37,11 +37,10 @@ module Images
         # Prevent touching the stolen record, which kicks off a job
         ActiveRecord::Base.no_touching do
           attach_images(stolen_record, image, stolen_record_location(stolen_record))
-          stolen_record.image_four_by_five.blob.metadata["image_id"] = image_id
-          stolen_record.image_four_by_five.blob.save
+          stamp(stolen_record.image_four_by_five.blob, "image_id" => image_id).save
         end
       elsif (existing_blob = stolen_record.image_four_by_five&.blob)
-        existing_blob.metadata["removed"] = true
+        stamp(existing_blob, "removed" => true)
         # We don't want to update the bike.updated_at unless this is a change
         return unless existing_blob.changed?
 
@@ -79,7 +78,7 @@ module Images
     def use_stolen_images_override_id?(stolen_record)
       images_updated = PublicImage.unscoped.where(imageable_type: "Bike", imageable_id: stolen_record.bike_id).maximum(:updated_at)
       return false if images_updated.blank? || stolen_record.image_four_by_five&.blob&.created_at.blank? ||
-        stolen_record.images_attached_id.blank? # handle if metadata is overwritten
+        stolen_record.images_attached_id.blank? # nothing recorded the image it came from
 
       stolen_record.image_four_by_five.blob.created_at > images_updated
     end
@@ -103,7 +102,13 @@ module Images
       ActiveStorage::Blob.create_and_upload!(
         io: generate_alert(template:, image:, location_text:),
         filename: "stolen-#{stolen_record.id}-#{template}.jpeg"
-      ).tap { it.update!(binx_data: {"stolen_record_id" => stolen_record.id}) }.tap(&:analyze)
+      ).tap { stamp(it, "stolen_record_id" => stolen_record.id).save! }.tap(&:analyze)
+    end
+
+    # Our references to the records an alert came from. Not metadata - that's ActiveStorage's,
+    # and analyze merges the whole hash back off its own read
+    def stamp(blob, values)
+      blob.tap { it.binx_data = it.binx_data.to_h.merge(values) }
     end
 
     def generate_alert(template:, image:, location_text:, convert: "jpeg")
@@ -221,7 +226,8 @@ module Images
     end
 
     conceal :image_and_id, :use_stolen_images_override_id?, :attach_images, :create_alert_blob,
-      :generate_alert, :template_path, :topbar_path, :bike_image_dimensions_for, :bike_image_offset,
-      :caption_overlay, :font, :fc_list_output, :fc_list_has?, :stolen_record_location
+      :stamp, :generate_alert, :template_path, :topbar_path, :bike_image_dimensions_for,
+      :bike_image_offset, :caption_overlay, :font, :fc_list_output, :fc_list_has?,
+      :stolen_record_location
   end
 end

--- a/db/migrate/20260729085100_add_binx_data_to_active_storage_blobs.rb
+++ b/db/migrate/20260729085100_add_binx_data_to_active_storage_blobs.rb
@@ -1,0 +1,8 @@
+class AddBinxDataToActiveStorageBlobs < ActiveRecord::Migration[8.0]
+  # ActiveStorage's metadata is a text column it serializes itself, and it permits whatever the
+  # client posts into it - PROTECTED_METADATA only covers Rails' own keys. Our references to the
+  # records a blob belongs to get their own jsonb column, out of that namespace and queryable.
+  def change
+    add_column :active_storage_blobs, :binx_data, :jsonb
+  end
+end

--- a/db/primary_replica_structure.sql
+++ b/db/primary_replica_structure.sql
@@ -185,7 +185,8 @@ CREATE TABLE public.active_storage_blobs (
     service_name character varying NOT NULL,
     byte_size bigint NOT NULL,
     checksum character varying,
-    created_at timestamp(6) without time zone NOT NULL
+    created_at timestamp(6) without time zone NOT NULL,
+    binx_data jsonb
 );
 
 
@@ -7476,6 +7477,7 @@ ALTER TABLE ONLY public.bug_reports
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20260729085100'),
 ('20260725192133'),
 ('20260725155657'),
 ('20260725155259'),

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -185,7 +185,8 @@ CREATE TABLE public.active_storage_blobs (
     service_name character varying NOT NULL,
     byte_size bigint NOT NULL,
     checksum character varying,
-    created_at timestamp(6) without time zone NOT NULL
+    created_at timestamp(6) without time zone NOT NULL,
+    binx_data jsonb
 );
 
 
@@ -7476,6 +7477,7 @@ ALTER TABLE ONLY public.bug_reports
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20260729085100'),
 ('20260725192133'),
 ('20260725155657'),
 ('20260725155259'),

--- a/spec/jobs/backfills/stolen_alert_blob_binx_data_job_spec.rb
+++ b/spec/jobs/backfills/stolen_alert_blob_binx_data_job_spec.rb
@@ -1,8 +1,8 @@
 require "rails_helper"
 
 RSpec.describe Backfills::StolenAlertBlobBinxDataJob, type: :job do
-  def create_blob(filename)
-    ActiveStorage::Blob.create_and_upload!(io: StringIO.new("photo"), filename:,
+  def create_blob(filename, metadata: {})
+    ActiveStorage::Blob.create_and_upload!(io: StringIO.new("photo"), filename:, metadata:,
       content_type: "image/jpeg")
   end
 
@@ -20,6 +20,19 @@ RSpec.describe Backfills::StolenAlertBlobBinxDataJob, type: :job do
       expect(alert_image.reload.binx_data).to eq({"stolen_record_id" => 42})
       expect(stamped_alert_image.reload.binx_data).to eq({"stolen_record_id" => 9})
       expect(user_upload.reload.binx_data).to be_nil
+    end
+
+    context "metadata from before binx_data" do
+      let!(:alert_image) { create_blob("stolen-42-four_by_five.jpeg", metadata: {"image_id" => 7, "identified" => true}) }
+      let!(:removed_alert_image) { create_blob("stolen-8-four_by_five.jpeg", metadata: {"removed" => true}) }
+
+      it "migrates image_id and removed, and leaves ActiveStorage's own keys" do
+        Sidekiq::Testing.inline! { described_class.perform_async }
+
+        expect(alert_image.reload.binx_data).to eq({"stolen_record_id" => 42, "image_id" => 7})
+        expect(alert_image.metadata).to eq({"image_id" => 7, "identified" => true})
+        expect(removed_alert_image.reload.binx_data).to eq({"stolen_record_id" => 8, "removed" => true})
+      end
     end
   end
 end

--- a/spec/jobs/backfills/stolen_alert_blob_binx_data_job_spec.rb
+++ b/spec/jobs/backfills/stolen_alert_blob_binx_data_job_spec.rb
@@ -1,0 +1,25 @@
+require "rails_helper"
+
+RSpec.describe Backfills::StolenAlertBlobBinxDataJob, type: :job do
+  def create_blob(filename)
+    ActiveStorage::Blob.create_and_upload!(io: StringIO.new("photo"), filename:,
+      content_type: "image/jpeg")
+  end
+
+  describe "perform" do
+    let!(:alert_image) { create_blob("stolen-42-opengraph.jpeg") }
+    let!(:stamped_alert_image) { create_blob("stolen-9-square.jpeg") }
+    # A file the user named, not one StolenProcessor minted
+    let!(:user_upload) { create_blob("stolen-bike.jpg") }
+
+    it "stamps the alert images the filename identifies" do
+      stamped_alert_image.update!(binx_data: {"stolen_record_id" => 9})
+
+      Sidekiq::Testing.inline! { described_class.perform_async }
+
+      expect(alert_image.reload.binx_data).to eq({"stolen_record_id" => 42})
+      expect(stamped_alert_image.reload.binx_data).to eq({"stolen_record_id" => 9})
+      expect(user_upload.reload.binx_data).to be_nil
+    end
+  end
+end

--- a/spec/jobs/bike_jobs/remove_orphaned_images_job_spec.rb
+++ b/spec/jobs/bike_jobs/remove_orphaned_images_job_spec.rb
@@ -105,6 +105,23 @@ RSpec.describe BikeJobs::RemoveOrphanedImagesJob, type: :lib do
       end
     end
 
+    context "blob stamped for the stolen_record, but not named for it" do
+      let!(:stamped_blob) do
+        ActiveStorage::Blob.create_and_upload!(io: StringIO.new("photo"), filename: "alert.jpeg",
+          content_type: "image/jpeg")
+          .tap { it.update_columns(created_at: time, binx_data: {"stolen_record_id" => stolen_record.id}) }
+      end
+
+      it "purges it, rather than leaving it for a reaper that skips the stamp" do
+        expect(stolen_record.reload.images_attached?).to be_truthy
+
+        instance.perform(stolen_record.id)
+
+        expect(ActiveStorage::Blob.where(id: stamped_blob.id)).to be_empty
+        expect(stolen_record.reload.images_attached?).to be_truthy
+      end
+    end
+
     context "images removed, with the attachments still present" do
       let(:stolen_record) { FactoryBot.create(:stolen_record) }
       let!(:public_image) { FactoryBot.create(:public_image, :with_image_file, imageable: bike) }

--- a/spec/jobs/clean_unattached_blobs_job_spec.rb
+++ b/spec/jobs/clean_unattached_blobs_job_spec.rb
@@ -1,0 +1,36 @@
+require "rails_helper"
+
+RSpec.describe CleanUnattachedBlobsJob, type: :job do
+  include_context :scheduled_job
+  include_examples :scheduled_job_tests
+
+  let(:stale) { Time.current - 31.days }
+
+  def create_blob(created_at:, filename: "bike.jpg", binx_data: nil)
+    ActiveStorage::Blob.create_and_upload!(io: StringIO.new("photo"), filename:,
+      content_type: "image/jpeg").tap { it.update_columns(created_at:, binx_data:) }
+  end
+
+  it "runs about daily" do
+    expect(described_class.frequency).to be > 23.hours
+  end
+
+  describe "perform" do
+    let(:stolen_record) { FactoryBot.create(:stolen_record) }
+    let!(:attached) { create_blob(created_at: stale).tap { stolen_record.image_square.attach(it) } }
+    let!(:orphan) { create_blob(created_at: stale) }
+    let!(:recent_orphan) { create_blob(created_at: Time.current - 29.days) }
+    # BikeJobs::RemoveOrphanedImagesJob owns these - a superseded one stays unattached on purpose.
+    # StolenProcessor stamps them; the filename covers the ones minted before it did.
+    let!(:alert_image) { create_blob(created_at: stale, binx_data: {"stolen_record_id" => 42}) }
+    let!(:legacy_alert_image) { create_blob(created_at: stale, filename: "stolen-42-opengraph.jpeg") }
+
+    it "purges only the aged blobs nothing references anymore" do
+      expect(described_class.new.blobs.map(&:id)).to eq([orphan.id])
+
+      Sidekiq::Testing.inline! { described_class.new.perform }
+      expect(ActiveStorage::Blob.pluck(:id))
+        .to match_array([attached.id, recent_orphan.id, alert_image.id, legacy_alert_image.id])
+    end
+  end
+end

--- a/spec/models/stolen_record_spec.rb
+++ b/spec/models/stolen_record_spec.rb
@@ -19,6 +19,22 @@ RSpec.describe StolenRecord, type: :model do
     end
   end
 
+  describe "images_attached_id" do
+    let(:stolen_record) { FactoryBot.create(:stolen_record, :with_images) }
+    let(:blob) { stolen_record.image_four_by_five.blob }
+
+    # The window before Backfills::StolenAlertBlobBinxDataJob migrates them
+    it "falls back to the metadata the alert images used before binx_data" do
+      blob.update!(metadata: blob.metadata.merge("image_id" => 12, "removed" => true))
+      expect(stolen_record.reload.images_attached_id).to eq 12
+      expect(stolen_record.images_attached?).to be_falsey
+
+      blob.update!(binx_data: {"image_id" => 13, "removed" => false})
+      expect(stolen_record.reload.images_attached_id).to eq 13
+      expect(stolen_record.images_attached?).to be_truthy
+    end
+  end
+
   describe "after_save hooks" do
     let(:bike) { FactoryBot.create(:bike) }
     let(:stolen_record) { FactoryBot.create(:stolen_record, bike: bike) }

--- a/spec/services/images/stolen_processor_spec.rb
+++ b/spec/services/images/stolen_processor_spec.rb
@@ -44,8 +44,8 @@ RSpec.describe Images::StolenProcessor do
       expect(stolen_record.image_square.attached?).to be_truthy
       expect(stolen_record.image_opengraph.attached?).to be_truthy
       expect(stolen_record.images_attached_id).to eq public_image.id
-      expect(stolen_record.reload.image_four_by_five.blob.metadata["image_id"]).to eq public_image.id
-      expect(stolen_record.image_four_by_five.blob.binx_data).to eq({"stolen_record_id" => stolen_record.id})
+      expect(stolen_record.reload.image_four_by_five.blob.binx_data)
+        .to eq({"stolen_record_id" => stolen_record.id, "image_id" => public_image.id})
       expect(stolen_record.bike.updated_at).to be_within(1).of Time.current
       # No new jobs are enqueued
       expect(BikeJobs::AfterStolenRecordSaveJob.jobs.count).to eq 0

--- a/spec/services/images/stolen_processor_spec.rb
+++ b/spec/services/images/stolen_processor_spec.rb
@@ -45,6 +45,7 @@ RSpec.describe Images::StolenProcessor do
       expect(stolen_record.image_opengraph.attached?).to be_truthy
       expect(stolen_record.images_attached_id).to eq public_image.id
       expect(stolen_record.reload.image_four_by_five.blob.metadata["image_id"]).to eq public_image.id
+      expect(stolen_record.image_four_by_five.blob.binx_data).to eq({"stolen_record_id" => stolen_record.id})
       expect(stolen_record.bike.updated_at).to be_within(1).of Time.current
       # No new jobs are enqueued
       expect(BikeJobs::AfterStolenRecordSaveJob.jobs.count).to eq 0


### PR DESCRIPTION
Pulled out of #3974, which needs a reaper because a direct upload lands in the bucket before anything references it.

- Adds a `binx_data` jsonb column to `active_storage_blobs` for our references to the records a blob belongs to. ActiveStorage's `metadata` is a text column it serializes itself: the client can post into it (`PROTECTED_METADATA` only covers Rails' own keys), `analyze` rewrites the whole hash off its own read, and it isn't queryable.
- `CleanUnattachedBlobsJob` purges unattached blobs older than 30 days, 1000 at a time, about daily.
- Stolen alert images are unattached on purpose (`dependent: false`, so links to a superseded one keep resolving) and `BikeJobs::RemoveOrphanedImagesJob` owns them. `Images::StolenProcessor` now stamps them with their `stolen_record_id`, which is both what the reaper skips on and what `RemoveOrphanedImagesJob` collects on — a blob exempt from one and invisible to the other would leak forever. The `image_id` and `removed` stamps move to `binx_data` too, with `StolenRecord#images_attached?`/`#images_attached_id` preferring it key by key.
- `Backfills::StolenAlertBlobBinxDataJob` stamps the existing alert blobs and carries those two keys across, retiring the `metadata` and `stolen-%` filename fallbacks. It's a `Sidekiq::IterableJob` — a deploy restart resumes at the cursor rather than rescanning — and it stamps only filenames matching StolenProcessor's own format, so a photo a user named `stolen-bike.jpg` doesn't get exempted from the reaper.
