### PR TITLE
Stop outbound connects from 500ing the request

### DIFF
--- a/app/models/public_image.rb
+++ b/app/models/public_image.rb
@@ -114,6 +114,9 @@ class PublicImage < ApplicationRecord
 
   def carrierwave? = !activestorage?
 
+  # Not carrierwave's `image?`, which answers from that column - blank on an activestorage row
+  def image_present? = image_url.present?
+
   # Both backends name their sizes the same, so callers pass one either way - the
   # activestorage dimensions are just larger
   def image_url(size = nil)

--- a/app/services/integrations/bike_book.rb
+++ b/app/services/integrations/bike_book.rb
@@ -2,11 +2,17 @@ module Integrations
   class BikeBook
     require "net/http"
 
+    # Registration blocks on this, so it has to give up well inside rack-timeout's 30s -
+    # Net::HTTP defaults to 60s. Dropping the lookup only costs bike book data
+    TIMEOUT_SECONDS = 5
+
     def make_request(query, method = nil)
       begin
         uri = URI("http://bikebook.io#{method}")
         uri.query = URI.encode_www_form(query)
-        res = Net::HTTP.get_response(uri)
+        res = Net::HTTP.start(uri.hostname, uri.port, open_timeout: TIMEOUT_SECONDS, read_timeout: TIMEOUT_SECONDS) do |http|
+          http.request(Net::HTTP::Get.new(uri))
+        end
       rescue
         return nil
       end

--- a/app/uploaders/application_uploader.rb
+++ b/app/uploaders/application_uploader.rb
@@ -21,6 +21,15 @@ class ApplicationUploader < CarrierWave::Uploader::Base
 
   after :remove, :delete_empty_upstream_dirs
 
+  # Carrierwave asks storage whether the object exists, which with fog is a HEAD request -
+  # paid by every mount validator and every `#{column}?`. A file is only retrieved when the
+  # column held an identifier, so remotely that's answer enough. File storage stays exact.
+  def blank?
+    return super if cached? || _storage.to_s != "CarrierWave::Storage::Fog"
+
+    file.nil?
+  end
+
   def store_dir
     "#{base_store_dir}/#{model.id}"
   end

--- a/app/views/public_images/_admin_public_image.html.haml
+++ b/app/views/public_images/_admin_public_image.html.haml
@@ -6,7 +6,7 @@
       .row
         .col-3
           .img-box
-            = image_tag(public_image.image_url(:small)) if public_image.image?
+            = image_tag(public_image.image_url(:small)) if public_image.image_present?
           %p.image-filename
             = public_image.name.truncate(18)
         .col-9

--- a/app/views/public_images/_public_image.html.haml
+++ b/app/views/public_images/_public_image.html.haml
@@ -13,11 +13,12 @@
 
     .processing
       = t(".processing")
-    - if image.image?
+    - if image.image_present?
       -# Versions are generated in a background job; the versioned src can 404 until the
       -# worker finishes, so image_fallback swaps to the synchronously-stored original
-      %img{ src: image.image_url(:small) || image.image_url,
-        data: { controller: "image-fallback", action: "error->image-fallback#useOriginal", "image-fallback-url-value": image.image_url } }
+      - original_url = image.image_url
+      %img{ src: image.image_url(:small) || original_url,
+        data: { controller: "image-fallback", action: "error->image-fallback#useOriginal", "image-fallback-url-value": original_url } }
     - else
       %em.missing-image
         = t(".missing_image")

--- a/config/initializers/carrierwave.rb
+++ b/config/initializers/carrierwave.rb
@@ -49,7 +49,10 @@ CarrierWave.configure do |config|
       aws_access_key_id: ENV["S3_ACCESS_KEY"],
       aws_secret_access_key: ENV["S3_SECRET_KEY"],
       region: "us-east-1",
-      path_style: true
+      path_style: true,
+      # Excon defaults to 60s and fog to 5 retries, so an unreachable S3 outlasts rack-timeout's
+      # 30s and the request 500s. Worst case here is 3 connects + 2 intervals = 17s
+      connection_options: {connect_timeout: 5, read_timeout: 10, write_timeout: 10, retry_limit: 2}
     }
     config.fog_directory = ENV["S3_BUCKET"]
     config.fog_attributes = {"Cache-Control" => "max-age=315576000"}

--- a/spec/models/public_image_spec.rb
+++ b/spec/models/public_image_spec.rb
@@ -62,6 +62,32 @@ RSpec.describe PublicImage, type: :model do
     end
   end
 
+  # ApplicationUploader#blank? answers from the retrieved file rather than asking storage,
+  # which with fog is a HEAD request on every render and every validation
+  describe "image?" do
+    it "is false without an image" do
+      expect(PublicImage.new.image?).to be_falsey
+    end
+
+    it "is true for a stored carrierwave image, reloaded" do
+      public_image = FactoryBot.create(:public_image, :with_image_file)
+      expect(public_image.reload.image?).to be_truthy
+    end
+
+    it "is true for a cached image, before storing" do
+      public_image = PublicImage.new(image: File.open(Rails.root.join("spec", "fixtures", "bike.jpg")))
+      expect(public_image.image?).to be_truthy
+    end
+  end
+
+  describe "image_present?" do
+    it "is true for an activestorage row, which image? says no to" do
+      public_image = FactoryBot.create(:public_image, :with_attached_file).reload
+      expect(public_image.image?).to be_falsey
+      expect(public_image.image_present?).to be_truthy
+    end
+  end
+
   describe "process_image_upload" do
     let(:bike) { FactoryBot.create(:bike) }
     let(:image_file) { File.open(Rails.root.join("spec", "fixtures", "bike.jpg")) }

--- a/spec/requests/bikes/edits_request_spec.rb
+++ b/spec/requests/bikes/edits_request_spec.rb
@@ -371,6 +371,20 @@ RSpec.describe Bikes::EditsController, type: :request do
     end
   end
 
+  context "photos template" do
+    let!(:carrierwave_image) { FactoryBot.create(:public_image, :with_image_file, imageable: bike) }
+    let!(:activestorage_image) { FactoryBot.create(:public_image, :with_attached_file, imageable: bike) }
+
+    it "renders an image for both storage backends" do
+      expect(carrierwave_image.reload.activestorage?).to be_falsey
+      expect(activestorage_image.reload.activestorage?).to be_truthy
+      get "#{base_url}/photos"
+      expect(response.code).to eq("200")
+      expect(response).to render_template(:photos)
+      expect(response.body).to_not include("missing-image")
+    end
+  end
+
   context "strava_gear template" do
     let!(:strava_integration) { FactoryBot.create(:strava_integration, :synced, user: current_user) }
     let!(:strava_gear) { FactoryBot.create(:strava_gear, strava_integration:, strava_id: "b12345", name: "My Road Bike") }

--- a/spec/services/integrations/bike_book_spec.rb
+++ b/spec/services/integrations/bike_book_spec.rb
@@ -66,4 +66,14 @@ RSpec.describe Integrations::BikeBook do
       end
     end
   end
+
+  # Registration renders inline, so an unreachable bikebook has to drop rather than block
+  describe "make_request timing out" do
+    after { WebMock.reset! } # this stub is registered outside a VCR cassette
+
+    it "returns nil" do
+      WebMock.stub_request(:get, /bikebook\.io/).to_timeout
+      expect(Integrations::BikeBook.new.get_model_list(manufacturer: "Giant")).to be_nil
+    end
+  end
 end

--- a/spec/uploaders/application_uploader_spec.rb
+++ b/spec/uploaders/application_uploader_spec.rb
@@ -1,0 +1,22 @@
+require "rails_helper"
+
+RSpec.describe ApplicationUploader do
+  # Only production stores with fog, so this builds the storage the app can't exercise
+  # otherwise. There are no fog_credentials in test, so reaching for the connection raises -
+  # which is the assertion: `blank?` has to answer without asking S3.
+  describe "blank? with fog storage" do
+    let(:uploader_class) do
+      Class.new(ApplicationUploader) { storage :fog }
+    end
+    let(:uploader) { uploader_class.new(PublicImage.new, :image) }
+
+    it "is false for a stored file, without a request" do
+      uploader.retrieve_from_store!("bike.jpg")
+      expect(uploader.blank?).to be_falsey
+    end
+
+    it "is true without a file" do
+      expect(uploader.blank?).to be_truthy
+    end
+  end
+end


### PR DESCRIPTION
Three `Rack::Timeout` 500s this morning ([133099407](https://app.honeybadger.io/projects/35931/faults/133099407), [133099410](https://app.honeybadger.io/projects/35931/faults/133099410), [133099414](https://app.honeybadger.io/projects/35931/faults/133099414)) were all requests blocked in TCP connect to an external host — killed at 30s with 2–8ms of db time, while the box kept serving everything else normally.

- **Carrierwave's `blank?` no longer asks storage.** It answered by HEADing the object, so every mount validator and every `#{column}?` in a view paid a round trip — `/bikes/*/edit/photos` ran p90 1.8s, p99 11.1s, nearly all of it view time. It answers from the retrieved file now; file storage still gives the exact answer.
- **Activestorage photos render again.** `image?` reads only the carrierwave column, so a register photo uploaded direct to R2 (#3974) has been showing "Missing image" on the photos page. `PublicImage#image_present?` answers for both backends.
- **Timeouts on the two callers that hung.** BikeBook and fog both defaulted to 60s, past rack-timeout's 30s, so an egress blip turned into 500s rather than a dropped lookup.

Left alone: the other `Integrations::` HTTP clients still set no timeouts, and the photos page has a `file_attachment` N+1 that the admin index already preloads away.
