### PR TITLE
Wait for search--form before testing its superseded-response verdict

### DIFF
--- a/app/javascript/controllers/search/form_controller.js
+++ b/app/javascript/controllers/search/form_controller.js
@@ -145,8 +145,8 @@ export default class extends Controller {
   // The frame's eager src fetch and a search submitted while it's still in flight
   // race each other. Turbo renders whichever lands last and rewrites history from
   // the frame, so the older response would drag the address bar back to the query
-  // the rider searched away from. A submit repoints src before its own response
-  // returns, so src names the search the frame should be showing.
+  // the rider searched away from. A src fetch assigns src before it is sent, so a
+  // response that no longer matches it is one the frame has moved on from.
   frameResponseSuperseded (url) {
     return this.differentSearchOnSamePage(url, this.frameElement?.getAttribute('src'))
   }

--- a/spec/integration/search/search_marketplace_spec.rb
+++ b/spec/integration/search/search_marketplace_spec.rb
@@ -115,13 +115,7 @@ RSpec.describe "Marketplace infinite scroll", :js, type: :system do
     JS
   end
 
-  # flaky: 2 — papering over, not a diagnosis. Two causes are already ruled out: the verdict
-  # is no longer read inside the listener (where it reported registration order instead of
-  # search--form's answer), and the wait is no longer too short for a round trip the release
-  # only then starts. What's left is a CI-only failure of the released response to reach the
-  # page at all, which nothing reproduces locally. The split assertion below is what will say
-  # which half is at fault next time it goes red; drop this tag once it has.
-  it "fills the kind counts on load, and keeps a search made before the results arrive", flaky: 2 do
+  it "fills the kind counts on load, and keeps a search made before the results arrive" do
     release_initial_results_load = hold_initial_results_load
     visit_marketplace_via_nav
 
@@ -130,6 +124,11 @@ RSpec.describe "Marketplace infinite scroll", :js, type: :system do
     # frame is held open here. All 17 listings (15 standard + 2 promoted) are for_sale,
     # so the for_sale count shows (17).
     expect(page).to have_css("[data-count-target='for_sale']", text: "(17)", wait: 10)
+
+    # The counts come from a different controller, so they don't mean search--form -
+    # which rejects the superseded response below - is listening yet. Dropping
+    # search_no_js is the first thing its connect does.
+    expect(page).to have_no_css("#search_no_js", visible: :all, wait: 10)
 
     search_primary_activity("Mountain biking")
     expect(page).to have_css("[data-test-id^='vehicle-thumbnail-linkspan-']", wait: 10, count: 6)


### PR DESCRIPTION
The marketplace example asserting that `search--form` rejects a results-frame response the rider has searched away from went red on [main](https://github.com/bikeindex/bike_index/actions/runs/31452561266/job/93660256046), through both of its retries. Nothing in it waited for that controller to connect: controllers load as separate modules, so the kind counts it checks first come from `search--kind-select-fields` and say nothing about `search--form`. When `search--form` connected late there was no `turbo:before-fetch-response` listener, the held unfiltered response rendered, and the verdict read `false` — delaying only that controller's asset reproduces the failure exactly, down to the 12 unfiltered results and the reverted address bar.

- **It waits on `search_no_js` dropping**, the first thing that connect does. Every assertion is unchanged, and `flaky: 2` goes with it — an example that fails through all its retries isn't waiting on a retry.
- **`frameResponseSuperseded`'s comment was wrong.** Turbo repoints `src` when a response lands, not when a submit is sent; a src fetch assigns it before the request goes out, which is the path that branch guards.
