### PR TITLE
Stop bootstrap defaults leaking into alerts

### DIFF
--- a/app/assets/tailwind/application.css
+++ b/app/assets/tailwind/application.css
@@ -106,6 +106,12 @@
     @apply tw:text-blue-700 tw:dark:text-blue-300 tw:font-bold tw:underline;
   }
 
+  /* Bootstrap's `.container p, ul, ol, dl` margins are in the legacy layer, which
+   * beats Tailwind's preflight -- restore the base spacing inside an alert */
+  .twalert :is(p, ul, ol, dl) {
+    @apply tw:m-0;
+  }
+
   /* Links inherit the alert's own color, so the underline is what marks them as links */
   .twalert-body .twlink {
     @apply tw:underline tw:hover:text-blue-800;

--- a/app/assets/tailwind/application.css
+++ b/app/assets/tailwind/application.css
@@ -116,9 +116,14 @@
     @apply tw:text-blue-700 tw:dark:text-blue-300 tw:font-bold tw:underline;
   }
 
-  /* Bootstrap's `.container p, ul, ol, dl` margins are in the legacy layer, which
-   * beats Tailwind's preflight -- restore the base spacing inside an alert */
-  .twalert :is(p, ul, ol, dl) {
+  /* Legacy's `.container` reaches into an alert two ways tailwind can't answer on
+   * its own: `font-size: 15px; line-height: 2em` by inheritance, and `p, ul, ol,
+   * dl` margins from a layer that beats preflight. Own both here. */
+  .twalert-body {
+    @apply tw:text-base;
+  }
+
+  .twalert-body :is(p, ul, ol, dl) {
     @apply tw:m-0;
   }
 

--- a/app/components/admin/bikes_table/component.rb
+++ b/app/components/admin/bikes_table/component.rb
@@ -8,7 +8,7 @@ module Admin
     # checkboxes, and skip_user to drop the owner column.
     class Component < ApplicationComponent
       # Digest of the markup inside the row cache — the cached_markup_digest spec keeps it current
-      MARKUP_DIGEST = "ad8574377d59"
+      MARKUP_DIGEST = "1bca5d716d6d"
 
       def initialize(bikes:, no_show_header: false, show_serial: false, render_sortable: false,
         skip_user: false, render_multi_check: false)

--- a/app/components/admin/users_table/component.rb
+++ b/app/components/admin/users_table/component.rb
@@ -6,7 +6,7 @@ module Admin
     # render_deleted to show the deleted_at column.
     class Component < ApplicationComponent
       # Digest of the markup inside the row cache — the cached_markup_digest spec keeps it current
-      MARKUP_DIGEST = "60fcabc0af9f"
+      MARKUP_DIGEST = "448686e5b4ff"
 
       def initialize(users:, render_sortable: false, render_deleted: false)
         @users = users

--- a/app/components/registrations/show/wrapper/component.rb
+++ b/app/components/registrations/show/wrapper/component.rb
@@ -8,7 +8,7 @@ module Registrations
       class Component < ApplicationComponent
         # Digest of the markup inside the cache block — the cached_markup_digest spec
         # keeps it current, following what this tree renders out into UI:: and elsewhere
-        MARKUP_DIGEST = "98c7981f56e1"
+        MARKUP_DIGEST = "3c3fe6f27cfb"
 
         def initialize(bike:, current_user:, view:, available_views:, bike_sticker: nil, current_alerts: {})
           @bike = bike

--- a/app/components/ui/alerts/base/component.html.erb
+++ b/app/components/ui/alerts/base/component.html.erb
@@ -1,5 +1,5 @@
 <div
-  class="twalert tw:flow-root tw:rounded-sm tw:border tw:p-4 tw:text-base tw:transition-all tw:duration-300 <%= @margin_classes %> <%= color_classes %>"
+  class="tw:flow-root tw:rounded-sm tw:border tw:p-4 tw:transition-all tw:duration-300 <%= @margin_classes %> <%= color_classes %>"
   role="alert"
   data-controller="ui--alert"
 >

--- a/app/components/ui/alerts/base/component.html.erb
+++ b/app/components/ui/alerts/base/component.html.erb
@@ -1,5 +1,5 @@
 <div
-  class="tw:flow-root tw:rounded-sm tw:border tw:p-4 tw:transition-all tw:duration-300 <%= @margin_classes %> <%= color_classes %>"
+  class="twalert tw:flow-root tw:rounded-sm tw:border tw:p-4 tw:text-base tw:transition-all tw:duration-300 <%= @margin_classes %> <%= color_classes %>"
   role="alert"
   data-controller="ui--alert"
 >
@@ -41,7 +41,7 @@
   <% end %>
 
   <% if @header.present? %>
-    <h4 class="uncap tw:mb-2! tw:text-lg! <%= header_color_classes %>">
+    <h4 class="tw:mb-2 tw:font-sans tw:text-lg tw:normal-case <%= header_color_classes %>">
       <%= @header %>
     </h4>
   <% end %>

--- a/app/components/ui/alerts/base/component.rb
+++ b/app/components/ui/alerts/base/component.rb
@@ -68,11 +68,8 @@ module UI
           TEXT_CLASSES[@kind]
         end
 
-        # The ! overrides bootstrap's alert colors
         def header_color_classes
-          return "twtext-color!" if @default_header_color
-
-          text_color_classes.gsub("00", "00!")
+          @default_header_color ? "twtext-color" : text_color_classes
         end
 
         def dismissable_color_classes

--- a/app/components/ui/alerts/object_error/component.html.erb
+++ b/app/components/ui/alerts/object_error/component.html.erb
@@ -1,5 +1,5 @@
 <%= render(UI::Alerts::Base::Component.new(header: header_text, kind: :error, dismissable: @dismissable)) do %>
-  <ul class="tw:mb-0! tw:list-inside tw:list-disc">
+  <ul class="tw:list-inside tw:list-disc">
     <% @error_messages.each do |message| %>
       <li><%= message %></li>
     <% end %>

--- a/spec/components/ui/alerts/base/component_spec.rb
+++ b/spec/components/ui/alerts/base/component_spec.rb
@@ -39,14 +39,14 @@ RSpec.describe UI::Alerts::Base::Component, type: :component do
   describe "header" do
     let(:options) { {text: "some text", header: "Banned user", kind: "error"} }
     it "colors the header for the kind" do
-      expect(component).to have_css('h4.tw\:text-red-800\!', text: "Banned user")
+      expect(component).to have_css("h4.tw:text-red-800", text: "Banned user")
     end
 
     context "default_header_color" do
       let(:options) { {text: "some text", header: "Banned user", kind: "error", default_header_color: true} }
       it "renders the header in the default text color" do
-        expect(component).to have_css('h4.twtext-color\!', text: "Banned user")
-        expect(component).to_not have_css('h4.tw\:text-red-800\!')
+        expect(component).to have_css("h4.twtext-color", text: "Banned user")
+        expect(component).to_not have_css("h4.tw:text-red-800")
       end
     end
   end


### PR DESCRIPTION
Bootstrap's defaults were reaching into `UI::Alerts::Base::Component`: the header rendered in the legacy heading color instead of the alert's, spacing and line-height came from `.container`, and the last paragraph's margin left a band of empty space at the bottom of the box.

- **The `!` variants were never needed, and one of them never existed.** `revised.scss` wraps legacy in `@layer legacy`, declared before `components`/`utilities`, so plain utilities already beat it. `header_color_classes` built its class with `gsub("00", "00!")` — a string Tailwind's source scanner never sees — so no rule was generated at all and the header fell through to `.header-font`'s color. That's the miscolored header.
- **The header owns its font and case** (`tw:font-sans tw:normal-case` rather than the legacy `uncap`), instead of depending on a legacy counter-rule that only wins because it's `!important` in an earlier layer.
- **`.twalert-body` owns what layers can't fix on their own** — `.container`'s `font-size: 15px; line-height: 2em` reach the alert by inheritance, and its `p, ul, ol, dl` margins come from a layer that outranks preflight.

Paragraphs inside an alert now sit at Tailwind's base margin of 0, so a body that wants a gap between two of them has to ask for one.