### PR TITLE
Stop API errors from going unreported and unlogged

### DIFF
--- a/app/controllers/api/base.rb
+++ b/app/controllers/api/base.rb
@@ -77,17 +77,47 @@ module API
     mount API::V3::RootV3
     mount API::V2::RootV2
 
+    # Anything raised in here escapes as a bare 500 with no JSON body and no
+    # Honeybadger notify - the shape that makes API 500s invisible. Every path out
+    # returns a Rack::Response, and every 5xx reports.
     def self.respond_to_error(e)
-      logger.error e unless Rails.env.test? # Breaks tests...
-      # Exception messages can carry invalid UTF-8 (scanner probe URLs, malformed
-      # params). Scrub before matching or serializing — an unscrubbed bad byte
-      # raises here and suppresses the Honeybadger notify below, leaving a bare 500.
-      message = e.message.to_s.dup.force_encoding(Encoding::UTF_8).scrub
+      message = error_message(e)
+      # Log the scrubbed message, not the exception - Grape's logger has no formatter,
+      # so Logger interpolates e.message and an exception that raises there takes the
+      # whole handler down before it reports.
+      logger.error "#{e.class}: #{message}" unless Rails.env.test? # Breaks tests...
       status_code = status_code_for(e, message)
-      Honeybadger.notify(e) if Rails.env.production? && status_code > 450 # Only notify for 500s
+      notify_error(e) if status_code > 450 # Only notify for 500s
       message = "OAuth error: #{message}" if /APIAuthorization::Errors/.match?(e.class.to_s)
       opts = {error: message}
-      opts[:trace] = e.backtrace[0, 10] unless Rails.env.production?
+      opts[:trace] = e.backtrace&.first(10) unless Rails.env.production?
+      error_response(opts, status_code)
+    rescue => handler_error
+      # Nothing fallible on this path - e.backtrace is what raised for some of the
+      # exceptions that land here.
+      notify_error(handler_error, context: {handling: e.class.to_s})
+      error_response({error: "Internal Server Error"}, 500)
+    end
+
+    # Reporting must never cost the response - notify is the last fallible call before
+    # the fallback returns, and it reads e.message to build the notice.
+    def self.notify_error(error, **opts)
+      Honeybadger.notify(error, **opts) if Rails.env.production?
+    rescue
+      nil
+    end
+
+    # Exception messages can carry invalid UTF-8 (scanner probe URLs, malformed
+    # params), and #message can raise outright. Falling back to the class name keeps
+    # status_code_for's mapping intact, so a RecordNotFound stays a 404.
+    def self.error_message(e)
+      e.message.to_s.dup.force_encoding(Encoding::UTF_8).scrub
+    rescue => message_error
+      notify_error(message_error, context: {handling: e.class.to_s})
+      e.class.to_s
+    end
+
+    def self.error_response(opts, status_code)
       Rack::Response.new(opts.to_json, status_code, {
         "Content-Type" => "application/json",
         "Access-Control-Allow-Origin" => "*",
@@ -109,5 +139,7 @@ module API
         (error.respond_to?(:status) && error.status) || 500
       end
     end
+
+    private_class_method :notify_error, :error_message, :error_response, :status_code_for
   end
 end

--- a/app/controllers/api/base.rb
+++ b/app/controllers/api/base.rb
@@ -83,9 +83,7 @@ module API
       # returns a Rack::Response, and every 5xx reports.
       def respond_to_error(e)
         message = error_message(e)
-        # Rails.logger, because Grape's own logger writes to $stdout and never reaches
-        # production.log. The scrubbed message rather than the exception, so a
-        # formatter reading e.message can't take the handler down before it reports.
+        # Rails.logger, since Grape's own logger writes to $stdout and never reaches production.log
         Rails.logger.error "#{e.class}: #{message}" unless Rails.env.test? # Breaks tests...
         status_code = status_code_for(e, message)
         notify_error(e) if status_code > 450 # Only notify for 500s

--- a/app/controllers/api/base.rb
+++ b/app/controllers/api/base.rb
@@ -77,69 +77,71 @@ module API
     mount API::V3::RootV3
     mount API::V2::RootV2
 
-    # Anything raised in here escapes as a bare 500 with no JSON body and no
-    # Honeybadger notify - the shape that makes API 500s invisible. Every path out
-    # returns a Rack::Response, and every 5xx reports.
-    def self.respond_to_error(e)
-      message = error_message(e)
-      # Log the scrubbed message, not the exception - Grape's logger has no formatter,
-      # so Logger interpolates e.message and an exception that raises there takes the
-      # whole handler down before it reports.
-      logger.error "#{e.class}: #{message}" unless Rails.env.test? # Breaks tests...
-      status_code = status_code_for(e, message)
-      notify_error(e) if status_code > 450 # Only notify for 500s
-      message = "OAuth error: #{message}" if /APIAuthorization::Errors/.match?(e.class.to_s)
-      opts = {error: message}
-      opts[:trace] = e.backtrace&.first(10) unless Rails.env.production?
-      error_response(opts, status_code)
-    rescue => handler_error
-      # Nothing fallible on this path - e.backtrace is what raised for some of the
-      # exceptions that land here.
-      notify_error(handler_error, context: {handling: e.class.to_s})
-      error_response({error: "Internal Server Error"}, 500)
-    end
+    class << self
+      # Anything raised in here escapes as a bare 500 with no JSON body and no
+      # Honeybadger notify - the shape that makes API 500s invisible. Every path out
+      # returns a Rack::Response, and every 5xx reports.
+      def respond_to_error(e)
+        message = error_message(e)
+        # Log the scrubbed message, not the exception - Grape's logger has no formatter,
+        # so Logger interpolates e.message and an exception that raises there takes the
+        # whole handler down before it reports.
+        logger.error "#{e.class}: #{message}" unless Rails.env.test? # Breaks tests...
+        status_code = status_code_for(e, message)
+        notify_error(e) if status_code > 450 # Only notify for 500s
+        message = "OAuth error: #{message}" if /APIAuthorization::Errors/.match?(e.class.to_s)
+        opts = {error: message}
+        opts[:trace] = e.backtrace&.first(10) unless Rails.env.production?
+        error_response(opts, status_code)
+      rescue => handler_error
+        # Nothing fallible on this path - e.backtrace is what raised for some of the
+        # exceptions that land here.
+        notify_error(handler_error, context: {handling: e.class.to_s})
+        error_response({error: "Internal Server Error"}, 500)
+      end
 
-    # Reporting must never cost the response - notify is the last fallible call before
-    # the fallback returns, and it reads e.message to build the notice.
-    def self.notify_error(error, **opts)
-      Honeybadger.notify(error, **opts) if Rails.env.production?
-    rescue
-      nil
-    end
+      private
 
-    # Exception messages can carry invalid UTF-8 (scanner probe URLs, malformed
-    # params), and #message can raise outright. Falling back to the class name keeps
-    # status_code_for's mapping intact, so a RecordNotFound stays a 404.
-    def self.error_message(e)
-      e.message.to_s.dup.force_encoding(Encoding::UTF_8).scrub
-    rescue => message_error
-      notify_error(message_error, context: {handling: e.class.to_s})
-      e.class.to_s
-    end
+      # Reporting must never cost the response - notify is the last fallible call before
+      # the fallback returns, and it reads e.message to build the notice.
+      def notify_error(error, **opts)
+        Honeybadger.notify(error, **opts) if Rails.env.production?
+      rescue
+        nil
+      end
 
-    def self.error_response(opts, status_code)
-      Rack::Response.new(opts.to_json, status_code, {
-        "Content-Type" => "application/json",
-        "Access-Control-Allow-Origin" => "*",
-        "Access-Control-Request-Method" => "*"
-      })
-    end
+      # Exception messages can carry invalid UTF-8 (scanner probe URLs, malformed
+      # params), and #message can raise outright. Falling back to the class name keeps
+      # status_code_for's mapping intact, so a RecordNotFound stays a 404.
+      def error_message(e)
+        e.message.to_s.dup.force_encoding(Encoding::UTF_8).scrub
+      rescue => message_error
+        notify_error(message_error, context: {handling: e.class.to_s})
+        e.class.to_s
+      end
 
-    def self.status_code_for(error, message)
-      eclass = error.class.to_s
-      if /OAuthUnauthorizedError/.match?(eclass)
-        401
-      elsif /OAuthForbiddenError/.match?(eclass)
-        403
-      elsif eclass.match?(/RecordNotFound/) || message.match?(/unable to find/i)
-        404
-      elsif error.is_a?(Rack::BadRequest) # malformed request body (e.g. empty multipart)
-        400
-      else
-        (error.respond_to?(:status) && error.status) || 500
+      def error_response(opts, status_code)
+        Rack::Response.new(opts.to_json, status_code, {
+          "Content-Type" => "application/json",
+          "Access-Control-Allow-Origin" => "*",
+          "Access-Control-Request-Method" => "*"
+        })
+      end
+
+      def status_code_for(error, message)
+        eclass = error.class.to_s
+        if /OAuthUnauthorizedError/.match?(eclass)
+          401
+        elsif /OAuthForbiddenError/.match?(eclass)
+          403
+        elsif eclass.match?(/RecordNotFound/) || message.match?(/unable to find/i)
+          404
+        elsif error.is_a?(Rack::BadRequest) # malformed request body (e.g. empty multipart)
+          400
+        else
+          (error.respond_to?(:status) && error.status) || 500
+        end
       end
     end
-
-    private_class_method :notify_error, :error_message, :error_response, :status_code_for
   end
 end

--- a/app/controllers/api/base.rb
+++ b/app/controllers/api/base.rb
@@ -83,10 +83,10 @@ module API
       # returns a Rack::Response, and every 5xx reports.
       def respond_to_error(e)
         message = error_message(e)
-        # Log the scrubbed message, not the exception - Grape's logger has no formatter,
-        # so Logger interpolates e.message and an exception that raises there takes the
-        # whole handler down before it reports.
-        logger.error "#{e.class}: #{message}" unless Rails.env.test? # Breaks tests...
+        # Rails.logger, because Grape's own logger writes to $stdout and never reaches
+        # production.log. The scrubbed message rather than the exception, so a
+        # formatter reading e.message can't take the handler down before it reports.
+        Rails.logger.error "#{e.class}: #{message}" unless Rails.env.test? # Breaks tests...
         status_code = status_code_for(e, message)
         notify_error(e) if status_code > 450 # Only notify for 500s
         message = "OAuth error: #{message}" if /APIAuthorization::Errors/.match?(e.class.to_s)

--- a/spec/requests/api/base_request_spec.rb
+++ b/spec/requests/api/base_request_spec.rb
@@ -70,5 +70,21 @@ RSpec.describe API::Base do
         expect(response.status).to eq 404
       end
     end
+
+    # Grape's logger is its own Logger.new($stdout), which never lands in
+    # production.log where every other error is logged
+    context "outside the test env" do
+      let(:error) do
+        raise StandardError, "some api failure"
+      rescue => e
+        e
+      end
+      before { allow(Rails.env).to receive(:test?).and_return(false) }
+
+      it "logs to the Rails logger" do
+        expect(Rails.logger).to receive(:error).with("StandardError: some api failure")
+        expect(response.status).to eq 500
+      end
+    end
   end
 end

--- a/spec/requests/api/base_request_spec.rb
+++ b/spec/requests/api/base_request_spec.rb
@@ -1,27 +1,74 @@
 require "rails_helper"
 
-# The one API error-handler behavior the endpoint request specs don't exercise:
-# an exception whose message carries invalid UTF-8 (enum errors interpolate the
-# raw param value — "'\xC3(' is not a valid frame_material" — and scanners send
-# probe bytes). The bad byte used to crash respond_to_error, yielding a bare 500
-# with no JSON body and no Honeybadger notify. Status mapping, the {"error": …}
-# envelope, and CORS headers are covered by the v2/v3 request specs.
+# The API error-handler behaviors the endpoint request specs don't exercise - each
+# is an exception that breaks respond_to_error itself, which used to escape as a
+# bare 500 with no JSON body and no Honeybadger notify. Status mapping, the
+# {"error": …} envelope, and CORS headers are covered by the v2/v3 request specs.
 RSpec.describe API::Base do
-  describe ".respond_to_error with an invalid-UTF-8 message" do
-    let(:invalid_utf8) { "'\xC3\x28' is not a valid frame_material".dup.force_encoding(Encoding::UTF_8) }
-    # respond_to_error reads e.backtrace, so raise the exception for real
-    let(:error) do
-      raise StandardError, invalid_utf8
-    rescue => e
-      e
+  describe ".respond_to_error" do
+    let(:response) { described_class.respond_to_error(error) }
+
+    context "with an invalid-UTF-8 message" do
+      # enum errors interpolate the raw param value - "'\xC3(' is not a valid
+      # frame_material" - and scanners send probe bytes
+      let(:invalid_utf8) { "'\xC3\x28' is not a valid frame_material".dup.force_encoding(Encoding::UTF_8) }
+      # respond_to_error reads e.backtrace, so raise the exception for real
+      let(:error) do
+        raise StandardError, invalid_utf8
+      rescue => e
+        e
+      end
+
+      it "scrubs the bad bytes instead of crashing" do
+        expect(invalid_utf8).not_to be_valid_encoding
+        expect(response.status).to eq 500
+        expect(JSON.parse(response.body.first)["error"]).to include "is not a valid frame_material"
+      end
     end
 
-    it "scrubs the bad bytes instead of crashing" do
-      expect(invalid_utf8).not_to be_valid_encoding
-      response = nil
-      expect { response = described_class.respond_to_error(error) }.not_to raise_error
-      expect(response.status).to eq 500
-      expect(JSON.parse(response.body.first)["error"]).to include "is not a valid frame_material"
+    context "with an exception whose message raises" do
+      # named, because the class name is what the fallback maps the status from
+      let(:error_class) do
+        stub_const("ActiveRecord::RecordNotFoundProbe", Class.new(ActiveRecord::RecordNotFound) {
+          def message = raise("message blew up")
+        })
+      end
+      let(:error) do
+        raise error_class
+      rescue => e
+        e
+      end
+
+      it "falls back to the class name, keeping the status mapping" do
+        expect(response.status).to eq 404
+        expect(JSON.parse(response.body.first)["error"]).to eq "ActiveRecord::RecordNotFoundProbe"
+      end
+    end
+
+    context "with an exception whose backtrace raises" do
+      let(:error_class) do
+        Class.new(StandardError) do
+          def backtrace = raise("backtrace blew up")
+        end
+      end
+      let(:error) do
+        raise error_class
+      rescue => e
+        e
+      end
+
+      it "answers from the fallback rather than escaping" do
+        expect(response.status).to eq 500
+        expect(JSON.parse(response.body.first)["error"]).to eq "Internal Server Error"
+      end
+    end
+
+    context "with an unraised exception" do
+      let(:error) { ActiveRecord::RecordNotFound.new }
+
+      it "handles the nil backtrace" do
+        expect(response.status).to eq 404
+      end
     end
   end
 end

--- a/spec/requests/api/base_request_spec.rb
+++ b/spec/requests/api/base_request_spec.rb
@@ -71,8 +71,6 @@ RSpec.describe API::Base do
       end
     end
 
-    # Grape's logger is its own Logger.new($stdout), which never lands in
-    # production.log where every other error is logged
     context "outside the test env" do
       let(:error) do
         raise StandardError, "some api failure"


### PR DESCRIPTION
34 API 500s in a day produced [zero Honeybadger faults](https://app.honeybadger.io/projects/35931) and zero lines in `production.log`. Two independent reasons the API could fail silently, both fixed here.

- **`respond_to_error` could raise before it reported.** It notifies for any status over 450, so a 500 with no fault means the handler itself died first and Grape emitted a bare 500 with no JSON body. Three live ways in: `logger.error e` fed the exception to a formatter that interpolates `e.message`; `e.backtrace[0, 10]` raised on a nil backtrace; and `e.message` can raise outright, not just carry invalid UTF-8 (#3915 covered only the bad bytes). Every path out now returns a `Rack::Response`, with reporting behind a `notify_error` helper so a failing notify can't cost the response.
- **A message that can't be read no longer downgrades the status.** It falls back to the class name, so a `RecordNotFound` stays a 404 instead of becoming a generic 500.
- **API errors now log to `Rails.logger`.** Grape's DSL logger defaults to its own `Logger.new($stdout)`, which the app never overrode — every one of the 24,567 ERROR lines in a day of `production.log` is request-ID tagged, none from Grape's. This matches how `config/initializers/instrumentation.rb` already routes Grape's request logs. Adds ~136 lines/day, the number of API requests that error.

The specific production trigger was **not** reproduced, so this may not be the last word on those 34 requests — but the handler can no longer swallow the evidence, and the next occurrence lands in Honeybadger with a class and backtrace, and in the log where you'd look for it.
