### PR TITLE
Drop search-results frame responses a newer search superseded

### DIFF
--- a/app/javascript/controllers/search/form_controller.js
+++ b/app/javascript/controllers/search/form_controller.js
@@ -1,14 +1,7 @@
 import { Controller } from '@hotwired/stimulus'
 import TimeLocalizer from '@bikeindex/time-localizer'
 
-/* global window, Date */
-
-// Record back/forward navigations at module scope: the popstate that re-enters a
-// search page fires before the controller reconnects, so a controller-scoped
-// listener would miss it. reloadRestoredFrame uses this to tell a restoration
-// (popstate, eager frame restored empty) from a link visit (turbo:before-visit,
-// frame fills itself).
-window.addEventListener('popstate', () => { window.searchLastPopAt = Date.now() })
+/* global window */
 
 // Connects to data-controller='search--form'
 export default class extends Controller {
@@ -43,7 +36,6 @@ export default class extends Controller {
     // both come back 429 during active searching. Catch the frame's response
     // here; the count fetch signals via the search:rate-limited window event.
     document.addEventListener('turbo:before-fetch-response', this.handleFetchResponse)
-    document.addEventListener('turbo:before-visit', this.handleBeforeVisit)
     document.addEventListener('turbo:fetch-request-error', this.handleFetchError)
     window.addEventListener('search:rate-limited', this.showRateLimited)
     window.addEventListener('popstate', this.handlePopstate)
@@ -56,7 +48,6 @@ export default class extends Controller {
     document.removeEventListener('turbo:frame-render', this.handleFrameRender)
     document.removeEventListener('turbo:load', this.handleTurboLoad)
     document.removeEventListener('turbo:before-fetch-response', this.handleFetchResponse)
-    document.removeEventListener('turbo:before-visit', this.handleBeforeVisit)
     document.removeEventListener('turbo:fetch-request-error', this.handleFetchError)
     window.removeEventListener('search:rate-limited', this.showRateLimited)
     window.removeEventListener('popstate', this.handlePopstate)
@@ -67,21 +58,11 @@ export default class extends Controller {
     this.refreshResults()
   }
 
-  // Link/programmatic visits (period & chart links) fire this; history navigation
-  // does not. Stamp it so reloadRestoredFrame can skip a frame the visit is
-  // already filling.
-  handleBeforeVisit = () => {
-    window.searchLastVisitAt = Date.now()
-    clearTimeout(this.emptyReloadTimer)
-  }
-
   // Clear any stale loading state, then bring the results frame in line with the
   // address bar. Runs on initial connect and after every Turbo page load.
   refreshResults () {
-    clearTimeout(this.emptyReloadTimer) // a new page load supersedes any pending poll
     this.clearStaleFrameBusy()
     this.reloadFrameIfUrlStale()
-    this.reloadRestoredFrame()
   }
 
   // The visible text filters live outside the results frame, so a back/forward
@@ -98,31 +79,6 @@ export default class extends Controller {
       const input = this.formTarget.querySelector(`input[name="${name}"]`)
       if (input) input.value = params.get(name) || ''
     })
-  }
-
-  // Turbo doesn't cache the eager results frame's contents and won't re-fetch a
-  // [complete] frame, so on a back/forward it comes back empty. Re-fetch its src
-  // so results reappear, like a real browser's BFCache restore.
-  //
-  // Scoped to a recent popstate that no link visit (turbo:before-visit) has
-  // superseded, so it never disturbs a search submit or a period/chart click.
-  // Restoration finalizes a tick or two after the load and can clobber an early
-  // reload, so retry until content sticks; handleFrameRender cancels it once it
-  // lands.
-  reloadRestoredFrame (attempt = 0) {
-    // Suppress only when a link visit is the most recent navigation (it fills the
-    // frame itself); a back/forward popstate, or the initial load, proceeds.
-    if ((window.searchLastPopAt || 0) < (window.searchLastVisitAt || 0)) return
-    const frame = this.frameElement
-    const src = frame?.getAttribute('src')
-    if (!src) return
-    if (frame.childElementCount > 0) return // populated - done
-    if (attempt >= 20) return // give up after ~2s rather than loop on a truly empty result
-    if (frame.hasAttribute('complete')) {
-      frame.removeAttribute('complete') // Turbo skips re-fetching a [complete] frame
-      frame.setAttribute('src', src)
-    }
-    this.emptyReloadTimer = setTimeout(() => this.reloadRestoredFrame(attempt + 1), 100)
   }
 
   // A back/forward restoration can leave the results frame showing a snapshot for
@@ -163,8 +119,6 @@ export default class extends Controller {
   }
 
   handleFrameRender = () => {
-    // Content landed, so a pending restore-reload poll is done.
-    if (this.frameElement?.childElementCount > 0) clearTimeout(this.emptyReloadTimer)
     // A frame render means results came back, so clear any failure notice
     this.hideNotices()
     // Run the time localization command on frame render

--- a/app/javascript/controllers/search/form_controller.js
+++ b/app/javascript/controllers/search/form_controller.js
@@ -131,17 +131,23 @@ export default class extends Controller {
   // address bar, not the form, so it's immune to combobox/form restore races.
   reloadFrameIfUrlStale () {
     const frame = this.frameElement
-    const src = frame?.getAttribute('src')
-    if (!src) return
-    const srcUrl = new URL(src, window.location.origin)
-    // Only reconcile within the same search page. A back/forward restoration can
-    // briefly leave one page's frame (eg marketplace_results_frame) in the DOM
-    // while the address bar is another page (/search/registrations); pointing the
-    // frame there fetches a response without that frame, which Turbo discards.
-    if (srcUrl.pathname !== window.location.pathname) return
-    if (srcUrl.search !== window.location.search) {
-      frame.setAttribute('src', window.location.href)
-    }
+    if (!this.differentSearchOnSamePage(frame?.getAttribute('src'), window.location.href)) return
+
+    frame.setAttribute('src', window.location.href)
+  }
+
+  // Two URLs asking the same search page for different results. Pairs on different
+  // pages never reconcile, so they don't count: a back/forward restoration can
+  // briefly leave one page's frame (eg marketplace_results_frame) in the DOM while
+  // the address bar is another page (/search/registrations), and a frame response
+  // that redirected elsewhere is still the one Turbo should render.
+  differentSearchOnSamePage (url, otherUrl) {
+    if (!url || !otherUrl) return false
+
+    const first = new URL(url, window.location.origin)
+    const second = new URL(otherUrl, window.location.origin)
+
+    return first.pathname === second.pathname && first.search !== second.search
   }
 
   // Turbo's [busy]/[aria-busy] loading state is transient, but a back/forward
@@ -171,13 +177,24 @@ export default class extends Controller {
   // The results frame eager-loads via its src; on a 429 Turbo just logs and
   // leaves the spinner spinning. Take over the response so the user sees why.
   handleFetchResponse = (event) => {
-    if (event.detail?.fetchResponse?.response?.status !== 429) return
+    const response = event.detail?.fetchResponse?.response
 
-    event.preventDefault() // stop Turbo's default handling of the throttled response
-    this.showRateLimited()
+    if (response?.status === 429) {
+      event.preventDefault() // stop Turbo's default handling of the throttled response
+      this.showRateLimited()
+      this.hideLoading() // drop the in-frame placeholder so it doesn't spin forever
+    } else if (event.target === this.frameElement && this.frameResponseSuperseded(response?.url)) {
+      event.preventDefault()
+    }
+  }
 
-    // Drop the in-frame loading placeholder so it doesn't spin forever
-    this.hideLoading()
+  // The frame's eager src fetch and a search submitted while it's still in flight
+  // race each other. Turbo renders whichever lands last and rewrites history from
+  // the frame, so the older response would drag the address bar back to the query
+  // the rider searched away from. A submit repoints src before its own response
+  // returns, so src names the search the frame should be showing.
+  frameResponseSuperseded (url) {
+    return this.differentSearchOnSamePage(url, this.frameElement?.getAttribute('src'))
   }
 
   // A fetch that rejects outright when the network drops never comes back with a

--- a/spec/integration/search_marketplace_spec.rb
+++ b/spec/integration/search_marketplace_spec.rb
@@ -84,6 +84,20 @@ RSpec.describe "Marketplace infinite scroll", :js, type: :system do
     find("#search-button").click
   end
 
+  # Hold back the unfiltered results the frame eager-loads on arrival. Returns the
+  # release, so the example decides when they land rather than racing a timer.
+  def hold_initial_results_load
+    held = Queue.new
+    page.driver.with_playwright_page do |playwright_page|
+      playwright_page.route("**/search/marketplace*", ->(route, request) {
+        held.pop if request.headers["turbo-frame"] == "marketplace_results_frame" &&
+          !request.url.include?("primary_activity=")
+        route.continue
+      })
+    end
+    -> { held.push(:release) }
+  end
+
   it "loads the kind counts on initial render" do
     visit_marketplace_via_nav
 
@@ -92,6 +106,20 @@ RSpec.describe "Marketplace infinite scroll", :js, type: :system do
     # longer auto-submits on load, so this guards that initial render still fills them.
     # All 17 listings (15 standard + 2 promoted) are for_sale, so the for_sale count shows (17).
     expect(page).to have_css("[data-count-target='for_sale']", text: "(17)", wait: 10)
+  end
+
+  it "keeps the searched results when the initial load lands after the search" do
+    release_initial_results_load = hold_initial_results_load
+    visit_marketplace_via_nav
+
+    search_primary_activity("Mountain biking")
+    expect(page).to have_css("[data-test-id^='vehicle-thumbnail-linkspan-']", wait: 10, count: 6)
+
+    # The unfiltered results are only now allowed to arrive - they mustn't take over
+    release_initial_results_load.call
+    page.driver.with_playwright_page { |playwright_page| playwright_page.wait_for_load_state(state: "networkidle") }
+    expect(page).to have_css("[data-test-id^='vehicle-thumbnail-linkspan-']", count: 6)
+    expect(page).to have_current_path(/primary_activity=#{primary_activity.id}/)
   end
 
   it "automatically loads the next page when scrolling to bottom" do

--- a/spec/integration/search_marketplace_spec.rb
+++ b/spec/integration/search_marketplace_spec.rb
@@ -98,19 +98,15 @@ RSpec.describe "Marketplace infinite scroll", :js, type: :system do
     -> { held.push(:release) }
   end
 
-  it "loads the kind counts on initial render" do
+  it "fills the kind counts on load, and keeps a search made before the results arrive" do
+    release_initial_results_load = hold_initial_results_load
     visit_marketplace_via_nav
 
     # Counts populate from /search/marketplace/counts once the search--kind-select-fields
-    # controller connects - no form submit required. The eager turbo-frame flow no
-    # longer auto-submits on load, so this guards that initial render still fills them.
-    # All 17 listings (15 standard + 2 promoted) are for_sale, so the for_sale count shows (17).
+    # controller connects - no form submit required, and no results either, since the
+    # frame is held open here. All 17 listings (15 standard + 2 promoted) are for_sale,
+    # so the for_sale count shows (17).
     expect(page).to have_css("[data-count-target='for_sale']", text: "(17)", wait: 10)
-  end
-
-  it "keeps the searched results when the initial load lands after the search" do
-    release_initial_results_load = hold_initial_results_load
-    visit_marketplace_via_nav
 
     search_primary_activity("Mountain biking")
     expect(page).to have_css("[data-test-id^='vehicle-thumbnail-linkspan-']", wait: 10, count: 6)

--- a/spec/support/system_spec_helpers.rb
+++ b/spec/support/system_spec_helpers.rb
@@ -98,13 +98,16 @@ module SystemSpecHelpers
   # whatever it overlays. ui--alert wires the close button in `connect` and
   # application.js lazy loads controllers, so a click landing before that module
   # arrives is swallowed. Click again, the way a rider whose click did nothing
-  # would, until the alert reports itself gone (the dismiss transition included).
-  def dismiss_flash_messages(wait: 10, attempts: 5)
-    attempts.times do
+  # would, for the whole of `wait` - a click is the only thing that dismisses an
+  # alert, so time spent waiting without clicking can never resolve one.
+  def dismiss_flash_messages(wait: 10)
+    deadline = Process.clock_gettime(Process::CLOCK_MONOTONIC) + wait
+    loop do
       all("#flash-messages [aria-label='Close']", minimum: 1).each { |close| retry_on_detach { close.click } }
       break if page.has_no_css?("#flash-messages [role='alert']", wait: 1)
+      break if Process.clock_gettime(Process::CLOCK_MONOTONIC) > deadline
     end
-    expect(page).to have_no_css("#flash-messages [role='alert']", wait:)
+    expect(page).to have_no_css("#flash-messages [role='alert']", wait: 1)
   end
 
   private


### PR DESCRIPTION
The results live in a turbo-frame that eager-loads via its `src`, while the search form sits outside the frame and submits into it. Those are independent Turbo fetches: Turbo renders whichever lands last, and then rewrites history from the frame's `src`, since the form submits with `turbo_action: "advance"`. So an initial load that returns after a search replaces the results with the query the rider searched away from, and drags the address bar back with it. This is the [flaky `keeps results and the primary_activity form in sync` failure](https://github.com/bikeindex/bike_index/actions/runs/31026249164/job/92375457707) — its screenshot has the form and the kind counts on "Mountain biking" above the 12 unfiltered listings.

- **`search--form` drops a frame response naming a different search than the frame's current `src`**, which a submit repoints before its own response returns. Comparing against `src` rather than the address bar is what keeps in-frame link navigation working — org pagination and sort links advance history only *after* their response loads, so against the address bar every one of them looks stale. `reloadFrameIfUrlStale` shares the same-page/different-query predicate rather than keeping its own copy.
- **Deletes `reloadRestoredFrame`**, which re-fetched the frame when a back/forward left it empty. The frame always renders with a child (the hidden loading placeholder, then the results), so it returned at `childElementCount > 0` on all 18 entries logged across the search specs — the back/forward example included. `turbo-cache-control: no-cache` means a back/forward re-fetches from the server rather than restoring the empty-frame snapshot it was written for. The module-scope popstate stamp, `searchLastVisitAt`, `handleBeforeVisit` and `emptyReloadTimer` only gated that poll, so they go too.
- **`dismiss_flash_messages` keeps clicking for the whole `wait`.** It retried already, but with two budgets that didn't meet — five attempts of roughly a second, then a ten second `have_no_css` during which nothing clicked. Since a click is the only thing that dismisses an alert (`ui--alert` is lazy loaded, so an early click is swallowed), that tail could never resolve one. Holding the controller's asset behind a Playwright route reproduces [the CI failure](https://github.com/bikeindex/bike_index/actions/runs/30923351026/job/92039382873) and measures it: single-click fails from 0.5s of delay, five attempts covers ~5s, this covers 9s.
- The frame regression spec holds the initial load open until the search has rendered, so the ordering is reproduced rather than waited for.
