### PR TITLE
Stop rendering marketplace pagination links for browsers that have JS

### DIFF
--- a/app/controllers/concerns/controller_helpers.rb
+++ b/app/controllers/concerns/controller_helpers.rb
@@ -13,7 +13,7 @@ module ControllerHelpers
     helper_method :current_user, :current_user_or_unconfirmed_user, :sign_in_partner, :user_root_url,
       :user_root_bike_search?, :current_organization, :passive_organization, :current_location,
       :page_id, :default_bike_search_path, :bikehub_url, :show_general_alert,
-      :display_dev_info?, :current_country_id, :current_currency
+      :display_dev_info?, :current_country_id, :current_currency, :turbo_request?
     before_action :enable_rack_profiler
 
     before_action do

--- a/app/javascript/controllers/search/pagination_fallback_controller.js
+++ b/app/javascript/controllers/search/pagination_fallback_controller.js
@@ -2,13 +2,17 @@ import { Controller } from '@hotwired/stimulus'
 
 // Connects to data-controller='search--pagination-fallback'
 //
-// The marketplace paginates two ways and renders both, since only the non-JS
-// half survives a page render. This swaps in the other one.
+// The marketplace ships pagination links whenever the server can't tell whether
+// the browser runs JS. It does, so hand the page back to infinite scroll.
 export default class extends Controller {
-  static targets = ['links', 'spinner']
+  static targets = ['links']
 
   connect () {
+    // The last page has no frame to scroll into, so its links are the only way out
+    const spinner = this.element.querySelector('[data-search-loading]')
+    if (!spinner || !this.hasLinksTarget) return
+
     this.linksTarget.remove()
-    if (this.hasSpinnerTarget) this.spinnerTarget.hidden = false
+    spinner.hidden = false
   }
 }

--- a/app/views/search/marketplace/_marketplace_results.html.erb
+++ b/app/views/search/marketplace/_marketplace_results.html.erb
@@ -16,28 +16,36 @@
   <% end %>
 </div>
 
-<% if @pagy.pages > 1 %>
-  <div data-controller="search--pagination-fallback">
-    <%#
-      Only one of these two survives search--pagination-fallback: the links are the
-      non-JS path, the lazy frame below appends the next page on scroll instead
-    %>
+<%#
+  A turbo request proves JS, so it gets infinite scroll alone. A full page render
+  might be a browser that can never fetch the lazy frame, so it gets pagination links
+  too - search--pagination-fallback drops them if JS turns out to be running.
+%>
+<% javascript_confirmed = turbo_request? %>
 
-    <div data-search--pagination-fallback-target="links">
-      <%= render(UI::Pagination::Component.new(pagy: @pagy, page_params: params,
-        size: :lg, data: {turbo_action: "advance"})) %>
-    </div>
-
-    <% if @pagy.next %>
-      <%= turbo_frame_tag "page_#{@pagy.next}", src: search_marketplace_path(page: @pagy.next, **params.except(:page, :controller, :action).permit!), loading: :lazy do %>
-        <div
-          hidden
-          data-search--pagination-fallback-target="spinner"
-          class="tw:py-4 tw:text-center"
-        >
-          <%= render UI::LoadingSpinner::Component.new(text: "Loading more...") %>
-        </div>
+<% next_page_frame = capture do %>
+  <% if @pagy.next %>
+    <%= turbo_frame_tag "page_#{@pagy.next}", src: search_marketplace_path(page: @pagy.next, **params.except(:page, :controller, :action).permit!), loading: :lazy do %>
+      <%= tag.div(class: "tw:py-4 tw:text-center", hidden: !javascript_confirmed, data: {search_loading: ""}) do %>
+        <%= render UI::LoadingSpinner::Component.new(text: "Loading more...") %>
       <% end %>
     <% end %>
-  </div>
+  <% end %>
+<% end %>
+
+<% if javascript_confirmed %>
+  <%= next_page_frame %>
+<% else %>
+  <%# Registrations search leaves the frame implicit; these links sit a page_N frame deeper, which the response has no match for %>
+  <% pagination = UI::Pagination::Component.new(pagy: @pagy, page_params: params, size: :lg,
+    data: {turbo_action: "advance", turbo_frame: :marketplace_results_frame}) %>
+  <% if pagination.render? %>
+    <div data-controller="search--pagination-fallback">
+      <div data-search--pagination-fallback-target="links">
+        <%= render(pagination) %>
+      </div>
+
+      <%= next_page_frame %>
+    </div>
+  <% end %>
 <% end %>

--- a/spec/integration/search/search_marketplace_spec.rb
+++ b/spec/integration/search/search_marketplace_spec.rb
@@ -132,8 +132,8 @@ RSpec.describe "Marketplace infinite scroll", :js, type: :system do
     expect_axe_clean
     # Verify the lazy-loading frame for page 2 exists (5 listings remain)
     expect(page).to have_css("turbo-frame#page_2[loading='lazy']", visible: :all)
-    # Pagination is the fallback for users without JS - here the links are gone,
-    # and the spinner they ship hidden alongside is showing instead
+    # Frame-rendered results are proof of JS, so the no-JS pagination links never
+    # render - only the frame's spinner
     expect(page).to have_no_link(exact_text: "2")
     expect(page).to have_text("Loading more...")
     scroll_to_lazy_load
@@ -186,6 +186,35 @@ RSpec.describe "Marketplace infinite scroll", :js, type: :system do
     # the visible input shows the display name
     expect(find("#primary_activity-hw-hidden-field", visible: false).value).to eq primary_activity.id.to_s
     expect(find("#primary_activity").value).to eq "Mountain biking"
+  end
+
+  # search_no_js reaches riders who do have JS: Search::RegistrationsController
+  # forwards it on the marketplace redirect, and it survives in any URL shared
+  # before search--form strips the hidden field. Those renders can't tell, so they
+  # ship both paginations and search--pagination-fallback picks.
+  it "hands a search_no_js render back to infinite scroll, except on the last page" do
+    page.current_window.resize_to(1280, 900)
+    visit "/search/marketplace?search_no_js=true"
+    expect(page).to have_css("[data-test-id^='vehicle-thumbnail-linkspan-']", wait: 10, count: 12)
+
+    # The links a rider without JS would have used are gone, the frame's spinner shows
+    expect(page).to have_no_link(exact_text: "2")
+    expect(page).to have_text("Loading more...")
+    scroll_to_lazy_load
+    expect(page).to have_css("[data-test-id^='vehicle-thumbnail-linkspan-']", wait: 10, count: 17)
+
+    # The last page has no frame to scroll into, so its links stay - they're the only
+    # way out for a rider who deep-linked here
+    visit "/search/marketplace?search_no_js=true&page=2"
+    expect(page).to have_css("[data-test-id^='vehicle-thumbnail-linkspan-']", wait: 10, count: 5)
+    expect(page).to have_no_text("Loading more...")
+    # Following one navigates the results frame, like registrations search - so page 1
+    # comes back in infinite-scroll mode, with no links of its own. Don't count
+    # thumbnails here: the click leaves the page scrolled down, so page 2 may already
+    # be lazy-loading.
+    click_link(exact_text: "1")
+    expect(page).to have_css("turbo-frame#page_2[loading='lazy']", visible: :all, wait: 10)
+    expect(page).to have_no_link(exact_text: "2")
   end
 
   # :flaky retry: a programmatic go_forward to a form-submitted (turbo advance)

--- a/spec/requests/search/marketplace_request_spec.rb
+++ b/spec/requests/search/marketplace_request_spec.rb
@@ -72,6 +72,31 @@ RSpec.describe Search::MarketplaceController, type: :request do
         end
       end
 
+      context "with more listings than fit on a page" do
+        let!(:extra_listings) { FactoryBot.create_list(:marketplace_listing, 13, :for_sale, seller:) }
+
+        it "renders pagination links only when it can't tell whether JS is running" do
+          # A turbo request proves JS, so infinite scroll is the whole story - rendering
+          # the links too would be markup thrown away on every lazily appended page
+          get base_url, as: :turbo_stream
+          expect(response.body).to include("id=\"page_2\"")
+          expect(response.body).to_not include("search--pagination-fallback")
+
+          get base_url, headers: {"Turbo-Frame" => "marketplace_results_frame"}
+          expect(response.body).to include("id=\"page_2\"")
+          expect(response.body).to_not include("search--pagination-fallback")
+
+          get "#{base_url}?search_no_js=true"
+          expect(response.body).to include("id=\"page_2\"")
+          expect(response.body).to include("search--pagination-fallback")
+
+          # The last page has no lazy frame, so its links are all a rider has
+          get "#{base_url}?search_no_js=true&page=2"
+          expect(response.body).to_not include("Loading more...")
+          expect(response.body).to include("search--pagination-fallback")
+        end
+      end
+
       context "promoted listings" do
         let(:paid_seller) { FactoryBot.create(:user, :with_address_record, address_in: :davis) }
         let!(:membership) { FactoryBot.create(:membership, user: paid_seller) }


### PR DESCRIPTION
#4090 rendered both paginations on every request and let Stimulus delete one, so a rider with JS paid for the no-JS links on page 1 and again on every lazily appended page.

- **A turbo request is proof that JS is running, so it now gets infinite scroll alone.** Only a non-turbo render is ambiguous — `search_no_js` reaches JS riders for real, via `Search::RegistrationsController#marketplace_redirect_params` and any URL shared before `search--form` strips the hidden field — and that's the one case that still ships both and swaps.
- **The last page keeps its links.** Nothing appends there, so a JS rider who deep-linked to it had no way forward or back. Guarding on the spinner is safe now that infinite-scrolled pages carry no links to leak.
- **The links navigate the results frame, the way registrations search does.** They sit a `page_N` frame deeper, which the response has no match for, so they name the frame explicitly. The spinner also drops its Stimulus target for `data-search-loading`, the app's existing "ships hidden, revealed by JS" marker — which incidentally brings a 429 on a lazy `page_N` fetch under `search--form`'s notice handling.
