### PR TITLE
Add RFC 8058 one-click unsubscribe to the newsletter

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -6,6 +6,8 @@ class UsersController < ApplicationController
   # the sign-in guard is bypassed by whatever link or bookmark lands on the signup form.
   before_action :redirect_forced_saml, only: %i[new create]
   before_action :find_user_from_token_for_password_reset!, only: %i[update_password_form_with_reset_token update_password_with_reset_token]
+  # RFC 8058 one-click POSTs arrive from the mail provider's servers, with no session or token
+  skip_before_action :verify_authenticity_token, only: %i[unsubscribe_update]
 
   def new
     @user ||= User.new(email: params[:email])
@@ -190,9 +192,13 @@ class UsersController < ApplicationController
     end
   end
 
+  # Forgery protection is skipped here, so the signed id is the only credential - trusting the
+  # session would let any page unsubscribe whoever visits it, without a click behind it
   def unsubscribe_update
-    user = current_user || User.find_signed(params[:id], purpose: :unsubscribe)
-    user.update_attribute :notification_newsletters, false if user.present?
+    User.find_signed(params[:id], purpose: :unsubscribe)&.update_attribute(:notification_newsletters, false)
+    # One-click clients read the status and nothing else
+    return head(:ok) if params["List-Unsubscribe"] == "One-Click"
+
     flash[:success] = translation(:successfully_unsubscribed)
     redirect_to(user_root_url) && return
   end

--- a/app/mailers/customer_mailer.rb
+++ b/app/mailers/customer_mailer.rb
@@ -65,6 +65,11 @@ class CustomerMailer < ApplicationMailer
     @_action_has_layout = false # layout is manually included here
     @mail_snippet_body = mail_snippet.body
     @title = mail_snippet.subject
+    @unsubscribe_signed_id = @user.unsubscribe_signed_id
+
+    # RFC 8058 one-click, required by Gmail and Yahoo for bulk senders
+    headers["List-Unsubscribe"] = "<#{unsubscribe_update_user_url(@unsubscribe_signed_id)}>"
+    headers["List-Unsubscribe-Post"] = "List-Unsubscribe=One-Click"
 
     mail(to: @user.email, subject: @title, tag: __callee__)
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -439,6 +439,11 @@ class User < ApplicationRecord
     magic_link_token
   end
 
+  # Newsletters are infrequent, so this outlives any reasonable "unsubscribe me" click
+  def unsubscribe_signed_id
+    signed_id(purpose: :unsubscribe, expires_in: 365.days)
+  end
+
   def update_last_login(ip_address)
     save! unless id.present? # throw an error that shows why the user isn't created
     update_columns(last_login_at: Time.current, last_login_ip: ip_address)

--- a/app/views/customer_mailer/newsletter.html.haml
+++ b/app/views/customer_mailer/newsletter.html.haml
@@ -24,8 +24,7 @@
         %p.less-strong.text-center.mt-5{style: "font-size: 85%"}
           Don't want to receive Bike Index newsletters?
           = link_to "update your contact preferences", edit_my_account_url, class: "gray-link"
-          - if @user.present?
-            or
-            = link_to "unsubscribe", unsubscribe_user_url(@user.signed_id(purpose: :unsubscribe, expires_in: 365.days)), class: "gray-link"
+          or
+          = link_to "unsubscribe", unsubscribe_user_url(@unsubscribe_signed_id), class: "gray-link"
 
 

--- a/app/views/users/unsubscribe.html.haml
+++ b/app/views/users/unsubscribe.html.haml
@@ -1,5 +1,5 @@
 .container
-  - unsubscribe_url = unsubscribe_update_user_path(@user.signed_id(purpose: :unsubscribe, expires_in: 365.days))
+  - unsubscribe_url = unsubscribe_update_user_path(@user.unsubscribe_signed_id)
   = render Sessions::SignInInterstitial::Component.new(url: unsubscribe_url,
     heading: t(".confirm_unsubscribe"),
     submit_text: t(".unsubscribe"))

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -126,6 +126,8 @@ Rails.application.routes.draw do
     end
     member do
       get "unsubscribe"
+      # A client without one-click opens the POST target in a browser; that GET gets the interstitial
+      get "unsubscribe_update", to: "users#unsubscribe", as: nil
       post "unsubscribe_update"
     end
   end

--- a/spec/mailers/customer_mailer_spec.rb
+++ b/spec/mailers/customer_mailer_spec.rb
@@ -256,16 +256,21 @@ RSpec.describe CustomerMailer, type: :mailer do
   describe "newsletter" do
     let(:mail_snippet) { FactoryBot.build(:mail_snippet, kind: :newsletter) }
     let(:user) { FactoryBot.create(:user) }
+    let(:mail) { CustomerMailer.newsletter(user:, mail_snippet:) }
 
     it "renders, includes unsubscribe" do
-      mail = CustomerMailer.newsletter(user:, mail_snippet:)
-
       expect(mail.from).to eq(["contact@bikeindex.org"])
       expect(mail.to).to eq([user.email])
       expect(mail.tag).to eq "newsletter"
       expect(mail.body.encoded).to match "unsubscribe"
       expect(mail.body.encoded).to match "binx-header-banner" # shared blue banner header, not the old logo
       expect(mail.body.encoded).to_not match "email_assets/logo.png"
+    end
+
+    it "includes one-click unsubscribe headers, pointing at the POST endpoint" do
+      expect(mail["List-Unsubscribe-Post"].value).to eq "List-Unsubscribe=One-Click"
+      signed_id = mail["List-Unsubscribe"].value[%r{/users/(.+)/unsubscribe_update>\z}, 1]
+      expect(User.find_signed(signed_id, purpose: :unsubscribe)).to eq user
     end
   end
 

--- a/spec/requests/users_request_spec.rb
+++ b/spec/requests/users_request_spec.rb
@@ -675,7 +675,7 @@ RSpec.describe UsersController, type: :request do
 
   describe "unsubscribe" do
     let!(:user) { FactoryBot.create(:user_confirmed, notification_newsletters: true) }
-    let(:signed_id) { user.signed_id(purpose: :unsubscribe, expires_in: 365.days) }
+    let(:signed_id) { user.unsubscribe_signed_id }
 
     it "renders" do
       expect(user.notification_newsletters).to be_truthy
@@ -737,7 +737,7 @@ RSpec.describe UsersController, type: :request do
 
   describe "unsubscribe_update" do
     let!(:user) { FactoryBot.create(:user_confirmed, notification_newsletters: true) }
-    let(:signed_id) { user.signed_id(purpose: :unsubscribe, expires_in: 365.days) }
+    let(:signed_id) { user.unsubscribe_signed_id }
 
     it "unsubscribes" do
       expect(user.notification_newsletters).to be_truthy
@@ -750,14 +750,33 @@ RSpec.describe UsersController, type: :request do
     context "current_user" do
       include_context :request_spec_logged_in_as_user
       let(:current_user) { FactoryBot.create(:user_confirmed, notification_newsletters: true) }
-      it "unsubscribes current user instead" do
+      it "unsubscribes the signed id's user, not the session's" do
         expect(current_user.notification_newsletters).to be_truthy
         post "#{base_url}/#{signed_id}/unsubscribe_update"
         expect(response.code).to eq("302")
         expect(flash[:success]).to be_present
-        expect(user.reload.notification_newsletters).to be_truthy
-        expect(current_user.reload.notification_newsletters).to be_falsey
+        expect(user.reload.notification_newsletters).to be_falsey
+        expect(current_user.reload.notification_newsletters).to be_truthy
       end
+    end
+
+    # RFC 8058 - the mail client's own unsubscribe button
+    context "one-click" do
+      include_context :test_csrf_token
+      it "unsubscribes without a session or a CSRF token" do
+        post "#{base_url}/#{signed_id}/unsubscribe_update", params: {"List-Unsubscribe" => "One-Click"}
+        expect(response.code).to eq("200")
+        expect(response.body).to be_blank
+        expect(user.reload.notification_newsletters).to be_falsey
+      end
+    end
+
+    # A mail client that doesn't do one-click opens the POST target in a browser
+    it "GET renders the interstitial rather than unsubscribing" do
+      get "#{base_url}/#{signed_id}/unsubscribe_update"
+      expect(response.code).to eq("200")
+      expect(response).to render_template("users/unsubscribe")
+      expect(user.reload.notification_newsletters).to be_truthy
     end
 
     context "with plain username" do


### PR DESCRIPTION
Gmail and Yahoo have required RFC 8058 one-click unsubscribe of senders above 5,000 messages/day since February 2024. The hard half was already here — `unsubscribe_update` is a POST endpoint taking a signed id that lasts a year, which is the right shape for the URL. What was missing is the two headers, and the fact that Google's POST arrives with no session and no CSRF token, so `protect_from_forgery` would have redirected it to the homepage without unsubscribing anyone.

- **`List-Unsubscribe` and `List-Unsubscribe-Post` on the newsletter**, the only bulk mail we send. The client renders its own unsubscribe button and POSTs deliberately, so there's no scanner exposure and no confirmation click to lose people at.
- **`unsubscribe_update` skips forgery protection, so a session can no longer be the credential.** `current_user ||` is gone and the signed id is the only way in — otherwise any page could unsubscribe whoever visits it. The UI flow is unaffected: the interstitial already embeds `current_user`'s own signed id in the form action.
- **The RFC forces the List-Unsubscribe URL to be the POST target**, so a client without one-click opens it in a browser. That GET routes to the interstitial, which still can't unsubscribe anyone without a click (#4073). One-click itself gets `head :ok` rather than the redirect a browser gets.

Three things worth checking before a newsletter goes out, none of them code here. The newsletter sends on Postmark's `outbound` (transactional) stream — bulk mail belongs on a broadcast stream, which is also where Postmark injects its *own* `List-Unsubscribe`, so watch for duplication if that moves. The RFC needs both headers inside the DKIM signature, and Postmark signs on send, so that wants checking against the `h=` tag on a real received message. And Rack::Attack's global 30-per-20s per-IP throttle covers this path — realistic unsubscribe volume is nowhere near it, but a 429 fails silently and leaves the reader subscribed while their client says otherwise.
