### PR TITLE
Unblock the GA4 region-sharded beacons in CSP

### DIFF
--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -4,6 +4,12 @@
 # See the Securing Rails Applications Guide for more information:
 # https://guides.rubyonrails.org/security.html#content-security-policy-header
 
+# GA4 shards the /g/collect beacon across regional hosts and falls back to an image when it
+# can't fetch, so every host belongs in both img_src and connect_src. `*.` never matches the
+# bare domain, hence each pair
+GOOGLE_ANALYTICS_HOSTS = ["https://*.google-analytics.com", "https://analytics.google.com",
+  "https://*.analytics.google.com", "https://stats.g.doubleclick.net"].freeze
+
 Rails.application.configure do
   config.content_security_policy do |policy|
     policy.default_src :self
@@ -26,7 +32,7 @@ Rails.application.configure do
       "https://connect.facebook.net",
       "https://pbs.twimg.com",
       "https://www.googleadservices.com",
-      "https://syndication.twitter.com", :data, :blob
+      "https://syndication.twitter.com", *GOOGLE_ANALYTICS_HOSTS, :data, :blob
     policy.object_src :none
     # unsafe_eval is required for application_revised.js jQuery - remove it when possible!
     policy.script_src :self, :unsafe_inline, :unsafe_eval,
@@ -45,13 +51,8 @@ Rails.application.configure do
       "https://www.gstatic.com", # Google Translate styles
       "https://cdn.jsdelivr.net",
       "https://api.mapbox.com"
-    policy.connect_src :self,
-      "https://*.google-analytics.com",
+    policy.connect_src :self, *GOOGLE_ANALYTICS_HOSTS,
       "https://*.tiles.mapbox.com",
-      # GA4 also routes /g/collect beacons to analytics.google.com and (region-redirected) www.google.com
-      "https://analytics.google.com",
-      # GA4 ad-personalization beacons to DoubleClick (/g/collect)
-      "https://stats.g.doubleclick.net",
       "https://api.honeybadger.io",
       "https://api.mapbox.com",
       "https://bikebook.herokuapp.com",
@@ -68,8 +69,7 @@ Rails.application.configure do
       "https://translate.googleapis.com", # Google Translate API
       "https://uploads.bikeindex.org",
       "https://www.facebook.com",
-      "https://www.google-analytics.com",
-      "https://www.google.com",
+      "https://www.google.com", # GA4 region-redirects some /g/collect beacons here
       "https://www.googletagmanager.com"
     policy.worker_src :self, :blob
     policy.frame_src :self,

--- a/spec/services/csp_report_spec.rb
+++ b/spec/services/csp_report_spec.rb
@@ -157,14 +157,16 @@ RSpec.describe CspReport do
 
     # blocked-uri / effective-directive pairs taken from the top CSP faults
     context "hosts our policy allowlists" do
-      {
-        "script-src-elem" => "https://www.googletagmanager.com/gtm.js?id=GTM-K88RMWC",
-        "script-src" => "https://connect.facebook.net/en_US/all.js",
-        "img-src" => "https://www.googleadservices.com/pagead/conversion/980892598/",
-        "font-src" => "https://fonts.gstatic.com/s/inter/v13/x.woff2",
-        "connect-src" => "https://region1.google-analytics.com/g/collect", # a *. source
-        "frame-src" => "https://js.stripe.com"
-      }.each do |directive, uri|
+      [["script-src-elem", "https://www.googletagmanager.com/gtm.js?id=GTM-K88RMWC"],
+        ["script-src", "https://connect.facebook.net/en_US/all.js"],
+        ["img-src", "https://www.googleadservices.com/pagead/conversion/980892598/"],
+        ["img-src", "https://stats.g.doubleclick.net/g/collect"],
+        ["img-src", "https://region1.google-analytics.com/g/collect"],
+        ["font-src", "https://fonts.gstatic.com/s/inter/v13/x.woff2"],
+        ["connect-src", "https://region1.google-analytics.com/g/collect"], # a *. source
+        ["connect-src", "https://analytics.google.com/g/collect"],
+        ["connect-src", "https://region1.analytics.google.com/g/collect"],
+        ["frame-src", "https://js.stripe.com"]].each do |directive, uri|
         it "permits #{directive} #{uri}" do
           expect(permits?(directive, uri)).to be_truthy
         end
@@ -172,12 +174,11 @@ RSpec.describe CspReport do
     end
 
     context "hosts our policy does not allowlist" do
-      {
-        "font-src" => "https://images.simplycodes.com/fonts/CircularXXWeb-Medium.woff2",
-        "connect-src" => "https://region1.analytics.google.com", # analytics.google.com is exact-match only
-        "frame-src" => "https://youtu.be",
-        "img-src" => "https://evil.example.com/tracker.gif"
-      }.each do |directive, uri|
+      [["font-src", "https://images.simplycodes.com/fonts/CircularXXWeb-Medium.woff2"],
+        ["frame-src", "https://youtu.be"],
+        # a *. source matches on the label boundary, not a bare suffix
+        ["connect-src", "https://analytics.google.com.evil.com/g/collect"],
+        ["img-src", "https://evil.example.com/tracker.gif"]].each do |directive, uri|
         it "does not permit #{directive} #{uri}" do
           expect(permits?(directive, uri)).to be_falsey
         end


### PR DESCRIPTION
GA4 beacons have been blocked in production for about a month. `connect_src` listed `analytics.google.com` as an exact match ([#3843](https://github.com/bikeindex/bike_index/pull/3843)), but GA4 shards `/g/collect` across regional hosts, so `region1.analytics.google.com` never matched — **24,928 of the last 25,826 CSP notices**, 96.5% of the whole project.

It was invisible until now because the per-request query string minted a separate fault every time. Normalizing `blocked-uri` in #4035 collapsed those into five faults, all dated to that deploy, and the real breakage fell out.

- **`img_src` and `connect_src` share one `GOOGLE_ANALYTICS_HOSTS` list.** GA also sends the beacon as an image when it can't fetch — that's the 545 `stats.g.doubleclick.net` notices — and `img_src` had no analytics host at all, so the same failure was queued up there behind a host we hadn't hit yet. Splatting one list into both makes the asymmetry impossible rather than fixing half of it.

- **Each host appears bare and wildcarded**, since `*.` deliberately never matches the bare domain — that rule is what the original fix tripped on. Retires `www.google-analytics.com` from `connect_src`, which `*.google-analytics.com` had already covered.

The spec's directive-keyed hashes become `[directive, uri]` pairs so one directive can hold several cases, and a negative case pins the wildcard to a label boundary (`analytics.google.com.evil.com` must not match) — the matcher is a hand-rolled `end_with?`, so that's the failure mode an edit to it would introduce silently.
