### PR TITLE
Alert: full-width body when a header is present

### DIFF
--- a/app/components/admin/bikes_table/component.rb
+++ b/app/components/admin/bikes_table/component.rb
@@ -8,7 +8,7 @@ module Admin
     # checkboxes, and skip_user to drop the owner column.
     class Component < ApplicationComponent
       # Digest of the markup inside the row cache — the cached_markup_digest spec keeps it current
-      MARKUP_DIGEST = "e88d056eec9a"
+      MARKUP_DIGEST = "55bd93d8018c"
 
       def initialize(bikes:, no_show_header: false, show_serial: false, render_sortable: false,
         skip_user: false, render_multi_check: false)

--- a/app/components/admin/bikes_table/component.rb
+++ b/app/components/admin/bikes_table/component.rb
@@ -8,7 +8,7 @@ module Admin
     # checkboxes, and skip_user to drop the owner column.
     class Component < ApplicationComponent
       # Digest of the markup inside the row cache — the cached_markup_digest spec keeps it current
-      MARKUP_DIGEST = "733c5c375e31"
+      MARKUP_DIGEST = "291716dd8fe5"
 
       def initialize(bikes:, no_show_header: false, show_serial: false, render_sortable: false,
         skip_user: false, render_multi_check: false)

--- a/app/components/admin/bikes_table/component.rb
+++ b/app/components/admin/bikes_table/component.rb
@@ -8,7 +8,7 @@ module Admin
     # checkboxes, and skip_user to drop the owner column.
     class Component < ApplicationComponent
       # Digest of the markup inside the row cache — the cached_markup_digest spec keeps it current
-      MARKUP_DIGEST = "291716dd8fe5"
+      MARKUP_DIGEST = "e88d056eec9a"
 
       def initialize(bikes:, no_show_header: false, show_serial: false, render_sortable: false,
         skip_user: false, render_multi_check: false)

--- a/app/components/admin/users_table/component.rb
+++ b/app/components/admin/users_table/component.rb
@@ -6,7 +6,7 @@ module Admin
     # render_deleted to show the deleted_at column.
     class Component < ApplicationComponent
       # Digest of the markup inside the row cache — the cached_markup_digest spec keeps it current
-      MARKUP_DIGEST = "bfe925f4cede"
+      MARKUP_DIGEST = "4334dc0781b2"
 
       def initialize(users:, render_sortable: false, render_deleted: false)
         @users = users

--- a/app/components/admin/users_table/component.rb
+++ b/app/components/admin/users_table/component.rb
@@ -6,7 +6,7 @@ module Admin
     # render_deleted to show the deleted_at column.
     class Component < ApplicationComponent
       # Digest of the markup inside the row cache — the cached_markup_digest spec keeps it current
-      MARKUP_DIGEST = "b95bf3bdc50d"
+      MARKUP_DIGEST = "bfe925f4cede"
 
       def initialize(users:, render_sortable: false, render_deleted: false)
         @users = users

--- a/app/components/admin/users_table/component.rb
+++ b/app/components/admin/users_table/component.rb
@@ -6,7 +6,7 @@ module Admin
     # render_deleted to show the deleted_at column.
     class Component < ApplicationComponent
       # Digest of the markup inside the row cache — the cached_markup_digest spec keeps it current
-      MARKUP_DIGEST = "4334dc0781b2"
+      MARKUP_DIGEST = "ec033295a1d5"
 
       def initialize(users:, render_sortable: false, render_deleted: false)
         @users = users

--- a/app/components/registrations/show/wrapper/component.rb
+++ b/app/components/registrations/show/wrapper/component.rb
@@ -8,7 +8,7 @@ module Registrations
       class Component < ApplicationComponent
         # Digest of the markup inside the cache block — the cached_markup_digest spec
         # keeps it current, following what this tree renders out into UI:: and elsewhere
-        MARKUP_DIGEST = "e65e4a892496"
+        MARKUP_DIGEST = "eaeb9ff03a26"
 
         def initialize(bike:, current_user:, view:, available_views:, bike_sticker: nil)
           @bike = bike

--- a/app/components/registrations/show/wrapper/component.rb
+++ b/app/components/registrations/show/wrapper/component.rb
@@ -8,7 +8,7 @@ module Registrations
       class Component < ApplicationComponent
         # Digest of the markup inside the cache block — the cached_markup_digest spec
         # keeps it current, following what this tree renders out into UI:: and elsewhere
-        MARKUP_DIGEST = "eaeb9ff03a26"
+        MARKUP_DIGEST = "273c36dffebd"
 
         def initialize(bike:, current_user:, view:, available_views:, bike_sticker: nil)
           @bike = bike

--- a/app/components/registrations/show/wrapper/component.rb
+++ b/app/components/registrations/show/wrapper/component.rb
@@ -8,7 +8,7 @@ module Registrations
       class Component < ApplicationComponent
         # Digest of the markup inside the cache block — the cached_markup_digest spec
         # keeps it current, following what this tree renders out into UI:: and elsewhere
-        MARKUP_DIGEST = "273c36dffebd"
+        MARKUP_DIGEST = "67772d7adcf3"
 
         def initialize(bike:, current_user:, view:, available_views:, bike_sticker: nil)
           @bike = bike

--- a/app/components/ui/alert/component.html.erb
+++ b/app/components/ui/alert/component.html.erb
@@ -27,7 +27,7 @@
   <% if @dismissable %>
     <button
       type="button"
-      class="tw:-mx-1.5 tw:-my-1.5 tw:ms-auto tw:inline-flex tw:h-8 tw:w-8 tw:items-center tw:justify-center tw:rounded-sm tw:p-1.5 tw:focus:ring-2 <%= dismissable_color_classes %>"
+      class="tw:-mx-1.5 tw:-my-1.5 tw:inline-flex tw:h-8 tw:w-8 tw:items-center tw:justify-center tw:rounded-sm tw:p-1.5 tw:focus:ring-2 <%= dismissable_color_classes %>"
       aria-label="Close"
       data-action="click->ui--alert#close"
     >

--- a/app/components/ui/alert/component.html.erb
+++ b/app/components/ui/alert/component.html.erb
@@ -1,5 +1,5 @@
 <div
-  class="tw:flex tw:items-baseline tw:gap-4 tw:rounded-sm tw:border tw:p-4 tw:transition-all tw:duration-300 <%= @margin_classes %> <%= color_classes %>"
+  class="tw:flex tw:flex-wrap tw:items-baseline tw:gap-x-4 tw:gap-y-2 tw:rounded-sm tw:border tw:p-4 tw:transition-all tw:duration-300 <%= @margin_classes %> <%= color_classes %>"
   role="alert"
   data-controller="ui--alert"
 >
@@ -13,13 +13,13 @@
     <span class="tw:sr-only"><%= @kind.to_s.titleize %></span>
   </div>
 
-  <div class="tw:grow">
-    <% if @header.present? %>
-      <h4 class="uncap tw:mb-0! tw:text-lg! <%= text_color_classes_important %>">
-        <%= @header %>
-      </h4>
-    <% end %>
+  <% if @header.present? %>
+    <h4 class="uncap tw:mb-0! tw:text-lg! <%= text_color_classes_important %>">
+      <%= @header %>
+    </h4>
+  <% end %>
 
+  <div class="<%= body_classes %>">
     <%= @text %>
     <%= content %>
   </div>

--- a/app/components/ui/alert/component.html.erb
+++ b/app/components/ui/alert/component.html.erb
@@ -14,7 +14,7 @@
   </div>
 
   <% if @header.present? %>
-    <h4 class="uncap tw:mb-0! tw:text-lg! <%= text_color_classes_important %>">
+    <h4 class="uncap tw:mb-0! tw:flex-1 tw:text-lg! <%= text_color_classes_important %>">
       <%= @header %>
     </h4>
   <% end %>

--- a/app/components/ui/alert/component.rb
+++ b/app/components/ui/alert/component.rb
@@ -31,7 +31,7 @@ module UI
 
       # order-last keeps the dismiss button, which is last in the DOM, up on the header row
       def body_classes
-        @header.present? ? "tw:order-last tw:w-full" : "tw:grow"
+        @header.present? ? "tw:order-last tw:basis-full" : "tw:grow"
       end
 
       def color_classes

--- a/app/components/ui/alert/component.rb
+++ b/app/components/ui/alert/component.rb
@@ -29,6 +29,11 @@ module UI
 
       private
 
+      # order-last keeps the dismiss button, which is last in the DOM, up on the header row
+      def body_classes
+        @header.present? ? "tw:order-last tw:w-full" : "tw:grow"
+      end
+
       def color_classes
         case @kind
         when :notice

--- a/app/components/ui/alert/component_preview.rb
+++ b/app/components/ui/alert/component_preview.rb
@@ -3,6 +3,8 @@
 module UI
   module Alert
     class ComponentPreview < ApplicationComponentPreview
+      CONFIRMATION_TEXT = "We've sent a confirmation link to your email. No need to wait — you can finish registering right now."
+
       # @!group Kind variants
       def notice
         render(UI::Alert::Component.new(text: "This is a notice alert", kind: :notice))
@@ -21,13 +23,24 @@ module UI
       end
 
       def purple
-        render(UI::Alert::Component.new(text: "We've sent a confirmation link to your email. No need to wait — you can finish registering right now.", kind: :purple))
+        render(UI::Alert::Component.new(text: CONFIRMATION_TEXT, kind: :purple))
       end
 
       def custom_icon
         envelope = ActionController::Base.helpers.inline_svg_tag("icons/envelope.svg",
           class: "tw:-mb-0.5 tw:h-4 tw:w-4 tw:shrink-0", aria_hidden: true)
         render(UI::Alert::Component.new(text: "Check your email", kind: :notice, icon: envelope))
+      end
+      # @!endgroup
+
+      # @!group Header variants
+      def with_header
+        render(UI::Alert::Component.new(header: "Registration incomplete", kind: :warning, text: CONFIRMATION_TEXT))
+      end
+
+      def dismissable_with_header
+        render(UI::Alert::Component.new(header: "Registration incomplete", kind: :warning, text: CONFIRMATION_TEXT,
+          dismissable: true))
       end
       # @!endgroup
 

--- a/app/components/ui/alerts/object_error/component.en.yml
+++ b/app/components/ui/alerts/object_error/component.en.yml
@@ -4,5 +4,6 @@ en:
     ui:
       alerts:
         object_error:
-          errors_prevented_this_from_being_saved: "%{errors_count} prevented this
-            %{object_name} from being saved:"
+          error_prevented_this_from_being_saved:
+            one: "%{count} error prevented this %{object_name} from being saved:"
+            other: "%{count} errors prevented this %{object_name} from being saved:"

--- a/app/components/ui/alerts/object_error/component.html.erb
+++ b/app/components/ui/alerts/object_error/component.html.erb
@@ -1,7 +1,7 @@
 <%= render(UI::Alert::Component.new(header: header_text, kind: :error, dismissable: @dismissable)) do %>
-  <ul class="tw:mt-2! tw:mb-0! tw:list-inside tw:list-disc">
+  <ul class="tw:mb-0! tw:list-inside tw:list-disc">
     <% @error_messages.each do |message| %>
-      <li class="tw:block"><%= message %></li>
+      <li><%= message %></li>
     <% end %>
   </ul>
 <% end %>

--- a/app/components/ui/alerts/object_error/component.rb
+++ b/app/components/ui/alerts/object_error/component.rb
@@ -18,8 +18,7 @@ module UI
         private
 
         def header_text
-          translation(".errors_prevented_this_from_being_saved", errors_count: @error_messages.count,
-            object_name: @name)
+          translation(".error_prevented_this_from_being_saved", count: @error_messages.count, object_name: @name)
         end
       end
     end

--- a/app/views/admin/mail_snippets/_form.html.erb
+++ b/app/views/admin/mail_snippets/_form.html.erb
@@ -2,7 +2,7 @@
 
 <% if @mail_snippet.organization_message? %>
   <%= render(UI::Alert::Component.new(kind: :error, header: "This is an Organization Message Snippet!")) do %>
-    <em class="small d-block mt-2">
+    <em class="small d-block">
       This should actually be
       <%= link_to "edited though the organization!", edit_mail_snippet_path_for(@mail_snippet) %>
     </em>
@@ -10,7 +10,7 @@
 <% end %>
 
 <%= render(UI::Alert::Component.new(kind: :info, header: "NOTE: Organization Message snippets are actually the entire email.")) do %>
-  <p class="mb-0 tw:mt-2">
+  <p class="mb-0">
     Organization Messages are editable through the organization's page and
     should probably be edited there (rather than here). Those kinds:
     <small class="d-block mt-2"><%= safe_join(MailSnippet.organization_message_kinds.map { |kind| content_tag(:code, MailSnippet.kind_humanized(kind)) }, ", ") %></small>

--- a/spec/components/ui/alerts/object_error/component_spec.rb
+++ b/spec/components/ui/alerts/object_error/component_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe UI::Alerts::ObjectError::Component, type: :component do
   end
 
   it "renders error messages" do
-    expect(component).to have_text("2 prevented this User from being saved:")
+    expect(component).to have_text("2 errors prevented this User from being saved:")
     expect(component).to have_text("Email can't be blank")
     expect(component).to have_text("Password is too short")
   end
@@ -40,7 +40,7 @@ RSpec.describe UI::Alerts::ObjectError::Component, type: :component do
     end
 
     it "uses singular 'error'" do
-      expect(component).to have_text("1 prevented")
+      expect(component).to have_text("1 error prevented")
     end
   end
 end


### PR DESCRIPTION
`UI::Alert` rendered with a `header:` now runs its body across the full alert width, on its own line below the header row, instead of indenting it into the icon's column.

- **The header shares the icon's line, the dismiss button stays with it.** `flex-1` on the header stops it wrapping below the icon at narrow widths (`flex-wrap` breaks a line before it shrinks anything), and `order-last` on the body lets it wrap past the button.
- **Vertical rhythm moved into the component** via `gap-y-2`, replacing the `mt-2` each `header:` caller had been adding for itself — `admin/dashboard/scheduled_jobs` never did, and its list sat flush against the header.
- **`Alerts::ObjectError` reads "1 error" / "2 errors prevented this User from being saved".** The count had no noun before. The key is renamed rather than restructured in place, so the four `translation.*.yml` entries — translations of the same defect, interpolating `%{errors_count}` — aren't handed a `count:` they can't use. **They need a translation.io sync**; until then non-en locales fall back to `:en` in production only (`config/application.rb`'s hash-form `i18n.fallbacks` drops the `:en` default in dev/test, so a non-en locale raises there — pre-existing, and it makes every en-only key a dev/test landmine).
- **Its bullets render again.** The `<li>`s carried `tw:block`, and `display: block` suppresses the list marker, so the `tw:list-disc` on the `<ul>` had never shown.
