### PR TITLE
Stop deploys 502ing by switching Puma to phased restarts

### DIFF
--- a/.cloud66/manifest.yml
+++ b/.cloud66/manifest.yml
@@ -2,3 +2,8 @@ production:
   rails:
     configuration:
       node_version: "24.15.0"
+  # usr1 is a Puma phased restart: workers recycle under a master that never dies, so
+  # nginx's socket never disappears. Env var changes still need a hard restart.
+  procfile_metadata:
+    web:
+      restart_signal: usr1

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -18,12 +18,16 @@ threads min_threads_count, max_threads_count
 # Jobs do not work on JRuby or Windows (both of which do not support
 # processes).
 #
-# Clustered + preload_app! gives copy-on-write memory savings when deployed.
 # bin/env defaults WEB_CONCURRENCY to 0 in local development.
 worker_count = ENV.fetch("WEB_CONCURRENCY", 3).to_i
 if worker_count.positive?
   workers worker_count
-  preload_app!
+  # Phased restart requires prune_bundler; preloading is incompatible with it, at the
+  # cost of the copy-on-write memory sharing.
+  prune_bundler
+  # Above rack_timeout's 30s service_timeout, so a draining worker finishes its
+  # slowest legal request instead of being killed partway through it.
+  worker_shutdown_timeout 45
 else
   workers 0
 end
@@ -31,5 +35,5 @@ end
 # Set the directory to Cloud 66 specific environment variable so that puma can follow symlinks to new code on redeployment
 #
 directory ENV.fetch("STACK_PATH", ".")
-# Make sure to bind to Cloud 66 specific socket so that NGINX can direct traffic here
-#
+
+# The nginx-facing socket bind lives in the Procfile's custom_web `-b` flag, not here.


### PR DESCRIPTION
Every deploy drops about a minute of requests. On July 29 that was 21 origin 502s inside the single minute 17:24 UTC, spread across 16 unrelated paths, with no Rails logs and no Honeybadger faults — nginx had no listener on `/tmp/web_server.sock` while Puma restarted.

- Cloud 66's default restart signal for Puma is `usr2`, a hard restart that tears the socket down and recreates it. `restart_signal: usr1` makes it a phased restart instead: workers recycle under a master that never dies, so the socket nginx proxies to never disappears.
- Phased restart is incompatible with `preload_app!`, so it becomes `prune_bundler`. That ends copy-on-write sharing between the three production workers — worth watching RSS on the first deploy. Review apps run `WEB_CONCURRENCY=1`, where there was no sharing to lose.
- `worker_shutdown_timeout 45`: Puma's 30s default is exactly `rack_timeout`'s `service_timeout`, so a draining worker could be SIGKILLed partway through a request that was still within its budget — reintroducing the same dropped-connection symptom for the slow tail.

Two things this doesn't cover. Env var changes still force a full hard restart, so those deploys will still blip. And old and new code now coexist for the length of a restart, which makes backward-compatible migrations an implicit requirement the repo has no lint or convention for yet.

Cloud 66 documents the metadata key as `web` even though the Procfile process is `custom_web`, and the page that would define the key 404s. If a deploy still shows an origin-502 minute in `binx_cf_edge 30M originminute`, `custom_web` is the thing to try before suspecting the signal.
