### PR TITLE
Hold the form while the email field has something to say

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,7 +21,7 @@ Run `bin/lint` to automatically format the code. Always use `bin/lint`, don't us
 - Omit named arguments' values from hashes (ie prefer `{x:, y:}` instead of `{x: x, y: y}`)
 - Prefer less code, by character count (excluding whitespace and comments). Use `bin/char_count {FILE OR FOLDER}` to get the non-whitespace character count
 - prefer un-abbreviated variable names
-- Keep comments pithy — often they aren't necessary. Explain *why* for a future reader; don't narrate the change that introduced the code
+- Keep comments pithy — often they aren't necessary. Explain *why* only where a reader would otherwise get it wrong; don't narrate the change that introduced the code, and don't defend a choice against an edit nobody would make — a failing test already defends it
 - **Service objects** (`app/services/`): a stateless service is a `module` with `extend Functionable` (see the `functionable` gem) — inputs passed as args, no instance state, private methods via `conceal` + a `# private below here` block. Reach for a `class` only when the object genuinely holds instance state across methods (e.g. a multi-step builder/updater). Don't write a stateless service as a `class` with `def self.` methods.
 
 ## Subagents

--- a/app/assets/stylesheets/kelsey/landing_pages.css
+++ b/app/assets/stylesheets/kelsey/landing_pages.css
@@ -102,6 +102,15 @@
   color: var(--redesign-blue-800);
 }
 
+/* After :hover, which still matches a disabled input in some browsers */
+.kelsey_styles .le-btn-primary:disabled {
+  background: #ffd660;
+  border-color: #ffd660;
+  transform: none;
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
 .kelsey_styles .le-btn-secondary {
   background-color: transparent;
   color: white;

--- a/app/components/ui/forms/email/component.en.yml
+++ b/app/components/ui/forms/email/component.en.yml
@@ -4,6 +4,6 @@ en:
     ui:
       forms:
         email:
-          did_you_mean: Did you mean %{email}?
+          did_you_mean_html: Did you mean %{email}?
           not_real: That doesn't look like your real email address. Please enter an email address where you receive email
           submit_anyway: Submit form anyway

--- a/app/components/ui/forms/email/component.en.yml
+++ b/app/components/ui/forms/email/component.en.yml
@@ -5,3 +5,4 @@ en:
       forms:
         email:
           did_you_mean: Did you mean %{email}?
+          not_real: That doesn't look like your real email address. Please enter an email address where you receive email

--- a/app/components/ui/forms/email/component.en.yml
+++ b/app/components/ui/forms/email/component.en.yml
@@ -5,5 +5,7 @@ en:
       forms:
         email:
           did_you_mean_html: Did you mean %{email}?
-          not_real: That doesn't look like your real email address. Please enter an email address where you receive email
+          not_real: >-
+            That doesn't look like your real email address. Please enter an email
+            address where you receive email
           submit_anyway: Submit form anyway

--- a/app/components/ui/forms/email/component.en.yml
+++ b/app/components/ui/forms/email/component.en.yml
@@ -6,3 +6,4 @@ en:
         email:
           did_you_mean: Did you mean %{email}?
           not_real: That doesn't look like your real email address. Please enter an email address where you receive email
+          submit_anyway: Submit form anyway

--- a/app/components/ui/forms/email/component.html.erb
+++ b/app/components/ui/forms/email/component.html.erb
@@ -1,7 +1,7 @@
 <%# focusout rather than blur, which doesn't bubble up to the controller. %>
 <div
   data-controller="ui--forms--email"
-  data-action="focusout->ui--forms--email#check"
+  data-action="focusout->ui--forms--email#check keydown.enter->ui--forms--email#checkOnEnter"
   data-ui--forms--email-message-value="<%= translation(".did_you_mean") %>"
 >
   <%= render(UI::Forms::Input::Component.new(form_builder: @form_builder, attribute: @attribute,

--- a/app/components/ui/forms/email/component.html.erb
+++ b/app/components/ui/forms/email/component.html.erb
@@ -1,8 +1,7 @@
 <%# focusout rather than blur, which doesn't bubble up to the controller. %>
 <div
   data-controller="ui--forms--email"
-  data-action="focusout->ui--forms--email#check keydown.enter->ui--forms--email#checkOnEnter"
-  data-ui--forms--email-message-value="<%= translation(".did_you_mean") %>"
+  data-action="focusout->ui--forms--email#check keydown.enter->ui--forms--email#checkOnEnter input->ui--forms--email#clear"
   data-ui--forms--email-reserved-value="<%= reserved_pattern %>"
 >
   <%= render(UI::Forms::Input::Component.new(form_builder: @form_builder, attribute: @attribute,
@@ -10,9 +9,19 @@
 
   <%# The region outlives the messages inside it -- one added along with its text has nothing to announce. %>
   <div aria-live="polite">
-    <%# hidden!, since the button's own tw:inline-flex sorts after tw:hidden. %>
-    <%= render(UI::Button::Component.new(color: :link, html_class: "tw:mt-1 tw:hidden! tw:text-sm",
-      data: {"ui--forms--email-target": "suggestion", action: "ui--forms--email#accept"})) %>
+    <%#
+      The paragraph is what hides, so the button inside it needs no tw:hidden of its own.
+      atomic, because only the address inside it changes -- the sentence around it is
+      what's worth announcing.
+    %>
+
+    <p
+      class="tw:mt-1 tw:hidden tw:text-sm"
+      aria-atomic="true"
+      data-ui--forms--email-target="suggestion"
+    >
+      <%= did_you_mean_markup %>
+    </p>
 
     <%# Text rather than a button, there being no correction to accept. %>
     <p
@@ -28,8 +37,10 @@
     %>
 
     <div>
+      <%# Gray rather than twlink's blue, so it reads as the lesser of the two ways out. %>
       <%= render(UI::Button::Component.new(text: translation(".submit_anyway"), color: :link,
-        html_class: "tw:mt-1 tw:hidden! tw:text-sm",
+        html_class: "tw:mt-1 tw:hidden! tw:text-sm tw:text-gray-500 tw:hover:text-gray-700 " \
+          "tw:dark:text-gray-400 tw:dark:hover:text-gray-200",
         data: {"ui--forms--email-target": "override", action: "ui--forms--email#submitAnyway"})) %>
     </div>
   </div>

--- a/app/components/ui/forms/email/component.html.erb
+++ b/app/components/ui/forms/email/component.html.erb
@@ -21,5 +21,16 @@
     >
       <%= translation(".not_real") %>
     </p>
+
+    <%#
+      The way past whichever message is showing, next to what it's asking about.
+      Wrapped, so it takes its own line without a display utility racing tw:inline-flex.
+    %>
+
+    <div>
+      <%= render(UI::Button::Component.new(text: translation(".submit_anyway"), color: :link,
+        html_class: "tw:mt-1 tw:hidden! tw:text-sm",
+        data: {"ui--forms--email-target": "override", action: "ui--forms--email#submitAnyway"})) %>
+    </div>
   </div>
 </div>

--- a/app/components/ui/forms/email/component.html.erb
+++ b/app/components/ui/forms/email/component.html.erb
@@ -3,14 +3,23 @@
   data-controller="ui--forms--email"
   data-action="focusout->ui--forms--email#check keydown.enter->ui--forms--email#checkOnEnter"
   data-ui--forms--email-message-value="<%= translation(".did_you_mean") %>"
+  data-ui--forms--email-reserved-value="<%= reserved_pattern %>"
 >
   <%= render(UI::Forms::Input::Component.new(form_builder: @form_builder, attribute: @attribute,
     required: @required, html_options: @html_options)) %>
 
-  <%# The region outlives the suggestion inside it -- one added along with its text has nothing to announce. %>
+  <%# The region outlives the messages inside it -- one added along with its text has nothing to announce. %>
   <div aria-live="polite">
     <%# hidden!, since the button's own tw:inline-flex sorts after tw:hidden. %>
     <%= render(UI::Button::Component.new(color: :link, html_class: "tw:mt-1 tw:hidden! tw:text-sm",
       data: {"ui--forms--email-target": "suggestion", action: "ui--forms--email#accept"})) %>
+
+    <%# Text rather than a button, there being no correction to accept. %>
+    <p
+      class="tw:mt-1 tw:hidden tw:text-sm tw:text-red-800 tw:dark:text-red-400"
+      data-ui--forms--email-target="warning"
+    >
+      <%= translation(".not_real") %>
+    </p>
   </div>
 </div>

--- a/app/components/ui/forms/email/component.rb
+++ b/app/components/ui/forms/email/component.rb
@@ -23,6 +23,13 @@ module UI
         def reserved_pattern
           EmailDomain::RESERVED_REGEX.source.gsub(/\s/, "").gsub("\\A", "^").gsub("\\z", "$")
         end
+
+        # Only the address is the button. It renders empty -- the controller fills it in,
+        # the address not being known until the field is checked.
+        def did_you_mean_markup
+          translation(".did_you_mean_html", email: render(UI::Button::Component.new(color: :link,
+            data: {"ui--forms--email-target": "correction", action: "ui--forms--email#accept"})))
+        end
       end
     end
   end

--- a/app/components/ui/forms/email/component.rb
+++ b/app/components/ui/forms/email/component.rb
@@ -15,6 +15,14 @@ module UI
           # UI::Forms::Input has no email kind, so the type comes from here
           @html_options = {type: "email", data: {"ui--forms--email-target": "input"}}.deep_merge(html_options)
         end
+
+        private
+
+        # The one definition of a domain no message reaches, spent client side too.
+        # JS has no \A or \z, where ^ and $ mean the same thing without /m.
+        def reserved_pattern
+          EmailDomain::RESERVED_REGEX.source.gsub(/\s/, "").gsub("\\A", "^").gsub("\\z", "$")
+        end
       end
     end
   end

--- a/app/components/ui/forms/email/component_preview/default.html.erb
+++ b/app/components/ui/forms/email/component_preview/default.html.erb
@@ -2,4 +2,7 @@
   <%= render(UI::Forms::Group::Component.new(form_builder: f, attribute: :email, required: true)) do %>
     <%= render(UI::Forms::Email::Component.new(form_builder: f, required: true)) %>
   <% end %>
+
+  <%# A message holds the form's own submit, so the preview needs one. %>
+  <%= render(UI::Button::Component.new(text: "Register", color: :primary, kind: :submit)) %>
 <% end %>

--- a/app/components/ui/forms/email/component_preview/mistyped.html.erb
+++ b/app/components/ui/forms/email/component_preview/mistyped.html.erb
@@ -2,4 +2,12 @@
   <%= render(UI::Forms::Group::Component.new(form_builder: f, attribute: :email)) do %>
     <%= render(UI::Forms::Email::Component.new(form_builder: f, html_options: {value: "you@gmial.con"})) %>
   <% end %>
+
+  <%= render(UI::Button::Component.new(text: "Register", color: :primary, kind: :submit)) %>
+
+  <%#
+    Stands in for a submit something else is holding -- ui--button--submit-spinner
+    disables the same bit to see off a second submit.
+  %>
+  <%= render(UI::Button::Component.new(text: "Held elsewhere", kind: :submit, disabled: true)) %>
 <% end %>

--- a/app/javascript/controllers/ui/forms/email_controller.js
+++ b/app/javascript/controllers/ui/forms/email_controller.js
@@ -17,6 +17,16 @@ export default class extends Controller {
     collapse('show', this.suggestionTarget)
   }
 
+  // Enter never leaves the field, so the value is checked here too -- and a suggestion
+  // takes the keystroke, since submitting past one is what it's there to ask about.
+  // Enter on the suggestion itself is the button's, which is what accepts it.
+  checkOnEnter (event) {
+    if (event.target !== this.inputTarget) return
+
+    this.check()
+    if (this.suggested) event.preventDefault()
+  }
+
   accept () {
     this.inputTarget.value = this.suggested
     collapse('hide', this.suggestionTarget)

--- a/app/javascript/controllers/ui/forms/email_controller.js
+++ b/app/javascript/controllers/ui/forms/email_controller.js
@@ -4,12 +4,13 @@ import { collapse } from 'utils/collapse_utils'
 // Connects to data-controller='ui--forms--email'
 // Offers a correction whenever the field is left holding a near-miss of a well known
 // email domain, and swaps it in if the suggestion is clicked. A domain no message can
-// arrive at gets the warning instead, which there's nothing to correct it to.
+// arrive at gets the warning instead, which there's nothing to correct it to. Either
+// one holds the form until it's answered, or the way past it is taken.
 export default class extends Controller {
-  static targets = ['input', 'suggestion', 'warning']
+  static targets = ['input', 'suggestion', 'warning', 'override']
   static values = { message: String, reserved: String }
 
-  // Whether the field has something to say, which is what holds enter back.
+  // Whether the field has something to say, which is what holds the form back.
   check () {
     const email = this.inputTarget.value
     // The domain's, the way the server's is -- SpamEstimator::Bike#reserved_email_domain?
@@ -23,12 +24,15 @@ export default class extends Controller {
     collapse(this.suggested ? 'show' : 'hide', this.suggestionTarget)
     collapse(reserved ? 'show' : 'hide', this.warningTarget)
 
-    return reserved || Boolean(this.suggested)
+    const held = reserved || Boolean(this.suggested)
+    this.hold(held)
+
+    return held
   }
 
-  // Enter never leaves the field, so the value is checked here too -- and either message
+  // Enter never leaves the field, so the value is checked here too -- and a message
   // takes the keystroke, since submitting past one is what it's there to ask about.
-  // Enter on the suggestion itself is the button's, which is what accepts it.
+  // Enter on a button of ours is that button's, which is what answers it.
   checkOnEnter (event) {
     if (event.target !== this.inputTarget) return
 
@@ -37,12 +41,37 @@ export default class extends Controller {
 
   accept () {
     this.inputTarget.value = this.suggested
-    collapse('hide', this.suggestionTarget)
     // Assigning a value fires neither event, and anything watching the field expects both.
     this.inputTarget.dispatchEvent(new Event('input', { bubbles: true }))
     this.inputTarget.dispatchEvent(new Event('change', { bubbles: true }))
+    // The correction can be a domain the warning is about, so it's checked like any other.
+    this.check()
     // The suggestion is on its way out, so focus can't stay on it.
     this.inputTarget.focus()
+  }
+
+  submitAnyway () {
+    collapse('hide', [this.suggestionTarget, this.warningTarget])
+    this.hold(false)
+    this.form?.requestSubmit()
+  }
+
+  // The submit belongs to the form rather than to us, so releasing it puts back only
+  // what we took -- ui--button--submit-spinner disables the same button to see off a
+  // second submit, and a clean focusout has no business undoing that.
+  hold (held) {
+    collapse(held ? 'show' : 'hide', this.overrideTarget)
+    this.holding?.forEach((submit) => { submit.disabled = false })
+    this.holding = held ? [...this.submits].filter((submit) => !submit.disabled) : []
+    this.holding.forEach((submit) => { submit.disabled = true })
+  }
+
+  get form () {
+    return this.element.closest('form')
+  }
+
+  get submits () {
+    return this.form?.querySelectorAll('[type="submit"]') ?? []
   }
 }
 

--- a/app/javascript/controllers/ui/forms/email_controller.js
+++ b/app/javascript/controllers/ui/forms/email_controller.js
@@ -3,28 +3,36 @@ import { collapse } from 'utils/collapse_utils'
 
 // Connects to data-controller='ui--forms--email'
 // Offers a correction whenever the field is left holding a near-miss of a well known
-// email domain, and swaps it in if the suggestion is clicked.
+// email domain, and swaps it in if the suggestion is clicked. A domain no message can
+// arrive at gets the warning instead, which there's nothing to correct it to.
 export default class extends Controller {
-  static targets = ['input', 'suggestion']
-  static values = { message: String }
+  static targets = ['input', 'suggestion', 'warning']
+  static values = { message: String, reserved: String }
 
+  // Whether the field has something to say, which is what holds enter back.
   check () {
-    this.suggested = suggest(this.inputTarget.value)
-    if (!this.suggested) return collapse('hide', this.suggestionTarget)
+    const email = this.inputTarget.value
+    // The domain's, the way the server's is -- SpamEstimator::Bike#reserved_email_domain?
+    const reserved = new RegExp(this.reservedValue, 'i').test(email.split('@').at(-1).trim())
+    this.suggested = reserved ? null : suggest(email)
 
-    // Before showing: collapse animates to the height the text gives it.
-    this.suggestionTarget.textContent = this.messageValue.replace('%{email}', this.suggested)
-    collapse('show', this.suggestionTarget)
+    // Set before showing: collapse animates to the height the text gives it.
+    if (this.suggested) {
+      this.suggestionTarget.textContent = this.messageValue.replace('%{email}', this.suggested)
+    }
+    collapse(this.suggested ? 'show' : 'hide', this.suggestionTarget)
+    collapse(reserved ? 'show' : 'hide', this.warningTarget)
+
+    return reserved || Boolean(this.suggested)
   }
 
-  // Enter never leaves the field, so the value is checked here too -- and a suggestion
+  // Enter never leaves the field, so the value is checked here too -- and either message
   // takes the keystroke, since submitting past one is what it's there to ask about.
   // Enter on the suggestion itself is the button's, which is what accepts it.
   checkOnEnter (event) {
     if (event.target !== this.inputTarget) return
 
-    this.check()
-    if (this.suggested) event.preventDefault()
+    if (this.check()) event.preventDefault()
   }
 
   accept () {

--- a/app/javascript/controllers/ui/forms/email_controller.js
+++ b/app/javascript/controllers/ui/forms/email_controller.js
@@ -7,8 +7,8 @@ import { collapse } from 'utils/collapse_utils'
 // arrive at gets the warning instead, which there's nothing to correct it to. Either
 // one holds the form until it's answered, or the way past it is taken.
 export default class extends Controller {
-  static targets = ['input', 'suggestion', 'warning', 'override']
-  static values = { message: String, reserved: String }
+  static targets = ['input', 'suggestion', 'correction', 'warning', 'override']
+  static values = { reserved: String }
 
   // Whether the field has something to say, which is what holds the form back.
   check () {
@@ -18,9 +18,7 @@ export default class extends Controller {
     this.suggested = reserved ? null : suggest(email)
 
     // Set before showing: collapse animates to the height the text gives it.
-    if (this.suggested) {
-      this.suggestionTarget.textContent = this.messageValue.replace('%{email}', this.suggested)
-    }
+    if (this.suggested) this.correctionTarget.textContent = this.suggested
     collapse(this.suggested ? 'show' : 'hide', this.suggestionTarget)
     collapse(reserved ? 'show' : 'hide', this.warningTarget)
 
@@ -28,6 +26,13 @@ export default class extends Controller {
     this.hold(held)
 
     return held
+  }
+
+  // Typing answers whatever was asked, so the field goes quiet and hands the form back
+  // until the value settles and focusout checks it again.
+  clear () {
+    collapse('hide', [this.suggestionTarget, this.warningTarget])
+    this.hold(false)
   }
 
   // Enter never leaves the field, so the value is checked here too -- and a message
@@ -42,6 +47,7 @@ export default class extends Controller {
   accept () {
     this.inputTarget.value = this.suggested
     // Assigning a value fires neither event, and anything watching the field expects both.
+    // The input is one of those watchers, so this runs clear() -- check() has to follow it.
     this.inputTarget.dispatchEvent(new Event('input', { bubbles: true }))
     this.inputTarget.dispatchEvent(new Event('change', { bubbles: true }))
     // The correction can be a domain the warning is about, so it's checked like any other.
@@ -51,8 +57,7 @@ export default class extends Controller {
   }
 
   submitAnyway () {
-    collapse('hide', [this.suggestionTarget, this.warningTarget])
-    this.hold(false)
+    this.clear()
     this.form?.requestSubmit()
   }
 

--- a/app/models/email_domain.rb
+++ b/app/models/email_domain.rb
@@ -25,6 +25,12 @@ class EmailDomain < ApplicationRecord
   include StatusHumanizable
 
   INVALID_REGEX = /[\/\\()\[\]=\s!"']/
+  # RFC 2606 / 6761 reserved domains, which no message ever arrives at. Also checked
+  # client side, so keep it to syntax JS shares -- see UI::Forms::Email::Component.
+  RESERVED_REGEX = /
+    \A(?:.+\.)?example\.(?:com|net|org)\z |
+    (?:\A|\.)(?:test|example|invalid|localhost)\z
+  /xi
   INVALID_DOMAIN = "(invalid).domain"
   EMAIL_MIN_COUNT = ENV.fetch("EMAIL_DOMAIN_BAN_USER_MIN_COUNT", 3).to_i
   STATUS_ENUM = {permitted: 0, provisional_ban: 1, banned: 2, ignored: 3}.freeze

--- a/app/services/spam_estimator/bike.rb
+++ b/app/services/spam_estimator/bike.rb
@@ -4,12 +4,6 @@ module SpamEstimator
 
     MARK_SPAM_PERCENT = 90 # May modify in the future!
 
-    # RFC 2606 / 6761 reserved domains, which can never be a real registrant
-    RESERVED_EMAIL_DOMAIN_REGEX = /
-      \A(?:.+\.)?example\.(?:com|net|org)\z |
-      (?:\A|\.)(?:test|example|invalid|localhost)\z
-    /xi
-
     def estimate(bike, stolen_record = nil)
       estimate = 0
       return estimate if bike.blank?
@@ -43,7 +37,7 @@ module SpamEstimator
       domain = email&.split("@")&.last&.strip
       return false if domain.blank?
 
-      domain.match?(RESERVED_EMAIL_DOMAIN_REGEX)
+      domain.match?(EmailDomain::RESERVED_REGEX)
     end
 
     def domain_estimate(email)

--- a/spec/components/ui/button/component_system_spec.rb
+++ b/spec/components/ui/button/component_system_spec.rb
@@ -18,7 +18,8 @@ RSpec.describe UI::Button::Component, :js, type: :system do
     expect(page).to have_button("Next")
     expect(page).to have_no_css(spinner)
 
-    fill_in "Email", with: "user@example.com"
+    # Not an RFC 2606 domain: the field holds the form on one, and this submit has to land
+    fill_in "Email", with: "user@bikeindex.org"
     click_button "Next"
 
     expect(page).to have_css(spinner)

--- a/spec/components/ui/button/component_system_spec.rb
+++ b/spec/components/ui/button/component_system_spec.rb
@@ -18,7 +18,6 @@ RSpec.describe UI::Button::Component, :js, type: :system do
     expect(page).to have_button("Next")
     expect(page).to have_no_css(spinner)
 
-    # Not an RFC 2606 domain: the field holds the form on one, and this submit has to land
     fill_in "Email", with: "user@bikeindex.org"
     click_button "Next"
 

--- a/spec/components/ui/forms/email/component_spec.rb
+++ b/spec/components/ui/forms/email/component_spec.rb
@@ -13,12 +13,19 @@ RSpec.describe UI::Forms::Email::Component, type: :component do
   it "renders an email field with both messages hidden" do
     expect(component).to have_css("input.twinput[type='email'][name='user[email]'][data-ui--forms--email-target='input']")
     expect(component).to_not have_css("input[required]")
-    expect(component).to have_css("[data-ui--forms--email-message-value='Did you mean %{email}?']")
-    expect(component).to have_css("[aria-live='polite'] button[class~='tw:hidden!'][data-ui--forms--email-target='suggestion']")
     expect(component).to have_css("[aria-live='polite'] p[class~='tw:hidden'][data-ui--forms--email-target='warning']",
       text: "That doesn't look like your real email address. Please enter an email address where you receive email")
     expect(component).to have_css("[aria-live='polite'] div button[class~='tw:hidden!'][data-ui--forms--email-target='override']",
       text: "Submit form anyway")
+  end
+
+  # Only the address is a button, and the controller is what fills it in
+  it "wraps an empty correction button in the message that carries it" do
+    expect(component).to have_css("p[data-ui--forms--email-target='suggestion']", text: "Did you mean ?")
+    expect(component).to have_css("p[data-ui--forms--email-target='suggestion'] " \
+      "button[data-ui--forms--email-target='correction']", text: "")
+    # the "?" sits against the button, with no space formatting could have left behind
+    expect(component.to_html).to include("</button>?")
   end
 
   # EmailDomain::RESERVED_REGEX is what the server checks, so this pins the syntax the

--- a/spec/components/ui/forms/email/component_spec.rb
+++ b/spec/components/ui/forms/email/component_spec.rb
@@ -17,6 +17,8 @@ RSpec.describe UI::Forms::Email::Component, type: :component do
     expect(component).to have_css("[aria-live='polite'] button[class~='tw:hidden!'][data-ui--forms--email-target='suggestion']")
     expect(component).to have_css("[aria-live='polite'] p[class~='tw:hidden'][data-ui--forms--email-target='warning']",
       text: "That doesn't look like your real email address. Please enter an email address where you receive email")
+    expect(component).to have_css("[aria-live='polite'] div button[class~='tw:hidden!'][data-ui--forms--email-target='override']",
+      text: "Submit form anyway")
   end
 
   # EmailDomain::RESERVED_REGEX is what the server checks, so this pins the syntax the

--- a/spec/components/ui/forms/email/component_spec.rb
+++ b/spec/components/ui/forms/email/component_spec.rb
@@ -10,11 +10,20 @@ RSpec.describe UI::Forms::Email::Component, type: :component do
   let(:component) { render_inline(described_class.new(form_builder:, **options)) }
   let(:options) { {} }
 
-  it "renders an email field with the suggestion hidden" do
+  it "renders an email field with both messages hidden" do
     expect(component).to have_css("input.twinput[type='email'][name='user[email]'][data-ui--forms--email-target='input']")
     expect(component).to_not have_css("input[required]")
     expect(component).to have_css("[data-ui--forms--email-message-value='Did you mean %{email}?']")
     expect(component).to have_css("[aria-live='polite'] button[class~='tw:hidden!'][data-ui--forms--email-target='suggestion']")
+    expect(component).to have_css("[aria-live='polite'] p[class~='tw:hidden'][data-ui--forms--email-target='warning']",
+      text: "That doesn't look like your real email address. Please enter an email address where you receive email")
+  end
+
+  # EmailDomain::RESERVED_REGEX is what the server checks, so this pins the syntax the
+  # two share -- \A and \z would leave the controller with an unusable pattern.
+  it "hands the controller the reserved-domain pattern as javascript reads it" do
+    expect(component.css("[data-controller]").first["data-ui--forms--email-reserved-value"])
+      .to eq '^(?:.+\.)?example\.(?:com|net|org)$|(?:^|\.)(?:test|example|invalid|localhost)$'
   end
 
   context "with required and html_options" do

--- a/spec/components/ui/forms/email/component_system_spec.rb
+++ b/spec/components/ui/forms/email/component_system_spec.rb
@@ -98,12 +98,18 @@ RSpec.describe UI::Forms::Email::Component, :js, type: :system do
     expect(page).to have_no_css(suggestion_button)
   end
 
-  it "checks a value the field is rendered with, and accepts it from the keyboard" do
+  it "checks a value the field is rendered with, and spends enter on the suggestion before the form" do
     visit("#{base_path}mistyped")
 
     find_field("Email").send_keys(:tab)
 
     expect(page).to have_button(suggestion)
+
+    find_field("Email").send_keys(:enter)
+
+    # submitting would have taken us off the preview, which still has the field and the suggestion
+    expect(page).to have_button(suggestion)
+    expect(page).to have_field("Email", with: "you@gmial.con")
 
     find_button(suggestion).send_keys(:enter)
 
@@ -111,5 +117,10 @@ RSpec.describe UI::Forms::Email::Component, :js, type: :system do
     expect(page).to have_no_css(suggestion_button)
     # the suggestion is gone, so focus goes back where it came from
     expect(page).to have_css("input[type='email']:focus")
+
+    # and with nothing left to ask about, enter reaches the form
+    find_field("Email").send_keys(:enter)
+
+    expect(page).to have_no_field("Email")
   end
 end

--- a/spec/components/ui/forms/email/component_system_spec.rb
+++ b/spec/components/ui/forms/email/component_system_spec.rb
@@ -5,8 +5,10 @@ require "rails_helper"
 RSpec.describe UI::Forms::Email::Component, :js, type: :system do
   let(:base_path) { "/rails/view_components/ui/forms/email/component/" }
   let(:suggestion) { "Did you mean you@gmail.com?" }
-  let(:suggestion_button) { "[aria-live='polite'] button" }
+  # the suggestion's text varies, so it's found by target rather than by name
+  let(:suggestion_button) { "[data-ui--forms--email-target='suggestion']" }
   let(:warning) { "That doesn't look like your real email address." }
+  let(:override) { "Submit form anyway" }
 
   # Leaving the field is what checks it
   def fill_in_email_and_leave(email)
@@ -17,21 +19,28 @@ RSpec.describe UI::Forms::Email::Component, :js, type: :system do
   it "checks the field on leaving it -- suggesting a correction, warning where there's none to offer, swapping it in when clicked" do
     visit("#{base_path}default")
 
-    # the button ships hidden -- an empty one in the tab order is both a stop to
-    # nowhere and a control with no name
+    # the buttons ship hidden -- an empty one in the tab order is both a stop to
+    # nowhere and a control with no name, and there's nothing yet to submit past
     expect(page).to have_no_css(suggestion_button)
+    expect(page).to have_no_button(override)
+    expect(page).to have_button("Register", disabled: false)
     expect_axe_clean
 
     fill_in_email_and_leave("you@gmial.con")
 
     # announced as it appears, so the region carries it rather than the button alone
     expect(page).to have_css("[aria-live='polite']", text: suggestion)
+    # the form's own submit is held while it stands, with the way past it alongside
+    expect(page).to have_button("Register", disabled: true)
+    expect(page).to have_button(override)
     expect_axe_clean
 
     click_on suggestion
 
     expect(page).to have_field("Email", with: "you@gmail.com")
     expect(page).to have_no_css(suggestion_button)
+    # answered, so the form is the user's again
+    expect(page).to have_button("Register", disabled: false)
 
     # a domain nobody knows keeps its name, but its ending is still checked
     fill_in_email_and_leave("you@bikeshop.con")
@@ -119,6 +128,7 @@ RSpec.describe UI::Forms::Email::Component, :js, type: :system do
     fill_in_email_and_leave("you@example.co")
 
     expect(page).to have_no_text(warning)
+    expect(page).to have_button("Register", disabled: false)
 
     # and enter is spent on the warning too, there being no correction to offer instead
     fill_in "Email", with: "you@example.com"
@@ -127,6 +137,11 @@ RSpec.describe UI::Forms::Email::Component, :js, type: :system do
     expect(page).to have_text(warning)
     # submitting would have taken us off the preview
     expect(page).to have_field("Email", with: "you@example.com")
+
+    # which is what the way past is for -- the address stands as typed
+    click_on override
+
+    expect(page).to have_no_field("Email")
   end
 
   it "checks a value the field is rendered with, and spends enter on the suggestion before the form" do
@@ -146,6 +161,9 @@ RSpec.describe UI::Forms::Email::Component, :js, type: :system do
 
     expect(page).to have_field("Email", with: "you@gmail.com")
     expect(page).to have_no_css(suggestion_button)
+    expect(page).to have_button("Register", disabled: false)
+    # releasing puts back only what the hold took, so a submit held elsewhere stays held
+    expect(page).to have_button("Held elsewhere", disabled: true)
     # the suggestion is gone, so focus goes back where it came from
     expect(page).to have_css("input[type='email']:focus")
 

--- a/spec/components/ui/forms/email/component_system_spec.rb
+++ b/spec/components/ui/forms/email/component_system_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe UI::Forms::Email::Component, :js, type: :system do
   let(:base_path) { "/rails/view_components/ui/forms/email/component/" }
   let(:suggestion) { "Did you mean you@gmail.com?" }
   let(:suggestion_button) { "[aria-live='polite'] button" }
+  let(:warning) { "That doesn't look like your real email address." }
 
   # Leaving the field is what checks it
   def fill_in_email_and_leave(email)
@@ -13,7 +14,7 @@ RSpec.describe UI::Forms::Email::Component, :js, type: :system do
     find_field("Email").send_keys(:tab)
   end
 
-  it "suggests a correction on leaving the field, holds its peace where it has none, and swaps it in when clicked" do
+  it "checks the field on leaving it -- suggesting a correction, warning where there's none to offer, swapping it in when clicked" do
     visit("#{base_path}default")
 
     # the button ships hidden -- an empty one in the tab order is both a stop to
@@ -96,6 +97,36 @@ RSpec.describe UI::Forms::Email::Component, :js, type: :system do
     fill_in_email_and_leave("you@gmail.com")
 
     expect(page).to have_no_css(suggestion_button)
+
+    # a domain RFC 2606 holds back has nothing to correct it to, so it's told rather than asked
+    fill_in_email_and_leave("you@example.com")
+
+    expect(page).to have_css("[aria-live='polite']", text: warning)
+    expect(page).to have_no_css(suggestion_button)
+    expect_axe_clean
+
+    # subdomains of one included, matching what the server scores as spam
+    fill_in_email_and_leave("you@mail.example.org")
+
+    expect(page).to have_text(warning)
+
+    # as are its endings, however deliverable the name in front of one reads
+    fill_in_email_and_leave("you@bikeshop.invalid")
+
+    expect(page).to have_text(warning)
+
+    # ".co" is a country's rather than one of them, so the field keeps its peace
+    fill_in_email_and_leave("you@example.co")
+
+    expect(page).to have_no_text(warning)
+
+    # and enter is spent on the warning too, there being no correction to offer instead
+    fill_in "Email", with: "you@example.com"
+    find_field("Email").send_keys(:enter)
+
+    expect(page).to have_text(warning)
+    # submitting would have taken us off the preview
+    expect(page).to have_field("Email", with: "you@example.com")
   end
 
   it "checks a value the field is rendered with, and spends enter on the suggestion before the form" do

--- a/spec/components/ui/forms/email/component_system_spec.rb
+++ b/spec/components/ui/forms/email/component_system_spec.rb
@@ -4,9 +4,11 @@ require "rails_helper"
 
 RSpec.describe UI::Forms::Email::Component, :js, type: :system do
   let(:base_path) { "/rails/view_components/ui/forms/email/component/" }
+  # the whole message is text; only the address inside it is the button
   let(:suggestion) { "Did you mean you@gmail.com?" }
-  # the suggestion's text varies, so it's found by target rather than by name
-  let(:suggestion_button) { "[data-ui--forms--email-target='suggestion']" }
+  let(:correction) { "you@gmail.com" }
+  # the correction's name varies, so the message is found by target rather than by name
+  let(:suggestion_message) { "[data-ui--forms--email-target='suggestion']" }
   let(:warning) { "That doesn't look like your real email address." }
   let(:override) { "Submit form anyway" }
 
@@ -21,7 +23,7 @@ RSpec.describe UI::Forms::Email::Component, :js, type: :system do
 
     # the buttons ship hidden -- an empty one in the tab order is both a stop to
     # nowhere and a control with no name, and there's nothing yet to submit past
-    expect(page).to have_no_css(suggestion_button)
+    expect(page).to have_no_css(suggestion_message)
     expect(page).to have_no_button(override)
     expect(page).to have_button("Register", disabled: false)
     expect_axe_clean
@@ -35,83 +37,95 @@ RSpec.describe UI::Forms::Email::Component, :js, type: :system do
     expect(page).to have_button(override)
     expect_axe_clean
 
-    click_on suggestion
+    # typing answers it, so the field goes quiet and hands the form back at once
+    find_field("Email").send_keys("m")
+
+    expect(page).to have_no_css(suggestion_message)
+    expect(page).to have_no_button(override)
+    expect(page).to have_button("Register", disabled: false)
+
+    # and it has its say again once the value settles
+    fill_in_email_and_leave("you@gmial.con")
+
+    expect(page).to have_css("[aria-live='polite']", text: suggestion)
+
+    click_on correction
 
     expect(page).to have_field("Email", with: "you@gmail.com")
-    expect(page).to have_no_css(suggestion_button)
+    expect(page).to have_no_css(suggestion_message)
     # answered, so the form is the user's again
     expect(page).to have_button("Register", disabled: false)
 
     # a domain nobody knows keeps its name, but its ending is still checked
     fill_in_email_and_leave("you@bikeshop.con")
 
-    expect(page).to have_button("Did you mean you@bikeshop.com?")
+    expect(page).to have_button("you@bikeshop.com")
 
     # a dropped letter is corrected however short it leaves the part
     fill_in_email_and_leave("you@macc.om")
 
-    expect(page).to have_button("Did you mean you@mac.com?")
+    expect(page).to have_button("you@mac.com")
 
     # a name that short is never corrected itself, though -- "max" isn't a mistyped "mac"
     fill_in_email_and_leave("you@max.com")
 
-    expect(page).to have_no_css(suggestion_button)
+    expect(page).to have_no_css(suggestion_message)
 
     # unless the ending is what's wrong: "mac" has a ".com" and nothing else
     fill_in_email_and_leave("you@mac.co")
 
-    expect(page).to have_button("Did you mean you@mac.com?")
+    expect(page).to have_button("you@mac.com")
 
     # which is only the names that have one -- gmx is a ".de", so its ending stands
     fill_in_email_and_leave("you@gmx.de")
 
-    expect(page).to have_no_css(suggestion_button)
+    expect(page).to have_no_css(suggestion_message)
 
     # a multi-label ending is matched whole, so a typo in the name doesn't cost it
     fill_in_email_and_leave("you@yahho.co.jp")
 
-    expect(page).to have_button("Did you mean you@yahoo.co.jp?")
+    expect(page).to have_button("you@yahoo.co.jp")
 
     # and yahoo keeps its own ".co.jp", vouching for ".com" or not
     fill_in_email_and_leave("you@yahoo.co.jp")
 
-    expect(page).to have_no_css(suggestion_button)
+    expect(page).to have_no_css(suggestion_message)
 
     # a dot with nothing on one side is its own typo, so the ending still has one to spend
     fill_in_email_and_leave("you@.gmail..come")
 
-    expect(page).to have_button(suggestion)
+    expect(page).to have_button(correction)
 
     # ".co" on a domain we don't know is a country's own
     fill_in_email_and_leave("you@bikeshop.co")
 
-    expect(page).to have_no_css(suggestion_button)
+    expect(page).to have_no_css(suggestion_message)
 
     # but a name with one ending vouches for it, so here it's a "com" rather than Colombia
     fill_in_email_and_leave("you@gmail.co")
 
-    expect(page).to have_button(suggestion)
+    expect(page).to have_button(correction)
 
     # the other typos need more of the part behind them -- "uol" isn't a mistyped "aol"
     fill_in_email_and_leave("you@uol.ro")
 
-    expect(page).to have_no_css(suggestion_button)
+    expect(page).to have_no_css(suggestion_message)
 
     # nothing close to a domain we know of
     fill_in_email_and_leave("you@bikeshop.example")
 
-    expect(page).to have_no_css(suggestion_button)
+    expect(page).to have_no_css(suggestion_message)
 
     # nor anything to say about an address that's already right
     fill_in_email_and_leave("you@gmail.com")
 
-    expect(page).to have_no_css(suggestion_button)
+    expect(page).to have_no_css(suggestion_message)
 
     # a domain RFC 2606 holds back has nothing to correct it to, so it's told rather than asked
     fill_in_email_and_leave("you@example.com")
 
     expect(page).to have_css("[aria-live='polite']", text: warning)
-    expect(page).to have_no_css(suggestion_button)
+    expect(page).to have_no_css(suggestion_message)
     expect_axe_clean
 
     # subdomains of one included, matching what the server scores as spam
@@ -123,6 +137,21 @@ RSpec.describe UI::Forms::Email::Component, :js, type: :system do
     fill_in_email_and_leave("you@bikeshop.invalid")
 
     expect(page).to have_text(warning)
+
+    # a correction can land on one, so accepting it swaps the question for the warning
+    fill_in_email_and_leave("you@example.con")
+
+    expect(page).to have_button("you@example.com")
+    # the message animates open over 200ms, and a click before it settles lands on nothing.
+    # The warning leaving on the same 200ms is what there is to wait on without reaching
+    # into the animation.
+    expect(page).to have_no_text(warning)
+
+    click_on "you@example.com"
+
+    expect(page).to have_text(warning)
+    expect(page).to have_no_css(suggestion_message)
+    expect(page).to have_button("Register", disabled: true)
 
     # ".co" is a country's rather than one of them, so the field keeps its peace
     fill_in_email_and_leave("you@example.co")
@@ -149,18 +178,18 @@ RSpec.describe UI::Forms::Email::Component, :js, type: :system do
 
     find_field("Email").send_keys(:tab)
 
-    expect(page).to have_button(suggestion)
+    expect(page).to have_button(correction)
 
     find_field("Email").send_keys(:enter)
 
     # submitting would have taken us off the preview, which still has the field and the suggestion
-    expect(page).to have_button(suggestion)
+    expect(page).to have_button(correction)
     expect(page).to have_field("Email", with: "you@gmial.con")
 
-    find_button(suggestion).send_keys(:enter)
+    find_button(correction).send_keys(:enter)
 
     expect(page).to have_field("Email", with: "you@gmail.com")
-    expect(page).to have_no_css(suggestion_button)
+    expect(page).to have_no_css(suggestion_message)
     expect(page).to have_button("Register", disabled: false)
     # releasing puts back only what the hold took, so a submit held elsewhere stays held
     expect(page).to have_button("Held elsewhere", disabled: true)

--- a/spec/integration/registration/register_spec.rb
+++ b/spec/integration/registration/register_spec.rb
@@ -3,8 +3,6 @@
 require "rails_helper"
 
 RSpec.describe "Register flow", :js, type: :system do
-  # Not an RFC 2606 domain: UI::Forms::Email holds the form on one, so "@example.com"
-  # never gets past step 1
   let(:owner_email) { "owner@bikeindex.org" }
   let!(:manufacturer) { FactoryBot.create(:manufacturer, name: "Surly") }
   let!(:red) { FactoryBot.create(:color, name: "Red") }

--- a/spec/integration/registration/register_spec.rb
+++ b/spec/integration/registration/register_spec.rb
@@ -3,7 +3,9 @@
 require "rails_helper"
 
 RSpec.describe "Register flow", :js, type: :system do
-  let(:owner_email) { "owner@example.com" }
+  # Not an RFC 2606 domain: UI::Forms::Email holds the form on one, so "@example.com"
+  # never gets past step 1
+  let(:owner_email) { "owner@bikeindex.org" }
   let!(:manufacturer) { FactoryBot.create(:manufacturer, name: "Surly") }
   let!(:red) { FactoryBot.create(:color, name: "Red") }
   let!(:blue) { FactoryBot.create(:color, name: "Blue") }


### PR DESCRIPTION
The email field only checked itself on `focusout`, so anything it had to say could be submitted straight past. It now checks on enter too, and holds the form until the message is answered.

- **Held submit.** While a message shows, the form's submit is disabled and a "Submit form anyway" link appears beside it. Enter in the field is held too; enter on the suggestion still accepts it. Releasing puts back only what the hold took — `ui--button--submit-spinner` disables the same button to see off a second submit, and a clean focusout has no business undoing that.
- **Reserved domains.** An address at an RFC 2606 domain — `you@example.com` most often, the placeholder typed in rather than replaced — gets "That doesn't look like your real email address. Please enter an email address where you receive email". There's no correction to offer, so it's text rather than a link.
- **One definition of the rule.** That moves to `EmailDomain::RESERVED_REGEX` (from `SpamEstimator::Bike`, which already scores it 100). The component hands the pattern's source to the controller instead of keeping a second copy, so client and server can't disagree — a component spec pins the JS-readable syntax.
- `le-btn-primary` gets a `:disabled` look it had no rule for, since the landing demo modal's submit is one the field now holds.

Worth a look before merge: this holds **every** caller, including sign-in (`sessions/new`), where whether an address is real is the server's answer and the copy is wrong-footed — say so and it can take a per-caller opt-out. And `register/step1`'s placeholder is still literally `you@example.com`, which the field now warns about.
