### PR TITLE
Add UI::ButtonGroup, a link/button take on the radio chips

### DIFF
--- a/app/components/org/search_results/bikes_table/component.rb
+++ b/app/components/org/search_results/bikes_table/component.rb
@@ -9,7 +9,7 @@ module Org
       # registrations on the show page). Pass render_sortable to enable sort links.
       class Component < ApplicationComponent
         # Digest of the markup inside the row cache — the cached_markup_digest spec keeps it current
-        MARKUP_DIGEST = "3e3766884307"
+        MARKUP_DIGEST = "bafe963e2a87"
 
         delegate :additional_registration_fields, :column_renames, to: :settings_component
 

--- a/app/components/org/search_results/bikes_table/component.rb
+++ b/app/components/org/search_results/bikes_table/component.rb
@@ -9,7 +9,7 @@ module Org
       # registrations on the show page). Pass render_sortable to enable sort links.
       class Component < ApplicationComponent
         # Digest of the markup inside the row cache — the cached_markup_digest spec keeps it current
-        MARKUP_DIGEST = "2167d97175a8"
+        MARKUP_DIGEST = "bafe963e2a87"
 
         delegate :additional_registration_fields, :column_renames, to: :settings_component
 

--- a/app/components/org/search_results/bikes_table/component.rb
+++ b/app/components/org/search_results/bikes_table/component.rb
@@ -9,7 +9,7 @@ module Org
       # registrations on the show page). Pass render_sortable to enable sort links.
       class Component < ApplicationComponent
         # Digest of the markup inside the row cache — the cached_markup_digest spec keeps it current
-        MARKUP_DIGEST = "bafe963e2a87"
+        MARKUP_DIGEST = "3e3766884307"
 
         delegate :additional_registration_fields, :column_renames, to: :settings_component
 

--- a/app/components/registrations/show/wrapper/component.rb
+++ b/app/components/registrations/show/wrapper/component.rb
@@ -8,7 +8,7 @@ module Registrations
       class Component < ApplicationComponent
         # Digest of the markup inside the cache block — the cached_markup_digest spec
         # keeps it current, following what this tree renders out into UI:: and elsewhere
-        MARKUP_DIGEST = "ea212bfe7564"
+        MARKUP_DIGEST = "59f32664e2d3"
 
         def initialize(bike:, current_user:, view:, available_views:, bike_sticker: nil, current_alerts: {})
           @bike = bike

--- a/app/components/registrations/show/wrapper/component.rb
+++ b/app/components/registrations/show/wrapper/component.rb
@@ -8,7 +8,7 @@ module Registrations
       class Component < ApplicationComponent
         # Digest of the markup inside the cache block — the cached_markup_digest spec
         # keeps it current, following what this tree renders out into UI:: and elsewhere
-        MARKUP_DIGEST = "1460e7bc32b6"
+        MARKUP_DIGEST = "59f32664e2d3"
 
         def initialize(bike:, current_user:, view:, available_views:, bike_sticker: nil, current_alerts: {})
           @bike = bike

--- a/app/components/registrations/show/wrapper/component.rb
+++ b/app/components/registrations/show/wrapper/component.rb
@@ -8,7 +8,7 @@ module Registrations
       class Component < ApplicationComponent
         # Digest of the markup inside the cache block — the cached_markup_digest spec
         # keeps it current, following what this tree renders out into UI:: and elsewhere
-        MARKUP_DIGEST = "59f32664e2d3"
+        MARKUP_DIGEST = "1460e7bc32b6"
 
         def initialize(bike:, current_user:, view:, available_views:, bike_sticker: nil, current_alerts: {})
           @bike = bike

--- a/app/components/ui/button_group/component.rb
+++ b/app/components/ui/button_group/component.rb
@@ -11,11 +11,6 @@ module UI
         UI::Button::Component::COLORS[:purple_outline]
       ].join(" ").freeze
 
-      # Not UI::Button's DISABLED_CLASSES: its pointer-events-none stops the browser
-      # applying a cursor at all, so the chip would keep the plain arrow. A disabled
-      # <button> takes no clicks anyway.
-      DISABLED_CHIP_CLASSES = "tw:disabled:opacity-50 tw:disabled:cursor-not-allowed"
-
       # The active half is inert until a chip flags itself data-active, the same way
       # UI::Button's is — the radio group restates it off its checked input instead.
       CHIP_CLASSES = [
@@ -23,7 +18,7 @@ module UI
         "tw:no-underline",
         UI::Button::Component::ACTIVE_COLORS[:purple_outline],
         UI::Button::Component::FOCUS_CLASSES,
-        DISABLED_CHIP_CLASSES
+        UI::Button::Component::DISABLED_CLASSES
       ].join(" ").freeze
 
       # full_width lays the chips out as equal columns that wrap, staying the same width

--- a/app/components/ui/button_group/component.rb
+++ b/app/components/ui/button_group/component.rb
@@ -11,6 +11,11 @@ module UI
         UI::Button::Component::COLORS[:purple_outline]
       ].join(" ").freeze
 
+      # Not UI::Button's DISABLED_CLASSES: its pointer-events-none stops the browser
+      # applying a cursor at all, so the chip would keep the plain arrow. A disabled
+      # <button> takes no clicks anyway.
+      DISABLED_CHIP_CLASSES = "tw:disabled:opacity-50 tw:disabled:cursor-not-allowed"
+
       # The active half is inert until a chip flags itself data-active, the same way
       # UI::Button's is — the radio group restates it off its checked input instead.
       CHIP_CLASSES = [
@@ -18,7 +23,7 @@ module UI
         "tw:no-underline",
         UI::Button::Component::ACTIVE_COLORS[:purple_outline],
         UI::Button::Component::FOCUS_CLASSES,
-        UI::Button::Component::DISABLED_CLASSES
+        DISABLED_CHIP_CLASSES
       ].join(" ").freeze
 
       # full_width lays the chips out as equal columns that wrap, staying the same width

--- a/app/components/ui/button_group/component.rb
+++ b/app/components/ui/button_group/component.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+module UI
+  module ButtonGroup
+    # A row of chips that navigate or act — the link/button counterpart of
+    # UI::Forms::RadioButtonGroup, which chips off RESTING_CHIP_CLASSES too.
+    class Component < ApplicationComponent
+      # Mirrors UI::Button color: :purple_outline, so retuning its grays reaches the chips
+      RESTING_CHIP_CLASSES = [
+        "tw:cursor-pointer tw:select-none tw:inline-flex tw:items-center tw:justify-center tw:rounded tw:px-3 tw:py-1 tw:text-sm tw:leading-snug tw:transition-colors",
+        UI::Button::Component::COLORS[:purple_outline]
+      ].join(" ").freeze
+
+      # The active half is inert until a chip flags itself data-active, the same way
+      # UI::Button's is — the radio group restates it off its checked input instead.
+      CHIP_CLASSES = [
+        RESTING_CHIP_CLASSES,
+        "tw:no-underline",
+        UI::Button::Component::ACTIVE_COLORS[:purple_outline],
+        UI::Button::Component::FOCUS_CLASSES,
+        UI::Button::Component::DISABLED_CLASSES
+      ].join(" ").freeze
+
+      # full_width lays the chips out as equal columns that wrap, staying the same width
+      # on every line — flex would size each line independently. auto-fit needs a
+      # definite minimum to count repetitions.
+      def self.layout_classes(full_width:)
+        full_width ? "tw:grid tw:grid-cols-[repeat(auto-fit,minmax(4rem,1fr))] tw:gap-2" : "tw:flex tw:flex-wrap tw:gap-2"
+      end
+
+      # entries: [{label:, href:, active:, disabled:}, …] — an entry without an href
+      # renders a <button>, and anything else in it (data:, title:, target:) becomes
+      # an attribute
+      def initialize(entries:, full_width: false)
+        @entries = entries
+        @full_width = full_width
+      end
+
+      def call
+        tag.div(class: self.class.layout_classes(full_width: @full_width)) do
+          safe_join(@entries.map { |entry| chip(entry) })
+        end
+      end
+
+      private
+
+      def chip(entry)
+        active = entry[:active] || nil
+        # A disabled entry is a <button disabled> even when it has an href — an <a>
+        # takes no disabled attribute, so a link would stay live
+        href = entry[:disabled] ? nil : entry[:href].presence
+        attributes = entry.except(:label, :href, :active).deep_merge(
+          class: CHIP_CLASSES,
+          data: {active:},
+          aria: href ? {current: active} : {pressed: active}
+        )
+        # The chip is inline-flex, so without the span each of a label's text runs and
+        # elements becomes a flex item and the whitespace between them collapses.
+        label = tag.span(entry[:label].html_safe)
+
+        href ? link_to(label, href, **attributes) : button_tag(label, type: "button", **attributes)
+      end
+    end
+  end
+end

--- a/app/components/ui/button_group/component_preview.rb
+++ b/app/components/ui/button_group/component_preview.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+module UI
+  module ButtonGroup
+    class ComponentPreview < ApplicationComponentPreview
+      # @!group Examples
+      def default
+        render(UI::ButtonGroup::Component.new(entries: [
+          {label: "All", href: "#", active: true},
+          {label: "Active", href: "#"},
+          {label: "Inactive", href: "#"}
+        ]))
+      end
+
+      def with_html_labels
+        render(UI::ButtonGroup::Component.new(entries: [
+          {label: "All", href: "#"},
+          {label: "only <strong>not</strong> impounded", href: "#", active: true},
+          {label: "only <strong>impounded</strong>", href: "#"}
+        ]))
+      end
+
+      # An entry without an href renders a <button> — for a group that a Stimulus
+      # controller handles rather than a navigation
+      def buttons
+        render(UI::ButtonGroup::Component.new(entries: [
+          {label: "Map", active: true, data: {action: "click->something#show"}},
+          {label: "List", data: {action: "click->something#show"}}
+        ]))
+      end
+
+      def with_disabled
+        render(UI::ButtonGroup::Component.new(entries: [
+          {label: "All", href: "#", active: true},
+          {label: "Stolen", href: "#"},
+          {label: "For sale", href: "#", disabled: true}
+        ]))
+      end
+
+      def full_width
+        render(UI::ButtonGroup::Component.new(full_width: true,
+          entries: %w[xs s m l xl].map { |size| {label: size.upcase, href: "#", active: size == "m"} }))
+      end
+      # @!endgroup
+    end
+  end
+end

--- a/app/components/ui/button_link/component_preview.rb
+++ b/app/components/ui/button_link/component_preview.rb
@@ -15,6 +15,25 @@ module UI
       def error
         render(UI::ButtonLink::Component.new(text: "Error Link", href: "#", color: :error))
       end
+
+      # White link with a soft danger outline
+      def danger_outline
+        render(UI::ButtonLink::Component.new(text: "Mark stolen", href: "#", color: :danger_outline))
+      end
+
+      # Filled purple primary
+      def purple
+        render(UI::ButtonLink::Component.new(text: "Purple Link", href: "#", color: :purple))
+      end
+
+      # White link with a purple outline (toggles to a purple tint when active)
+      def purple_outline
+        render(UI::ButtonLink::Component.new(text: "Purple outline", href: "#", color: :purple_outline))
+      end
+
+      def link
+        render(UI::ButtonLink::Component.new(text: "Link style", href: "#", color: :link))
+      end
       # @!endgroup
 
       # @!group States

--- a/app/components/ui/button_link/component_preview.rb
+++ b/app/components/ui/button_link/component_preview.rb
@@ -15,25 +15,6 @@ module UI
       def error
         render(UI::ButtonLink::Component.new(text: "Error Link", href: "#", color: :error))
       end
-
-      # White link with a soft danger outline
-      def danger_outline
-        render(UI::ButtonLink::Component.new(text: "Mark stolen", href: "#", color: :danger_outline))
-      end
-
-      # Filled purple primary
-      def purple
-        render(UI::ButtonLink::Component.new(text: "Purple Link", href: "#", color: :purple))
-      end
-
-      # White link with a purple outline (toggles to a purple tint when active)
-      def purple_outline
-        render(UI::ButtonLink::Component.new(text: "Purple outline", href: "#", color: :purple_outline))
-      end
-
-      def link
-        render(UI::ButtonLink::Component.new(text: "Link style", href: "#", color: :link))
-      end
       # @!endgroup
 
       # @!group States

--- a/app/components/ui/forms/radio_button_group/component.rb
+++ b/app/components/ui/forms/radio_button_group/component.rb
@@ -4,24 +4,17 @@ module UI
   module Forms
     module RadioButtonGroup
       class Component < ApplicationComponent
-        # Mirrors UI::Button color: :purple_outline (resting + active), driving the
-        # active state off the checked radio so the two stay visually in lockstep.
+        # The resting chip comes straight from UI::ButtonGroup, so the two groups look
+        # the same. Only the checked/focus states have to be restated, since those hang
+        # off the radio rather than the chip's own :active/:focus.
         CHIP_CLASSES = [
-          "tw:cursor-pointer tw:select-none tw:inline-flex tw:items-center tw:justify-center tw:mb-0! tw:rounded tw:px-3 tw:py-1 tw:text-sm tw:leading-snug tw:transition-colors",
-          # The resting half comes straight from the button, so retuning its grays
-          # reaches the chips. Only the checked/focus states have to be restated,
-          # since those hang off the radio rather than :active/:focus.
-          UI::Button::Component::COLORS[:purple_outline],
+          UI::ButtonGroup::Component::RESTING_CHIP_CLASSES,
+          "tw:mb-0!", # the chip is a <label>, which legacy CSS gives a bottom margin
           "tw:has-[:checked]:bg-purple-500 tw:has-[:checked]:text-white tw:has-[:checked]:border-purple-500",
           "tw:has-[:checked]:hover:bg-purple-500 tw:has-[:checked]:hover:border-purple-500",
           "tw:has-[:checked]:ring-2 tw:has-[:checked]:ring-purple-500/40",
           "tw:has-[:focus-visible]:outline-none tw:has-[:focus-visible]:ring-3 tw:has-[:focus-visible]:ring-purple-500/40"
         ].join(" ").freeze
-
-        # Equal columns that wrap, staying the same width on every line — flex would
-        # size each line independently. auto-fit needs a definite minimum to count
-        # repetitions, and a column still grows past 4rem for a label that needs it.
-        FULL_WIDTH_CLASSES = "tw:grid tw:grid-cols-[repeat(auto-fit,minmax(4rem,1fr))]"
 
         # full_width: chips share the row evenly (the frame-size XS-XL selector),
         # rather than each taking only the width of its label.
@@ -35,7 +28,7 @@ module UI
         end
 
         def call
-          tag.div(class: [@full_width ? FULL_WIDTH_CLASSES : "tw:flex tw:flex-wrap", "tw:gap-2"].join(" ")) do
+          tag.div(class: UI::ButtonGroup::Component.layout_classes(full_width: @full_width)) do
             safe_join(@entries.map { |option| chip(option) })
           end
         end

--- a/spec/components/ui/button_group/component_spec.rb
+++ b/spec/components/ui/button_group/component_spec.rb
@@ -40,7 +40,9 @@ RSpec.describe UI::ButtonGroup::Component, type: :component do
     it "renders a disabled button rather than a link" do
       expect(component).to have_css("a", count: 1)
       expect(component).to have_css("button[type='button'][disabled]", text: "For sale")
-      expect(component.css("button").first["class"].split).to include("tw:disabled:pointer-events-none")
+      expect(component.css("button").first["class"].split).to include("tw:disabled:cursor-not-allowed")
+      # pointer-events-none would stop the browser applying that cursor
+      expect(component.css("button").first["class"]).to_not include("pointer-events-none")
     end
   end
 

--- a/spec/components/ui/button_group/component_spec.rb
+++ b/spec/components/ui/button_group/component_spec.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe UI::ButtonGroup::Component, type: :component do
+  let(:entries) { [{label: "All", href: "/all"}, {label: "Active", href: "/active", active: true}] }
+  let(:component) { render_inline(described_class.new(entries:)) }
+
+  it "renders a link per entry, flagging the active one" do
+    expect(component).to have_css("a", count: 2)
+    expect(component).to have_css("a[href='/all']", text: "All")
+    expect(component).to have_css("a[href='/active'][data-active='true'][aria-current='true']", text: "Active")
+    expect(component).to have_no_css("a[href='/all'][data-active]")
+    expect(component).to have_css("div.tw\\:flex-wrap")
+  end
+
+  it "renders html labels" do
+    expect(render_inline(described_class.new(entries: [{label: "only <strong>not</strong> impounded", href: "/x"}]))).to have_css("a span strong", text: "not")
+  end
+
+  # The chip carries the classes the radio group's <label> chips are built from, so the
+  # two groups can't drift apart
+  it "styles the chips like the radio group's" do
+    expect(component.css("a").first["class"].split).to include(*described_class::RESTING_CHIP_CLASSES.split)
+  end
+
+  context "entries without an href" do
+    let(:entries) { [{label: "Map", active: true, data: {action: "click->map#show"}}, {label: "List"}] }
+
+    it "renders buttons that don't submit, keeping the passed data attributes" do
+      expect(component).to have_css("button[type='button']", count: 2)
+      expect(component).to have_css("button[data-active='true'][aria-pressed='true'][data-action='click->map#show']", text: "Map")
+    end
+  end
+
+  context "disabled entries" do
+    let(:entries) { [{label: "All", href: "/all"}, {label: "For sale", href: "/for_sale", disabled: true}] }
+
+    # An <a> takes no disabled attribute, so the chip has to be a button to be inert
+    it "renders a disabled button rather than a link" do
+      expect(component).to have_css("a", count: 1)
+      expect(component).to have_css("button[type='button'][disabled]", text: "For sale")
+      expect(component.css("button").first["class"].split).to include("tw:disabled:pointer-events-none")
+    end
+  end
+
+  context "full_width" do
+    let(:component) do
+      render_inline(described_class.new(full_width: true,
+        entries: %w[xs s m l xl].map { |size| {label: size.upcase, href: "/#{size}", active: size == "m"} }))
+    end
+
+    it "lays the chips out as evenly sized columns that wrap" do
+      expect(component).to have_css("a", count: 5)
+      expect(component.css("div").first["class"]).to include("repeat(auto-fit,minmax(4rem,1fr))")
+    end
+  end
+end

--- a/spec/components/ui/button_group/component_spec.rb
+++ b/spec/components/ui/button_group/component_spec.rb
@@ -40,9 +40,7 @@ RSpec.describe UI::ButtonGroup::Component, type: :component do
     it "renders a disabled button rather than a link" do
       expect(component).to have_css("a", count: 1)
       expect(component).to have_css("button[type='button'][disabled]", text: "For sale")
-      expect(component.css("button").first["class"].split).to include("tw:disabled:cursor-not-allowed")
-      # pointer-events-none would stop the browser applying that cursor
-      expect(component.css("button").first["class"]).to_not include("pointer-events-none")
+      expect(component.css("button").first["class"].split).to include("tw:disabled:pointer-events-none")
     end
   end
 

--- a/spec/components/ui/button_group/component_system_spec.rb
+++ b/spec/components/ui/button_group/component_system_spec.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe UI::ButtonGroup::Component, :js, type: :system do
+  let(:base_path) { "/rails/view_components/ui/button_group/component/" }
+
+  it "renders the chips as links" do
+    visit("#{base_path}default")
+
+    expect(page).to have_link "All"
+    expect(page).to have_link "Active"
+    expect(page).to have_css "a[aria-current='true']", text: "All"
+    expect_axe_clean
+
+    visit("#{base_path}with_html_labels")
+
+    # The chip is inline-flex, so each text run/element is a separate flex item —
+    # without the wrapping span the whitespace between them gets collapsed
+    expect(page).to have_link "only not impounded"
+    expect(page).to have_link "only impounded"
+  end
+
+  it "renders the chips as buttons, disabled ones included" do
+    visit("#{base_path}buttons")
+
+    expect(page).to have_css "button[aria-pressed='true']", text: "Map"
+    expect_axe_clean
+
+    visit("#{base_path}with_disabled")
+
+    expect(page).to have_link "All"
+    expect(page).to have_button "For sale", disabled: true
+    expect_axe_clean
+  end
+end


### PR DESCRIPTION
`UI::Forms::RadioButtonGroup` renders a row of purple-outline chips backed by sr-only radios. `UI::ButtonGroup` renders that same row for the cases that aren't a form field — each chip either navigates (an `<a>`) or acts (a `<button>`).

- **`entries: [{label:, href:, active:, disabled:}, …]`**, mirroring the radio group's API. No `href` renders a `<button type="button">`; anything else in the hash (`data:`, `title:`, `target:`) becomes an attribute. A disabled entry is a `<button disabled>` even when it has an `href`, since an `<a>` takes no disabled attribute.
- **The chip look now has one home.** `RESTING_CHIP_CLASSES` and `layout_classes` move here, and the radio group builds its `<label>` chips from them — its rendered classes are unchanged, which is why the two `MARKUP_DIGEST`s move.
- The active chip carries `data-active` (driving the `is-active` variant, same as `UI::Button`) plus `aria-current` on links / `aria-pressed` on buttons, so the state isn't color-only.

No call sites yet — the existing Bootstrap `btn-group` filter rows (`organized/stickers`, `bikes_edit` frame size) are the obvious candidates for a follow-up.
