### PR TITLE
Stop close-serial search scanning every bike

### DIFF
--- a/.claude/skills/pr/SKILL.md
+++ b/.claude/skills/pr/SKILL.md
@@ -30,7 +30,15 @@ Then run `bin/lint` to auto-format the code (it also picks up whatever `/simplif
 
 Scope specs the same way — the ones covering what the branch changed, never a bare `bundle exec rspec` or a whole top-level directory (see the `rspec-testing` skill). CI runs the full suite; a green PR isn't your job to prove locally.
 
-Then review the changed files against the repo's `CLAUDE.md` (root and any nested ones in touched directories) and fix anything that doesn't conform — code-style guidelines (functional style, no argument mutation, omitted hash values like `{x:}`, private methods, unabbreviated names, pithy comments), testing conventions, and frontend rules. Only touch lines this branch already changed; don't reformat unrelated code.
+Then review the changed files against the repo's `CLAUDE.md` (root and any nested ones in touched directories) and fix anything that doesn't conform — code-style guidelines (functional style, no argument mutation, omitted hash values like `{x:}`, private methods, unabbreviated names), testing conventions, and frontend rules. Only touch lines this branch already changed; don't reformat unrelated code.
+
+**Then review every comment the branch adds or edits — this step is required, not conditional on the diff looking clean.** List them:
+
+```bash
+git diff "origin/$BASE"...HEAD -U0 | grep -E '^\+\s*(#|//|/\*|\*)'
+```
+
+Judge each one against the **Comments** section of `CLAUDE.md`, and reach a verdict of keep / razor / delete on every line — a comment survives only by carrying a *why* the code can't. Deleting is the common outcome and razoring is the next most common; leaving a block untouched should be the exception you can justify. Watch hardest for the ones you wrote to explain your own reasoning as you worked: narration of the change, mechanism the code already shows, and a second sentence justifying the first.
 
 Then check the branch's translations for a hardcoded "bike" where the string means the registration's cycle type — a registration is as often an e-scooter, a stroller or a wheelchair:
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,9 +24,35 @@ Run `bin/lint` to automatically format the code. Always use `bin/lint`, don't us
 - Prefer less code, by character count (excluding whitespace and comments). Use `bin/char_count {FILE OR FOLDER}` to get the non-whitespace character count
 - prefer un-abbreviated variable names
 - Use full class/module names everywhere — `UI::Forms::Combobox::Component`, not the `Combobox::Component` that lexical scope also resolves from inside `UI::Forms`
-- Keep comments pithy — often they aren't necessary. Explain *why* only where a reader would otherwise get it wrong; don't narrate the change that introduced the code, and don't defend a choice against an edit nobody would make — a failing test already defends it
+- Default to no comment — see **Comments** below for when one earns its place
 - **Prefer composition over inheritance and `include`.** Share behavior by calling an object that owns it, not by mixing a module into several classes or adding a base class. A `module` extracted only to be `include`d in two classes is usually one of those classes with a parameter — pass the difference in as an argument instead. Rails' own extension points (`ApplicationRecord`, `ApplicationJob`, `ActiveSupport::Concern` for controller filters) are fine; new mixins of our own are what to avoid.
 - **Service objects** (`app/services/`): a stateless service is a `module` with `extend Functionable` (see the `functionable` gem) — inputs passed as args, no instance state, private methods via `conceal` + a `# private below here` block. Don't write a stateless service as a `class` with `def self.` methods.
+
+### Comments
+
+- **Default to no comment.** Code shows *how*; a comment earns its place only by carrying *why* — a non-obvious constraint, a deliberate deviation, a gotcha, a workaround.
+- **Never narrate the code.** "Loop over users", "parse the body" — the line below already says it.
+- **Never narrate the change.** "Fixed X", "updated to Y", "as requested". The diff and the commit hold that history; a comment repeating it outlives the change and goes stale.
+- **Don't defend a choice against an edit nobody would make.** A failing test already defends it.
+- **Warranted ≠ warranted as written — razor the wording too.** Keep the one non-obvious fact a reader needs *at that line*, and cut the rest: mechanism the code already shows, where the value gets used downstream, second-order consequences, and the justification's justification. Multi-line blocks rarely survive intact:
+
+  ```ruby
+  # Levenshtein can't use an index, so Postgres would scan every bike. The `%`
+  # operator hits index_bikes_on_serial_normalized_no_space_trgm instead, and
+  # takes its threshold from a session setting, which we set to 0.2 rather than
+  # the 0.3 default because 0.3 dropped too many real matches when we measured it.
+  ```
+
+  becomes
+
+  ```ruby
+  # `%` reads its threshold from a session setting; 0.2 rather than the 0.3
+  # default keeps ~98% of the LEVENSHTEIN < 3 matches
+  ```
+
+- **Re-earn the comment when you edit the code under it.** Rewrite it to fit the new shape rather than appending a clause per change.
+
+None of this governs magic comments, `# rubocop:disable` (keep its justification), or `TODO:`/`HACK:`/`NOTE:` markers.
 
 ## Subagents
 

--- a/app/controllers/organized/registrations_controller.rb
+++ b/app/controllers/organized/registrations_controller.rb
@@ -158,9 +158,6 @@ module Organized
       return if chart_only?
 
       @pagy, @bikes = pagy(:countish, @available_bikes.reorder("bikes.#{sort_column} #{sort_direction}"), limit: @per_page, page: permitted_page)
-      if @interpreted_params[:serial]
-        @close_serials = organization_bikes.search_close_serials(@interpreted_params).limit(25)
-      end
     end
 
     # Set filter params for settings component on initial (non-turbo) page load

--- a/app/javascript/controllers/org/multi_search_controller.js
+++ b/app/javascript/controllers/org/multi_search_controller.js
@@ -2,6 +2,9 @@ import { Controller } from '@hotwired/stimulus'
 
 /* global Turbo, requestAnimationFrame */
 
+// Each serial is a separate search, so a long paste otherwise opens a request per serial at once
+const MAX_CONCURRENT_SEARCHES = 4
+
 // Connects to data-controller='org--multi-search'
 export default class extends Controller {
   static targets = ['textarea', 'button', 'serialChips', 'results', 'searchAll', 'searchAllHint']
@@ -118,7 +121,7 @@ export default class extends Controller {
     this.renderPlaceholderChips(serials)
     this.buttonTarget.disabled = true
 
-    await Promise.all(serials.map((serial, index) => this.searchItem(serial, index)))
+    await this.searchAllItems(serials)
 
     // Wait a frame for Turbo stream DOM updates to complete
     await new Promise(resolve => requestAnimationFrame(resolve))
@@ -129,6 +132,19 @@ export default class extends Controller {
     window.timeLocalizer?.localize()
     this.buttonTarget.disabled = false
     this.searching = false
+  }
+
+  // Runs every search, MAX_CONCURRENT_SEARCHES of them in flight at a time
+  async searchAllItems (serials) {
+    const pending = serials.map((serial, index) => ({ serial, index }))
+    const runNext = async () => {
+      while (pending.length) {
+        const { serial, index } = pending.shift()
+        await this.searchItem(serial, index)
+      }
+    }
+    const workers = Math.min(MAX_CONCURRENT_SEARCHES, pending.length)
+    await Promise.all(Array.from({ length: workers }, runNext))
   }
 
   alignTableColumns () {

--- a/app/javascript/controllers/org/multi_search_controller.js
+++ b/app/javascript/controllers/org/multi_search_controller.js
@@ -2,8 +2,8 @@ import { Controller } from '@hotwired/stimulus'
 
 /* global Turbo, requestAnimationFrame */
 
-// Each serial is a separate search, so a long paste otherwise opens a request per serial at once
-const MAX_CONCURRENT_SEARCHES = 4
+// A long paste would otherwise open one request per serial at once
+const MAX_CONCURRENT_SEARCHES = 6
 
 // Connects to data-controller='org--multi-search'
 export default class extends Controller {
@@ -134,17 +134,11 @@ export default class extends Controller {
     this.searching = false
   }
 
-  // Runs every search, MAX_CONCURRENT_SEARCHES of them in flight at a time
   async searchAllItems (serials) {
-    const pending = serials.map((serial, index) => ({ serial, index }))
-    const runNext = async () => {
-      while (pending.length) {
-        const { serial, index } = pending.shift()
-        await this.searchItem(serial, index)
-      }
+    for (let start = 0; start < serials.length; start += MAX_CONCURRENT_SEARCHES) {
+      await Promise.all(serials.slice(start, start + MAX_CONCURRENT_SEARCHES)
+        .map((serial, offset) => this.searchItem(serial, start + offset)))
     }
-    const workers = Math.min(MAX_CONCURRENT_SEARCHES, pending.length)
-    await Promise.all(Array.from({ length: workers }, runNext))
   }
 
   alignTableColumns () {

--- a/app/models/concerns/bike_searchable.rb
+++ b/app/models/concerns/bike_searchable.rb
@@ -1,10 +1,10 @@
 module BikeSearchable
   extend ActiveSupport::Concern
 
-  # index_bikes_on_serial_normalized_no_space_trgm answers `%`, whose threshold comes from a
-  # session setting. 0.2 keeps ~98% of the LEVENSHTEIN < 3 matches that 0.3 (the default) drops
+  # pg_trgm's 0.3 default drops ~5% of the LEVENSHTEIN < 3 matches, and 47% of the two-edit
+  # ones on serials of 8 characters or fewer
   CLOSE_SERIAL_SIMILARITY = 0.2
-  # More close matches than any caller paginates through
+  # Deeper than any caller paginates
   CLOSE_SERIAL_LIMIT = 1000
 
   class << self
@@ -266,19 +266,18 @@ module BikeSearchable
     # TODO: actually make private?
     # Private (internal only) methods below here, as defined at the start
 
-    # LEVENSHTEIN is unindexable, so on its own it scans every bike. `%` narrows the candidates
-    # via the trigram index first - but it reads its threshold from a session setting, so the
-    # ids have to be selected eagerly, inside the transaction that SET LOCAL applies to.
+    # LEVENSHTEIN can't use an index; `%` narrows the candidates through the trigram one, and
+    # takes its threshold from a session setting - hence the eager select inside a transaction
     def close_serial_ids(interpreted_params)
-      serial_no_space = interpreted_params[:serial_no_space]
+      serial, serial_no_space = interpreted_params.values_at(:serial, :serial_no_space)
       transaction do
-        connection.execute("SET LOCAL pg_trgm.similarity_threshold = #{BikeSearchable::CLOSE_SERIAL_SIMILARITY}")
-        # serials_not_containing excludes exact matches too
-        serials_not_containing(interpreted_params[:serial], serial_no_space)
+        connection.execute("SET LOCAL pg_trgm.similarity_threshold = #{CLOSE_SERIAL_SIMILARITY}")
+        serials_not_containing(serial, serial_no_space) # also excludes exact matches
           .non_serial_matches(interpreted_params)
           .where("serial_normalized_no_space % ?", serial_no_space)
           .where("LEVENSHTEIN(serial_normalized_no_space, ?) < 3", serial_no_space)
-          .limit(BikeSearchable::CLOSE_SERIAL_LIMIT)
+          .unscope(:includes).reorder(nil) # default_scope's eager loads and sort triple an id select
+          .limit(CLOSE_SERIAL_LIMIT)
           .pluck(:id)
       end
     end

--- a/app/models/concerns/bike_searchable.rb
+++ b/app/models/concerns/bike_searchable.rb
@@ -1,6 +1,12 @@
 module BikeSearchable
   extend ActiveSupport::Concern
 
+  # index_bikes_on_serial_normalized_no_space_trgm answers `%`, whose threshold comes from a
+  # session setting. 0.2 keeps ~98% of the LEVENSHTEIN < 3 matches that 0.3 (the default) drops
+  CLOSE_SERIAL_SIMILARITY = 0.2
+  # More close matches than any caller paginates through
+  CLOSE_SERIAL_LIMIT = 1000
+
   class << self
     # searchable_interpreted_params returns the args for by all other public methods in this class
     # query_params:
@@ -231,10 +237,7 @@ module BikeSearchable
     def search_close_serials(interpreted_params)
       return none if interpreted_params[:serial].blank? # normalized_serial blank
 
-      # serials_not_containing excludes exact matches too
-      serials_not_containing(interpreted_params[:serial], interpreted_params[:serial_no_space])
-        .non_serial_matches(interpreted_params)
-        .where("LEVENSHTEIN(serial_normalized_no_space, ?) < 3", interpreted_params[:serial_no_space])
+      where(id: close_serial_ids(interpreted_params))
     end
 
     def search_serials_containing(interpreted_params)
@@ -262,6 +265,23 @@ module BikeSearchable
 
     # TODO: actually make private?
     # Private (internal only) methods below here, as defined at the start
+
+    # LEVENSHTEIN is unindexable, so on its own it scans every bike. `%` narrows the candidates
+    # via the trigram index first - but it reads its threshold from a session setting, so the
+    # ids have to be selected eagerly, inside the transaction that SET LOCAL applies to.
+    def close_serial_ids(interpreted_params)
+      serial_no_space = interpreted_params[:serial_no_space]
+      transaction do
+        connection.execute("SET LOCAL pg_trgm.similarity_threshold = #{BikeSearchable::CLOSE_SERIAL_SIMILARITY}")
+        # serials_not_containing excludes exact matches too
+        serials_not_containing(interpreted_params[:serial], serial_no_space)
+          .non_serial_matches(interpreted_params)
+          .where("serial_normalized_no_space % ?", serial_no_space)
+          .where("LEVENSHTEIN(serial_normalized_no_space, ?) < 3", serial_no_space)
+          .limit(BikeSearchable::CLOSE_SERIAL_LIMIT)
+          .pluck(:id)
+      end
+    end
 
     def non_serial_matches(interpreted_params)
       # For each of the of the colors, call searching_matching_color_ids with the color_id on the previous ;)

--- a/spec/support/shared_examples/bike_searchable.rb
+++ b/spec/support/shared_examples/bike_searchable.rb
@@ -321,6 +321,14 @@ RSpec.shared_examples "bike_searchable" do
         expect(organization.bikes.search_close_serials(interpreted_params).pluck(:id)).to eq([stolen_bike.id])
       end
     end
+    context "close serial under the default trigram similarity threshold" do
+      let!(:similar_bike) { FactoryBot.create(:bike, serial_number: "G8FA08255") }
+      let(:query_params) { {serial: "G8FY082T5", stolenness: "all"} }
+      # Two edits apart but only 0.25 similar, so CLOSE_SERIAL_SIMILARITY has to be below pg_trgm's 0.3 default
+      it "returns the match" do
+        expect(Bike.search_close_serials(interpreted_params).pluck(:id)).to eq([similar_bike.id])
+      end
+    end
   end
 
   describe "search_serials_containing" do


### PR DESCRIPTION
A 12-serial org multi-search with "search all bikes" on timed out ([fault 133446869](https://app.honeybadger.io/projects/35931/faults/133446869) — 10 notices in the same second). `search_close_serials` ran `LEVENSHTEIN(...) < 3` against all 1.95M bikes, and the `LIMIT 25` made it worse: the planner walked `index_bikes_current_listing_order` expecting to fill 25 rows early, so it computed levenshtein for every bike. 16.8s per serial, and the page fires one request per pasted serial at once.

- **`%` narrows the candidates through `index_bikes_on_serial_normalized_no_space_trgm` first**, and LEVENSHTEIN refines them. `%` takes its threshold from a session setting, so the ids are selected eagerly inside the transaction `SET LOCAL` applies to — `search_close_serials` still returns a relation, now `where(id: …)`. It also has to `unscope(:includes)`: `pluck(:id)` routes through `apply_join_dependency` whenever `includes_values` is set, and `default_includes` turned an id-only select into five LEFT JOINs.
- **The threshold is 0.2, not pg_trgm's 0.3 default.** Over 8,000 synthetic 1- and 2-edit mutations of real serials, 0.3 drops ~5% of the `LEVENSHTEIN < 3` matches overall and **47% of the two-edit ones on serials of 8 characters or fewer** — the median serial is 11. 0.2 keeps 98–99.8%. The new shared example is a pair 0.3 would drop.
- **The browser runs 6 searches at a time**, and `search_organization_bikes`'s `@close_serials` is gone — no view has ever read it, and it was only free while the relation stayed lazy.
- **Riding along, unrelated to the search fix:** comments get their own AGENTS.md section — when one earns its place, and how far to cut one that does — in place of the single "keep comments pithy" bullet, and `/pr` gains a required keep/razor/delete pass over every comment a branch touches.

Measured against a local copy of production (1.947M bikes), the fault's own serial goes 16817ms → 45ms, and all 12 of its serials run concurrently in 7.8s — now bounded by the *exact*-match searches, not the close-serial ones.

Two things this deliberately doesn't touch. `BikeServices::Searcher#friendly_find_serial_ids` still runs the same unindexable `LEVENSHTEIN` over `normalized_serial_segments` (btree only, no trigram index) for API v1/v2 `close_serials` — v3 goes through the fixed path, so the two now diverge. And `/o/:org/registrations/multi_search_response` sits under the global `requests/ip` throttle at 30/20s rather than the `SEARCH_DATA_PREFIXES` bucket that already exists for exactly this kind of repeated XHR — a long enough paste 429s regardless of how fast the query is, which the client-side cap can't fix.
