### PR TITLE
Say why a magic link failed, not just that it did

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -42,7 +42,7 @@ class SessionsController < ApplicationController
 
   def magic_link
     @token = params[:token]
-    @incorrect_token = params[:incorrect_token].presence
+    @failure = magic_link_failure(params[:incorrect_token]) if params[:incorrect_token].present?
   end
 
   def sign_in_with_magic_link
@@ -131,6 +131,16 @@ class SessionsController < ApplicationController
   # redirect_forced_saml before_action; here only magic-link vs password remains.
   def login_method_for(email)
     Organization.passwordless_email_matching(email).present? ? "magic_link" : "password"
+  end
+
+  # Whatever killed a magic link token, it matches no user afterward - so the timestamp baked
+  # into the token is the only thing left to read. Old enough and it timed out; recent and it
+  # was spent signing in, or replaced by the link in a newer email.
+  def magic_link_failure(token)
+    return :unrecognized unless SecurityTokenizer.recognized_token?(token)
+
+    expired = SecurityTokenizer.token_time(token) < Time.current - User::AUTH_TOKEN_EXPIRY
+    expired ? :expired : :already_used
   end
 
   def send_magic_link_and_redirect(user)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -69,6 +69,9 @@ class User < ApplicationRecord
   include AddressRecordedWithinBoundingBox
 
   EMAIL_REGEX = /\A(\S+)@(.+)\.(\S+)\z/
+  # How long an emailed token stays good for. SessionsController reads it to tell an expired
+  # magic link apart from one that was already spent
+  AUTH_TOKEN_EXPIRY = 2.hours
 
   cattr_accessor :current_user
 
@@ -398,7 +401,7 @@ class User < ApplicationRecord
   end
 
   def auth_token_expired?(auth_token_type)
-    auth_token_time(auth_token_type) < (Time.current - 2.hours)
+    auth_token_time(auth_token_type) < (Time.current - AUTH_TOKEN_EXPIRY)
   end
 
   def accepted_vendor_terms_of_service?

--- a/app/services/security_tokenizer.rb
+++ b/app/services/security_tokenizer.rb
@@ -19,8 +19,13 @@ module SecurityTokenizer
   end
 
   def token_time(str)
-    t, toke = str.to_s.split("-")
-    t = (t.present? && toke.present? && t.to_i > EARLIEST_TOKEN_TIME) ? t.to_i : EARLIEST_TOKEN_TIME
-    Time.at(t)
+    recognized_token?(str) ? Time.at(str.to_s.split("-").first.to_i) : Time.at(EARLIEST_TOKEN_TIME)
+  end
+
+  # token_time floors anything it can't read at EARLIEST_TOKEN_TIME, which reads as long
+  # expired - ask this first when "we can't read this" needs a different answer to "this timed out"
+  def recognized_token?(str)
+    time, hex = str.to_s.split("-")
+    time.present? && hex.present? && time.to_i > EARLIEST_TOKEN_TIME
   end
 end

--- a/app/views/sessions/magic_link.html.haml
+++ b/app/views/sessions/magic_link.html.haml
@@ -4,15 +4,17 @@
   - else
     %h3= t(".sign_in_with_magic_link")
     - if @failure
-      .alert.alert-warning.mt-2.mb-4
-        - if @failure == :expired
-          %h3.header-font-alt.mb-2= t(".link_expired")
-          %p= t(".links_work_for", hours: User::AUTH_TOKEN_EXPIRY.in_hours.to_i)
-        - elsif @failure == :already_used
-          %h3.header-font-alt.mb-2= t(".link_already_used")
-          %p= t(".only_the_newest_link_works")
-        - else
-          %h3.header-font-alt.mb-2= t(".unable_to_auth")
+      - header = t(".unable_to_auth")
+      - detail = nil
+      - if @failure == :expired
+        - header = t(".link_expired")
+        - detail = t(".links_work_for", hours: User::AUTH_TOKEN_EXPIRY.in_hours.to_i)
+      - elsif @failure == :already_used
+        - header = t(".link_already_used")
+        - detail = t(".only_the_newest_link_works")
+      = render UI::Alerts::Base::Component.new(kind: :warning, header:, margin_classes: "tw:mt-2 tw:mb-4") do
+        - if detail
+          %p= detail
         %p= t(".reenter_email")
 
     %p= t(".enter_email_address")

--- a/app/views/sessions/magic_link.html.haml
+++ b/app/views/sessions/magic_link.html.haml
@@ -3,10 +3,17 @@
     = render Sessions::SignInInterstitial::Component.new(url: sign_in_with_magic_link_session_path, fields: { token: @token })
   - else
     %h3= t(".sign_in_with_magic_link")
-    - if @incorrect_token
+    - if @failure
       .alert.alert-warning.mt-2.mb-4
-        %h3.header-font-alt.mb-2=t(".unable_to_auth")
-        %p=t(".reenter_email")
+        - if @failure == :expired
+          %h3.header-font-alt.mb-2= t(".link_expired")
+          %p= t(".links_work_for", hours: User::AUTH_TOKEN_EXPIRY.in_hours.to_i)
+        - elsif @failure == :already_used
+          %h3.header-font-alt.mb-2= t(".link_already_used")
+          %p= t(".only_the_newest_link_works")
+        - else
+          %h3.header-font-alt.mb-2= t(".unable_to_auth")
+        %p= t(".reenter_email")
 
     %p= t(".enter_email_address")
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -4778,6 +4778,12 @@ en:
       enter_email_address: Enter your email address, we'll send you an email with
         a link to log in.
       get_sign_in_link: Get sign in link
+      link_already_used: That sign in link has already been used
+      link_expired: That sign in link has expired
+      links_work_for: Sign in links work for %{hours} hours after they're sent.
+      only_the_newest_link_works: >-
+        You may already be signed in somewhere else. If you asked for more than one
+        email, only the link in the newest one works.
       reenter_email: Please re-enter your email address to receive a new token
       sign_in_with_magic_link: Passwordless sign in
       unable_to_auth: Unable to authenticate that token

--- a/spec/controllers/sessions_controller_spec.rb
+++ b/spec/controllers/sessions_controller_spec.rb
@@ -74,7 +74,7 @@ RSpec.describe SessionsController, type: :controller do
   describe "magic_link" do
     it "renders" do
       get :magic_link
-      expect(assigns(:incorrect_token)).to be_falsey
+      expect(assigns(:failure)).to be_falsey
       expect(cookies.signed[:auth]).to be_nil
       expect(response.code).to eq "200"
       expect(response).to render_template("magic_link")
@@ -83,7 +83,7 @@ RSpec.describe SessionsController, type: :controller do
     context "incorrect_token" do
       it "renders" do
         get :magic_link, params: {incorrect_token: SecurityTokenizer.new_token}
-        expect(assigns(:incorrect_token)).to be_truthy
+        expect(assigns(:failure)).to be_truthy
         expect(cookies.signed[:auth]).to be_nil
         expect(response.code).to eq "200"
         expect(response).to render_template("magic_link")

--- a/spec/requests/sessions_request_spec.rb
+++ b/spec/requests/sessions_request_spec.rb
@@ -249,6 +249,31 @@ RSpec.describe SessionsController, type: :request do
       expect(Capybara.string(response.body))
         .to have_css("form[action='/session/sign_in_with_magic_link'] input[name='token'][value='#{token}']", visible: :hidden)
     end
+
+    # A dead token is dead the same way whatever killed it, so the reason comes from the
+    # timestamp inside it. Getting this wrong reads as "the site is broken" rather than
+    # "you already did this"
+    context "incorrect_token" do
+      def failure_for(token)
+        get "/session/magic_link", params: {incorrect_token: token}
+        expect(response).to render_template(:magic_link)
+        response.body
+      end
+
+      it "names the timeout for a token older than the window" do
+        expect(failure_for(SecurityTokenizer.new_token(3.hours.ago))).to match(/link has expired/i)
+      end
+
+      it "says it was already used for a token inside the window" do
+        expect(failure_for(SecurityTokenizer.new_token)).to match(/already been used/i)
+      end
+
+      it "stays generic for a token it can't read" do
+        body = failure_for("mangled-by-some-email-client")
+        expect(body).to match(/unable to authenticate/i)
+        expect(body).to_not match(/already been used|link has expired/i)
+      end
+    end
   end
 
   describe "sign_in_with_magic_link" do
@@ -259,6 +284,20 @@ RSpec.describe SessionsController, type: :request do
       expect(response).to redirect_to admin_root_url
       expect(superadmin.reload.magic_link_token).to be_nil
       expect(superadmin.last_login_at).to be_within(1.second).of Time.current
+    end
+
+    # The biggest bucket of real failures: the link worked, and then got clicked again
+    it "tells a spent token it was already used, not that something went wrong" do
+      user = FactoryBot.create(:user_confirmed)
+      token = user.refreshed_magic_link_token
+      post "/session/sign_in_with_magic_link", params: {token:}
+      expect(user.reload.magic_link_token).to be_nil
+      delete "/session"
+
+      post "/session/sign_in_with_magic_link", params: {token:}
+      expect(response).to redirect_to magic_link_session_path(incorrect_token: token)
+      follow_redirect!
+      expect(response.body).to match(/already been used/i)
     end
 
     it "redirects back to return_to when passed (review-app banner)" do


### PR DESCRIPTION
Follow-up to #4073. That PR stopped email scanners spending magic-link tokens, but scanners were only one of the reasons sign-in was failing — and every reason showed the same "Unable to authenticate that token" page.

Across the two days of logs behind #4073, 122 of 380 magic-link sign-ins failed: **33 were re-clicks of a link that had already worked**, 11 were superseded by a newer email, and the rest had timed out. All three read to the user as "this site is broken", which is what the original report said.

- **The reason comes from the token's own timestamp.** A dead token matches no user whatever killed it, so there's no record left to consult — but every token is `<epoch>-<hex>`. Older than the window and it timed out; recent and it was either spent signing in or replaced by a newer link. Unparseable keeps the generic message, so a mangled URL never gets told it "expired".
- **`SecurityTokenizer.recognized_token?`** — `token_time` already decides parseable-or-not and then throws the answer away, floored at `EARLIEST_TOKEN_TIME`. `BParam` carries a comment explaining that convention precisely because it's invisible at the call site; this stops it needing a third one.
- **`User::AUTH_TOKEN_EXPIRY`** replaces the bare `2.hours` in `auth_token_expired?`, and the copy interpolates it, so the window we tell people about can't drift from the one we enforce.

The three messages:

| Reason | Copy |
| --- | --- |
| Expired | That sign in link has expired — Sign in links work for 2 hours after they're sent. |
| Already used / superseded | That sign in link has already been used — You may already be signed in somewhere else. If you asked for more than one email, only the link in the newest one works. |
| Unparseable | Unable to authenticate that token |

"Already used" and "superseded" are deliberately one message: both leave a token matching no user, so the copy has to cover both honestly. Collapsing them for real would mean not spending the token on use — the other follow-up, and the one that removes those 33 failures outright rather than explaining them.

Signed-in users never reach this page; `skip_if_signed_in` already bounces them to their account with "you're already signed in".
