### PR TITLE
Scroll long modal bodies instead of pushing them off-screen

### DIFF
--- a/app/components/registrations/show/wrapper/component.rb
+++ b/app/components/registrations/show/wrapper/component.rb
@@ -8,7 +8,7 @@ module Registrations
       class Component < ApplicationComponent
         # Digest of the markup inside the cache block — the cached_markup_digest spec
         # keeps it current, following what this tree renders out into UI:: and elsewhere
-        MARKUP_DIGEST = "5f851681e24e"
+        MARKUP_DIGEST = "e6aac93ab137"
 
         def initialize(bike:, current_user:, view:, available_views:, bike_sticker: nil)
           @bike = bike

--- a/app/components/registrations/show/wrapper/component.rb
+++ b/app/components/registrations/show/wrapper/component.rb
@@ -8,7 +8,7 @@ module Registrations
       class Component < ApplicationComponent
         # Digest of the markup inside the cache block — the cached_markup_digest spec
         # keeps it current, following what this tree renders out into UI:: and elsewhere
-        MARKUP_DIGEST = "67772d7adcf3"
+        MARKUP_DIGEST = "5f851681e24e"
 
         def initialize(bike:, current_user:, view:, available_views:, bike_sticker: nil)
           @bike = bike

--- a/app/components/registrations/show/wrapper/component.rb
+++ b/app/components/registrations/show/wrapper/component.rb
@@ -8,7 +8,7 @@ module Registrations
       class Component < ApplicationComponent
         # Digest of the markup inside the cache block — the cached_markup_digest spec
         # keeps it current, following what this tree renders out into UI:: and elsewhere
-        MARKUP_DIGEST = "e6aac93ab137"
+        MARKUP_DIGEST = "24cc9ac6d614"
 
         def initialize(bike:, current_user:, view:, available_views:, bike_sticker: nil)
           @bike = bike

--- a/app/components/ui/modal/component.html.erb
+++ b/app/components/ui/modal/component.html.erb
@@ -4,28 +4,29 @@
   data-ui--modal-open-on-connect-value="<%= @open %>"
   data-action="click->ui--modal#backdropClick keydown->ui--modal#handleKeydown"
   class="
-    tw:m-auto tw:max-h-dvh tw:w-full tw:max-w-lg tw:bg-transparent tw:px-4
-    tw:pt-4 tw:backdrop:bg-black/50 tw:backdrop:backdrop-blur-sm
-    tw:open:flex tw:open:flex-col tw:open:items-center
-    tw:open:justify-center
+    tw:m-auto tw:max-h-dvh tw:w-full tw:max-w-lg tw:overflow-y-auto
+    tw:overscroll-contain tw:bg-transparent tw:px-4 tw:backdrop:bg-black/50
+    tw:backdrop:backdrop-blur-sm
   "
 >
   <%#
-    overflow-hidden is also what lets this column shrink past its content, so a
-    tall body scrolls instead of pushing the title bar off-screen
+    The dialog is the scroller, so the rounded ends stay off-screen until you
+    reach them. clip rather than hidden: hidden would make this the scrollport
+    and strand the sticky title bar
   %>
 
   <div
     class="
-      tw:flex tw:w-full tw:flex-col tw:overflow-hidden tw:rounded-xl
-      tw:bg-white tw:shadow-xl tw:dark:bg-gray-800
+      tw:my-4 tw:w-full tw:overflow-clip tw:rounded-xl tw:bg-white
+      tw:shadow-xl tw:dark:bg-gray-800
     "
   >
     <% if @title %>
       <div
         class="
-          tw:flex tw:items-center tw:justify-between tw:border-b
-          tw:border-gray-200 tw:px-5 tw:py-4 tw:dark:border-gray-700
+          tw:sticky tw:top-0 tw:flex tw:items-center tw:justify-between
+          tw:border-b tw:border-gray-200 tw:bg-white tw:px-5 tw:py-4
+          tw:dark:border-gray-700 tw:dark:bg-gray-800
         "
       >
         <h3 class="tw:text-lg tw:font-semibold tw:text-gray-900 tw:dark:text-white">
@@ -58,7 +59,7 @@
       </div>
     <% end %>
 
-    <div class="twtext-color tw:overflow-y-auto tw:overscroll-contain tw:px-5 tw:py-4">
+    <div class="twtext-color tw:px-5 tw:py-4">
       <%= body %>
     </div>
   </div>

--- a/app/components/ui/modal/component.html.erb
+++ b/app/components/ui/modal/component.html.erb
@@ -4,15 +4,20 @@
   data-ui--modal-open-on-connect-value="<%= @open %>"
   data-action="click->ui--modal#backdropClick keydown->ui--modal#handleKeydown"
   class="
-    tw:m-auto tw:w-full tw:max-w-lg tw:bg-transparent tw:p-0
+    tw:m-auto tw:max-h-dvh tw:w-full tw:max-w-lg tw:bg-transparent tw:p-4
     tw:backdrop:bg-black/50 tw:backdrop:backdrop-blur-sm tw:open:flex
-    tw:open:items-center tw:open:justify-center
+    tw:open:flex-col tw:open:items-center tw:open:justify-center
   "
 >
+  <%#
+    overflow-hidden is also what lets this column shrink past its content, so a
+    tall body scrolls instead of pushing the title bar off-screen
+  %>
+
   <div
     class="
-      tw:mx-4 tw:w-full tw:overflow-hidden tw:rounded-xl tw:bg-white
-      tw:shadow-xl tw:dark:bg-gray-800
+      tw:flex tw:w-full tw:flex-col tw:overflow-hidden tw:rounded-xl
+      tw:bg-white tw:shadow-xl tw:dark:bg-gray-800
     "
   >
     <% if @title %>
@@ -52,7 +57,7 @@
       </div>
     <% end %>
 
-    <div class="twtext-color tw:px-5 tw:py-4">
+    <div class="twtext-color tw:overflow-y-auto tw:overscroll-contain tw:px-5 tw:py-4">
       <%= body %>
     </div>
   </div>

--- a/app/components/ui/modal/component.html.erb
+++ b/app/components/ui/modal/component.html.erb
@@ -4,9 +4,10 @@
   data-ui--modal-open-on-connect-value="<%= @open %>"
   data-action="click->ui--modal#backdropClick keydown->ui--modal#handleKeydown"
   class="
-    tw:m-auto tw:max-h-dvh tw:w-full tw:max-w-lg tw:bg-transparent tw:p-4
-    tw:backdrop:bg-black/50 tw:backdrop:backdrop-blur-sm tw:open:flex
-    tw:open:flex-col tw:open:items-center tw:open:justify-center
+    tw:m-auto tw:max-h-dvh tw:w-full tw:max-w-lg tw:bg-transparent tw:px-4
+    tw:pt-4 tw:backdrop:bg-black/50 tw:backdrop:backdrop-blur-sm
+    tw:open:flex tw:open:flex-col tw:open:items-center
+    tw:open:justify-center
   "
 >
   <%#

--- a/app/components/ui/modal/component_preview/default.html.erb
+++ b/app/components/ui/modal/component_preview/default.html.erb
@@ -2,6 +2,8 @@
   <%= render(UI::Button::Component.new(text: "Open Settings", data: { open_modal: "settings-modal" })) %>
 
   <%= render(UI::Button::Component.new(text: "Open Confirmation", data: { open_modal: "confirm-modal" })) %>
+
+  <%= render(UI::Button::Component.new(text: "Open Long", data: { open_modal: "long-modal" })) %>
 </div>
 
 <%= render(UI::Modal::Component.new(title: "Settings", id: "settings-modal")) do |modal| %>
@@ -17,5 +19,62 @@
     </p>
 
     <%= render(UI::Button::Component.new(text: "Confirm", color: :primary, data: { action: "click->ui--modal#close" })) %>
+  <% end %>
+<% end %>
+
+<%= render(UI::Modal::Component.new(title: "Long content", id: "long-modal")) do |modal| %>
+  <% modal.with_body do %>
+    <p class="tw:mb-4">
+      I'm baby hipster runoff herman miller somatic, lacto-ferment YOLO burrata
+      birth chart tbh cornhole praxis meh vinyl ice bath. Pickled cahiers yr
+      orange wine. Succulents monstera kale chips, normcore next level paleo
+      reading series before they sold out pork belly. Yr normcore new balance
+      moon phase edison bulb tarot pull live-edge omakase. Reading series
+      fingerstache thrifted manifesting, bruh tinned fish church-key hot
+      chicken. Fingerstache koji mumblecore sambas enamel pin neutra moka pot,
+      YOLO praxis.
+    </p>
+
+    <p class="tw:mb-4">
+      Vaporware van life pét-nat baffler, kombucha nepo baby shakshuka knoll
+      squid occupy slugging wolf cut oat milk cardigan. Bedroom pop abolition
+      gorpcore semiotics. Hyperpop moss wall chronically online, black garlic
+      normcore flexitarian conservas forage polycule pothos YIMBY. Banh mi
+      ottessa moshfegh girl dinner adaptogen bolaño monstera. Sound bath
+      furikake beard before they sold out dad shoes needle felting, mustache
+      babitz man braid affogato.
+    </p>
+
+    <p class="tw:mb-4">
+      Meggings same gibraltar brainrot freegan nepo baby. Keffiyeh manifesting
+      wabi-sabi pickled cupping fiddle leaf lambrusco braun. Edison bulb chia
+      polaroid, indigo dye shoegaze swag pandan cacio e pepe artisan sambas
+      doomer omakase vagus nerve. Sambas black trumpet PBR&amp;B tonx vaporware
+      williamsburg asymmetrical cacio e pepe natural wine y2k. Slugging
+      cold-pressed schlitz signet, koji paleo knoll iPhone enneagram austin
+      listicle. Etsy mid-century bespoke crucifix.
+    </p>
+
+    <p class="tw:mb-4">
+      Cassette literally skateboard cornhole leggings. Late capitalism lynch
+      copper mug, pug pop-up orange wine viral. Signet craft beer burrata
+      lumbersexual dreamcatcher vibe check yes plz meggings sound bath.
+      Breadcrumbing gochujang vagus nerve waistcoat live-edge gravel bike
+      biohack jawn blue bottle supper club truffaut. Ottessa moshfegh delulu
+      JOMO bolaño. Abolition tbh drinking vinegar visible mending dog dad.
+    </p>
+
+    <p class="tw:mb-4">
+      Normcore pour-over yo la tengo, street art amaro gut health poutine
+      cupping sound bath pop-up ego death you probably haven't heard of them raw
+      denim art party gastropub. Knoll art party small batch, oyster hour
+      slow-carb jawn marxism sally rooney shoreditch granny square adaptogen
+      literally n+1. Feeld manifesting matcha lo-fi nootropic. Organic tarkovsky
+      birria four tet matcha single-origin coffee hammock lomo farm-to-table.
+      Salvia bluesky messenger bag in this economy air plant Brooklyn etsy koji
+      breathwork stereolab jawn.
+    </p>
+
+    <%= render(UI::Button::Component.new(text: "Done", color: :primary, data: { action: "click->ui--modal#close" })) %>
   <% end %>
 <% end %>

--- a/spec/components/ui/modal/component_system_spec.rb
+++ b/spec/components/ui/modal/component_system_spec.rb
@@ -16,6 +16,13 @@ RSpec.describe UI::Modal::Component, :js, type: :system do
     find('button[aria-label="Close"]').click
 
     expect(page).not_to have_css("dialog[open]")
+
+    # Short enough that the body has to scroll rather than grow the dialog
+    resize_window(width: 800, height: 400)
+    click_button "Open Long"
+
+    expect(page).to have_text("Fingerstache koji mumblecore")
+    expect(find('#long-modal button[aria-label="Close"]')).not_to be_obscured
   end
 
   it "opens a server-opened modal on load, without adding the param" do

--- a/spec/components/ui/modal/component_system_spec.rb
+++ b/spec/components/ui/modal/component_system_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe UI::Modal::Component, :js, type: :system do
 
     # Short enough that the body has to scroll rather than grow the dialog
     resize_window(width: 800, height: 400)
-    click_button "Open Long"
+    open_modal(find_button("Open Long"))
 
     expect(page).to have_text("Fingerstache koji mumblecore")
     expect(find('#long-modal button[aria-label="Close"]')).not_to be_obscured

--- a/spec/support/system_spec_helpers.rb
+++ b/spec/support/system_spec_helpers.rb
@@ -27,6 +27,12 @@ module SystemSpecHelpers
     end
   end
 
+  # Resize for this example only -- the browser context is recreated between
+  # examples, so the configured viewport comes back on its own.
+  def resize_window(width:, height:)
+    page.driver.with_playwright_page { |playwright_page| playwright_page.set_viewport_size(width:, height:) }
+  end
+
   def browser_cookie_value(name)
     page.driver.with_playwright_page do |playwright_page|
       playwright_page.context.cookies.find { |cookie| cookie["name"] == name }&.fetch("value")


### PR DESCRIPTION
A `UI::Modal` taller than the viewport centered itself, pushing the title bar and its close button off-screen with no way to scroll or dismiss it. The dialog is now the scroll container, capped at the viewport, with the title bar pinned by `sticky`.

- **Scrolling the dialog rather than the body carries the panel with it**, so both rounded ends only come into view when you reach them instead of sitting at the screen edge the whole way down.
- **`overflow-clip` on the panel, not `overflow-hidden`** — `hidden` would make the panel a scrollport of its own and leave the sticky title bar with nothing to stick to.
- **`Registrations::Show::Wrapper`'s `MARKUP_DIGEST` moves** — the modal renders inside its fragment cache, so the key has to change for the new markup to be served.
- A long-content modal joins the `default` preview, and a new `resize_window` spec helper forces the overflow rather than leaving it to depend on the fixture out-growing the 1920×1080 test viewport.
