### PR TITLE
Restore the saved search distance alongside the location

### DIFF
--- a/app/javascript/controllers/search/kind_select_fields_controller.js
+++ b/app/javascript/controllers/search/kind_select_fields_controller.js
@@ -109,6 +109,12 @@ export default class extends Controller {
       }
       // Then set the location from whatever we got
       this.locationTarget.value = location
+      // Restore the distance saved with it, unless the field holds something
+      // other than the placeholder default - that came from the URL
+      const distance = localStorage.getItem(`${this.storageKeyPrefix}searchDistance`)
+      if (distance && this.distanceTarget.value === this.distanceTarget.placeholder) {
+        this.distanceTarget.value = distance
+      }
     }
   }
 

--- a/spec/components/search/form/component_system_spec.rb
+++ b/spec/components/search/form/component_system_spec.rb
@@ -107,6 +107,11 @@ RSpec.describe Search::Form::Component, :js, type: :system do
 
       expect_localstorage_location(location:, distance:)
 
+      # The re-rendered preview ignores the query string, so the form restores
+      # both saved values rather than rendering them
+      expect(page).to have_field("location", with: location, visible: :all)
+      expect(page).to have_field("distance", with: distance, visible: :all)
+
       target_params = {
         distance: [distance],
         location: [location],


### PR DESCRIPTION
`setSearchProximity` saves `searchLocation` and `searchDistance` together on submit, but its restore branch only brought the location back — so a page that restores a saved location renders it next to the *default* distance, and the next save writes that default over the saved one. A user who searched "Portland, OR" within 251 miles silently drops to 100 the next time they search from a page without distance params.

- **The restore branch restores the distance too**, unless the field holds something other than its placeholder — the placeholder is the default distance, so anything else came from the URL and wins.
- This is the [flaky `submits after selecting a color` failure](https://github.com/bikeindex/bike_index/actions/runs/31046304411/job/92442627689): the preview re-renders ignoring the query string, so an extra `setSearchProximity` there saved `distance=100` over the 251 the example submitted. The added spec assertions pin the restored pair.
