### PR TITLE
Only warn about insecure authorization for cleartext http

### DIFF
--- a/app/services/oauth_redirect_uri.rb
+++ b/app/services/oauth_redirect_uri.rb
@@ -1,0 +1,11 @@
+module OauthRedirectUri
+  extend Functionable
+
+  # Custom schemes (native apps) and loopback (RFC 8252) never reach the network
+  def cleartext?(redirect_uri)
+    uri = URI.parse(redirect_uri.to_s)
+    uri.scheme == "http" && !%w[localhost 127.0.0.1 ::1].include?(uri.hostname)
+  rescue URI::InvalidURIError
+    false
+  end
+end

--- a/app/services/oauth_redirect_uri.rb
+++ b/app/services/oauth_redirect_uri.rb
@@ -4,7 +4,7 @@ module OauthRedirectUri
   # Custom schemes (native apps) and loopback (RFC 8252) never reach the network
   def cleartext?(redirect_uri)
     uri = URI.parse(redirect_uri.to_s)
-    uri.scheme == "http" && !%w[localhost 127.0.0.1 ::1].include?(uri.hostname)
+    uri.scheme == "http" && !%w[localhost 127.0.0.1 ::1].include?(uri.hostname&.downcase)
   rescue URI::InvalidURIError
     false
   end

--- a/app/views/doorkeeper/authorizations/new.html.haml
+++ b/app/views/doorkeeper/authorizations/new.html.haml
@@ -33,15 +33,15 @@
               = hidden_field_tag :scope, @pre_auth.scope
               = submit_tag 'Authorize', class: 'btn btn-primary btn-lg'
           .col-xs-6
-            = form_tag oauth_authorization_path, method: :delete do
+            = form_tag oauth_authorization_path, method: :delete, id: 'deny-authorization' do
               = hidden_field_tag :client_id, @pre_auth.client.uid
               = hidden_field_tag :redirect_uri, @pre_auth.redirect_uri
               = hidden_field_tag :state, @pre_auth.state
               = hidden_field_tag :response_type, @pre_auth.response_type
               = hidden_field_tag :scope, @pre_auth.scope
               = submit_tag 'Deny', class: 'btn btn-secondary btn-lg'
-  
-- unless params[:redirect_uri][/\Ahttps:/]
+
+- if OauthRedirectUri.cleartext?(@pre_auth.redirect_uri)
   - modal_body = capture_haml do
     .modal-body
       %p
@@ -54,22 +54,18 @@
     .modal-btn-footer
       .row
         .col-xs-8.offset-sm-2
-          %button.btn.btn-primary{ type: 'button' }
+          %button.btn.btn-primary{ type: 'submit', form: 'deny-authorization' }
             Cancel authorization
       .insecure-continuing-explanation
-        %hr    
+        %hr
         %p.less-strong
           %small
             If you're aware of the risks and still want to authorize this application you can close this modal.
             %br
-            This 
+            This
             %em
               only makes sense
             if you're testing an application or something similar.
 
   / Heads up: The title for this modal is css styled by its id
-  = render partial: '/shared/modal', locals: { title: 'Insecure Authorization!', id: 'insecure-authorization-modal', modal_body: modal_body }
-
-  / Show the modal!
-  :javascript
-    $(document).ready(function() {$('#insecure-authorization-modal').modal('show') });
+  = render partial: '/shared/modal', locals: { title: 'Insecure Authorization!', id: 'insecure-authorization-modal', modal_body: modal_body, start_open: true }

--- a/spec/requests/oauth_authorizations_request_spec.rb
+++ b/spec/requests/oauth_authorizations_request_spec.rb
@@ -55,6 +55,30 @@ RSpec.describe Oauth::AuthorizationsController, type: :request do
         expect(response.body).to match(/form action=.\/oauth\/authorize/)
         expect(response.body).to_not include("fbevents.js")
       end
+      context "non-https redirect_uri" do
+        before { doorkeeper_app.update(redirect_uri:) }
+
+        context "custom scheme, like a native app" do
+          let(:redirect_uri) { "bikeindex://oauth-callback" }
+          it "renders without the insecure authorization modal" do
+            get authorization_url
+            expect(response.code).to eq("200")
+            expect(response.body).to_not match("insecure-authorization-modal")
+          end
+        end
+
+        context "cleartext http" do
+          let(:redirect_uri) { "http://app.com" }
+          it "renders the insecure authorization modal, its cancel button denying" do
+            get authorization_url
+            expect(response.code).to eq("200")
+            expect(response.body).to match("insecure-authorization-modal")
+            # Cancelling has to deny - closing the modal is the documented way to continue anyway
+            expect(response.body).to match(/<form[^>]*id="deny-authorization"/)
+            expect(response.body).to match(/<button[^>]*form="deny-authorization"/)
+          end
+        end
+      end
       context "no scope" do
         let(:scope_param) { "" }
         it "errors" do

--- a/spec/services/oauth_redirect_uri_spec.rb
+++ b/spec/services/oauth_redirect_uri_spec.rb
@@ -1,0 +1,32 @@
+require "rails_helper"
+
+RSpec.describe OauthRedirectUri do
+  describe "cleartext?" do
+    it "is true for http, which puts the grant on the wire" do
+      expect(OauthRedirectUri.cleartext?("http://example.com/oauth")).to be_truthy
+      expect(OauthRedirectUri.cleartext?("HTTP://example.com/oauth")).to be_truthy
+    end
+
+    it "is false for https" do
+      expect(OauthRedirectUri.cleartext?("https://example.com/oauth")).to be_falsey
+    end
+
+    it "is false for the custom schemes native apps redirect to" do
+      ["bikeindex://oauth-callback", "org.bikeindex.app:/oauth", "urn:ietf:wg:oauth:2.0:oob"].each do |redirect_uri|
+        expect(OauthRedirectUri.cleartext?(redirect_uri)).to be_falsey
+      end
+    end
+
+    it "is false for loopback, which never leaves the device" do
+      ["http://localhost:3000/oauth", "http://127.0.0.1:3000/oauth", "http://[::1]:3000/oauth"].each do |redirect_uri|
+        expect(OauthRedirectUri.cleartext?(redirect_uri)).to be_falsey
+      end
+    end
+
+    it "is false for blank and unparseable uris" do
+      [nil, "", "http://exa mple.com"].each do |redirect_uri|
+        expect(OauthRedirectUri.cleartext?(redirect_uri)).to be_falsey
+      end
+    end
+  end
+end

--- a/spec/services/oauth_redirect_uri_spec.rb
+++ b/spec/services/oauth_redirect_uri_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe OauthRedirectUri do
     end
 
     it "is false for loopback, which never leaves the device" do
-      ["http://localhost:3000/oauth", "http://127.0.0.1:3000/oauth", "http://[::1]:3000/oauth"].each do |redirect_uri|
+      ["http://localhost:3000/oauth", "http://LOCALHOST:3000/oauth", "http://127.0.0.1:3000/oauth", "http://[::1]:3000/oauth"].each do |redirect_uri|
         expect(OauthRedirectUri.cleartext?(redirect_uri)).to be_falsey
       end
     end


### PR DESCRIPTION
The authorization prompt has warned "This application isn't connecting to Bike Index in a secure way" since 2016, on any `redirect_uri` not starting with `https:` — so it fired for native-app custom schemes, `urn:ietf:wg:oauth:2.0:oob` and loopback. #4050's Confidential checkbox tells mobile apps to register as public clients using PKCE, which is exactly the configuration that trips it.

- **`OauthRedirectUri.cleartext?` decides now**, so only non-loopback `http://` warns. Doorkeeper's own `URIChecker.loopback_uri?` isn't reused for the loopback half because it rejects the hostname `localhost`, the most common dev redirect uri.
- **"Cancel authorization" submits the deny form.** It was a `type="button"` with no handler, so it did nothing — and it can't merely dismiss the modal, since the small print below it makes dismissing the *continue anyway* path.
- **The modal opens through `shared/_modal`'s `start_open:`** rather than its own inline `$(…).modal("show")`.

Which redirect URIs can be *registered* is unchanged — `force_ssl_in_redirect_uri` is still `false`. Rejecting cleartext at registration would be the deeper fix, but that validator runs on every save, so existing `http://` apps would need grandfathering first.
