### PR TITLE
Re-record the five expired VCR cassettes

### DIFF
--- a/.claude/skills/rspec-testing/SKILL.md
+++ b/.claude/skills/rspec-testing/SKILL.md
@@ -25,8 +25,7 @@ When something fails outside the files you changed, re-run that spec file on its
 - Use **request specs**, not controller specs — request specs go through the full middleware/routing stack, so they catch breakage controller specs can't see. Everything making the same request should be in a single test.
 - Avoid testing private methods.
 - Avoid mocking objects.
-  - If making external requests, use VCR. Don't manually write VCR cassettes — record them by running the tests.
-  - Cassettes that get modified when you run specs locally are re-recordings, not unrelated churn — they're supposed to update regularly. Commit them with your branch; don't revert them to "keep the PR focused".
+  - If making external requests, use VCR. Never write or edit a cassette by hand — record them by running the tests (see [VCR cassettes](#vcr-cassettes-never-hand-edit-always-re-record)).
 - Don't use `tap` to bundle factory creation with follow-up setup. Create the record in `let`/`let!`, then do the follow-up work on its own line (a separate statement, or a `before` block). One thing per line reads better and keeps the factory call clean.
 
 ### Good
@@ -45,6 +44,20 @@ let!(:bike_transferred) do
   end
 end
 ```
+
+## VCR cassettes: never hand-edit, always re-record
+
+**Never open a cassette and change it.** Not a URL, not a token, not a timestamp, not an interaction — no matter how small or how obviously right the edit looks. A cassette is a recording of what a real service actually said; an edited one asserts something no service ever returned, and the spec passes against a fiction. This has no exceptions.
+
+The only way a cassette changes is a spec run that records it:
+
+- **Stale or wrong contents** — `rm` the file and run the spec. VCR writes it from scratch, holding exactly the requests the spec makes now. Re-recording *without* deleting only writes back the requests still being made, so interactions the spec has stopped making survive forever — and because VCR times `re_record_interval` from the cassette's oldest interaction, one stale entry re-triggers re-recording on every run.
+- **Cassette missing for a resource that doesn't exist yet** — leave it absent and the spec red. Don't fabricate one.
+- **Secrets** — `spec/rails_helper.rb`'s `filter_sensitive_data` and `before_record` handle them. Add the key there; don't scrub the file by hand.
+
+**Commit what a run re-records.** A modified cassette is a re-recording, not unrelated churn — cassettes carry a `re_record_interval` and are meant to update. Commit it on the branch you're on, whatever that branch is about. Never `git checkout` it away to keep a diff focused.
+
+`git status` after a spec run is the only signal; a run that re-records prints nothing.
 
 ## Stubbing ENV
 

--- a/spec/vcr_cassettes/StripeSubscription-create_for-invalid_user_id.yml
+++ b/spec/vcr_cassettes/StripeSubscription-create_for-invalid_user_id.yml
@@ -10,9 +10,9 @@ http_interactions:
       User-Agent:
       - Stripe/v1 RubyBindings/13.4.1
       X-Stripe-Client-Telemetry:
-      - '{"last_request_metrics":{"request_id":"req_MfVth8xGxigJEM","request_duration_ms":0}}'
+      - '{"last_request_metrics":{"request_id":"req_SZ2D2C0tGwhocN","request_duration_ms":538}}'
       Idempotency-Key:
-      - 4acadfaf-aa07-4a9c-ac26-50daa2308598
+      - 469dc7c9-b239-4ea0-b8d0-4407d9167c64
       Stripe-Version:
       - 2025-01-27.acacia
       Content-Type:
@@ -29,7 +29,7 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Tue, 28 Apr 2026 00:20:48 GMT
+      - Thu, 06 Aug 2026 20:40:39 GMT
       Content-Type:
       - application/json
       Content-Length:
@@ -52,17 +52,18 @@ http_interactions:
       Content-Security-Policy:
       - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
         img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
-        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=WbwGuuQv-cO0ZaZfJzeqR34qifTlJCJMAiYVm1lf3Xbrjfy0AJIRsX-bwpL9NwIvxCqxxCDm3pwab-sN
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=Xnl-3oo1U72yb5p-RB6hov5EgVjIxPtLlG_y3d_tWA9WEg-LHUsWvUDnGPBgfkCQZ9olF-E5Zh-wvNd5;
+        report-to csp
       Idempotency-Key:
-      - 4acadfaf-aa07-4a9c-ac26-50daa2308598
+      - 469dc7c9-b239-4ea0-b8d0-4407d9167c64
       Original-Request:
-      - req_Hpdosal17KOssR
+      - req_lHnZk3tWkiQZMz
       Report-To:
-      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=WbwGuuQv-cO0ZaZfJzeqR34qifTlJCJMAiYVm1lf3Xbrjfy0AJIRsX-bwpL9NwIvxCqxxCDm3pwab-sN&t=1"}],"include_subdomains":true}'
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=Xnl-3oo1U72yb5p-RB6hov5EgVjIxPtLlG_y3d_tWA9WEg-LHUsWvUDnGPBgfkCQZ9olF-E5Zh-wvNd5&t=1"}],"include_subdomains":true}'
       Reporting-Endpoints:
-      - csp="https://q.stripe.com/csp-report-v2?q=WbwGuuQv-cO0ZaZfJzeqR34qifTlJCJMAiYVm1lf3Xbrjfy0AJIRsX-bwpL9NwIvxCqxxCDm3pwab-sN&t=1"
+      - csp="https://q.stripe.com/csp-report-v2?q=Xnl-3oo1U72yb5p-RB6hov5EgVjIxPtLlG_y3d_tWA9WEg-LHUsWvUDnGPBgfkCQZ9olF-E5Zh-wvNd5&t=1"
       Request-Id:
-      - req_Hpdosal17KOssR
+      - req_lHnZk3tWkiQZMz
       Stripe-Version:
       - 2025-01-27.acacia
       Vary:
@@ -84,22 +85,22 @@ http_interactions:
             "doc_url": "https://stripe.com/docs/error-codes/resource-missing",
             "message": "No such customer: 'cus_xxxx'",
             "param": "customer",
-            "request_log_url": "https://dashboard.stripe.com/acct_2Ksnm0T0GBfX0vyPUIxE/test/workbench/logs?object=req_Hpdosal17KOssR",
+            "request_log_url": "https://dashboard.stripe.com/acct_2Ksnm0T0GBfX0vyPUIxE/test/workbench/logs?object=req_lHnZk3tWkiQZMz",
             "type": "invalid_request_error"
           }
         }
-  recorded_at: Tue, 28 Apr 2026 00:20:48 GMT
+  recorded_at: Thu, 06 Aug 2026 20:40:39 GMT
 - request:
     method: post
     uri: https://api.stripe.com/v1/checkout/sessions
     body:
       encoding: UTF-8
-      string: success_url=http%3A%2F%2Ftest.host%2Fmembership%2Fsuccess%3Fsession_id%3D%7BCHECKOUT_SESSION_ID%7D&cancel_url=http%3A%2F%2Ftest.host%2Fmembership%2Fnew&mode=subscription&line_items[0][quantity]=1&line_items[0][price]=price_0Qs5rim0T0GBfX0vE7Q7cyoG&customer_email=user1679s%40bikeindex.org
+      string: success_url=http%3A%2F%2Ftest.host%2Fmembership%2Fsuccess%3Fsession_id%3D%7BCHECKOUT_SESSION_ID%7D&cancel_url=http%3A%2F%2Ftest.host%2Fmembership%2Fnew&mode=subscription&line_items[0][quantity]=1&line_items[0][price]=price_0Qs5rim0T0GBfX0vE7Q7cyoG&customer_email=user2s%40bikeindex.org
     headers:
       User-Agent:
       - Stripe/v1 RubyBindings/13.4.1
       Idempotency-Key:
-      - 480279ce-f8fc-4cbc-ba8d-16e778b84b7e
+      - 5926973a-96e7-4b3a-8b90-3fcbc836f73a
       Stripe-Version:
       - 2025-01-27.acacia
       Content-Type:
@@ -116,11 +117,11 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Tue, 28 Apr 2026 00:20:48 GMT
+      - Thu, 06 Aug 2026 20:40:39 GMT
       Content-Type:
       - application/json
       Content-Length:
-      - '3776'
+      - '3766'
       Connection:
       - keep-alive
       Access-Control-Allow-Credentials:
@@ -139,17 +140,18 @@ http_interactions:
       Content-Security-Policy:
       - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
         img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
-        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=WbwGuuQv-cO0ZaZfJzeqR34qifTlJCJMAiYVm1lf3Xbrjfy0AJIRsX-bwpL9NwIvxCqxxCDm3pwab-sN
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=Xnl-3oo1U72yb5p-RB6hov5EgVjIxPtLlG_y3d_tWA9WEg-LHUsWvUDnGPBgfkCQZ9olF-E5Zh-wvNd5;
+        report-to csp
       Idempotency-Key:
-      - 480279ce-f8fc-4cbc-ba8d-16e778b84b7e
+      - 5926973a-96e7-4b3a-8b90-3fcbc836f73a
       Original-Request:
-      - req_7zUWXwHGGdMLbt
+      - req_eArwJIvRHaqfyu
       Report-To:
-      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=WbwGuuQv-cO0ZaZfJzeqR34qifTlJCJMAiYVm1lf3Xbrjfy0AJIRsX-bwpL9NwIvxCqxxCDm3pwab-sN&t=1"}],"include_subdomains":true}'
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=Xnl-3oo1U72yb5p-RB6hov5EgVjIxPtLlG_y3d_tWA9WEg-LHUsWvUDnGPBgfkCQZ9olF-E5Zh-wvNd5&t=1"}],"include_subdomains":true}'
       Reporting-Endpoints:
-      - csp="https://q.stripe.com/csp-report-v2?q=WbwGuuQv-cO0ZaZfJzeqR34qifTlJCJMAiYVm1lf3Xbrjfy0AJIRsX-bwpL9NwIvxCqxxCDm3pwab-sN&t=1"
+      - csp="https://q.stripe.com/csp-report-v2?q=Xnl-3oo1U72yb5p-RB6hov5EgVjIxPtLlG_y3d_tWA9WEg-LHUsWvUDnGPBgfkCQZ9olF-E5Zh-wvNd5&t=1"
       Request-Id:
-      - req_7zUWXwHGGdMLbt
+      - req_eArwJIvRHaqfyu
       Stripe-Should-Retry:
       - 'false'
       Stripe-Version:
@@ -168,7 +170,7 @@ http_interactions:
       encoding: UTF-8
       string: |-
         {
-          "id": "cs_test_a1mQFKniDllWidhN4Rj8MtJt3LrQ1hVidhHSHShuXr2SMUTpYvWhZ6dejP",
+          "id": "cs_test_a1TPaD3z3DqqRPV5b9oGCvladjUhDbumxpLItcKmOBCT4LjzNIxjHQ3XK6",
           "object": "checkout.session",
           "adaptive_pricing": {
             "enabled": true
@@ -192,7 +194,7 @@ http_interactions:
             "font_family": "default",
             "icon": {
               "type": "url",
-              "url": "https://stripe-camo.global.ssl.fastly.net/b4482d0007d24b441c7905466ea522c2ee3dcc6a8eff7f58350343a828cf242e/68747470733a2f2f73332e616d617a6f6e6177732e636f6d2f7374726970652d75706c6f6164732f616363745f324b736e6d3054304742665830767950554978456d65726368616e742d69636f6e2d3436393534342d42696b65496e6465784c6f676f2e706e67/6d65726368616e745f69643d616363745f324b736e6d30543047426658307679505549784526636c69656e743d5041594d454e545f50414745"
+              "url": "https://d1wqzb5bdbcre6.cloudfront.net/b4482d0007d24b441c7905466ea522c2ee3dcc6a8eff7f58350343a828cf242e/68747470733a2f2f73332e616d617a6f6e6177732e636f6d2f7374726970652d75706c6f6164732f616363745f324b736e6d3054304742665830767950554978456d65726368616e742d69636f6e2d3436393534342d42696b65496e6465784c6f676f2e706e67/6d65726368616e745f69643d616363745f324b736e6d30543047426658307679505549784526636c69656e743d5041594d454e545f50414745"
             },
             "logo": null
           },
@@ -206,7 +208,7 @@ http_interactions:
           },
           "consent": null,
           "consent_collection": null,
-          "created": 1777335648,
+          "created": 1786048839,
           "currency": "usd",
           "currency_conversion": null,
           "custom_fields": [],
@@ -222,16 +224,16 @@ http_interactions:
           "customer_details": {
             "address": null,
             "business_name": null,
-            "email": "user1679s@bikeindex.org",
+            "email": "user2s@bikeindex.org",
             "individual_name": null,
             "name": null,
             "phone": null,
             "tax_exempt": "none",
             "tax_ids": null
           },
-          "customer_email": "user1679s@bikeindex.org",
+          "customer_email": "user2s@bikeindex.org",
           "discounts": [],
-          "expires_at": 1777422048,
+          "expires_at": 1786135239,
           "integration_identifier": null,
           "invoice": null,
           "invoice_creation": null,
@@ -287,8 +289,8 @@ http_interactions:
             "amount_tax": 0
           },
           "ui_mode": "hosted",
-          "url": "https://checkout.stripe.com/c/pay/cs_test_a1mQFKniDllWidhN4Rj8MtJt3LrQ1hVidhHSHShuXr2SMUTpYvWhZ6dejP#fidnandhYHdWcXxpYCc%2FJ2FgY2RwaXEnKSdicGRmZGhqaWBTZHdsZGtxJz8nZmprcXdqaScpJ2R1bE5gfCc%2FJ3VuWnFgdnFaX09BbE1nX0lWR2ZkUVxvNXY3RG0yaEtgJyknY3dqaFZgd3Ngdyc%2FcXdwYCknZ2RmbmJ3anBrYUZqaWp3Jz8nJmNjY2NjYycpJ2lkfGpwcVF8dWAnPyd2bGtiaWBabHFgaCcpJ2BrZGdpYFVpZGZgbWppYWB3dic%2FcXdwYHgl",
+          "url": "https://checkout.stripe.com/c/pay/cs_test_a1TPaD3z3DqqRPV5b9oGCvladjUhDbumxpLItcKmOBCT4LjzNIxjHQ3XK6#fidnandhYHdWcXxpYCc%2FJ2FgY2RwaXEnKSdicGRmZGhqaWBTZHdsZGtxJz8nZmprcXdqaScpJ2R1bE5gfCc%2FJ3VuWnFgdnFaX09BbE1nX0lWR2ZkUVxvNXY3RG0yaEtgJyknY3dqaFZgd3Ngdyc%2FcXdwYCknZ2RmbmJ3anBrYUZqaWp3Jz8nJmNjY2NjYycpJ2lkfGpwcVF8dWAnPyd2bGtiaWBabHFgaCcpJ2BrZGdpYFVpZGZgbWppYWB3dic%2FcXdwYHgl",
           "wallet_options": null
         }
-  recorded_at: Tue, 28 Apr 2026 00:20:49 GMT
+  recorded_at: Thu, 06 Aug 2026 20:40:39 GMT
 recorded_with: VCR 6.4.0

--- a/spec/vcr_cassettes/StripeSubscription-create_for-success.yml
+++ b/spec/vcr_cassettes/StripeSubscription-create_for-success.yml
@@ -5,14 +5,12 @@ http_interactions:
     uri: https://api.stripe.com/v1/checkout/sessions
     body:
       encoding: UTF-8
-      string: success_url=http%3A%2F%2Ftest.host%2Fmembership%2Fsuccess%3Fsession_id%3D%7BCHECKOUT_SESSION_ID%7D&cancel_url=http%3A%2F%2Ftest.host%2Fmembership%2Fnew&mode=subscription&line_items[0][quantity]=1&line_items[0][price]=price_0Qs5rim0T0GBfX0vE7Q7cyoG&customer_email=user1677s%40bikeindex.org
+      string: success_url=http%3A%2F%2Ftest.host%2Fmembership%2Fsuccess%3Fsession_id%3D%7BCHECKOUT_SESSION_ID%7D&cancel_url=http%3A%2F%2Ftest.host%2Fmembership%2Fnew&mode=subscription&line_items[0][quantity]=1&line_items[0][price]=price_0Qs5rim0T0GBfX0vE7Q7cyoG&customer_email=user1s%40bikeindex.org
     headers:
       User-Agent:
       - Stripe/v1 RubyBindings/13.4.1
-      X-Stripe-Client-Telemetry:
-      - '{"last_request_metrics":{"request_id":"req_6F5fpz6Ihgs46l","request_duration_ms":1}}'
       Idempotency-Key:
-      - '02472972-e5e5-4489-ab9d-5295900ce97f'
+      - 9806515a-f4df-430e-b933-14df55b5a1a0
       Stripe-Version:
       - 2025-01-27.acacia
       Content-Type:
@@ -29,11 +27,11 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Tue, 28 Apr 2026 00:20:48 GMT
+      - Thu, 06 Aug 2026 20:40:39 GMT
       Content-Type:
       - application/json
       Content-Length:
-      - '3776'
+      - '3766'
       Connection:
       - keep-alive
       Access-Control-Allow-Credentials:
@@ -52,17 +50,18 @@ http_interactions:
       Content-Security-Policy:
       - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
         img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
-        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=2EgX3QsnqsA07w1cVbtpxpsAyHXvheI20S8WEqke_hBiw683RyLrl6edTH35AOzI3FsMWGS0s8e8fqI3
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=oQrtPnNnzcZBn_WP-rD66dtkZNRt_3UrYAPkg3lfehm0lxOmpGODNDrwFrLN_eeboY0RSqkpc49laQIE;
+        report-to csp
       Idempotency-Key:
-      - '02472972-e5e5-4489-ab9d-5295900ce97f'
+      - 9806515a-f4df-430e-b933-14df55b5a1a0
       Original-Request:
-      - req_MfVth8xGxigJEM
+      - req_SZ2D2C0tGwhocN
       Report-To:
-      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=2EgX3QsnqsA07w1cVbtpxpsAyHXvheI20S8WEqke_hBiw683RyLrl6edTH35AOzI3FsMWGS0s8e8fqI3&t=1"}],"include_subdomains":true}'
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=oQrtPnNnzcZBn_WP-rD66dtkZNRt_3UrYAPkg3lfehm0lxOmpGODNDrwFrLN_eeboY0RSqkpc49laQIE&t=1"}],"include_subdomains":true}'
       Reporting-Endpoints:
-      - csp="https://q.stripe.com/csp-report-v2?q=2EgX3QsnqsA07w1cVbtpxpsAyHXvheI20S8WEqke_hBiw683RyLrl6edTH35AOzI3FsMWGS0s8e8fqI3&t=1"
+      - csp="https://q.stripe.com/csp-report-v2?q=oQrtPnNnzcZBn_WP-rD66dtkZNRt_3UrYAPkg3lfehm0lxOmpGODNDrwFrLN_eeboY0RSqkpc49laQIE&t=1"
       Request-Id:
-      - req_MfVth8xGxigJEM
+      - req_SZ2D2C0tGwhocN
       Stripe-Should-Retry:
       - 'false'
       Stripe-Version:
@@ -81,7 +80,7 @@ http_interactions:
       encoding: UTF-8
       string: |-
         {
-          "id": "cs_test_a1kR92giRfpMYQ3z9348aS7QstqQxMWPAxfk559oG7M9szEu6MrOYS6qIG",
+          "id": "cs_test_a1N4iGT5Dw2yYUJuZ2nX9Wum2JLYD4xYftoGSHtbSZXDw38KeNOfy76MMY",
           "object": "checkout.session",
           "adaptive_pricing": {
             "enabled": true
@@ -105,7 +104,7 @@ http_interactions:
             "font_family": "default",
             "icon": {
               "type": "url",
-              "url": "https://stripe-camo.global.ssl.fastly.net/b4482d0007d24b441c7905466ea522c2ee3dcc6a8eff7f58350343a828cf242e/68747470733a2f2f73332e616d617a6f6e6177732e636f6d2f7374726970652d75706c6f6164732f616363745f324b736e6d3054304742665830767950554978456d65726368616e742d69636f6e2d3436393534342d42696b65496e6465784c6f676f2e706e67/6d65726368616e745f69643d616363745f324b736e6d30543047426658307679505549784526636c69656e743d5041594d454e545f50414745"
+              "url": "https://d1wqzb5bdbcre6.cloudfront.net/b4482d0007d24b441c7905466ea522c2ee3dcc6a8eff7f58350343a828cf242e/68747470733a2f2f73332e616d617a6f6e6177732e636f6d2f7374726970652d75706c6f6164732f616363745f324b736e6d3054304742665830767950554978456d65726368616e742d69636f6e2d3436393534342d42696b65496e6465784c6f676f2e706e67/6d65726368616e745f69643d616363745f324b736e6d30543047426658307679505549784526636c69656e743d5041594d454e545f50414745"
             },
             "logo": null
           },
@@ -119,7 +118,7 @@ http_interactions:
           },
           "consent": null,
           "consent_collection": null,
-          "created": 1777335648,
+          "created": 1786048839,
           "currency": "usd",
           "currency_conversion": null,
           "custom_fields": [],
@@ -135,16 +134,16 @@ http_interactions:
           "customer_details": {
             "address": null,
             "business_name": null,
-            "email": "user1677s@bikeindex.org",
+            "email": "user1s@bikeindex.org",
             "individual_name": null,
             "name": null,
             "phone": null,
             "tax_exempt": "none",
             "tax_ids": null
           },
-          "customer_email": "user1677s@bikeindex.org",
+          "customer_email": "user1s@bikeindex.org",
           "discounts": [],
-          "expires_at": 1777422048,
+          "expires_at": 1786135239,
           "integration_identifier": null,
           "invoice": null,
           "invoice_creation": null,
@@ -200,8 +199,8 @@ http_interactions:
             "amount_tax": 0
           },
           "ui_mode": "hosted",
-          "url": "https://checkout.stripe.com/c/pay/cs_test_a1kR92giRfpMYQ3z9348aS7QstqQxMWPAxfk559oG7M9szEu6MrOYS6qIG#fidnandhYHdWcXxpYCc%2FJ2FgY2RwaXEnKSdicGRmZGhqaWBTZHdsZGtxJz8nZmprcXdqaScpJ2R1bE5gfCc%2FJ3VuWnFgdnFaX09BbE1nX0lWR2ZkUVxvNXY3RG0yaEtgJyknY3dqaFZgd3Ngdyc%2FcXdwYCknZ2RmbmJ3anBrYUZqaWp3Jz8nJmNjY2NjYycpJ2lkfGpwcVF8dWAnPyd2bGtiaWBabHFgaCcpJ2BrZGdpYFVpZGZgbWppYWB3dic%2FcXdwYHgl",
+          "url": "https://checkout.stripe.com/c/pay/cs_test_a1N4iGT5Dw2yYUJuZ2nX9Wum2JLYD4xYftoGSHtbSZXDw38KeNOfy76MMY#fidnandhYHdWcXxpYCc%2FJ2FgY2RwaXEnKSdicGRmZGhqaWBTZHdsZGtxJz8nZmprcXdqaScpJ2R1bE5gfCc%2FJ3VuWnFgdnFaX09BbE1nX0lWR2ZkUVxvNXY3RG0yaEtgJyknY3dqaFZgd3Ngdyc%2FcXdwYCknZ2RmbmJ3anBrYUZqaWp3Jz8nJmNjY2NjYycpJ2lkfGpwcVF8dWAnPyd2bGtiaWBabHFgaCcpJ2BrZGdpYFVpZGZgbWppYWB3dic%2FcXdwYHgl",
           "wallet_options": null
         }
-  recorded_at: Tue, 28 Apr 2026 00:20:48 GMT
+  recorded_at: Thu, 06 Aug 2026 20:40:39 GMT
 recorded_with: VCR 6.4.0

--- a/spec/vcr_cassettes/bike_creator-include_bike_book.yml
+++ b/spec/vcr_cassettes/bike_creator-include_bike_book.yml
@@ -31,13 +31,13 @@ http_interactions:
       Content-Type:
       - application/json;charset=utf-8
       Date:
-      - Thu, 05 Feb 2026 03:43:15 GMT
+      - Thu, 06 Aug 2026 20:40:43 GMT
       Nel:
       - '{"report_to":"heroku-nel","response_headers":["Via"],"max_age":3600,"success_fraction":0.01,"failure_fraction":0.1}'
       Report-To:
-      - '{"group":"heroku-nel","endpoints":[{"url":"https://nel.heroku.com/reports?s=1EjkcrzWA7AV4UCmCOFI25LnBjxH5t7mucIJbu4m39Q%3D\u0026sid=af571f24-03ee-46d1-9f90-ab9030c2c74c\u0026ts=1770262995"}],"max_age":3600}'
+      - '{"group":"heroku-nel","endpoints":[{"url":"https://nel.heroku.com/reports?s=QUTXa1wQmK9iL047FMn7EzY5jX%2B%2FxRCBYHVN8W8dV0c%3D\u0026sid=af571f24-03ee-46d1-9f90-ab9030c2c74c\u0026ts=1786048843"}],"max_age":3600}'
       Reporting-Endpoints:
-      - heroku-nel="https://nel.heroku.com/reports?s=1EjkcrzWA7AV4UCmCOFI25LnBjxH5t7mucIJbu4m39Q%3D&sid=af571f24-03ee-46d1-9f90-ab9030c2c74c&ts=1770262995"
+      - heroku-nel="https://nel.heroku.com/reports?s=QUTXa1wQmK9iL047FMn7EzY5jX%2B%2FxRCBYHVN8W8dV0c%3D&sid=af571f24-03ee-46d1-9f90-ab9030c2c74c&ts=1786048843"
       Server:
       - Heroku
       Via:
@@ -63,5 +63,5 @@ http_interactions:
         Racing Mushroom Wing Grip w/ SE Rubber End Plugs","cgroup":"Additional parts"},{"component_type":"saddle","description":"SE
         Classic w/ Bottle Opener","cgroup":"Additional parts"},{"component_type":"seatpost","description":"SE
         Straight Post, 27.2mm","cgroup":"Additional parts"}]}'
-  recorded_at: Thu, 05 Feb 2026 03:43:15 GMT
-recorded_with: VCR 6.3.1
+  recorded_at: Thu, 06 Aug 2026 20:40:43 GMT
+recorded_with: VCR 6.4.0

--- a/spec/vcr_cassettes/payments_controller-donation-customer.yml
+++ b/spec/vcr_cassettes/payments_controller-donation-customer.yml
@@ -1,290 +1,6 @@
 ---
 http_interactions:
 - request:
-    method: get
-    uri: https://api.stripe.com/v1/checkout/sessions/cs_test_a15Mb9Rte6MgOkvjOovuH4VBeagLKw74LLFBFUvSGJHBYt83eesNXRKatJ
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - Stripe/v1 RubyBindings/13.4.1
-      X-Stripe-Client-Telemetry:
-      - '{"last_request_metrics":{"request_id":"req_9I3m5j22TAKGtF","request_duration_ms":421}}'
-      Stripe-Version:
-      - 2025-01-27.acacia
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Server:
-      - nginx
-      Date:
-      - Sun, 02 Feb 2025 18:32:03 GMT
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '2721'
-      Connection:
-      - keep-alive
-      Access-Control-Allow-Credentials:
-      - 'true'
-      Access-Control-Allow-Methods:
-      - GET, HEAD, PUT, PATCH, POST, DELETE
-      Access-Control-Allow-Origin:
-      - "*"
-      Access-Control-Expose-Headers:
-      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
-        X-Stripe-Privileged-Session-Required
-      Access-Control-Max-Age:
-      - '300'
-      Cache-Control:
-      - no-cache, no-store
-      Content-Security-Policy:
-      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
-        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; upgrade-insecure-requests;
-        report-uri https://q.stripe.com/csp-violation?q=JF20kzjnC6OfVpMM8733X2_t-8rdEeqkmDQHC1EeqHOdkWxCuBmnxjXgXfeuWfAqi2bil5PECQUMIfKu
-      Cross-Origin-Opener-Policy-Report-Only:
-      - same-origin; report-to="coop"
-      Report-To:
-      - '{"group":"coop","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/coop-report"}],"include_subdomains":true}'
-      Reporting-Endpoints:
-      - coop="https://q.stripe.com/coop-report"
-      Request-Id:
-      - req_tDpQOe37cNftcB
-      Stripe-Version:
-      - 2025-01-27.acacia
-      Vary:
-      - Origin
-      X-Stripe-Priority-Routing-Enabled:
-      - 'true'
-      X-Stripe-Routing-Context-Priority-Tier:
-      - api-testmode
-      X-Wc:
-      - AB
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains; preload
-    body:
-      encoding: UTF-8
-      string: |-
-        {
-          "id": "cs_test_a15Mb9Rte6MgOkvjOovuH4VBeagLKw74LLFBFUvSGJHBYt83eesNXRKatJ",
-          "object": "checkout.session",
-          "adaptive_pricing": {
-            "enabled": false
-          },
-          "after_expiration": null,
-          "allow_promotion_codes": null,
-          "amount_subtotal": 7500,
-          "amount_total": 7500,
-          "automatic_tax": {
-            "enabled": false,
-            "liability": null,
-            "status": null
-          },
-          "billing_address_collection": null,
-          "cancel_url": "http://test.host/payments/new",
-          "client_reference_id": null,
-          "client_secret": null,
-          "consent": null,
-          "consent_collection": null,
-          "created": 1738521123,
-          "currency": "usd",
-          "currency_conversion": null,
-          "custom_fields": [],
-          "custom_text": {
-            "after_submit": null,
-            "shipping_address": null,
-            "submit": null,
-            "terms_of_service_acceptance": null
-          },
-          "customer": "cus_JmR9ccDp8JD2Mo",
-          "customer_creation": null,
-          "customer_details": {
-            "address": null,
-            "email": "testly@bikeindex.org",
-            "name": null,
-            "phone": null,
-            "tax_exempt": "none",
-            "tax_ids": null
-          },
-          "customer_email": null,
-          "discounts": [],
-          "expires_at": 1738607523,
-          "invoice": null,
-          "invoice_creation": {
-            "enabled": false,
-            "invoice_data": {
-              "account_tax_ids": null,
-              "custom_fields": null,
-              "description": null,
-              "footer": null,
-              "issuer": null,
-              "metadata": {},
-              "rendering_options": null
-            }
-          },
-          "livemode": false,
-          "locale": null,
-          "metadata": {},
-          "mode": "payment",
-          "payment_intent": null,
-          "payment_link": null,
-          "payment_method_collection": "if_required",
-          "payment_method_configuration_details": null,
-          "payment_method_options": {
-            "card": {
-              "request_three_d_secure": "automatic"
-            }
-          },
-          "payment_method_types": [
-            "card"
-          ],
-          "payment_status": "unpaid",
-          "phone_number_collection": {
-            "enabled": false
-          },
-          "recovered_from": null,
-          "saved_payment_method_options": {
-            "allow_redisplay_filters": [
-              "always"
-            ],
-            "payment_method_remove": null,
-            "payment_method_save": null
-          },
-          "setup_intent": null,
-          "shipping_address_collection": null,
-          "shipping_cost": null,
-          "shipping_details": null,
-          "shipping_options": [],
-          "status": "open",
-          "submit_type": "donate",
-          "subscription": null,
-          "success_url": "http://test.host/payments/success?session_id={CHECKOUT_SESSION_ID}",
-          "total_details": {
-            "amount_discount": 0,
-            "amount_shipping": 0,
-            "amount_tax": 0
-          },
-          "ui_mode": "hosted",
-          "url": "https://checkout.stripe.com/c/pay/cs_test_a15Mb9Rte6MgOkvjOovuH4VBeagLKw74LLFBFUvSGJHBYt83eesNXRKatJ#fidkdWxOYHwnPyd1blpxYHZxWl9PQWxNZ19JVkdmZFFcbzV2N0RtMmhLYCcpJ2N3amhWYHdzYHcnP3F3cGApJ2lkfGpwcVF8dWAnPyd2bGtiaWBabHFgaCcpJ2BrZGdpYFVpZGZgbWppYWB3dic%2FcXdwYHgl"
-        }
-  recorded_at: Sun, 02 Feb 2025 18:32:03 GMT
-- request:
-    method: get
-    uri: https://api.stripe.com/v1/customers/cus_JmR9ccDp8JD2Mo
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - Stripe/v1 RubyBindings/13.4.1
-      X-Stripe-Client-Telemetry:
-      - '{"last_request_metrics":{"request_id":"req_tDpQOe37cNftcB","request_duration_ms":237}}'
-      Stripe-Version:
-      - 2025-01-27.acacia
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Server:
-      - nginx
-      Date:
-      - Sun, 02 Feb 2025 18:32:04 GMT
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '760'
-      Connection:
-      - keep-alive
-      Access-Control-Allow-Credentials:
-      - 'true'
-      Access-Control-Allow-Methods:
-      - GET, HEAD, PUT, PATCH, POST, DELETE
-      Access-Control-Allow-Origin:
-      - "*"
-      Access-Control-Expose-Headers:
-      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
-        X-Stripe-Privileged-Session-Required
-      Access-Control-Max-Age:
-      - '300'
-      Cache-Control:
-      - no-cache, no-store
-      Content-Security-Policy:
-      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
-        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; upgrade-insecure-requests;
-        report-uri https://q.stripe.com/csp-violation?q=JF20kzjnC6OfVpMM8733X2_t-8rdEeqkmDQHC1EeqHOdkWxCuBmnxjXgXfeuWfAqi2bil5PECQUMIfKu
-      Cross-Origin-Opener-Policy-Report-Only:
-      - same-origin; report-to="coop"
-      Report-To:
-      - '{"group":"coop","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/coop-report"}],"include_subdomains":true}'
-      Reporting-Endpoints:
-      - coop="https://q.stripe.com/coop-report"
-      Request-Id:
-      - req_FG6R3pdIZKv8Ws
-      Stripe-Version:
-      - 2025-01-27.acacia
-      Vary:
-      - Origin
-      X-Stripe-Priority-Routing-Enabled:
-      - 'true'
-      X-Stripe-Routing-Context-Priority-Tier:
-      - api-testmode
-      X-Wc:
-      - AB
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains; preload
-    body:
-      encoding: UTF-8
-      string: |-
-        {
-          "id": "cus_JmR9ccDp8JD2Mo",
-          "object": "customer",
-          "address": {
-            "city": null,
-            "country": "US",
-            "line1": null,
-            "line2": null,
-            "postal_code": "60647",
-            "state": null
-          },
-          "balance": 0,
-          "created": 1625255017,
-          "currency": null,
-          "default_source": null,
-          "delinquent": false,
-          "description": null,
-          "discount": null,
-          "email": "testly@bikeindex.org",
-          "invoice_prefix": "80897ED8",
-          "invoice_settings": {
-            "custom_fields": null,
-            "default_payment_method": null,
-            "footer": null,
-            "rendering_options": null
-          },
-          "livemode": false,
-          "metadata": {},
-          "name": "Testly",
-          "next_invoice_sequence": 1,
-          "phone": null,
-          "preferred_locales": [],
-          "shipping": null,
-          "tax_exempt": "none",
-          "test_clock": null
-        }
-  recorded_at: Sun, 02 Feb 2025 18:32:04 GMT
-- request:
     method: post
     uri: https://api.stripe.com/v1/checkout/sessions
     body:
@@ -294,9 +10,9 @@ http_interactions:
       User-Agent:
       - Stripe/v1 RubyBindings/13.4.1
       X-Stripe-Client-Telemetry:
-      - '{"last_request_metrics":{"request_id":"req_2B6EBOJReXe3ci","request_duration_ms":353}}'
+      - '{"last_request_metrics":{"request_id":"req_CuVCn4o25kE13X","request_duration_ms":403}}'
       Idempotency-Key:
-      - 8d1ab461-3bf3-4427-988e-cc5e6fb1f8a5
+      - 25a69115-4fec-4355-b4c7-d312aa4253bc
       Stripe-Version:
       - 2025-01-27.acacia
       Content-Type:
@@ -313,7 +29,7 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Wed, 05 Aug 2026 21:48:05 GMT
+      - Thu, 06 Aug 2026 21:09:32 GMT
       Content-Type:
       - application/json
       Content-Length:
@@ -336,18 +52,18 @@ http_interactions:
       Content-Security-Policy:
       - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
         img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
-        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=uuKOZiToS9Fpnr9sUY7AQj2XRLXiHBXe6hX5DqgOA9hMAouBOOcdNA6D-WndtZBpj41y6Kpb_vTzi3dl;
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=Mw7kssNmEnD80v_jD8dxAKfGm_yl5F_rwKe0a4b8opYDTnTb33ZBQs0oprm4NoXmoo6VPaDZ_MlQvJg8;
         report-to csp
       Idempotency-Key:
-      - 8d1ab461-3bf3-4427-988e-cc5e6fb1f8a5
+      - 25a69115-4fec-4355-b4c7-d312aa4253bc
       Original-Request:
-      - req_vmGtn6AFeHwx1l
+      - req_yXBgvA6y2Q1pTM
       Report-To:
-      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=uuKOZiToS9Fpnr9sUY7AQj2XRLXiHBXe6hX5DqgOA9hMAouBOOcdNA6D-WndtZBpj41y6Kpb_vTzi3dl&t=1"}],"include_subdomains":true}'
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=Mw7kssNmEnD80v_jD8dxAKfGm_yl5F_rwKe0a4b8opYDTnTb33ZBQs0oprm4NoXmoo6VPaDZ_MlQvJg8&t=1"}],"include_subdomains":true}'
       Reporting-Endpoints:
-      - csp="https://q.stripe.com/csp-report-v2?q=uuKOZiToS9Fpnr9sUY7AQj2XRLXiHBXe6hX5DqgOA9hMAouBOOcdNA6D-WndtZBpj41y6Kpb_vTzi3dl&t=1"
+      - csp="https://q.stripe.com/csp-report-v2?q=Mw7kssNmEnD80v_jD8dxAKfGm_yl5F_rwKe0a4b8opYDTnTb33ZBQs0oprm4NoXmoo6VPaDZ_MlQvJg8&t=1"
       Request-Id:
-      - req_vmGtn6AFeHwx1l
+      - req_yXBgvA6y2Q1pTM
       Stripe-Should-Retry:
       - 'false'
       Stripe-Version:
@@ -366,7 +82,7 @@ http_interactions:
       encoding: UTF-8
       string: |-
         {
-          "id": "cs_test_a1LnuN6mJ2RszGkrKu3Fa304gly9PKgmNmXxhl4naEdUIBnNpMA8Z4IUxY",
+          "id": "cs_test_a1ek3L3cFHK5yf8Ui4VpREa3U1phpjikkc7EzQLkljF0SxBQALjWGayCPj",
           "object": "checkout.session",
           "adaptive_pricing": {
             "enabled": true
@@ -404,7 +120,7 @@ http_interactions:
           },
           "consent": null,
           "consent_collection": null,
-          "created": 1785966485,
+          "created": 1786050572,
           "currency": "usd",
           "currency_conversion": null,
           "custom_fields": [],
@@ -429,7 +145,7 @@ http_interactions:
           },
           "customer_email": null,
           "discounts": [],
-          "expires_at": 1786052885,
+          "expires_at": 1786136972,
           "integration_identifier": null,
           "invoice": null,
           "invoice_creation": {
@@ -496,8 +212,8 @@ http_interactions:
             "amount_tax": 0
           },
           "ui_mode": "hosted",
-          "url": "https://checkout.stripe.com/c/pay/cs_test_a1LnuN6mJ2RszGkrKu3Fa304gly9PKgmNmXxhl4naEdUIBnNpMA8Z4IUxY#fidnandhYHdWcXxpYCc%2FJ2FgY2RwaXEnKSdicGRmZGhqaWBTZHdsZGtxJz8nZmprcXdqaScpJ2R1bE5gfCc%2FJ3VuWnFgdnFaX09BbE1nX0lWR2ZkUVxvNXY3RG0yaEtgJyknY3dqaFZgd3Ngdyc%2FcXdwYCknZ2RmbmJ3anBrYUZqaWp3Jz8nJmNjY2NjYycpJ2lkfGpwcVF8dWAnPyd2bGtiaWBabHFgaCcpJ2BrZGdpYFVpZGZgbWppYWB3dic%2FcXdwYHgl",
+          "url": "https://checkout.stripe.com/c/pay/cs_test_a1ek3L3cFHK5yf8Ui4VpREa3U1phpjikkc7EzQLkljF0SxBQALjWGayCPj#fidnandhYHdWcXxpYCc%2FJ2FgY2RwaXEnKSdicGRmZGhqaWBTZHdsZGtxJz8nZmprcXdqaScpJ2R1bE5gfCc%2FJ3VuWnFgdnFaX09BbE1nX0lWR2ZkUVxvNXY3RG0yaEtgJyknY3dqaFZgd3Ngdyc%2FcXdwYCknZ2RmbmJ3anBrYUZqaWp3Jz8nJmNjY2NjYycpJ2lkfGpwcVF8dWAnPyd2bGtiaWBabHFgaCcpJ2BrZGdpYFVpZGZgbWppYWB3dic%2FcXdwYHgl",
           "wallet_options": null
         }
-  recorded_at: Wed, 05 Aug 2026 21:48:05 GMT
+  recorded_at: Thu, 06 Aug 2026 21:09:32 GMT
 recorded_with: VCR 6.4.0

--- a/spec/vcr_cassettes/payments_controller-donation.yml
+++ b/spec/vcr_cassettes/payments_controller-donation.yml
@@ -1,187 +1,18 @@
 ---
 http_interactions:
 - request:
-    method: get
-    uri: https://api.stripe.com/v1/checkout/sessions/cs_test_a1Fxrx8qKEjVCIlg3uzbh0Vlm4X8lktOLLtjUc9vVmbtOAs1Kl8wVFwhPo
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - Stripe/v1 RubyBindings/13.4.1
-      X-Stripe-Client-Telemetry:
-      - '{"last_request_metrics":{"request_id":"req_OGjgLxm5ZU4mHT","request_duration_ms":412}}'
-      Stripe-Version:
-      - 2025-01-27.acacia
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Server:
-      - nginx
-      Date:
-      - Sun, 02 Feb 2025 18:32:03 GMT
-      Content-Type:
-      - application/json
-      Content-Length:
-      - '2615'
-      Connection:
-      - keep-alive
-      Access-Control-Allow-Credentials:
-      - 'true'
-      Access-Control-Allow-Methods:
-      - GET, HEAD, PUT, PATCH, POST, DELETE
-      Access-Control-Allow-Origin:
-      - "*"
-      Access-Control-Expose-Headers:
-      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required,
-        X-Stripe-Privileged-Session-Required
-      Access-Control-Max-Age:
-      - '300'
-      Cache-Control:
-      - no-cache, no-store
-      Content-Security-Policy:
-      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
-        img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; upgrade-insecure-requests;
-        report-uri https://q.stripe.com/csp-violation?q=JF20kzjnC6OfVpMM8733X2_t-8rdEeqkmDQHC1EeqHOdkWxCuBmnxjXgXfeuWfAqi2bil5PECQUMIfKu
-      Cross-Origin-Opener-Policy-Report-Only:
-      - same-origin; report-to="coop"
-      Report-To:
-      - '{"group":"coop","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/coop-report"}],"include_subdomains":true}'
-      Reporting-Endpoints:
-      - coop="https://q.stripe.com/coop-report"
-      Request-Id:
-      - req_mAlODZvHOGmgsv
-      Stripe-Version:
-      - 2025-01-27.acacia
-      Vary:
-      - Origin
-      X-Stripe-Priority-Routing-Enabled:
-      - 'true'
-      X-Stripe-Routing-Context-Priority-Tier:
-      - api-testmode
-      X-Wc:
-      - AB
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains; preload
-    body:
-      encoding: UTF-8
-      string: |-
-        {
-          "id": "cs_test_a1Fxrx8qKEjVCIlg3uzbh0Vlm4X8lktOLLtjUc9vVmbtOAs1Kl8wVFwhPo",
-          "object": "checkout.session",
-          "adaptive_pricing": {
-            "enabled": false
-          },
-          "after_expiration": null,
-          "allow_promotion_codes": null,
-          "amount_subtotal": 4000,
-          "amount_total": 4000,
-          "automatic_tax": {
-            "enabled": false,
-            "liability": null,
-            "status": null
-          },
-          "billing_address_collection": null,
-          "cancel_url": "http://test.host/payments/new",
-          "client_reference_id": null,
-          "client_secret": null,
-          "consent": null,
-          "consent_collection": null,
-          "created": 1738521122,
-          "currency": "usd",
-          "currency_conversion": null,
-          "custom_fields": [],
-          "custom_text": {
-            "after_submit": null,
-            "shipping_address": null,
-            "submit": null,
-            "terms_of_service_acceptance": null
-          },
-          "customer": null,
-          "customer_creation": "if_required",
-          "customer_details": {
-            "address": null,
-            "email": "user3s@bikeiasdndex.org",
-            "name": null,
-            "phone": null,
-            "tax_exempt": "none",
-            "tax_ids": null
-          },
-          "customer_email": "user3s@bikeiasdndex.org",
-          "discounts": [],
-          "expires_at": 1738607522,
-          "invoice": null,
-          "invoice_creation": {
-            "enabled": false,
-            "invoice_data": {
-              "account_tax_ids": null,
-              "custom_fields": null,
-              "description": null,
-              "footer": null,
-              "issuer": null,
-              "metadata": {},
-              "rendering_options": null
-            }
-          },
-          "livemode": false,
-          "locale": null,
-          "metadata": {},
-          "mode": "payment",
-          "payment_intent": null,
-          "payment_link": null,
-          "payment_method_collection": "if_required",
-          "payment_method_configuration_details": null,
-          "payment_method_options": {
-            "card": {
-              "request_three_d_secure": "automatic"
-            }
-          },
-          "payment_method_types": [
-            "card"
-          ],
-          "payment_status": "unpaid",
-          "phone_number_collection": {
-            "enabled": false
-          },
-          "recovered_from": null,
-          "saved_payment_method_options": null,
-          "setup_intent": null,
-          "shipping_address_collection": null,
-          "shipping_cost": null,
-          "shipping_details": null,
-          "shipping_options": [],
-          "status": "open",
-          "submit_type": "donate",
-          "subscription": null,
-          "success_url": "http://test.host/payments/success?session_id={CHECKOUT_SESSION_ID}",
-          "total_details": {
-            "amount_discount": 0,
-            "amount_shipping": 0,
-            "amount_tax": 0
-          },
-          "ui_mode": "hosted",
-          "url": "https://checkout.stripe.com/c/pay/cs_test_a1Fxrx8qKEjVCIlg3uzbh0Vlm4X8lktOLLtjUc9vVmbtOAs1Kl8wVFwhPo#fidkdWxOYHwnPyd1blpxYHZxWl9PQWxNZ19JVkdmZFFcbzV2N0RtMmhLYCcpJ2N3amhWYHdzYHcnP3F3cGApJ2lkfGpwcVF8dWAnPyd2bGtiaWBabHFgaCcpJ2BrZGdpYFVpZGZgbWppYWB3dic%2FcXdwYHgl"
-        }
-  recorded_at: Sun, 02 Feb 2025 18:32:03 GMT
-- request:
     method: post
     uri: https://api.stripe.com/v1/checkout/sessions
     body:
       encoding: UTF-8
-      string: submit_type=donate&line_items[0][price_data][unit_amount]=4000&line_items[0][price_data][currency]=MXN&line_items[0][price_data][product_data][name]=Donation&line_items[0][price_data][product_data][images][0]=https%3A%2F%2Ffiles.bikeindex.org%2Fuploads%2FPu%2F151203%2Freg_hance.jpg&line_items[0][quantity]=1&mode=payment&success_url=http%3A%2F%2Ftest.host%2Fpayments%2Fsuccess%3Fsession_id%3D%7BCHECKOUT_SESSION_ID%7D&cancel_url=http%3A%2F%2Ftest.host%2Fpayments%2Fnew&customer_email=user30s%40bikeindex.org
+      string: submit_type=donate&line_items[0][price_data][unit_amount]=4000&line_items[0][price_data][currency]=MXN&line_items[0][price_data][product_data][name]=Donation&line_items[0][price_data][product_data][images][0]=https%3A%2F%2Ffiles.bikeindex.org%2Fuploads%2FPu%2F151203%2Freg_hance.jpg&line_items[0][quantity]=1&mode=payment&success_url=http%3A%2F%2Ftest.host%2Fpayments%2Fsuccess%3Fsession_id%3D%7BCHECKOUT_SESSION_ID%7D&cancel_url=http%3A%2F%2Ftest.host%2Fpayments%2Fnew&customer_email=user3s%40bikeindex.org
     headers:
       User-Agent:
       - Stripe/v1 RubyBindings/13.4.1
       X-Stripe-Client-Telemetry:
       - '{"last_request_metrics":{"request_id":"req_MUlgTes1WDja7o","request_duration_ms":0}}'
       Idempotency-Key:
-      - 41508444-c009-40bd-848d-2a44a7333065
+      - 4d4d080d-d965-4dc5-940c-88f4cf39c74e
       Stripe-Version:
       - 2025-01-27.acacia
       Content-Type:
@@ -198,11 +29,11 @@ http_interactions:
       Server:
       - nginx
       Date:
-      - Wed, 05 Aug 2026 21:48:05 GMT
+      - Thu, 06 Aug 2026 21:09:32 GMT
       Content-Type:
       - application/json
       Content-Length:
-      - '3869'
+      - '3867'
       Connection:
       - keep-alive
       Access-Control-Allow-Credentials:
@@ -221,18 +52,18 @@ http_interactions:
       Content-Security-Policy:
       - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
         img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src
-        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=uuKOZiToS9Fpnr9sUY7AQj2XRLXiHBXe6hX5DqgOA9hMAouBOOcdNA6D-WndtZBpj41y6Kpb_vTzi3dl;
+        'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=Mw7kssNmEnD80v_jD8dxAKfGm_yl5F_rwKe0a4b8opYDTnTb33ZBQs0oprm4NoXmoo6VPaDZ_MlQvJg8;
         report-to csp
       Idempotency-Key:
-      - 41508444-c009-40bd-848d-2a44a7333065
+      - 4d4d080d-d965-4dc5-940c-88f4cf39c74e
       Original-Request:
-      - req_2B6EBOJReXe3ci
+      - req_CuVCn4o25kE13X
       Report-To:
-      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=uuKOZiToS9Fpnr9sUY7AQj2XRLXiHBXe6hX5DqgOA9hMAouBOOcdNA6D-WndtZBpj41y6Kpb_vTzi3dl&t=1"}],"include_subdomains":true}'
+      - '{"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=Mw7kssNmEnD80v_jD8dxAKfGm_yl5F_rwKe0a4b8opYDTnTb33ZBQs0oprm4NoXmoo6VPaDZ_MlQvJg8&t=1"}],"include_subdomains":true}'
       Reporting-Endpoints:
-      - csp="https://q.stripe.com/csp-report-v2?q=uuKOZiToS9Fpnr9sUY7AQj2XRLXiHBXe6hX5DqgOA9hMAouBOOcdNA6D-WndtZBpj41y6Kpb_vTzi3dl&t=1"
+      - csp="https://q.stripe.com/csp-report-v2?q=Mw7kssNmEnD80v_jD8dxAKfGm_yl5F_rwKe0a4b8opYDTnTb33ZBQs0oprm4NoXmoo6VPaDZ_MlQvJg8&t=1"
       Request-Id:
-      - req_2B6EBOJReXe3ci
+      - req_CuVCn4o25kE13X
       Stripe-Should-Retry:
       - 'false'
       Stripe-Version:
@@ -251,7 +82,7 @@ http_interactions:
       encoding: UTF-8
       string: |-
         {
-          "id": "cs_test_a1zpaN5ARR8gLLCpXb5Uc6B5eqBiXlHJX6AGnv5ude45PsVKsOpXZAGkjx",
+          "id": "cs_test_a1mRtZ0dI7QRAktdb2hlOnxsx4JhG1Ov4PG0JSPRIDKgcUp25Juk6577pz",
           "object": "checkout.session",
           "adaptive_pricing": {
             "enabled": true
@@ -289,7 +120,7 @@ http_interactions:
           },
           "consent": null,
           "consent_collection": null,
-          "created": 1785966485,
+          "created": 1786050572,
           "currency": "mxn",
           "currency_conversion": null,
           "custom_fields": [],
@@ -305,16 +136,16 @@ http_interactions:
           "customer_details": {
             "address": null,
             "business_name": null,
-            "email": "user30s@bikeindex.org",
+            "email": "user3s@bikeindex.org",
             "individual_name": null,
             "name": null,
             "phone": null,
             "tax_exempt": "none",
             "tax_ids": null
           },
-          "customer_email": "user30s@bikeindex.org",
+          "customer_email": "user3s@bikeindex.org",
           "discounts": [],
-          "expires_at": 1786052885,
+          "expires_at": 1786136972,
           "integration_identifier": null,
           "invoice": null,
           "invoice_creation": {
@@ -374,8 +205,8 @@ http_interactions:
             "amount_tax": 0
           },
           "ui_mode": "hosted",
-          "url": "https://checkout.stripe.com/c/pay/cs_test_a1zpaN5ARR8gLLCpXb5Uc6B5eqBiXlHJX6AGnv5ude45PsVKsOpXZAGkjx#fidnandhYHdWcXxpYCc%2FJ2FgY2RwaXEnKSdicGRmZGhqaWBTZHdsZGtxJz8nZmprcXdqaScpJ2R1bE5gfCc%2FJ3VuWnFgdnFaX09BbE1nX0lWR2ZkUVxvNXY3RG0yaEtgJyknY3dqaFZgd3Ngdyc%2FcXdwYCknZ2RmbmJ3anBrYUZqaWp3Jz8nJmNjY2NjYycpJ2lkfGpwcVF8dWAnPyd2bGtiaWBabHFgaCcpJ2BrZGdpYFVpZGZgbWppYWB3dic%2FcXdwYHgl",
+          "url": "https://checkout.stripe.com/c/pay/cs_test_a1mRtZ0dI7QRAktdb2hlOnxsx4JhG1Ov4PG0JSPRIDKgcUp25Juk6577pz#fidnandhYHdWcXxpYCc%2FJ2FgY2RwaXEnKSdicGRmZGhqaWBTZHdsZGtxJz8nZmprcXdqaScpJ2R1bE5gfCc%2FJ3VuWnFgdnFaX09BbE1nX0lWR2ZkUVxvNXY3RG0yaEtgJyknY3dqaFZgd3Ngdyc%2FcXdwYCknZ2RmbmJ3anBrYUZqaWp3Jz8nJmNjY2NjYycpJ2lkfGpwcVF8dWAnPyd2bGtiaWBabHFgaCcpJ2BrZGdpYFVpZGZgbWppYWB3dic%2FcXdwYHgl",
           "wallet_options": null
         }
-  recorded_at: Wed, 05 Aug 2026 21:48:05 GMT
+  recorded_at: Thu, 06 Aug 2026 21:09:32 GMT
 recorded_with: VCR 6.4.0


### PR DESCRIPTION
The five cassettes were all past their `re_record_interval` — 60 days for the Stripe and payments ones, 6 months for `bike_book` — so every local spec run re-recorded them and left the tree dirty. Re-recorded from the real services.

- **The two payments cassettes were recorded from scratch, with the files removed first.** VCR derives re-recording from a cassette's *oldest* interaction, and both held a stale 2025-02-02 checkout-session GET the spec no longer makes. Re-recording only writes back the requests the spec does make, so those episodes never refreshed and the interval blew again on the next run — hence the large deletions there.
- **The cassette rules get their own section in the `rspec-testing` skill**, covering both never hand-editing one and not reverting a re-recording to keep a diff focused.
- Extracted from `sethherr/optional-local-ci` so the re-records can land on their own.
