### PR TITLE
Attribute bug reports to the Reply-To when we sent the mail

### DIFF
--- a/app/jobs/backfills/bug_report_sender_job.rb
+++ b/app/jobs/backfills/bug_report_sender_job.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+module Backfills
+  # Re-attribute the bug reports the mailbox recorded as being from us, back before it read
+  # Reply-To. Only the reports whose inbound email is still around can be backfilled - Action
+  # Mailbox incinerates them after 30 days
+  class BugReportSenderJob < ApplicationJob
+    sidekiq_options queue: "low_priority", retry: false
+
+    def perform
+      # Small batches - reading a report's mail holds its whole raw email, attachments and all
+      bug_reports.find_each(batch_size: 100) do |bug_report|
+        email, from_name = sender_for(bug_report.inbound_email)
+        next if email.blank? || email == bug_report.email
+
+        # user_id resolved to our own account - nil lets the model re-derive it from the real sender
+        bug_report.update!(email:, from_name:, user_id: nil)
+      end
+    end
+
+    private
+
+    def bug_reports
+      BugReport.where("email LIKE ?", "%@#{BugReport::OUR_EMAIL_DOMAIN}").where.not(inbound_email_id: nil)
+        .includes(inbound_email: {raw_email_attachment: :blob})
+    end
+
+    # A blob can go missing without its inbound email row - skip rather than stall the backfill
+    def sender_for(inbound_email)
+      BugReport.sender_from_mail(inbound_email.mail)
+    rescue ActiveStorage::FileNotFoundError
+      nil
+    end
+  end
+end

--- a/app/mailboxes/bug_reports_mailbox.rb
+++ b/app/mailboxes/bug_reports_mailbox.rb
@@ -1,9 +1,10 @@
 class BugReportsMailbox < ApplicationMailbox
   def process
+    email, from_name = BugReport.sender_from_mail(mail)
     bug_report = BugReport.create!(
       inbound_email:,
-      email: mail.from&.first,
-      from_name: mail[:from]&.display_names&.first,
+      email:,
+      from_name:,
       receiver: BugReport.receiver_from_mail(mail),
       subject: mail.subject,
       body: body_text,

--- a/app/models/bug_report.rb
+++ b/app/models/bug_report.rb
@@ -83,13 +83,26 @@ class BugReport < ApplicationRecord
     value.to_s.delete_suffix("@#{OUR_EMAIL_DOMAIN}")
   end
 
+  # Who wrote in, as [email, name]. Mail our app sends itself - the contact form, admin
+  # notifications - is From: contact@bikeindex.org with the person who wrote in as the Reply-To,
+  # so attribute those to them rather than to us
+  def self.sender_from_mail(mail)
+    field = (our_address?(mail.from&.first) && mail[:reply_to].presence) || mail[:from]
+
+    [EmailNormalizer.normalize(field&.addresses&.first), field&.display_names&.first]
+  end
+
+  def self.our_address?(value)
+    value.to_s.downcase.end_with?("@#{OUR_EMAIL_DOMAIN}")
+  end
+  private_class_method :our_address?
+
   # Which of our addresses the email was sent to (contact@, support@, bugs@, ...). Prefer an
   # address of ours, since a message can be addressed to a mix of recipients. X-Original-To is
   # the envelope recipient Postmark's ingress prepends, the only source when we're bcc'd
   def self.receiver_from_mail(mail)
     recipients = Array(mail.to) + Array(mail.cc)
-    address = ([mail["X-Original-To"]&.to_s] + recipients)
-      .find { it.to_s.downcase.end_with?("@#{OUR_EMAIL_DOMAIN}") } || recipients.first
+    address = ([mail["X-Original-To"]&.to_s] + recipients).find { our_address?(it) } || recipients.first
 
     EmailNormalizer.normalize(address)
   end
@@ -123,8 +136,9 @@ class BugReport < ApplicationRecord
     self.email = EmailNormalizer.normalize(email)
     self.receiver = EmailNormalizer.normalize(receiver)
     self.user_id ||= User.fuzzy_email_find(email)&.id
-    # booleans snapshot the sender's status at report time - don't re-derive on update
-    return unless new_record? && user.present?
+    # booleans snapshot the sender's status - re-taken only when the sender changes, so an
+    # ordinary update keeps the snapshot from when the report came in
+    return unless user_id_changed? && user.present?
 
     self.is_member = user.member?
     self.is_paid_organization = user.paid_org?

--- a/spec/jobs/backfills/bug_report_sender_job_spec.rb
+++ b/spec/jobs/backfills/bug_report_sender_job_spec.rb
@@ -1,0 +1,56 @@
+require "rails_helper"
+
+RSpec.describe Backfills::BugReportSenderJob, type: :job do
+  include ActionMailbox::TestHelper
+
+  let(:instance) { described_class.new }
+
+  describe "perform" do
+    let(:user) { FactoryBot.create(:user_confirmed, email: "sender@example.com") }
+    let!(:membership) { FactoryBot.create(:membership, user:) }
+    let(:mail) do
+      Mail.new do
+        from '"Bike Index" <contact@bikeindex.org>'
+        reply_to "Sender Person <sender@example.com>"
+        to "contact@bikeindex.org"
+        subject "Bike Recovery"
+        body "I got it back"
+      end
+    end
+    let(:inbound_email) { create_inbound_email_from_source(mail.to_s) }
+    let(:our_user) { FactoryBot.create(:user_confirmed, email: "contact@bikeindex.org") }
+    let!(:bug_report) do
+      FactoryBot.create(:bug_report, inbound_email:, email: "contact@bikeindex.org",
+        from_name: "Bike Index", user_id: our_user.id)
+    end
+
+    it "re-attributes the report to the Reply-To sender, re-taking the membership snapshot" do
+      expect(user.reload.member?).to be_truthy
+      expect(bug_report.is_member).to be_falsey
+      instance.perform
+
+      expect(bug_report.reload).to have_attributes(email: "sender@example.com",
+        from_name: "Sender Person", user_id: user.id, is_member: true)
+    end
+
+    context "with a report from outside our domain" do
+      let!(:bug_report) { FactoryBot.create(:bug_report, inbound_email:, email: "someone@example.com") }
+
+      it "leaves it alone" do
+        instance.perform
+
+        expect(bug_report.reload.email).to eq "someone@example.com"
+      end
+    end
+
+    context "with the inbound email incinerated" do
+      let!(:bug_report) { FactoryBot.create(:bug_report, email: "contact@bikeindex.org", inbound_email: nil) }
+
+      it "leaves it alone" do
+        instance.perform
+
+        expect(bug_report.reload.email).to eq "contact@bikeindex.org"
+      end
+    end
+  end
+end

--- a/spec/mailboxes/bug_reports_mailbox_spec.rb
+++ b/spec/mailboxes/bug_reports_mailbox_spec.rb
@@ -61,6 +61,62 @@ RSpec.describe BugReportsMailbox do
     end
   end
 
+  context "sent by us, with the sender in Reply-To" do
+    let(:mail) do
+      Mail.new do
+        from '"Bike Index" <contact@bikeindex.org>'
+        reply_to "Sender Person <sender@example.com>"
+        to "contact@bikeindex.org"
+        subject "Bike Recovery"
+        body "I got it back"
+      end
+    end
+
+    it "attributes the report to the Reply-To" do
+      expect { receive_inbound_email_from_source(mail.to_s) }.to change(BugReport, :count).by 1
+
+      expect(BugReport.last).to have_attributes(email: "sender@example.com",
+        from_name: "Sender Person", receiver: "contact@bikeindex.org", subject: "Bike Recovery")
+    end
+  end
+
+  context "sent by us, without a Reply-To" do
+    let(:mail) do
+      Mail.new do
+        from '"Bike Index" <contact@bikeindex.org>'
+        to "contact@bikeindex.org"
+        subject "Stolen notification blocked!"
+        body "It was blocked"
+      end
+    end
+
+    it "attributes the report to us" do
+      expect { receive_inbound_email_from_source(mail.to_s) }.to change(BugReport, :count).by 1
+
+      expect(BugReport.last).to have_attributes(email: "contact@bikeindex.org",
+        from_name: "Bike Index", subject: "Stolen notification blocked!")
+    end
+  end
+
+  context "with a Reply-To from someone outside our domain" do
+    let(:mail) do
+      Mail.new do
+        from "Someone Reporting <someone@example.com>"
+        reply_to "someone-else@example.com"
+        to "bugs@bikeindex.org"
+        subject "Hi"
+        body "Hello"
+      end
+    end
+
+    it "attributes the report to the From" do
+      expect { receive_inbound_email_from_source(mail.to_s) }.to change(BugReport, :count).by 1
+
+      expect(BugReport.last).to have_attributes(email: "someone@example.com",
+        from_name: "Someone Reporting")
+    end
+  end
+
   context "addressed to another address" do
     it "still routes to a bug report" do
       expect do


### PR DESCRIPTION
Mail our app sends itself goes out `From: "Bike Index" <contact@bikeindex.org>` — Postmark signs for our domain, so a stranger's address can't go in `From`. The person who wrote in is the `Reply-To`, which `AdminMailer#feedback_notification_email` already sets. The mailbox read `From`, so **208 of 393 bug reports** were recorded as being from us and linked to the `contact@bikeindex.org` user account. Only ~16 of those are genuinely internal (`Stolen notification blocked!`); the rest are contact-form submissions from real people, 127 of them titled "Bike Recovery".

- **`BugReport.sender_from_mail` prefers the `Reply-To` when `From` is on our domain**, and returns the display name from whichever field it picked. A sender outside our domain is untouched, so a normal reporter who sets their own `Reply-To` still gets attributed to their `From`.
- **`Backfills::BugReportSenderJob` re-attributes the existing reports**, for the ones whose inbound email Action Mailbox hasn't incinerated yet (30 days). It clears `user_id` so the model re-derives it from the corrected address.
- **The membership booleans re-snapshot when a report's sender changes.** They're a point-in-time record of the sender's status, so they deliberately don't move on an ordinary update — but the backfilled reports would otherwise link to a real member while still reading as non-members in the admin's "Only members" / "Only paid org" filters, which is exactly where these reports get triaged.

One thing this doesn't touch: `BugReportAutoPrioritizeJob` detects app-generated mail by matching fixed subjects (`bike recovery`, `stolen notification blocked!`) and auto-ignores them. That was a proxy for "we sent this to ourselves" — and after this change `email` no longer identifies such mail, since it now holds the real sender. Worth replacing the regexes with a persisted flag set at ingest, but that's a schema change and a separate PR. Today's behavior is unchanged either way, including the pre-existing case where a real person emailing contact@ with the subject "Recovered bike" gets auto-ignored.
