### PR TITLE
Put the input focus ring back to blue

### DIFF
--- a/app/assets/tailwind/application.css
+++ b/app/assets/tailwind/application.css
@@ -139,7 +139,7 @@
   .twinput {
     @apply tw:bg-white tw:border tw:border-gray-200 tw:dark:bg-gray-700 tw:dark:border-gray-700 tw:rounded-sm
       tw:placeholder-gray-500 tw:text-gray-900 tw:text-base tw:dark:placeholder-gray-400 tw:dark:text-gray-200
-      tw:focus-visible:outline-0 tw:focus-visible:ring tw:focus-visible:ring-blue-400 tw:focus-visible:border-blue-400 tw:dark:focus-visible:ring-blue-500 tw:dark:focus:border-blue-500
+      tw:focus-visible:outline-0 tw:focus-visible:ring tw:focus-visible:ring-blue-400 tw:focus-visible:border-blue-400 tw:dark:focus-visible:ring-blue-500 tw:dark:focus-visible:border-blue-500
       tw:w-full tw:py-1.5 tw:px-2.5 tw:block;
   }
   /* block + the gap to its field, so a label spaces the same whatever renders

--- a/app/assets/tailwind/application.css
+++ b/app/assets/tailwind/application.css
@@ -139,7 +139,7 @@
   .twinput {
     @apply tw:bg-white tw:border tw:border-gray-200 tw:dark:bg-gray-700 tw:dark:border-gray-700 tw:rounded-sm
       tw:placeholder-gray-500 tw:text-gray-900 tw:text-base tw:dark:placeholder-gray-400 tw:dark:text-gray-200
-      tw:focus-visible:outline-0 tw:focus-visible:ring tw:focus-visible:ring-purple-500/40 tw:focus-visible:border-purple-500 tw:dark:focus-visible:ring-purple-500/40 tw:dark:focus:border-purple-500
+      tw:focus-visible:outline-0 tw:focus-visible:ring tw:focus-visible:ring-blue-400 tw:focus-visible:border-blue-400 tw:dark:focus-visible:ring-blue-500 tw:dark:focus:border-blue-500
       tw:w-full tw:py-1.5 tw:px-2.5 tw:block;
   }
   /* block + the gap to its field, so a label spaces the same whatever renders


### PR DESCRIPTION
#4067 retuned `.twinput` alongside the button palette, so a focused text input rings purple — and nothing else followed it there. `UI::Forms::Combobox` (`--hw-focus-color`), the file-upload label's `peer-focus-visible` ring and the legacy `.select2-*` rules all still ring blue, so the input a rider tabs into stopped matching the one beside it.

- **The ring and focus border go back to blue-400/blue-500**, which is what every other focus ring in the app already is. Buttons, the dropdown's active entry and the radio-button chips stay purple — that's the palette #4067 was actually for.
- **The dark border is gated on `focus-visible` now**, like the five classes beside it. It was the one on plain `focus:`, so clicking a `<select>` in dark mode drew a border with no ring around it, and nothing at all in light mode — a text field never showed it, since browsers match `:focus-visible` on anything that takes typed input.
- **The resting border stays where #4067 put it** (gray-200, dark gray-700). Only the focus styles move.
