### PR TITLE
Show current mail snippets in the customize-emails preview

### DIFF
--- a/app/assets/stylesheets/revised/emails/email_components.scss
+++ b/app/assets/stylesheets/revised/emails/email_components.scss
@@ -163,10 +163,6 @@ $alert-warning-color: #ffc107;
   p {
     margin: 12px 0 0;
   }
-
-  &.subtle {
-    margin-top: $vertical-height;
-  }
 }
 
 .finished-registration-security {

--- a/app/components/emails/finished_registration/component.html.erb
+++ b/app/components/emails/finished_registration/component.html.erb
@@ -48,7 +48,7 @@
 
   <% unless claimed? %>
     <div class="finished-registration-cta">
-      <%= link_to claim_cta_text, bike_url_with_token, "data-pm-no-track" => true, class: "binx-button" %>
+      <%= link_to cta_text, bike_url_with_token, "data-pm-no-track" => true, class: "binx-button" %>
 
       <p>
         <%= translation("sign_up_on_bikeindexorg_to_claim_your_bik", bike_type: bike.type) %>
@@ -99,7 +99,7 @@
 
   <% if show_view_bike_cta? %>
     <div class="finished-registration-cta">
-      <%= link_to translation("view_your_bike"), bike_url_with_token, "data-pm-no-track" => true, class: "binx-button" %>
+      <%= link_to cta_text, bike_url_with_token, "data-pm-no-track" => true, class: "binx-button" %>
     </div>
   <% end %>
 </div>
@@ -236,6 +236,8 @@
         <strong><%= translation("spread_the_word_title") %></strong>
         <%= translation("spread_the_word_body") %>
       </p>
+
+      <%= link_to cta_text, bike_url_with_token, "data-pm-no-track" => true, class: "binx-button" %>
     </div>
 
     <table

--- a/app/components/emails/finished_registration/component.html.erb
+++ b/app/components/emails/finished_registration/component.html.erb
@@ -45,6 +45,16 @@
       </p>
     <% end %>
   <% end %>
+
+  <% unless claimed? %>
+    <div class="finished-registration-cta">
+      <%= link_to claim_cta_text, bike_url_with_token, "data-pm-no-track" => true, class: "binx-button" %>
+
+      <p>
+        <%= translation("sign_up_on_bikeindexorg_to_claim_your_bik", bike_type: bike.type) %>
+      </p>
+    </div>
+  <% end %>
 </div>
 
 <% if show_after_welcome_snippet? %>
@@ -90,14 +100,6 @@
   <% if show_view_bike_cta? %>
     <div class="finished-registration-cta">
       <%= link_to translation("view_your_bike"), bike_url_with_token, "data-pm-no-track" => true, class: "binx-button" %>
-    </div>
-  <% elsif !claimed? %>
-    <div class="finished-registration-cta">
-      <%= link_to claim_cta_text, bike_url_with_token, "data-pm-no-track" => true, class: "binx-button" %>
-
-      <p>
-        <%= translation("sign_up_on_bikeindexorg_to_claim_your_bik", bike_type: bike.type) %>
-      </p>
     </div>
   <% end %>
 </div>

--- a/app/components/emails/finished_registration/component.html.erb
+++ b/app/components/emails/finished_registration/component.html.erb
@@ -87,7 +87,11 @@
     </div>
   <% end %>
 
-  <% unless claimed? %>
+  <% if show_view_bike_cta? %>
+    <div class="finished-registration-cta">
+      <%= link_to translation("view_your_bike"), bike_url_with_token, "data-pm-no-track" => true, class: "binx-button" %>
+    </div>
+  <% elsif !claimed? %>
     <div class="finished-registration-cta">
       <%= link_to claim_cta_text, bike_url_with_token, "data-pm-no-track" => true, class: "binx-button" %>
 
@@ -116,7 +120,7 @@
       <tbody>
         <tr>
           <td class="locking-copy">
-            <h3>
+            <h3 class="uncap" style="font-weight: 400">
               <%= translation("use_a_ulock") %> <%= translation("cable_locks_should_never_be_used") %>
             </h3>
           </td>
@@ -220,10 +224,6 @@
         </tr>
       </tbody>
     </table>
-
-    <div class="finished-registration-cta subtle">
-      <%= link_to translation("view_your_bike"), bike_url_with_token, "data-pm-no-track" => true, class: "binx-button" %>
-    </div>
   </div>
 <% end %>
 
@@ -234,10 +234,6 @@
         <strong><%= translation("spread_the_word_title") %></strong>
         <%= translation("spread_the_word_body") %>
       </p>
-
-      <% if claimed? %>
-        <%= link_to translation("view_your_bike"), bike_url_with_token, "data-pm-no-track" => true, class: "binx-button" %>
-      <% end %>
     </div>
 
     <table

--- a/app/components/emails/finished_registration/component.rb
+++ b/app/components/emails/finished_registration/component.rb
@@ -9,14 +9,19 @@ module Emails
           ownership.organization_id.blank?
       end
 
-      def initialize(ownership:, bike: nil, email_preview: false)
+      def initialize(ownership:, bike: nil, email_preview: false, versioned: true)
         @ownership = ownership
         @bike = bike
         @email_preview = email_preview
+        @versioned = versioned
       end
 
       def email_sent_at
         @ownership&.created_at if @ownership&.persisted?
+      end
+
+      def snippet_time
+        email_sent_at if @versioned
       end
 
       private
@@ -39,6 +44,10 @@ module Emails
 
       def show_default_security_section?
         !show_security_snippet? && !bike.status_impounded?
+      end
+
+      def show_view_bike_cta?
+        claimed? && !bike.status_impounded?
       end
 
       def show_whats_next_section?
@@ -92,7 +101,7 @@ module Emails
       end
 
       def organization_snippet_body(kind)
-        @organization_snippet_bodies ||= Hash.new { |h, k| h[k] = organization&.mail_snippet_body(k, time: email_sent_at) }
+        @organization_snippet_bodies ||= Hash.new { |h, k| h[k] = organization&.mail_snippet_body(k, time: snippet_time) }
         @organization_snippet_bodies[kind]
       end
 

--- a/app/components/emails/finished_registration/component.rb
+++ b/app/components/emails/finished_registration/component.rb
@@ -90,7 +90,8 @@ module Emails
         end
       end
 
-      def claim_cta_text
+      def cta_text
+        return translation("view_your_bike") if claimed?
         return translation("claim_the_bike_type", bike_type: bike.type) if registered_by_owner?
 
         translation("confirm_this_bike_type", bike_type: bike.type)

--- a/app/components/emails/graduated_notification/component.rb
+++ b/app/components/emails/graduated_notification/component.rb
@@ -3,14 +3,19 @@
 module Emails
   module GraduatedNotification
     class Component < ApplicationComponent
-      def initialize(graduated_notification:, bike: nil, email_preview: false)
+      def initialize(graduated_notification:, bike: nil, email_preview: false, versioned: true)
         @graduated_notification = graduated_notification
         @bike = bike
         @email_preview = email_preview
+        @versioned = versioned
       end
 
       def email_sent_at
         @graduated_notification.sent_at
+      end
+
+      def snippet_time
+        email_sent_at if @versioned
       end
 
       private
@@ -24,7 +29,7 @@ module Emails
       end
 
       def organization_snippet_body
-        MailSnippet.for_organization(organization_id: organization.id, kind: "graduated_notification", time: email_sent_at)&.body
+        MailSnippet.for_organization(organization_id: organization.id, kind: "graduated_notification", time: snippet_time)&.body
       end
 
       def tokenized_url

--- a/app/components/emails/impound_claim_approved_or_denied/component.rb
+++ b/app/components/emails/impound_claim_approved_or_denied/component.rb
@@ -3,12 +3,17 @@
 module Emails
   module ImpoundClaimApprovedOrDenied
     class Component < ApplicationComponent
-      def initialize(impound_claim:)
+      def initialize(impound_claim:, versioned: true)
         @impound_claim = impound_claim
+        @versioned = versioned
       end
 
       def email_sent_at
         @impound_claim&.resolved_at
+      end
+
+      def snippet_time
+        email_sent_at if @versioned
       end
 
       private
@@ -28,7 +33,7 @@ module Emails
       def organization_message_snippet_body
         return nil unless @impound_claim.organized? && snippet_kind.present?
 
-        MailSnippet.for_organization(organization_id: organization.id, kind: snippet_kind, time: email_sent_at)&.body
+        MailSnippet.for_organization(organization_id: organization.id, kind: snippet_kind, time: snippet_time)&.body
       end
 
       def snippet_kind

--- a/app/components/emails/parking_notification/component.rb
+++ b/app/components/emails/parking_notification/component.rb
@@ -3,14 +3,19 @@
 module Emails
   module ParkingNotification
     class Component < ApplicationComponent
-      def initialize(parking_notification:, bike: nil, email_preview: false)
+      def initialize(parking_notification:, bike: nil, email_preview: false, versioned: true)
         @parking_notification = parking_notification
         @bike = bike
         @email_preview = email_preview
+        @versioned = versioned
       end
 
       def email_sent_at
         @parking_notification.sent_at
+      end
+
+      def snippet_time
+        email_sent_at if @versioned
       end
 
       private
@@ -24,7 +29,7 @@ module Emails
       end
 
       def organization_snippet_body
-        MailSnippet.for_organization(organization_id: organization.id, kind: @parking_notification.kind, time: email_sent_at)&.body
+        MailSnippet.for_organization(organization_id: organization.id, kind: @parking_notification.kind, time: snippet_time)&.body
       end
 
       def impound_record

--- a/app/components/emails/partial_registration/component.rb
+++ b/app/components/emails/partial_registration/component.rb
@@ -3,13 +3,18 @@
 module Emails
   module PartialRegistration
     class Component < ApplicationComponent
-      def initialize(b_param:, email_preview: false)
+      def initialize(b_param:, email_preview: false, versioned: true)
         @b_param = b_param
         @email_preview = email_preview
+        @versioned = versioned
       end
 
       def email_sent_at
         @b_param&.created_at if @b_param&.persisted?
+      end
+
+      def snippet_time
+        email_sent_at if @versioned
       end
 
       private
@@ -23,7 +28,7 @@ module Emails
       end
 
       def organization_snippet_body
-        organization&.mail_snippet_body("partial_registration", time: email_sent_at)
+        organization&.mail_snippet_body("partial_registration", time: snippet_time)
       end
     end
   end

--- a/app/controllers/organized/emails_controller.rb
+++ b/app/controllers/organized/emails_controller.rb
@@ -12,9 +12,10 @@ module Organized
       @email_preview = true
       @organization = current_organization
       component = OrganizedServices::EmailPreview.view_component(
-        kind: @kind, organization: current_organization, user: current_user, params: params
+        kind: @kind, organization: current_organization, user: current_user, params:,
+        versioned: Binxtils::InputNormalizer.boolean(params[:versioned])
       )
-      @email_sent_at = component.email_sent_at if Binxtils::InputNormalizer.boolean(params[:versioned])
+      @email_sent_at = component.snippet_time
       render component, layout: "email"
     end
 

--- a/app/services/organized_services/email_preview.rb
+++ b/app/services/organized_services/email_preview.rb
@@ -5,26 +5,26 @@ module OrganizedServices
     # Placeholder for tokenized URLs in email previews — to make sure preview token links don't work
     TOKEN_PATH = "/404"
 
-    def view_component(kind:, organization:, user:, params:)
+    def view_component(kind:, organization:, user:, params:, versioned:)
       if ParkingNotification.kinds.include?(kind)
         parking_notification = find_or_build_parking_notification(kind:, organization:, user:, params:)
         bike = parking_notification.bike || default_bike(organization:, user:)
-        Emails::ParkingNotification::Component.new(parking_notification:, bike:, email_preview: true)
+        Emails::ParkingNotification::Component.new(parking_notification:, bike:, email_preview: true, versioned:)
       elsif kind == "graduated_notification"
         graduated_notification = find_or_build_graduated_notification(organization:, user:, params:)
         bike = graduated_notification.bike || default_bike(organization:, user:)
-        Emails::GraduatedNotification::Component.new(graduated_notification:, bike:, email_preview: true)
+        Emails::GraduatedNotification::Component.new(graduated_notification:, bike:, email_preview: true, versioned:)
       elsif %w[impound_claim_approved impound_claim_denied].include?(kind)
         Emails::ImpoundClaimApprovedOrDenied::Component.new(
-          impound_claim: find_or_build_impound_claim(kind:, organization:, params:)
+          impound_claim: find_or_build_impound_claim(kind:, organization:, params:), versioned:
         )
       elsif kind == "partial_registration"
         b_param = organization.b_params.order(:created_at).last ||
           BParam.new(organization_id: organization.id)
-        Emails::PartialRegistration::Component.new(b_param:, email_preview: true)
+        Emails::PartialRegistration::Component.new(b_param:, email_preview: true, versioned:)
       else
         bike = (kind == "organization_stolen_message") ? default_stolen_bike(organization:, user:) : default_bike(organization:, user:)
-        Emails::FinishedRegistration::Component.new(ownership: bike.current_ownership, bike:, email_preview: true)
+        Emails::FinishedRegistration::Component.new(ownership: bike.current_ownership, bike:, email_preview: true, versioned:)
       end
     end
 

--- a/app/views/shared/_claim_message.html.erb
+++ b/app/views/shared/_claim_message.html.erb
@@ -2,7 +2,7 @@
 <% ownership = bike.current_ownership %>
 <% skip_to_see ||= false %>
 
-<p style="font-style: italic">
+<p>
   <% if OrganizationDisplayer.avatar?(ownership.organization) %>
     <%= image_tag ownership.organization.avatar.url(:medium), alt: ownership.organization.name, class: "claim-message-org-avatar" %>
   <% end %>

--- a/app/views/shared/_claim_message.html.erb
+++ b/app/views/shared/_claim_message.html.erb
@@ -2,7 +2,7 @@
 <% ownership = bike.current_ownership %>
 <% skip_to_see ||= false %>
 
-<p>
+<p style="font-style: italic">
   <% if OrganizationDisplayer.avatar?(ownership.organization) %>
     <%= image_tag ownership.organization.avatar.url(:medium), alt: ownership.organization.name, class: "claim-message-org-avatar" %>
   <% end %>

--- a/db/seeds/seed_organized_emails.rb
+++ b/db/seeds/seed_organized_emails.rb
@@ -10,7 +10,7 @@ user = User.find_by_email("user@bikeindex.org")
 raise "missing Brakebills org or test users" if brakebills.blank? || member.blank? || user.blank?
 
 # --- Mail snippets ---
-# Bodies for the "structural" snippets (header/welcome/footer/security/partial_registration)
+# Bodies for the "structural" snippets (header/welcome/after_welcome/footer/security/partial_registration)
 # are copied verbatim from the dev database's Brakebills records. The notification-kind
 # snippets exercise the `organization_message_snippet` paths in OrganizedMailer previews.
 snippets = {
@@ -30,6 +30,14 @@ snippets = {
     body: <<~HTML
       <p style="color: purple; margin: 20px 0; text-align: center;">
         <strong>We can add text here!</strong> - this is the <em>welcome</em>  snippet
+      </p>
+    HTML
+  },
+  "after_welcome" => {
+    is_enabled: true,
+    body: <<~HTML
+      <p style="color: purple; margin: 20px 0; text-align: center;">
+        <strong>We can add text here!</strong> - this is the <em>After Welcome</em>  snippet
       </p>
     HTML
   },

--- a/spec/components/emails/finished_registration/component_spec.rb
+++ b/spec/components/emails/finished_registration/component_spec.rb
@@ -28,7 +28,8 @@ RSpec.describe Emails::FinishedRegistration::Component, type: :component do
       expect(component).to have_content("Use a U-Lock")
       expect(component).to_not have_content("thieves are jerks")
       expect(component).to have_content("tempo-snippet")
-      expect(component.css("a.binx-button").map { |a| a.text.strip }).to eq(["View your bike"])
+      # Below the bike details, and again in the promo callout
+      expect(component.css("a.binx-button").map { |a| a.text.strip }).to eq(["View your bike", "View your bike"])
       expect(component.css(".finished-registration-bike-box a.binx-button").count).to eq 1
     end
     context "tempo_snippet not is_enabled" do
@@ -84,9 +85,10 @@ RSpec.describe Emails::FinishedRegistration::Component, type: :component do
       expect(component).to_not have_content("Registration complete")
       expect(component).to_not have_content("Confirm your registration")
       expect(component).to have_content("Claim your bike")
-      expect(component).to have_link("Confirm this #{bike.type}")
       expect(component).to_not have_link("View your bike")
-      # Above the bike details
+      # Above the bike details, and again in the promo callout
+      expect(component.css("a.binx-button").map { |a| a.text.strip })
+        .to eq(["Confirm this #{bike.type}", "Confirm this #{bike.type}"])
       expect(component.css(".finished-registration-intro a.binx-button").count).to eq 1
       expect(component).to_not have_content("What's next?")
     end

--- a/spec/components/emails/finished_registration/component_spec.rb
+++ b/spec/components/emails/finished_registration/component_spec.rb
@@ -28,7 +28,6 @@ RSpec.describe Emails::FinishedRegistration::Component, type: :component do
       expect(component).to have_content("Use a U-Lock")
       expect(component).to_not have_content("thieves are jerks")
       expect(component).to have_content("tempo-snippet")
-      # The only button, and it's in the bike details card
       expect(component.css("a.binx-button").map { |a| a.text.strip }).to eq(["View your bike"])
       expect(component.css(".finished-registration-bike-box a.binx-button").count).to eq 1
     end
@@ -87,6 +86,8 @@ RSpec.describe Emails::FinishedRegistration::Component, type: :component do
       expect(component).to have_content("Claim your bike")
       expect(component).to have_link("Confirm this #{bike.type}")
       expect(component).to_not have_link("View your bike")
+      # Above the bike details
+      expect(component.css(".finished-registration-intro a.binx-button").count).to eq 1
       expect(component).to_not have_content("What's next?")
     end
   end

--- a/spec/components/emails/finished_registration/component_spec.rb
+++ b/spec/components/emails/finished_registration/component_spec.rb
@@ -28,6 +28,9 @@ RSpec.describe Emails::FinishedRegistration::Component, type: :component do
       expect(component).to have_content("Use a U-Lock")
       expect(component).to_not have_content("thieves are jerks")
       expect(component).to have_content("tempo-snippet")
+      # The only button, and it's in the bike details card
+      expect(component.css("a.binx-button").map { |a| a.text.strip }).to eq(["View your bike"])
+      expect(component.css(".finished-registration-bike-box a.binx-button").count).to eq 1
     end
     context "tempo_snippet not is_enabled" do
       let(:tempo_snippet_is_enabled) { false }
@@ -58,6 +61,7 @@ RSpec.describe Emails::FinishedRegistration::Component, type: :component do
       expect(component).to have_content("donating")
       expect(component).to_not have_content("What's next?")
       expect(component).to_not have_content("tempo-snippet")
+      expect(component.css(".finished-registration-bike-box a.binx-button").map { |a| a.text.strip }).to eq(["View your bike"])
     end
   end
 
@@ -82,6 +86,7 @@ RSpec.describe Emails::FinishedRegistration::Component, type: :component do
       expect(component).to_not have_content("Confirm your registration")
       expect(component).to have_content("Claim your bike")
       expect(component).to have_link("Confirm this #{bike.type}")
+      expect(component).to_not have_link("View your bike")
       expect(component).to_not have_content("What's next?")
     end
   end

--- a/spec/requests/organized/emails_request_spec.rb
+++ b/spec/requests/organized/emails_request_spec.rb
@@ -237,8 +237,17 @@ RSpec.describe Organized::EmailsController, type: :request do
             end
           end
 
-          it "renders snippets as they were at ownership.created_at" do
+          it "renders the current snippets, and the snippets at ownership.created_at when versioned" do
             get "#{base_url}/finished_registration"
+            expect(response.status).to eq(200)
+            expect(response.body).to include("welcome now")
+            expect(response.body).to include("after_welcome now")
+            expect(response.body).to include("security now")
+            expect(response.body).to_not include("welcome when sent")
+            expect(response.body).to_not include("after_welcome when sent")
+            expect(response.body).to_not include("security when sent")
+
+            get "#{base_url}/finished_registration", params: {versioned: true}
             expect(response.status).to eq(200)
             expect(response.body).to include("welcome when sent")
             expect(response.body).to include("after_welcome when sent")

--- a/spec/services/organized_services/email_preview_spec.rb
+++ b/spec/services/organized_services/email_preview_spec.rb
@@ -4,9 +4,10 @@ RSpec.describe OrganizedServices::EmailPreview do
   let(:organization) { FactoryBot.create(:organization) }
   let(:user) { FactoryBot.create(:user) }
   let(:params) { ActionController::Parameters.new }
+  let(:versioned) { false }
 
   describe "view_component" do
-    subject(:component) { described_class.view_component(kind:, organization:, user:, params:) }
+    subject(:component) { described_class.view_component(kind:, organization:, user:, params:, versioned:) }
 
     context "with a parking_notification kind" do
       let(:kind) { "appears_abandoned_notification" }


### PR DESCRIPTION
A snippet edited today never showed up in `/o/<slug>/emails/finished_registration/edit`. The preview renders the organization's most recent bike, and the email components were resolving snippets through PaperTrail as of that ownership's `created_at` — so anything newer than the bike was reified away. The layout has never done that to header/footer snippets unless the preview asks with `?versioned=true`; the components now follow the same rule.

- **`versioned` is threaded from the controller through `OrganizedServices::EmailPreview` into all five email components**, where `snippet_time` is the single expression for "render snippets as of" — the layout takes `@email_sent_at` from it rather than re-deriving it. Sent emails and the `?versioned=true` previews (parking and graduated notification pages) are unchanged.
- **The finished registration CTA moved and now reads the same in both places it appears** — `cta_text` is "View your bike" once claimed and "Confirm this bike" before that. Claimed registrations show it below the bike details; unclaimed ones show it above the bike details and the after-welcome snippet, where the "sign up to claim" copy belongs. The spread-the-word callout keeps its copy of the button; the What's next section no longer has a third.
- **Brakebills seeds an `after_welcome` snippet**, alongside the other structural ones.
