### PR TITLE
Catch gift-card SEO-spam profiles

### DIFF
--- a/app/services/spam_estimator/user.rb
+++ b/app/services/spam_estimator/user.rb
@@ -4,7 +4,7 @@ module SpamEstimator
 
     MARK_SPAM_PERCENT = 90 # May modify in the future!
 
-    # crypto, gambling and adult terms that SEO-spam profiles exist to promote.
+    # crypto, gambling, adult and gift-card terms that SEO-spam profiles exist to promote.
     # Word boundaries matter: usernames are auto-generated random strings, so
     # unanchored substrings ("Judith", "Hagen", "Sloth", "Donohue") would ban real people.
     SEO_SPAM_REGEX = /(?:
@@ -21,7 +21,18 @@ module SpamEstimator
         nap\s+tien | dang\s+nhap | truc\s+tuyen | khuyen\s+mai | uy\s+tin |
         game\s+bai | co\s+bac | song\s+bac | xo\s+so | lo\s+de |
         link\s+truy\s+cap | clip\s+(?:hot|nong)
-      )\b | 18\+
+      )\b | 18\+ |
+      # Gift-card "check your balance" farms run the brand together in usernames and
+      # domains (mcgiftgiftcardmall3, vanillaprepaid.io), so these can't be \b-anchored.
+      # "prepaid" stays qualified — bare, it matches prepaid funerals and SIM cards.
+      gift\s?cards? | gift\s?code |
+      (?:mc|my|wm|walmart|five\s?back|vanilla|visa|amex|master(?:card)?)-?\s?e?-?gift |
+      prepaid\s?(?:gift|card|visa|master|balance|cent(?:er|re)) |
+      (?:one|my)-?\s?vanilla | vanilla-?\s?(?:balance|prepaid) | secure-?\s?spend |
+      (?:card|gift)\s?balance | balance\s?(?:check|inquiry|inquiries) |
+      check\s?(?:my|your|the)?\s?balance | reward\s?cards? |
+      card\s?activation | activate\s+(?:my\s|your\s|the\s)?(?:gift\s?)?card |
+      redeem\s+(?:code|card)
     )/xi
 
     def estimate(user)

--- a/app/services/spam_estimator/user.rb
+++ b/app/services/spam_estimator/user.rb
@@ -24,11 +24,9 @@ module SpamEstimator
       )\b | 18\+ |
       # Gift-card "check your balance" farms run the brand together in usernames and
       # domains (mcgiftgiftcardmall3, vanillaprepaid.io), so these can't be \b-anchored.
-      # "prepaid" stays qualified — bare, it matches prepaid funerals and SIM cards.
-      gift\s?(?:cards?|code) |
+      gift\s?(?:cards?|code) | prepaid |
       (?:mc|my|wm|walmart|five\s?back|vanilla|visa|amex|master(?:card)?)-?\s?e?-?gift |
-      prepaid\s?(?:gift|card|visa|master|balance|cent(?:er|re)) |
-      (?:one|my)-?\s?vanilla | vanilla-?\s?(?:balance|prepaid) | secure-?\s?spend |
+      (?:one|my)-?\s?vanilla | vanilla-?\s?balance | secure-?\s?spend |
       (?:card|gift)\s?balance | balance\s?(?:check|inquiry|inquiries) |
       check\s?(?:my|your|the)?\s?balance | reward\s?cards? |
       card\s?activation | activate\s+(?:my\s|your\s|the\s)?(?:gift\s?)?card |

--- a/app/services/spam_estimator/user.rb
+++ b/app/services/spam_estimator/user.rb
@@ -25,7 +25,7 @@ module SpamEstimator
       # Gift-card "check your balance" farms run the brand together in usernames and
       # domains (mcgiftgiftcardmall3, vanillaprepaid.io), so these can't be \b-anchored.
       # "prepaid" stays qualified — bare, it matches prepaid funerals and SIM cards.
-      gift\s?cards? | gift\s?code |
+      gift\s?(?:cards?|code) |
       (?:mc|my|wm|walmart|five\s?back|vanilla|visa|amex|master(?:card)?)-?\s?e?-?gift |
       prepaid\s?(?:gift|card|visa|master|balance|cent(?:er|re)) |
       (?:one|my)-?\s?vanilla | vanilla-?\s?(?:balance|prepaid) | secure-?\s?spend |

--- a/spec/services/spam_estimator/user_spec.rb
+++ b/spec/services/spam_estimator/user_spec.rb
@@ -78,14 +78,18 @@ RSpec.describe SpamEstimator::User do
       end
     end
 
-    context "legitimate businesses that say prepaid" do
-      # bare "prepaid" matched funeral directors and travel-SIM sellers, so it's qualified
-      it "stays below the threshold" do
+    context "legitimate businesses using gift-card vocabulary" do
+      # bare "prepaid" matched funeral directors and travel-SIM sellers, so it's qualified.
+      # A shop mentioning gift cards once is 30 on top of the link's 50 — it takes a second
+      # reference to reach the threshold, which is what separates a shop from a link farm.
+      it "stays below the threshold, even alongside a promotional link" do
         ["Organize a prepaid funeral in Adelaide. We offer pre-arranged and prepaid funeral options.",
-          "Prepaid travel SIM cards and eSIMs, so you stay connected overseas without roaming fees."]
+          "Prepaid travel SIM cards and eSIMs, so you stay connected overseas without roaming fees.",
+          "Community bike shop. We do tune-ups, wheel builds and fittings. Gift cards available in store."]
           .each do |legitimate_description|
-            expect(described_class.estimate(User.new(show_bikes: true, name:, description: legitimate_description)))
-              .to be < SpamEstimator::User::MARK_SPAM_PERCENT
+            legitimate = User.new(show_bikes: true, name:, description: legitimate_description,
+              my_bikes_hash: {"link_target" => "https://shop.example"})
+            expect(described_class.estimate(legitimate)).to be < SpamEstimator::User::MARK_SPAM_PERCENT
           end
       end
     end

--- a/spec/services/spam_estimator/user_spec.rb
+++ b/spec/services/spam_estimator/user_spec.rb
@@ -52,6 +52,44 @@ RSpec.describe SpamEstimator::User do
       end
     end
 
+    context "gift-card balance-check profile" do
+      let(:name) { "McGift Giftcardmall" }
+      let(:description) do
+        "This platform offers a secure way to access gift card services. Whether conducting " \
+          "mcgift.giftcardmall balance inquiries or completing mcgiftcard activation, every " \
+          "step is directed through a verified pathway to official encrypted servers."
+      end
+
+      it "is above the spam threshold" do
+        expect(described_class.estimate(user)).to be > SpamEstimator::User::MARK_SPAM_PERCENT
+      end
+    end
+
+    context "gift-card brand run together in a username" do
+      # these profiles smash the brand into usernames and domains, so the gift-card
+      # terms deliberately aren't \b-anchored the way the crypto/gambling ones are
+      let(:user) do
+        User.new(show_bikes: true, username: "vanillaprepaid6",
+          my_bikes_hash: {"link_target" => "https://vanilla-prepaid.cc/"})
+      end
+
+      it "counts references inside the run-together string" do
+        expect(described_class.estimate(user)).to be > SpamEstimator::User::MARK_SPAM_PERCENT
+      end
+    end
+
+    context "legitimate businesses that say prepaid" do
+      # bare "prepaid" matched funeral directors and travel-SIM sellers, so it's qualified
+      it "stays below the threshold" do
+        ["Organize a prepaid funeral in Adelaide. We offer pre-arranged and prepaid funeral options.",
+          "Prepaid travel SIM cards and eSIMs, so you stay connected overseas without roaming fees."]
+          .each do |legitimate_description|
+            expect(described_class.estimate(User.new(show_bikes: true, name:, description: legitimate_description)))
+              .to be < SpamEstimator::User::MARK_SPAM_PERCENT
+          end
+      end
+    end
+
     context "real names that contain spam terms as substrings" do
       # usernames are auto-generated random strings, so substring matching would ban real people
       it "does not count them as references" do

--- a/spec/services/spam_estimator/user_spec.rb
+++ b/spec/services/spam_estimator/user_spec.rb
@@ -79,15 +79,14 @@ RSpec.describe SpamEstimator::User do
     end
 
     context "prepaid outside a gift-card context" do
-      # bare "prepaid" matched prepaid funerals and travel SIMs, so the term is qualified.
-      # Those profiles may well be spam for other reasons — the point is only that the
-      # word on its own isn't a gift-card reference.
-      it "is not counted as a reference" do
+      # the profiles this caught — prepaid funerals, travel SIMs, mobile recharge — are
+      # link-only profiles with no registrations, so the bare term stays unqualified
+      it "counts as a reference" do
         ["Pre-arranged and prepaid funeral options across Adelaide.",
           "Prepaid travel SIM cards and eSIMs, so you stay connected overseas."]
-          .each do |unrelated_description|
-            expect(described_class.seo_spam_matches(User.new(show_bikes: true, description: unrelated_description)))
-              .to eq({})
+          .each do |description|
+            expect(described_class.seo_spam_matches(User.new(show_bikes: true, description:)))
+              .to eq({"prepaid" => 1})
           end
       end
     end

--- a/spec/services/spam_estimator/user_spec.rb
+++ b/spec/services/spam_estimator/user_spec.rb
@@ -78,19 +78,31 @@ RSpec.describe SpamEstimator::User do
       end
     end
 
-    context "legitimate businesses using gift-card vocabulary" do
-      # bare "prepaid" matched funeral directors and travel-SIM sellers, so it's qualified.
-      # A shop mentioning gift cards once is 30 on top of the link's 50 — it takes a second
-      # reference to reach the threshold, which is what separates a shop from a link farm.
-      it "stays below the threshold, even alongside a promotional link" do
-        ["Organize a prepaid funeral in Adelaide. We offer pre-arranged and prepaid funeral options.",
-          "Prepaid travel SIM cards and eSIMs, so you stay connected overseas without roaming fees.",
-          "Community bike shop. We do tune-ups, wheel builds and fittings. Gift cards available in store."]
-          .each do |legitimate_description|
-            legitimate = User.new(show_bikes: true, name:, description: legitimate_description,
-              my_bikes_hash: {"link_target" => "https://shop.example"})
-            expect(described_class.estimate(legitimate)).to be < SpamEstimator::User::MARK_SPAM_PERCENT
+    context "prepaid outside a gift-card context" do
+      # bare "prepaid" matched prepaid funerals and travel SIMs, so the term is qualified.
+      # Those profiles may well be spam for other reasons — the point is only that the
+      # word on its own isn't a gift-card reference.
+      it "is not counted as a reference" do
+        ["Pre-arranged and prepaid funeral options across Adelaide.",
+          "Prepaid travel SIM cards and eSIMs, so you stay connected overseas."]
+          .each do |unrelated_description|
+            expect(described_class.seo_spam_matches(User.new(show_bikes: true, description: unrelated_description)))
+              .to eq({})
           end
+      end
+    end
+
+    context "a shop that sells gift cards" do
+      # one reference is 30 on top of the link's 50 — it takes a second to reach the
+      # threshold, which is what separates a real shop from a link farm
+      let(:description) { "Community bike shop. We do tune-ups, wheel builds and fittings. Gift cards available in store." }
+      let(:user) do
+        User.new(show_bikes: true, name:, description:, my_bikes_hash: {"link_target" => "https://shop.example"})
+      end
+
+      it "stays below the threshold" do
+        expect(described_class.seo_spam_matches(user).values.sum).to eq 1
+        expect(described_class.estimate(user)).to be < SpamEstimator::User::MARK_SPAM_PERCENT
       end
     end
 


### PR DESCRIPTION
The "check your gift card balance" farms — giftcardmall/mygift/mcgift clones, Vanilla, SecureSpend, Activ, Joker, prepaid-balance sites — scored 50–70 against a threshold of 90. Their descriptions are fluent LLM prose, so `SpamEstimator::Text` reads them as ordinary writing, and none of the crypto/gambling/adult terms apply. The only signal firing was "has an outbound link, owns no bikes", which is 50 on its own.

- **The new terms deliberately aren't `\b`-anchored**, unlike the rest of the list. These brands run the words together in usernames and domains (`mcgiftgiftcardmall3`, `vanillaprepaid.io`, `walmartgiftorg`), so anchoring would miss them.
- **122 profiles newly cross the threshold** across all 143,625 `show_bikes` users, none of them owning a non-spam bike, with no score regressions. None of the five admin-reversed `seo_spam` bans match the new terms, and only 3 of a 5,000 sample of existing ones do — this vocabulary is near-orthogonal to what's already caught. An admin had separately hand-banned one MCGift GiftCardMall profile for `spamming`.
- **Existing profiles won't be re-scored** until their user record changes, since `AfterUserChangeJob` is the job's only caller. Clearing the backlog needs a separate sweep.

`prepaid` is deliberately bare rather than qualified to a gift-card context. It picks up four profiles outside the vertical — a prepaid funeral director, two travel-SIM sellers, a mobile-recharge site — all of which are link-only profiles with no registrations.

Known exposure: a shop with a promotional link and no registered bikes that mentions gift cards *and* a balance check would clear 90. No user in the corpus does, and a single mention lands at 80.
