### PR TITLE
Permit region_string in BikeServices::StolenRecordUpdator

### DIFF
--- a/app/components/register/step1/component.en.yml
+++ b/app/components/register/step1/component.en.yml
@@ -16,9 +16,8 @@ en:
         register_your_bike_with_org_html: Register your %{cycle_type} with %{org_name}!
         start_over: Start over
         start_over_certain: Start over?
-        start_over_discards: >-
-          This begins a new %{cycle_type} registration — nothing you've entered here
-          carries over.
+        start_over_discards: This begins a new registration — nothing you've entered
+          here carries over.
         vehicle_type: Vehicle type
         yes_start_over: Yes, start over
         your_info: Your info

--- a/app/components/register/step1/component.html.erb
+++ b/app/components/register/step1/component.html.erb
@@ -87,7 +87,7 @@
       <%= render UI::Modal::Component.new(id: "start-over-modal", title: translation(".start_over_certain")) do |modal| %>
         <% modal.with_body do %>
           <p class="tw:mb-0">
-            <%= translation(".start_over_discards", cycle_type:) %>
+            <%= translation(".start_over_discards") %>
           </p>
 
           <div class="tw:mt-5 tw:text-center">

--- a/app/services/bike_services/stolen_record_updator.rb
+++ b/app/services/bike_services/stolen_record_updator.rb
@@ -3,7 +3,7 @@ module BikeServices
     # Used to be in StolenRecord - but now it's here. Eventually, I'd like to actually do permitted params handling in here
     # recovery_tweet, recovery_share # We edit this in the admin panel
     OLD_ATTR_ACCESSIBLE = (%i[police_report_number police_report_department locking_description lock_defeat_description
-      timezone date_stolen bike creation_organization_id country_id region_record_id street postal_code city latitude
+      timezone date_stolen bike creation_organization_id country_id region_record_id region_string street postal_code city latitude
       longitude theft_description current phone secondary_phone phone_for_everyone
       phone_for_users phone_for_shops phone_for_police receive_notifications proof_of_ownership
       approved recovered_at recovered_description index_helped_recovery can_share_recovery
@@ -61,7 +61,7 @@ module BikeServices
 
     def permitted_attributes(params)
       ActionController::Parameters.new(params).permit(:phone, :secondary_phone, :street, :city, :postal_code,
-        :country_id, :region_record_id, :police_report_number, :police_report_department, :estimated_value,
+        :country_id, :region_record_id, :region_string, :police_report_number, :police_report_department, :estimated_value,
         :theft_description, :locking_description, :lock_defeat_description, :proof_of_ownership,
         :receive_notifications, :phone_for_everyone, :phone_for_users,
         :phone_for_shops, :phone_for_police, :skip_geocoding)

--- a/spec/models/bike_spec.rb
+++ b/spec/models/bike_spec.rb
@@ -225,8 +225,9 @@ RSpec.describe Bike, type: :model do
           bike.update(created_at: Time.current - 2.days)
           allow(bike).to receive(:phone) { "1112223333" }
           # Accepts properties
-          stolen_record = bike.build_new_stolen_record(country_id: country.id)
+          stolen_record = bike.build_new_stolen_record(country_id: country.id, region_string: "Vlaanderen")
           expect(stolen_record.country_id).to eq country.id
+          expect(stolen_record.region_string).to eq "Vlaanderen"
           expect(stolen_record.phone).to eq "1112223333"
           expect(stolen_record.date_stolen).to be > Time.current - 1.second
           expect(stolen_record.creation_organization_id).to be_blank

--- a/spec/services/bike_services/stolen_record_updator_spec.rb
+++ b/spec/services/bike_services/stolen_record_updator_spec.rb
@@ -19,6 +19,30 @@ RSpec.describe BikeServices::StolenRecordUpdator do
         expect { stolen_record_updator.update_records }.to change(StolenRecord, :count).by(1)
         expect(bike.reload.status).to eq "status_stolen"
       end
+      context "region_string passed" do
+        let(:stolen_params) do
+          {date_stolen: Time.current.to_s, street: "Sarphatistraat 32", city: "Amsterdam",
+           postal_code: "1018 GL", country_id: Country.netherlands.id,
+           region_string: "North Holland", skip_geocoding: true}
+        end
+        let(:updator) { BikeServices::StolenRecordUpdator.new(bike:, b_param: BParam.new(params: {stolen_record: stolen_params}.as_json)) }
+        it "assigns the region_string" do
+          stolen_record = updator.update_records
+          expect(stolen_record.reload).to have_attributes(city: "Amsterdam",
+            region_string: "North Holland", region_record_id: nil)
+        end
+        context "region_string matching a state" do
+          let(:state) { FactoryBot.create(:state_new_york) }
+          let(:stolen_params) do
+            {date_stolen: Time.current.to_s, city: "New York", postal_code: "10007",
+             country_id: state.country_id, region_string: "New York", skip_geocoding: true}
+          end
+          it "assigns the region_record" do
+            stolen_record = updator.update_records
+            expect(stolen_record.reload).to have_attributes(region_record_id: state.id, region_string: nil)
+          end
+        end
+      end
       context "existing stolen_record" do
         let(:stolen_record) { FactoryBot.create(:stolen_record) }
         let(:bike) { stolen_record.bike }


### PR DESCRIPTION
`BikeServices::StolenRecordUpdator` never permitted `region_string`, so a region with no `State` record behind it — most addresses outside the US — was dropped on the way into the stolen record, even though the column exists and `Bike#build_new_stolen_record` slices for it.

- **`region_string` joins `OLD_ATTR_ACCESSIBLE` and `permitted_attributes`**, the two lists the updator's write paths slice against. A region that does match a state still resolves to `region_record_id` and clears itself, which is `Geocodeable#assign_region_record` doing its usual job.
- **The start over modal drops the vehicle type from its copy** — "This begins a new registration — nothing you've entered here carries over."
