### PR TITLE
Require the address on register step 2 for orgs that ask for it

### DIFF
--- a/app/components/register/step2/component.html.erb
+++ b/app/components/register/step2/component.html.erb
@@ -377,7 +377,8 @@
       >
         <%# _attributes explicitly: form_with has no model to infer nested attributes from %>
         <%= f.fields_for :address_record_attributes, address_record do |address_form| %>
-          <%= render UI::Forms::AddressGroup::Component.new(form_builder: address_form) %>
+          <%= render UI::Forms::AddressGroup::Component.new(form_builder: address_form,
+              required: organization.enabled?("require_reg_address")) %>
         <% end %>
       </div>
     <% end %>

--- a/app/components/registrations/show/wrapper/component.rb
+++ b/app/components/registrations/show/wrapper/component.rb
@@ -8,7 +8,7 @@ module Registrations
       class Component < ApplicationComponent
         # Digest of the markup inside the cache block — the cached_markup_digest spec
         # keeps it current, following what this tree renders out into UI:: and elsewhere
-        MARKUP_DIGEST = "298e764e84e8"
+        MARKUP_DIGEST = "e65e4a892496"
 
         def initialize(bike:, current_user:, view:, available_views:, bike_sticker: nil)
           @bike = bike

--- a/app/components/ui/forms/address_group/component.en.yml
+++ b/app/components/ui/forms/address_group/component.en.yml
@@ -11,3 +11,4 @@ en:
           postal_code: Postal code
           region: Region
           state: State
+          street_2: Address line 2

--- a/app/components/ui/forms/address_group/component.html.erb
+++ b/app/components/ui/forms/address_group/component.html.erb
@@ -2,17 +2,21 @@
   data-controller="ui--forms--address-group"
   data-ui--forms--address-group-us-id-value="<%= us_country_id %>"
 >
-  <%= render(UI::Forms::Group::Component.new(form_builder: @form, attribute: :street, kind: :text_field, label_text: street_label)) %>
+  <%= render(UI::Forms::Group::Component.new(form_builder: @form, attribute: :street, kind: :text_field, label_text: street_label, required: @required)) %>
+
+  <% if @street_2 %>
+    <%= render(UI::Forms::Group::Component.new(form_builder: @form, attribute: :street_2, kind: :text_field, label_text: translation(".street_2"))) %>
+  <% end %>
 
   <div class="tw:grid tw:grid-cols-2 tw:gap-x-2">
-    <%= render(UI::Forms::Group::Component.new(form_builder: @form, attribute: :city, kind: :text_field, label_text: translation(".city"))) %>
+    <%= render(UI::Forms::Group::Component.new(form_builder: @form, attribute: :city, kind: :text_field, label_text: translation(".city"), required: @required)) %>
 
     <div
       data-ui--forms--address-group-target="state"
       class="<%= state_hidden_class %>"
     >
-      <%= render(UI::Forms::Group::Component.new(form_builder: @form, attribute: :region_record_id, label_text: translation(".state"))) do %>
-        <%= @form.collection_select(:region_record_id, State.united_states, :id, :name, {include_blank: true}, {class: "twinput tw:w-full"}) %>
+      <%= render(UI::Forms::Group::Component.new(form_builder: @form, attribute: :region_record_id, label_text: translation(".state"), required: @required)) do %>
+        <%= @form.collection_select(:region_record_id, State.united_states, :id, :name, {include_blank: true}, {class: "twinput tw:w-full", required: state_required?}) %>
       <% end %>
     </div>
 
@@ -20,15 +24,21 @@
       data-ui--forms--address-group-target="region"
       class="<%= region_hidden_class %>"
     >
-      <%= render(UI::Forms::Group::Component.new(form_builder: @form, attribute: :region_string, kind: :text_field, label_text: translation(".region"))) %>
+      <%# Input rather than kind:, so the label can be starred while the hidden field isn't required %>
+      <%= render(UI::Forms::Group::Component.new(form_builder: @form, attribute: :region_string, label_text: translation(".region"), required: @required)) do %>
+        <%= render(UI::Forms::Input::Component.new(form_builder: @form, attribute: :region_string, required: region_required?)) %>
+      <% end %>
     </div>
   </div>
 
   <div class="tw:grid tw:grid-cols-2 tw:gap-x-2">
-    <%= render(UI::Forms::Group::Component.new(form_builder: @form, attribute: :postal_code, kind: :text_field, label_text: translation(".postal_code"))) %>
+    <%= render(UI::Forms::Group::Component.new(form_builder: @form, attribute: :postal_code, kind: :text_field, label_text: translation(".postal_code"), required: @required)) %>
 
-    <%= render(UI::Forms::Group::Component.new(form_builder: @form, attribute: :country_id, label_text: translation(".country"))) do %>
-      <%= @form.select(:country_id, Country.select_options, {prompt: translation(".choose_country"), selected: selected_country_id}, {class: "twinput tw:w-full", data: {action: "change->ui--forms--address-group#toggleCountry", "ui--forms--address-group-target": "country"}}) %>
+    <%= render(UI::Forms::Group::Component.new(form_builder: @form, attribute: :country_id, label_text: translation(".country"), required: @required)) do %>
+      <%= render(UI::Forms::Select::Component.new(form_builder: @form, attribute: :country_id, required: @required,
+          option_tags: Country.select_options,
+          options: {prompt: translation(".choose_country"), selected: selected_country_id},
+          html_options: {class: "tw:w-full", data: {action: "change->ui--forms--address-group#toggleCountry", "ui--forms--address-group-target": "country"}})) %>
     <% end %>
   </div>
 </div>

--- a/app/components/ui/forms/address_group/component.rb
+++ b/app/components/ui/forms/address_group/component.rb
@@ -8,10 +8,13 @@ module UI
       # address attributes (street, city, region_record_id, region_string,
       # postal_code, country_id)
       class Component < ApplicationComponent
-        def initialize(form_builder:, street_label: nil, default_country_id: Country.united_states_id)
+        def initialize(form_builder:, street_label: nil, default_country_id: Country.united_states_id,
+          required: false, street_2: false)
           @form = form_builder
           @street_label = street_label
           @default_country_id = default_country_id
+          @required = required
+          @street_2 = street_2
         end
 
         private
@@ -21,7 +24,7 @@ module UI
         end
 
         def us_country_id
-          Country.united_states_id
+          @us_country_id ||= Country.united_states_id
         end
 
         # The object's country, falling back to the default, so the dropdown and the
@@ -42,6 +45,12 @@ module UI
         def us_selected?
           selected_country_id == us_country_id
         end
+
+        # Only the visible one of the state/region pair is required — the browser can't
+        # report validity on a hidden field
+        def state_required? = @required && us_selected?
+
+        def region_required? = @required && !us_selected?
       end
     end
   end

--- a/app/components/ui/forms/address_group/component_preview.rb
+++ b/app/components/ui/forms/address_group/component_preview.rb
@@ -5,7 +5,14 @@ module UI
     module AddressGroup
       class ComponentPreview < ApplicationComponentPreview
         def default
-          {template: "ui/forms/address_group/component_preview/default"}
+          {template: "ui/forms/address_group/component_preview/default",
+           locals: {required: false, street_2: false}}
+        end
+
+        # Every field but street_2 is required
+        def required
+          {template: "ui/forms/address_group/component_preview/default",
+           locals: {required: true, street_2: true}}
         end
       end
     end

--- a/app/components/ui/forms/address_group/component_preview/default.html.erb
+++ b/app/components/ui/forms/address_group/component_preview/default.html.erb
@@ -1,3 +1,3 @@
 <%= form_with(model: AddressRecord.new, url: "#", builder: BikeIndexFormBuilder) do |f| %>
-  <%= render(UI::Forms::AddressGroup::Component.new(form_builder: f)) %>
+  <%= render(UI::Forms::AddressGroup::Component.new(form_builder: f, required:, street_2:)) %>
 <% end %>

--- a/app/javascript/controllers/ui/forms/address_group_controller.js
+++ b/app/javascript/controllers/ui/forms/address_group_controller.js
@@ -7,12 +7,21 @@ export default class extends Controller {
   static values = { usId: Number }
 
   toggleCountry () {
-    const isUs = Number(this.countryTarget.value) === this.usIdValue
+    const isUs = this.isUs
+    // Whichever of the pair is showing carries the required attribute - the browser
+    // won't submit a form with a hidden required field, and can't focus it to say why.
+    // Blanked rather than disabled, so the country it no longer matches is cleared
+    const required = this.stateSelect.required || this.regionInput.required
     this.stateTarget.classList.toggle('tw:hidden', !isUs)
     this.regionTarget.classList.toggle('tw:hidden', isUs)
-    if (!isUs) {
-      const select = this.stateTarget.querySelector('select')
-      if (select) select.value = ''
-    }
+    if (!isUs) this.stateSelect.value = ''
+    this.stateSelect.required = required && isUs
+    this.regionInput.required = required && !isUs
   }
+
+  get isUs () { return Number(this.countryTarget.value) === this.usIdValue }
+
+  get stateSelect () { return this.stateTarget.querySelector('select') }
+
+  get regionInput () { return this.regionTarget.querySelector('input') }
 }

--- a/spec/components/ui/forms/address_group/component_spec.rb
+++ b/spec/components/ui/forms/address_group/component_spec.rb
@@ -18,6 +18,42 @@ RSpec.describe UI::Forms::AddressGroup::Component, type: :component do
     expect(component).to have_css("input[name='address_record[postal_code]']")
     expect(component).to have_css("select[name='address_record[country_id]']")
     expect(component).to have_css("label", text: "Address")
+    expect(component).to have_no_css("input[name='address_record[street_2]']")
+    expect(component).to have_no_css("[required]")
+  end
+
+  context "with street_2" do
+    let(:options) { {street_2: true} }
+
+    it "renders the street_2 field" do
+      expect(component).to have_css("input[name='address_record[street_2]']")
+      expect(component).to have_css("label", text: "Address line 2")
+    end
+  end
+
+  context "with required" do
+    let(:options) { {required: true, street_2: true} }
+
+    it "requires every field but street_2" do
+      expect(component).to have_css("input[name='address_record[street]'][required]")
+      expect(component).to have_css("input[name='address_record[city]'][required]")
+      expect(component).to have_css("select[name='address_record[region_record_id]'][required]")
+      expect(component).to have_css("input[name='address_record[postal_code]'][required]")
+      expect(component).to have_css("select[name='address_record[country_id]'][required]")
+      expect(component).to have_css("input[name='address_record[street_2]']:not([required])")
+      # The hidden region_string is left optional - the browser can't report validity on it
+      expect(component).to have_css("input[name='address_record[region_string]']:not([required])")
+    end
+
+    context "with a non-US country" do
+      let!(:country) { FactoryBot.create(:country, name: "Testland") }
+      let(:address_record) { AddressRecord.new(country_id: country.id) }
+
+      it "moves required to region_string" do
+        expect(component).to have_css("input[name='address_record[region_string]'][required]")
+        expect(component).to have_css("select[name='address_record[region_record_id]']:not([required])")
+      end
+    end
   end
 
   context "with a street_label" do

--- a/spec/components/ui/forms/address_group/component_system_spec.rb
+++ b/spec/components/ui/forms/address_group/component_system_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe UI::Forms::AddressGroup::Component, :js, type: :system do
+  let(:preview_path) { "/rails/view_components/ui/forms/address_group/component/required" }
+  let(:state_select) { "select[name='address_record[region_record_id]']" }
+  let(:region_input) { "input[name='address_record[region_string]']" }
+
+  it "moves required to whichever of the state/region pair the country shows" do
+    FactoryBot.create(:state_california)
+    Country.canada
+    visit(preview_path)
+    expect_axe_clean("select-name")
+
+    expect(page).to have_css("#{state_select}[required]")
+    expect(page).to have_css("#{region_input}:not([required])", visible: :all)
+
+    select "Canada", from: "address_record[country_id]"
+    expect(page).to have_css("#{region_input}[required]")
+    expect(page).to have_css("#{state_select}:not([required])", visible: :all)
+
+    select "United States", from: "address_record[country_id]"
+    expect(page).to have_css("#{state_select}[required]")
+    expect(page).to have_css("#{region_input}:not([required])", visible: :all)
+  end
+end

--- a/spec/requests/register_request_spec.rb
+++ b/spec/requests/register_request_spec.rb
@@ -452,6 +452,10 @@ RSpec.describe RegisterController, type: :request do
       end
 
       context "reg_address" do
+        def address_street_field
+          Nokogiri::HTML(response.body).at_css("[name='bike[address_record_attributes][street]']")
+        end
+
         it "shows the address fields, except for statuses with their own address record" do
           organization.update_column :enabled_feature_slugs, ["reg_address"]
           get register_path(b_param_token: b_param.id_token, step: 2)
@@ -465,6 +469,16 @@ RSpec.describe RegisterController, type: :request do
           b_param.update(params: b_param.params.deep_merge("bike" => {"status" => "status_stolen"}))
           get register_path(b_param_token: b_param.id_token, step: 2)
           expect(status_field("address_record_attributes")["class"]).to include "tw:hidden"
+        end
+
+        it "only requires the address when the organization requires it" do
+          organization.update_column :enabled_feature_slugs, ["reg_address"]
+          get register_path(b_param_token: b_param.id_token, step: 2)
+          expect(address_street_field["required"]).to be_nil
+
+          organization.update_column :enabled_feature_slugs, %w[reg_address require_reg_address]
+          get register_path(b_param_token: b_param.id_token, step: 2)
+          expect(address_street_field["required"]).to eq "required"
         end
       end
     end


### PR DESCRIPTION
`UI::Forms::AddressGroup` takes `required:` and `street_2:`, and register step 2 passes `required:` from the organization's `require_reg_address` — the way it already gates `student_id` on `require_reg_student_id`.

- **Everything but street_2** gets the required attribute and a starred label.
- **Only the showing half of the state/region pair is required.** The browser won't submit a form holding a hidden required field, and can't focus it to say why, so the Stimulus controller moves `required` across when the country changes.
- The country and region fields now render through `UI::Forms::Select` / `UI::Forms::Input` rather than hand-rolled `twinput` markup.
