### PR TITLE
Add a reload_database action to the Review App workflow

### DIFF
--- a/.github/workflows/kamal-deploy.yml
+++ b/.github/workflows/kamal-deploy.yml
@@ -5,23 +5,23 @@ name: Kamal build & deploy
 # image to GHCR, then run a kamal command over SSH. Callers pass the bits that
 # differ (image tag, service label, the kamal command, concurrency, environment).
 #
-# Callers: review-app.yml (per-PR deploy/destroy) and sandbox.yml (main deploy).
-# The `run` job also handles destroy — it just runs whatever `command` it's given
-# and skips the build (there's nothing to build for a teardown).
+# Callers: review-app.yml (per-PR deploy/destroy/reload_database) and sandbox.yml
+# (main deploy). The `run` job just runs whatever `command` it's given; callers
+# with nothing to build (a teardown, a database reload) pass `build: false`.
 
 on:
   workflow_call:
     inputs:
-      action:
-        description: "deploy (build then run) or destroy (run only, no build)"
-        type: string
-        default: deploy
+      build:
+        description: Build and push the image before running the command
+        type: boolean
+        default: true
       ref:
         description: Git ref to check out for the build and the kamal command
         required: true
         type: string
       command:
-        description: The kamal command to run on the host (deploy or destroy)
+        description: The kamal command to run on the host
         required: true
         type: string
       image_tag:
@@ -67,10 +67,10 @@ env:
   IMAGE_NAME: ${{ github.repository }}
 
 jobs:
-  # Skipped on destroy (nothing to build). A superseded build is wasted work and
-  # safe to cancel — the kamal run below is the part that must never be killed.
+  # A superseded build is wasted work and safe to cancel — the kamal run below is
+  # the part that must never be killed.
   build:
-    if: inputs.action == 'deploy'
+    if: inputs.build
     runs-on: ubuntu-latest
     concurrency:
       group: ${{ inputs.concurrency_prefix }}-build
@@ -126,12 +126,12 @@ jobs:
 
   run:
     needs: build
-    # Runs after a successful build on deploy, and on its own for destroy (which
-    # skips build, leaving needs.build.result == 'skipped'). A build cancelled by a
-    # newer push leaves 'cancelled', so the stale deploy is skipped here too.
+    # Runs after a successful build, and on its own when there's nothing to build
+    # (leaving needs.build.result == 'skipped'). A build cancelled by a newer push
+    # leaves 'cancelled', so the stale deploy is skipped here too.
     if: >-
       !cancelled() &&
-      (inputs.action != 'deploy' || needs.build.result == 'success')
+      (!inputs.build || needs.build.result == 'success')
     runs-on: ubuntu-latest
     concurrency:
       group: ${{ inputs.concurrency_prefix }}
@@ -140,8 +140,8 @@ jobs:
       name: ${{ inputs.environment_name }}
       url: ${{ inputs.environment_url }}
     # These feed .kamal/secrets-ci via Dotenv variable substitution when kamal runs.
-    # Destroy needs the same bundle even though it uses little of it — avoids silent
-    # empty-string substitutions causing odd failures.
+    # The non-deploy commands need the same bundle even though they use little of
+    # it — avoids silent empty-string substitutions causing odd failures.
     env:
       IMAGE_TAG: ${{ inputs.image_tag }}
       KAMAL_CONFIG: ${{ inputs.kamal_config }}

--- a/.github/workflows/review-app.yml
+++ b/.github/workflows/review-app.yml
@@ -1,9 +1,10 @@
 name: Review App
 
-# Deploys / destroys per-PR review apps via the shared kamal-deploy.yml reusable
-# workflow (build + kamal command) to the shared review host. This file owns only
-# the PR lifecycle around it: resolving the trigger, labelling, surfacing the
-# deployment, and PR failure comments. See docs/review-apps.md for host setup.
+# Deploys / destroys / reloads the database of per-PR review apps via the shared
+# kamal-deploy.yml reusable workflow (build + kamal command) to the shared review
+# host. This file owns only the PR lifecycle around it: resolving the trigger,
+# labelling, surfacing the deployment, and PR failure comments. See
+# docs/review-apps.md for host setup.
 #
 # Triggers:
 #   - workflow_dispatch   : operator clicks "Run workflow" in Actions UI, OR
@@ -26,11 +27,11 @@ on:
         required: true
         type: string
       action:
-        description: "deploy or destroy"
+        description: "deploy, destroy, or reload_database (drop + create/migrate/seed)"
         required: true
         type: choice
         default: deploy
-        options: [deploy, destroy]
+        options: [deploy, destroy, reload_database]
   pull_request:
     types: [closed]
 
@@ -45,7 +46,7 @@ env:
   # Marks the `report` job's failure comment so it can be found again. Each comment
   # also carries the failing commit's SHA (`<!-- sha:… -->`), so `report` edits in
   # place only when the SAME commit fails again. The comment is hidden (minimized as
-  # OUTDATED), never deleted, once it's stale — either the deploy succeeds (`post`)
+  # OUTDATED), never deleted, once it's stale — either the op succeeds (`post`)
   # or a newer commit is deployed (`report` hides the prior commit's comment).
   FAILURE_COMMENT_MARKER: "<!-- review-app-failure -->"
 
@@ -117,26 +118,28 @@ jobs:
           gh pr edit "${{ steps.set.outputs.pr_number }}" --repo "$GITHUB_REPOSITORY" --add-label "$REVIEW_LABEL" || true
 
   # Build (deploy only) + run the kamal command, via the shared reusable workflow.
-  # Deploy checks out the PR head; destroy checks out the default branch — it tears
-  # down by PR number and needs none of the PR's code, and a PR predating a
+  # Deploy checks out the PR head; the other actions check out the default branch —
+  # they act on the PR by number and need none of its code, and a PR predating a
   # bin/kamal_review change would otherwise fail on its stale checkout.
   op:
-    name: ${{ needs.resolve.outputs.action == 'destroy' && 'Destroy' || 'Deploy' }} ${{ needs.resolve.outputs.pr_number }}
+    name: ${{ needs.resolve.outputs.action }} ${{ needs.resolve.outputs.pr_number }}
     needs: resolve
     if: needs.resolve.outputs.proceed == 'true'
     uses: ./.github/workflows/kamal-deploy.yml
     secrets: inherit
     with:
-      action: ${{ needs.resolve.outputs.action }}
+      build: ${{ needs.resolve.outputs.action == 'deploy' }}
       ref: ${{ needs.resolve.outputs.action == 'deploy' && needs.resolve.outputs.head_sha || github.event.repository.default_branch }}
-      command: ${{ needs.resolve.outputs.action == 'deploy' && format('bin/kamal_review deploy --app {0}', needs.resolve.outputs.pr_number) || format('bin/kamal_review destroy --app {0}', needs.resolve.outputs.pr_number) }}
+      # Each action is also the bin/kamal_review subcommand of the same name.
+      command: ${{ format('bin/kamal_review {0} --app {1}', needs.resolve.outputs.action, needs.resolve.outputs.pr_number) }}
       image_tag: pr-${{ needs.resolve.outputs.pr_number }}-${{ needs.resolve.outputs.head_sha }}
       service_label: bike-index-pr-${{ needs.resolve.outputs.pr_number }}
       sprockets_cache_prefix: review-app-sprockets
       pr_title: ${{ needs.resolve.outputs.pr_title }}
       concurrency_prefix: review-app-${{ needs.resolve.outputs.pr_number }}
       environment_name: review-app
-      environment_url: ${{ needs.resolve.outputs.action == 'deploy' && format('https://pr-{0}.review.bikeindex.org', needs.resolve.outputs.pr_number) || '' }}
+      # Empty only for destroy — every other action leaves the app serving that URL.
+      environment_url: ${{ needs.resolve.outputs.action != 'destroy' && format('https://pr-{0}.review.bikeindex.org', needs.resolve.outputs.pr_number) || '' }}
 
   # PR-side follow-ups the generic reusable workflow can't own.
   post:
@@ -174,10 +177,10 @@ jobs:
               state: "success",
               environment_url: process.env.DEPLOY_URL,
             })
-      # A successful deploy makes the `report` job's failure comment stale. Hide it
+      # A successful op makes the `report` job's failure comment stale. Hide it
       # (minimize as OUTDATED) rather than delete — the record stays on the PR.
-      - name: Hide stale deploy-failure comment
-        if: needs.resolve.outputs.action == 'deploy' && needs.op.result == 'success'
+      - name: Hide stale failure comment
+        if: needs.resolve.outputs.action != 'destroy' && needs.op.result == 'success'
         env:
           GH_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ needs.resolve.outputs.pr_number }}
@@ -255,9 +258,9 @@ jobs:
           set -euo pipefail
           sha_marker="<!-- sha:$HEAD_SHA -->"
           body="$FAILURE_COMMENT_MARKER $sha_marker
-          🚨 **Review app ${ACTION} failed** for \`${HEAD_SHA:0:7}\` — [run logs](${RUN_URL})
+          🚨 **Review app ${ACTION//_/ } failed** for \`${HEAD_SHA:0:7}\` — [run logs](${RUN_URL})
 
-          Push a fix to retry automatically, or re-run the Review App workflow manually."
+          Re-run the Review App workflow to retry (a push re-dispatches a deploy)."
           # Edit in place only when THIS commit failed before; a comment for an older
           # commit is left untouched here and hidden below.
           cid=$(gh api "repos/$GITHUB_REPOSITORY/issues/$PR_NUMBER/comments" --paginate \

--- a/bin/kamal_review
+++ b/bin/kamal_review
@@ -6,6 +6,7 @@
 #   bin/kamal_review <kamal args...> --app <review-app>   # any kamal command
 #   bin/kamal_review deploy  --app <review-app> [--version <tag>]
 #   bin/kamal_review destroy --app <review-app>
+#   bin/kamal_review reload_database --app <review-app>
 #
 # <review-app> identifies the PR in any of these forms — all the same app:
 #   3594   pr-3594   pr-3594.review.bikeindex.org   https://pr-3594.review.bikeindex.org
@@ -18,11 +19,14 @@
 # shared-redis accessories live only in the pr-* config, not sandbox's.
 #   bin/kamal_review accessory reboot db --app 0
 #
-# deploy/destroy require an explicit --app and run the per-PR lifecycle:
+# deploy/destroy/reload_database require an explicit --app and run the per-PR lifecycle:
 #   deploy  — kamal deploy --version <tag> --skip-push (tag via --version or IMAGE_TAG)
 #   destroy — purge the PR's ActiveStorage objects from the shared R2 bucket, kamal
 #             app remove, drop the per-PR databases + role, flush its redis db
 #             (unless a still-running PR shares it), remove its containers + volumes
+#   reload_database — reset the app's data in place (containers, image and role are
+#             left alone): purge its R2 objects, flush its redis db, drop both
+#             databases, then db:prepare (create, load schema, seed) in the app
 # deploy is idempotent — same path on first and subsequent deploys;
 # bin/docker-entrypoint creates the per-PR Postgres role on first boot and
 # db:prepare handles schema/seed-or-migrate.
@@ -43,11 +47,12 @@ Usage:
   bin/kamal_review <kamal args...> --app <review-app>   # any kamal command
   bin/kamal_review deploy  --app <review-app> [--version <tag>]
   bin/kamal_review destroy --app <review-app>
+  bin/kamal_review reload_database --app <review-app>   # drop, then create/migrate/seed
 
 <review-app> is a PR, in any of these equivalent forms:
   3594   pr-3594   pr-3594.review.bikeindex.org   https://pr-3594.review.bikeindex.org
 
-Passthrough defaults --app to the persistent 'sandbox' app; deploy/destroy require it.
+Passthrough defaults --app to the persistent 'sandbox' app; the lifecycle commands require it.
 
 Examples:
   bin/kamal_review app logs -f                       # sandbox (default)
@@ -56,6 +61,7 @@ Examples:
   bin/kamal_review accessory reboot db --app 0       # accessories live in the pr-* config
   bin/kamal_review deploy  --app 3594 --version pr-3594-abc123
   bin/kamal_review destroy --app 3594
+  bin/kamal_review reload_database --app 3594
 
 Env:  REVIEW_APP_HOST (default host.review.bikeindex.org); secrets via .kamal/secrets.
 USAGE
@@ -122,7 +128,7 @@ esac
 
 mode=""
 case "$1" in
-  deploy | destroy) mode="$1"; shift ;;
+  deploy | destroy | reload_database) mode="$1"; shift ;;
 esac
 
 # Passthrough: any kamal command, --app anywhere, defaults to sandbox. Always
@@ -149,8 +155,8 @@ if [[ -z "$mode" ]]; then
   exec kamal "${kamal_args[@]}" --config-file "$CONFIG"
 fi
 
-# deploy/destroy lifecycle: --app is required (no default — a destroy must never
-# fall back to PR 0); --version (or IMAGE_TAG) supplies the deploy image tag.
+# Lifecycle commands: --app is required (no default — a destroy must never fall
+# back to PR 0); --version (or IMAGE_TAG) supplies the deploy image tag.
 app=""
 version="${IMAGE_TAG:-}"
 while [[ $# -gt 0 ]]; do
@@ -173,8 +179,52 @@ appname="bike-index-${slug}"
 role="bike_index_pr_${pr_number}"
 primary_db="bike_index_review_pr_${pr_number}_primary"
 analytics_db="bike_index_review_pr_${pr_number}_analytics"
+# FORCE terminates the connections the running app holds open.
+drop_databases_sql="-c 'DROP DATABASE IF EXISTS ${primary_db} WITH (FORCE)' \
+  -c 'DROP DATABASE IF EXISTS ${analytics_db} WITH (FORCE)'"
 
 kamal() { command kamal "$@" --config-file "$CONFIG"; }
+
+review_host_unreachable() {
+  echo "Error: can't reach the review host; $slug was left untouched." >&2
+  exit 1
+}
+
+# Ask the host which other running PRs the mod-N allocation (see
+# export_review_app_env) points at our logical redis DB — flushing it would drop
+# their cache and queues. Prints them as " pr-<n>" and returns non-zero when the
+# host is unreachable, so callers can bail before touching anything.
+redis_db_shared_with() {
+  local running other shared=""
+  running="$(kamal server exec --raw "docker ps --format '{{.Label \"service\"}}'" 2>/dev/null)" || return 1
+  for other in $(printf '%s\n' "$running" | sed -n 's/^bike-index-pr-//p'); do
+    if [[ "$other" != "$pr_number" ]] && (( (other % REDIS_DATABASES) + 1 == REVIEW_APP_REDIS_DB )); then
+      shared="${shared} pr-${other}"
+    fi
+  done
+  printf '%s' "$shared"
+}
+
+# $1 is redis_db_shared_with's output. Best-effort, like the rest of the teardown.
+flush_redis_db() {
+  if [[ -n "$1" ]]; then
+    echo "==> Skipping the redis flush: logical DB $REVIEW_APP_REDIS_DB is still in use by$1"
+  else
+    echo "==> Flushing redis logical DB $REVIEW_APP_REDIS_DB"
+    kamal accessory exec redis --reuse "redis-cli -n ${REVIEW_APP_REDIS_DB} FLUSHDB" || true
+  fi
+}
+
+# The PR's ActiveStorage blobs live in the shared R2 dev bucket (cloudflare_dev) at
+# the bucket root with random keys — no per-PR prefix to drop — so delete them
+# through the running app, whose database lists exactly this PR's blobs (keys are
+# globally unique, so no other app's objects are touched). Best-effort: a broken or
+# already-gone app just leaves the blobs.
+purge_r2_objects() {
+  echo "==> Purging this PR's ActiveStorage objects from R2"
+  kamal app exec --reuse --roles web \
+    "bin/rails runner 'ActiveStorage::Blob.find_each { |blob| blob.service.delete(blob.key) }'" || true
+}
 
 case "$mode" in
   deploy)
@@ -201,32 +251,13 @@ case "$mode" in
     ;;
 
   destroy)
-    # Ask the host what's running before touching anything. Two reasons, both of
-    # which bite now that every closed PR runs destroy: mod-N allocation (see
-    # export_review_app_env) can point our logical redis DB at a PR that's still
-    # up, whose cache and queues a FLUSHDB would drop; and every step below is
-    # `|| true`, so an unreachable host would otherwise report a clean teardown
-    # and let the workflow strip the label and GHCR images off a live app.
-    if ! running="$(kamal server exec --raw "docker ps --format '{{.Label \"service\"}}'" 2>/dev/null)"; then
-      echo "Error: can't reach the review host. $slug may still be running, so nothing was destroyed." >&2
-      exit 1
-    fi
-    redis_shared_with=""
-    for other in $(printf '%s\n' "$running" | sed -n 's/^bike-index-pr-//p'); do
-      if [[ "$other" != "$pr_number" ]] && (( (other % REDIS_DATABASES) + 1 == REVIEW_APP_REDIS_DB )); then
-        redis_shared_with="${redis_shared_with} pr-${other}"
-      fi
-    done
+    # Probe the host before touching anything: every step below is `|| true`, so an
+    # unreachable host would otherwise report a clean teardown and let the workflow
+    # strip the label and GHCR images off a live app.
+    redis_shared_with="$(redis_db_shared_with)" || review_host_unreachable
 
-    # ActiveStorage attachments land in the shared R2 dev bucket (cloudflare_dev)
-    # at the bucket root with random keys — no per-PR prefix to drop — so delete
-    # them through the running app, whose database lists exactly this PR's blobs
-    # (keys are globally unique, so no other app's objects are touched). Must run
-    # before `app remove` drops the container and its R2 credentials. Best-effort
-    # like the rest of destroy: a broken/already-gone app just leaves the blobs.
-    echo "==> Purging this PR's ActiveStorage objects from R2"
-    kamal app exec --reuse --roles web \
-      "bin/rails runner 'ActiveStorage::Blob.find_each { |blob| blob.service.delete(blob.key) }'" || true
+    # Must run before `app remove` drops the container and its R2 credentials.
+    purge_r2_objects
 
     echo "==> Destroying review app $slug"
     kamal app remove || true
@@ -236,18 +267,10 @@ case "$mode" in
     # them. Best-effort (|| true) with no ON_ERROR_STOP, so a failed DROP (e.g. a
     # db that was never created) doesn't skip the rest.
     kamal accessory exec db --reuse \
-      "psql -U postgres -d postgres \
-        -c 'DROP DATABASE IF EXISTS ${primary_db} WITH (FORCE)' \
-        -c 'DROP DATABASE IF EXISTS ${analytics_db} WITH (FORCE)' \
+      "psql -U postgres -d postgres $drop_databases_sql \
         -c 'DROP ROLE IF EXISTS ${role}'" || true
 
-    if [[ -n "$redis_shared_with" ]]; then
-      echo "==> Skipping the redis flush: logical DB $REVIEW_APP_REDIS_DB is still in use by${redis_shared_with}"
-    else
-      echo "==> Flushing redis logical DB $REVIEW_APP_REDIS_DB"
-      kamal accessory exec redis --reuse \
-        "redis-cli -n ${REVIEW_APP_REDIS_DB} FLUSHDB" || true
-    fi
+    flush_redis_db "$redis_shared_with"
 
     # Named volumes outlive `kamal app remove`, so drop them or they leak on the
     # host. `app remove` prunes its roles in parallel and docker serialises prune
@@ -259,5 +282,28 @@ case "$mode" in
        docker volume rm ${appname}_storage ${appname}_uploads" || true
 
     echo "==> Done."
+    ;;
+
+  reload_database)
+    redis_shared_with="$(redis_db_shared_with)" || review_host_unreachable
+
+    # Both run before the drop: the blob keys only exist in the database we're about
+    # to drop, and the FLUSHDB would otherwise wipe the search autocomplete the seeds
+    # load into that same logical redis DB.
+    purge_r2_objects
+    flush_redis_db "$redis_shared_with"
+
+    # Strict, unlike destroy's drop — a half-dropped database must not be reported
+    # as a reload. Rails reconnects the connections FORCE terminates.
+    echo "==> Dropping databases ($primary_db, $analytics_db)"
+    kamal accessory exec db --reuse \
+      "psql -U postgres -d postgres -v ON_ERROR_STOP=1 $drop_databases_sql"
+
+    # The task bin/docker-entrypoint runs at boot; it seeds because the databases
+    # were just created. Slow — the seed imports the manufacturer spreadsheets.
+    echo "==> Creating, migrating and seeding"
+    kamal app exec --reuse --roles web "bin/rails db:prepare"
+
+    echo "==> Done. URL: https://${slug}.review.bikeindex.org"
     ;;
 esac

--- a/docs/review-apps.md
+++ b/docs/review-apps.md
@@ -21,7 +21,7 @@ bin/kamal_review app details  --app pr-3594.review.bikeindex.org
 bin/kamal_review app version  --app https://pr-3594.review.bikeindex.org
 ```
 
-All four resolve to PR `3594`; with no `--app` it defaults to the persistent sandbox app, and `--app sandbox` names it explicitly ([below](#sandbox-persistent-main-deploy)). (It also drives the `deploy`/`destroy` lifecycle — see [Deploying locally](#deploying-locally).) It uses `REVIEW_APP_HOST` + `.kamal/secrets`, so the 1Password setup above is a prerequisite. The `shared-db`/`shared-redis` accessories live only in the per-PR config, so accessory commands need an explicit `--app 0` (or any PR) — e.g. reboot Postgres after changing its `shared_preload_libraries`:
+All four resolve to PR `3594`; with no `--app` it defaults to the persistent sandbox app, and `--app sandbox` names it explicitly ([below](#sandbox-persistent-main-deploy)). (It also drives the `deploy`/`destroy`/`reload_database` lifecycle — see [Deploying locally](#deploying-locally).) It uses `REVIEW_APP_HOST` + `.kamal/secrets`, so the 1Password setup above is a prerequisite. The `shared-db`/`shared-redis` accessories live only in the per-PR config, so accessory commands need an explicit `--app 0` (or any PR) — e.g. reboot Postgres after changing its `shared_preload_libraries`:
 
 ```bash
 bin/kamal_review accessory reboot db --app 0
@@ -31,7 +31,7 @@ bin/kamal_review accessory reboot db --app 0
 
 Alongside the per-PR apps, `main` is continuously deployed to **[sandbox.review.bikeindex.org](https://sandbox.review.bikeindex.org)** — think of it as a review app that never gets a PR number and is never destroyed. It shares `config/deploy.review.yml`: with no `REVIEW_APP_PR_NUMBER` set, the ERB resolves the `sandbox` slug and omits the `accessories:` block (so a sandbox deploy can't touch the shared infra the PR apps depend on). It differs only in using Redis logical DB `0` (the one the PR mod-1023 allocation never hands out).
 
-For `bin/kamal_review`, with no `--app` given it defaults to sandbox - but you can also use `--app sandbox` to target it. This works for passthrough commands only, since sandbox is deployed by its own workflow, not the `deploy`/`destroy` lifecycle:
+For `bin/kamal_review`, with no `--app` given it defaults to sandbox - but you can also use `--app sandbox` to target it. This works for passthrough commands only, since sandbox is deployed by its own workflow, not the `deploy`/`destroy`/`reload_database` lifecycle:
 
 ```bash
 bin/kamal_review shell        --app sandbox   # bash on sandbox
@@ -56,6 +56,7 @@ Once labeled:
 - **Push → auto-redeploys**: ci.yml's `dispatch` job dispatches this workflow. (No `pull_request: synchronize` trigger — it would leave a skipped review-app check on every push to every unlabeled PR.)
   - A fork's push fires `on: push` in the fork, not here, so this repo's `dispatch` job never sees it — fork PRs only deploy via manual `workflow_dispatch`.
 - **Destroy without closing**: re-run with `destroy` (also removes the label).
+- **Reset the data**: re-run with `reload_database` ([below](#reloading-the-database)) — the label is left alone.
 
 Only CI's on-push dispatch and `closed` are wired up, so toggling the label by hand does nothing until the next push.
 
@@ -65,12 +66,13 @@ The step that isn't idempotent is the redis flush, because mod-1023 allocation c
 
 ## How a deploy works
 
-Four jobs: `resolve` (PR number + deploy/destroy, and labels on deploy), `op` (calls the shared `kamal-deploy.yml` reusable workflow to build + run the kamal command), `post` (PR-side follow-ups: deployment link, failure-comment cleanup, label removal + GHCR image cleanup on destroy), `report` (failure-only). The reusable workflow's `build` job cancels superseded builds (`cancel-in-progress`) while its `run` job serializes per PR *without* cancellation, since killing kamal mid-deploy can strand the deploy lock. `kamal-deploy.yml` is shared with `sandbox.yml`.
+Four jobs: `resolve` (PR number + action, and labels on deploy), `op` (calls the shared `kamal-deploy.yml` reusable workflow to build + run the kamal command), `post` (PR-side follow-ups: deployment link, failure-comment cleanup, label removal + GHCR image cleanup on destroy), `report` (failure-only). The reusable workflow's `build` job cancels superseded builds (`cancel-in-progress`) while its `run` job serializes per PR *without* cancellation, since killing kamal mid-deploy can strand the deploy lock. `kamal-deploy.yml` is shared with `sandbox.yml`.
 
 | Trigger | Action | What runs |
 |---|---|---|
 | `workflow_dispatch` → deploy (operator, or auto-dispatched by ci.yml on push to a labeled PR) | `deploy` | add `review-app` label, build image, deploy |
 | `workflow_dispatch` → destroy | `destroy` | tear down, remove label, delete PR images from GHCR |
+| `workflow_dispatch` → reload_database | `reload_database` | drop both databases, then create + seed them again ([below](#reloading-the-database)) |
 | `pull_request: closed` (any PR) | `destroy` | tear down, remove label, delete PR images from GHCR |
 
 Fork PRs are filtered by `resolve`'s same-repo check (`proceed=false`). On **deploy**:
@@ -84,6 +86,10 @@ Fork PRs are filtered by `resolve`'s same-repo check (`proceed=false`). On **dep
 4. The `review-app` environment surfaces the URL ("View deployment").
 
 Destroy reverses it: purge the PR's ActiveStorage objects from the shared R2 bucket (while the app's still up — see [storage](#storage-is-shared)), `kamal app remove`, drop both databases + the role, `FLUSHDB` the assigned Redis logical DB (unless a running PR shares it — see [teardown](#the-review-app-label-is-the-deploy-gate)), remove any container `app remove` left behind along with the volumes, and delete every `pr-<N>-<sha>` GHCR image version (best-effort, `packages: write`).
+
+### Reloading the database
+
+`reload_database` resets a running app's data to a freshly seeded state without redeploying — for when seeds change, or a demo leaves the data in a mess. Containers, image, volumes and the Postgres role are untouched; only the two databases are rebuilt, by `bin/kamal_review reload_database --app <pr>` (which also purges the PR's R2 objects and flushes its redis DB first — see the comments there for why the order matters). It runs the same `db:prepare` the entrypoint runs at boot, so it's as slow as a first deploy, and the app serves partly-seeded data while it runs.
 
 **Failures comment on the PR.** These runs are `workflow_dispatch`-triggered, so their check runs never hit the PR's rollup. The `report` job comments the failure (edited in place on repeats); the next successful deploy deletes it.
 
@@ -104,7 +110,7 @@ Each app gets a `cron` container (a Kamal [`servers` role](https://kamal-deploy.
 | `Dockerfile`, `.dockerignore` | Production-style image (Thruster + Puma + Sidekiq). Used only by review apps. |
 | `bin/docker-entrypoint` | Creates the per-PR Postgres **superuser** role + runs `db:prepare` (schema + seed) on first boot |
 | `bin/thrust` | Thruster binstub used by the image's `CMD` |
-| `bin/kamal_review` | Run kamal against one review app — `deploy`/`destroy` lifecycle plus arbitrary passthrough commands (resolves the PR number from any id form, sets `REVIEW_APP_*` + `--config-file`) |
+| `bin/kamal_review` | Run kamal against one review app — `deploy`/`destroy`/`reload_database` lifecycle plus arbitrary passthrough commands (resolves the PR number from any id form, sets `REVIEW_APP_*` + `--config-file`) |
 | `config/deploy.review.yml` | Kamal config for both targets — ERB derives `pr-<N>` (with `REVIEW_APP_PR_NUMBER`) or the `sandbox` slug (without); accessories emitted for PR apps only |
 | `.github/workflows/sandbox.yml` | Thin caller of `kamal-deploy.yml` for the `main`→sandbox deploy, dispatched on every push to `main` — see [Sandbox](#sandbox-persistent-main-deploy) |
 | `.github/workflows/kamal-deploy.yml` | Reusable (`workflow_call`) build + kamal-command workflow shared by review-app and sandbox deploys |
@@ -154,6 +160,7 @@ These are the same values as the `REVIEW_APP_*` GitHub Environment secrets ([Ini
 
 ```bash
 bin/kamal_review deploy --app <pr_number> --version <image_tag>
+bin/kamal_review reload_database --app <pr_number>   # drop + reseed, no redeploy
 ```
 
 `REVIEW_APP_HOST` defaults to `host.review.bikeindex.org`; export it only to target a different host under the `*.review.bikeindex.org` wildcard.


### PR DESCRIPTION
Adds a third Review App action alongside `deploy` and `destroy`: `reload_database` rebuilds a running app's databases in place, for when seeds change or a demo leaves the data in a mess — previously the only reset was destroy + redeploy, which rebuilds and re-pushes an image to get back to the same code.

- **Drops both databases, then runs the same `db:prepare` `bin/docker-entrypoint` runs at boot.** Containers, image, volumes and the Postgres role stay put; the PR's R2 objects and redis DB are cleared first (the script has the ordering rationale).
- **`destroy` now shares it** — the host probe, redis flush, R2 purge and DROP statements are written once.
- **`kamal-deploy.yml` takes `build:` instead of `action:`**, since it only ever asked "is this a deploy?" to decide whether to build.
