### PR TITLE
Update faraday to 2.x, dropping the deprecated faraday_middleware

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -87,7 +87,7 @@ gem "postmark-rails" # Transactional email
 gem "MailchimpMarketing", github: "mailchimp/mailchimp-marketing-ruby" # Marketing emails
 gem "facebookbusiness", github: "facebook/facebook-ruby-business-sdk", branch: "main" # For promoted alerts
 gem "down" # used to generate a local tempfile
-gem "faraday_middleware" # Manage faraday request flow
+gem "faraday-follow_redirects" # Follow redirects in faraday requests
 gem "ruby-saml" # Organization SSO
 
 # OAuth provider, Grape, associated parts of API V2

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,14 +8,16 @@ GIT
 
 GIT
   remote: https://github.com/facebook/facebook-ruby-business-sdk.git
-  revision: c64b51f862c2359d289a9aea6d317cf1218595aa
+  revision: 32f0d8dfe59606310da4ece4f9926c03f71aaa26
   branch: main
   specs:
-    facebookbusiness (0.15.0.2)
+    facebookbusiness (26.0.0)
+      capi_param_builder_ruby (>= 1.3.0)
       concurrent-ruby (~> 1.1)
-      countries (~> 3.0)
-      faraday (~> 1.0)
-      json (~> 2.2)
+      countries (>= 3, < 7)
+      faraday (~> 2.6)
+      faraday-multipart (~> 1.0, >= 1.0.4)
+      json (~> 2.6)
       money (~> 6.13)
 
 GIT
@@ -153,6 +155,7 @@ GEM
       uniform_notifier (~> 1.11)
     byebug (13.0.0)
       reline (>= 0.6.0)
+    capi_param_builder_ruby (1.3.0)
     capybara (3.40.0)
       addressable
       matrix
@@ -186,10 +189,8 @@ GEM
     coffee-script-source (1.12.2)
     concurrent-ruby (1.3.8)
     connection_pool (3.0.2)
-    countries (3.1.0)
-      i18n_data (~> 0.11.0)
-      sixarm_ruby_unaccent (~> 1.1)
-      unicode_utils (~> 1.4)
+    countries (6.0.1)
+      unaccent (~> 0.3)
     crack (1.0.0)
       bigdecimal
       rexml
@@ -254,31 +255,16 @@ GEM
     factory_bot_rails (6.5.1)
       factory_bot (~> 6.5)
       railties (>= 6.1.0)
-    faraday (1.10.4)
-      faraday-em_http (~> 1.0)
-      faraday-em_synchrony (~> 1.0)
-      faraday-excon (~> 1.1)
-      faraday-httpclient (~> 1.0)
-      faraday-multipart (~> 1.0)
-      faraday-net_http (~> 1.0)
-      faraday-net_http_persistent (~> 1.0)
-      faraday-patron (~> 1.0)
-      faraday-rack (~> 1.0)
-      faraday-retry (~> 1.0)
-      ruby2_keywords (>= 0.0.4)
-    faraday-em_http (1.0.0)
-    faraday-em_synchrony (1.0.1)
-    faraday-excon (1.1.0)
-    faraday-httpclient (1.0.1)
+    faraday (2.14.3)
+      faraday-net_http (>= 2.0, < 3.5)
+      json
+      logger
+    faraday-follow_redirects (0.5.0)
+      faraday (>= 1, < 3)
     faraday-multipart (1.2.0)
       multipart-post (~> 2.0)
-    faraday-net_http (1.0.2)
-    faraday-net_http_persistent (1.2.0)
-    faraday-patron (1.0.0)
-    faraday-rack (1.0.0)
-    faraday-retry (1.0.4)
-    faraday_middleware (1.2.1)
-      faraday (~> 1.0)
+    faraday-net_http (3.4.4)
+      net-http (~> 0.5)
     fast_blank (1.0.1)
     ffi (1.17.4-arm64-darwin)
     ffi (1.17.4-x86_64-linux-gnu)
@@ -418,7 +404,6 @@ GEM
       rainbow (>= 2.2.2, < 4.0)
       ruby-progressbar (~> 1.8, >= 1.8.1)
       terminal-table (>= 1.5.1)
-    i18n_data (0.11.0)
     i18n_generators (2.2.2)
       activerecord (>= 3.0.0)
       railties (>= 3.0.0)
@@ -515,7 +500,7 @@ GEM
       prism (~> 1.5)
     monetize (1.12.0)
       money (~> 6.12)
-    money (6.16.0)
+    money (6.19.0)
       i18n (>= 0.6.4, <= 2)
     money-rails (1.15.0)
       activesupport (>= 3.0)
@@ -530,6 +515,8 @@ GEM
       mustermann (>= 1.0.0)
     naught (1.1.0)
     nenv (0.3.0)
+    net-http (0.9.1)
+      uri (>= 0.11.1)
     net-imap (0.6.6)
       date
       net-protocol
@@ -771,7 +758,6 @@ GEM
     ruby-vips (2.3.0)
       ffi (~> 1.12)
       logger
-    ruby2_keywords (0.0.5)
     rubyzip (1.3.0)
     sanitize (7.0.0)
       crass (~> 1.0.2)
@@ -805,7 +791,6 @@ GEM
     singleton (0.3.0)
     sitemap_generator (7.1.0)
       builder (~> 3.0)
-    sixarm_ruby_unaccent (1.2.0)
     skylight (7.1.1)
       activesupport (>= 7.2.0)
     sprockets (4.2.1)
@@ -874,13 +859,13 @@ GEM
       simple_oauth (~> 0.3.0)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
+    unaccent (0.4.0)
     unf (0.1.4)
       unf_ext
     unf_ext (0.0.7.7)
     unicode-display_width (3.2.0)
       unicode-emoji (~> 4.1)
     unicode-emoji (4.2.0)
-    unicode_utils (1.4.0)
     uniform_notifier (1.18.0)
     uri (1.1.1)
     useragent (0.16.11)
@@ -938,7 +923,7 @@ DEPENDENCIES
   down
   facebookbusiness!
   factory_bot_rails
-  faraday_middleware
+  faraday-follow_redirects
   fast_blank
   flamegraph
   flipper

--- a/app/jobs/spreadsheets/importer_job.rb
+++ b/app/jobs/spreadsheets/importer_job.rb
@@ -42,7 +42,7 @@ module Spreadsheets
 
     def connection
       Faraday.new do |faraday|
-        faraday.use FaradayMiddleware::FollowRedirects, limit: 15
+        faraday.use Faraday::FollowRedirects::Middleware, limit: 15
         faraday.adapter Faraday.default_adapter
         faraday.options.timeout = 30
         faraday.options.open_timeout = 10

--- a/app/jobs/update_email_domain_job.rb
+++ b/app/jobs/update_email_domain_job.rb
@@ -86,7 +86,7 @@ class UpdateEmailDomainJob < ScheduledJob
     return false if EmailDomain.invalid_domain?(domain)
 
     conn = Faraday.new do |faraday|
-      faraday.use FaradayMiddleware::FollowRedirects, limit: 15
+      faraday.use Faraday::FollowRedirects::Middleware, limit: 15
       faraday.adapter Faraday.default_adapter
       # Set reasonable timeouts to avoid hanging
       faraday.options.timeout = 5 # 5 seconds for open/read timeout


### PR DESCRIPTION
`faraday_middleware` is deprecated and requires `faraday ~> 1.0`, which held us at 1.10.4. We used exactly one thing from it — `FollowRedirects`, in two jobs — so it's replaced with `faraday-follow_redirects`, the official extraction.

- **The other seven Faraday connections needed no changes.** They use `request :json` / `response :json` / `:url_encoded`, which moved from faraday_middleware into faraday 2 core.
- **`facebookbusiness` had to move too**, off a 2021 revision that also wanted `faraday ~> 1.0`. Upstream `main` is now 26.0.0, which pulls countries 3→6 and money 6.19 along with it.
- **Nothing tests that jump.** The code using the SDK is the private `app/services/facebook` submodule, which isn't checked out in CI and whose spec is guarded off there. Checked by hand against the submodule instead: every call it makes still exists in v26, and it pins `api_version = "v23.0"`, so the Graph API version it talks to is unchanged. Worth exercising theft alert ad creation against the real API before this merges.
