### PR TITLE
Move to Rails 8.1 defaults and retire the :hybrid cookie shim

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -28,7 +28,7 @@ module Bikeindex
     config.redis_cache_url = ENV.fetch("REDIS_CACHE_URL", config.redis_default_url)
     config.redis_rack_attack_url = ENV.fetch("REDIS_RACK_ATTACK_URL", config.redis_cache_url)
 
-    config.load_defaults 8.0
+    config.load_defaults 8.1
 
     # Clear Rails default security headers - secure_headers gem manages these instead
     # (secure_headers has a bug where it tries to delete lowercase keys but Rails uses mixed case)

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -909,26 +909,6 @@
       "note": "HEAD requests falling through to strava_receive_event is harmless - it will just return 200 OK"
     },
     {
-      "warning_type": "Remote Code Execution",
-      "warning_code": 110,
-      "fingerprint": "9ae68e59cfee3e5256c0540dadfeb74e6b72c91997fdb60411063a6e8518144a",
-      "check_name": "CookieSerialization",
-      "message": "Use of unsafe cookie serialization strategy `:hybrid` might lead to remote code execution",
-      "file": "config/initializers/cookies_serializer.rb",
-      "line": 8,
-      "link": "https://brakemanscanner.org/docs/warning_types/unsafe_deserialization",
-      "code": "Rails.application.config.action_dispatch.cookies_serializer = :hybrid",
-      "render_path": null,
-      "location": null,
-      "user_input": null,
-      "confidence": "Medium",
-      "cwe_id": [
-        565,
-        502
-      ],
-      "note": "Standard Rails migration strategy from Marshal to JSON cookie serialization. :hybrid is the recommended transitional setting"
-    },
-    {
       "warning_type": "SQL Injection",
       "warning_code": 0,
       "fingerprint": "9de2dec925781dd5563bb05130413fef190ee0c95cead55d2442d4dac71c28bc",

--- a/config/initializers/cookies_serializer.rb
+++ b/config/initializers/cookies_serializer.rb
@@ -1,8 +1,0 @@
-# Be sure to restart your server when you modify this file.
-
-# Specify a serializer for the signed and encrypted cookie jars.
-# Valid options are :json, :marshal, and :hybrid.
-
-# Set to :hybrid because it was set to :marshal prior to 5.1
-# See: https://github.com/rails/rails/issues/33580
-Rails.application.config.action_dispatch.cookies_serializer = :hybrid


### PR DESCRIPTION
`config.load_defaults 8.0 → 8.1`, plus removal of a cookie-serializer shim that had been holding back a Rails default since 2020.

- **The two 8.1 defaults with real blast radius have no call sites here.** `action_on_path_relative_redirect = :raise` — no `redirect_to` takes a path-relative string, and the dynamic `return_to` in `handle_target` is already gated on `$BASE_URL` or a leading `/`. `raise_on_missing_required_finder_order_columns = true` — every model has an order-column fallback.
- **`config.yjit` narrows rather than widens.** `load_defaults 7.2` already set it `true` in every environment, so 8.1's `!Rails.env.local?` only turns YJIT *off* in development and test — production and sandbox are unchanged.
- **`config/initializers/cookies_serializer.rb` is deleted rather than re-pinned to `:json`.** This is independent of the bump — `:json` has been the framework default since `load_defaults 7.0`, and the file was a Marshal→JSON transition shim from the 2020 Rails 5.2 upgrade. Its brakeman ignore goes with it, since that file is hand-maintained.
- **Any cookie still Marshal-serialized becomes unreadable**, signing out users dormant since 2020 — `:hybrid` reads Marshal but has only written JSON since. Current payloads are JSON-safe either way: the auth cookie is `[user.id, user.auth_token]`, and the session holds strings, ids and booleans.
