### PR TITLE
Update sandbox-test-setup web-sandbox section

### DIFF
--- a/.claude/skills/sandbox-test-setup/SKILL.md
+++ b/.claude/skills/sandbox-test-setup/SKILL.md
@@ -33,21 +33,21 @@ sandbox**; `/home/user/bike_index` uses **Claude Code web sandbox**.
 
 ## Local macOS (Conductor workspace)
 
-Ruby 4.0.2 is installed via [mise](https://mise.jdx.dev/), but Claude
+Ruby 4.0.5 is installed via [mise](https://mise.jdx.dev/), but Claude
 Code's shell sometimes spawns subprocesses without the mise shim on
 PATH — bare `ruby` then resolves to `/usr/bin/ruby` (2.6) and `bundle`
 fails with `Could not find 'bundler' (4.0.0.beta2)`. **The Ruby is
 installed; the PATH just isn't right** — don't reinstall, don't edit
 the Gemfile.
 
-Check first; only prefix PATH if `ruby -v` doesn't already print 4.0.2
+Check first; only prefix PATH if `ruby -v` doesn't already print 4.0.5
 (`mise exec -- ruby`/`bundle` are unreliable in this harness — they
 can still resolve to system 2.6, so use the direct prefix):
 
 ```bash
 ruby -v
-# If it's not 4.0.2:
-export PATH="/Users/seth/.local/share/mise/installs/ruby/4.0.2/bin:$PATH"
+# If it's not 4.0.5:
+export PATH="/Users/seth/.local/share/mise/installs/ruby/4.0.5/bin:$PATH"
 ```
 
 Then run specs the normal way:

--- a/.claude/skills/sandbox-test-setup/SKILL.md
+++ b/.claude/skills/sandbox-test-setup/SKILL.md
@@ -134,33 +134,46 @@ applies to any spec that renders the layout.
 
 ## Claude Code web sandbox
 
-The Gemfile pins `ruby "4.0.2"` and `Gemfile.lock` pins
-`BUNDLED WITH 4.0.0.beta2`. No prebuilt 4.0.2 binary is reachable
-(`cache.ruby-lang.org` is 403'd, `ruby/ruby-builder`'s toolcache tops
-out at `3.5.0-preview1`), so build from the GitHub source tag — about
-8–10 min on a 4-core sandbox. Don't fall back to 3.x and patch the
-Gemfile; Bundler 4.x's resolver behaves differently and you'll waste
-time chasing fake regressions. Once `/opt/ruby-4.0.2/x64/` exists,
+`Gemfile` pins the Ruby version (`ruby "4.0.5"` at time of writing —
+**read the current pin from the `ruby` line in `Gemfile`**, it moves) and
+`Gemfile.lock` pins `BUNDLED WITH 4.0.15`. No prebuilt binary for that
+version is reachable (`cache.ruby-lang.org` is 403'd, `ruby/ruby-builder`'s
+toolcache tops out at `3.5.0-preview1`), so build from the GitHub source
+tag — about 8–10 min on a 4-core sandbox. Don't fall back to 3.x and patch
+the Gemfile; Bundler 4.x's resolver behaves differently and you'll waste
+time chasing fake regressions. Once `/opt/ruby-<version>/x64/` exists,
 `bundle install` works as-is.
 
-## One-shot Ruby 4.0.2 build
+You also need **libvips** on the box — the app loads `ruby-vips` at boot,
+so without it every Ruby entry point (`db:migrate`, `rspec`, `rails`) dies
+with `LoadError: Could not open library 'vips.so.42'`. It's not a build
+dep, so install it separately: `apt-get install -y libvips42` (run
+`apt-get update` first if a fetch 404s).
 
-Skip if `/opt/ruby-4.0.2/x64/bin/ruby --version` already prints 4.0.2.
-Two quirks the bash block handles: (1) GitHub source tarballs lack a
-pre-generated `configure`, so `autogen.sh` runs first; (2) `make install`
-fetches ~30 bundled gems via `BASERUBY`, whose hardcoded CA bundle
-doesn't include the sandbox egress-proxy CA — so we pre-stage every
-bundled gem with `curl` (which honours
-`/etc/ssl/certs/ca-certificates.crt`) before `make install`.
+## One-shot Ruby build
+
+Set `RUBYVER` to the pin from `Gemfile`. Skip if
+`/opt/ruby-$RUBYVER/x64/bin/ruby --version` already prints it. Three
+quirks the bash block handles: (1) GitHub's archive-tarball endpoint
+(`/archive/refs/tags/*.tar.gz`) **403s through the sandbox proxy** even
+though plain `git` over https to github.com works — so clone the tag
+shallowly instead of `curl`-ing a tarball; (2) the source tree ships no
+pre-generated `configure`, so `autogen.sh` runs first; (3) `make install`
+fetches ~30 bundled gems via `BASERUBY`, whose hardcoded CA bundle doesn't
+include the sandbox egress-proxy CA — so we pre-stage every bundled gem
+with `curl` (which honours `/etc/ssl/certs/ca-certificates.crt`) before
+`make install`.
 
 ```bash
-# 1. Source — GitHub tag tarball (cache.ruby-lang.org is blocked)
-mkdir -p /tmp/ruby-build-src && cd /tmp/ruby-build-src
-curl -sfL "https://github.com/ruby/ruby/archive/refs/tags/v4.0.2.tar.gz" \
-  | tar -xz
-cd ruby-4.0.2
+RUBYVER=$(grep -oE '^ruby "([0-9.]+)"' /home/user/bike_index/Gemfile | grep -oE '[0-9.]+')
 
-# 2. Generate ./configure (GitHub source tarballs don't ship it)
+# 1. Source — shallow git clone of the tag. The archive tarball URL 403s here;
+#    codeload does too. `git clone` over https is what works.
+mkdir -p /tmp/ruby-build-src && cd /tmp/ruby-build-src
+git clone --depth 1 --branch "v${RUBYVER}" https://github.com/ruby/ruby.git "ruby-${RUBYVER}"
+cd "ruby-${RUBYVER}"
+
+# 2. Generate ./configure (the source tree doesn't ship it)
 ./autogen.sh
 
 # 3. Pre-stage every bundled gem (avoids the rubygems-cert MITM issue)
@@ -173,8 +186,8 @@ done < gems/bundled_gems
 
 # 4. Configure + build + install (BASERUBY = preinstalled /opt/ruby-3.3.6)
 mkdir -p /tmp/ruby-build-src/build && cd /tmp/ruby-build-src/build
-/tmp/ruby-build-src/ruby-4.0.2/configure \
-  --prefix=/opt/ruby-4.0.2/x64 \
+"/tmp/ruby-build-src/ruby-${RUBYVER}/configure" \
+  --prefix="/opt/ruby-${RUBYVER}/x64" \
   --enable-shared \
   --disable-install-doc \
   --with-openssl-dir=/usr
@@ -182,12 +195,12 @@ make -j"$(nproc)"
 SSL_CERT_FILE=/etc/ssl/certs/ca-certificates.crt make install
 
 # 5. Match the GitHub-Actions hostedtoolcache layout some shebangs assume
-mkdir -p /opt/hostedtoolcache/Ruby/4.0.2
-[ -e /opt/hostedtoolcache/Ruby/4.0.2/x64 ] || \
-  ln -s /opt/ruby-4.0.2/x64 /opt/hostedtoolcache/Ruby/4.0.2/x64
+mkdir -p "/opt/hostedtoolcache/Ruby/${RUBYVER}"
+[ -e "/opt/hostedtoolcache/Ruby/${RUBYVER}/x64" ] || \
+  ln -s "/opt/ruby-${RUBYVER}/x64" "/opt/hostedtoolcache/Ruby/${RUBYVER}/x64"
 
 cd /home/user/bike_index
-/opt/ruby-4.0.2/x64/bin/ruby --version   # => ruby 4.0.2 ... [x86_64-linux]
+"/opt/ruby-${RUBYVER}/x64/bin/ruby" --version   # => ruby $RUBYVER ... [x86_64-linux]
 ```
 
 ## Toolchain on PATH
@@ -198,8 +211,8 @@ lives only on `/usr/sbin`.
 
 ```bash
 CHROME_DIR=$(ls -d /opt/pw-browsers/chromium-*/chrome-linux | sort -V | tail -1)
-export PATH="/opt/ruby-4.0.2/x64/bin:$CHROME_DIR:/usr/local/bin:/usr/bin:/bin:/usr/sbin"
-export LD_LIBRARY_PATH="/opt/ruby-4.0.2/x64/lib:$LD_LIBRARY_PATH"
+export PATH="/opt/ruby-4.0.5/x64/bin:$CHROME_DIR:/usr/local/bin:/usr/bin:/bin:/usr/sbin"
+export LD_LIBRARY_PATH="/opt/ruby-4.0.5/x64/lib:$LD_LIBRARY_PATH"
 bundle install
 ```
 
@@ -320,13 +333,15 @@ trusts the self-signed cert.
 
 ## End-to-end recap
 
-Assumes Ruby 4.0.2 is already built. Combines the steps above:
+Assumes the pinned Ruby is already built (paths below use 4.0.5 — swap for
+the current pin). Combines the steps above:
 
 ```bash
 CHROME_DIR=$(ls -d /opt/pw-browsers/chromium-*/chrome-linux | sort -V | tail -1)
-export PATH="/opt/ruby-4.0.2/x64/bin:$CHROME_DIR:/usr/local/bin:/usr/bin:/bin:/usr/sbin"
-export LD_LIBRARY_PATH="/opt/ruby-4.0.2/x64/lib:$LD_LIBRARY_PATH"
+export PATH="/opt/ruby-4.0.5/x64/bin:$CHROME_DIR:/usr/local/bin:/usr/bin:/bin:/usr/sbin"
+export LD_LIBRARY_PATH="/opt/ruby-4.0.5/x64/lib:$LD_LIBRARY_PATH"
 service postgresql start && service redis-server start
+apt-get install -y libvips42   # ruby-vips loads at boot; without it every rails/rspec run dies
 cd /home/user/bike_index
 bundle install
 eval "$(ruby bin/env --export)"
@@ -342,10 +357,13 @@ LOCAL_CHROME_OVERRIDE=1 bundle exec rspec spec/integration   # system; CDN proxy
 
 Quick probe: `curl -sIL --max-time 5 "https://<host>" -o /dev/null -w "%{http_code}\n"`.
 
-- **Allowed**: github.com, codeload.github.com, rubygems.org,
+- **Allowed**: github.com (git-over-https clone/fetch), rubygems.org,
   registry.npmjs.org, storage.googleapis.com, files.pythonhosted.org.
 - **Blocked**: cache.ruby-lang.org, cdn.jsdelivr.net, most generic CDNs,
-  download.ruby-lang.org, api.github.com.
+  download.ruby-lang.org, api.github.com. Also GitHub's codeload /
+  archive-tarball endpoints (`/archive/refs/tags/*.tar.gz`,
+  `codeload.github.com`) 403 through the proxy — `git clone` the tag
+  instead of downloading a tarball.
 
 If a tool's default download URL is blocked, look for a GitHub or
 npm-registry alternative before giving up.


### PR DESCRIPTION
Fixes discovered running specs in the Claude Code web sandbox:

- Read the Ruby version from Gemfile (now 4.0.5, was hardcoded 4.0.2) via a
  RUBYVER variable so the recipe tracks the pin. Correct BUNDLED WITH to
  4.0.15.
- GitHub's archive-tarball and codeload endpoints 403 through the sandbox
  proxy even though git-over-https works, so clone the tag shallowly
  instead of curling a tarball. Note this in the network section.
- Document the libvips requirement: ruby-vips loads at boot, so without
  libvips42 every rails/rspec/db:migrate run dies with LoadError vips.so.42.
