### PR TITLE
Add a placeholder to register step 2's owner name field

### DIFF
--- a/.claude/skills/frontend-screenshots/SKILL.md
+++ b/.claude/skills/frontend-screenshots/SKILL.md
@@ -108,7 +108,13 @@ $BASE_URL/rails/view_components/<preview_path>/<scenario>
 
 Use this bare route, not Lookbook's `/lookbook/...`, which wraps the component in its own browser chrome.
 
-The preview page loads Tailwind and renders the component standalone (no site chrome), so this is the one case that captures the viewport rather than the full page (`fullPage: false`); a small ViewComponent render-timing line at the bottom is harmless. Everything else still applies — same PII/seed-data gate, same `(url-path, page-slug)` naming (use a slug like `banner-signed-in`).
+The preview page loads Tailwind and renders the component standalone (no site chrome), so a preview that fits the viewport captures at `fullPage: false`; a small ViewComponent render-timing line at the bottom is harmless. **A preview taller than the viewport still captures `fullPage: true`** — page-sized components (a whole registration step, a long form) put the changed field below 900px, and cropping it out is the one thing the shot exists to show. Measure before choosing:
+
+```js
+() => document.querySelector('<selector for what changed>').getBoundingClientRect().top + window.scrollY
+```
+
+Everything else still applies — same PII/seed-data gate, same `(url-path, page-slug)` naming (use a slug like `banner-signed-in`).
 
 Previews that query the dev DB (e.g. `User.admins.first`) render nothing when that data is missing — if the state doesn't appear, seed first with `bundle exec rails db:seed`. This is component-only: a preview can't show layout/stacking against the rest of the page (e.g. a navbar z-index fix), so use a real page for those.
 

--- a/app/components/register/step2/component.en.yml
+++ b/app/components/register/step2/component.en.yml
@@ -47,6 +47,7 @@ en:
         optional: optional
         or: or
         owner_name: Owner name
+        owner_name_placeholder: First & Last name
         owner_registration: Owner Registration
         owner_registration_description: Registering for myself or on behalf of owner
         phone: Phone

--- a/app/components/register/step2/component.html.erb
+++ b/app/components/register/step2/component.html.erb
@@ -342,7 +342,8 @@
     <% if user_name_required? %>
       <%= render UI::Forms::Group::Component.new(form_builder: f, attribute: :user_name,
           label_text: translation(".owner_name"), required: true,
-          html_options: {value: bike["user_name"], autocomplete: "name"}) %>
+          html_options: {value: bike["user_name"], autocomplete: "name",
+            placeholder: translation(".owner_name_placeholder")}) %>
     <% end %>
 
     <%# The organization's own asks sit under its heading, alongside the contact fields %>


### PR DESCRIPTION
Step 2's owner name input had no placeholder, so nothing signalled it wants a full name rather than a first name or a nickname.

- **`First & Last name` on the `user_name` field**, which only renders when `user_name_required?` — a registration made on someone else's behalf, or one whose owner email isn't the signed-in user's. The `register/step2` `for_someone_else` preview is where it shows.
- **`frontend-screenshots` stops cropping tall previews.** Capturing that preview is what turned it up: its blanket `fullPage: false` for preview URLs cut off the field this PR changes, which sits at ~1120px.
