### PR TITLE
Cut the emailed token window to 10 minutes, index the lookup

### DIFF
--- a/app/components/register/step_confirm/component.rb
+++ b/app/components/register/step_confirm/component.rb
@@ -2,9 +2,8 @@
 
 module Register
   module StepConfirm
-    # Where the emailed confirmation link lands. Nothing is confirmed by rendering it -
-    # confirming is single use, and a link scanner runs this page's JS, so the form waits
-    # for a click rather than posting itself
+    # Where the emailed confirmation link lands. Confirming is single use and scanners run the
+    # page's JS, so the form waits for a click rather than submitting on render
     class Component < ApplicationComponent
       def initialize(b_param:, token:)
         @b_param = b_param

--- a/app/components/sessions/sign_in_interstitial/component.rb
+++ b/app/components/sessions/sign_in_interstitial/component.rb
@@ -2,9 +2,8 @@
 
 module Sessions
   module SignInInterstitial
-    # Emailed links have to be GETs, so they land on a page that renders this and it posts
-    # what the link carried. Scanners follow the link and run its JS, so the form waits for a
-    # click — submitting on render would let them spend the token, or unsubscribe the reader.
+    # Emailed links have to be GETs, so they land here and post what the link carried. Scanners
+    # run the page's JS too, so the form waits for a click rather than submitting on render
     class Component < ApplicationComponent
       def initialize(url:, fields: {}, heading: nil, submit_text: nil)
         @url = url

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -25,8 +25,7 @@ class ApplicationController < ActionController::Base
     redirect_to user_root_url
   end
 
-  # Overrides hand back the form they were given rather than redirecting, so they share the
-  # copy from here - one scope literal instead of one per controller
+  # Shared with the controllers that override handle_unverified_request to re-render
   def invalid_authenticity_token_message
     translation(:invalid_authenticity_token, scope: [:controllers, :application, :handle_unverified_request])
   end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -46,7 +46,7 @@ class SessionsController < ApplicationController
   end
 
   def sign_in_with_magic_link
-    user = User.find_by_magic_link_token(params[:token])
+    user = User.find_for_auth_token("magic_link_token", params[:token])
     if user.present? && !user.auth_token_expired?("magic_link_token")
       user.confirm(user.confirmation_token) unless user.confirmed?
       @user = user

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -94,8 +94,7 @@ class SessionsController < ApplicationController
     end
   end
 
-  # Rather than dumping a would-be sign in at user_root_url, hand back the form they
-  # submitted - losing the session that failed the check is exactly when they need it
+  # Hand back the form they submitted rather than dumping them at user_root_url
   def handle_unverified_request
     flash.now[:error] = invalid_authenticity_token_message
     case action_name
@@ -133,9 +132,7 @@ class SessionsController < ApplicationController
     Organization.passwordless_email_matching(email).present? ? "magic_link" : "password"
   end
 
-  # Whatever killed a magic link token, it matches no user afterward - so the timestamp baked
-  # into the token is the only thing left to read. Old enough and it timed out; recent and it
-  # was spent signing in, or replaced by the link in a newer email.
+  # A dead token matches no user whatever killed it, so its timestamp is all that's left to read
   def magic_link_failure(token)
     return :unrecognized unless SecurityTokenizer.recognized_token?(token)
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -215,7 +215,7 @@ class UsersController < ApplicationController
     @token = params[:token].presence
     return @user = current_user if @token.blank? && current_user.present?
 
-    @user = User.find_by_token_for_password_reset(@token) if @token.present?
+    @user = User.find_for_auth_token("token_for_password_reset", @token)
     return true if @user.present? && !@user.auth_token_expired?("token_for_password_reset")
 
     remove_session

--- a/app/models/ambassador.rb
+++ b/app/models/ambassador.rb
@@ -57,11 +57,12 @@
 #
 # Indexes
 #
-#  index_users_on_address_record_id         (address_record_id)
-#  index_users_on_email                     (email) WHERE (deleted_at IS NULL)
-#  index_users_on_email_trgm                (email) WHERE (deleted_at IS NULL) USING gin
-#  index_users_on_token_for_password_reset  (token_for_password_reset)
-#  index_users_on_username                  (username) WHERE (deleted_at IS NULL)
+#  index_users_on_address_record_id             (address_record_id)
+#  index_users_on_email                         (email) WHERE (deleted_at IS NULL)
+#  index_users_on_email_trgm                    (email) WHERE (deleted_at IS NULL) USING gin
+#  index_users_on_magic_link_token_outstanding  (magic_link_token) WHERE (magic_link_token IS NOT NULL)
+#  index_users_on_token_for_password_reset      (token_for_password_reset)
+#  index_users_on_username                      (username) WHERE (deleted_at IS NULL)
 #
 class Ambassador < User
   default_scope -> { ambassadors }

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -70,9 +70,7 @@ class User < ApplicationRecord
   include AddressRecordedWithinBoundingBox
 
   EMAIL_REGEX = /\A(\S+)@(.+)\.(\S+)\z/
-  # How long an emailed token stays good for - magic link sign in and password reset alike.
-  # 99% of magic links are clicked inside 5 minutes, so a long window is exposure without
-  # much use. SessionsController also reads it to tell an expired link from a spent one
+  # How long an emailed token stays good for - magic link sign in and password reset alike
   AUTH_TOKEN_EXPIRY = 10.minutes
 
   cattr_accessor :current_user
@@ -169,9 +167,7 @@ class User < ApplicationRecord
   scope :member, -> { includes(:memberships).merge(Membership.active) }
 
   class << self
-    # Emailed tokens are looked up through here, never find_by_<column>: a blank token there
-    # matches IS NULL, which is nearly every row, leaving only auth_token_expired? between a
-    # tokenless request and someone else's account
+    # Never find_by_<column> for these - a blank token matches IS NULL, which is nearly every row
     def find_for_auth_token(auth_token_type, token)
       where(auth_token_type => token).first if token.present?
     end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -57,11 +57,12 @@
 #
 # Indexes
 #
-#  index_users_on_address_record_id         (address_record_id)
-#  index_users_on_email                     (email) WHERE (deleted_at IS NULL)
-#  index_users_on_email_trgm                (email) WHERE (deleted_at IS NULL) USING gin
-#  index_users_on_token_for_password_reset  (token_for_password_reset)
-#  index_users_on_username                  (username) WHERE (deleted_at IS NULL)
+#  index_users_on_address_record_id             (address_record_id)
+#  index_users_on_email                         (email) WHERE (deleted_at IS NULL)
+#  index_users_on_email_trgm                    (email) WHERE (deleted_at IS NULL) USING gin
+#  index_users_on_magic_link_token_outstanding  (magic_link_token) WHERE (magic_link_token IS NOT NULL)
+#  index_users_on_token_for_password_reset      (token_for_password_reset)
+#  index_users_on_username                      (username) WHERE (deleted_at IS NULL)
 #
 class User < ApplicationRecord
   include FeatureFlaggable
@@ -69,9 +70,10 @@ class User < ApplicationRecord
   include AddressRecordedWithinBoundingBox
 
   EMAIL_REGEX = /\A(\S+)@(.+)\.(\S+)\z/
-  # How long an emailed token stays good for. SessionsController reads it to tell an expired
-  # magic link apart from one that was already spent
-  AUTH_TOKEN_EXPIRY = 2.hours
+  # How long an emailed token stays good for - magic link sign in and password reset alike.
+  # 99% of magic links are clicked inside 5 minutes, so a long window is exposure without
+  # much use. SessionsController also reads it to tell an expired link from a spent one
+  AUTH_TOKEN_EXPIRY = 10.minutes
 
   cattr_accessor :current_user
 
@@ -167,6 +169,13 @@ class User < ApplicationRecord
   scope :member, -> { includes(:memberships).merge(Membership.active) }
 
   class << self
+    # Emailed tokens are looked up through here, never find_by_<column>: a blank token there
+    # matches IS NULL, which is nearly every row, leaving only auth_token_expired? between a
+    # tokenless request and someone else's account
+    def find_for_auth_token(auth_token_type, token)
+      where(auth_token_type => token).first if token.present?
+    end
+
     def fuzzy_email_find(email)
       UserEmail.confirmed.fuzzy_user_find(email)
     end

--- a/app/services/security_tokenizer.rb
+++ b/app/services/security_tokenizer.rb
@@ -22,8 +22,7 @@ module SecurityTokenizer
     recognized_token?(str) ? Time.at(str.to_s.split("-").first.to_i) : Time.at(EARLIEST_TOKEN_TIME)
   end
 
-  # token_time floors anything it can't read at EARLIEST_TOKEN_TIME, which reads as long
-  # expired - ask this first when "we can't read this" needs a different answer to "this timed out"
+  # token_time floors what it can't read at EARLIEST_TOKEN_TIME, which reads as long expired
   def recognized_token?(str)
     time, hex = str.to_s.split("-")
     time.present? && hex.present? && time.to_i > EARLIEST_TOKEN_TIME

--- a/app/views/sessions/magic_link.html.haml
+++ b/app/views/sessions/magic_link.html.haml
@@ -8,7 +8,7 @@
       - detail = nil
       - if @failure == :expired
         - header = t(".link_expired")
-        - detail = t(".links_work_for", hours: User::AUTH_TOKEN_EXPIRY.in_hours.to_i)
+        - detail = t(".links_work_for", duration: distance_of_time_in_words(User::AUTH_TOKEN_EXPIRY))
       - elsif @failure == :already_used
         - header = t(".link_already_used")
         - detail = t(".only_the_newest_link_works")

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -4780,7 +4780,7 @@ en:
       get_sign_in_link: Get sign in link
       link_already_used: That sign in link has already been used
       link_expired: That sign in link has expired
-      links_work_for: Sign in links work for %{hours} hours after they're sent.
+      links_work_for: Sign in links work for %{duration} after they're sent.
       only_the_newest_link_works: >-
         You may already be signed in somewhere else. If you asked for more than one
         email, only the link in the newest one works.

--- a/db/migrate/20260808224655_add_magic_link_token_index_to_users.rb
+++ b/db/migrate/20260808224655_add_magic_link_token_index_to_users.rb
@@ -2,8 +2,7 @@ class AddMagicLinkTokenIndexToUsers < ActiveRecord::Migration[8.1]
   disable_ddl_transaction!
 
   def change
-    # Signing in looks the token up across every user; only the few with an outstanding
-    # link are worth indexing, so this stays small
+    # Only the few users with an outstanding link are worth indexing
     add_index :users, :magic_link_token, where: "magic_link_token IS NOT NULL",
       name: "index_users_on_magic_link_token_outstanding", algorithm: :concurrently
   end

--- a/db/migrate/20260808224655_add_magic_link_token_index_to_users.rb
+++ b/db/migrate/20260808224655_add_magic_link_token_index_to_users.rb
@@ -1,0 +1,10 @@
+class AddMagicLinkTokenIndexToUsers < ActiveRecord::Migration[8.1]
+  disable_ddl_transaction!
+
+  def change
+    # Signing in looks the token up across every user; only the few with an outstanding
+    # link are worth indexing, so this stays small
+    add_index :users, :magic_link_token, where: "magic_link_token IS NOT NULL",
+      name: "index_users_on_magic_link_token_outstanding", algorithm: :concurrently
+  end
+end

--- a/db/primary_replica_structure.sql
+++ b/db/primary_replica_structure.sql
@@ -7599,6 +7599,13 @@ CREATE INDEX index_users_on_email_trgm ON public.users USING gin (email public.g
 
 
 --
+-- Name: index_users_on_magic_link_token_outstanding; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_users_on_magic_link_token_outstanding ON public.users USING btree (magic_link_token) WHERE (magic_link_token IS NOT NULL);
+
+
+--
 -- Name: index_users_on_token_for_password_reset; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -7720,6 +7727,7 @@ ALTER TABLE ONLY public.bug_reports
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20260808224655'),
 ('20260808100000'),
 ('20260807153129'),
 ('20260807132506'),

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -7599,6 +7599,13 @@ CREATE INDEX index_users_on_email_trgm ON public.users USING gin (email public.g
 
 
 --
+-- Name: index_users_on_magic_link_token_outstanding; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_users_on_magic_link_token_outstanding ON public.users USING btree (magic_link_token) WHERE (magic_link_token IS NOT NULL);
+
+
+--
 -- Name: index_users_on_token_for_password_reset; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -7720,6 +7727,7 @@ ALTER TABLE ONLY public.bug_reports
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20260808224655'),
 ('20260808100000'),
 ('20260807153129'),
 ('20260807132506'),

--- a/spec/components/register/step_confirm/component_spec.rb
+++ b/spec/components/register/step_confirm/component_spec.rb
@@ -6,8 +6,7 @@ RSpec.describe Register::StepConfirm::Component, type: :component do
   let(:component) { render_inline(described_class.new(b_param:, token: "sometoken")) }
   let(:b_param) { FactoryBot.create(:b_param, params: {bike: {owner_email: "someone@bikeindex.org"}}) }
 
-  # Confirming is single use, and a link scanner runs the page's JS - so the token only
-  # goes anywhere on a click
+  # Confirming is single use, and scanners run the page's JS
   it "posts the token, and waits for a click to do it" do
     expect(component).to have_css("form[action='/register/confirm_email'][method='post']")
     expect(component).to have_no_css("[data-controller='auto-submit']")

--- a/spec/components/sessions/sign_in_interstitial/component_system_spec.rb
+++ b/spec/components/sessions/sign_in_interstitial/component_system_spec.rb
@@ -2,8 +2,7 @@
 
 require "rails_helper"
 
-# Request specs post directly, so a real browser is the only place that can prove the form
-# doesn't submit itself — which is the whole point of the interstitial
+# Request specs post directly, so only a real browser can prove the form doesn't submit itself
 RSpec.describe Sessions::SignInInterstitial::Component, :js, type: :system do
   let(:base_url) { "/rails/view_components/sessions/sign_in_interstitial/component" }
 

--- a/spec/controllers/sessions_controller_spec.rb
+++ b/spec/controllers/sessions_controller_spec.rb
@@ -140,7 +140,7 @@ RSpec.describe SessionsController, type: :controller do
       end
       context "magic_link expired" do
         it "renders" do
-          user.update_auth_token("magic_link_token", Time.current - 121.minutes)
+          user.update_auth_token("magic_link_token", (User::AUTH_TOKEN_EXPIRY + 1.minute).ago)
           og_token = user.magic_link_token
           request.env["HTTP_CF_CONNECTING_IP"] = "66.66.66.66"
           post :sign_in_with_magic_link, params: {token: og_token}

--- a/spec/integration/registration/register_spec.rb
+++ b/spec/integration/registration/register_spec.rb
@@ -177,8 +177,7 @@ RSpec.describe "Register flow", :js, type: :system do
     expect(ActiveStorage::Blob.find_signed!(b_param.image_signed_id).filename.to_s)
       .to eq "bike_photo-landscape.jpeg"
 
-    # Following the link lands on the interstitial; confirming is single use, so it waits
-    # for the click rather than spending the token on a scanner's visit
+    # The emailed link lands on the interstitial, which waits for a click
     visit confirmation_link
     click_button "Continue"
 

--- a/spec/integration/signup_spec.rb
+++ b/spec/integration/signup_spec.rb
@@ -24,8 +24,8 @@ RSpec.describe "Signup", :js, type: :system do
     expect(user.confirmed?).to be_falsey
 
     Email::ConfirmationJob.drain
-    # Lands on the interstitial, which waits for the click rather than spending the token on
-    # a scanner's visit. That the GET alone doesn't confirm is users_request_spec's job
+    # The interstitial waits for a click; that the GET alone doesn't confirm is
+    # users_request_spec's job
     visit emailed_path("/users/confirm")
     expect(user.reload.confirmed?).to be_falsey
     click_button "Sign in"

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -586,8 +586,8 @@ RSpec.describe User, type: :model do
       end
       it "input time" do
         user = FactoryBot.create(:user)
-        user.update_auth_token("token_for_password_reset", (Time.current - 121.minutes).to_i)
-        expect(user.reload.auth_token_time("token_for_password_reset")).to be < (Time.current - 1.hours)
+        user.update_auth_token("token_for_password_reset", (User::AUTH_TOKEN_EXPIRY + 1.minute).ago.to_i)
+        expect(user.reload.auth_token_time("token_for_password_reset")).to be < (Time.current - User::AUTH_TOKEN_EXPIRY)
         expect(user.auth_token_expired?("token_for_password_reset")).to be_truthy
       end
     end
@@ -603,12 +603,14 @@ RSpec.describe User, type: :model do
         expect(user.auth_token_time("magic_link_token")).to be > Time.current - 2.seconds
         expect(user.auth_token_expired?("magic_link_token")).to be_falsey
       end
-      it "uses input time, it returns the token" do
+      it "uses input time, and expires once past the window" do
         user = FactoryBot.create(:user)
-        user.update_auth_token("magic_link_token", (Time.current - 1.hour).to_i)
-        user.reload
-        expect(user.auth_token_time("magic_link_token")).to be < (Time.current - 1.hours)
+        user.update_auth_token("magic_link_token", 1.minute.ago.to_i)
+        expect(user.reload.auth_token_time("magic_link_token")).to be_within(1.second).of(1.minute.ago)
         expect(user.auth_token_expired?("magic_link_token")).to be_falsey
+
+        user.update_auth_token("magic_link_token", (User::AUTH_TOKEN_EXPIRY + 1.minute).ago.to_i)
+        expect(user.reload.auth_token_expired?("magic_link_token")).to be_truthy
       end
     end
   end
@@ -666,7 +668,7 @@ RSpec.describe User, type: :model do
       token = user.refreshed_magic_link_token
       expect(token).to be_present
       expect(user.refreshed_magic_link_token).to eq token
-      user.update_auth_token("magic_link_token", (Time.current - 3.hours).to_i)
+      user.update_auth_token("magic_link_token", (User::AUTH_TOKEN_EXPIRY + 1.minute).ago.to_i)
       expect(user.refreshed_magic_link_token).to_not eq token
     end
   end

--- a/spec/requests/emailed_token_routes_request_spec.rb
+++ b/spec/requests/emailed_token_routes_request_spec.rb
@@ -39,8 +39,8 @@ RSpec.describe "emailed token routes", type: :request do
     flows.select { |flow| flow[key] }.map { |flow| flow[:interstitial] }
   end
 
-  # Includes .rb, so a component that renders from `call` or a controller counts. The shared
-  # component's own files name it without being a flow, so they're not callers
+  # Includes .rb, so a component rendering from `call` counts. The shared component's own
+  # files name it without being callers
   let(:app_sources) do
     Dir.glob(Rails.root.join("app/**/*.{rb,haml,erb}"))
       .to_h { |file| [Pathname.new(file).relative_path_from(Rails.root).to_s, File.read(file)] }
@@ -52,8 +52,8 @@ RSpec.describe "emailed token routes", type: :request do
   end
 
   # What actually renders an emailed link's form: each flow's own template, plus the shared
-  # component it delegates to. Other forms submit themselves for good reasons - a search box
-  # reacting to a filter - so only these are held to waiting for a click.
+  # component it delegates to. Other forms submit themselves for good reasons, so only these
+  # are held to waiting for a click
   def emailed_form_sources
     paths = flows.map { |flow| flow[:interstitial] } +
       Dir.glob(Rails.root.join("app/components/sessions/sign_in_interstitial/*.{rb,erb}"))
@@ -77,8 +77,7 @@ RSpec.describe "emailed token routes", type: :request do
       .to match_array interstitials_where(:shared_component)
   end
 
-  # A scanner following an emailed link runs the page's JS too, so submitting on render hands
-  # it the action: spending the token, or unsubscribing someone who never asked to be
+  # Scanners run the page's JS, so submitting on render hands them the action
   it "leaves every emailed-link form for the reader to submit" do
     submitting = emailed_form_sources.select do |path|
       File.read(Rails.root.join(path)).match?(/auto.submit|requestSubmit|data-controller/)

--- a/spec/requests/feedbacks_request_spec.rb
+++ b/spec/requests/feedbacks_request_spec.rb
@@ -26,8 +26,8 @@ RSpec.describe FeedbacksController, type: :request do
     end
     let!(:user) { FactoryBot.create(:user_confirmed) }
 
-    # Nothing else covers ApplicationController's own handler - the controllers that override
-    # it never reach this branch, and it shipped a missing translation key for years
+    # Nothing else covers ApplicationController's own handler - the controllers that
+    # override it never reach this branch
     context "with a null origin" do
       include_context :test_csrf_token
 

--- a/spec/requests/sessions_request_spec.rb
+++ b/spec/requests/sessions_request_spec.rb
@@ -261,7 +261,8 @@ RSpec.describe SessionsController, type: :request do
       end
 
       it "names the timeout for a token older than the window" do
-        expect(failure_for(SecurityTokenizer.new_token(3.hours.ago))).to match(/link has expired/i)
+        stale = SecurityTokenizer.new_token((User::AUTH_TOKEN_EXPIRY + 1.minute).ago)
+        expect(failure_for(stale)).to match(/link has expired/i)
       end
 
       it "says it was already used for a token inside the window" do
@@ -284,6 +285,17 @@ RSpec.describe SessionsController, type: :request do
       expect(response).to redirect_to admin_root_url
       expect(superadmin.reload.magic_link_token).to be_nil
       expect(superadmin.last_login_at).to be_within(1.second).of Time.current
+    end
+
+    # find_by with a blank token matches IS NULL - the first user without an outstanding
+    # link, which is nearly everyone. Nothing but the expiry check kept that from signing
+    # someone in, so a blank token must never reach the lookup
+    it "signs nobody in for a blank or missing token" do
+      [{token: ""}, {}].each do |params|
+        post "/session/sign_in_with_magic_link", params: params
+        expect(response).to redirect_to magic_link_session_path(incorrect_token: params[:token])
+        expect(response.cookies["auth"]).to be_blank
+      end
     end
 
     # The biggest bucket of real failures: the link worked, and then got clicked again

--- a/spec/requests/sessions_request_spec.rb
+++ b/spec/requests/sessions_request_spec.rb
@@ -250,9 +250,7 @@ RSpec.describe SessionsController, type: :request do
         .to have_css("form[action='/session/sign_in_with_magic_link'] input[name='token'][value='#{token}']", visible: :hidden)
     end
 
-    # A dead token is dead the same way whatever killed it, so the reason comes from the
-    # timestamp inside it. Getting this wrong reads as "the site is broken" rather than
-    # "you already did this"
+    # A dead token matches no user whatever killed it, so the reason comes from its timestamp
     context "incorrect_token" do
       def failure_for(token)
         get "/session/magic_link", params: {incorrect_token: token}
@@ -287,9 +285,7 @@ RSpec.describe SessionsController, type: :request do
       expect(superadmin.last_login_at).to be_within(1.second).of Time.current
     end
 
-    # find_by with a blank token matches IS NULL - the first user without an outstanding
-    # link, which is nearly everyone. Nothing but the expiry check kept that from signing
-    # someone in, so a blank token must never reach the lookup
+    # find_by with a blank token matches IS NULL - nearly every user
     it "signs nobody in for a blank or missing token" do
       [{token: ""}, {}].each do |params|
         post "/session/sign_in_with_magic_link", params: params

--- a/spec/requests/users_request_spec.rb
+++ b/spec/requests/users_request_spec.rb
@@ -438,7 +438,7 @@ RSpec.describe UsersController, type: :request do
     end
     context "auth token expired" do
       it "redirects" do
-        user.update_auth_token("token_for_password_reset", Time.current - 121.minutes)
+        user.update_auth_token("token_for_password_reset", (User::AUTH_TOKEN_EXPIRY + 1.minute).ago)
         og_token = user.token_for_password_reset
         get "#{base_url}/update_password_form_with_reset_token", params: {token: user.token_for_password_reset}
         expect(response).to redirect_to request_password_reset_form_users_path
@@ -576,7 +576,7 @@ RSpec.describe UsersController, type: :request do
     end
     context "auth token expired" do
       it "redirects" do
-        user.update_auth_token("token_for_password_reset", Time.current - 3.hours)
+        user.update_auth_token("token_for_password_reset", (User::AUTH_TOKEN_EXPIRY + 1.minute).ago)
         user.reload
         og_token = user.token_for_password_reset
         post "#{base_url}/update_password_with_reset_token", params: valid_params


### PR DESCRIPTION
Follow-up to #4073 and #4076. Two days of production logs put 99% of magic-link clicks within 5 minutes of the email being sent, and 99.7% within 15 — so a two-hour token was exposure with almost nothing to show for it.

- **`User::AUTH_TOKEN_EXPIRY` drops from 2 hours to 10 minutes**, password reset tokens included since they share it. The window is stated to users via `distance_of_time_in_words`, so the copy tracks the constant instead of carrying its own hardcoded unit — which is how "2 hours" got baked into the string in #4076.
- **`users.magic_link_token` gets an index.** It had none, so every sign-in attempt seq-scanned `users`. Partial on `IS NOT NULL`, which is only the handful with a link outstanding, so it stays tiny.
- **Specs stop hardcoding the window.** Eight sites carried `121.minutes` / `3.hours` / `1.hour`, all meaning "past the expiry"; they now read `(User::AUTH_TOKEN_EXPIRY + 1.minute).ago`.
