### PR TITLE
Label register step 1's email field with the organization's custom label

### DIFF
--- a/app/components/register/step1/component.en.yml
+++ b/app/components/register/step1/component.en.yml
@@ -8,7 +8,7 @@ en:
         electric_motorized: "⚡️ Electric (motorized)"
         email: Email
         email_placeholder: you@example.com
-        email_placeholder_school: "%{org_name} email"
+        email_school: "%{org_name} email"
         just_the_essentials: Just the essentials to start.
         next: Next
         no_need_to_wait: We'll email a confirmation link — you don't have to wait

--- a/app/components/register/step1/component.html.erb
+++ b/app/components/register/step1/component.html.erb
@@ -59,7 +59,7 @@
     <%= render Register::SectionLabel::Component.new(text: translation(".your_info"), divider: true) %>
 
     <%= render(UI::Forms::Group::Component.new(form_builder: f, attribute: :owner_email,
-        label_text: translation(".email"), required: true, wrapper_class: "tw:mb-6")) do %>
+        label_text: email_label, required: true, wrapper_class: "tw:mb-6")) do %>
       <%= render UI::Forms::Email::Component.new(form_builder: f, attribute: :owner_email, required: true,
           html_options: {value: @b_param.owner_email, placeholder: email_placeholder}) %>
     <% end %>

--- a/app/components/register/step1/component.rb
+++ b/app/components/register/step1/component.rb
@@ -35,12 +35,15 @@ module Register
         tag.span(cycle_type, data: {"register--heading-target": "cycleType"})
       end
 
-      # A university wants the campus address, not any address the rider has. The label a
-      # paid organization sets in admin wins; failing that a school's name stands in for
-      # the example, which is what the legacy embed form does with the same setting
-      def email_placeholder
+      # owner_email is the setting bikes/new labels its email field with
+      def email_label
         helpers.registration_field_label(organization, "owner_email", strip_tags: true) ||
-          (translation(".email_placeholder_school", org_name: organization.short_name) if organization&.school?) ||
+          (translation(".email_school", org_name: organization.short_name) if organization&.school?) ||
+          translation(".email")
+      end
+
+      def email_placeholder
+        helpers.registration_field_label(organization, "email_placeholder", strip_tags: true) ||
           translation(".email_placeholder")
       end
 

--- a/app/jobs/update_organization_associations_job.rb
+++ b/app/jobs/update_organization_associations_job.rb
@@ -17,6 +17,7 @@ class UpdateOrganizationAssociationsJob < ApplicationJob
       organization.update(skip_update: true, updated_at: Time.current)
       add_organization_manufacturers(organization)
       update_organization_stolen_message(organization)
+      update_email_placeholder(organization)
 
       if organization.enabled?("impound_bikes_locations")
         # If there is isn't a default impound bikes location and there should be, set one
@@ -76,6 +77,28 @@ class UpdateOrganizationAssociationsJob < ApplicationJob
       OrganizationManufacturer.create(manufacturer_id: manufacturer_id,
         organization_id: organization.id)
     end
+  end
+
+  # Whatever domain the organization's own people sign in with is the one its
+  # registrations ask for
+  def update_email_placeholder(organization)
+    return if organization.registration_field_labels["email_placeholder"].present?
+
+    domain = organization.user_email_domain.presence || auto_user_email_domain(organization)
+    return if domain.blank?
+
+    organization.update(skip_update: true, registration_field_labels:
+      organization.registration_field_labels.merge("email_placeholder" => "you@#{domain}"))
+  end
+
+  # The auto user is Bike Index's own account when an organization has no members of
+  # its own, which says nothing about the organization's domain
+  def auto_user_email_domain(organization)
+    email = organization.auto_user&.email
+    return if email.blank? || email == ENV["AUTO_ORG_MEMBER"]
+
+    domain = email.split("@").last
+    domain unless domain == "bikeindex.org"
   end
 
   def update_organization_stolen_message(organization)

--- a/app/models/organization_feature.rb
+++ b/app/models/organization_feature.rb
@@ -113,9 +113,14 @@ class OrganizationFeature < ApplicationRecord
       REG_FIELDS
     end
 
+    # Customizable by any paid organization, unlike the reg fields
+    def email_customizable_labels
+      %w[owner_email email_placeholder]
+    end
+
     def reg_fields_with_customizable_labels
       # Can't rename bike_stickers
-      %w[owner_email] + reg_fields - %w[reg_bike_sticker]
+      email_customizable_labels + reg_fields - %w[reg_bike_sticker]
     end
 
     def reg_fields_organization_uniq

--- a/app/views/admin/organizations/_form.html.haml
+++ b/app/views/admin/organizations/_form.html.haml
@@ -197,25 +197,27 @@
                 %span.small.less-strong Ask Seth for help changing this, it's delicate
 
           - OrganizationFeature.reg_fields_with_customizable_labels.each do |reg_field|
-            -# Separate handling for owner_email
-            - if reg_field == "owner_email" && @organization.paid?
-              .form-group.small
-                = label_tag "reg_label-#{reg_field}" do
+            -# The email fields aren't features, so paid? is what gates them
+            - email_field = OrganizationFeature.email_customizable_labels.include?(reg_field)
+            - next unless email_field ? @organization.paid? : @organization.enabled?(reg_field)
+            .form-group.small
+              = label_tag "reg_label-#{reg_field}" do
+                - if reg_field == "owner_email"
                   Custom Label for
                   %em Owner Email
                   (e.g. "uiowa.edu email")
                   %small.less-strong often desired by universities
-                = text_field_tag "reg_label-#{reg_field}", registration_field_label(@organization, reg_field), {class: "form-control"}
-            - elsif @organization.enabled?(reg_field)
-              - reg_attr = OrganizationFeature.reg_field_to_bike_attrs(reg_field)
-              - reg_attr_title = reg_attr.titleize(keep_id_suffix: true)
-              .form-group.small
-                = label_tag "reg_label-#{reg_field}" do
+                - elsif reg_field == "email_placeholder"
+                  Custom Placeholder for
+                  %em Owner Email
+                  (e.g. "you@uiowa.edu")
+                  %small.less-strong the greyed out example inside the empty field
+                - else
                   Custom Label for
-                  %em= reg_attr_title
+                  %em= OrganizationFeature.reg_field_to_bike_attrs(reg_field).titleize(keep_id_suffix: true)
                   %small.less-strong
                     leave blank unless it's <strong>absolutely</strong> required - default behavior is preferred
-                = text_field_tag "reg_label-#{reg_field}", registration_field_label(@organization, reg_field), {class: "form-control"}
+              = text_field_tag "reg_label-#{reg_field}", registration_field_label(@organization, reg_field), {class: "form-control"}
 
           - if @organization.enabled?("organization_stolen_message")
             - organization_stolen_message = OrganizationStolenMessage.for(@organization)

--- a/db/seeds/seed_organizations.rb
+++ b/db/seeds/seed_organizations.rb
@@ -86,7 +86,8 @@ if brakebills.avatar.blank?
 end
 
 brakebills_landing_template = File.read(Rails.root.join("db/seeds/brakebills_landing_page.html.erb"))
-brakebills.update!(landing_html: ERB.new(brakebills_landing_template).result(binding))
+brakebills.update!(landing_html: ERB.new(brakebills_landing_template).result(binding),
+  registration_field_labels: {owner_email: "Brakebills email"})
 
 # --- Ike's Bikes ---
 ikes = Organization.find_by_name("Ikes Bike's") || Organization.create(name: "Ikes Bike's", website: "", short_name: "Ikes", show_on_map: true)

--- a/spec/components/register/step1/component_spec.rb
+++ b/spec/components/register/step1/component_spec.rb
@@ -15,32 +15,45 @@ RSpec.describe Register::Step1::Component, type: :component do
       steps: BikeServices::Register.steps(reloaded, sequence: nil)))
   end
 
+  # Minus the required "*" the label carries
+  def email_label
+    page.find("label[for='b_param_owner_email']").text.delete("*").strip
+  end
+
   def email_placeholder
     page.find("input[name='b_param[owner_email]']")["placeholder"]
   end
 
-  describe "the email placeholder" do
-    # The same setting the legacy embed form reads, so a university asking for the
-    # campus address keeps asking for it here
-    it "takes the organization's, and falls back to the example address" do
+  describe "the email label and placeholder" do
+    it "take the organization's, and fall back to the generic word and example address" do
       render_step_1
+      expect(email_label).to eq "Email"
       expect(email_placeholder).to eq "you@example.com"
 
       # A school has a name worth asking by, without anyone setting one
       organization.update(kind: "school")
       render_step_1
-      expect(email_placeholder).to eq "Brakebills email"
+      expect(email_label).to eq "Brakebills email"
 
-      # The label set in admin wins over the school's name
+      # The admin label wins over the school's name, and names the field rather
+      # than the address inside it
       organization.update(registration_field_labels: {owner_email: "brakebills.edu email"})
       render_step_1
-      expect(email_placeholder).to eq "brakebills.edu email"
+      expect(email_label).to eq "brakebills.edu email"
+      expect(email_placeholder).to eq "you@example.com"
+
+      organization.update(registration_field_labels: {owner_email: "brakebills.edu email",
+                                                      email_placeholder: "you@brakebills.edu"})
+      render_step_1
+      expect(email_placeholder).to eq "you@brakebills.edu"
+      expect(email_label).to eq "brakebills.edu email"
     end
 
-    it "is the example address without an organization" do
+    it "are the generic word and example address without an organization" do
       b_param.update(params: {bike: {owner_email: "owner@bikeindex.org"}}.as_json)
       render_step_1
 
+      expect(email_label).to eq "Email"
       expect(email_placeholder).to eq "you@example.com"
     end
   end

--- a/spec/jobs/update_organization_associations_job_spec.rb
+++ b/spec/jobs/update_organization_associations_job_spec.rb
@@ -162,4 +162,53 @@ RSpec.describe UpdateOrganizationAssociationsJob, type: :job do
       expect(organization_stolen_message.reload.is_enabled).to be_falsey
     end
   end
+
+  describe "email_placeholder" do
+    let(:organization) { FactoryBot.create(:organization) }
+
+    def email_placeholder
+      organization.reload.registration_field_labels["email_placeholder"]
+    end
+
+    it "takes the user_email_domain, and doesn't overwrite an existing placeholder" do
+      instance.perform(organization.id)
+      expect(email_placeholder).to be_blank
+
+      organization.update(user_email_domain: "uiowa.edu", skip_update: true)
+      instance.perform(organization.id)
+      expect(email_placeholder).to eq "you@uiowa.edu"
+
+      organization.update(user_email_domain: "brakebills.edu", skip_update: true)
+      instance.perform(organization.id)
+      expect(email_placeholder).to eq "you@uiowa.edu"
+    end
+
+    context "with an auto_user" do
+      let(:user) { FactoryBot.create(:user_confirmed, email: "sarah@uiowa.edu") }
+      let(:organization) { FactoryBot.create(:organization_with_auto_user, user:) }
+
+      it "takes the auto_user's domain" do
+        instance.perform(organization.id)
+        expect(email_placeholder).to eq "you@uiowa.edu"
+      end
+
+      context "auto_user is the AUTO_ORG_MEMBER" do
+        let(:user) { FactoryBot.create(:user_confirmed, email: ENV["AUTO_ORG_MEMBER"]) }
+
+        it "doesn't set a placeholder" do
+          instance.perform(organization.id)
+          expect(email_placeholder).to be_blank
+        end
+      end
+
+      context "auto_user is a bikeindex.org address" do
+        let(:user) { FactoryBot.create(:user_confirmed, email: "seth@bikeindex.org") }
+
+        it "doesn't set a placeholder" do
+          instance.perform(organization.id)
+          expect(email_placeholder).to be_blank
+        end
+      end
+    end
+  end
 end

--- a/spec/models/organization_feature_spec.rb
+++ b/spec/models/organization_feature_spec.rb
@@ -82,8 +82,8 @@ RSpec.describe OrganizationFeature, type: :model do
     let(:organization) { FactoryBot.build(:organization) }
     it "includes expected" do
       labeled_fields = OrganizationFeature.reg_fields_with_customizable_labels
-      expect(labeled_fields.count).to eq OrganizationFeature::REG_FIELDS.count
       expect(labeled_fields).to include("owner_email")
+      expect(labeled_fields).to include("email_placeholder")
       expect(labeled_fields).to_not include("reg_bike_sticker")
     end
   end
@@ -92,7 +92,8 @@ RSpec.describe OrganizationFeature, type: :model do
     let(:target_kinds) do
       %w[regional_bike_counts passwordless_users graduated_notifications
         organization_stolen_message saml_sso reg_extra_registration_number
-        reg_organization_affiliation reg_address reg_phone reg_student_id owner_email]
+        reg_organization_affiliation reg_address reg_phone reg_student_id owner_email
+        email_placeholder]
     end
     it "is expected" do
       expect(OrganizationFeature.with_admin_organization_attributes).to match_array target_kinds

--- a/spec/requests/admin/organizations_request_spec.rb
+++ b/spec/requests/admin/organizations_request_spec.rb
@@ -55,6 +55,16 @@ RSpec.describe Admin::OrganizationsController, type: :request do
       expect(response.status).to eq(200)
       expect(response).to render_template("admin/organizations/edit")
     end
+    context "paid" do
+      let(:organization) { FactoryBot.create(:organization_with_organization_features, enabled_feature_slugs: "reg_address") }
+      it "renders the email label and placeholder fields" do
+        Country.united_states
+        get "#{base_url}/#{organization.to_param}/edit"
+        expect(response.status).to eq(200)
+        expect(response.body).to include('name="reg_label-owner_email"')
+        expect(response.body).to include('name="reg_label-email_placeholder"')
+      end
+    end
     context "saml_sso enabled" do
       let(:organization) { FactoryBot.create(:organization_with_organization_features, enabled_feature_slugs: "saml_sso") }
       it "renders the SAML configuration section" do
@@ -290,7 +300,10 @@ RSpec.describe Admin::OrganizationsController, type: :request do
       end
     end
     context "updating registration labels" do
-      let(:target) { {reg_student_id: "party label", reg_address: "useful label", owner_email: "<p>stuff</p> again", unknown_attr: "Whoop"} }
+      let(:target) do
+        {reg_student_id: "party label", reg_address: "useful label", owner_email: "<p>stuff</p> again",
+         email_placeholder: "you@party.edu", unknown_attr: "Whoop"}
+      end
       let(:update_params) do
         {
           :organization => {name: "new name"},
@@ -298,6 +311,7 @@ RSpec.describe Admin::OrganizationsController, type: :request do
           "reg_label-reg_address" => "useful label",
           "reg_label-reg_organization_affiliation" => "  ",
           "reg_label-owner_email" => "<p>stuff</p> again ",
+          "reg_label-email_placeholder" => "you@party.edu",
           "reg_label-unknown_attr" => "Whoop"
 
         }


### PR DESCRIPTION
Register step 1 read the organization's `owner_email` label into the email field's *placeholder* (#4112). It labels the field with it now — which is what `bikes/new` and the org embed fields have always done with the same setting — and a new `email_placeholder` registration label takes over the placeholder. A school's short name still stands in when nothing is set ("Brakebills email"), now as the label.

- **`UpdateOrganizationAssociationsJob` fills a blank `email_placeholder`** with `you@user_email_domain`, or the auto user's domain when that isn't set — skipping the Bike Index account that stands in for an organization without members of its own. An admin's own value is never overwritten.
- **Both keys are editable in the admin organization form**, gated on `paid?` rather than a feature slug. The three near-identical `reg_label-` inputs collapse into one skeleton that varies only its copy.
- **Brakebills seeds an `owner_email` label**, so dev and review apps show a customized field.

Worth a look before this merges: an organization that set `owner_email` to an example address (`you@uiowa.edu`) — because the legacy `/registrations/embed` renders that key as a placeholder — will now see it as the field's label, and wants moving to the new key.
