### PR TITLE
Only show the impound update action for the org's own record

### DIFF
--- a/app/components/registrations/show/org_top_actions/impound_update/component.rb
+++ b/app/components/registrations/show/org_top_actions/impound_update/component.rb
@@ -13,7 +13,7 @@ module Registrations
           end
 
           def render?
-            @bike.status_impounded? && impound_record.present?
+            @bike.status_impounded? && impound_record&.organization_id == @organization.id
           end
 
           private

--- a/app/components/registrations/show/org_top_actions/wrapper/component.rb
+++ b/app/components/registrations/show/org_top_actions/wrapper/component.rb
@@ -90,7 +90,13 @@ module Registrations
           end
 
           def show_update_impound?
-            show_impound? && staff? && impounded?
+            show_impound? && staff? && impounded_by_organization?
+          end
+
+          # The update form posts to this org's impound routes, which another
+          # org's record - or an unorganized one, which has no display_id - isn't in
+          def impounded_by_organization?
+            impounded? && @bike.current_impound_record&.organization_id == @organization.id
           end
 
           def show_parking_notifications?

--- a/app/components/registrations/show/org_top_actions/wrapper/component_preview.rb
+++ b/app/components/registrations/show/org_top_actions/wrapper/component_preview.rb
@@ -19,7 +19,7 @@ module Registrations
             {
               "With owner" => component(preview_bike(:status_with_owner)),
               "Stolen" => component(stolen_bike),
-              "Impounded" => component(preview_bike(:status_impounded)),
+              "Impounded" => component(impounded_bike),
               "Unregistered parking notification" => component(preview_bike(:unregistered_parking_notification)),
               "With parking notification" => component(bike_with_parking_notification),
               "Limited (non-staff) member" => component(preview_bike(:status_with_owner), org_role: :limited),
@@ -38,6 +38,13 @@ module Registrations
           # Stolen is the one state carried by an association rather than the status
           def stolen_bike
             preview_bike(:status_stolen).tap { |bike| bike.current_stolen_record = ::StolenRecord.new }
+          end
+
+          # The update action only shows for the previewing org's own record
+          def impounded_bike
+            preview_bike(:status_impounded).tap do |bike|
+              bike.current_impound_record = ::ImpoundRecord.new(organization_id: lookbook_organization.id, display_id: "0001")
+            end
           end
 
           # A live count and the notification panel are DB queries, so this variety

--- a/app/components/registrations/show/wrapper/component.rb
+++ b/app/components/registrations/show/wrapper/component.rb
@@ -8,7 +8,7 @@ module Registrations
       class Component < ApplicationComponent
         # Digest of the markup inside the cache block — the cached_markup_digest spec
         # keeps it current, following what this tree renders out into UI:: and elsewhere
-        MARKUP_DIGEST = "0b9c0ce42900"
+        MARKUP_DIGEST = "298e764e84e8"
 
         def initialize(bike:, current_user:, view:, available_views:, bike_sticker: nil)
           @bike = bike

--- a/spec/components/registrations/show/org_top_actions/wrapper/component_spec.rb
+++ b/spec/components/registrations/show/org_top_actions/wrapper/component_spec.rb
@@ -41,6 +41,9 @@ RSpec.describe Registrations::Show::OrgTopActions::Wrapper::Component, type: :co
 
   context "when impounded" do
     let(:status) { :status_impounded }
+    let(:impound_organization_id) { organization.id }
+    let(:impound_record) { ImpoundRecord.new(organization_id: impound_organization_id, display_id: "0001") }
+    let(:bike) { Bike.new(status:, cycle_type: "bike", current_impound_record: impound_record) }
 
     # The owner isn't messageable, and there's no point filing a parking
     # notification against a bike that's already impounded
@@ -51,6 +54,24 @@ RSpec.describe Registrations::Show::OrgTopActions::Wrapper::Component, type: :co
 
     context "and limited" do
       let(:org_role) { :limited }
+
+      it "renders no impound update" do
+        expect(action_panels).to eq(%w[notifications_show])
+      end
+    end
+
+    context "by another organization" do
+      let(:impound_organization_id) { FactoryBot.create(:organization).id }
+
+      it "renders no impound update" do
+        expect(action_panels).to eq(%w[notifications_show])
+      end
+    end
+
+    # An unorganized impound record has a nil display_id, so rendering the form
+    # raised UrlGenerationError rather than just linking to the wrong org
+    context "by no organization" do
+      let(:impound_record) { ImpoundRecord.new }
 
       it "renders no impound update" do
         expect(action_panels).to eq(%w[notifications_show])


### PR DESCRIPTION
A staff member at an `impound_bikes` org viewing an impounded bike got the **Update Impound Record** action no matter who impounded it — the form then pointed into *their* org's impound routes, which the record isn't in. An unorganized impound record has a nil `display_id` by design, so `organization_impound_record_path` couldn't build a URL at all and the registration page 500'd ([133103079](https://app.honeybadger.io/projects/35931/faults/133103079)).

- Both the action button and its panel now require `current_impound_record.organization_id` to match the viewing org. Another org's record silently pointed at a display_id the org's `friendly_find!` would 404 on, so that case was broken too, just more quietly.
- The wrapper preview's impounded bike carries an impound record now, so the preview renders the update panel it's meant to show.
