### PR TITLE
Track additional email confirmations as notifications

### DIFF
--- a/app/jobs/email/additional_email_confirmation_job.rb
+++ b/app/jobs/email/additional_email_confirmation_job.rb
@@ -1,12 +1,21 @@
 module Email
   class AdditionalEmailConfirmationJob < ApplicationJob
-    sidekiq_options queue: "notify"
+    sidekiq_options queue: "notify", retry: 3
 
     def perform(user_email_id)
       user_email = UserEmail.find_by(id: user_email_id)
       return if user_email.blank?
 
-      CustomerMailer.additional_email_confirmation(user_email).deliver_now
+      notifications = user_email.notifications.additional_email_confirmation
+        .where("created_at > ?", Time.current - 1.minute)
+      return if notifications.delivery_success.any?
+
+      notification = notifications.last ||
+        Notification.create(kind: "additional_email_confirmation", notifiable: user_email)
+
+      notification.track_email_delivery do
+        CustomerMailer.additional_email_confirmation(user_email).deliver_now
+      end
     end
   end
 end

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -267,7 +267,7 @@ class Notification < ApplicationRecord
   end
 
   def calculated_email
-    c_email = notifiable&.email if b_param? || notifiable_type == "Payment"
+    c_email = notifiable&.email if b_param? || %w[Payment UserEmail].include?(notifiable_type)
     c_email ||= notifiable&.receiver_email if stolen_notification?
     c_email ||= user&.email if user_id.present?
     c_email ||= notifiable&.user_email if customer_contact?

--- a/app/models/user_email.rb
+++ b/app/models/user_email.rb
@@ -20,6 +20,7 @@
 class UserEmail < ActiveRecord::Base
   belongs_to :user, touch: true
   belongs_to :old_user, class_name: "User", touch: true
+  has_many :notifications, as: :notifiable
 
   validates_presence_of :user_id, :email
 

--- a/config/notification_kinds_enums.yml
+++ b/config/notification_kinds_enums.yml
@@ -32,3 +32,4 @@
 :graduated_notification: 33
 :organization_invitation: 34
 :parking_notification: 35
+:additional_email_confirmation: 36

--- a/spec/jobs/email/additional_email_confirmation_job_spec.rb
+++ b/spec/jobs/email/additional_email_confirmation_job_spec.rb
@@ -1,10 +1,38 @@
 require "rails_helper"
 
 RSpec.describe Email::AdditionalEmailConfirmationJob, type: :job do
+  let(:user_email) { FactoryBot.create(:user_email, confirmation_token: "xxxx") }
+
   it "sends a confirm your additional email, email" do
-    user_email = FactoryBot.create(:user_email)
     ActionMailer::Base.deliveries = []
-    described_class.new.perform(user_email.id)
-    expect(ActionMailer::Base.deliveries.empty?).to be_falsey
+    expect { described_class.new.perform(user_email.id) }.to change(Notification, :count).by 1
+
+    expect(ActionMailer::Base.deliveries.count).to eq 1
+    notification = Notification.last
+    expect(notification.kind).to eq "additional_email_confirmation"
+    expect(notification.notifiable_id).to eq user_email.id
+    expect(notification.user_id).to eq user_email.user_id
+    expect(notification.message_channel_target).to eq user_email.email
+    expect(notification.delivery_status).to eq "delivery_success"
+
+    # It doesn't send again immediately
+    expect { described_class.new.perform(user_email.id) }.to change(Notification, :count).by 0
+    expect(ActionMailer::Base.deliveries.count).to eq 1
+  end
+
+  context "with InactiveRecipientError" do
+    let(:inactive_recipient_error) do
+      Postmark::ApiInputError.build("error", {"ErrorCode" => 406, "Message" => "inactive"})
+    end
+    before { allow(CustomerMailer).to receive(:additional_email_confirmation).and_raise(inactive_recipient_error) }
+
+    it "swallows the error and marks user_email errored" do
+      expect { described_class.new.perform(user_email.id) }.to change(Notification, :count).by 1
+
+      notification = Notification.last
+      expect(notification.delivery_status).to eq "delivery_failure"
+      expect(notification.delivery_error).to eq "Postmark::InactiveRecipientError"
+      expect(user_email.reload.last_email_errored).to be_truthy
+    end
   end
 end


### PR DESCRIPTION
`Email::AdditionalEmailConfirmationJob` called `deliver_now` bare, so a Postmark `InactiveRecipientError` — a hard bounce, spam complaint, or manual suppression on the address someone just added — crashed the job instead of being recorded ([HB fault](https://app.honeybadger.io/projects/35931/faults/133082976)).

- The send now goes through `Notification#track_email_delivery`, like the other confirmation emails, so an undeliverable address is stored on the notification and flags the `UserEmail` as errored rather than raising.
- `Notification#calculated_email` reads `notifiable.email` for a `UserEmail`, so `message_channel_target` is the additional address rather than the account's primary one.
