### PR TITLE
Authorize every SSO assertion against the organization's domain

### DIFF
--- a/app/models/organization_saml_configuration.rb
+++ b/app/models/organization_saml_configuration.rb
@@ -31,6 +31,7 @@ class OrganizationSamlConfiguration < ApplicationRecord
   validates :organization_id, presence: true, uniqueness: true
   validates :idp_entity_id, :idp_sso_target_url, :idp_cert, presence: true, if: :enabled?
   validate :idp_certificates_parseable
+  validate :organization_claims_a_domain, if: :enabled?
 
   before_validation :set_calculated_attributes
   after_commit :update_organization
@@ -70,6 +71,13 @@ class OrganizationSamlConfiguration < ApplicationRecord
     rescue OpenSSL::X509::CertificateError
       errors.add(attribute, "is not a valid X.509 certificate")
     end
+  end
+
+  # Every assertion is authorized against the domain, so without one this config can't sign anyone in
+  def organization_claims_a_domain
+    return if organization&.user_email_domain.present?
+
+    errors.add(:base, "Organization must have a permitted domain to enable SAML SSO")
   end
 
   def update_organization

--- a/app/services/saml/assertion_processor.rb
+++ b/app/services/saml/assertion_processor.rb
@@ -25,11 +25,10 @@ module Saml
       return failure("assertion is missing an email") if email.blank?
 
       organization = saml_configuration.organization
-      # An org's IdP may only ever authenticate emails on the domain that org claims for SSO.
-      # Guarding the whole resolution rather than provisioning alone is what keeps an assertion
-      # for someone else's address - another org's admin, a superadmin - from signing them in.
+      # Guards the whole resolution, not just provisioning: otherwise an assertion for any address -
+      # another org's admin, a superadmin - links or returns an existing account and signs it in.
       return failure("#{email} is not on this organization's SSO domain") unless
-        Organization.saml_email_matching(email)&.id == organization.id
+        organization == Organization.saml_email_matching(email)
 
       # One lookup drives both the returning-user short-circuit and the post-login update.
       identity = SsoIdentity.for(organization:, provider:, uid: name_id) ||

--- a/app/services/saml/assertion_processor.rb
+++ b/app/services/saml/assertion_processor.rb
@@ -25,10 +25,16 @@ module Saml
       return failure("assertion is missing an email") if email.blank?
 
       organization = saml_configuration.organization
+      # An org's IdP may only ever authenticate emails on the domain that org claims for SSO.
+      # Guarding the whole resolution rather than provisioning alone is what keeps an assertion
+      # for someone else's address - another org's admin, a superadmin - from signing them in.
+      return failure("#{email} is not on this organization's SSO domain") unless
+        Organization.saml_email_matching(email)&.id == organization.id
+
       # One lookup drives both the returning-user short-circuit and the post-login update.
       identity = SsoIdentity.for(organization:, provider:, uid: name_id) ||
         SsoIdentity.new(organization:, provider:, uid: name_id)
-      user = identity.user || User.fuzzy_confirmed_or_unconfirmed_email_find(email) || provision_user(email, organization)
+      user = identity.user || User.fuzzy_confirmed_or_unconfirmed_email_find(email) || provision_user(email)
       return failure("no Bike Index account for #{email}") if user.blank?
 
       # The IdP vouched for this email, so confirm the account (as the magic-link path
@@ -59,12 +65,8 @@ module Saml
       EmailNormalizer.normalize(raw)
     end
 
-    # Only mint an account when the email's domain is the one this org claims for SSO, so an
-    # assertion can never create an account on a domain that routes logins somewhere else.
     # Provisioning grants no organization role - that is user_role_for_user_email_domain's job.
-    def provision_user(email, organization)
-      return nil unless Organization.saml_email_matching(email)&.id == organization.id
-
+    def provision_user(email)
       UserServices::PasswordlessCreator.find_or_create(email).first
     end
 

--- a/spec/factories/organization_saml_configurations.rb
+++ b/spec/factories/organization_saml_configurations.rb
@@ -1,6 +1,10 @@
 FactoryBot.define do
   factory :organization_saml_configuration do
-    organization { FactoryBot.create(:organization_with_organization_features, enabled_feature_slugs: "saml_sso") }
+    # Sequenced because two saml_sso organizations may not claim the same domain
+    sequence(:organization) do |n|
+      FactoryBot.create(:organization_with_organization_features,
+        enabled_feature_slugs: "saml_sso", user_email_domain: "sso-#{n}.example.com")
+    end
 
     trait :enabled do
       enabled { true }

--- a/spec/models/organization_saml_configuration_spec.rb
+++ b/spec/models/organization_saml_configuration_spec.rb
@@ -42,6 +42,19 @@ RSpec.describe OrganizationSamlConfiguration, type: :model do
       end
     end
 
+    context "organization without a permitted domain" do
+      let(:saml_configuration) { FactoryBot.build(:organization_saml_configuration, :enabled, organization:) }
+      let(:organization) { FactoryBot.create(:organization_with_organization_features, enabled_feature_slugs: "saml_sso") }
+      it "can't be enabled" do
+        expect(saml_configuration).to_not be_valid
+        expect(saml_configuration.errors.full_messages)
+          .to include("Organization must have a permitted domain to enable SAML SSO")
+
+        saml_configuration.enabled = false
+        expect(saml_configuration).to be_valid
+      end
+    end
+
     context "invalid certificate" do
       it "adds an error" do
         saml_configuration.assign_attributes(idp_entity_id: "https://idp.example.edu/",

--- a/spec/requests/admin/organizations_request_spec.rb
+++ b/spec/requests/admin/organizations_request_spec.rb
@@ -245,7 +245,10 @@ RSpec.describe Admin::OrganizationsController, type: :request do
       end
     end
     context "update organization_saml_configuration" do
-      let(:organization) { FactoryBot.create(:organization_with_organization_features, enabled_feature_slugs: "saml_sso") }
+      let(:organization) do
+        FactoryBot.create(:organization_with_organization_features,
+          enabled_feature_slugs: "saml_sso", user_email_domain: "example.edu")
+      end
       let(:saml_attributes) do
         {enabled: "1", idp_entity_id: "https://idp.example.edu/",
          idp_sso_target_url: "https://idp.example.edu/idp/profile/SAML2/POST/SSO",

--- a/spec/requests/saml_callback_request_spec.rb
+++ b/spec/requests/saml_callback_request_spec.rb
@@ -102,8 +102,7 @@ RSpec.describe "SAML SSO login", :saml_env, type: :request do
         end
       end
 
-      # An IdP may only vouch for its own domain, so no resolution path may reach a user here -
-      # not provisioning, not linking an existing account, not a previously linked identity.
+      # No resolution path may reach a user: not provisioning, not linking, not a returning identity
       context "asserted email domain not in the org" do
         let(:email) { "outsider@gmail.com" }
         it "does not provision or sign in" do

--- a/spec/requests/saml_callback_request_spec.rb
+++ b/spec/requests/saml_callback_request_spec.rb
@@ -102,12 +102,36 @@ RSpec.describe "SAML SSO login", :saml_env, type: :request do
         end
       end
 
+      # An IdP may only vouch for its own domain, so no resolution path may reach a user here -
+      # not provisioning, not linking an existing account, not a previously linked identity.
       context "asserted email domain not in the org" do
         let(:email) { "outsider@gmail.com" }
         it "does not provision or sign in" do
           expect { post_callback }.not_to change(User, :count)
           expect(response).to redirect_to(new_session_path)
           expect(signed_in?).to be false
+        end
+
+        context "an account already exists for the asserted email" do
+          let!(:existing) { FactoryBot.create(:user_confirmed, email:) }
+          it "does not link or sign in" do
+            expect { post_callback }.not_to change(SsoIdentity, :count)
+            expect(response).to redirect_to(new_session_path)
+            expect(signed_in?).to be false
+          end
+        end
+
+        context "an identity already links the asserted NameID" do
+          let(:name_id) { "stable-idp-uid" }
+          let!(:identity) do
+            FactoryBot.create(:sso_identity, organization:, provider: "saml", uid: name_id,
+              user: FactoryBot.create(:user_confirmed, email:))
+          end
+          it "does not sign in" do
+            post_callback(name_id:)
+            expect(response).to redirect_to(new_session_path)
+            expect(signed_in?).to be false
+          end
         end
       end
     end

--- a/spec/services/saml/settings_builder_spec.rb
+++ b/spec/services/saml/settings_builder_spec.rb
@@ -2,7 +2,10 @@ require "rails_helper"
 
 RSpec.describe Saml::SettingsBuilder, :saml_env do
   let(:idp_cert) { File.read(Rails.root.join("spec/fixtures/saml/idp_cert.pem")) }
-  let(:organization) { FactoryBot.create(:organization_with_organization_features, enabled_feature_slugs: "saml_sso") }
+  let(:organization) do
+    FactoryBot.create(:organization_with_organization_features,
+      enabled_feature_slugs: "saml_sso", user_email_domain: "example.edu")
+  end
   let(:saml_configuration) { FactoryBot.create(:organization_saml_configuration, :enabled, organization:) }
   subject(:settings) { described_class.build(saml_configuration) }
 


### PR DESCRIPTION
`Saml::AssertionProcessor` checked the asserted email's domain inside `provision_user` — the last of the three branches that resolve an assertion to a user. `identity.user` and `User.fuzzy_confirmed_or_unconfirmed_email_find(email)` both ran ahead of it with no check at all, so an organization's IdP could assert any address on Bike Index — another organization's admin, a superadmin — and be signed in as that user, with the auto-confirm below activating the account if it happened to be unconfirmed. Configuring an IdP is superadmin-gated, so this was never an org-admin escalation path, but the IdP behind it is customer-controlled.

- **The check moves above the whole resolution**, where it holds for every branch rather than one. `provision_user` drops its own copy along with its `organization` argument, so that part of the diff is shorter than what it replaces.
- **A previously linked identity is re-checked now too.** An organization that loses its claim on a domain stops being able to sign in identities it linked while it held it — deliberate, and the third of the new callback specs.
- **The same invariant is stated at configuration time**: `OrganizationSamlConfiguration` won't validate with `enabled` set unless its organization claims a `user_email_domain`, alongside the IdP entity id / SSO url / cert it already requires there. Without one there's nothing to authorize assertions against, so the configuration is dead on arrival — it fails closed today, since `saml_email_matching` filters on `where.not(user_email_domain: nil)`, but silently.

That validation lives on the configuration rather than on `Organization` because `enabled_feature_slugs` is recomputed by `set_calculated_attributes` on every organization save. Gated on it, the check would fire far from anything anyone would call an SSO change — including `OrganizationSamlConfiguration#update_organization`, whose bare `organization.update(...)` would just start returning false. On the configuration it fires when a superadmin ticks "enabled", and the error renders on the admin organization form that carries both fields.
