### PR TITLE
Stop the combobox arrow keys crashing on an empty listbox

### DIFF
--- a/.claude/skills/sandbox-test-setup/SKILL.md
+++ b/.claude/skills/sandbox-test-setup/SKILL.md
@@ -9,6 +9,7 @@ description: >-
   `bundle` or `bin/lint`, needs a running dev server, or hits any of these:
   `env: 'ruby': No such file or directory`, `Could not find 'bundler' (4.0.0.beta2)`,
   `Bundler::RubyVersionMismatch`, `command not found: rspec`,
+  `uninitialized constant Pathname` from a `bin/` script,
   `Sprockets::Rails::Helper::AssetNotFound`, `tailwind.css is not present`,
   `LoadError: Could not open library 'vips.so.42'`, or a Playwright
   browser-not-found or build-number mismatch. The fix is almost never a reinstall

--- a/.claude/skills/sandbox-test-setup/references/local-macos.md
+++ b/.claude/skills/sandbox-test-setup/references/local-macos.md
@@ -2,10 +2,12 @@
 
 Ruby 4.0.6 is installed via [mise](https://mise.jdx.dev/), but Claude
 Code's shell sometimes spawns subprocesses without the mise shim on
-PATH — bare `ruby` then resolves to `/usr/bin/ruby` (2.6) and `bundle`
-fails with `Could not find 'bundler' (4.0.0.beta2)`. **The Ruby is
+PATH — bare `ruby` then resolves to `/usr/bin/ruby` (2.6). **The Ruby is
 installed; the PATH just isn't right** — don't reinstall, don't edit
-the Gemfile.
+the Gemfile. It surfaces differently depending on the entry point:
+
+- `bundle` / `bundle exec` → `Could not find 'bundler' (4.0.x)`
+- a `bin/` script (`bin/rspec`, `bin/lint`) → `uninitialized constant Pathname`
 
 Check first; only prefix PATH if `ruby -v` doesn't already print 4.0.6
 (`mise exec -- ruby`/`bundle` are unreliable in this harness — they
@@ -14,8 +16,12 @@ can still resolve to system 2.6, so use the direct prefix):
 ```bash
 ruby -v
 # If it's not 4.0.6:
-export PATH="/Users/seth/.local/share/mise/installs/ruby/4.0.6/bin:$PATH"
+export PATH="$HOME/.local/share/mise/shims:$PATH"
 ```
+
+The shims directory rather than an `installs/ruby/<version>/bin` path:
+it resolves through `mise.toml`, so it doesn't go stale at the next Ruby
+bump, and it covers Node too.
 
 Then run specs the normal way:
 

--- a/app/javascript/utils/hw_combobox_patch.js
+++ b/app/javascript/utils/hw_combobox_patch.js
@@ -22,6 +22,14 @@ HwComboboxController.prototype.navigate = function (event) {
   navigate.call(this, event)
 }
 
+// The arrow keys pick an option by index, and the gem's wrap-around hands back `undefined`
+// for an empty list -- so ArrowUp on a closed combobox (only ArrowDown opens one first)
+// throws, after the deselect every selection begins with has blanked the field.
+const selectIndex = HwComboboxController.prototype._selectIndex
+HwComboboxController.prototype._selectIndex = function (index) {
+  if (this._visibleOptionElements.length) selectIndex.call(this, index)
+}
+
 // A combobox holding a selection shows its display text, and the caret lands wherever
 // the click did -- so typing inserts into the middle, matches no option, and the gem
 // clears the hidden field along with the selection the user had

--- a/app/javascript/utils/hw_combobox_patch.js
+++ b/app/javascript/utils/hw_combobox_patch.js
@@ -22,9 +22,8 @@ HwComboboxController.prototype.navigate = function (event) {
   navigate.call(this, event)
 }
 
-// The arrow keys pick an option by index, and the gem's wrap-around hands back `undefined`
-// for an empty list -- so ArrowUp on a closed combobox (only ArrowDown opens one first)
-// throws, after the deselect every selection begins with has blanked the field.
+// ArrowUp doesn't open a closed combobox the way ArrowDown does, so it picks out of a
+// hidden listbox -- and the gem's wrap-around hands back `undefined` for an empty list.
 const selectIndex = HwComboboxController.prototype._selectIndex
 HwComboboxController.prototype._selectIndex = function (index) {
   if (this._visibleOptionElements.length) selectIndex.call(this, index)

--- a/app/javascript/utils/hw_combobox_patch.js
+++ b/app/javascript/utils/hw_combobox_patch.js
@@ -22,8 +22,21 @@ HwComboboxController.prototype.navigate = function (event) {
   navigate.call(this, event)
 }
 
-// ArrowUp doesn't open a closed combobox the way ArrowDown does, so it picks out of a
-// hidden listbox -- and the gem's wrap-around hands back `undefined` for an empty list.
+// The gem opens a closed combobox on ArrowDown but not ArrowUp, which WAI-ARIA's pattern
+// opens onto the last option. `_expand` follows `open` because stimulus delivers the
+// `expandedValue` callback too late for the keystroke that set it -- the gem does the same.
+const prepareToFilter = HwComboboxController.prototype.prepareToFilter
+HwComboboxController.prototype.prepareToFilter = function (event) {
+  if (event.key === 'ArrowUp' && this._isClosed) {
+    this.open()
+    this._expand()
+  }
+
+  prepareToFilter.call(this, event)
+}
+
+// Home and End pick by index without opening anything, so they reach the empty option list
+// a closed combobox has -- and the gem's wrap-around hands back `undefined` for that.
 const selectIndex = HwComboboxController.prototype._selectIndex
 HwComboboxController.prototype._selectIndex = function (index) {
   if (this._visibleOptionElements.length) selectIndex.call(this, index)

--- a/spec/components/ui/forms/combobox/component_system_spec.rb
+++ b/spec/components/ui/forms/combobox/component_system_spec.rb
@@ -44,9 +44,7 @@ RSpec.describe UI::Forms::Combobox::Component, :js, type: :system do
   end
 
   context "with a selection already made" do
-    # Typing used to insert wherever the click left the caret, mangling the display into a
-    # query matching no option -- which cleared the hidden field, and the selection with it
-    it "replaces the display rather than typing into the middle of it" do
+    it "keeps the selection under an arrow key, and replaces it whole when typing" do
       visit "/rails/view_components/ui/forms/combobox/component/default"
 
       expect(page).to have_css('[aria-expanded="false"]', wait: 10)
@@ -56,31 +54,21 @@ RSpec.describe UI::Forms::Combobox::Component, :js, type: :system do
 
       expect(find_field("Cycle type").value).to eq "Unicycle"
 
-      # Clicking in selects the display, so the first keystroke replaces it
+      # ArrowUp doesn't open a closed listbox, so it used to pick out of an empty one and
+      # throw -- past the deselect that starts a selection, which had emptied the field
+      find_field("Cycle type").send_keys(:up)
+
+      expect(find_field("Cycle type").value).to eq "Unicycle"
+      expect(find("input[name='cycle_type']", visible: :hidden).value).to eq "Unicycle"
+
+      # Typing used to insert wherever the click left the caret, mangling the display into
+      # a query matching no option -- which cleared the hidden field. Clicking in selects
+      # the display now, so the first keystroke replaces it.
       find_field("Cycle type").click
       send_keys("tand")
 
       expect(find_field("Cycle type").value).to eq "Tandem"
       expect(find("input[name='cycle_type']", visible: :hidden).value).to eq "Tandem"
-    end
-
-    # ArrowUp doesn't open a closed listbox the way ArrowDown does, so it used to pick out
-    # of an empty one -- throwing partway through, with the selection already cleared
-    it "keeps the selection when an arrow key has nothing to move through" do
-      visit "/rails/view_components/ui/forms/combobox/component/default"
-
-      expect(page).to have_css('[aria-expanded="false"]', wait: 10)
-
-      find_field("Cycle type").click
-      find('[role="option"]', text: "Unicycle", exact_text: true).click
-
-      expect(page).to have_css('[aria-expanded="false"]')
-
-      # Focuses without clicking, the way tabbing in does -- a click would reopen it
-      find_field("Cycle type").send_keys(:up)
-
-      expect(find_field("Cycle type").value).to eq "Unicycle"
-      expect(find("input[name='cycle_type']", visible: :hidden).value).to eq "Unicycle"
     end
   end
 

--- a/spec/components/ui/forms/combobox/component_system_spec.rb
+++ b/spec/components/ui/forms/combobox/component_system_spec.rb
@@ -41,10 +41,16 @@ RSpec.describe UI::Forms::Combobox::Component, :js, type: :system do
     send_keys(:escape)
 
     expect(page).to have_css('[aria-expanded="false"]')
+
+    # ArrowUp opens onto the last option, the mirror of ArrowDown's first
+    find_field("Cycle type").send_keys(:up)
+
+    expect(page).to have_css('[aria-expanded="true"]')
+    expect(find_field("Cycle type").value).to eq all('[role="option"]').last.text
   end
 
   context "with a selection already made" do
-    it "keeps the selection under an arrow key, and replaces it whole when typing" do
+    it "keeps the selection under End, and replaces it whole when typing" do
       visit "/rails/view_components/ui/forms/combobox/component/default"
 
       expect(page).to have_css('[aria-expanded="false"]', wait: 10)
@@ -54,9 +60,9 @@ RSpec.describe UI::Forms::Combobox::Component, :js, type: :system do
 
       expect(find_field("Cycle type").value).to eq "Unicycle"
 
-      # ArrowUp doesn't open a closed listbox, so it used to pick out of an empty one and
-      # throw -- past the deselect that starts a selection, which had emptied the field
-      find_field("Cycle type").send_keys(:up)
+      # The gem takes End too, and opens nothing for it -- so it used to throw picking out
+      # of the closed listbox, past the deselect that had already emptied the hidden field
+      find_field("Cycle type").send_keys(:end)
 
       expect(find_field("Cycle type").value).to eq "Unicycle"
       expect(find("input[name='cycle_type']", visible: :hidden).value).to eq "Unicycle"

--- a/spec/components/ui/forms/combobox/component_system_spec.rb
+++ b/spec/components/ui/forms/combobox/component_system_spec.rb
@@ -63,6 +63,25 @@ RSpec.describe UI::Forms::Combobox::Component, :js, type: :system do
       expect(find_field("Cycle type").value).to eq "Tandem"
       expect(find("input[name='cycle_type']", visible: :hidden).value).to eq "Tandem"
     end
+
+    # ArrowUp doesn't open a closed listbox the way ArrowDown does, so it used to pick out
+    # of an empty one -- throwing partway through, with the selection already cleared
+    it "keeps the selection when an arrow key has nothing to move through" do
+      visit "/rails/view_components/ui/forms/combobox/component/default"
+
+      expect(page).to have_css('[aria-expanded="false"]', wait: 10)
+
+      find_field("Cycle type").click
+      find('[role="option"]', text: "Unicycle", exact_text: true).click
+
+      expect(page).to have_css('[aria-expanded="false"]')
+
+      # Focuses without clicking, the way tabbing in does -- a click would reopen it
+      find_field("Cycle type").send_keys(:up)
+
+      expect(find_field("Cycle type").value).to eq "Unicycle"
+      expect(find("input[name='cycle_type']", visible: :hidden).value).to eq "Unicycle"
+    end
   end
 
   context "inside a form" do


### PR DESCRIPTION
`hw_combobox`'s arrow keys pick an option by index, and the gem's wrap-around returns `undefined` for an empty list — which `_select` then dereferences. A closed combobox has an empty list, and the gem opens one on ArrowDown but not ArrowUp, so ArrowUp threw every time: the [`getAttribute` TypeError](https://app.honeybadger.io/projects/61305/faults/133043592) coming from `/search/registrations` and `/register?step=1`.

- **ArrowUp opens the listbox onto its last option**, which is what WAI-ARIA's combobox pattern asks for and the mirror of the ArrowDown the gem already handles — so the key has something to move through rather than needing to be defended against.
- **`_selectIndex` is guarded** for the cases that stay empty: Home and End open nothing either way, and an async listbox hasn't loaded on first keypress. Guarding the shared callee rather than each handler keeps the key list in the gem.
- **The crash was silent as well as noisy.** It lands past the deselect `_select` opens with, so the input went on showing the selection while the hidden field it submits was already empty — which is what the End example asserts.

`sandbox-test-setup`'s macOS reference points at the mise shims rather than a version-pinned `installs/ruby/4.0.6/bin`, and names the symptom a `bin/` script gives without them: `uninitialized constant Pathname`, which reads nothing like the bundler error it listed.
