### PR TITLE
Route /r/ short URLs straight to the registration page

### DIFF
--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -2,7 +2,6 @@ class RegistrationsController < ApplicationController
   before_action :allow_x_frame, except: %i[new show]
   skip_before_action :verify_authenticity_token, only: [:create] # Because it was causing issues, and we don't need it here
   before_action :simple_header, except: %i[show edit]
-  around_action :set_reading_role, only: %i[show]
   layout "reg_embed"
 
   def show

--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -2,6 +2,7 @@ class RegistrationsController < ApplicationController
   before_action :allow_x_frame, except: %i[new show]
   skip_before_action :verify_authenticity_token, only: [:create] # Because it was causing issues, and we don't need it here
   before_action :simple_header, except: %i[show edit]
+  around_action :set_reading_role, only: %i[show]
   layout "reg_embed"
 
   def show

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -167,6 +167,9 @@ Rails.application.routes.draw do
     member { post :is_private }
   end
 
+  # Short_id forms the resources :id segment can't match (prefix + slash, dots).
+  # Before resources so it wins for "r/..." paths; its constraint leaves plain ids alone.
+  get "registrations/*id", to: "registrations#show", constraints: {id: /r\W.*/i}, format: false
   resources :registrations, only: %i[new create show edit] do
     collection { get :embed }
   end
@@ -208,8 +211,7 @@ Rails.application.routes.draw do
     end
   end
 
-  # Short_id forms the resources :id segment can't match (prefix + slash, dots).
-  # Before resources so it wins for "r/..." paths; its constraint leaves plain ids alone.
+  # Short_id forms the resources :id segment can't match; before resources, as with registrations above
   get "bikes/*id", to: "bikes#show", constraints: {id: /r\W.*/i}, format: false
   resources :bikes, except: %i[index edit] do
     collection { get :scanned }
@@ -507,7 +509,7 @@ Rails.application.routes.draw do
 
   # Short bike URLs: /r/<short_id> (and /R/...). The whole path is passed through
   # so ShortId#decode strips the "r/" prefix itself, even when the body starts with "r".
-  get "*id", to: "bikes#show", constraints: {id: %r{[rR]/.*}}, format: false
+  get "*id", to: "registrations#show", constraints: {id: %r{[rR]/.*}}, format: false
   # Short bike_version URLs: /v/<short_id> (and /V/...)
   get "*id", to: "bike_versions#show", constraints: {id: %r{[vV]/.*}}, format: false
   # Short marketplace_listing URLs: /m/<short_id> (and /M/...)

--- a/spec/requests/bikes/show_request_spec.rb
+++ b/spec/requests/bikes/show_request_spec.rb
@@ -21,9 +21,9 @@ RSpec.describe "BikesController#show", type: :request do
   end
   context "short_id" do
     let(:ownership) { FactoryBot.create(:ownership, bike: FactoryBot.create(:bike, id: 35)) }
-    it "finds the bike from any short_id form and the /r/ short URL" do
+    it "finds the bike from any short_id form" do
       expect(bike.short_id).to eq "r/35"
-      ["#{base_url}/35", "#{base_url}/z", "#{base_url}/r/z", "#{base_url}/R/Z", "#{base_url}/r/35", "#{base_url}/R.Z-", "/r/z", "/R/Z", "/r/Z"].each do |path|
+      ["#{base_url}/35", "#{base_url}/z", "#{base_url}/r/z", "#{base_url}/R/Z", "#{base_url}/r/35", "#{base_url}/R.Z-"].each do |path|
         get path
         expect(response).to render_template(:show)
         expect(assigns(:bike)).to eq bike
@@ -33,7 +33,7 @@ RSpec.describe "BikesController#show", type: :request do
       let(:ownership) { FactoryBot.create(:ownership, bike: FactoryBot.create(:bike, id: 34992)) }
       it "does not double-strip the prefix" do
         expect(bike.short_id).to eq "r/R00"
-        get "/#{bike.short_id}"
+        get "#{base_url}/#{bike.short_id}"
         expect(response).to render_template(:show)
         expect(assigns(:bike)).to eq bike
       end

--- a/spec/requests/registrations/show_request_spec.rb
+++ b/spec/requests/registrations/show_request_spec.rb
@@ -3,8 +3,8 @@ require "rails_helper"
 RSpec.describe "RegistrationsController#show", type: :request do
   include_context :request_spec_logged_in_as_user_if_present
   let(:base_url) { "/registrations" }
-  # show reads from the replica, so anything it first_or_creates has to exist already
-  before { RearGearType.fixed && Country.united_states }
+  # Required when rendering bike details, otherwise it raises ReadOnlyError
+  before { RearGearType.fixed }
 
   context "consumer view" do
     let(:bike) { FactoryBot.create(:bike, :with_ownership_claimed, :with_primary_activity) }

--- a/spec/requests/registrations/show_request_spec.rb
+++ b/spec/requests/registrations/show_request_spec.rb
@@ -3,8 +3,12 @@ require "rails_helper"
 RSpec.describe "RegistrationsController#show", type: :request do
   include_context :request_spec_logged_in_as_user_if_present
   let(:base_url) { "/registrations" }
-  # Required when rendering bike details, otherwise it raises ReadOnlyError
-  before { RearGearType.fixed }
+  # show reads from the replica, and the render reaches both of these first_or_create
+  # singletons — outside of test they're already-existing rows, so they only select
+  before do
+    RearGearType.fixed
+    Country.united_states
+  end
 
   context "consumer view" do
     let(:bike) { FactoryBot.create(:bike, :with_ownership_claimed, :with_primary_activity) }

--- a/spec/requests/registrations/show_request_spec.rb
+++ b/spec/requests/registrations/show_request_spec.rb
@@ -3,8 +3,8 @@ require "rails_helper"
 RSpec.describe "RegistrationsController#show", type: :request do
   include_context :request_spec_logged_in_as_user_if_present
   let(:base_url) { "/registrations" }
-  # Required when rendering bike details, otherwise it raises ReadOnlyError
-  before { RearGearType.fixed }
+  # show reads from the replica, so anything it first_or_creates has to exist already
+  before { RearGearType.fixed && Country.united_states }
 
   context "consumer view" do
     let(:bike) { FactoryBot.create(:bike, :with_ownership_claimed, :with_primary_activity) }
@@ -130,23 +130,21 @@ RSpec.describe "RegistrationsController#show", type: :request do
     let(:bike) { FactoryBot.create(:bike, :with_ownership_claimed, id: 35) }
     let(:current_user) { bike.reload.user }
 
-    it "finds the bike from the decimal id and from the short_id body" do
+    it "finds the bike from any short_id form and the /r/ short URL" do
       expect(bike.short_id).to eq "r/35"
-      ["#{base_url}/35", "#{base_url}/z", "#{base_url}/Z"].each do |path|
+      ["#{base_url}/35", "#{base_url}/z", "#{base_url}/r/z", "#{base_url}/R.Z-", "/r/z", "/R/Z"].each do |path|
         get path
         expect(response.status).to eq(200)
         expect(whitespace_normalized_body_text).to match("Your bike")
       end
     end
 
-    context "with the redesign enabled" do
-      before { Flipper.enable_actor(:bike_show_redesign_toggle, current_user) }
+    context "short_id body starting with the prefix letter" do
+      let(:bike) { FactoryBot.create(:bike, :with_ownership_claimed, id: 34992) }
 
-      it "redirects the /r/ short URL here" do
-        get "/r/z"
-        expect(response).to redirect_to(registration_path(bike))
-        get "/r/z"
-        follow_redirect!
+      it "does not double-strip the prefix" do
+        expect(bike.short_id).to eq "r/R00"
+        get "/#{bike.short_id}"
         expect(response.status).to eq(200)
         expect(whitespace_normalized_body_text).to match("Your bike")
       end


### PR DESCRIPTION
`/r/21J-HW` landed on `bikes#show` and only reached the redesign through its `show_redesign?` redirect, so the short URL rendered the legacy page for anyone without the flag. It now routes to `registrations#show` directly, and the URL stays short.

- **`/registrations/r/z` routes at all now** — a short_id's `/` (and `.`) can't cross a `:id` segment, so registrations gets the same glob-before-the-resource route bikes already has.
- **`registrations#show` reads from the replica**, as `bikes#show` does. Nothing under `Registrations::Show::Wrapper` writes; the two `first_or_create` singletons the render reaches are `Country.united_states_id`, which short-circuits to a static id outside of test, and `RearGearType.fixed`, which only selects — the exposure `bikes#show` already carries.
- `/v/` and `/m/` are unchanged: versions have no redesign, and the marketplace short URL redirects to its item, so it already follows whatever the bike URL does.
