### PR TITLE
Retry flash dismissal until it lands, instead of clicking once

### DIFF
--- a/spec/support/system_spec_helpers.rb
+++ b/spec/support/system_spec_helpers.rb
@@ -95,10 +95,16 @@ module SystemSpecHelpers
   end
 
   # Flash messages are fixed position, so an undismissed one intercepts clicks on
-  # whatever it overlays. Wait out the dismiss transition before moving on.
-  def dismiss_flash_messages(wait: 10)
-    all("#flash-messages [aria-label='Close']", minimum: 1).each(&:click)
-    expect(page).to have_no_css("#flash-messages [role='alert']", wait:)
+  # whatever it overlays. Like open_modal, ui--alert wires its close action in
+  # `connect`, so a click landing before that lazy loaded controller arrives does
+  # nothing -- click again until the region clears.
+  def dismiss_flash_messages(attempts: 10)
+    expect(page).to have_css("#flash-messages [role='alert']")
+    attempts.times do
+      retry_on_detach { all("#flash-messages [aria-label='Close']", wait: 0).each(&:click) }
+      return if page.has_no_css?("#flash-messages [role='alert']", wait: 1)
+    end
+    raise "#flash-messages never cleared after #{attempts} dismiss clicks"
   end
 
   private


### PR DESCRIPTION
`dismiss_flash_messages` clicked each close button once, then waited 10s for the region to clear. But `ui--alert` wires its close action in `connect` and `application.js` lazy loads controllers, so a click landing before that module arrives hits a button with no listener and is silently swallowed — and every caller dismisses right after a page load, which is exactly when that's most likely. Under CPU load it failed 1 run in 8.

- **Click again until the region clears**, the way `open_modal` already handles the same lazy-load race a few lines up. Same ~10s ceiling; under the load that reproduced the failure, 16 runs (80 dismissals) came back clean.
- **Presence is asserted up front** instead of by `minimum: 1` inside the loop, so a retry can't raise a fresh `ExpectationNotMet` when the region clears between the probe and the lookup. `retry_on_detach` wraps the query rather than one click, so it re-finds instead of re-clicking a node that's already gone.
