### PR TITLE
Fix screen reader announcements for alerts, swatches and badges

### DIFF
--- a/app/components/admin/bikes_table/component.rb
+++ b/app/components/admin/bikes_table/component.rb
@@ -8,7 +8,7 @@ module Admin
     # checkboxes, and skip_user to drop the owner column.
     class Component < ApplicationComponent
       # Digest of the markup inside the row cache — the cached_markup_digest spec keeps it current
-      MARKUP_DIGEST = "a75298460b21"
+      MARKUP_DIGEST = "629572d4c5b2"
 
       def initialize(bikes:, no_show_header: false, show_serial: false, render_sortable: false,
         skip_user: false, render_multi_check: false)

--- a/app/components/admin/bikes_table/component.rb
+++ b/app/components/admin/bikes_table/component.rb
@@ -8,7 +8,7 @@ module Admin
     # checkboxes, and skip_user to drop the owner column.
     class Component < ApplicationComponent
       # Digest of the markup inside the row cache — the cached_markup_digest spec keeps it current
-      MARKUP_DIGEST = "1bca5d716d6d"
+      MARKUP_DIGEST = "a75298460b21"
 
       def initialize(bikes:, no_show_header: false, show_serial: false, render_sortable: false,
         skip_user: false, render_multi_check: false)

--- a/app/components/admin/users_table/component.rb
+++ b/app/components/admin/users_table/component.rb
@@ -6,7 +6,7 @@ module Admin
     # render_deleted to show the deleted_at column.
     class Component < ApplicationComponent
       # Digest of the markup inside the row cache — the cached_markup_digest spec keeps it current
-      MARKUP_DIGEST = "448686e5b4ff"
+      MARKUP_DIGEST = "6418e8e8da96"
 
       def initialize(users:, render_sortable: false, render_deleted: false)
         @users = users

--- a/app/components/admin/users_table/component.rb
+++ b/app/components/admin/users_table/component.rb
@@ -6,7 +6,7 @@ module Admin
     # render_deleted to show the deleted_at column.
     class Component < ApplicationComponent
       # Digest of the markup inside the row cache — the cached_markup_digest spec keeps it current
-      MARKUP_DIGEST = "6418e8e8da96"
+      MARKUP_DIGEST = "02e574109e07"
 
       def initialize(users:, render_sortable: false, render_deleted: false)
         @users = users

--- a/app/components/registrations/show/wrapper/component.rb
+++ b/app/components/registrations/show/wrapper/component.rb
@@ -8,7 +8,7 @@ module Registrations
       class Component < ApplicationComponent
         # Digest of the markup inside the cache block — the cached_markup_digest spec
         # keeps it current, following what this tree renders out into UI:: and elsewhere
-        MARKUP_DIGEST = "3c3fe6f27cfb"
+        MARKUP_DIGEST = "21dbdf3258c7"
 
         def initialize(bike:, current_user:, view:, available_views:, bike_sticker: nil, current_alerts: {})
           @bike = bike

--- a/app/components/registrations/show/wrapper/component.rb
+++ b/app/components/registrations/show/wrapper/component.rb
@@ -8,7 +8,7 @@ module Registrations
       class Component < ApplicationComponent
         # Digest of the markup inside the cache block — the cached_markup_digest spec
         # keeps it current, following what this tree renders out into UI:: and elsewhere
-        MARKUP_DIGEST = "21dbdf3258c7"
+        MARKUP_DIGEST = "4751ab7f0f98"
 
         def initialize(bike:, current_user:, view:, available_views:, bike_sticker: nil, current_alerts: {})
           @bike = bike

--- a/app/components/ui/alerts/base/component.en.yml
+++ b/app/components/ui/alerts/base/component.en.yml
@@ -1,0 +1,9 @@
+en:
+  components:
+    ui:
+      alerts:
+        base:
+          error: Error
+          notice: Notice
+          success: Success
+          warning: Warning

--- a/app/components/ui/alerts/base/component.en.yml
+++ b/app/components/ui/alerts/base/component.en.yml
@@ -1,9 +1,11 @@
+---
 en:
   components:
     ui:
       alerts:
         base:
           error: Error
+          info: Info
           notice: Notice
           success: Success
           warning: Warning

--- a/app/components/ui/alerts/base/component.html.erb
+++ b/app/components/ui/alerts/base/component.html.erb
@@ -10,7 +10,7 @@
       <%= helpers.inline_svg_tag(default_icon, class: "tw:h-4 tw:w-4", aria_hidden: true) %>
     <% end %>
 
-    <span class="tw:sr-only"><%= @kind.to_s.titleize %></span>
+    <span class="tw:sr-only"><%= announcement %></span>
   </div>
 
   <% if @dismissable %>

--- a/app/components/ui/alerts/base/component.rb
+++ b/app/components/ui/alerts/base/component.rb
@@ -12,8 +12,6 @@ module UI
           purple: "tw:text-purple-800 tw:dark:text-purple-400"
         }.freeze
         KINDS = TEXT_CLASSES.keys.freeze
-        # :purple names a color rather than a meaning - announce it as what it is, a notice
-        ANNOUNCED_AS = {purple: :notice}.freeze
 
         # icon: rendered markup, e.g. inline_svg_tag("icons/envelope.svg", class: "tw:h-4 tw:w-4") -
         # replaces the default info icon
@@ -30,9 +28,10 @@ module UI
 
         private
 
-        # What a screen reader reads in place of the icon
+        # What a screen reader reads in place of the icon. :purple names a color rather
+        # than a meaning, so it announces the meaning it actually carries
         def announcement
-          translation(".#{ANNOUNCED_AS.fetch(@kind, @kind)}")
+          translation((@kind == :purple) ? ".info" : ".#{@kind}")
         end
 
         def normalized_kind(kind)

--- a/app/components/ui/alerts/base/component.rb
+++ b/app/components/ui/alerts/base/component.rb
@@ -12,6 +12,8 @@ module UI
           purple: "tw:text-purple-800 tw:dark:text-purple-400"
         }.freeze
         KINDS = TEXT_CLASSES.keys.freeze
+        # :purple names a color rather than a meaning - announce it as what it is, a notice
+        ANNOUNCED_AS = {purple: :notice}.freeze
 
         # icon: rendered markup, e.g. inline_svg_tag("icons/envelope.svg", class: "tw:h-4 tw:w-4") -
         # replaces the default info icon
@@ -27,6 +29,11 @@ module UI
         end
 
         private
+
+        # What a screen reader reads in place of the icon
+        def announcement
+          translation(".#{ANNOUNCED_AS.fetch(@kind, @kind)}")
+        end
 
         def normalized_kind(kind)
           return kind.to_sym if KINDS.include?(kind&.to_sym)

--- a/app/components/ui/badge/component.rb
+++ b/app/components/ui/badge/component.rb
@@ -70,15 +70,16 @@ module UI
       private
 
       # An inline icon (@icon is a path under app/assets/images, sans .svg) takes
-      # precedence over the status dot
+      # precedence over the status dot. Both are decorative - the badge's text is
+      # its accessible name - so they stay out of the accessibility tree.
       def leading_element
-        return helpers.inline_svg_tag("#{@icon}.svg", class: "tw:mr-1 tw:size-3.5") if @icon.present?
+        return helpers.inline_svg_tag("#{@icon}.svg", class: "tw:mr-1 tw:size-3.5", aria_hidden: true) if @icon.present?
         indicator_dot if @indicator
       end
 
       # A small status dot inheriting the badge's text color
       def indicator_dot
-        content_tag(:span, "", class: "tw:mr-1.5 tw:inline-block tw:size-1.5 tw:rounded-full tw:bg-current")
+        content_tag(:span, "", class: "tw:mr-1.5 tw:inline-block tw:size-1.5 tw:rounded-full tw:bg-current", aria: {hidden: true})
       end
 
       def custom_title?

--- a/app/components/ui/color_swatch/component.rb
+++ b/app/components/ui/color_swatch/component.rb
@@ -4,6 +4,9 @@ module UI
   module ColorSwatch
     # A small square showing a bike color. The display-less "cover-up" color
     # renders Color::COVER_UP_SWATCH's multicolor blend instead of a solid fill.
+    #
+    # Decorative: every caller prints the color name beside the swatch, so giving the
+    # swatch an accessible name of its own would announce "Red Red".
     class Component < ApplicationComponent
       # leading-[0] collapses the empty box's line-height strut so align-baseline
       # sits its bottom on the text baseline instead of floating above it
@@ -21,7 +24,7 @@ module UI
       end
 
       def call
-        content_tag(:span, "", class: "#{BASE_CLASSES} #{SIZES[@size]} #{ALIGNS[@align]}", style: swatch_style, title: @name)
+        content_tag(:span, "", class: "#{BASE_CLASSES} #{SIZES[@size]} #{ALIGNS[@align]}", style: swatch_style, aria: {hidden: true})
       end
 
       private

--- a/spec/components/search/everything_combobox_options/component_spec.rb
+++ b/spec/components/search/everything_combobox_options/component_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Search::EverythingComboboxOptions::Component, type: :component do
     it "renders an option with the color swatch and 'that are' prefix" do
       expect(rendered.css(".hw-combobox__option").size).to eq 1
       expect(rendered.css(".hw-combobox__option .sch_").text).to include("Registrations that are")
-      expect(rendered.css(".hw-combobox__option span[title='Blue']").attr("style").value).to include("background: #00f")
+      expect(rendered.css(".hw-combobox__option span[aria-hidden]").attr("style").value).to include("background: #00f")
       expect(rendered.css(".hw-combobox__option .label").text).to eq "Blue"
     end
   end
@@ -20,7 +20,7 @@ RSpec.describe Search::EverythingComboboxOptions::Component, type: :component do
     let(:matches) { [{"search_id" => "c_9", "text" => Color::COVER_UP_NAME, "category" => "colors", "display" => nil}] }
 
     it "renders the multicolor swatch instead of a display fill" do
-      swatch = rendered.css(".hw-combobox__option span[title='#{Color::COVER_UP_NAME}']")
+      swatch = rendered.css(".hw-combobox__option span[aria-hidden]")
       expect(swatch.attr("style").value).to eq "background: #{Color::COVER_UP_SWATCH}"
     end
   end

--- a/spec/components/ui/alerts/base/component_spec.rb
+++ b/spec/components/ui/alerts/base/component_spec.rb
@@ -14,6 +14,24 @@ RSpec.describe UI::Alerts::Base::Component, type: :component do
     expect(component).to_not have_selector("button")
   end
 
+  describe "screen reader announcement" do
+    it "announces each kind's meaning, translated" do
+      %w[notice error warning success].each do |kind|
+        alert = render_inline(described_class.new(text: "some text", kind:))
+        expect(alert.css(".tw\\:sr-only").text).to eq I18n.t("components.ui.alerts.base.#{kind}")
+      end
+    end
+
+    context "purple" do
+      let(:options) { {text: "some text", kind: "purple"} }
+
+      it "announces the meaning rather than the color" do
+        expect(component.css(".tw\\:sr-only").text).to eq I18n.t("components.ui.alerts.base.notice")
+        expect(component.to_html).to_not include "Purple"
+      end
+    end
+  end
+
   describe "icon" do
     let(:icon) { ActionController::Base.helpers.inline_svg_tag("icons/envelope.svg", class: "tw:h-4 tw:w-4") }
     let(:options) { {text: "some text", icon:} }

--- a/spec/components/ui/alerts/base/component_spec.rb
+++ b/spec/components/ui/alerts/base/component_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe UI::Alerts::Base::Component, type: :component do
       let(:options) { {text: "some text", kind: "purple"} }
 
       it "announces the meaning rather than the color" do
-        expect(component.css(".tw\\:sr-only").text).to eq I18n.t("components.ui.alerts.base.notice")
+        expect(component.css(".tw\\:sr-only").text).to eq I18n.t("components.ui.alerts.base.info")
         expect(component.to_html).to_not include "Purple"
       end
     end

--- a/spec/components/ui/badge/component_spec.rb
+++ b/spec/components/ui/badge/component_spec.rb
@@ -77,6 +77,25 @@ RSpec.describe UI::Badge::Component, type: :component do
     end
   end
 
+  describe "decorative leading elements" do
+    context "with an icon" do
+      let(:options) { {text:, icon: "link"} }
+
+      it "hides the icon from screen readers" do
+        expect(component.css("svg[aria-hidden='true']")).to be_present
+        expect(component).to have_text("Test Badge")
+      end
+    end
+
+    context "with an indicator" do
+      let(:options) { {text:, indicator: true} }
+
+      it "hides the dot from screen readers" do
+        expect(component.css("span[aria-hidden='true']")).to be_present
+      end
+    end
+  end
+
   context "with content block" do
     let(:component) { render_inline(described_class.new(text: "Fallback")) { "Block content" } }
 

--- a/spec/components/ui/color_swatch/component_spec.rb
+++ b/spec/components/ui/color_swatch/component_spec.rb
@@ -16,9 +16,14 @@ RSpec.describe UI::ColorSwatch::Component, type: :component do
     it "renders a solid swatch using the display color" do
       swatch = component.css("span").first
       expect(swatch["style"]).to eq "background: #386ed2"
-      expect(swatch["title"]).to eq "Blue"
       expect(component.to_html).to include("tw:inline-block")
       expect(component.to_html).to include("tw:rounded-xs")
+    end
+
+    it "is hidden from screen readers, which read the name beside it" do
+      swatch = component.css("span").first
+      expect(swatch["aria-hidden"]).to eq "true"
+      expect(swatch["title"]).to be_nil
     end
 
     it "defaults to the md size, middle alignment" do
@@ -62,7 +67,6 @@ RSpec.describe UI::ColorSwatch::Component, type: :component do
     it "renders the multicolor blend instead of a solid fill" do
       swatch = component.css("span").first
       expect(swatch["style"]).to eq "background: #{Color::COVER_UP_SWATCH}"
-      expect(swatch["title"]).to eq Color::COVER_UP_NAME
     end
   end
 end


### PR DESCRIPTION
Three components were putting the wrong thing — or nothing useful — into the accessibility tree.

- **`UI::Alerts::Base` announced "Purple".** The `sr-only` span beside the icon rendered `@kind.to_s.titleize`, which reads fine for `:error` and `:warning` but names a color for `:purple` — the kind register step 2's "we've sent a confirmation link" alert uses. It now renders a translated string from a new sidecar, and `:purple` announces "Info", matching the `icons/info.svg` it already shows. The old text was hardcoded English, in an app with Dutch and Norwegian locales.
- **`UI::ColorSwatch` announced "Red Red".** `title: @name` gave the swatch an accessible name duplicating the visible label right beside it. All four call sites print the color name next to the swatch, so it's decorative — `aria-hidden` instead.
- **`UI::Badge`'s leading icon and indicator dot** are decorative for the same reason: the badge's text is its accessible name.

No visual change — every edit is an `sr-only` or `aria` attribute.

`MARKUP_DIGEST` covers a component's Ruby and sidecar as well as its markup, so `Admin::BikesTable`, `Admin::UsersTable` and `Registrations::Show::Wrapper` all pick up new digests.

`components.ui.alerts.base.*` is en-only and wants a translation.io sync — `raise_on_missing_translations` is on in dev and test, so a non-en alert render raises until the other four locales have the keys.
