### PR TITLE
Match postmark's undeliverable errors by class, not by name

### DIFF
--- a/app/jobs/backfills/notification_delivery_error_rename_job.rb
+++ b/app/jobs/backfills/notification_delivery_error_rename_job.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+module Backfills
+  # delivery_error holds the class name postmark raised. postmark 1.23 renamed
+  # InvalidEmailAddressError, so rows written before the 1.25.1 bump in #2961 carry the old name
+  class NotificationDeliveryErrorRenameJob < ApplicationJob
+    include Sidekiq::IterableJob
+
+    sidekiq_options queue: "low_priority", retry: false
+
+    LEGACY_NAME = "Postmark::InvalidEmailAddressError"
+    CURRENT_NAME = "Postmark::InvalidEmailRequestError"
+
+    # batch_size has to be passed - the enumerator hands in_batches an explicit `of: nil` without it
+    def build_enumerator(cursor:)
+      active_record_relations_enumerator(notifications, cursor:, batch_size: 1_000)
+    end
+
+    # Renamed rows drop out of the relation, but the cursor moves forward by id, so a resumed
+    # run doesn't skip anything
+    def each_iteration(batch)
+      batch.update_all(delivery_error: CURRENT_NAME)
+    end
+
+    private
+
+    def notifications
+      Notification.where(delivery_error: LEGACY_NAME)
+    end
+  end
+end

--- a/app/jobs/email/magic_login_link_job.rb
+++ b/app/jobs/email/magic_login_link_job.rb
@@ -16,7 +16,7 @@ module Email
       raise e if user.nil?
 
       user_email_for(user)&.update_last_email_errored!(email_errored: true)
-      raise e unless Notification::UNDELIVERABLE_ERRORS.include?(e.class.to_s)
+      raise e unless Notification::UNDELIVERABLE_ERRORS.any? { |error_class| e.is_a?(error_class) }
     end
 
     private

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -38,7 +38,9 @@ class Notification < ApplicationRecord
   MESSAGE_CHANNEL_ENUM = {email: 0, text: 1}.freeze
   DELIVERY_STATUS_ENUM = {delivery_pending: 0, delivery_success: 1, delivery_failure: 2}.freeze
 
-  UNDELIVERABLE_ERRORS = %w[Postmark::InactiveRecipientError Postmark::InvalidEmailAddressError].freeze
+  UNDELIVERABLE_ERRORS = [Postmark::InactiveRecipientError, Postmark::InvalidEmailRequestError].freeze
+  # delivery_error holds the class name. postmark 1.23 renamed InvalidEmailAddressError, older rows have the old name
+  INVALID_EMAIL_ERROR_NAMES = %w[Postmark::InvalidEmailRequestError Postmark::InvalidEmailAddressError].freeze
 
   enum :kind, KIND_ENUM
   enum :message_channel, MESSAGE_CHANNEL_ENUM
@@ -245,7 +247,7 @@ class Notification < ApplicationRecord
     update(delivery_status: "delivery_failure", delivery_error: e.class)
     user_email&.update_last_email_errored!(email_errored: true)
 
-    raise e unless UNDELIVERABLE_ERRORS.include?(delivery_error)
+    raise e unless UNDELIVERABLE_ERRORS.any? { |error_class| e.is_a?(error_class) }
   end
 
   def delivery_error_spam?
@@ -253,7 +255,7 @@ class Notification < ApplicationRecord
   end
 
   def delivery_error_invalid?
-    delivery_error == "Postmark::InvalidEmailAddressError"
+    INVALID_EMAIL_ERROR_NAMES.include?(delivery_error)
   end
 
   private

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -39,8 +39,6 @@ class Notification < ApplicationRecord
   DELIVERY_STATUS_ENUM = {delivery_pending: 0, delivery_success: 1, delivery_failure: 2}.freeze
 
   UNDELIVERABLE_ERRORS = [Postmark::InactiveRecipientError, Postmark::InvalidEmailRequestError].freeze
-  # delivery_error holds the class name. postmark 1.23 renamed InvalidEmailAddressError, older rows have the old name
-  INVALID_EMAIL_ERROR_NAMES = %w[Postmark::InvalidEmailRequestError Postmark::InvalidEmailAddressError].freeze
 
   enum :kind, KIND_ENUM
   enum :message_channel, MESSAGE_CHANNEL_ENUM
@@ -255,7 +253,7 @@ class Notification < ApplicationRecord
   end
 
   def delivery_error_invalid?
-    INVALID_EMAIL_ERROR_NAMES.include?(delivery_error)
+    delivery_error == "Postmark::InvalidEmailRequestError"
   end
 
   private

--- a/spec/jobs/backfills/notification_delivery_error_rename_job_spec.rb
+++ b/spec/jobs/backfills/notification_delivery_error_rename_job_spec.rb
@@ -1,0 +1,24 @@
+require "rails_helper"
+
+RSpec.describe Backfills::NotificationDeliveryErrorRenameJob, type: :job do
+  describe "perform" do
+    def create_notification(delivery_error)
+      FactoryBot.create(:notification, delivery_status: "delivery_failure", delivery_error:)
+    end
+
+    let!(:legacy) { create_notification("Postmark::InvalidEmailAddressError") }
+    let!(:current) { create_notification("Postmark::InvalidEmailRequestError") }
+    let!(:spam) { create_notification("Postmark::InactiveRecipientError") }
+
+    it "renames only the legacy error" do
+      expect(legacy.delivery_error_invalid?).to be_falsey
+
+      Sidekiq::Testing.inline! { described_class.perform_async }
+
+      expect(legacy.reload.delivery_error).to eq "Postmark::InvalidEmailRequestError"
+      expect(legacy.delivery_error_invalid?).to be_truthy
+      expect(current.reload.delivery_error).to eq "Postmark::InvalidEmailRequestError"
+      expect(spam.reload.delivery_error).to eq "Postmark::InactiveRecipientError"
+    end
+  end
+end

--- a/spec/models/notification_spec.rb
+++ b/spec/models/notification_spec.rb
@@ -257,5 +257,17 @@ RSpec.describe Notification, type: :model do
         end
       end
     end
+
+    context "with InvalidEmailRequestError" do
+      let(:invalid_email_error) { Postmark::ApiInputError.build("error", {"ErrorCode" => 300}) }
+      it "adds the error to the notification without raising" do
+        expect(notification.reload.delivery_status).to eq "delivery_pending"
+        notification.track_email_delivery { raise invalid_email_error }
+
+        expect(notification.reload.delivery_status).to eq "delivery_failure"
+        expect(notification.delivery_error).to eq "Postmark::InvalidEmailRequestError"
+        expect(notification.delivery_error_invalid?).to be_truthy
+      end
+    end
   end
 end


### PR DESCRIPTION
`Notification#track_email_delivery` already meant to record an undeliverable address and move on, but it decided by comparing `e.class.to_s` against a list of strings. postmark 1.23 renamed `InvalidEmailAddressError` to `InvalidEmailRequestError`, so the bump to 1.25.1 in #2961 quietly stopped matching and every send to a junk address re-raised instead — [1,260 occurrences](https://app.honeybadger.io/projects/35931/faults/129918592), mostly `Email::PartialRegistrationJob` on garbage `owner_email` values.

- **`UNDELIVERABLE_ERRORS` holds the classes themselves**, matched with `is_a?` at both call sites. The old name is still a deprecated alias for the same object, so a class-based list would never have broken here — and the next rename raises `NameError` at boot rather than silently falling through to `raise e`.
- **`Backfills::NotificationDeliveryErrorRenameJob` renames the rows written under the old name**, so `delivery_error` — a persisted class name the admin table reads — carries one name rather than two the read predicate has to know about. Run it from the console; nothing schedules it.
