### PR TITLE
Resolve UI::ActiveLink's current page in the browser

### DIFF
--- a/.claude/skills/frontend-conventions/SKILL.md
+++ b/.claude/skills/frontend-conventions/SKILL.md
@@ -73,7 +73,7 @@ The same instinct applies beyond buttons: **check `app/components/ui/` and `app/
 
 ## Current-page links: always `UI::ActiveLink`
 
-**Every link that goes `aria-current` on the page it points at goes through `UI::ActiveLink::Component`** — never `current_page?` in a template, and never a Stimulus controller of your own comparing `window.location`. It always derives the state in the browser (`app/javascript/controllers/ui/active_link_controller.js`), so there's no way to pass the answer in: `match:` is the only control over what counts as the page it points at. Any layout rendering one needs `<%= tag.attributes(body_attributes) %>` on its `<body>`. See `app/components/ui/active_link/`.
+**Every link that goes `aria-current` on the page it points at goes through `UI::ActiveLink::Component`** — never `current_page?` in a template, and never a Stimulus controller of your own comparing `window.location`. It always derives the state in the browser (`app/javascript/controllers/ui/active_link_controller.js`), so there's no way to pass the answer in: `match:` is the only control over what counts as the page it points at. Any layout rendering one opens its `<body>` with `body_tag`. See `app/components/ui/active_link/`.
 
 ## Showing and hiding elements: always use the collapse helpers
 

--- a/.claude/skills/frontend-conventions/SKILL.md
+++ b/.claude/skills/frontend-conventions/SKILL.md
@@ -73,7 +73,7 @@ The same instinct applies beyond buttons: **check `app/components/ui/` and `app/
 
 ## Current-page links: always `UI::ActiveLink`
 
-**Every link that takes an `active` class on the page it points at goes through `UI::ActiveLink::Component`** — never `current_page?` in a template, and never a Stimulus controller of your own comparing `window.location`. It always derives the state in the browser (`app/javascript/controllers/ui/active_link_controller.js`), which is what a link inside a fragment cache needs, so there's no way to pass the answer in: `match:` is the only control over what counts as the page it points at. Any layout rendering one needs `data-page-route="<%= page_route %>"` on its `<body>`. See `app/components/ui/active_link/`.
+**Every link that goes `aria-current` on the page it points at goes through `UI::ActiveLink::Component`** — never `current_page?` in a template, and never a Stimulus controller of your own comparing `window.location`. It always derives the state in the browser (`app/javascript/controllers/ui/active_link_controller.js`), so there's no way to pass the answer in: `match:` is the only control over what counts as the page it points at. Any layout rendering one needs `data-page-route="<%= page_route %>"` on its `<body>`. See `app/components/ui/active_link/`.
 
 ## Showing and hiding elements: always use the collapse helpers
 

--- a/.claude/skills/frontend-conventions/SKILL.md
+++ b/.claude/skills/frontend-conventions/SKILL.md
@@ -73,7 +73,7 @@ The same instinct applies beyond buttons: **check `app/components/ui/` and `app/
 
 ## Current-page links: always `UI::ActiveLink`
 
-**Every link that goes `aria-current` on the page it points at goes through `UI::ActiveLink::Component`** — never `current_page?` in a template, and never a Stimulus controller of your own comparing `window.location`. It always derives the state in the browser (`app/javascript/controllers/ui/active_link_controller.js`), so there's no way to pass the answer in: `match:` is the only control over what counts as the page it points at. Any layout rendering one needs `data-page-route="<%= page_route %>"` on its `<body>`. See `app/components/ui/active_link/`.
+**Every link that goes `aria-current` on the page it points at goes through `UI::ActiveLink::Component`** — never `current_page?` in a template, and never a Stimulus controller of your own comparing `window.location`. It always derives the state in the browser (`app/javascript/controllers/ui/active_link_controller.js`), so there's no way to pass the answer in: `match:` is the only control over what counts as the page it points at. Any layout rendering one needs `<%= tag.attributes(body_attributes) %>` on its `<body>`. See `app/components/ui/active_link/`.
 
 ## Showing and hiding elements: always use the collapse helpers
 

--- a/.claude/skills/frontend-conventions/SKILL.md
+++ b/.claude/skills/frontend-conventions/SKILL.md
@@ -71,7 +71,7 @@ The same instinct applies beyond buttons: **check `app/components/ui/` and `app/
 
 ## Current-page links: always `UI::ActiveLink`
 
-**Every link that takes an `active` class on the page it points at goes through `UI::ActiveLink::Component`** — never `current_page?` in a template, and never a Stimulus controller of your own comparing `window.location`. It resolves the state in the browser (`app/javascript/controllers/ui/active_link_controller.js`), which is what a link inside a fragment cache needs; `match:` widens what counts as the page it points at, and a caller that already knows the answer passes `active:`. Any layout rendering one needs `data-page-route="<%= page_route %>"` on its `<body>`. See `app/components/ui/active_link/`.
+**Every link that takes an `active` class on the page it points at goes through `UI::ActiveLink::Component`** — never `current_page?` in a template, and never a Stimulus controller of your own comparing `window.location`. It always derives the state in the browser (`app/javascript/controllers/ui/active_link_controller.js`), which is what a link inside a fragment cache needs, so there's no way to pass the answer in: `match:` is the only control over what counts as the page it points at. Any layout rendering one needs `data-page-route="<%= page_route %>"` on its `<body>`. See `app/components/ui/active_link/`.
 
 ## Showing and hiding elements: always use the collapse helpers
 

--- a/.claude/skills/frontend-conventions/SKILL.md
+++ b/.claude/skills/frontend-conventions/SKILL.md
@@ -69,6 +69,10 @@ The same instinct applies beyond buttons: **check `app/components/ui/` and `app/
 
 **Every typeahead / autocomplete / combobox goes through `UI::Forms::Combobox::Component`** — never a new Stimulus controller that fetches matches and renders its own menu. See `app/components/ui/forms/combobox/` (component + `component_preview.rb`) and `spec/components/ui/forms/combobox` for how to invoke it.
 
+## Current-page links: always `UI::ActiveLink`
+
+**Every link that takes an `active` class on the page it points at goes through `UI::ActiveLink::Component`** — never `current_page?` in a template, and never a Stimulus controller of your own comparing `window.location`. It resolves the state in the browser (`app/javascript/controllers/ui/active_link_controller.js`), which is what a link inside a fragment cache needs; `match:` widens what counts as the page it points at, and a caller that already knows the answer passes `active:`. Any layout rendering one needs `data-page-route="<%= page_route %>"` on its `<body>`. See `app/components/ui/active_link/`.
+
 ## Showing and hiding elements: always use the collapse helpers
 
 Any time you show, hide, or toggle an element in response to interaction, go through the shared collapse helpers. **Never** hand-roll it with the `hidden` attribute, `element.style.display`, `element.hidden = true`, or ad-hoc `classList.add('tw:hidden')` — those skip the shared show/hide animation and the `tw:hidden!`/`tw:hidden` class contract the rest of the app depends on.

--- a/.claude/skills/sandbox-test-setup/references/local-macos.md
+++ b/.claude/skills/sandbox-test-setup/references/local-macos.md
@@ -38,12 +38,6 @@ If `rails_helper` aborts complaining about a pending migration, run
 `bundle exec rails db:create db:migrate` first
 (`ActiveRecord::Migration.maintain_test_schema!`).
 
-`bin/turbo_tests` (and so `bin/ci`) runs each worker against its own
-`bikeindex_test_<WORKSPACE_ID>` database, which nothing creates on
-demand — a fresh workspace fails with `ActiveRecord::NoDatabaseError:
-Database not found`. `bin/rake parallel:prepare` creates them, and
-`bin/ci` runs it as its own step.
-
 Lint with `bin/lint` (same PATH prefix if needed). Postgres, redis,
 and the jsdelivr proxy are handled by your local dev environment, so
 nothing else here applies **except** the Tailwind build in SKILL.md,

--- a/.claude/skills/sandbox-test-setup/references/local-macos.md
+++ b/.claude/skills/sandbox-test-setup/references/local-macos.md
@@ -38,6 +38,12 @@ If `rails_helper` aborts complaining about a pending migration, run
 `bundle exec rails db:create db:migrate` first
 (`ActiveRecord::Migration.maintain_test_schema!`).
 
+`bin/turbo_tests` (and so `bin/ci`) runs each worker against its own
+`bikeindex_test_<WORKSPACE_ID>` database, which nothing creates on
+demand — a fresh workspace fails with `ActiveRecord::NoDatabaseError:
+Database not found`. `bin/rake parallel:prepare` creates them, and
+`bin/ci` runs it as its own step.
+
 Lint with `bin/lint` (same PATH prefix if needed). Postgres, redis,
 and the jsdelivr proxy are handled by your local dev environment, so
 nothing else here applies **except** the Tailwind build in SKILL.md,

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -75,7 +75,7 @@ Worth delegating enumeration at all rather than eyeballing a grep: in that same 
 
 Uses RSpec. All business logic should be tested. The `rspec-testing` skill covers project-specific style (`context`+`let`, request specs over controller specs, avoiding mocks). A test that fails intermittently is the `fixing-flaky-failures` skill — coverage is never what gives way to make CI green.
 
-**Run specs through `bin/turbo_tests <the paths your change touches>`** — it compiles assets and keeps the test Redis off the dev database, and a serial `bundle exec rspec` over a directory takes many times longer. **Don't run `bin/ci`** (the whole suite, whole-repo lint) unless you're asked to or a specific problem needs it — CI runs the full suite on push, and a local one pins the machine you're sharing. A suite failure is not a reason to re-run the suite: re-run the failing spec file.
+**Run `bundle exec rspec <the spec paths your change touches>`** — not `bin/turbo_tests`, which is the parallel runner for the whole suite. **Don't run `bin/ci`** (the whole suite, plus whole-repo lint and scan) unless you're asked to or a specific problem needs it: CI runs the full suite on push, and a local run pins the machine you're sharing. A suite failure is not a reason to re-run the suite — re-run the failing spec file.
 
 **Never hand-edit a VCR cassette**, and never `git checkout` away one a spec run re-recorded — cassettes only change by being recorded, and a re-recording gets committed on whatever branch you're on. To clear stale contents, `rm` the file and re-run the spec.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -75,7 +75,7 @@ Worth delegating enumeration at all rather than eyeballing a grep: in that same 
 
 Uses RSpec. All business logic should be tested. The `rspec-testing` skill covers project-specific style (`context`+`let`, request specs over controller specs, avoiding mocks). A test that fails intermittently is the `fixing-flaky-failures` skill — coverage is never what gives way to make CI green.
 
-**Verify with `bundle exec rspec` over the spec paths your change touches** — not `bin/turbo_tests` or `bin/ci`, whole-suite runners CI already does on push. Prefer running a smaller set of tests since CI will run the whole suite. A `:js` spec failing on a missing Tailwind build is the `sandbox-test-setup` skill, not a reason to switch runners.
+**Verify with `bundle exec rspec` over the spec files covering what you changed — usually one to three.** Not `bin/turbo_tests` or `bin/ci`. CI runs the whole suite on push; yours is a smoke test, and every extra minute of it delays the next fix. A whole directory — `spec/integration`, `spec/components` — is a suite run by another name, whichever runner you use. "It renders on every page, so anything could break" is the rationalization to watch for: run the specs that assert the behaviour you changed and let CI find the rest. A red example is not a reason to re-run its directory — re-run that example. Say which specs you ran and why those. A `:js` spec failing on a missing Tailwind build is the `sandbox-test-setup` skill, not a reason to switch runners.
 
 **Never hand-edit a VCR cassette**, and never `git checkout` away one a spec run re-recorded — cassettes only change by being recorded, and a re-recording gets committed on whatever branch you're on. To clear stale contents, `rm` the file and re-run the spec.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -75,7 +75,7 @@ Worth delegating enumeration at all rather than eyeballing a grep: in that same 
 
 Uses RSpec. All business logic should be tested. The `rspec-testing` skill covers project-specific style (`context`+`let`, request specs over controller specs, avoiding mocks). A test that fails intermittently is the `fixing-flaky-failures` skill — coverage is never what gives way to make CI green.
 
-**Verify with `bundle exec rspec` over the spec paths your change touches** — not `bin/turbo_tests` or `bin/ci`, whole-suite runners CI already does on push and that pin the machine you're sharing. A suite failure is not a reason to re-run the suite — re-run the failing spec file. A `:js` spec failing on a missing Tailwind build is the `sandbox-test-setup` skill, not a reason to switch runners.
+**Verify with `bundle exec rspec` over the spec paths your change touches** — not `bin/turbo_tests` or `bin/ci`, whole-suite runners CI already does on push. Prefer running a smaller set of tests since CI will run the whole suite. A `:js` spec failing on a missing Tailwind build is the `sandbox-test-setup` skill, not a reason to switch runners.
 
 **Never hand-edit a VCR cassette**, and never `git checkout` away one a spec run re-recorded — cassettes only change by being recorded, and a re-recording gets committed on whatever branch you're on. To clear stale contents, `rm` the file and re-run the spec.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -75,7 +75,7 @@ Worth delegating enumeration at all rather than eyeballing a grep: in that same 
 
 Uses RSpec. All business logic should be tested. The `rspec-testing` skill covers project-specific style (`context`+`let`, request specs over controller specs, avoiding mocks). A test that fails intermittently is the `fixing-flaky-failures` skill — coverage is never what gives way to make CI green.
 
-**Anything broader than a handful of files goes through `bin/ci`** — it runs locally what CI runs. A serial `bundle exec rspec` over a directory takes many times longer, and `bin/turbo_tests`, which it runs the suite through, is also what compiles assets and keeps the test Redis off the dev database.
+**Run specs through `bin/turbo_tests <the paths your change touches>`** — it compiles assets and keeps the test Redis off the dev database, and a serial `bundle exec rspec` over a directory takes many times longer. **Don't run `bin/ci`** (the whole suite, whole-repo lint) unless you're asked to or a specific problem needs it — CI runs the full suite on push, and a local one pins the machine you're sharing. A suite failure is not a reason to re-run the suite: re-run the failing spec file.
 
 **Never hand-edit a VCR cassette**, and never `git checkout` away one a spec run re-recorded — cassettes only change by being recorded, and a re-recording gets committed on whatever branch you're on. To clear stale contents, `rm` the file and re-run the spec.
 

--- a/app/assets/javascripts/revised/pages/welcome/index.coffee
+++ b/app/assets/javascripts/revised/pages/welcome/index.coffee
@@ -1,8 +1,6 @@
 # Note: this is also loaded on info pages - because the recovery slider is included in get_your_stolen_bike_back
 class BikeIndex.WelcomeIndex extends BikeIndex
   constructor: ->
-    # Because of caching, manually update the active link
-    @updateActiveLink()
     # Early exit if no recovery stories, ie on a news page without them
     return unless $('#recovery-stories-container').length
     @translator = new BikeIndex.GoogleTranslate()
@@ -21,11 +19,6 @@ class BikeIndex.WelcomeIndex extends BikeIndex
 
     $(window).scroll ->
       $('.root-landing-who').addClass('scrolled')
-
-  updateActiveLink: ->
-    if window.location.pathname.match("info/how-to-get-your-stolen-bike-back")
-      $(".primary-nav-item .active").removeClass("active")
-      $("#getStolenBackLink").addClass("active")
 
   # Return the DOM node for the slide with index `index` in the slides
   # container element.

--- a/app/components/admin/navbar/component.html.erb
+++ b/app/components/admin/navbar/component.html.erb
@@ -8,7 +8,7 @@
       <% shortcut_links.each do |link| %>
         <li>
           <%= render UI::ActiveLink::Component.new(text: link[:title], path: link[:path],
-                html_class: NAV_LINK_CLASS, match: link[:match]) %>
+                class: NAV_LINK_CLASS, match: link[:match]) %>
         </li>
       <% end %>
 

--- a/app/components/admin/navbar/component.rb
+++ b/app/components/admin/navbar/component.rb
@@ -20,7 +20,8 @@ module Admin
       private
 
       # Shorter labels and a deliberate order, so the titles don't derive from nav_select_links.
-      # The match does, so a shortcut can't disagree with the picker about which page it's on.
+      # The match does, so a shortcut and the picker agree on how wide the current page is,
+      # even though one resolves in the browser and the other here.
       def shortcut_links
         {"Users" => admin_users_path,
          "Bikes" => admin_bikes_path,

--- a/app/components/admin/navbar/component.rb
+++ b/app/components/admin/navbar/component.rb
@@ -20,8 +20,7 @@ module Admin
       private
 
       # Shorter labels and a deliberate order, so the titles don't derive from nav_select_links.
-      # The match does, so a shortcut and the picker agree on how wide the current page is,
-      # even though one resolves in the browser and the other here.
+      # The match does, so a shortcut and the picker agree on how wide the current page is.
       def shortcut_links
         {"Users" => admin_users_path,
          "Bikes" => admin_bikes_path,

--- a/app/components/admin/navbar/component.rb
+++ b/app/components/admin/navbar/component.rb
@@ -71,8 +71,10 @@ module Admin
           .detect { |link| on_page?(link, match_for(link)) } || invoices_edit_link
       end
 
+      # The picker names the current page in prose, which UI::ActiveLink can't answer for it —
+      # the links themselves go active in the browser
       def on_page?(link, match)
-        UI::ActiveLink::Component.active?(path: link[:path], match:, view: helpers)
+        helpers.current_page_active?(link[:path], match == :controller)
       end
 
       def nav_link_for(path)

--- a/app/components/org/menu_items/component.html.erb
+++ b/app/components/org/menu_items/component.html.erb
@@ -9,7 +9,7 @@
   <% when :link %>
     <li>
       <%= render UI::ActiveLink::Component.new(text: item[:label], path: item[:path],
-            active: active_state(item), match: MATCHES.fetch(item[:active], :path),
+            match: item[:match], matching_controllers: item[:matching_controllers],
             html_class: link_classes(item)) %>
     </li>
   <% when :super_admin_link %>

--- a/app/components/org/menu_items/component.html.erb
+++ b/app/components/org/menu_items/component.html.erb
@@ -10,7 +10,7 @@
     <li>
       <%= render UI::ActiveLink::Component.new(text: item[:label], path: item[:path],
             match: item[:match], matching_controllers: item[:matching_controllers],
-            html_class: link_classes(item)) %>
+            class: link_classes(item)) %>
     </li>
   <% when :super_admin_link %>
     <li class="less-strong mt-4">

--- a/app/components/org/menu_items/component.rb
+++ b/app/components/org/menu_items/component.rb
@@ -3,7 +3,7 @@
 module Org
   module MenuItems
     class Component < ApplicationComponent
-      # The cache marks these for UI::ActiveLink to resolve per request, at these granularities
+      # The cache marks these for UI::ActiveLink to resolve in the browser, at these granularities
       MATCHES = UI::ActiveLink::Component.match_table(auto: :path, match_controller: :controller,
         on_registrations_index: :controller_action)
 

--- a/app/components/org/menu_items/component.rb
+++ b/app/components/org/menu_items/component.rb
@@ -3,19 +3,14 @@
 module Org
   module MenuItems
     class Component < ApplicationComponent
-      # The cache marks these for UI::ActiveLink to resolve in the browser, at these granularities
-      MATCHES = UI::ActiveLink::Component.match_table(auto: :path, match_controller: :controller,
-        on_registrations_index: :controller_action)
-
       def initialize(organization:, current_user:, controller_namespace:, controller_name:, action_name:,
-        is_dropdown: false, unregistered_parking_notification: nil)
+        is_dropdown: false)
         @organization = organization
         @current_user = current_user
         @controller_namespace = controller_namespace
         @controller_name = controller_name
         @action_name = action_name
         @is_dropdown = is_dropdown
-        @unregistered_parking_notification = unregistered_parking_notification
       end
 
       def render?
@@ -73,9 +68,13 @@ module Org
       # Always emits a divider above `item` so the injected link is visually
       # separated from the add-bike row, regardless of what's already in `items`.
       def insert_after_add_bike(items, item)
-        index = items.index { |i| i[:active] == :on_bikes_new }
+        index = items.index { |i| i[:path] == add_bike_link[:path] }
         return items + [divider, item] unless index
         items.dup.insert(index + 1, divider, item)
+      end
+
+      def add_bike_link
+        @add_bike_link ||= OrganizedServices::UserMenuItems.add_bike_link(@organization)
       end
 
       def dashboard_link
@@ -122,31 +121,6 @@ module Org
 
       def disabled_classes(item)
         item[:secondary] ? "disabled-menu-item menu-item secondary-item" : "disabled-menu-item menu-item"
-      end
-
-      # Resolves the per-request active state for items the cache marked with a symbol.
-      # Returns true/false for explicit cases, nil to defer to UI::ActiveLink.
-      def active_state(item)
-        return nil if MATCHES.key?(item[:active])
-
-        case item[:active]
-        when :on_bikes_new
-          on_bikes_new? && !on_bikes_new_with_parking_notification?
-        when :on_bikes_new_with_parking_notification
-          on_bikes_new_with_parking_notification?
-        when :on_registration_sequences
-          on_registration_sequences?
-        else
-          item[:active]
-        end
-      end
-
-      def on_bikes_new?
-        organized_controller?("bikes") && @action_name == "new"
-      end
-
-      def on_bikes_new_with_parking_notification?
-        on_bikes_new? && @unregistered_parking_notification.present?
       end
     end
   end

--- a/app/components/page_block/footer/component.html.erb
+++ b/app/components/page_block/footer/component.html.erb
@@ -193,15 +193,22 @@
       <div class="container">
         <div class="row">
           <div class="col-md-6 text-left">
-            <%= form_tag nil, method: :get, class: "locale-form" do %>
+            <%#
+              No action: the footer is cached across every page, so the URL to add the locale
+              to is the one the browser is on -- which an action-less GET form submits to
+            %>
+
+            <%= tag.form method: :get, class: "locale-form", data: {
+                  controller: "page-block--locale-select",
+                  action: "submit->page-block--locale-select#submit change->page-block--locale-select#submit"
+                } do %>
               <div class="row">
                 <div class="form-group">
                   <%= label_tag(:locale, translation(".language")) %>
 
                   <%= select_tag(:locale,
                   options_for_select(helpers.language_choices, selected: I18n.locale),
-                  class: "form-control-sm",
-                  onchange: "this.form.submit()") %>
+                  class: "form-control-sm") %>
 
                   <% if @current_user.present? && @current_user.preferred_language != I18n.locale %>
                     <em class="below-input-help text-right">

--- a/app/components/page_block/footer/component.rb
+++ b/app/components/page_block/footer/component.rb
@@ -5,7 +5,7 @@ module PageBlock
     class Component < ApplicationComponent
       FACEBOOK_PIXEL_ID = "199066297131941"
       # Digest of the cached template — the cached_markup_digest spec keeps it current
-      MARKUP_DIGEST = "72083256b39d"
+      MARKUP_DIGEST = "9da7dcda1cfb"
 
       def initialize(current_user:, skip_facebook:, passive_organization: nil)
         @current_user = current_user

--- a/app/components/page_block/footer/component.rb
+++ b/app/components/page_block/footer/component.rb
@@ -5,19 +5,20 @@ module PageBlock
     class Component < ApplicationComponent
       FACEBOOK_PIXEL_ID = "199066297131941"
       # Digest of the cached template — the cached_markup_digest spec keeps it current
-      MARKUP_DIGEST = "044b088c867b"
+      MARKUP_DIGEST = "b2673dcab47a"
 
-      def initialize(current_user:, skip_facebook:, page_id:, passive_organization: nil)
+      def initialize(current_user:, skip_facebook:, passive_organization: nil)
         @current_user = current_user
         @skip_facebook = skip_facebook
-        @page_id = page_id
         @passive_organization = passive_organization
       end
 
       private
 
+      # No page_id: the links resolve their own active state in the browser, so one render
+      # serves every page
       def cache_key
-        [MARKUP_DIGEST, @page_id, @current_user, @passive_organization, @skip_facebook]
+        [MARKUP_DIGEST, @current_user, @passive_organization, @skip_facebook]
       end
     end
   end

--- a/app/components/page_block/footer/component.rb
+++ b/app/components/page_block/footer/component.rb
@@ -5,7 +5,7 @@ module PageBlock
     class Component < ApplicationComponent
       FACEBOOK_PIXEL_ID = "199066297131941"
       # Digest of the cached template — the cached_markup_digest spec keeps it current
-      MARKUP_DIGEST = "af14fcdea273"
+      MARKUP_DIGEST = "044b088c867b"
 
       def initialize(current_user:, skip_facebook:, page_id:, passive_organization: nil)
         @current_user = current_user

--- a/app/components/page_block/footer/component.rb
+++ b/app/components/page_block/footer/component.rb
@@ -5,7 +5,7 @@ module PageBlock
     class Component < ApplicationComponent
       FACEBOOK_PIXEL_ID = "199066297131941"
       # Digest of the cached template — the cached_markup_digest spec keeps it current
-      MARKUP_DIGEST = "b2673dcab47a"
+      MARKUP_DIGEST = "4f63f67897ab"
 
       def initialize(current_user:, skip_facebook:, passive_organization: nil)
         @current_user = current_user
@@ -15,8 +15,8 @@ module PageBlock
 
       private
 
-      # No page_id: the links resolve their own active state in the browser, so one render
-      # serves every page
+      # No page_id: the links resolve their own active state in the browser and the locale
+      # form submits to whatever URL it's on, so one render serves every page
       def cache_key
         [MARKUP_DIGEST, @current_user, @passive_organization, @skip_facebook]
       end

--- a/app/components/page_block/footer/component.rb
+++ b/app/components/page_block/footer/component.rb
@@ -5,7 +5,7 @@ module PageBlock
     class Component < ApplicationComponent
       FACEBOOK_PIXEL_ID = "199066297131941"
       # Digest of the cached template — the cached_markup_digest spec keeps it current
-      MARKUP_DIGEST = "fd977c7c926c"
+      MARKUP_DIGEST = "9da7dcda1cfb"
 
       def initialize(current_user:, skip_facebook:, passive_organization: nil)
         @current_user = current_user

--- a/app/components/page_block/footer/component.rb
+++ b/app/components/page_block/footer/component.rb
@@ -5,7 +5,7 @@ module PageBlock
     class Component < ApplicationComponent
       FACEBOOK_PIXEL_ID = "199066297131941"
       # Digest of the cached template — the cached_markup_digest spec keeps it current
-      MARKUP_DIGEST = "9da7dcda1cfb"
+      MARKUP_DIGEST = "7321d145a368"
 
       def initialize(current_user:, skip_facebook:, passive_organization: nil)
         @current_user = current_user

--- a/app/components/page_block/footer/component.rb
+++ b/app/components/page_block/footer/component.rb
@@ -5,7 +5,7 @@ module PageBlock
     class Component < ApplicationComponent
       FACEBOOK_PIXEL_ID = "199066297131941"
       # Digest of the cached template — the cached_markup_digest spec keeps it current
-      MARKUP_DIGEST = "9da7dcda1cfb"
+      MARKUP_DIGEST = "3eb7805df916"
 
       def initialize(current_user:, skip_facebook:, passive_organization: nil)
         @current_user = current_user

--- a/app/components/page_block/footer/component.rb
+++ b/app/components/page_block/footer/component.rb
@@ -5,7 +5,7 @@ module PageBlock
     class Component < ApplicationComponent
       FACEBOOK_PIXEL_ID = "199066297131941"
       # Digest of the cached template — the cached_markup_digest spec keeps it current
-      MARKUP_DIGEST = "b0a6f8b24dea"
+      MARKUP_DIGEST = "af14fcdea273"
 
       def initialize(current_user:, skip_facebook:, page_id:, passive_organization: nil)
         @current_user = current_user

--- a/app/components/page_block/footer/component.rb
+++ b/app/components/page_block/footer/component.rb
@@ -5,7 +5,7 @@ module PageBlock
     class Component < ApplicationComponent
       FACEBOOK_PIXEL_ID = "199066297131941"
       # Digest of the cached template — the cached_markup_digest spec keeps it current
-      MARKUP_DIGEST = "0955a0111f18"
+      MARKUP_DIGEST = "aa906ff17c13"
 
       def initialize(current_user:, skip_facebook:, passive_organization: nil)
         @current_user = current_user

--- a/app/components/page_block/footer/component.rb
+++ b/app/components/page_block/footer/component.rb
@@ -5,7 +5,7 @@ module PageBlock
     class Component < ApplicationComponent
       FACEBOOK_PIXEL_ID = "199066297131941"
       # Digest of the cached template — the cached_markup_digest spec keeps it current
-      MARKUP_DIGEST = "3eb7805df916"
+      MARKUP_DIGEST = "72083256b39d"
 
       def initialize(current_user:, skip_facebook:, passive_organization: nil)
         @current_user = current_user

--- a/app/components/page_block/footer/component_preview.rb
+++ b/app/components/page_block/footer/component_preview.rb
@@ -7,12 +7,12 @@ module PageBlock
 
       # @display legacy_stylesheet true
       def default
-        render(PageBlock::Footer::Component.new(current_user: nil, skip_facebook: false, page_id: "welcome_index"))
+        render(PageBlock::Footer::Component.new(current_user: nil, skip_facebook: false))
       end
 
       # @display legacy_stylesheet true
       def signed_in
-        render(PageBlock::Footer::Component.new(current_user: lookbook_user, skip_facebook: false, page_id: "welcome_index"))
+        render(PageBlock::Footer::Component.new(current_user: lookbook_user, skip_facebook: false))
       end
       # @endgroup
     end

--- a/app/components/page_block/main_content/content/component.html.erb
+++ b/app/components/page_block/main_content/content/component.html.erb
@@ -66,9 +66,7 @@
           <ul class="tw:m-0 tw:mb-4 tw:list-none">
             <% if content_page_type == "news" %>
               <li>
-                <%# A search is a narrower page than this link points at; paging isn't %>
-                <%= render UI::ActiveLink::Component.new(text: translation(".bike_index_news"),
-                      path: news_index_path, match: :unfiltered_path) %>
+                <%= render UI::ActiveLink::Component.new(text: translation(".bike_index_news"), path: news_index_path) %>
               </li>
             <% end %>
 

--- a/app/components/page_block/main_content/content/component.html.erb
+++ b/app/components/page_block/main_content/content/component.html.erb
@@ -66,13 +66,9 @@
           <ul class="tw:m-0 tw:mb-4 tw:list-none">
             <% if content_page_type == "news" %>
               <li>
-                <%#
-                  Only the unfiltered index: a search or a period is a narrower page than
-                  this link points at, which is what :full_path tells apart
-                %>
-
+                <%# A search is a narrower page than this link points at; paging isn't %>
                 <%= render UI::ActiveLink::Component.new(text: translation(".bike_index_news"),
-                      path: news_index_path, match: :full_path) %>
+                      path: news_index_path, match: :unfiltered_path) %>
               </li>
             <% end %>
 

--- a/app/components/page_block/main_content/content/component.html.erb
+++ b/app/components/page_block/main_content/content/component.html.erb
@@ -66,8 +66,13 @@
           <ul class="tw:m-0 tw:mb-4 tw:list-none">
             <% if content_page_type == "news" %>
               <li>
-                <%= render UI::ActiveLink::Component.new(text: translation(".bike_index_news"), path: news_index_path,
-                      active: @action_name == "index" && !helpers.sortable_search_params?) %>
+                <%#
+                  Only the unfiltered index: a search or a period is a narrower page than
+                  this link points at, which is what :full_path tells apart
+                %>
+
+                <%= render UI::ActiveLink::Component.new(text: translation(".bike_index_news"),
+                      path: news_index_path, match: :full_path) %>
               </li>
             <% end %>
 

--- a/app/components/page_block/main_content/organized/component.rb
+++ b/app/components/page_block/main_content/organized/component.rb
@@ -7,12 +7,10 @@ module PageBlock
       # positioned over
       class Component < ApplicationComponent
         def initialize(current_organization:, current_user:, passive_organization:,
-          unregistered_parking_notification:, show_general_alert:, controller_namespace:,
-          controller_name:, action_name:)
+          show_general_alert:, controller_namespace:, controller_name:, action_name:)
           @current_organization = current_organization
           @current_user = current_user
           @passive_organization = passive_organization
-          @unregistered_parking_notification = unregistered_parking_notification
           @show_general_alert = show_general_alert
           @controller_namespace = controller_namespace
           @controller_name = controller_name
@@ -24,8 +22,7 @@ module PageBlock
         def menu_items
           Org::MenuItems::Component.new(organization: @current_organization, current_user: @current_user,
             controller_namespace: @controller_namespace, controller_name: @controller_name,
-            action_name: @action_name,
-            unregistered_parking_notification: @unregistered_parking_notification)
+            action_name: @action_name)
         end
 
         # The dashboard itself shows the link, even for an organization without the feature

--- a/app/components/page_block/main_content/wrapper/component.rb
+++ b/app/components/page_block/main_content/wrapper/component.rb
@@ -36,7 +36,7 @@ module PageBlock
           force_landing_page_render: false, current_user: nil, current_organization: nil,
           passive_organization: nil, show_general_alert: false, blog: nil, related_blogs: nil,
           bike: nil, bike_og: nil, og_email: nil, edit_template: nil, edit_templates: nil,
-          oauth_application: nil, unregistered_parking_notification: nil, source: nil)
+          oauth_application: nil, source: nil)
           @controller_namespace = controller_namespace
           @controller_name = controller_name
           @action_name = action_name
@@ -52,7 +52,6 @@ module PageBlock
           @edit_template = edit_template
           @edit_templates = edit_templates
           @oauth_application = oauth_application
-          @unregistered_parking_notification = unregistered_parking_notification
           @source = source
           @kind = self.class.kind(controller_namespace:, controller_name:, action_name:,
             force_landing_page_render:)
@@ -108,7 +107,6 @@ module PageBlock
             current_organization: @current_organization,
             current_user: @current_user,
             passive_organization: @passive_organization,
-            unregistered_parking_notification: @unregistered_parking_notification,
             show_general_alert: @show_general_alert,
             controller_namespace: @controller_namespace,
             controller_name: @controller_name,

--- a/app/components/page_block/navbar/menu_link/component.rb
+++ b/app/components/page_block/navbar/menu_link/component.rb
@@ -15,7 +15,7 @@ module PageBlock
 
         def call
           render(UI::ActiveLink::Component.new(text: @label, path: @path, match: @match,
-            html_class: css_class, **@html_options))
+            class: css_class, **@html_options))
         end
 
         private

--- a/app/components/page_block/navbar/menu_link/component.rb
+++ b/app/components/page_block/navbar/menu_link/component.rb
@@ -5,30 +5,20 @@ module PageBlock
     module MenuLink
       # One menu manifest item, as an anchor
       class Component < ApplicationComponent
-        # The symbol states leave the current-page check to UI::ActiveLink, at these granularities
-        MATCHES = UI::ActiveLink::Component.match_table(auto: :path, match_controller: :controller)
-        ACTIVE_STATES = (MATCHES.keys + [true, false]).freeze
-
-        def initialize(label:, path:, active: :auto, link_class: nil, html_options: {})
-          raise_if_invalid_value!(:active, active, ACTIVE_STATES)
-
+        def initialize(label:, path:, match: :path, link_class: nil, html_options: {})
           @label = label
           @path = path
-          @active = active
+          @match = match
           @link_class = link_class
           @html_options = html_options
         end
 
         def call
-          render(UI::ActiveLink::Component.new(text: @label, path: @path, html_class: css_class,
-            active: resolved_active, match: MATCHES.fetch(@active, :path), **@html_options))
+          render(UI::ActiveLink::Component.new(text: @label, path: @path, match: @match,
+            html_class: css_class, **@html_options))
         end
 
         private
-
-        def resolved_active
-          @active unless MATCHES.key?(@active)
-        end
 
         def css_class
           ["nav-link", @link_class].compact.join(" ")

--- a/app/components/page_block/navbar/organization_menu/component.rb
+++ b/app/components/page_block/navbar/organization_menu/component.rb
@@ -5,14 +5,12 @@ module PageBlock
     module OrganizationMenu
       # The passive organization's dropdown, between the logo and the primary menu
       class Component < ApplicationComponent
-        def initialize(organization:, current_user:, controller_namespace:, controller_name:, action_name:,
-          unregistered_parking_notification: nil)
+        def initialize(organization:, current_user:, controller_namespace:, controller_name:, action_name:)
           @organization = organization
           @current_user = current_user
           @controller_namespace = controller_namespace
           @controller_name = controller_name
           @action_name = action_name
-          @unregistered_parking_notification = unregistered_parking_notification
         end
 
         def render?
@@ -24,8 +22,7 @@ module PageBlock
         def menu_items
           Org::MenuItems::Component.new(organization: @organization, current_user: @current_user,
             controller_namespace: @controller_namespace, controller_name: @controller_name,
-            action_name: @action_name, is_dropdown: true,
-            unregistered_parking_notification: @unregistered_parking_notification)
+            action_name: @action_name, is_dropdown: true)
         end
       end
     end

--- a/app/components/page_block/navbar/primary_menu/component.rb
+++ b/app/components/page_block/navbar/primary_menu/component.rb
@@ -20,7 +20,7 @@ module PageBlock
             {label: translation(".help"), path: help_path},
             {label: translation(".stolen_bike"), path: get_your_stolen_bike_back_path},
             {label: translation(".donate"), path: why_donate_path},
-            {label: translation(".blog"), path: news_index_path, active: :match_controller},
+            {label: translation(".blog"), path: news_index_path, match: :controller},
             marketplace_item("d-lg-block"),
             search_item("d-none d-lg-block")]
         end
@@ -29,12 +29,12 @@ module PageBlock
         # route is what matches, not the stolenness this happens to link to
         def search_item(item_class)
           {label: translation(".search"), path: helpers.default_bike_search_path,
-           active: :controller_action, item_class:}
+           match: :controller_action, item_class:}
         end
 
         def marketplace_item(item_class)
           {label: translation(".marketplace"), path: search_marketplace_path,
-           active: :controller_action, item_class:}
+           match: :controller_action, item_class:}
         end
 
         def account_items

--- a/app/components/page_block/navbar/primary_menu/component.rb
+++ b/app/components/page_block/navbar/primary_menu/component.rb
@@ -18,9 +18,7 @@ module PageBlock
             {type: :divider, item_class: "d-lg-none"},
             *account_items,
             {label: translation(".help"), path: help_path},
-            # Because of caching, this needs to be set to be active with JS (welcome/index.coffee)
-            {label: translation(".stolen_bike"), path: get_your_stolen_bike_back_path, active: false,
-             html_options: {id: "getStolenBackLink"}},
+            {label: translation(".stolen_bike"), path: get_your_stolen_bike_back_path},
             {label: translation(".donate"), path: why_donate_path},
             {label: translation(".blog"), path: news_index_path, active: :match_controller},
             marketplace_item("d-lg-block"),

--- a/app/components/page_block/navbar/settings_menu/component.rb
+++ b/app/components/page_block/navbar/settings_menu/component.rb
@@ -21,7 +21,7 @@ module PageBlock
              path: edit_my_account_path,
              html_options: {id: "navUserSettingLink", data: {email: @current_user_or_unconfirmed_user.email}}},
             {type: :divider},
-            {label: translation(".logout"), path: goodbye_path, active: false}].compact
+            {label: translation(".logout"), path: goodbye_path}].compact
         end
 
         def organization_items
@@ -31,7 +31,7 @@ module PageBlock
 
           organizations.map { |organization|
             {label: translation(".view_org", org_name: organization.name),
-             path: organization_root_path(organization_id: organization.to_param), active: false}
+             path: organization_root_path(organization_id: organization.to_param)}
           } + [{type: :divider}]
         end
 

--- a/app/components/page_block/navbar/wrapper/component.html.erb
+++ b/app/components/page_block/navbar/wrapper/component.html.erb
@@ -1,18 +1,22 @@
-<%# logo_only renders one link -- not worth a cache round trip %>
-<% cache_if(!@logo_only, cache_key) do %>
-  <nav class="primary-header-nav" <%= tag.attributes(controller_attributes) %>>
-    <div class="container">
-      <a href="<%= helpers.user_root_url %>" class="primary-logo">
-        <%= image_tag "revised/logo.svg", class: "primary-nav", alt: "Bike Index home" %>
-      </a>
+<nav class="primary-header-nav" <%= tag.attributes(controller_attributes) %>>
+  <div class="container">
+    <a href="<%= helpers.user_root_url %>" class="primary-logo">
+      <%= image_tag "revised/logo.svg", class: "primary-nav", alt: "Bike Index home" %>
+    </a>
 
-      <% unless @logo_only %>
-        <%= link_to news_path("bike-index--now-a-nonprofit"), class: "nonprofit-subtitle" do %>
-          <%= translation(".the_nonprofit_bike_registry") %>
-        <% end %>
+    <% unless @logo_only %>
+      <%= link_to news_path("bike-index--now-a-nonprofit"), class: "nonprofit-subtitle" do %>
+        <%= translation(".the_nonprofit_bike_registry") %>
+      <% end %>
 
-        <%= render organization_menu %>
+      <%#
+        The one part of the navbar that varies by page: it re-adds a feature-gated link
+        on that link's own page. Rendering it outside the cache is what lets the cache
+        key be the user alone.
+      %>
+      <%= render organization_menu %>
 
+      <% cache(cache_key) do %>
         <% if @current_user.blank? %>
           <div class="center-navbar-signup-link-container">
             <%= link_to translation(".sign_up"), new_user_url, class: "center-navbar-signup-link signup-link upcase" %>
@@ -42,6 +46,6 @@
 
         <%= render primary_menu %>
       <% end %>
-    </div>
-  </nav>
-<% end %>
+    <% end %>
+  </div>
+</nav>

--- a/app/components/page_block/navbar/wrapper/component.rb
+++ b/app/components/page_block/navbar/wrapper/component.rb
@@ -7,7 +7,7 @@ module PageBlock
       # logo_only renders just the logo, for the OAuth authorization prompt.
       class Component < ApplicationComponent
         # Digest of the cached template — the cached_markup_digest spec keeps it current
-        MARKUP_DIGEST = "93ec9b35e500"
+        MARKUP_DIGEST = "80919d2a260e"
 
         def initialize(logo_only: false, current_user: nil, current_user_or_unconfirmed_user: nil,
           passive_organization: nil, controller_namespace: nil, controller_name: nil, action_name: nil)

--- a/app/components/page_block/navbar/wrapper/component.rb
+++ b/app/components/page_block/navbar/wrapper/component.rb
@@ -7,16 +7,11 @@ module PageBlock
       # logo_only renders just the logo, for the OAuth authorization prompt.
       class Component < ApplicationComponent
         # Digest of the cached template — the cached_markup_digest spec keeps it current
-        MARKUP_DIGEST = "619cb9def56c"
+        MARKUP_DIGEST = "f9f06be8db33"
 
-        def initialize(logo_only: false, page_id: nil, current_user: nil, current_user_or_unconfirmed_user: nil,
+        def initialize(logo_only: false, current_user: nil, current_user_or_unconfirmed_user: nil,
           passive_organization: nil, controller_namespace: nil, controller_name: nil, action_name: nil)
-          # Everything below keys the fragment cache, so a caller that forgets one would
-          # otherwise share a single render across every page
-          raise ArgumentError, "page_id is required unless logo_only" if page_id.blank? && !logo_only
-
           @logo_only = logo_only
-          @page_id = page_id
           @current_user = current_user
           @current_user_or_unconfirmed_user = current_user_or_unconfirmed_user
           @passive_organization = passive_organization
@@ -37,8 +32,10 @@ module PageBlock
                     "resize@window->page-block--navbar#reposition"}}
         end
 
+        # The cached region is the menus below the organization one, which are the same on
+        # every page a user sees
         def cache_key
-          [MARKUP_DIGEST, @page_id, @current_user_or_unconfirmed_user, @passive_organization]
+          [MARKUP_DIGEST, @current_user_or_unconfirmed_user]
         end
 
         def organization_menu

--- a/app/components/page_block/navbar/wrapper/component.rb
+++ b/app/components/page_block/navbar/wrapper/component.rb
@@ -7,7 +7,7 @@ module PageBlock
       # logo_only renders just the logo, for the OAuth authorization prompt.
       class Component < ApplicationComponent
         # Digest of the cached template — the cached_markup_digest spec keeps it current
-        MARKUP_DIGEST = "07e07ab3111e"
+        MARKUP_DIGEST = "a75c37da8ae7"
 
         def initialize(logo_only: false, current_user: nil, current_user_or_unconfirmed_user: nil,
           passive_organization: nil, controller_namespace: nil, controller_name: nil, action_name: nil)

--- a/app/components/page_block/navbar/wrapper/component.rb
+++ b/app/components/page_block/navbar/wrapper/component.rb
@@ -7,7 +7,7 @@ module PageBlock
       # logo_only renders just the logo, for the OAuth authorization prompt.
       class Component < ApplicationComponent
         # Digest of the cached template — the cached_markup_digest spec keeps it current
-        MARKUP_DIGEST = "a989eab8823a"
+        MARKUP_DIGEST = "24e6583dc976"
 
         def initialize(logo_only: false, current_user: nil, current_user_or_unconfirmed_user: nil,
           passive_organization: nil, controller_namespace: nil, controller_name: nil, action_name: nil)

--- a/app/components/page_block/navbar/wrapper/component.rb
+++ b/app/components/page_block/navbar/wrapper/component.rb
@@ -7,7 +7,7 @@ module PageBlock
       # logo_only renders just the logo, for the OAuth authorization prompt.
       class Component < ApplicationComponent
         # Digest of the cached template — the cached_markup_digest spec keeps it current
-        MARKUP_DIGEST = "24e6583dc976"
+        MARKUP_DIGEST = "07e07ab3111e"
 
         def initialize(logo_only: false, current_user: nil, current_user_or_unconfirmed_user: nil,
           passive_organization: nil, controller_namespace: nil, controller_name: nil, action_name: nil)

--- a/app/components/page_block/navbar/wrapper/component.rb
+++ b/app/components/page_block/navbar/wrapper/component.rb
@@ -7,7 +7,7 @@ module PageBlock
       # logo_only renders just the logo, for the OAuth authorization prompt.
       class Component < ApplicationComponent
         # Digest of the cached template — the cached_markup_digest spec keeps it current
-        MARKUP_DIGEST = "a727ee7c1f6a"
+        MARKUP_DIGEST = "d9b817ef9c1c"
 
         def initialize(logo_only: false, page_id: nil, current_user: nil, current_user_or_unconfirmed_user: nil,
           passive_organization: nil, controller_namespace: nil, controller_name: nil, action_name: nil,

--- a/app/components/page_block/navbar/wrapper/component.rb
+++ b/app/components/page_block/navbar/wrapper/component.rb
@@ -7,11 +7,10 @@ module PageBlock
       # logo_only renders just the logo, for the OAuth authorization prompt.
       class Component < ApplicationComponent
         # Digest of the cached template — the cached_markup_digest spec keeps it current
-        MARKUP_DIGEST = "d9b817ef9c1c"
+        MARKUP_DIGEST = "619cb9def56c"
 
         def initialize(logo_only: false, page_id: nil, current_user: nil, current_user_or_unconfirmed_user: nil,
-          passive_organization: nil, controller_namespace: nil, controller_name: nil, action_name: nil,
-          unregistered_parking_notification: nil)
+          passive_organization: nil, controller_namespace: nil, controller_name: nil, action_name: nil)
           # Everything below keys the fragment cache, so a caller that forgets one would
           # otherwise share a single render across every page
           raise ArgumentError, "page_id is required unless logo_only" if page_id.blank? && !logo_only
@@ -24,7 +23,6 @@ module PageBlock
           @controller_namespace = controller_namespace
           @controller_name = controller_name
           @action_name = action_name
-          @unregistered_parking_notification = unregistered_parking_notification
         end
 
         private
@@ -40,15 +38,13 @@ module PageBlock
         end
 
         def cache_key
-          [MARKUP_DIGEST, @page_id, @current_user_or_unconfirmed_user, @passive_organization,
-            @unregistered_parking_notification]
+          [MARKUP_DIGEST, @page_id, @current_user_or_unconfirmed_user, @passive_organization]
         end
 
         def organization_menu
           PageBlock::Navbar::OrganizationMenu::Component.new(organization: @passive_organization,
             current_user: @current_user, controller_namespace: @controller_namespace,
-            controller_name: @controller_name, action_name: @action_name,
-            unregistered_parking_notification: @unregistered_parking_notification)
+            controller_name: @controller_name, action_name: @action_name)
         end
 
         def primary_menu

--- a/app/components/page_block/navbar/wrapper/component.rb
+++ b/app/components/page_block/navbar/wrapper/component.rb
@@ -7,7 +7,7 @@ module PageBlock
       # logo_only renders just the logo, for the OAuth authorization prompt.
       class Component < ApplicationComponent
         # Digest of the cached template — the cached_markup_digest spec keeps it current
-        MARKUP_DIGEST = "24e6583dc976"
+        MARKUP_DIGEST = "93ec9b35e500"
 
         def initialize(logo_only: false, current_user: nil, current_user_or_unconfirmed_user: nil,
           passive_organization: nil, controller_namespace: nil, controller_name: nil, action_name: nil)

--- a/app/components/page_block/navbar/wrapper/component.rb
+++ b/app/components/page_block/navbar/wrapper/component.rb
@@ -7,7 +7,7 @@ module PageBlock
       # logo_only renders just the logo, for the OAuth authorization prompt.
       class Component < ApplicationComponent
         # Digest of the cached template — the cached_markup_digest spec keeps it current
-        MARKUP_DIGEST = "80919d2a260e"
+        MARKUP_DIGEST = "24e6583dc976"
 
         def initialize(logo_only: false, current_user: nil, current_user_or_unconfirmed_user: nil,
           passive_organization: nil, controller_namespace: nil, controller_name: nil, action_name: nil)

--- a/app/components/page_block/navbar/wrapper/component_preview.rb
+++ b/app/components/page_block/navbar/wrapper/component_preview.rb
@@ -6,10 +6,7 @@ module PageBlock
       class ComponentPreview < ApplicationComponentPreview
         # @!group Navbar
 
-        # page_id keys the fragment cache — a real page's id would serve this preview's
-        # render to that page when dev caching is on
-        PAGE = {page_id: "lookbook_preview", controller_namespace: nil,
-                controller_name: "welcome", action_name: "index"}.freeze
+        PAGE = {controller_namespace: nil, controller_name: "welcome", action_name: "index"}.freeze
 
         # @display legacy_stylesheet true
         def default

--- a/app/components/ui/active_link/component.rb
+++ b/app/components/ui/active_link/component.rb
@@ -2,11 +2,12 @@
 
 module UI
   module ActiveLink
-    # Adds "active" to the link's class on the page it points at. The browser decides, in
-    # ui/active_link_controller.js, so a link rendered into a fragment cache doesn't carry the
-    # answer for whichever page filled it. match: widens or narrows what counts as the page it
-    # points at: its query string too, or only its controller, or its controller and action —
-    # which is what a link carrying query params (a search, a filtered index) needs.
+    # Marks the link aria-current on the page it points at, which the is-active variant
+    # (application.css) styles. The browser decides, in ui/active_link_controller.js, so a link
+    # rendered into a fragment cache doesn't carry the answer for whichever page filled it.
+    # match: widens or narrows what counts as the page it points at: its query string too, or
+    # only its controller, or its controller and action — which is what a link carrying query
+    # params (a search, a filtered index) needs.
     class Component < ApplicationComponent
       MATCHES = [:path, :full_path, :controller, :controller_action].freeze
       # The matches the browser answers with a route rather than with the URL

--- a/app/components/ui/active_link/component.rb
+++ b/app/components/ui/active_link/component.rb
@@ -13,23 +13,19 @@ module UI
       # The matches the browser answers with a route rather than with the URL
       ROUTE_MATCHES = [:controller, :controller_action].freeze
 
-      def initialize(path:, text: nil, match: :path, matching_controllers: [], html_class: nil,
-        data: {}, **html_options)
+      def initialize(path:, text: nil, match: :path, matching_controllers: [], data: {}, **html_options)
         raise_if_invalid_value!(:match, match, MATCHES)
-        # html_class is what reaches the anchor, so a passed class would be dropped rather than merged
-        raise ArgumentError, "class is not supported, you must use the keyword arg html_class" if html_options.key?(:class)
 
         @path = path
         @text = text
         @match = match
         @matching_controllers = matching_controllers
-        @html_class = html_class
         @data = data
         @html_options = html_options
       end
 
       def call
-        link_to(link_text, @path, **@html_options, class: @html_class.presence, data: link_data)
+        link_to(link_text, @path, **@html_options, data: link_data)
       end
 
       private

--- a/app/components/ui/active_link/component.rb
+++ b/app/components/ui/active_link/component.rb
@@ -15,6 +15,10 @@ module UI
 
       def initialize(path:, text: nil, match: :path, matching_controllers: [], data: {}, **html_options)
         raise_if_invalid_value!(:match, match, MATCHES)
+        # Only a :controller match compares controllers, so anywhere else these would be
+        # compared against a controller#action and never hit
+        raise ArgumentError, "matching_controllers: needs match: :controller" if
+          matching_controllers.any? && match != :controller
 
         @path = path
         @text = text
@@ -43,8 +47,9 @@ module UI
           "ui--active-link-routes-value": link_routes).compact
       end
 
-      # The link's own route, which the browser compares the page's against — it can't resolve
-      # one itself. A menu entry whose section spans two controllers lists the other too.
+      # What the browser compares the page against — it can't resolve a route itself. One
+      # controller#action, or one controller per entry when that's what the match compares,
+      # so a menu entry whose section spans two of them lists the other too.
       def link_routes
         return unless @match.in?(ROUTE_MATCHES)
 
@@ -53,6 +58,8 @@ module UI
 
       def route(url)
         recognized = Rails.application.routes.recognize_path(url)
+        return recognized[:controller] if @match == :controller
+
         "#{recognized[:controller]}##{recognized[:action]}"
       rescue ActionController::RoutingError
         nil

--- a/app/components/ui/active_link/component.rb
+++ b/app/components/ui/active_link/component.rb
@@ -15,10 +15,10 @@ module UI
       # What sortable_search_params? counts as a search, for :unfiltered_path to ask in the
       # browser. period is the exception it makes for itself: only a period other than "all"
       # narrows the page, so the controller reads that one's value rather than its presence.
-      FILTER_PARAMS = (Binxtils::SortableHelper::BASE_SEARCH_KEYS +
+      FILTER_PARAMS = ((Binxtils::SortableHelper::BASE_SEARCH_KEYS +
         Binxtils::SortableHelper.extra_search_keys)
-        .flat_map { |key| key.is_a?(Hash) ? key.keys : [key] }
-        .-(%i[direction sort period per_page]).map(&:to_s).freeze
+        .flat_map { |key| key.is_a?(Hash) ? key.keys : [key] } -
+        %i[direction sort period per_page]).map(&:to_s).freeze
 
       def initialize(path:, text: nil, match: :path, matching_controllers: [], html_class: nil,
         data: {}, **html_options)

--- a/app/components/ui/active_link/component.rb
+++ b/app/components/ui/active_link/component.rb
@@ -2,10 +2,12 @@
 
 module UI
   module ActiveLink
-    # Adds "active" to the link's class on the page it points at. match: widens what counts as
-    # that page — the target's controller, or its controller and action, which is what a link
-    # carrying query params (a search, a filtered index) needs. A caller that already knows the
-    # answer passes active: rather than being routed around the component.
+    # Adds "active" to the link's class on the page it points at. The browser decides, in
+    # ui/active_link_controller.js, so a link rendered into a fragment cache doesn't carry the
+    # answer for whichever page filled it. match: widens what counts as the page it points at —
+    # the target's controller, or its controller and action, which is what a link carrying query
+    # params (a search, a filtered index) needs. A caller that already knows the answer passes
+    # active: rather than being routed around the component.
     class Component < ApplicationComponent
       MATCHES = [:path, :controller, :controller_action].freeze
 
@@ -27,28 +29,27 @@ module UI
           end
         end
 
-        private
-
-        # Recognizing each end once yields both halves, where going through current_page_active?
-        # first would recognize both again for the controller alone. The request is recognized
-        # under its own verb: a page rendered by a failed PATCH dispatched #update, and the GET
-        # route for that same URL is #show.
-        def controller_action_match?(path, view)
-          target = recognized(path)
-          current = recognized(view.request.url, view.request.request_method)
-          return false if target.nil? || current.nil?
-
-          target[:controller] == current[:controller] && target[:action] == current[:action]
-        end
-
-        def recognized(url, verb = :get)
-          Rails.application.routes.recognize_path(url, method: verb)
+        # The controller and action a URL resolves to. A link's doesn't depend on the request,
+        # which is what lets the browser hold the comparison: it reads the page's own off the
+        # body, and can't resolve a route itself.
+        def route(url, verb = :get)
+          recognized = Rails.application.routes.recognize_path(url, method: verb)
+          "#{recognized[:controller]}##{recognized[:action]}"
         rescue ActionController::RoutingError
           nil
         end
+
+        private
+
+        # The request is recognized under its own verb: a page rendered by a failed PATCH
+        # dispatched #update, and the GET route for that same URL is #show
+        def controller_action_match?(path, view)
+          target = route(path)
+          target.present? && target == route(view.request.url, view.request.request_method)
+        end
       end
 
-      def initialize(path:, text: nil, active: nil, match: :path, html_class: nil, **html_options)
+      def initialize(path:, text: nil, active: nil, match: :path, html_class: nil, data: {}, **html_options)
         raise_if_invalid_value!(:match, match, MATCHES)
         # The component builds its own class, so a passed one is dropped rather than merged
         raise ArgumentError, "class is not supported, you must use the keyword arg html_class" if html_options.key?(:class)
@@ -58,11 +59,12 @@ module UI
         @active = active
         @match = match
         @html_class = html_class
+        @data = data
         @html_options = html_options
       end
 
       def call
-        link_to(link_text, @path, **@html_options, class: link_class)
+        link_to(link_text, @path, **@html_options, class: link_class, data: link_data)
       end
 
       private
@@ -75,13 +77,16 @@ module UI
       end
 
       def link_class
-        [@html_class, ("active" if active?)].compact.join(" ").presence
+        [@html_class, ("active" if @active)].compact.join(" ").presence
       end
 
-      def active?
-        return @active unless @active.nil?
+      # A caller that passed active: has already answered, so the link goes out without a
+      # controller to answer it again
+      def link_data
+        return @data unless @active.nil?
 
-        self.class.active?(path: @path, match: @match, view: helpers)
+        @data.merge(controller: "ui--active-link", "ui--active-link-match-value": @match,
+          "ui--active-link-route-value": (self.class.route(@path) unless @match == :path)).compact
       end
     end
   end

--- a/app/components/ui/active_link/component.rb
+++ b/app/components/ui/active_link/component.rb
@@ -4,67 +4,31 @@ module UI
   module ActiveLink
     # Adds "active" to the link's class on the page it points at. The browser decides, in
     # ui/active_link_controller.js, so a link rendered into a fragment cache doesn't carry the
-    # answer for whichever page filled it. match: widens what counts as the page it points at —
-    # the target's controller, or its controller and action, which is what a link carrying query
-    # params (a search, a filtered index) needs. A caller that already knows the answer passes
-    # active: rather than being routed around the component.
+    # answer for whichever page filled it. match: widens or narrows what counts as the page it
+    # points at: its query string too, or only its controller, or its controller and action —
+    # which is what a link carrying query params (a search, a filtered index) needs.
     class Component < ApplicationComponent
-      MATCHES = [:path, :controller, :controller_action].freeze
+      MATCHES = [:path, :full_path, :controller, :controller_action].freeze
+      # The matches the browser answers with a route rather than with the URL
+      ROUTE_MATCHES = [:controller, :controller_action].freeze
 
-      class << self
-        # A menu whose manifest names its own active states translates them here, mapping each
-        # onto a match. The matches map to themselves, so either vocabulary reaches the same
-        # place and a renamed match takes its aliases with it.
-        def match_table(**aliases)
-          MATCHES.index_by(&:itself).merge(aliases).freeze
-        end
-
-        # A caller that needs the answer without a link — a menu picking out its current
-        # entry — asks here rather than rendering one to find out
-        def active?(path:, match:, view:)
-          case match
-          when :path then view.current_page_active?(path)
-          when :controller then view.current_page_active?(path, true)
-          else controller_action_match?(path, view)
-          end
-        end
-
-        # The controller and action a URL resolves to. A link's doesn't depend on the request,
-        # which is what lets the browser hold the comparison: it reads the page's own off the
-        # body, and can't resolve a route itself.
-        def route(url, verb = :get)
-          recognized = Rails.application.routes.recognize_path(url, method: verb)
-          "#{recognized[:controller]}##{recognized[:action]}"
-        rescue ActionController::RoutingError
-          nil
-        end
-
-        private
-
-        # The request is recognized under its own verb: a page rendered by a failed PATCH
-        # dispatched #update, and the GET route for that same URL is #show
-        def controller_action_match?(path, view)
-          target = route(path)
-          target.present? && target == route(view.request.url, view.request.request_method)
-        end
-      end
-
-      def initialize(path:, text: nil, active: nil, match: :path, html_class: nil, data: {}, **html_options)
+      def initialize(path:, text: nil, match: :path, matching_controllers: [], html_class: nil,
+        data: {}, **html_options)
         raise_if_invalid_value!(:match, match, MATCHES)
         # The component builds its own class, so a passed one is dropped rather than merged
         raise ArgumentError, "class is not supported, you must use the keyword arg html_class" if html_options.key?(:class)
 
         @path = path
         @text = text
-        @active = active
         @match = match
+        @matching_controllers = matching_controllers
         @html_class = html_class
         @data = data
         @html_options = html_options
       end
 
       def call
-        link_to(link_text, @path, **@html_options, class: link_class, data: link_data)
+        link_to(link_text, @path, **@html_options, class: @html_class, data: link_data)
       end
 
       private
@@ -76,17 +40,25 @@ module UI
           raise(ArgumentError, "text: or block content is required")
       end
 
-      def link_class
-        [@html_class, ("active" if @active)].compact.join(" ").presence
+      def link_data
+        @data.merge(controller: [@data[:controller], "ui--active-link"].compact.join(" "),
+          "ui--active-link-match-value": @match,
+          "ui--active-link-routes-value": link_routes).compact
       end
 
-      # A caller that passed active: has already answered, so the link goes out without a
-      # controller to answer it again
-      def link_data
-        return @data unless @active.nil?
+      # The link's own route, which the browser compares the page's against — it can't resolve
+      # one itself. A menu entry whose section spans two controllers lists the other too.
+      def link_routes
+        return unless @match.in?(ROUTE_MATCHES)
 
-        @data.merge(controller: "ui--active-link", "ui--active-link-match-value": @match,
-          "ui--active-link-route-value": (self.class.route(@path) unless @match == :path)).compact
+        [route(@path), *@matching_controllers].compact.join(" ").presence
+      end
+
+      def route(url)
+        recognized = Rails.application.routes.recognize_path(url)
+        "#{recognized[:controller]}##{recognized[:action]}"
+      rescue ActionController::RoutingError
+        nil
       end
     end
   end

--- a/app/components/ui/active_link/component.rb
+++ b/app/components/ui/active_link/component.rb
@@ -6,12 +6,19 @@ module UI
     # (application.css) styles. The browser decides, in ui/active_link_controller.js, so a link
     # rendered into a fragment cache doesn't carry the answer for whichever page filled it.
     # match: widens or narrows what counts as the page it points at: its query string too, or
-    # only its controller, or its controller and action — which is what a link carrying query
-    # params (a search, a filtered index) needs.
+    # everything but a search of it, or only its controller, or its controller and action —
+    # which is what a link carrying query params (a search, a filtered index) needs.
     class Component < ApplicationComponent
-      MATCHES = [:path, :full_path, :controller, :controller_action].freeze
+      MATCHES = [:path, :full_path, :unfiltered_path, :controller, :controller_action].freeze
       # The matches the browser answers with a route rather than with the URL
       ROUTE_MATCHES = [:controller, :controller_action].freeze
+      # What sortable_search_params? counts as a search, for :unfiltered_path to ask in the
+      # browser. period is the exception it makes for itself: only a period other than "all"
+      # narrows the page, so the controller reads that one's value rather than its presence.
+      FILTER_PARAMS = (Binxtils::SortableHelper::BASE_SEARCH_KEYS +
+        Binxtils::SortableHelper.extra_search_keys)
+        .flat_map { |key| key.is_a?(Hash) ? key.keys : [key] }
+        .-(%i[direction sort period per_page]).map(&:to_s).freeze
 
       def initialize(path:, text: nil, match: :path, matching_controllers: [], html_class: nil,
         data: {}, **html_options)
@@ -44,7 +51,12 @@ module UI
       def link_data
         @data.merge(controller: [@data[:controller], "ui--active-link"].compact.join(" "),
           "ui--active-link-match-value": @match,
-          "ui--active-link-routes-value": link_routes).compact
+          "ui--active-link-routes-value": link_routes,
+          "ui--active-link-filters-value": link_filters).compact
+      end
+
+      def link_filters
+        FILTER_PARAMS.join(" ") if @match == :unfiltered_path
       end
 
       # The link's own route, which the browser compares the page's against — it can't resolve

--- a/app/components/ui/active_link/component.rb
+++ b/app/components/ui/active_link/component.rb
@@ -6,19 +6,12 @@ module UI
     # (application.css) styles. The browser decides, in ui/active_link_controller.js, so a link
     # rendered into a fragment cache doesn't carry the answer for whichever page filled it.
     # match: widens or narrows what counts as the page it points at: its query string too, or
-    # everything but a search of it, or only its controller, or its controller and action —
-    # which is what a link carrying query params (a search, a filtered index) needs.
+    # only its controller, or its controller and action — which is what a link carrying query
+    # params (a search, a filtered index) needs.
     class Component < ApplicationComponent
-      MATCHES = [:path, :full_path, :unfiltered_path, :controller, :controller_action].freeze
+      MATCHES = [:path, :full_path, :controller, :controller_action].freeze
       # The matches the browser answers with a route rather than with the URL
       ROUTE_MATCHES = [:controller, :controller_action].freeze
-      # What sortable_search_params? counts as a search, for :unfiltered_path to ask in the
-      # browser. period is the exception it makes for itself: only a period other than "all"
-      # narrows the page, so the controller reads that one's value rather than its presence.
-      FILTER_PARAMS = ((Binxtils::SortableHelper::BASE_SEARCH_KEYS +
-        Binxtils::SortableHelper.extra_search_keys)
-        .flat_map { |key| key.is_a?(Hash) ? key.keys : [key] } -
-        %i[direction sort period per_page]).map(&:to_s).freeze
 
       def initialize(path:, text: nil, match: :path, matching_controllers: [], html_class: nil,
         data: {}, **html_options)
@@ -51,12 +44,7 @@ module UI
       def link_data
         @data.merge(controller: [@data[:controller], "ui--active-link"].compact.join(" "),
           "ui--active-link-match-value": @match,
-          "ui--active-link-routes-value": link_routes,
-          "ui--active-link-filters-value": link_filters).compact
-      end
-
-      def link_filters
-        FILTER_PARAMS.join(" ") if @match == :unfiltered_path
+          "ui--active-link-routes-value": link_routes).compact
       end
 
       # The link's own route, which the browser compares the page's against — it can't resolve

--- a/app/components/ui/active_link/component_preview.rb
+++ b/app/components/ui/active_link/component_preview.rb
@@ -46,6 +46,13 @@ module UI
           path: "#{PREVIEW_PATH}/match_full_path", match: :full_path, html_class: "twlink"))
       end
 
+      # The index this link points at, still current while it's paged or sorted and no longer
+      # current once a search narrows it. Add ?page=2, then ?query=x, to see the two apart.
+      def match_unfiltered_path
+        render(UI::ActiveLink::Component.new(text: "This preview, unsearched",
+          path: "#{PREVIEW_PATH}/match_unfiltered_path", match: :unfiltered_path, html_class: "twlink"))
+      end
+
       # Anything beyond html_class passes through to the anchor
       def with_html_options
         render(UI::ActiveLink::Component.new(text: "Opens in a new tab", path: "#{PREVIEW_PATH}/with_html_options",

--- a/app/components/ui/active_link/component_preview.rb
+++ b/app/components/ui/active_link/component_preview.rb
@@ -46,13 +46,6 @@ module UI
           path: "#{PREVIEW_PATH}/match_full_path", match: :full_path, html_class: "twlink"))
       end
 
-      # The index this link points at, still current while it's paged or sorted and no longer
-      # current once a search narrows it. Add ?page=2, then ?query=x, to see the two apart.
-      def match_unfiltered_path
-        render(UI::ActiveLink::Component.new(text: "This preview, unsearched",
-          path: "#{PREVIEW_PATH}/match_unfiltered_path", match: :unfiltered_path, html_class: "twlink"))
-      end
-
       # Anything beyond html_class passes through to the anchor
       def with_html_options
         render(UI::ActiveLink::Component.new(text: "Opens in a new tab", path: "#{PREVIEW_PATH}/with_html_options",

--- a/app/components/ui/active_link/component_preview.rb
+++ b/app/components/ui/active_link/component_preview.rb
@@ -10,25 +10,25 @@ module UI
       # @!group Variants
       # Points at another page, so it stays a plain link
       def default
-        render(UI::ActiveLink::Component.new(text: "Support", path: "/support", html_class: "twlink"))
+        render(UI::ActiveLink::Component.new(text: "Support", path: "/support", class: "twlink"))
       end
 
       # The path this scenario is served from — active, with no wider match needed
       def current_page
         render(UI::ActiveLink::Component.new(text: "This preview", path: "#{PREVIEW_PATH}/current_page",
-          html_class: "twlink"))
+          class: "twlink"))
       end
 
       # A different page of the same controller: active only because match: widens it
       def match_controller
         render(UI::ActiveLink::Component.new(text: "A sibling preview", path: "#{PREVIEW_PATH}/default",
-          match: :controller, html_class: "twlink"))
+          match: :controller, class: "twlink"))
       end
 
       # The same link at the default match: :path, for the contrast
       def match_path
         render(UI::ActiveLink::Component.new(text: "A sibling preview", path: "#{PREVIEW_PATH}/default",
-          html_class: "twlink"))
+          class: "twlink"))
       end
 
       # Ignores the query string, which match: :path wouldn't. Every scenario here shares one
@@ -36,25 +36,25 @@ module UI
       def match_controller_action
         render(UI::ActiveLink::Component.new(text: "This scenario, other params",
           path: "#{PREVIEW_PATH}/match_controller_action?example=1",
-          match: :controller_action, html_class: "twlink"))
+          match: :controller_action, class: "twlink"))
       end
 
       # The path this scenario is served from, active only while the page carries no params of
       # its own — match: :path ignores them. Add ?example=1 to the URL to see the difference.
       def match_full_path
         render(UI::ActiveLink::Component.new(text: "This preview, exactly",
-          path: "#{PREVIEW_PATH}/match_full_path", match: :full_path, html_class: "twlink"))
+          path: "#{PREVIEW_PATH}/match_full_path", match: :full_path, class: "twlink"))
       end
 
-      # Anything beyond html_class passes through to the anchor
+      # Anything beyond class passes through to the anchor
       def with_html_options
         render(UI::ActiveLink::Component.new(text: "Opens in a new tab", path: "#{PREVIEW_PATH}/with_html_options",
-          html_class: "twlink", id: "preview-active-link", target: "_blank"))
+          class: "twlink", id: "preview-active-link", target: "_blank"))
       end
 
       # Markup inside the link, in place of text:
       def with_block_content
-        render(UI::ActiveLink::Component.new(path: "#{PREVIEW_PATH}/with_block_content", html_class: "twlink")) do
+        render(UI::ActiveLink::Component.new(path: "#{PREVIEW_PATH}/with_block_content", class: "twlink")) do
           tag.strong("Block content")
         end
       end

--- a/app/components/ui/active_link/component_preview.rb
+++ b/app/components/ui/active_link/component_preview.rb
@@ -13,7 +13,7 @@ module UI
         render(UI::ActiveLink::Component.new(text: "Support", path: "/support", html_class: "nav-link"))
       end
 
-      # The path this scenario is served from — active, with no match_controller needed
+      # The path this scenario is served from — active, with no wider match needed
       def current_page
         render(UI::ActiveLink::Component.new(text: "This preview", path: "#{PREVIEW_PATH}/current_page",
           html_class: "nav-link"))
@@ -39,10 +39,11 @@ module UI
           match: :controller_action, html_class: "nav-link"))
       end
 
-      # A caller that already knows the state passes active:, skipping the current-page check
-      def active_forced
-        render(UI::ActiveLink::Component.new(text: "Forced active", path: "/support",
-          active: true, html_class: "nav-link"))
+      # The path this scenario is served from, active only while the page carries no params of
+      # its own — match: :path ignores them. Add ?example=1 to the URL to see the difference.
+      def match_full_path
+        render(UI::ActiveLink::Component.new(text: "This preview, exactly",
+          path: "#{PREVIEW_PATH}/match_full_path", match: :full_path, html_class: "nav-link"))
       end
 
       # Anything beyond html_class passes through to the anchor

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -79,30 +79,6 @@ class ApplicationController < ActionController::Base
     params.permit(:locale).merge(options)
   end
 
-  def locale_from_request_header
-    request.env.fetch("HTTP_ACCEPT_LANGUAGE", "").scan(/^[a-z]{2}/).first
-  end
-
-  def locale_from_request_params
-    params[:locale].to_s.strip
-  end
-
-  def requested_locale
-    return @requested_locale if defined?(@requested_locale)
-
-    requested_locale =
-      locale_from_request_params.presence ||
-      current_user&.preferred_language.presence ||
-      locale_from_request_header.presence
-
-    @requested_locale =
-      if I18n.available_locales.include?(requested_locale.to_s.to_sym)
-        requested_locale
-      else
-        I18n.default_locale
-      end
-  end
-
   # Around filter to ensure locale (language and timezone) are set only per request
   def set_locale(&action)
     # Parse the timezone params if they are passed (tested in admin#dashboard#index)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -74,6 +74,30 @@ class ApplicationController < ActionController::Base
       .to_h # Use to_h here to prevent unpermitted params logs over and over
   end
 
+  def locale_from_request_header
+    request.env.fetch("HTTP_ACCEPT_LANGUAGE", "").scan(/^[a-z]{2}/).first
+  end
+
+  def locale_from_request_params
+    params[:locale].to_s.strip
+  end
+
+  def requested_locale
+    return @requested_locale if defined?(@requested_locale)
+
+    requested_locale =
+      locale_from_request_params.presence ||
+      current_user&.preferred_language.presence ||
+      locale_from_request_header.presence
+
+    @requested_locale =
+      if I18n.available_locales.include?(requested_locale.to_s.to_sym)
+        requested_locale
+      else
+        I18n.default_locale
+      end
+  end
+
   def default_url_options(options = {})
     # forward locale param when provided
     params.permit(:locale).merge(options)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -83,24 +83,25 @@ class ApplicationController < ActionController::Base
   end
 
   def requested_locale
-    return @requested_locale if defined?(@requested_locale)
+    @requested_locale ||= available_locale(locale_from_request_params.presence || implicit_locale)
+  end
 
-    requested_locale =
-      locale_from_request_params.presence ||
-      current_user&.preferred_language.presence ||
-      locale_from_request_header.presence
+  # The locale the request would render in without its locale param, which is what makes the
+  # param redundant -- default_url_options drops one rather than trailing it across every link
+  def implicit_locale
+    @implicit_locale ||= available_locale(current_user&.preferred_language.presence ||
+      locale_from_request_header.presence)
+  end
 
-    @requested_locale =
-      if I18n.available_locales.include?(requested_locale.to_s.to_sym)
-        requested_locale
-      else
-        I18n.default_locale
-      end
+  def available_locale(locale)
+    I18n.available_locales.include?(locale.to_s.to_sym) ? locale : I18n.default_locale
   end
 
   def default_url_options(options = {})
-    # forward locale param when provided
-    params.permit(:locale).merge(options)
+    return options if locale_from_request_params.blank? ||
+      locale_from_request_params == implicit_locale.to_s
+
+    {locale: locale_from_request_params}.merge(options)
   end
 
   # Around filter to ensure locale (language and timezone) are set only per request

--- a/app/controllers/concerns/controller_helpers.rb
+++ b/app/controllers/concerns/controller_helpers.rb
@@ -12,7 +12,7 @@ module ControllerHelpers
   included do
     helper_method :current_user, :current_user_or_unconfirmed_user, :sign_in_partner, :user_root_url,
       :user_root_bike_search?, :current_organization, :passive_organization, :current_location,
-      :page_id, :default_bike_search_path, :bikehub_url, :show_general_alert,
+      :page_id, :page_route, :default_bike_search_path, :bikehub_url, :show_general_alert,
       :display_dev_info?, :current_country_id, :current_currency, :turbo_request?,
       :render_donation_request?
     before_action :enable_rack_profiler
@@ -267,6 +267,12 @@ module ControllerHelpers
 
     scope ||= [:controllers, controller_namespace, controller_name, controller_method.to_sym]
     ActiveSupport::HtmlSafeTranslation.translate(key, **kwargs, scope: scope.compact)
+  end
+
+  # The browser's half of UI::ActiveLink's controller matching. Not page_id, which two
+  # controllers override to borrow another page's styles.
+  def page_route
+    "#{controller_path}##{action_name}"
   end
 
   # This is overridden in FeedbacksController and InfoController

--- a/app/controllers/concerns/controller_helpers.rb
+++ b/app/controllers/concerns/controller_helpers.rb
@@ -12,7 +12,7 @@ module ControllerHelpers
   included do
     helper_method :current_user, :current_user_or_unconfirmed_user, :sign_in_partner, :user_root_url,
       :user_root_bike_search?, :current_organization, :passive_organization, :current_location,
-      :page_id, :page_route, :implicit_locale, :default_bike_search_path, :bikehub_url, :show_general_alert,
+      :page_id, :body_attributes, :page_route, :implicit_locale, :default_bike_search_path, :bikehub_url, :show_general_alert,
       :display_dev_info?, :current_country_id, :current_currency, :turbo_request?,
       :render_donation_request?
     before_action :enable_rack_profiler
@@ -269,8 +269,15 @@ module ControllerHelpers
     ActiveSupport::HtmlSafeTranslation.translate(key, **kwargs, scope: scope.compact)
   end
 
-  # The browser's half of UI::ActiveLink's controller matching. Not page_id, which two
-  # controllers override to borrow another page's styles.
+  # What the browser reads off the page rather than off an element, for the components whose
+  # markup is a fragment cache shared by every page. A layout that renders one and forgets
+  # these fails silently -- the link just never goes current -- so they travel together.
+  def body_attributes
+    {data: {page_route:, implicit_locale:}}
+  end
+
+  # The browser's half of UI::ActiveLink's controller matching. Not page_id, which controllers
+  # override to borrow another page's styles.
   def page_route
     "#{controller_path}##{action_name}"
   end
@@ -302,6 +309,11 @@ module ControllerHelpers
   def available_locale(locale)
     I18n.available_locales.include?(locale.to_s.to_sym) ? locale : I18n.default_locale
   end
+
+  # Private in ApplicationController before the move here, and only implicit_locale is a
+  # helper_method -- which reaches a private one anyway
+  private :locale_from_request_header, :locale_from_request_params, :requested_locale,
+    :available_locale
 
   # This is overridden in FeedbacksController and InfoController
   def page_id

--- a/app/controllers/concerns/controller_helpers.rb
+++ b/app/controllers/concerns/controller_helpers.rb
@@ -12,7 +12,7 @@ module ControllerHelpers
   included do
     helper_method :current_user, :current_user_or_unconfirmed_user, :sign_in_partner, :user_root_url,
       :user_root_bike_search?, :current_organization, :passive_organization, :current_location,
-      :page_id, :body_attributes, :page_route, :implicit_locale, :default_bike_search_path, :bikehub_url, :show_general_alert,
+      :page_id, :implicit_locale, :default_bike_search_path, :bikehub_url, :show_general_alert,
       :display_dev_info?, :current_country_id, :current_currency, :turbo_request?,
       :render_donation_request?
     before_action :enable_rack_profiler
@@ -267,19 +267,6 @@ module ControllerHelpers
 
     scope ||= [:controllers, controller_namespace, controller_name, controller_method.to_sym]
     ActiveSupport::HtmlSafeTranslation.translate(key, **kwargs, scope: scope.compact)
-  end
-
-  # What the browser reads off the page rather than off an element, for the components whose
-  # markup is a fragment cache shared by every page. A layout that renders one and forgets
-  # these fails silently -- the link just never goes current -- so they travel together.
-  def body_attributes
-    {data: {page_route:, implicit_locale:}}
-  end
-
-  # The browser's half of UI::ActiveLink's controller matching. Not page_id, which controllers
-  # override to borrow another page's styles.
-  def page_route
-    "#{controller_path}##{action_name}"
   end
 
   def locale_from_request_header

--- a/app/controllers/concerns/controller_helpers.rb
+++ b/app/controllers/concerns/controller_helpers.rb
@@ -344,7 +344,7 @@ module ControllerHelpers
     request.format.turbo_stream? || turbo_frame_request?
   end
 
-  protected
+  private
 
   # passive_organization is the organization set for the user - which is persisted in session
   # The user may or may not be interacting with the current_organization in any given request

--- a/app/controllers/concerns/controller_helpers.rb
+++ b/app/controllers/concerns/controller_helpers.rb
@@ -12,7 +12,7 @@ module ControllerHelpers
   included do
     helper_method :current_user, :current_user_or_unconfirmed_user, :sign_in_partner, :user_root_url,
       :user_root_bike_search?, :current_organization, :passive_organization, :current_location,
-      :page_id, :page_route, :default_bike_search_path, :bikehub_url, :show_general_alert,
+      :page_id, :page_route, :implicit_locale, :default_bike_search_path, :bikehub_url, :show_general_alert,
       :display_dev_info?, :current_country_id, :current_currency, :turbo_request?,
       :render_donation_request?
     before_action :enable_rack_profiler
@@ -273,6 +273,34 @@ module ControllerHelpers
   # controllers override to borrow another page's styles.
   def page_route
     "#{controller_path}##{action_name}"
+  end
+
+  def locale_from_request_header
+    request.env.fetch("HTTP_ACCEPT_LANGUAGE", "").scan(/^[a-z]{2}/).first
+  end
+
+  def locale_from_request_params
+    params[:locale].to_s.strip
+  end
+
+  # The locale a request carrying no locale param renders in. The footer's language switcher
+  # leaves the param off for this one, and has to add it for every other -- dropping it would
+  # land the visitor back here. Doorkeeper's controllers reach it through the layout.
+  def implicit_locale
+    @implicit_locale ||= available_locale(current_user&.preferred_language.presence ||
+      locale_from_request_header.presence)
+  end
+
+  def requested_locale
+    @requested_locale ||= if locale_from_request_params.present?
+      available_locale(locale_from_request_params)
+    else
+      implicit_locale
+    end
+  end
+
+  def available_locale(locale)
+    I18n.available_locales.include?(locale.to_s.to_sym) ? locale : I18n.default_locale
   end
 
   # This is overridden in FeedbacksController and InfoController

--- a/app/controllers/concerns/controller_helpers.rb
+++ b/app/controllers/concerns/controller_helpers.rb
@@ -269,39 +269,6 @@ module ControllerHelpers
     ActiveSupport::HtmlSafeTranslation.translate(key, **kwargs, scope: scope.compact)
   end
 
-  def locale_from_request_header
-    request.env.fetch("HTTP_ACCEPT_LANGUAGE", "").scan(/^[a-z]{2}/).first
-  end
-
-  def locale_from_request_params
-    params[:locale].to_s.strip
-  end
-
-  # The locale a request carrying no locale param renders in. The footer's language switcher
-  # leaves the param off for this one, and has to add it for every other -- dropping it would
-  # land the visitor back here. Doorkeeper's controllers reach it through the layout.
-  def implicit_locale
-    @implicit_locale ||= available_locale(current_user&.preferred_language.presence ||
-      locale_from_request_header.presence)
-  end
-
-  def requested_locale
-    @requested_locale ||= if locale_from_request_params.present?
-      available_locale(locale_from_request_params)
-    else
-      implicit_locale
-    end
-  end
-
-  def available_locale(locale)
-    I18n.available_locales.include?(locale.to_s.to_sym) ? locale : I18n.default_locale
-  end
-
-  # Private in ApplicationController before the move here, and only implicit_locale is a
-  # helper_method -- which reaches a private one anyway
-  private :locale_from_request_header, :locale_from_request_params, :requested_locale,
-    :available_locale
-
   # This is overridden in FeedbacksController and InfoController
   def page_id
     @page_id ||= [
@@ -332,6 +299,34 @@ module ControllerHelpers
   end
 
   private
+
+  def locale_from_request_header
+    request.env.fetch("HTTP_ACCEPT_LANGUAGE", "").scan(/^[a-z]{2}/).first
+  end
+
+  def locale_from_request_params
+    params[:locale].to_s.strip
+  end
+
+  # The locale a request carrying no locale param renders in. The footer's language switcher
+  # leaves the param off for this one, and has to add it for every other -- dropping it would
+  # land the visitor back here. Doorkeeper's controllers reach it through the layout.
+  def implicit_locale
+    @implicit_locale ||= available_locale(current_user&.preferred_language.presence ||
+      locale_from_request_header.presence)
+  end
+
+  def requested_locale
+    @requested_locale ||= if locale_from_request_params.present?
+      available_locale(locale_from_request_params)
+    else
+      implicit_locale
+    end
+  end
+
+  def available_locale(locale)
+    I18n.available_locales.include?(locale.to_s.to_sym) ? locale : I18n.default_locale
+  end
 
   # passive_organization is the organization set for the user - which is persisted in session
   # The user may or may not be interacting with the current_organization in any given request

--- a/app/controllers/concerns/controller_helpers.rb
+++ b/app/controllers/concerns/controller_helpers.rb
@@ -12,7 +12,7 @@ module ControllerHelpers
   included do
     helper_method :current_user, :current_user_or_unconfirmed_user, :sign_in_partner, :user_root_url,
       :user_root_bike_search?, :current_organization, :passive_organization, :current_location,
-      :page_id, :implicit_locale, :default_bike_search_path, :bikehub_url, :show_general_alert,
+      :page_id, :default_bike_search_path, :bikehub_url, :show_general_alert,
       :display_dev_info?, :current_country_id, :current_currency, :turbo_request?,
       :render_donation_request?
     before_action :enable_rack_profiler
@@ -299,34 +299,6 @@ module ControllerHelpers
   end
 
   private
-
-  def locale_from_request_header
-    request.env.fetch("HTTP_ACCEPT_LANGUAGE", "").scan(/^[a-z]{2}/).first
-  end
-
-  def locale_from_request_params
-    params[:locale].to_s.strip
-  end
-
-  # The locale a request carrying no locale param renders in. The footer's language switcher
-  # leaves the param off for this one, and has to add it for every other -- dropping it would
-  # land the visitor back here. Doorkeeper's controllers reach it through the layout.
-  def implicit_locale
-    @implicit_locale ||= available_locale(current_user&.preferred_language.presence ||
-      locale_from_request_header.presence)
-  end
-
-  def requested_locale
-    @requested_locale ||= if locale_from_request_params.present?
-      available_locale(locale_from_request_params)
-    else
-      implicit_locale
-    end
-  end
-
-  def available_locale(locale)
-    I18n.available_locales.include?(locale.to_s.to_sym) ? locale : I18n.default_locale
-  end
 
   # passive_organization is the organization set for the user - which is persisted in session
   # The user may or may not be interacting with the current_organization in any given request

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -8,7 +8,7 @@ module ApplicationHelper
   # goes current. The route isn't page_id, which controllers override to borrow another page's
   # styles.
   def body_tag(html_class: nil, **html_options, &block)
-    tag.body(id: page_id, class: html_class, **html_options,
+    tag.body(id: page_id, class: html_class.presence || body_class, **html_options,
       data: {page_route: "#{controller_path}##{action_name}"}, &block)
   end
 
@@ -40,22 +40,6 @@ module ApplicationHelper
       action_name:,
       force_landing_page_render: @force_landing_page_render
     ) == :organized
-  end
-
-  def body_class
-    if controller_name == "landing_pages" || @force_landing_page_render
-      if %w[for_schools for_law_enforcement].include?(action_name)
-        "kelsey_landing-page-body"
-      else
-        "landing-page-body"
-      end
-    elsif controller_name == "info" && action_name == "resources"
-      "kelsey_landing-page-body"
-    elsif main_content_organized?
-      "organized-body"
-    elsif controller_name == "registrations" && action_name == "show"
-      "tw:bg-[#f7f6fb]"
-    end
   end
 
   # Deprecated - UI::Forms::NestedFields::Component replaces this. Every set this adds shares one
@@ -143,5 +127,23 @@ module ApplicationHelper
       data
     end
     CodeRay.scan(JSON.pretty_generate(cleaned_data), :json).div.html_safe
+  end
+
+  private
+
+  def body_class
+    if controller_name == "landing_pages" || @force_landing_page_render
+      if %w[for_schools for_law_enforcement].include?(action_name)
+        "kelsey_landing-page-body"
+      else
+        "landing-page-body"
+      end
+    elsif controller_name == "info" && action_name == "resources"
+      "kelsey_landing-page-body"
+    elsif main_content_organized?
+      "organized-body"
+    elsif controller_name == "registrations" && action_name == "show"
+      "tw:bg-[#f7f6fb]"
+    end
   end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -2,13 +2,12 @@ module ApplicationHelper
   include Binxtils::NavHelper
   include Binxtils::SortableHelper
 
-  # What the browser reads off the page rather than off an element, for the components whose
-  # markup is a fragment cache shared by every page. A layout that renders one and forgets
-  # these fails silently -- the link just never goes current -- so they travel together.
-  # The route is UI::ActiveLink's controller matching, not page_id, which controllers override
-  # to borrow another page's styles.
+  # UI::ActiveLink's controller matching reads the route off the page rather than off the link,
+  # since the link's markup is a fragment cache shared by every page. A layout that renders one
+  # and forgets this fails silently -- the link just never goes current. Not page_id, which
+  # controllers override to borrow another page's styles.
   def body_attributes
-    {data: {page_route: "#{controller_path}##{action_name}", implicit_locale:}}
+    {data: {page_route: "#{controller_path}##{action_name}"}}
   end
 
   def notification_delivery_display(status)

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -2,6 +2,15 @@ module ApplicationHelper
   include Binxtils::NavHelper
   include Binxtils::SortableHelper
 
+  # What the browser reads off the page rather than off an element, for the components whose
+  # markup is a fragment cache shared by every page. A layout that renders one and forgets
+  # these fails silently -- the link just never goes current -- so they travel together.
+  # The route is UI::ActiveLink's controller matching, not page_id, which controllers override
+  # to borrow another page's styles.
+  def body_attributes
+    {data: {page_route: "#{controller_path}##{action_name}", implicit_locale:}}
+  end
+
   def notification_delivery_display(status)
     text = if status == "delivery_success"
       check_mark

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -2,12 +2,14 @@ module ApplicationHelper
   include Binxtils::NavHelper
   include Binxtils::SortableHelper
 
-  # UI::ActiveLink's controller matching reads the route off the page rather than off the link,
-  # since the link's markup is a fragment cache shared by every page. A layout that renders one
-  # and forgets this fails silently -- the link just never goes current. Not page_id, which
-  # controllers override to borrow another page's styles.
-  def body_attributes
-    {data: {page_route: "#{controller_path}##{action_name}"}}
+  # Every layout's <body>. UI::ActiveLink's controller matching reads the route off the page
+  # rather than off the link, since the link's markup is a fragment cache shared by every page,
+  # and a layout that opens its own <body> and forgets it fails silently -- the link just never
+  # goes current. The route isn't page_id, which controllers override to borrow another page's
+  # styles.
+  def body_tag(html_class: nil, **html_options, &block)
+    tag.body(id: page_id, class: html_class, **html_options,
+      data: {page_route: "#{controller_path}##{action_name}"}, &block)
   end
 
   def notification_delivery_display(status)

--- a/app/javascript/controllers/page_block/locale_select_controller.js
+++ b/app/javascript/controllers/page_block/locale_select_controller.js
@@ -9,13 +9,7 @@ export default class extends Controller {
     event.preventDefault()
     const locale = event.currentTarget.querySelector('[name="locale"]').value
     const url = new URL(window.location.href)
-    // The locale the page already renders in without a param -- a preference or the browser's
-    // language, not necessarily the default one, so the server hands it down on the body
-    if (locale === document.body.dataset.implicitLocale) {
-      url.searchParams.delete('locale')
-    } else {
-      url.searchParams.set('locale', locale)
-    }
+    url.searchParams.set('locale', locale)
     window.location.href = url.pathname + url.search
   }
 }

--- a/app/javascript/controllers/page_block/locale_select_controller.js
+++ b/app/javascript/controllers/page_block/locale_select_controller.js
@@ -1,0 +1,21 @@
+import { Controller } from '@hotwired/stimulus'
+
+// Connects to data-controller='page-block--locale-select'
+// The footer is one cached fragment for every page, so the form carries no action and submits
+// to whatever URL the browser is on. Rebuilding that URL here keeps the page's own params,
+// which a GET submit would drop.
+export default class extends Controller {
+  submit (event) {
+    event.preventDefault()
+    const locale = event.currentTarget.querySelector('[name="locale"]').value
+    const url = new URL(window.location.href)
+    // The locale the page already renders in without a param -- a preference or the browser's
+    // language, not necessarily the default one, so the server hands it down on the body
+    if (locale === document.body.dataset.implicitLocale) {
+      url.searchParams.delete('locale')
+    } else {
+      url.searchParams.set('locale', locale)
+    }
+    window.location.href = url.pathname + url.search
+  }
+}

--- a/app/javascript/controllers/ui/active_link_controller.js
+++ b/app/javascript/controllers/ui/active_link_controller.js
@@ -9,13 +9,21 @@ const controllerOf = (route) => route.split('#')[0]
 const ROUTE_MATCHES = ['controller', 'controller_action']
 
 // Connects to data-controller='ui--active-link'
-// Renders UI::ActiveLink::Component's active state, which the server can't: these links are
+// Renders UI::ActiveLink::Component's aria-current, which the server can't: these links are
 // cached fragments, so the markup is shared by every page it was rendered for.
 export default class extends Controller {
   static values = { match: String, routes: String }
 
   connect () {
-    this.element.classList.toggle('active', this.isActive())
+    if (this.isActive()) this.element.setAttribute('aria-current', this.ariaCurrent())
+    else this.element.removeAttribute('aria-current')
+  }
+
+  // "page" is reserved for the link whose own URL is the current one. A widened match means
+  // the current page sits inside what the link points at, not that it is it -- aria-current's
+  // "true", so a reader isn't told a link elsewhere is where it already is
+  ariaCurrent () {
+    return ROUTE_MATCHES.includes(this.matchValue) ? 'true' : 'page'
   }
 
   isActive () {

--- a/app/javascript/controllers/ui/active_link_controller.js
+++ b/app/javascript/controllers/ui/active_link_controller.js
@@ -12,7 +12,7 @@ const ROUTE_MATCHES = ['controller', 'controller_action']
 // Renders UI::ActiveLink::Component's aria-current, which the server can't: these links are
 // cached fragments, so the markup is shared by every page it was rendered for.
 export default class extends Controller {
-  static values = { match: String, routes: String, filters: String }
+  static values = { match: String, routes: String }
 
   connect () {
     if (this.isActive()) this.element.setAttribute('aria-current', this.ariaCurrent())
@@ -27,49 +27,20 @@ export default class extends Controller {
   }
 
   isActive () {
-    if (ROUTE_MATCHES.includes(this.matchValue)) return this.routeMatches()
-    if (this.matchValue === 'unfiltered_path') return this.unfilteredPathMatches()
-
-    return this.pathMatches()
-  }
-
-  // Null off-site, where the page can never be what the link points at
-  linkUrl () {
-    const url = new URL(this.element.href, window.location.href)
-
-    return url.origin === window.location.origin ? url : null
+    return ROUTE_MATCHES.includes(this.matchValue) ? this.routeMatches() : this.pathMatches()
   }
 
   // Mirrors current_page?: the query string counts when the link carries one, so a search
   // link stays active on page 2. full_path counts it either way.
   pathMatches () {
-    const url = this.linkUrl()
-    if (!url) return false
+    const url = new URL(this.element.href, window.location.href)
+    // Off-site, the page can never be what the link points at
+    if (url.origin !== window.location.origin) return false
     if (url.search || this.matchValue === 'full_path') {
       return url.pathname + url.search === window.location.pathname + window.location.search
     }
 
     return trimSlash(url.pathname) === trimSlash(window.location.pathname)
-  }
-
-  // Mirrors sortable_search_params?: the index stays this link's page while paging or sorting
-  // it, and stops being it once a search narrows it. The names come from the server, which is
-  // where the list of them lives.
-  unfilteredPathMatches () {
-    const url = new URL(this.element.href, window.location.href)
-    if (url.origin !== window.location.origin) return false
-    if (trimSlash(url.pathname) !== trimSlash(window.location.pathname)) return false
-
-    const params = new URLSearchParams(window.location.search)
-    const filters = this.filtersValue.split(' ')
-    // A blank value isn't a search, the way `.reject(&:blank?)` doesn't count one
-    for (const [name, value] of params) {
-      if (!value) continue
-      if (name.startsWith('search_') || filters.includes(name.replace(/\[\]$/, ''))) return false
-      if (name === 'period' && value !== 'all') return false
-    }
-
-    return true
   }
 
   // The page's route comes off the body, since only the server can resolve one. A link whose

--- a/app/javascript/controllers/ui/active_link_controller.js
+++ b/app/javascript/controllers/ui/active_link_controller.js
@@ -12,7 +12,7 @@ const ROUTE_MATCHES = ['controller', 'controller_action']
 // Renders UI::ActiveLink::Component's aria-current, which the server can't: these links are
 // cached fragments, so the markup is shared by every page it was rendered for.
 export default class extends Controller {
-  static values = { match: String, routes: String }
+  static values = { match: String, routes: String, filters: String }
 
   connect () {
     if (this.isActive()) this.element.setAttribute('aria-current', this.ariaCurrent())
@@ -27,7 +27,10 @@ export default class extends Controller {
   }
 
   isActive () {
-    return ROUTE_MATCHES.includes(this.matchValue) ? this.routeMatches() : this.pathMatches()
+    if (ROUTE_MATCHES.includes(this.matchValue)) return this.routeMatches()
+    if (this.matchValue === 'unfiltered_path') return this.unfilteredPathMatches()
+
+    return this.pathMatches()
   }
 
   // Mirrors current_page?: the query string counts when the link carries one, so a search
@@ -40,6 +43,26 @@ export default class extends Controller {
     }
 
     return trimSlash(url.pathname) === trimSlash(window.location.pathname)
+  }
+
+  // Mirrors sortable_search_params?: the index stays this link's page while paging or sorting
+  // it, and stops being it once a search narrows it. The names come from the server, which is
+  // where the list of them lives.
+  unfilteredPathMatches () {
+    const url = new URL(this.element.href, window.location.href)
+    if (url.origin !== window.location.origin) return false
+    if (trimSlash(url.pathname) !== trimSlash(window.location.pathname)) return false
+
+    const params = new URLSearchParams(window.location.search)
+    const filters = this.filtersValue.split(' ')
+    // A blank value isn't a search, the way `.reject(&:blank?)` doesn't count one
+    for (const [name, value] of params) {
+      if (!value) continue
+      if (name.startsWith('search_') || filters.includes(name.replace(/\[\]$/, ''))) return false
+      if (name === 'period' && value !== 'all') return false
+    }
+
+    return true
   }
 
   // The page's route comes off the body, since only the server can resolve one. A link whose

--- a/app/javascript/controllers/ui/active_link_controller.js
+++ b/app/javascript/controllers/ui/active_link_controller.js
@@ -6,25 +6,27 @@ const trimSlash = (path) => path.length > 1 ? path.replace(/\/$/, '') : path
 const controllerOf = (route) => route.split('#')[0]
 
 // Connects to data-controller='ui--active-link'
-// Renders UI::ActiveLink::Component's active state, which the server can't: these links
-// are cached fragments, so the markup is shared by every page it was rendered for.
+// Renders UI::ActiveLink::Component's active state, which the server can't: these links are
+// cached fragments, so the markup is shared by every page it was rendered for.
 export default class extends Controller {
-  static values = { match: String, route: String }
+  static values = { match: String, routes: String }
 
   connect () {
     this.element.classList.toggle('active', this.isActive())
   }
 
   isActive () {
-    return this.matchValue === 'path' ? this.pathMatches() : this.routeMatches()
+    return this.hasRoutesValue ? this.routeMatches() : this.pathMatches()
   }
 
-  // Mirrors current_page?: the query string counts only when the link carries one, so a
-  // search link stays active on page 2
+  // Mirrors current_page?: the query string counts when the link carries one, so a search
+  // link stays active on page 2. full_path counts it either way.
   pathMatches () {
     const url = new URL(this.element.href, window.location.href)
     if (url.origin !== window.location.origin) return false
-    if (url.search) return url.pathname + url.search === window.location.pathname + window.location.search
+    if (url.search || this.matchValue === 'full_path') {
+      return url.pathname + url.search === window.location.pathname + window.location.search
+    }
 
     return trimSlash(url.pathname) === trimSlash(window.location.pathname)
   }
@@ -32,9 +34,10 @@ export default class extends Controller {
   // The page's route comes off the body, since only the server can resolve one
   routeMatches () {
     const pageRoute = document.body.dataset.pageRoute
-    if (!this.hasRouteValue || !pageRoute) return false
-    if (this.matchValue === 'controller_action') return this.routeValue === pageRoute
+    if (!pageRoute) return false
 
-    return controllerOf(this.routeValue) === controllerOf(pageRoute)
+    return this.routesValue.split(' ').some((route) => this.matchValue === 'controller_action'
+      ? route === pageRoute
+      : controllerOf(route) === controllerOf(pageRoute))
   }
 }

--- a/app/javascript/controllers/ui/active_link_controller.js
+++ b/app/javascript/controllers/ui/active_link_controller.js
@@ -1,0 +1,40 @@
+import { Controller } from '@hotwired/stimulus'
+
+// Rails' current_page? ignores a trailing slash on either side
+const trimSlash = (path) => path.length > 1 ? path.replace(/\/$/, '') : path
+
+const controllerOf = (route) => route.split('#')[0]
+
+// Connects to data-controller='ui--active-link'
+// Renders UI::ActiveLink::Component's active state, which the server can't: these links
+// are cached fragments, so the markup is shared by every page it was rendered for.
+export default class extends Controller {
+  static values = { match: String, route: String }
+
+  connect () {
+    this.element.classList.toggle('active', this.isActive())
+  }
+
+  isActive () {
+    return this.matchValue === 'path' ? this.pathMatches() : this.routeMatches()
+  }
+
+  // Mirrors current_page?: the query string counts only when the link carries one, so a
+  // search link stays active on page 2
+  pathMatches () {
+    const url = new URL(this.element.href, window.location.href)
+    if (url.origin !== window.location.origin) return false
+    if (url.search) return url.pathname + url.search === window.location.pathname + window.location.search
+
+    return trimSlash(url.pathname) === trimSlash(window.location.pathname)
+  }
+
+  // The page's route comes off the body, since only the server can resolve one
+  routeMatches () {
+    const pageRoute = document.body.dataset.pageRoute
+    if (!this.hasRouteValue || !pageRoute) return false
+    if (this.matchValue === 'controller_action') return this.routeValue === pageRoute
+
+    return controllerOf(this.routeValue) === controllerOf(pageRoute)
+  }
+}

--- a/app/javascript/controllers/ui/active_link_controller.js
+++ b/app/javascript/controllers/ui/active_link_controller.js
@@ -19,15 +19,19 @@ export default class extends Controller {
     else this.element.removeAttribute('aria-current')
   }
 
+  get routeMatch () {
+    return ROUTE_MATCHES.includes(this.matchValue)
+  }
+
   // "page" is reserved for the link whose own URL is the current one. A widened match means
   // the current page sits inside what the link points at, not that it is it -- aria-current's
   // "true", so a reader isn't told a link elsewhere is where it already is
   ariaCurrent () {
-    return ROUTE_MATCHES.includes(this.matchValue) ? 'true' : 'page'
+    return this.routeMatch ? 'true' : 'page'
   }
 
   isActive () {
-    return ROUTE_MATCHES.includes(this.matchValue) ? this.routeMatches() : this.pathMatches()
+    return this.routeMatch ? this.routeMatches() : this.pathMatches()
   }
 
   // Mirrors current_page?: the query string counts when the link carries one, so a search
@@ -49,8 +53,7 @@ export default class extends Controller {
     const pageRoute = document.body.dataset.pageRoute
     if (!pageRoute || !this.hasRoutesValue) return false
 
-    return this.routesValue.split(' ').some((route) => this.matchValue === 'controller_action'
-      ? route === pageRoute
-      : controllerOf(route) === controllerOf(pageRoute))
+    return this.routesValue.split(' ')
+      .includes(this.matchValue === 'controller_action' ? pageRoute : controllerOf(pageRoute))
   }
 }

--- a/app/javascript/controllers/ui/active_link_controller.js
+++ b/app/javascript/controllers/ui/active_link_controller.js
@@ -33,11 +33,18 @@ export default class extends Controller {
     return this.pathMatches()
   }
 
+  // Null off-site, where the page can never be what the link points at
+  linkUrl () {
+    const url = new URL(this.element.href, window.location.href)
+
+    return url.origin === window.location.origin ? url : null
+  }
+
   // Mirrors current_page?: the query string counts when the link carries one, so a search
   // link stays active on page 2. full_path counts it either way.
   pathMatches () {
-    const url = new URL(this.element.href, window.location.href)
-    if (url.origin !== window.location.origin) return false
+    const url = this.linkUrl()
+    if (!url) return false
     if (url.search || this.matchValue === 'full_path') {
       return url.pathname + url.search === window.location.pathname + window.location.search
     }

--- a/app/javascript/controllers/ui/active_link_controller.js
+++ b/app/javascript/controllers/ui/active_link_controller.js
@@ -5,6 +5,9 @@ const trimSlash = (path) => path.length > 1 ? path.replace(/\/$/, '') : path
 
 const controllerOf = (route) => route.split('#')[0]
 
+// UI::ActiveLink::Component::ROUTE_MATCHES — the rest compare the URL
+const ROUTE_MATCHES = ['controller', 'controller_action']
+
 // Connects to data-controller='ui--active-link'
 // Renders UI::ActiveLink::Component's active state, which the server can't: these links are
 // cached fragments, so the markup is shared by every page it was rendered for.
@@ -16,7 +19,7 @@ export default class extends Controller {
   }
 
   isActive () {
-    return this.hasRoutesValue ? this.routeMatches() : this.pathMatches()
+    return ROUTE_MATCHES.includes(this.matchValue) ? this.routeMatches() : this.pathMatches()
   }
 
   // Mirrors current_page?: the query string counts when the link carries one, so a search
@@ -31,10 +34,11 @@ export default class extends Controller {
     return trimSlash(url.pathname) === trimSlash(window.location.pathname)
   }
 
-  // The page's route comes off the body, since only the server can resolve one
+  // The page's route comes off the body, since only the server can resolve one. A link whose
+  // own path didn't resolve renders no routes, and matches nothing rather than falling back.
   routeMatches () {
     const pageRoute = document.body.dataset.pageRoute
-    if (!pageRoute) return false
+    if (!pageRoute || !this.hasRoutesValue) return false
 
     return this.routesValue.split(' ').some((route) => this.matchValue === 'controller_action'
       ? route === pageRoute

--- a/app/services/organized_services/user_menu_items.rb
+++ b/app/services/organized_services/user_menu_items.rb
@@ -8,21 +8,14 @@
 # Item shapes:
 #   {type: :divider}
 #   {type: :disabled, label:, secondary:} # component drops these in dropdown
-#   {type: :link, label:, path:, secondary:, active:}
+#   {type: :link, label:, path:, secondary:, match:, matching_controllers:}
 #
 # The component appends a trailing divider (for non-ambassador orgs, unless
 # rendering as a dropdown for a non-superuser) and a super_admin_link
 # (for superusers).
 #
-# `active:` is one of these, which Org::MenuItems::Component::MATCHES hands to
-# UI::ActiveLink as the match: granularity for the browser to resolve:
-#   :auto                                  - match: :path
-#   :match_controller                      - match: :controller
-#   :on_registrations_index                - match: :controller_action
-# or one of these, which the component computes from the current request:
-#   :on_bikes_new
-#   :on_bikes_new_with_parking_notification
-#   :on_registration_sequences             - also matches the pages controller
+# `match:` and `matching_controllers:` are UI::ActiveLink's, which resolves them
+# in the browser. Nothing here depends on which page is current.
 module OrganizedServices
   module UserMenuItems
     extend Functionable
@@ -33,14 +26,20 @@ module OrganizedServices
     def for(organization:, current_user:)
       return [] if organization.nil? || current_user.nil?
 
-      Rails.cache.fetch(["organized_menu_items_v1", organization.id, current_user.cache_key_with_version]) do
+      Rails.cache.fetch(["organized_menu_items_v2", organization.id, current_user.cache_key_with_version]) do
         build_items(organization, current_user)
       end
     end
 
     # Public helpers for the component to inject route-specific overrides
     # (so the menu still shows the dashboard / bulk-imports link when the
-    # user is on those pages, even if the org doesn't have the feature).
+    # user is on those pages, even if the org doesn't have the feature),
+    # and to find where in the menu to inject them.
+    def add_bike_link(organization)
+      link(translation(:add_a_bike),
+        routes.new_organization_bike_path(organization.to_param), match: :full_path)
+    end
+
     def dashboard_link(organization)
       link("#{organization.short_name} dashboard",
         routes.organization_dashboard_index_path(organization_id: organization.to_param))
@@ -50,13 +49,14 @@ module OrganizedServices
       bulk_label = organization.ascend_or_broken_ascend? ? translation(:ascend_imports) : translation(:bulk_imports)
       link(bulk_label,
         routes.organization_bulk_imports_path(organization_id: organization.to_param),
-        active: :match_controller)
+        match: :controller)
     end
 
+    # Editing a page of a sequence is the same section of the menu, on its own controller
     def registration_sequences_link(organization)
       link(translation(:manage_registration_sequences),
         routes.organization_registration_sequences_path(organization_id: organization.to_param),
-        active: :on_registration_sequences)
+        match: :controller, matching_controllers: ["organized/registration_sequence_pages"])
     end
 
     #
@@ -109,13 +109,13 @@ module OrganizedServices
       items = [
         link(translation(:org_bikes, org_name: organization.short_name),
           routes.organization_registrations_path(organization_id: organization.to_param),
-          active: :on_registrations_index)
+          match: :controller_action)
       ]
 
       if organization.enabled?("impound_bikes")
         items << link(translation(:impounded_bikes),
           routes.organization_impound_records_path(organization_id: organization.to_param),
-          secondary: true, active: :match_controller)
+          secondary: true, match: :controller)
       end
 
       if organization.enabled?("show_partial_registrations")
@@ -138,9 +138,10 @@ module OrganizedServices
       items
     end
 
+    # Both add-a-bike links are organized/bikes#new, told apart by the parking_notification
+    # param — so they match on the full path rather than on the page they share
     def add_bike_items(organization)
-      items = [link(translation(:add_a_bike),
-        routes.new_organization_bike_path(organization.to_param), active: :on_bikes_new)]
+      items = [add_bike_link(organization)]
 
       divider_below = organization.show_bulk_import? || organization.lightspeed_or_broken_lightspeed? ||
         organization.enabled?("parking_notifications")
@@ -158,7 +159,7 @@ module OrganizedServices
           routes.organization_parking_notifications_path(organization_id: organization.to_param))
         items << link(translation(:parking_notification_unregistered),
           routes.new_organization_bike_path(organization.to_param, parking_notification: true),
-          secondary: true, active: :on_bikes_new_with_parking_notification)
+          secondary: true, match: :full_path)
       end
 
       items
@@ -170,7 +171,7 @@ module OrganizedServices
       items << if organization.enabled?("bike_stickers")
         link(translation(:registration_stickers),
           routes.organization_stickers_path(organization_id: organization.to_param),
-          active: :match_controller)
+          match: :controller)
       else
         {type: :disabled, label: translation(:registration_stickers), secondary: false}
       end
@@ -183,25 +184,25 @@ module OrganizedServices
       if organization.enabled?("csv_exports")
         items << link(translation(:exports),
           routes.organization_exports_path(organization_id: organization.to_param),
-          active: :match_controller)
+          match: :controller)
       end
 
       if organization.enabled?("graduated_notifications")
         items << link(translation(:graduated_notifications),
           routes.organization_graduated_notifications_path(organization_id: organization.to_param),
-          active: :match_controller)
+          match: :controller)
       end
 
       if organization.enabled?("model_audits")
         items << link(translation(:model_audits),
           routes.organization_model_audits_path(organization_id: organization.to_param),
-          active: :match_controller)
+          match: :controller)
       end
 
       if organization.impound_claims?
         items << link(translation(:impounded_claims),
           routes.organization_impound_claims_path(organization_id: organization.to_param),
-          active: :match_controller)
+          match: :controller)
       end
 
       items
@@ -213,7 +214,7 @@ module OrganizedServices
       items = []
       items << divider if additional_divider
       items << link(translation(:manage_users),
-        routes.organization_users_path(organization_id: organization.to_param), active: :match_controller)
+        routes.organization_users_path(organization_id: organization.to_param), match: :controller)
 
       if organization.enabled?("impound_bikes")
         items << link(translation(:manage_impounding, org_name: organization.short_name),
@@ -227,7 +228,7 @@ module OrganizedServices
 
       if organization.enabled?("customize_emails")
         items << link(translation(:custom_emails),
-          routes.organization_emails_path(organization_id: organization.to_param), active: :match_controller)
+          routes.organization_emails_path(organization_id: organization.to_param), match: :controller)
       elsif organization.enabled?("organization_stolen_message")
         items << link(translation(:stolen_message),
           routes.edit_organization_email_path("organization_stolen_message", organization_id: organization.to_param))
@@ -245,8 +246,8 @@ module OrganizedServices
       items
     end
 
-    def link(label, path, secondary: false, active: :auto)
-      {type: :link, label:, path:, secondary:, active:}
+    def link(label, path, secondary: false, match: :path, matching_controllers: [])
+      {type: :link, label:, path:, secondary:, match:, matching_controllers:}
     end
 
     def divider

--- a/app/services/organized_services/user_menu_items.rb
+++ b/app/services/organized_services/user_menu_items.rb
@@ -15,7 +15,7 @@
 # (for superusers).
 #
 # `active:` is one of these, which Org::MenuItems::Component::MATCHES hands to
-# UI::ActiveLink as the match: granularity to resolve per request:
+# UI::ActiveLink as the match: granularity for the browser to resolve:
 #   :auto                                  - match: :path
 #   :match_controller                      - match: :controller
 #   :on_registrations_index                - match: :controller_action

--- a/app/views/layouts/admin.html.erb
+++ b/app/views/layouts/admin.html.erb
@@ -38,7 +38,7 @@
   <% admin_body_class = "vendor-signup-page" if current_page?(:vendor_signup) %>
   <% admin_body_class = "news-page" if controller_name == "news" %>
 
-  <%= body_tag(html_class: admin_body_class || body_class) do %>
+  <%= body_tag(html_class: admin_body_class) do %>
     <%= render(PageBlock::ReviewAppBanner::Component.from_env(current_user:, return_to: request.fullpath)) %>
 
     <%= render(Admin::Navbar::Component.new(current_user:)) %>

--- a/app/views/layouts/admin.html.erb
+++ b/app/views/layouts/admin.html.erb
@@ -38,11 +38,7 @@
   <% admin_body_class = "vendor-signup-page" if current_page?(:vendor_signup) %>
   <% admin_body_class = "news-page" if controller_name == "news" %>
 
-  <body
-    id="<%= page_id %>"
-    class="<%= admin_body_class || body_class %>"
-    <%= tag.attributes(body_attributes) %>
-  >
+  <%= body_tag(html_class: admin_body_class || body_class) do %>
     <%= render(PageBlock::ReviewAppBanner::Component.from_env(current_user:, return_to: request.fullpath)) %>
 
     <%= render(Admin::Navbar::Component.new(current_user:)) %>
@@ -52,5 +48,5 @@
     <section id="admin-content" class="pb-4 mb-4">
       <div class="container-fluid mt-4 pb-4"><%= yield %></div>
     </section>
-  </body>
+  <% end %>
 </html>

--- a/app/views/layouts/admin.html.erb
+++ b/app/views/layouts/admin.html.erb
@@ -38,7 +38,11 @@
   <% admin_body_class = "vendor-signup-page" if current_page?(:vendor_signup) %>
   <% admin_body_class = "news-page" if controller_name == "news" %>
 
-  <body id="<%= page_id %>" class="<%= admin_body_class || body_class %>">
+  <body
+    id="<%= page_id %>"
+    class="<%= admin_body_class || body_class %>"
+    data-page-route="<%= page_route %>"
+  >
     <%= render(PageBlock::ReviewAppBanner::Component.from_env(current_user:, return_to: request.fullpath)) %>
 
     <%= render(Admin::Navbar::Component.new(current_user:)) %>

--- a/app/views/layouts/admin.html.erb
+++ b/app/views/layouts/admin.html.erb
@@ -41,7 +41,7 @@
   <body
     id="<%= page_id %>"
     class="<%= admin_body_class || body_class %>"
-    data-page-route="<%= page_route %>"
+    <%= tag.attributes(body_attributes) %>
   >
     <%= render(PageBlock::ReviewAppBanner::Component.from_env(current_user:, return_to: request.fullpath)) %>
 

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -51,8 +51,7 @@
   <body
     id="<%= page_id %>"
     class="<%= body_class %>"
-    data-page-route="<%= page_route %>"
-    data-implicit-locale="<%= implicit_locale %>"
+    <%= tag.attributes(body_attributes) %>
   >
     <a
       href="#main-content"

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -67,7 +67,7 @@
 
     <%= render(PageBlock::ReviewAppBanner::Component.from_env(current_user:, return_to: request.fullpath)) %>
 
-    <%= render PageBlock::Navbar::Wrapper::Component.new(current_user:, current_user_or_unconfirmed_user:, passive_organization:, page_id:, controller_namespace:, controller_name:, action_name:) %>
+    <%= render PageBlock::Navbar::Wrapper::Component.new(current_user:, current_user_or_unconfirmed_user:, passive_organization:, controller_namespace:, controller_name:, action_name:) %>
 
     <% if render_donation_request? %>
       <%= render PageBlock::LawEnforcementDonation::Component.new(current_user:) %>
@@ -122,7 +122,7 @@
     <% end %>
 
     <%# Skip the Meta pixel on org/oauth pages and when blocked params are present (search_email is PII, and the pixel %>
-    <%# auto-sends the URL query string). In the cache key too, since page_id ignores query params. %>
+    <%# auto-sends the URL query string) %>
     <% skip_facebook = controller_namespace.in?(%w[organized org_public oauth]) || controller_name == "organizations" || params.key?(:search_email) || params.key?(:proximity) %>
 
     <%= render PageBlock::Footer::Component.new(current_user:, skip_facebook:, passive_organization:) %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -48,7 +48,11 @@
     <!--[if IE]>$('body').prepend("<div id='old-browser-warning'><h4>Your browser is out of date!</h4><p>As a result, Bike Index will not function correctly. <a href=\"http://whatbrowser.com\">Learn more here</a>.</p></div>")<![endif]-->
   </head>
 
-  <body id="<%= page_id %>" class="<%= body_class %>">
+  <body
+    id="<%= page_id %>"
+    class="<%= body_class %>"
+    data-page-route="<%= page_route %>"
+  >
     <a
       href="#main-content"
       class="

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -48,7 +48,7 @@
     <!--[if IE]>$('body').prepend("<div id='old-browser-warning'><h4>Your browser is out of date!</h4><p>As a result, Bike Index will not function correctly. <a href=\"http://whatbrowser.com\">Learn more here</a>.</p></div>")<![endif]-->
   </head>
 
-  <%= body_tag(html_class: body_class) do %>
+  <%= body_tag do %>
     <a
       href="#main-content"
       class="

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -48,11 +48,7 @@
     <!--[if IE]>$('body').prepend("<div id='old-browser-warning'><h4>Your browser is out of date!</h4><p>As a result, Bike Index will not function correctly. <a href=\"http://whatbrowser.com\">Learn more here</a>.</p></div>")<![endif]-->
   </head>
 
-  <body
-    id="<%= page_id %>"
-    class="<%= body_class %>"
-    <%= tag.attributes(body_attributes) %>
-  >
+  <%= body_tag(html_class: body_class) do %>
     <a
       href="#main-content"
       class="
@@ -131,5 +127,5 @@
   I18n.defaultLocale = <%== I18n.default_locale.to_json %>
   I18n.locale = <%== I18n.locale.to_json %>
 </script>
-  </body>
+  <% end %>
 </html>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -52,6 +52,7 @@
     id="<%= page_id %>"
     class="<%= body_class %>"
     data-page-route="<%= page_route %>"
+    data-implicit-locale="<%= implicit_locale %>"
   >
     <a
       href="#main-content"

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -125,7 +125,7 @@
     <%# auto-sends the URL query string). In the cache key too, since page_id ignores query params. %>
     <% skip_facebook = controller_namespace.in?(%w[organized org_public oauth]) || controller_name == "organizations" || params.key?(:search_email) || params.key?(:proximity) %>
 
-    <%= render PageBlock::Footer::Component.new(current_user:, skip_facebook:, page_id:, passive_organization:) %>
+    <%= render PageBlock::Footer::Component.new(current_user:, skip_facebook:, passive_organization:) %>
 
     <script>
   I18n.defaultLocale = <%== I18n.default_locale.to_json %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -67,7 +67,7 @@
 
     <%= render(PageBlock::ReviewAppBanner::Component.from_env(current_user:, return_to: request.fullpath)) %>
 
-    <%= render PageBlock::Navbar::Wrapper::Component.new(current_user:, current_user_or_unconfirmed_user:, passive_organization:, page_id:, controller_namespace:, controller_name:, action_name:, unregistered_parking_notification: @unregistered_parking_notification) %>
+    <%= render PageBlock::Navbar::Wrapper::Component.new(current_user:, current_user_or_unconfirmed_user:, passive_organization:, page_id:, controller_namespace:, controller_name:, action_name:) %>
 
     <% if render_donation_request? %>
       <%= render PageBlock::LawEnforcementDonation::Component.new(current_user:) %>
@@ -114,8 +114,7 @@
           og_email: @og_email,
           edit_template: @edit_template,
           edit_templates: @edit_templates,
-          oauth_application: @application,
-          unregistered_parking_notification: @unregistered_parking_notification
+          oauth_application: @application
         )) do %>
           <%= yield %>
         <% end %>

--- a/app/views/layouts/application_bikehub.html.erb
+++ b/app/views/layouts/application_bikehub.html.erb
@@ -33,7 +33,7 @@
     </script>
   </head>
 
-  <body id="<%= page_id %>" class="<%= body_class %>" style="padding-top: 0;">
+  <%= body_tag(style: "padding-top: 0;") do %>
     <%# This is either the signup or signin page %>
     <% signup_page = controller_name != "sessions" %>
 
@@ -129,7 +129,7 @@
         </div>
       </div>
     </div>
-  </body>
+  <% end %>
 
   <%= render "/shared/analytics" %>
 

--- a/app/views/layouts/component_preview.html.erb
+++ b/app/views/layouts/component_preview.html.erb
@@ -39,6 +39,7 @@
   <body
     class="<%= params.dig(:lookbook, :display, :theme) %>"
     style="padding: 0;"
+    data-page-route="<%= page_route %>"
   >
     <%# NOTE: at some point, make the padding optional %>
     <div class="tw:p-4"><%= yield %></div>

--- a/app/views/layouts/component_preview.html.erb
+++ b/app/views/layouts/component_preview.html.erb
@@ -40,6 +40,7 @@
     class="<%= params.dig(:lookbook, :display, :theme) %>"
     style="padding: 0;"
     data-page-route="<%= page_route %>"
+    data-implicit-locale="<%= implicit_locale %>"
   >
     <%# NOTE: at some point, make the padding optional %>
     <div class="tw:p-4"><%= yield %></div>

--- a/app/views/layouts/component_preview.html.erb
+++ b/app/views/layouts/component_preview.html.erb
@@ -39,8 +39,7 @@
   <body
     class="<%= params.dig(:lookbook, :display, :theme) %>"
     style="padding: 0;"
-    data-page-route="<%= page_route %>"
-    data-implicit-locale="<%= implicit_locale %>"
+    <%= tag.attributes(body_attributes) %>
   >
     <%# NOTE: at some point, make the padding optional %>
     <div class="tw:p-4"><%= yield %></div>

--- a/app/views/layouts/component_preview.html.erb
+++ b/app/views/layouts/component_preview.html.erb
@@ -36,12 +36,8 @@
   </head>
 
   <%# NOTE: This sets the theme. Padding set to 0 because revised stylesheet in bike box %>
-  <body
-    class="<%= params.dig(:lookbook, :display, :theme) %>"
-    style="padding: 0;"
-    <%= tag.attributes(body_attributes) %>
-  >
+  <%= body_tag(html_class: params.dig(:lookbook, :display, :theme), style: "padding: 0;") do %>
     <%# NOTE: at some point, make the padding optional %>
     <div class="tw:p-4"><%= yield %></div>
-  </body>
+  <% end %>
 </html>

--- a/app/views/layouts/doorkeeper.html.erb
+++ b/app/views/layouts/doorkeeper.html.erb
@@ -30,6 +30,7 @@
     id="<%= page_id %>"
     class="<%= 'organized-body' if main_content_organized? %>"
     data-page-route="<%= page_route %>"
+    data-implicit-locale="<%= implicit_locale %>"
   >
     <%= render PageBlock::Navbar::Wrapper::Component.new(logo_only: true) %>
 

--- a/app/views/layouts/doorkeeper.html.erb
+++ b/app/views/layouts/doorkeeper.html.erb
@@ -29,6 +29,7 @@
   <body
     id="<%= page_id %>"
     class="<%= 'organized-body' if main_content_organized? %>"
+    data-page-route="<%= page_route %>"
   >
     <%= render PageBlock::Navbar::Wrapper::Component.new(logo_only: true) %>
 

--- a/app/views/layouts/doorkeeper.html.erb
+++ b/app/views/layouts/doorkeeper.html.erb
@@ -26,7 +26,7 @@
     <!--[if IE]>$('body').prepend("<div id='old-browser-warning'><h4>Your browser is out of date!</h4><p>As a result, Bike Index will not function correctly. <a href=\"http://whatbrowser.com\">Learn more here</a>.</p></div>")<![endif]-->
   </head>
 
-  <body id="<%= page_id %>" <%= tag.attributes(body_attributes) %>>
+  <%= body_tag do %>
     <%= render PageBlock::Navbar::Wrapper::Component.new(logo_only: true) %>
 
     <%= render(UI::Alerts::FlashMessage::Component.new(flash:)) %>
@@ -43,5 +43,5 @@
     <%# OAuth pages never load the marketing pixel %>
     <%= render PageBlock::Footer::Component.new(current_user:, skip_facebook: true) %>
     <%= render "/shared/analytics" %>
-  </body>
+  <% end %>
 </html>

--- a/app/views/layouts/doorkeeper.html.erb
+++ b/app/views/layouts/doorkeeper.html.erb
@@ -29,8 +29,7 @@
   <body
     id="<%= page_id %>"
     class="<%= 'organized-body' if main_content_organized? %>"
-    data-page-route="<%= page_route %>"
-    data-implicit-locale="<%= implicit_locale %>"
+    <%= tag.attributes(body_attributes) %>
   >
     <%= render PageBlock::Navbar::Wrapper::Component.new(logo_only: true) %>
 

--- a/app/views/layouts/doorkeeper.html.erb
+++ b/app/views/layouts/doorkeeper.html.erb
@@ -26,11 +26,7 @@
     <!--[if IE]>$('body').prepend("<div id='old-browser-warning'><h4>Your browser is out of date!</h4><p>As a result, Bike Index will not function correctly. <a href=\"http://whatbrowser.com\">Learn more here</a>.</p></div>")<![endif]-->
   </head>
 
-  <body
-    id="<%= page_id %>"
-    class="<%= 'organized-body' if main_content_organized? %>"
-    <%= tag.attributes(body_attributes) %>
-  >
+  <body id="<%= page_id %>" <%= tag.attributes(body_attributes) %>>
     <%= render PageBlock::Navbar::Wrapper::Component.new(logo_only: true) %>
 
     <%= render(UI::Alerts::FlashMessage::Component.new(flash:)) %>

--- a/app/views/layouts/doorkeeper.html.erb
+++ b/app/views/layouts/doorkeeper.html.erb
@@ -45,7 +45,7 @@
     </div>
 
     <%# OAuth pages never load the marketing pixel %>
-    <%= render PageBlock::Footer::Component.new(current_user:, skip_facebook: true, page_id:) %>
+    <%= render PageBlock::Footer::Component.new(current_user:, skip_facebook: true) %>
     <%= render "/shared/analytics" %>
   </body>
 </html>

--- a/config/locales/.translation_io
+++ b/config/locales/.translation_io
@@ -5,4 +5,4 @@
 # ignore the conflicts and "sync" again, it will fix this file for you.
 
 ---
-timestamp: 1784560542
+timestamp: 1787084179

--- a/config/locales/localization.it.yml
+++ b/config/locales/localization.it.yml
@@ -25,6 +25,7 @@ it:
       format:
         delimiter: "."
         format: "%n %u"
+        negative_format: "-%n %u"
         precision: 2
         separator: ","
         significant: false
@@ -33,6 +34,7 @@ it:
     format:
       delimiter: "."
       precision: 2
+      round_mode: default
       separator: ","
       significant: false
       strip_insignificant_zeros: false

--- a/config/locales/translation.es.yml
+++ b/config/locales/translation.es.yml
@@ -755,7 +755,8 @@ es:
         theft_description: Descripción del robo
         time: Tiempo
         tsved_at: Tsved en
-        zipcode: Código Postal
+        postal_code: Código Postal
+        region_string: Región
       theft_alert:
         end_at: Finalizar en
         notes: Notas
@@ -1857,6 +1858,9 @@ es:
       no_one_but_the_user_and_bike_index_admins: Solo el usuario (y los administradores
         de Bike Index) pueden verlo.
       test_registration: registro de pruebas
+    stolen_map:
+      unavailable: No se pudo cargar el mapa; es posible que su navegador o dispositivo
+        no lo admita.
   bikes_edit:
     accessories:
       add_a_component: Agregar un componente
@@ -2221,9 +2225,9 @@ es:
       sessionable:
         sign_in_and_redirect:
           logged_in: "¡Sesión iniciada!"
-          organization_signed_in: Has iniciado sesión
           user_is_banned: Lo sentimos, pero parece que su cuenta ha sido bloqueada.
             Si desconoce el motivo, póngase en contacto con nosotros.
+          organization_signed_in: Has iniciado sesión
         skip_if_signed_in:
           already_signed_in: "¡Ya has iniciado sesión!"
     feedbacks:
@@ -2412,8 +2416,6 @@ es:
       create:
         invalid_email_or_password: Correo electrónico/contraseña no válidos
       create_magic_link:
-        link_sent: "¡Enlace de inicio de sesión enviado! Simplemente haz clic en el
-          enlace de tu correo electrónico para iniciar sesión."
         user_not_found: No se pudo encontrar a ese usuario.
     stolen_notifications:
       create:
@@ -2522,6 +2524,21 @@ es:
           Si el problema persiste, es probable que una VPN o una extensión de privacidad
           esté ocultando información necesaria. Intente desactivarlas para bikeindex.org.
           Si el problema continúa, envíe un correo electrónico a contact@bikeindex.org.
+    register:
+      acknowledge:
+        acknowledge_everything: Marque todas las casillas para aceptar estas reglas.
+      confirm_email:
+        confirmation_link_expired: Ese enlace de confirmación ha caducado; revisa
+          tu correo electrónico para obtener uno nuevo.
+        signed_in_as_other: Has iniciado sesión como %{email}, por lo que mantuvimos
+          tu cuenta. El registro sigue guardado en la dirección de correo electrónico
+          que te enviamos.
+      find_b_param:
+        registration_not_found: No pudimos encontrar ese registro; inicie uno nuevo
+          a continuación.
+      sign_in_confirmed_user:
+        unable_to_sign_in: Hemos confirmado tu correo electrónico, pero no pudimos
+          iniciar sesión en esa cuenta.
   customer_mailer:
     additional_email_confirmation:
       html:
@@ -3983,8 +4000,6 @@ es:
       try_for_free: Pruébalo gratis
       year: año
   layouts:
-    application:
-      skip_to_main_content: Ir al contenido principal
     application_bikehub:
       accounts_powered_by_bike_index: Las cuentas de BikeHub están gestionadas por
         Bike Index, el principal registro de bicicletas.
@@ -4021,6 +4036,8 @@ es:
     revised_messages:
       error: error
       please_fix_the_following: Por favor, corrija lo siguiente %{errors}
+    application:
+      skip_to_main_content: Ir al contenido principal
   locales:
     en: Inglés
     nb: Noruego (Bokmål)
@@ -4108,6 +4125,12 @@ es:
     welcome_index: 'El mejor registro de bicicletas: Sencillo, seguro y gratuito.'
     registrations_embed: Formulario de registro para el Índice de Bicicletas %{organization}
       integrable. Registra tu bicicleta gratis ahora mismo.
+    search_marketplace_index: Bicicletas en venta en Bike Index. Busca en el mercado
+      por fabricante, precio y ubicación.
+    search_registrations_index: Bicicletas registradas esta semana
+    strava_search_index: Vincula tu equipo de Strava con tus registros de Bike Index.
+      Busca, filtra y actualiza tus actividades en lote para asignar equipo a las
+      rutas que no lo tengan.
   meta_titles:
     bikes_index: Resultados de la búsqueda
     bikes_new: "¡Inscribe una bicicleta!"
@@ -4149,6 +4172,16 @@ es:
     my_accounts_show: Índice de bicicletas
     search_registrations_index: Resultados de la búsqueda
     registrations_embed: Registra una bicicleta con %{organization}
+    register_acknowledgment: Comprobación de seguridad para su %{cycle_type}
+    register_confirm: Confirmando tu correo electrónico
+    register_create: "¡Registra tu vehículo!"
+    register_report: Cuéntanos qué pasó.
+    register_review: Revise su comprobación de seguridad %{cycle_type}
+    register_show: Su registro %{cycle_type}
+    register_step_1: "¡Registra tu vehículo!"
+    register_step_2: Agregue los detalles de su %{cycle_type}
+    search_marketplace_index: Mercado de índices de bicicletas
+    strava_search_index: Índice de bicicletas Búsqueda en Strava
   money:
     currencies:
       en: Dólar estadounidense
@@ -4709,7 +4742,6 @@ es:
         save: Ahorrar
       show:
         abbreviation: Abreviatura
-        choose_file: Seleccione archivo...
         contact_to_update_html: Contacte con %{link} para actualizar la abreviatura.
         delete_organization: Eliminar organización
         i_would_like_to_terminate_my_account: Me gustaría cancelar mi cuenta en Bike
@@ -4742,15 +4774,6 @@ es:
       index:
         matches_visible: visible
         parking_notifications: notificaciones de estacionamiento
-      show_details:
-        address: DIRECCIÓN
-        bike: Bicicleta
-        by: Creado por
-        created: Creado en
-        internal_notes: Notas internas
-        message: Mensaje
-        notification_number: Notificación#
-        resolved: Resuelto
       table:
         address: DIRECCIÓN
         bike: Bicicleta
@@ -4874,6 +4897,14 @@ es:
       subject: Únete a %{organization_name} en Bike Index
     partial_registration:
       subject: "¡Completa tu registro en el Índice de Bicicletas %{organization_name}!"
+    partial_register_confirmation:
+      subject: Confirma tu correo electrónico para finalizar tu %{organization_name}registro
+    partial_register_confirmation_abandoned:
+      subject: Finaliza el reporte de tu %{cycle_type} abandonado.
+    partial_register_confirmation_found:
+      subject: Finaliza el informe de tu hallazgo %{cycle_type}
+    partial_register_confirmation_stolen:
+      subject: Finaliza la denuncia de tu %{cycle_type} robado.
   payments:
     form:
       donation_header: "¡Ayúdanos a apoyar nuestros esfuerzos!"
@@ -4969,9 +5000,13 @@ es:
       sign_in_with_magic_link: Inicio de sesión sin contraseña
       unable_to_auth: No se pudo autenticar ese token.
       your_email_address: Su dirección de correo electrónico
-    magic_link_sent:
-      follow_the_link_back: '¡Sigue el enlace del correo electrónico para iniciar sesión!'
-      we_sent_a_magic_sign_in_link: Te hemos enviado un enlace mágico para iniciar sesión
+      link_already_used: Ese enlace de inicio de sesión ya ha sido utilizado.
+      link_expired: El enlace para iniciar sesión ha caducado.
+      links_work_for: Los enlaces de inicio de sesión funcionan para %{duration} después
+        de ser enviados.
+      only_the_newest_link_works: Es posible que ya hayas iniciado sesión en otro
+        sitio. Si solicitaste más de un correo electrónico, solo funcionará el enlace
+        del más reciente.
     new:
       email: correo electrónico
       forgot_your_password: "¿Olvidaste tu contraseña?"
@@ -4988,6 +5023,10 @@ es:
       sign_in_without_password: Iniciar sesión sin contraseña
     identify:
       different_email: Inicia sesión con un correo electrónico diferente.
+    magic_link_sent:
+      follow_the_link_back: "¡Sigue el enlace del correo electrónico para iniciar
+        sesión!"
+      we_sent_a_magic_sign_in_link: Te enviamos una señal mágica en el enlace
   shared:
     bike_search_form:
       anywhere: En cualquier lugar
@@ -5017,22 +5056,6 @@ es:
         correo de registro. Agrega fotos y detalles del %{bike_type} para mostrar
         lo que hace que tu vehículo sea tuyo. Esperamos que tu %{bike_type} no sea
         robado, pero si lo es, estaremos aquí cuando más nos necesites.
-    content_skeleton:
-      about: Acerca
-      bicycle_serials: Series de bicicletas
-      bike_index_news: Todas las noticias de Bike Index
-      bike_index_store: Tienda de índices de bicicletas
-      design_and_developer_resources: Recursos de diseño y desarrollo
-      donate: Donar
-      donate_today: Dona hoy
-      help: Ayuda
-      how_to_get_your_stolen_bike_back: Cómo recuperar tu bicicleta robada
-      make_a_difference: Marca la diferencia en la lucha contra el robo de bicicletas.
-      other_pages: Otras páginas
-      protect_your_bike: Registre su bicicleta
-      related: Relacionado
-      sign_up_your_organization: Inscriba su organización
-      where: Dónde
     donation_form:
       501c3_nonprofit: Organización sin fines de lucro 501(c)(3)
       bike_index_is_a_nonprofit_html: Bike Index es un %{nonprofit_link} <small class="less-strong">EIN
@@ -5045,15 +5068,6 @@ es:
       what_does_your_donation_do: "¿Qué se consigue con tu donación?"
     donation_modal:
       donation_header: "¡Ayúdanos a apoyar nuestros esfuerzos!"
-    edit_bike_skeleton:
-      edit: Editar
-      owned_but_hasnt_been_claimed_html: Es propiedad de <em>%{owner_email}</em> ,
-        pero aún no ha sido reclamado.
-      owned_with_permission_to_edit_html: Propiedad de <em>%{owner_email}</em> pero
-        %{org_name} tiene permiso para editar.
-      view_bike: Ver %{bike_type}
-      view_bike_version: Ver %{bike_type} versión
-      edit_pages: 'Editar páginas %{bike_type}:'
     email_bike_box:
       color: Color
       color_may_be_incorrect: El color puede ser incorrecto. ¡Por favor, actualícelo
@@ -5194,20 +5208,6 @@ es:
       you: Tú
       your_bikes: Tus bicicletas
       your_preferences: Tus preferencias
-    law_enforcement_donation_modal:
-      bikeindex_is_a_nonprofit: Bike Index es una organización sin fines de lucro
-        501(c)(3). Dependemos de donaciones para brindar estos servicios. Recomendamos
-        a las agencias policiales como %{org_name} que donen al menos $20 al año para
-        apoyar nuestra labor.
-      contact_bike_owners: Contacta con los propietarios de las bicicletas antes de
-        que sus bicicletas sean marcadas como robadas.
-      email_for_access_html: Para obtener acceso, envíe un correo electrónico a %{email_link}.
-      greeting: Hola %{user_name},
-      law_enforcement_features: 'Contamos con una serie de funciones diseñadas específicamente
-        para agentes del orden:'
-      multiple_serial_search_pane: Panel de búsqueda de múltiples números de serie
-      thank_you: "¡Muchísimas gracias por usar Bike Index!"
-      thanks_for_using_bike_index: "¡Gracias por usar Bike Index!"
     organized_menu_items:
       add_a_bike: Añade una bicicleta
       ascend_imports: Importaciones Ascend
@@ -5239,49 +5239,21 @@ es:
       super_admin_view: Superadministrador de %{org_name}
       multi_search: Búsqueda múltiple
       manage_registration_sequences: Gestionar secuencias de registro
-    organized_skeleton:
-      additional_features_html: Bike Index ofrece funciones adicionales para organizaciones
-        policiales verificadas. Comuníquese con %{email_link} para activarlas.
-      admin_panel: Panel de administración
-      how_integration_works: cómo funciona la integración
-      integrate_bike_index_with_ascend: Integrar Bike Index con Ascend
-      integrate_bike_index_with_lightspeed: Integra Bike Index con Lightspeed.
-      link_to_register_html: "<strong>%{link}</strong> para registrar automáticamente
-        las bicicletas que vendes a tus clientes."
-      other_point_of_sale_system: "¿Otro sistema de punto de venta?"
-      read_a_full_explanation_html: Lea una explicación completa de %{link}.
-      register_bikes_with_link_html: Registra bicicletas con nuestro <strong>%{link}</strong>
-      streamlined_bike_shop_registration_page: Página de registro simplificada para
-        la tienda de bicicletas
-      subscription_expired_html: Tu suscripción a Bike Index ha caducado. Ponte en
-        contacto con %{email_link} para reactivarla.
-      use_ascend: "¿Usar Ascend?"
-      use_lightspeed_retail_pos: "¿Utilizas el sistema POS Lightspeed Retail?"
-      viewing_our_streamlined_page: Actualmente estás viendo nuestra página de registro
-        simplificada de la tienda de bicicletas, que es la que recomendamos usar.
-    user_general_alert:
-      add_location_theft_bike_title_html: Agregue la ubicación del robo de su <strong>%{bike_title}</strong>
-      add_photo_theft_bike_title_html: Agrega una foto a tu <strong>%{bike_title}</strong>
-      confirm_your_phone_number: Confirma tu número de teléfono
-      location_critical_html: "<strong>Es fundamental para la recuperación</strong>
-        que incluya la dirección o la calle transversal donde le robaron su %{bike_type}."
-      missing_stolen_photo_title: Por favor, añade una foto.
-      photo_critical_html: Las alertas promocionadas exitosas <strong>deben tener
-        una imagen.</strong>
-      stolen_missing_location_title: Por favor, añada la ubicación del robo.
-      verification_code: Código de verificación
-      verify_number: Verificar %{phone_number}
-      without_location_all_is_lost: Sin una ubicación no podemos difundir la noticia
-        del robo y la gente no sabrá dónde buscar su %{bike_type}.
-      without_photo_all_is_lost: Si no tienes fotos de tu moto, busca una imagen de
-        archivo en internet y súbela. Sin alguna imagen, la alerta publicitaria no
-        será efectiva.
     recovery_display:
       bike: Bicicleta
       recovered_date: recuperado %{date}
       translated_from_english: traducido del inglés
     shops_map:
       map_of_partner_locations: Mapa de ubicaciones de socios
+    register_flow:
+      date_found_required: Por favor, díganos cuándo lo encontró.
+      date_stolen_required: Por favor, díganos cuándo fue robado.
+      email_required: Se requiere correo electrónico para registrarse.
+      location_found_required: Por favor, díganos dónde lo encontró.
+      location_stolen_required: Por favor, díganos dónde fue robado.
+      manufacturer_required: El fabricante está obligado a registrarse.
+      name_required: Se requiere el nombre del propietario para registrarse.
+      unable_to_save: No podemos guardar ese registro, por favor inténtelo de nuevo.
   stolen:
     index:
       ambassador: embajador
@@ -5376,12 +5348,9 @@ es:
         Index.
       already_have_a_bike_index_account: "¿Ya tienes una cuenta en Bike Index?"
       already_have_an_account: "¿Ya tienes una cuenta?"
-      better_password: mejor
       get_bike_indexs_newsletter: Suscríbete al boletín de Bike Index
       get_on_bike_index: Índice de bicicletas
       log_in: conectarse
-      password_helper_text_html: La contraseña debe tener al menos 12 caracteres.
-        Una contraseña más larga es %{better_password_link}.
       sign_up: Inscríbete
       sign_up_using_facebook: Regístrate usando Facebook
       sign_up_using_globalid: Regístrate usando globaliD
@@ -5416,10 +5385,15 @@ es:
       stolen: "¡Robado!"
       this_user_has_no_bikes_yet: "¡Este usuario aún no tiene bicicletas!"
       this_users_bikes: Las bicicletas de este usuario
+      banned_only_visible_to_superusers: Su perfil solo es visible porque usted es
+        un superusuario.
+      banned_user: Este usuario está baneado.
+      profile_hidden: Este perfil no se comparte públicamente.
+      profile_hidden_owner: Solo es visible para ti porque es tu página.
+      profile_hidden_superuser: Solo es visible porque eres un superusuario.
     unsubscribe:
-      if_not_click_button: Si no lo eres, haz clic en el botón de abajo.
       unsubscribe: Cancelar suscripción
-      you_should_be_unsubscribed_automatically: Deberías darte de baja automáticamente.
+      confirm_unsubscribe: Confirma que deseas darte de baja.
     update_password_form_with_reset_token:
       and_try_not_to_forget_it: y trata de no olvidarlo...
       better_password: mejor
@@ -5486,11 +5460,6 @@ es:
       index:
         loading_results: Cargando resultados...
   components:
-    sessions:
-      sign_in_interstitial:
-        if_not_click_button: Si no lo eres, haz clic en el botón de abajo.
-        sign_in: Iniciar sesión
-        you_should_be_signed_in_automatically: Deberías iniciar sesión automáticamente.
     search:
       everything_combobox:
         query_items_description: Cuadro combinado de descripciones de búsqueda
@@ -5526,9 +5495,6 @@ es:
         bike_box_view: Ver como lista
         thumbnail_view: Ver como miniaturas
     search_results:
-      frame:
-        rate_limited: Se han realizado demasiadas búsquedas demasiado rápido; se ha
-          alcanzado el límite de solicitudes. Espere un momento y vuelva a intentarlo.
       bike_box:
         location: Ubicación
         posted_at: Listado
@@ -5545,6 +5511,12 @@ es:
       container:
         no_results: No se encontraron registros que coincidieran exactamente con su
           búsqueda.
+      frame:
+        fetch_failed: No se pudieron cargar estos resultados; compruebe su conexión
+          e inténtelo de nuevo.
+        rate_limited: Se han realizado demasiadas búsquedas demasiado rápido; se ha
+          alcanzado el límite de solicitudes. Espere un momento y vuelva a intentarlo.
+        retry: Intentar otra vez
     page_block:
       marketplace_listing_panel:
         condition: Condición
@@ -5598,9 +5570,11 @@ es:
           de reseñas.
         pr_link: 'PR #%{number}'
         commit_tooltip: 'Commit actual:'
-        label_sandbox: Sandbox
         superadmin_button: Iniciar sesión como superadministrador
         superadmin_signed_in: Sesión iniciada como superadministrador
+        label_development: Desarrollo
+        label_sandbox: Salvadera
+        no_superadmin: No hay superusuario (no puede iniciar sesión)
       footer:
         about: Acerca
         ambassadors: Embajadores
@@ -5616,7 +5590,6 @@ es:
           de lucro 501(c)(3) - EIN 81-4296194"
         dev_and_design_resources: Recursos de desarrollo y diseño
         donate: Donar
-        faq_and_help: Preguntas frecuentes y ayuda
         how_to_get_your_stolen_bike_back: Recupera su bicicleta
         language: Idioma
         law_enforcement: Fuerzas y Cuerpos de Seguridad
@@ -5636,39 +5609,121 @@ es:
         who_we_serve: A quién servimos
         legal: Legal
         social_media: Redes sociales
-        status_page: Página de estado
-        register_a_bike: Registra una bicicleta
+        faq_and_help: Preguntas frecuentes y ayuda
         marketplace: Mercado
+        register_a_bike: Registre su bicicleta
         search: Buscar
+        status_page: Página de estado
+      law_enforcement_donation:
+        bikeindex_is_a_nonprofit: Bike Index es una organización sin fines de lucro
+          501(c)(3). Dependemos de donaciones para brindar estos servicios. Recomendamos
+          a las agencias policiales como %{org_name} que donen al menos $20 al año
+          para apoyar nuestra labor.
+        contact_bike_owners: Contacta con los propietarios de las bicicletas antes
+          de que sus bicicletas sean marcadas como robadas.
+        email_for_access_html: Para obtener acceso, envíe un correo electrónico a
+          %{email_link}.
+        greeting: Hola %{user_name},
+        law_enforcement_features: 'Contamos con una serie de funciones diseñadas específicamente
+          para agentes del orden:'
+        multiple_serial_search_pane: Panel de búsqueda de múltiples números de serie
+        thank_you: "¡Muchísimas gracias por usar Bike Index!"
+        thanks_for_using_bike_index: "¡Gracias por usar Bike Index!"
+      main_content:
+        content:
+          about: Acerca
+          bicycle_serials: Series de bicicletas
+          bike_index_news: Todas las noticias de Bike Index
+          bike_index_store: Tienda de índices de bicicletas
+          design_and_developer_resources: Recursos de diseño y desarrollo
+          donate: Donar
+          donate_today: Dona hoy
+          help: Ayuda
+          how_to_get_your_stolen_bike_back: Cómo recuperar tu bicicleta robada
+          make_a_difference: Marca la diferencia en la lucha contra el robo de bicicletas.
+          other_pages: Otras páginas
+          protect_your_bike: Registre su bicicleta
+          related: Relacionado
+          sign_up_your_organization: Inscriba su organización
+          where: Dónde
+        edit_bike:
+          edit: Editar
+          edit_pages: 'Editar páginas %{bike_type}:'
+          owned_but_hasnt_been_claimed_html: Es propiedad de <em>%{owner_email}</em>
+            , pero aún no ha sido reclamado.
+          owned_with_permission_to_edit_html: Propiedad de <em>%{owner_email}</em>
+            pero %{org_name} tiene permiso para editar.
+          view_bike: Ver %{bike_type}
+          view_bike_version: Ver %{bike_type} versión
+        organized:
+          additional_features_html: Bike Index ofrece funciones adicionales para organizaciones
+            policiales verificadas. Comuníquese con %{email_link} para activarlas.
+          admin_panel: Panel de administración
+          how_integration_works: cómo funciona la integración
+          integrate_bike_index_with_ascend: Integrar Bike Index con Ascend
+          integrate_bike_index_with_lightspeed: Integra Bike Index con Lightspeed.
+          link_to_register_html: "<strong>%{link}</strong> para registrar automáticamente
+            las bicicletas que vendes a tus clientes."
+          other_point_of_sale_system: "¿Otro sistema de punto de venta?"
+          read_a_full_explanation_html: Lea una explicación completa de %{link}.
+          register_bikes_with_link_html: Registra bicicletas con nuestro <strong>%{link}</strong>
+          streamlined_bike_shop_registration_page: Página de registro simplificada
+            para la tienda de bicicletas
+          subscription_expired_html: Tu suscripción a Bike Index ha caducado. Ponte
+            en contacto con %{email_link} para reactivarla.
+          use_ascend: "¿Usar Ascend?"
+          use_lightspeed_retail_pos: "¿Utilizas el sistema POS Lightspeed Retail?"
+          viewing_our_streamlined_page: Actualmente estás viendo nuestra página de
+            registro simplificada de la tienda de bicicletas, que es la que recomendamos
+            usar.
       navbar:
         primary_menu:
           blog: Blog
           donate: Donar
           help: Ayuda
           log_in: conectarse
-          stolen_bike: "¿Bicicleta robada?"
-          search: Buscar
           marketplace: Mercado
+          search: Buscar
           sign_up: Inscríbete
+          stolen_bike: "¿Bicicleta robada?"
         settings_menu:
           logout: Cierre de sesión
+          marketplace_messages: Mensajes del mercado
           register_a_new_bike: Registre su bicicleta
+          settings_menu: Ajustes
           user_settings: "%{user_email} ajustes"
           view_org: Ver %{org_name}
-          marketplace_messages: Mensajes del mercado
           your_registrations: Sus registros
-          settings_menu: Ajustes
         wrapper:
+          menu: Menú
           sign_up: Inscríbete
           the_nonprofit_bike_registry: el registro de bicicletas sin ánimo de lucro
-          menu: Menú
+      user_alerts:
+        phone_waiting_confirmation:
+          confirm_your_phone_number: Confirma tu número de teléfono
+          verification_code: Código de verificación
+          verify_number: Verificar %{phone_number}
+        stolen_bike_without_location:
+          add_location_theft_bike_title_html: Agregue la ubicación del robo de su
+            <strong>%{bike_title}</strong>
+          location_critical_html: "<strong>Es fundamental para la recuperación</strong>
+            que incluya la dirección o la calle transversal donde le robaron su %{bike_type}."
+          stolen_missing_location_title: Por favor, añada la ubicación del robo.
+          without_location_all_is_lost: Sin una ubicación no podemos difundir la noticia
+            del robo y la gente no sabrá dónde buscar su %{bike_type}.
+        theft_alert_without_photo:
+          add_photo_theft_bike_title_html: Agrega una foto a tu <strong>%{bike_title}</strong>
+          missing_stolen_photo_title: Por favor, añade una foto.
+          photo_critical_html: Las alertas promocionadas exitosas <strong>deben tener
+            una imagen.</strong>
+          without_photo_all_is_lost: Si no tienes fotos de tu %{bike_type}, busca
+            una imagen de archivo en internet y súbela. Sin una imagen, la alerta
+            promocionada no será efectiva.
+        unfinished_registration:
+          finish_the_required_steps: completar los pasos requeridos
+          not_registered_yet_html: "¡Tu %{cycle_type} aún no está registrado! Por
+            favor %{finish_link}"
     emails:
-      confirmation_email:
-        click_to_sign_in_html: ¡Haz clic en el botón <em>Iniciar sesión</em> para finalizar
-          el registro!
-        follow_this_link_to_sign_in: Sigue este enlace para iniciar sesión
-        sign_in: Iniciar sesión
-        youre_almost_there: "¡Ya casi llegas!"
       partials:
         bike_box:
           bike_photo: Foto de bicicleta
@@ -5773,6 +5828,21 @@ es:
         just_a_few_steps_away_html: "¡Estás a solo unos pasos de registrar tu <strong>%{color_and_brand}</strong>
           en el registro de bicicletas más completo del mundo!"
         youre_almost_done: "¡Ya casi terminas!"
+      confirmation_email:
+        click_to_sign_in_html: ¡Haz clic en el botón <em>"Iniciar sesión</em> " para
+          finalizar tu registro!
+        follow_this_link_to_sign_in: Sigue este enlace para iniciar sesión.
+        sign_in: Iniciar sesión
+        youre_almost_there: "¡Ya casi llegas!"
+      partial_register_confirmation:
+        click_below_to_pick_up_where_you_left_off: Haz clic a continuación para confirmar
+          esta dirección de correo electrónico y continuar donde lo dejaste.
+        confirm_and_continue: Confirmar mi correo electrónico
+        confirm_your_email: Confirma tu correo electrónico
+        link_signs_you_in: Este enlace te da acceso a Bike Index, así que no lo reenvíes.
+          Funciona durante %{days} días.
+        we_saved_your_registration_html: Hemos guardado tu registro para una <strong>%{color_and_brand}</strong>
+          en el registro de bicicletas más completo del mundo.
     messages:
       thread_show:
         can_not_send_new_message: Lo sentimos, no puedes enviar un nuevo mensaje.
@@ -5810,10 +5880,6 @@ es:
         year: año
       chart_async_frame:
         loading_chart: Cargando gráfico...
-      alerts:
-        object_error:
-          errors_prevented_this_from_being_saved: "%{errors_count} impidió que se
-            guardara este %{object_name}:"
       forms:
         legacy_form_well:
           address_record:
@@ -5832,88 +5898,52 @@ es:
           address_record_with_default:
             edit_my_account_path: editar en mi cuenta
             use_account_address: Utilice la dirección de la cuenta
+        address_group:
+          address: DIRECCIÓN
+          choose_country: Elige un país
+          city: Ciudad
+          country: País
+          postal_code: Código Postal
+          region: Región
+          state: Estado
+          street_2: Línea de dirección 2
+        combobox_manufacturer:
+          placeholder: Empiece a escribir, por ejemplo, %{name}
+        combobox_manufacturer_options:
+          unknown_manufacturer: Fabricante desconocido
+        email:
+          did_you_mean_html: "¿Te referías a %{email}?"
+          not_real: Esa no parece ser tu dirección de correo electrónico real. Por
+            favor, introduce una dirección de correo electrónico donde recibas correos
+            electrónicos.
+          submit_anyway: Enviar formulario de todos modos
+        file_upload:
+          no_file_chosen: No se ha seleccionado ningún archivo.
+          take_picture: Toma una foto
+          upload: Subir
+          upload_failed: Falló la carga
+          uploading: subir
+        group:
+          optional: opcional
+      alerts:
+        base:
+          error: Error
+          info: Información
+          notice: Aviso
+          success: Éxito
+          warning: Advertencia
+        flash_message:
+          signed_in_html: "¡Has iniciado sesión! Puedes %{link} si prefieres no iniciar
+            sesión mediante un enlace enviado por correo electrónico."
+          signed_in_link: establecer una contraseña para iniciar sesión
+          signed_up_html: "¡Te has registrado en Bike Index! Puedes %{link} si prefieres
+            no iniciar sesión mediante un enlace enviado por correo electrónico."
+          signed_up_link: establecer una contraseña para iniciar sesión
+        object_error:
+          error_prevented_this_from_being_saved:
+            one: 'El error %{count} impidió que se guardara este %{object_name}:'
+            other: 'Los errores %{count} impidieron que se guardara este %{object_name}:'
     org:
-      search:
-        form:
-          doesnt_look_like_serial: Esto no parece un número de serie. Los números de
-            serie suelen tener 6 o más letras y números, y se encuentran debajo del
-            corchete inferior.
-          search_for_serial_number: Buscar número de serie
-          submit: entregar
-          search_notes: Notas de búsqueda
-          search_owner_email_or_name: Buscar el correo electrónico o el nombre del propietario
-        wrapper:
-          affiliation: Afiliación
-          avery_exportable: Exportable de Avery
-          bike: registro
-          e_vehicle_propulsion: Vehículo eléctrico (propulsión)
-          e_vehicles_for_audit: 'Vehículos eléctricos para auditoría:'
-          link: Enlace
-          matching_bikes_html: "%{count} %{cycle_type} coincidentes"
-          mfg_model_color_html: fabricante, modelo, <span class="less-strong">color</span>
-          phone: Teléfono
-          reg_address: DIRECCIÓN
-          registered_bikes_html: "%{count} %{cycle_type} coincidente para %{org_name}"
-          student_id: Carné de estudiante
-          vehicle: registro
-          view_matching_any_audit: ver coincidencia con cualquier auditoría
-        settings:
-          address: 'DIRECCIÓN:'
-          all: todo
-          avery_cell: Exportable de Avery
-          bike: registro
-          color_cell: Color
-          create_export_of_vehicles: Crear exportación de la búsqueda %{cycle_type}
-          created_at_cell: Registrado
-          creation_description_cell: Fuente
-          cycle_type_cell: Tipo de vehículo
-          default: por defecto
-          filter_impounded_html: únicamente <strong>confiscado</strong>
-          filter_no_address_html: "<strong>Sin</strong> dirección"
-          filter_no_sticker_html: "<strong>Sin</strong> pegatina"
-          filter_not_impounded_html: solo que <strong>no</strong> fue confiscado
-          filter_not_stolen_or_impounded_html: no robado ni confiscado
-          filter_stolen_html: solo robado
-          filter_with_address_html: solo <strong>con</strong> dirección
-          filter_with_stickers_html: solo <strong>con</strong> pegatinas
-          impound_id_cell: ID del depósito
-          impounded_cell: Incautado
-          manufacturer_cell: Fabricante
-          model_cell: Modelo
-          none: ninguno
-          notes_cell: Notas de registro
-          owner_email_cell: Enviado a
-          owner_name_cell: Nombre del propietario
-          propulsion_type_cell: Vehículo eléctrico (propulsión)
-          reg_address_cell: DIRECCIÓN
-          reg_extra_registration_number_cell: Secundario#
-          reg_organization_affiliation_cell: Afiliación
-          reg_phone_cell: Teléfono
-          reg_student_id_cell: Carné de estudiante
-          serial_number_cell: De serie
-          settings: ajustes
-          show_notes_search: mostrar notas de búsqueda
-          status: 'Estado:'
-          status_cell: Estado
-          sticker_cell: Etiqueta engomada
-          stickers: 'Pegatinas:'
-          stolen_cell: Robado
-          updated_at_cell: Actualizado
-          url_cell: URL
-          vehicle: registro
-          visible_columns: Columnas visibles
-          multi_search: búsqueda serial múltiple
-      search_results:
-        multi_result_chip:
-          no_results: no hay coincidencias
-        multi_results:
-          first_n_shown_html: "— primero %{limit} mostrado,"
-          no_exact_matches: 'No hay coincidencias exactas. Números de serie cercanos:'
-          no_matches_found: No se encontraron coincidencias
-          result_count_html: "— %{count} %{results}"
-          serial_label: 'De serie:'
-          view_all: ver todo
-          sticker_label: 'Etiqueta engomada:'
       location_address_fields:
         address: DIRECCIÓN
         choose_country: Elige un país
@@ -6038,3 +6068,599 @@ es:
         reprocess_instruction: Regrese aquí y haga clic en el botón "Reprocesar importación"
           que aparece a continuación.
         unknown_ascend_name: Nombre de Ascend desconocido
+      parking_notification_details:
+        address: DIRECCIÓN
+        bike: Bicicleta
+        by: Creado por
+        created: Creado en
+        internal_notes: Notas internas
+        message: Mensaje
+        notification_number: Notificación#
+        resolved: Resuelto
+      search:
+        form:
+          doesnt_look_like_serial: Esto no parece un número de serie. Los números
+            de serie suelen tener 6 o más letras y números, y se encuentran debajo
+            del corchete inferior.
+          search_for_serial_number: Buscar número de serie
+          search_notes: Notas de búsqueda
+          search_owner_email_or_name: Buscar el correo electrónico o el nombre del
+            propietario
+          submit: entregar
+        settings:
+          address: 'DIRECCIÓN:'
+          all: todo
+          avery_cell: Exportable de Avery
+          bike: registro
+          color_cell: Color
+          create_export_of_vehicles: Crear exportación de la búsqueda %{cycle_type}
+          created_at_cell: Registrado
+          creation_description_cell: Fuente
+          cycle_type_cell: Tipo de vehículo
+          default: por defecto
+          filter_impounded_html: únicamente <strong>confiscado</strong>
+          filter_no_address_html: "<strong>Sin</strong> dirección"
+          filter_no_sticker_html: "<strong>Sin</strong> pegatina"
+          filter_not_impounded_html: solo que <strong>no</strong> fue confiscado
+          filter_not_stolen_or_impounded_html: no robado ni confiscado
+          filter_stolen_html: solo robado
+          filter_with_address_html: solo <strong>con</strong> dirección
+          filter_with_stickers_html: solo <strong>con</strong> pegatinas
+          impound_id_cell: ID del depósito
+          impounded_cell: Incautado
+          manufacturer_cell: Fabricante
+          model_cell: Modelo
+          multi_search: búsqueda serial múltiple
+          none: ninguno
+          notes_cell: Notas de registro
+          owner_email_cell: Enviado a
+          owner_name_cell: Nombre del propietario
+          propulsion_type_cell: Vehículo eléctrico (propulsión)
+          reg_address_cell: DIRECCIÓN
+          reg_extra_registration_number_cell: Secundario#
+          reg_organization_affiliation_cell: Afiliación
+          reg_phone_cell: Teléfono
+          reg_student_id_cell: Carné de estudiante
+          serial_number_cell: De serie
+          settings: ajustes
+          show_notes_search: mostrar notas de búsqueda
+          status: 'Estado:'
+          status_cell: Estado
+          sticker_cell: Etiqueta engomada
+          stickers: 'Pegatinas:'
+          stolen_cell: Robado
+          updated_at_cell: Actualizado
+          url_cell: URL
+          vehicle: registro
+          visible_columns: Columnas visibles
+        wrapper:
+          affiliation: Afiliación
+          avery_exportable: Exportable de Avery
+          bike: registro
+          e_vehicle_propulsion: Vehículo eléctrico (propulsión)
+          e_vehicles_for_audit: 'Vehículos eléctricos para auditoría:'
+          link: Enlace
+          matching_bikes_html: "%{count} %{cycle_type} coincidentes"
+          mfg_model_color_html: fabricante, modelo, <span class="less-strong">color</span>
+          phone: Teléfono
+          reg_address: DIRECCIÓN
+          registered_bikes_html: "%{count} %{cycle_type} coincidente para %{org_name}"
+          student_id: Carné de estudiante
+          vehicle: registro
+          view_matching_any_audit: ver coincidencia con cualquier auditoría
+      search_results:
+        bikes_table:
+          assign_bike_sticker: Asignar pegatina
+          avery: "¿Avery?"
+          color: Color
+          email_hidden: Correo electrónico oculto
+          hidden_not_registered: oculto, no registrado con %{org_name}
+          impound_id: ID del depósito
+          impounded: Incautado
+          link_sticker: pegatina de enlace
+          manufacturer: Fabricante
+          model: Modelo
+          notes: Notas de registro
+          owner_name: Nombre del propietario
+          propulsion_type: Propulsión
+          registered: Registrado
+          secondary_number: Secundario#
+          sent_to: Enviado a
+          serial: De serie
+          source: Fuente
+          status_cell: Estado
+          sticker: Etiqueta engomada
+          stolen: Robado
+          updated: Actualizado
+          url: URL
+          vehicle_type: Tipo de vehículo
+        multi_result_chip:
+          no_results: no hay coincidencias
+        multi_results:
+          first_n_shown_html: "— primero %{limit} mostrado,"
+          no_exact_matches: 'No hay coincidencias exactas. Números de serie cercanos:'
+          no_matches_found: No se encontraron coincidencias
+          result_count_html: "— %{count} %{results}"
+          serial_label: 'De serie:'
+          sticker_label: 'Etiqueta engomada:'
+          view_all: ver todo
+    atom:
+      serial:
+        hidden: oculto
+        hidden_because_status: porque %{bike_type} es %{status}
+        hidden_for_unauthorized_users: oculto para usuarios no autorizados
+        made_without_serial: hecho sin número de serie
+        unknown: desconocido
+    register:
+      acknowledgment_check:
+        i_name_html: Yo, %{name},
+        registrants_name: nombre del registrante
+      acknowledgment_progress:
+        progress_saved: Progreso guardado · Confirmación del vehículo eléctrico ·
+          Paso %{number} de %{total}
+      back_link:
+        back: Atrás
+      page:
+        retry_failed: No pudimos guardar la información en este momento; no se ha
+          perdido nada de lo que ingresaste. Inténtalo de nuevo en un momento.
+      page_content:
+        electric_detected: "⚡️ Se detectó un vehículo eléctrico (motorizado)."
+        have_questions: "¿Tiene alguna pregunta sobre estas políticas?"
+        read_the_faq: Preguntas frecuentes sobre el reconocimiento de vehículos eléctricos
+      review_summary:
+        a_quick_review: Un breve repaso de todo lo que usted reconoció.
+        a_quick_review_tap: Un breve repaso de todo lo que has confirmado. Pulsa "Revisar"
+          para volver a consultar un protocolo.
+        review: Revisar
+        youre_almost_done: Ya casi terminas.
+      step1:
+        bike_info_html: "%{cycle_type} información"
+        electric_helper: Verificamos que sean eléctricas para poder marcarlas y comprobar
+          su certificación.
+        electric_motorized: "⚡️ Eléctrico (motorizado)"
+        email: Email
+        email_placeholder: tú@ejemplo.com
+        email_school: "%{org_name} correo electrónico"
+        just_the_essentials: Solo lo esencial para empezar.
+        next: Próximo
+        no_need_to_wait: Le enviaremos un enlace de confirmación por correo electrónico;
+          no tiene que esperar para continuar.
+        register_your_vehicle: "¡Registra tu vehículo!"
+        register_your_vehicle_with_org: "¡Registra tu vehículo con %{org_name}!"
+        start_over: Volver a empezar
+        start_over_certain: "¿Empezar de nuevo?"
+        start_over_discards: Esto inicia un nuevo registro; nada de lo que haya introducido
+          aquí se conservará.
+        vehicle_type: Tipo de vehículo
+        yes_start_over: Sí, empezar de nuevo
+        your_info: Tu información
+      step2:
+        add_another_color: Añade otro color
+        add_your_bikes_details: Agregue los detalles de su %{cycle_type}
+        additional_serial_sticker_number: Número de serie/etiqueta adicional
+        affiliation: "%{org_name} afiliación"
+        are_you_certain: "¿Estás seguro?"
+        attach_photo: Adjuntar foto de %{cycle_type}
+        bike_details: "%{cycle_type} detalles"
+        bottom_bracket: Soporte inferior
+        cm: centímetro
+        color: Color
+        complete_registration: Registro completo %{cycle_type}
+        confirmation_link_sent: 'Te hemos enviado un enlace de confirmación a tu correo
+          electrónico. No tienes que esperar: puedes finalizar tu registro ahora mismo.'
+        contact_info: Información de contacto
+        database_public_note: "¡Nuestra base de datos es pública! Podrás ajustar la
+          configuración de privacidad de las fotos individuales de tu registro más
+          adelante."
+        email: Email
+        enter_size: Introduzca el tamaño
+        found: Encontrado/Abandonado
+        found_description: Encontré esto %{cycle_type}
+        frame_size: Tamaño del marco
+        from_step_1: Desde el paso 1
+        head_tube: Tubo de dirección
+        how_to_find_serial: Cómo encontrar su número de serie
+        i_just_dont_know_the_serial: Simplemente no conozco el número de serie.
+        im_100_sure: Estoy 100% seguro
+        inches: pulgadas
+        information_for_org: Información para %{org_name}
+        is_a_handmade_frame: Es un marco hecho a mano
+        it_probably_has_a_serial_number: Probablemente tenga un número de serie.
+        missing_serial: Número de serie extraviado
+        model: Modelo
+        model_placeholder: Por ejemplo, Marlin 7
+        model_year: Año del modelo
+        model_year_placeholder: p. ej. 2023
+        more_useful_registration: Cuanto más añadas, más útil será el registro.
+        nevermind: No importa
+        next: Próximo
+        optional: opcional
+        or: o
+        owner_name: Nombre del propietario
+        owner_name_placeholder: Nombre y apellido
+        owner_registration: Registro del propietario
+        owner_registration_description: Registro para mí mismo o en nombre del propietario.
+        phone: Teléfono
+        phone_placeholder: "(555) 000-0000"
+        phone_required_found: Se requiere el teléfono para registrar un %{cycle_type}
+          encontrado.
+        phone_required_stolen: Se requiere el teléfono para registrar un %{cycle_type}
+          robado.
+        primary_color_blank: Color primario — por ejemplo, negro
+        read_how_to_find_html: Lea sobre %{how_to_find_link} <small>(se abre en una
+          ventana aparte)</small>
+        rear_dropouts: punteras traseras
+        register_with_org: Regístrate con %{org_name}
+        register_with_org_description: "%{org_name} podrá ver y ayudar a gestionar
+          este registro."
+        registration_type: Tipo de registro
+        remove_additional_color: Eliminar color
+        second_color_blank: Segundo color — por ejemplo, rojo
+        serial_help_intro: 'La mayoría de las bicicletas tienen su número de serie
+          grabado en el cuadro. Busca tu número de serie:'
+        serial_location_bottom_bracket: parte inferior del soporte inferior
+        serial_location_head_tube: en el tubo de dirección
+        serial_location_rear_dropouts: en las punteras traseras
+        serial_number: Número de serie
+        serial_placeholder: Obligatorio — o marcar como faltante
+        sticker_number: Número de pegatina del índice de bicicletas
+        sticker_placeholder: p. ej. A 471 829
+        stolen: Robado
+        stolen_description: Este %{cycle_type} ha sido robado.
+        student_id: Carné de estudiante
+        third_color_blank: Tercer color
+        up_to_3: hasta 3
+        very_very_few_bikes_html: "<em>Muy</em> pocos %{cycle_types} se fabrican sin
+          números de serie. A menos que este %{cycle_type}:"
+        view_serial_guide: Consulte la guía completa de números de serie.
+        was_made_before_1970: Fue fabricado antes de 1970.
+        wheres_my_serial: "¿Dónde está mi número de serie?"
+        without_serial: Este %{cycle_type} se hizo sin número de serie.
+        without_serial_number: Este %{cycle_type} se fabricó sin número de serie.
+      step_acknowledgment:
+        continue: Continuar
+      step_acknowledgment_review:
+        complete_registration: Registro completo %{cycle_type}
+      step_confirm:
+        confirming_your_email: Confirmando tu correo electrónico
+        continue: Continuar
+        continue_where_you_left_off: Continúa y retomaremos donde lo dejaste.
+      step_finished:
+        add_impound_details: Añade detalles sobre dónde encontraste el %{cycle_type}
+        add_photos: Agrega fotos de tu %{cycle_type}
+        confirming_lets_you: 'Confirmar tu correo electrónico te permite:'
+        do_these_things: Haz estas cosas para tener la mejor oportunidad de recuperarlo.
+        finish_adding: Finaliza la adición de tu %{cycle_type} al Índice de Bicicletas
+        listed_as_found: El %{bike_display} aparece en Bike Index.
+        listed_as_stolen: Tu %{bike_display} aparece como robada en Bike Index.
+        owner_can_claim: Su propietario puede encontrarlo aquí y reclamarlo; le enviaremos
+          un correo electrónico cuando alguien lo haga.
+        progress_saved: Progreso guardado
+        register_another: Registrar otro vehículo
+        registered_for_owner_html: La %{bike_display} está registrada en Bike Index.
+          Le hemos enviado un correo electrónico a %{email} para que pueda reclamar
+          el registro.
+        registration_complete: "¡Registro completado!"
+        report_it_stolen: Finaliza la denuncia de tu %{cycle_type} robado y aprovecha
+          nuestra red comunitaria.
+        reported_stolen: Denunciado como robado
+        verify_your_email_html: 'Un paso más: verifica tu correo electrónico. Te enviamos
+          un enlace de confirmación a %{email}; haz clic en él para finalizar tu registro.
+          Toda la información que ingresaste se guardará.'
+        view_the_registration: Ver el registro
+        view_your_registration: Ver su registro
+        we_will_keep_watch: Tu %{bike_display} está registrada en Bike Index. La vigilaremos;
+          si se denuncia como robada, toda la comunidad estará pendiente.
+      step_report:
+        about_the_one_you_found: Acerca del %{cycle_type} que encontraste
+        address_where_you_found_it: Dirección donde lo encontraste
+        complete_registration: Registro completo %{cycle_type}
+        contact_and_sharing: Contacto y compartición
+        department_city: Departamento/ciudad
+        estimated_value: Valor estimado (%{currency})
+        have_proof_of_ownership: Tengo pruebas de que soy el propietario de este %{cycle_type}
+        help_us_reunite: Ayúdanos a devolvérselo a su dueño.
+        how_did_you_find_it: "¿Cómo encontraste el %{cycle_type}?"
+        how_was_it_locked: "¿Cómo se bloqueó %{cycle_type}?"
+        how_was_the_lock_defeated: "¿Cómo se logró abrir la cerradura?"
+        next: Próximo
+        police_report: Informe policial
+        receive_notifications: Envíame un correo electrónico si tuiteamos sobre esto
+          %{cycle_type} o si encontramos una posible coincidencia.
+        report_number: Número de informe
+        report_your_stolen: Denuncie su %{cycle_type} robado
+        show_phone_police: Policía
+        show_phone_shops: Tiendas de bicicletas
+        show_phone_users: Usuarios de Bike Index que han iniciado sesión
+        the_more_we_know: Cuanto más sepamos, mayores serán las posibilidades de recuperarlo.
+        theft_details: Detalles del robo
+        what_happened: "¿Qué pasó?"
+        what_happened_placeholder: Por ejemplo, estaba enganchado a un estante fuera
+          de la cafetería, y ya no estaba cuando volví a salir.
+        when_and_where: Cuándo y dónde
+        when_did_you_find_it: "¿Cuándo lo encontraste?"
+        when_was_it_stolen: "¿Cuándo fue robado el %{cycle_type}?"
+        where_was_it_stolen: "¿Dónde fue robado?"
+        who_can_see_your_phone: "¿Quién puede ver tu número de teléfono?"
+        without_a_report: Presentar una denuncia policial le da a su %{cycle_type}
+          la mejor oportunidad de regresar; puede agregar el número más tarde.
+    registrations:
+      show:
+        bike_details:
+          frame_material: Material del marco
+          frame_size: Tamaño del marco
+          handlebar_type: Tipo de manillar
+          manufacturer: Fabricante
+          model: Modelo
+          other_serial: Otro número de serie/registro/etiqueta
+          serial: De serie
+          title: "%{bike_type} detalles"
+          vehicle_type: Tipo de vehículo
+          year: Año
+        bike_index_card:
+          activity: Actividad
+          frame_material: Material del marco
+          id: IDENTIFICACIÓN
+          registered_since: Registrado desde
+          this_bike_on_bike_index: Esto %{bike_type} en Índice de Bicicletas
+        component_list:
+          component_no_info: "-"
+          componentyear: "%{componentyear}"
+          drivetrain: Tren de transmisión
+          drivetrain_fixed: Engranaje fijo
+          drivetrain_front: Tren de transmisión delantero
+          drivetrain_rear: Tren de transmisión trasero
+          front: Frente
+          front_rear: Delantero y trasero
+          front_tire_width: Ancho del neumático delantero
+          front_wheel_diameter: Diámetro de la rueda delantera
+          full_spec_sheet: Hoja de especificaciones completa
+          hide: Esconder
+          other: Otro
+          paint_description: Descripción del color
+          propulsion_type: Propulsión
+          rear: Trasero
+          rear_tire_width: Ancho del neumático trasero
+          rear_wheel_diameter: Diámetro de la rueda trasera
+          show_all: Mostrar todo
+          tire_width: Ancho del neumático
+          tire_width_narrow_false: Neumático ancho
+          tire_width_narrow_true: Neumático estrecho
+          wheel_diameter: Diámetro de la rueda
+        contact_owner:
+          contact_the_owner: Contacta con el propietario
+          know_something_about_this_bike_type: "¿Sabes algo sobre esto %{bike_type}?"
+          link_url: URL del enlace
+          send_message: Enviar mensaje
+          where_did_you_see_this_bike: "¿Dónde viste esto %{bike_type}? Si nos contactas
+            por un anuncio que encontraste en línea, incluye un enlace en el campo
+            a continuación."
+        current_alerts:
+          claim_impound:
+            add_a_stolen_bike: agregar un %{bike_type} robado
+            choose_stolen_bike: Elija robado %{bike_type}
+            claim_found_bike: Reclamación encontrada %{bike_type}
+            claim_impounded_bike: Reclamación confiscada %{bike_type}
+            claim_submitted: Esta reclamación fue presentada
+            claim_was_status: Su reclamación era %{status}; debería haber recibido
+              un correo electrónico con los siguientes pasos.
+            claim_with_this_bike_type: Tienes una reclamación %{status} con este %{bike_type}.
+            does_this_look_like_your_bike: "¿Esto se parece a tu %{bike_type}?"
+            need_stolen_bike_html: Necesitas un %{bike_type} robado registrado para
+              presentar una reclamación — %{add_link}.
+            no_editing_after_submitting: Una vez enviada, no podrá editar la reclamación.
+            open_claim: Reclamación abierta
+            prove_its_yours: 'Verifica tu propiedad: agrega detalles que demuestren
+              que este %{bike_type} es tuyo.'
+            save_message: Guardar mensaje
+            select_your_stolen_bike: Seleccione el %{bike_type} robado que posee y
+              que coincide con este depósito.
+            submit_claim: Presentar reclamación
+            view_claimed_bike_type: ver los %{kind} %{bike_type} reclamados
+            your_claim: Su reclamación
+          claim_invitation:
+            claim_bike_type: Reclamación %{bike_type}
+            claim_it_so_you_can_update_your_listing: Reclámalo para poder actualizar
+              tu anuncio.
+            claim_your_bike_type: Reclama tu %{bike_type}
+            read_more: leer más
+            registered_your_bike_on_index_html: Registré mi %{bike_type} en Bike Index,
+              una plataforma gratuita y sin fines de lucro de registro de bicicletas
+              y recuperación de bicicletas robadas %{read_more_link}.
+            sign_up: inscribirse
+            sign_up_to_claim: Inscríbete
+            to_see_your_bike_sign_up_html: Para ver tu %{bike_type} y reclamarlo como
+              tuyo, %{sign_up_link} con la dirección de correo electrónico donde recibiste
+              tu correo electrónico de registro.
+            were_honored_to_have_your_bike: Nos sentimos honrados de tener su %{bike_type}
+              en el Índice.
+          notification_token:
+            mark_graduated_resolved: Marca %{bike_type} restante
+            mark_parking_resolved: Marca %{bike_type} recuperada
+            no_futher_action_necessary: "¡No es necesario realizar ninguna otra acción!"
+            organization_sent_this_message: "%{org_name} envió esta notificación"
+            please_email_organization_with_questions_html: Envíe un correo electrónico
+              a %{email_link} si tiene alguna pregunta.
+            you_have_already_marked_remaining: Ya has marcado este %{bike_type} restante
+            you_have_already_marked_resolved: Has marcado esta notificación como resuelta
+          recovery_prompt:
+            can_we_share_your_story: "¿Podemos compartir tu historia?"
+            did_we_help: "¿Les hemos ayudado?"
+            how_did_you_get_it_back: "¿Cómo lo recuperaste?"
+            its_also_how_we_get_better_at_recovering: También es la forma en que mejoramos
+              nuestra capacidad de recuperación %{bike_type}.
+            mark_recovered: Mark se recuperó
+            mark_your_bike_recovered: "¡Marca tu %{bike_type} recuperado!"
+            nevermind: No importa
+            please_tell_us_how_you_got_your_bike: Por favor, cuéntanos cómo recuperaste
+              tu %{bike_type}, ¡realmente nos importa!
+            when_did_you_recover_it: "¿Cuándo lo recuperaste?"
+          scanned_sticker:
+            change_the_bike_sticker_linked_to: Cambia el %{bike_type} al que enlaza.
+            is_this_linked_to_incorrect_bike: "¿Está esta pegatina vinculada al %{bike_type}
+              incorrecto?"
+            switch_to_new_bike_id: Cambiar a un nuevo ID %{bike_type}
+            update: Actualizar
+            you_scanned_this_sticker_html: Usted escaneó %{sticker}, que está asignado
+              a este %{bike_type}.
+          sent_to_new_owner:
+            you_sent_this_bike_html: Enviaste este %{bike_type} a %{owner_email} y
+              aún no ha sido reclamado. Puedes actualizarlo.
+        impound_details:
+          found_at: Encontrado en
+          found_details: Se encontraron detalles
+          impound_details: Detalles del depósito
+          impounded_at: Incautado en
+          location: Ubicación
+          org_impound_record: "%{org_name} registro de depósito"
+        impound_record_fields:
+          created: Creado
+          impounded_by: Incautado por
+          impounded_from: Incautado de
+          last_update_by: Última actualización por
+          status: Estado
+        legacy_view_link:
+          switch_to_classic: Volver al visor anterior
+          using_new_view: Estás probando el nuevo visor %{bike_type}.
+          view_in_legacy: Ver %{bike_type} en el visor antiguo
+        map:
+          unavailable: No se pudo cargar el mapa; es posible que su navegador o dispositivo
+            no lo admita.
+        org_top_actions:
+          impound_update:
+            title: Actualizar el registro de incautación
+          message_owner:
+            know_something_about_this_bike_type: "¿Sabes algo sobre esto %{bike_type}?"
+            link_url: URL del enlace
+            send_message: Enviar mensaje
+            where_did_you_see_this_bike: "¿Dónde viste esto %{bike_type}? Si nos contactas
+              por un anuncio que encontraste en línea, incluye un enlace en el campo
+              a continuación."
+          parking_notification_form:
+            address_or_intersection: Dirección o intersección
+            create_parking_notification: Crear una nueva notificación de estacionamiento
+            impound_this_bike_type: Confiscar esto %{bike_type}
+            map_hint: Arrastra el mapa para que el marcador señale el lugar.
+            map_unavailable: No se pudo cargar el mapa; la ubicación aún estaba configurada
+              desde su dispositivo.
+            parking_notification_notes_html: "%{org_name} Las notas internas <small>no
+              se muestran al usuario.</small>"
+          parking_notification_show:
+            no_notifications: No hay notificaciones de estacionamiento para este %{bike_type}
+            parking_notifications: notificaciones de estacionamiento
+            view_all: Ver todas las notificaciones para este %{bike_type}
+            view_notification: Ver notificación
+          wrapper:
+            impound: Confiscar
+            message_owner: Mensaje del propietario
+            new_parking_notice: Nuevo aviso de estacionamiento
+            update_impound_record: Actualizar el registro de incautación
+            view_notifications: Ver notificaciones
+            view_notifications_active_html: "<strong>%{count}</strong> Activo"
+            view_notifications_resolved_html: "<strong>%{count}</strong> Resuelto"
+        owner_phone:
+          or_call: O llame
+        photos:
+          add_photo: Añadir foto
+          bike_photo: "%{bike_type} foto"
+          color_may_not_match: "¡El color puede no coincidir!"
+          stock_photo: Foto de archivo de un %{year} %{model}
+        primary_colors:
+          primary_color:
+            one: Color primario
+            other: Colores primarios
+        status:
+          found: Encontró
+          impounded: Incautado
+          not_stolen: No robado
+          stolen: Robado
+          unregistered: No registrado
+        stolen_details:
+          department_city: Departamento y ciudad
+          description_of_incident: Descripción del incidente
+          location: Ubicación
+          locking_circumvented: El bloqueo eludido
+          locking_description: Descripción del bloqueo
+          police_report: Informe policial n.º
+          stolen_at: Robado en
+          stolen_details: Detalles del robo
+        toggle_view:
+          switch_to_legacy_default: Cambiar al visor antiguo por defecto.
+          switch_to_new: Cambiar a la nueva vista
+          try_new_view: "¡Prueba el nuevo visor %{bike_type}!"
+          view_in_new: Ver en un nuevo visor
+          viewing_in_legacy: Visor antiguo (por defecto se utiliza el nuevo visor)
+        wrapper_consumer:
+          about_this_bike: Acerca de esto %{bike_type}
+          audience_owner: Tu %{bike_type}
+          audience_public: Vista pública
+          audience_sent_away: Ya no es tu %{bike_type}
+          edit_this_bike: Edita esto %{bike_type}
+          mark_stolen: Marca robada
+          registered_protected: Registrado y protegido
+          sell_on_marketplace: Vender en el mercado
+          share: Compartir
+          share_my_page: Comparte mi página
+        wrapper_org_admin:
+          about_this_bike: Acerca de esto %{bike_type}
+          assign_sticker: Asignar pegatina
+          audit: Auditoría de vehículos eléctricos
+          avery_exportable: Exportable de Avery
+          claimed: Afirmado
+          creation_source: Fuente
+          creator: Creador
+          credibility: Credibilidad
+          edit: Editar
+          has_duplicate_serials: tiene números de serie duplicados
+          internal_notes: Notas internas
+          is_false: FALSO
+          is_true: verdadero
+          link_sticker: Pegatina de enlace
+          no_duplicate_serials: Sin duplicados. Números de serie
+          no_other_registrations: No se encontró ninguno
+          no_registration_information: No se muestra información de registro para
+            %{org_name}
+          not_audited: No auditado
+          not_registered_message: La información de contacto del propietario no está
+            disponible para bicicletas que no pertenezcan a su organización. Sin embargo,
+            puede agregar notas internas.
+          not_registered_title: No está registrado con %{org_name}
+          note_by: Nota de %{user}
+          notes_placeholder: 'Nueva nota interna: tus notas anteriores se conservan
+            en el hilo.'
+          org_can_edit: "%{org_name} puede editar esto %{bike_type}"
+          org_can_edit_sub: Incluso después de que se reclame %{bike_type}.
+          organization_registered: Organización
+          other_registrations: Otros registros de este usuario
+          other_registrations_count_html: "%{count} otros registros"
+          owner_access: Propietario y acceso
+          owner_email: Email
+          owner_name: Nombre
+          owner_phone: Teléfono
+          photo_archive: Archivo fotográfico
+          post_note: Nota postal
+          posts_as: Publicaciones como %{user}
+          registration_information: Información de registro
+          registration_number: Registro del índice de bicicletas
+          restricted_message: El contacto con el propietario está disponible para
+            el personal administrativo y de apoyo. Puede agregar notas y solicitar
+            la retirada del vehículo.
+          restricted_title: Restringido para tu rol
+          role_limited: Limitado
+          role_staff: Personal
+          showing_recent: Mostrando el %{count} más reciente
+          sticker: Etiqueta engomada
+          sticker_claimed: afirmado
+          sticker_code: Código de la pegatina
+          unregistered_owner: Este %{bike_type} no está registrado a ningún usuario.
+            Se agregó para realizar un seguimiento de las notificaciones de estacionamiento.
+          view_all_registrations: ver todo →
+    sessions:
+      sign_in_interstitial:
+        click_button_to_continue: Haz clic en el botón de abajo para continuar.
+        finish_signing_in: Finalizar el registro
+        sign_in: Iniciar sesión
+  user_emails:
+    confirm:
+      confirm_email: Confirmar correo electrónico
+      confirm_this_email: Confirmar %{user_email}

--- a/config/locales/translation.it.yml
+++ b/config/locales/translation.it.yml
@@ -752,7 +752,8 @@ it:
         theft_description: Descrizione del furto
         time: Ora
         tsved_at: Tsved a
-        zipcode: Codice postale
+        postal_code: Codice postale
+        region_string: Regione
       theft_alert:
         end_at: Finisce il
         notes: Note
@@ -1850,6 +1851,9 @@ it:
       no_one_but_the_user_and_bike_index_admins: Nessuno, a parte l'utente (e gli
         amministratori di Bike Index), può vederlo
       test_registration: registrazione di test
+    stolen_map:
+      unavailable: 'Impossibile caricare la mappa: il browser o il dispositivo in
+        uso potrebbero non supportarla.'
   bikes_edit:
     accessories:
       add_a_component: Aggiungi un componente
@@ -2221,9 +2225,9 @@ it:
       sessionable:
         sign_in_and_redirect:
           logged_in: Accesso effettuato!
-          organization_signed_in: Hai effettuato l'accesso
           user_is_banned: Ci dispiace, ma sembra che il tuo account sia stato bloccato.
             Se hai dubbi sui motivi, ti preghiamo di contattarci.
+          organization_signed_in: Hai effettuato l'accesso
         skip_if_signed_in:
           already_signed_in: Hai già effettuato l'accesso!
     feedbacks:
@@ -2412,8 +2416,6 @@ it:
       create:
         invalid_email_or_password: Indirizzo email/password non validi
       create_magic_link:
-        link_sent: Link di accesso inviato! Basta cliccare sul link nella tua email
-          per accedere.
         user_not_found: Impossibile trovare quell'utente
     stolen_notifications:
       create:
@@ -2519,6 +2521,21 @@ it:
           Se il problema persiste, è probabile che una VPN o un''estensione per la
           privacy stia bloccando le informazioni necessarie: prova a disattivarle
           per bikeindex.org. Se il problema persiste, invia un''e-mail a contact@bikeindex.org.'
+    register:
+      acknowledge:
+        acknowledge_everything: Seleziona tutte le caselle per accettare queste regole
+      confirm_email:
+        confirmation_link_expired: 'Quel link di conferma è scaduto: controlla la
+          tua email per trovarne uno nuovo.'
+        signed_in_as_other: Hai effettuato l'accesso come %{email}, quindi ti abbiamo
+          mantenuto in quell'account. La registrazione è ancora salvata all'indirizzo
+          email che ti abbiamo inviato.
+      find_b_param:
+        registration_not_found: 'Non abbiamo trovato questa registrazione: avviane
+          una nuova qui sotto.'
+      sign_in_confirmed_user:
+        unable_to_sign_in: Abbiamo confermato il tuo indirizzo email, ma non siamo
+          riusciti ad accedere al tuo account.
   customer_mailer:
     additional_email_confirmation:
       html:
@@ -4004,8 +4021,6 @@ it:
       try_for_free: Prova gratis
       year: anno
   layouts:
-    application:
-      skip_to_main_content: Vai al contenuto principale
     application_bikehub:
       accounts_powered_by_bike_index: Gli account BikeHub sono gestiti da Bike Index,
         il principale registro di biciclette.
@@ -4041,6 +4056,8 @@ it:
     revised_messages:
       error: errore
       please_fix_the_following: Correggi i seguenti %{errors}
+    application:
+      skip_to_main_content: Vai al contenuto principale
   locales:
     en: Inglese
     nb: Norvegese (Bokmål)
@@ -4128,6 +4145,13 @@ it:
     welcome_index: 'Il miglior registro per biciclette: semplice, sicuro e gratuito.'
     registrations_embed: Modulo di registrazione Bike Index %{organization} incorporabile.
       Registra la tua bici gratuitamente, ora!
+    search_marketplace_index: Biciclette in vendita su Bike Index. Cerca sul mercato
+      per produttore, prezzo e località.
+    search_registrations_index: Cerca le biciclette che sono state registrate su Bike
+      Index
+    strava_search_index: Associa la tua attrezzatura Strava alle tue registrazioni
+      Bike Index. Cerca, filtra e aggiorna in blocco le tue attività per assegnare
+      l'attrezzatura alle uscite in cui manca.
   meta_titles:
     bikes_index: Risultati della ricerca
     bikes_new: Registra una bicicletta!
@@ -4169,6 +4193,16 @@ it:
     my_accounts_show: Indice Tu in bicicletta
     search_registrations_index: Risultati della ricerca
     registrations_embed: Registra una bicicletta con %{organization}
+    register_acknowledgment: Controllo di sicurezza per il tuo %{cycle_type}
+    register_confirm: Conferma la tua email
+    register_create: Registra il tuo veicolo!
+    register_report: Raccontaci cos'è successo
+    register_review: Rivedi il tuo controllo di sicurezza %{cycle_type}
+    register_show: La tua registrazione %{cycle_type}
+    register_step_1: Registra il tuo veicolo!
+    register_step_2: Aggiungi i dettagli del tuo %{cycle_type}.
+    search_marketplace_index: Mercato di Bike Index
+    strava_search_index: Indice biciclette Ricerca Strava
   money:
     currencies:
       en: USD
@@ -4733,7 +4767,6 @@ it:
         save: Salva
       show:
         abbreviation: Abbreviazione
-        choose_file: Seleziona il file...
         contact_to_update_html: Contatta %{link} per aggiornare l'abbreviazione
         delete_organization: Elimina l'organizzazione
         i_would_like_to_terminate_my_account: Vorrei chiudere il mio account con Bike
@@ -4764,15 +4797,6 @@ it:
       index:
         matches_visible: visibile
         parking_notifications: Notifiche di parcheggio
-      show_details:
-        address: Indirizzo
-        bike: Bicicletta
-        by: Creato da
-        created: Creato a
-        internal_notes: Note interne
-        message: Messaggio
-        notification_number: Notifica#
-        resolved: Risolto
       table:
         address: Indirizzo
         bike: Bicicletta
@@ -4895,6 +4919,14 @@ it:
       subject: Unisciti a %{organization_name} su Bike Index
     partial_registration:
       subject: Completa la tua registrazione a %{organization_name}Bike Index!
+    partial_register_confirmation:
+      subject: Conferma la tua email per completare la tua %{organization_name}registrazione
+    partial_register_confirmation_abandoned:
+      subject: Completa la segnalazione del tuo %{cycle_type} abbandonato
+    partial_register_confirmation_found:
+      subject: Completa la segnalazione del tuo ritrovamento %{cycle_type}
+    partial_register_confirmation_stolen:
+      subject: Completa la segnalazione del tuo %{cycle_type} rubato
   payments:
     form:
       donation_header: Aiutaci a sostenere i nostri sforzi!
@@ -4990,9 +5022,13 @@ it:
       sign_in_with_magic_link: Accesso senza password
       unable_to_auth: Impossibile autenticare il token
       your_email_address: Il tuo indirizzo di posta elettronica
-    magic_link_sent:
-      follow_the_link_back: Segui il link nella email per accedere!
-      we_sent_a_magic_sign_in_link: Ti abbiamo inviato un link magico per accedere
+      link_already_used: Quel link di accesso è già stato utilizzato
+      link_expired: Il link di accesso è scaduto.
+      links_work_for: I link di accesso funzionano per %{duration} dopo essere stati
+        inviati.
+      only_the_newest_link_works: Potresti aver già effettuato l'accesso da qualche
+        altra parte. Se hai richiesto più di un indirizzo email, solo il link presente
+        nell'ultimo messaggio sarà valido.
     new:
       email: e-mail
       forgot_your_password: Hai dimenticato la password?
@@ -5008,6 +5044,9 @@ it:
       sign_in_without_password: Accedi senza password
     identify:
       different_email: Accedi con un indirizzo email diverso
+    magic_link_sent:
+      follow_the_link_back: Segui il link nell'email per accedere!
+      we_sent_a_magic_sign_in_link: Ti abbiamo inviato un link magico per accedere
   shared:
     bike_search_form:
       anywhere: Ovunque
@@ -5037,23 +5076,6 @@ it:
         di registrazione. Aggiungi foto e dettagli del %{bike_type} per mostrare cosa
         rende il tuo veicolo unico. Speriamo che il tuo %{bike_type} non venga rubato,
         ma se dovesse succedere, saremo qui quando ne avrai più bisogno.
-    content_skeleton:
-      about: Di
-      bicycle_serials: Serie di biciclette
-      bike_index_news: Tutte le notizie di Bike Index
-      bike_index_store: Negozio Bike Index
-      design_and_developer_resources: Risorse per la progettazione e lo sviluppo
-      donate: Donare
-      donate_today: Fai una donazione oggi
-      help: Aiuto
-      how_to_get_your_stolen_bike_back: Come recuperare la bicicletta rubata
-      make_a_difference: Contribuisci a fare la differenza nella lotta contro il furto
-        di biciclette.
-      other_pages: Altre pagine
-      protect_your_bike: Proteggi la tua bicicletta
-      related: Imparentato
-      sign_up_your_organization: Registra la tua organizzazione
-      where: Dove
     donation_form:
       501c3_nonprofit: organizzazione senza scopo di lucro 501(c)(3)
       bike_index_is_a_nonprofit_html: Bike Index è un <small class="less-strong">EIN
@@ -5067,15 +5089,6 @@ it:
       what_does_your_donation_do: A cosa serve la tua donazione?
     donation_modal:
       donation_header: Aiutaci a sostenere i nostri sforzi!
-    edit_bike_skeleton:
-      edit: Modifica
-      edit_pages: 'Modifica le pagine %{bike_type}:'
-      owned_but_hasnt_been_claimed_html: Di proprietà di <em>%{owner_email}</em> ma
-        non è stato ancora reclamato
-      owned_with_permission_to_edit_html: Di proprietà di <em>%{owner_email}</em>
-        ma %{org_name} ha il permesso di modificarlo
-      view_bike: Visualizza %{bike_type}
-      view_bike_version: Visualizza la versione %{bike_type}
     email_bike_box:
       color: Colore
       color_may_be_incorrect: Il colore potrebbe non essere corretto. Si prega di
@@ -5212,20 +5225,6 @@ it:
       you: Voi
       your_bikes: Le tue biciclette
       your_preferences: Le tue preferenze
-    law_enforcement_donation_modal:
-      bikeindex_is_a_nonprofit: Bike Index è un'organizzazione no-profit 501(c)(3).
-        Dipendiamo dalle donazioni per fornire questi servizi. Raccomandiamo alle
-        forze dell'ordine come %{org_name} di donare almeno 20 dollari all'anno per
-        sostenere le nostre attività.
-      contact_bike_owners: Contatta i proprietari delle biciclette prima che vengano
-        segnalate come rubate.
-      email_for_access_html: Invia un'e-mail a %{email_link} per accedere.
-      greeting: Ciao %{user_name},
-      law_enforcement_features: 'Disponiamo di diverse funzionalità progettate specificamente
-        per gli agenti delle forze dell''ordine:'
-      multiple_serial_search_pane: Pannello di ricerca seriale multiplo
-      thank_you: Grazie mille per aver utilizzato Bike Index!
-      thanks_for_using_bike_index: Grazie per aver utilizzato Bike Index!
     organized_menu_items:
       add_a_bike: Aggiungi una bicicletta
       ascend_imports: Ascend Imports
@@ -5258,49 +5257,21 @@ it:
       super_admin_view: Super Amministratore per %{org_name}
       multi_search: Ricerca multipla
       manage_registration_sequences: Gestire le sequenze di registrazione
-    organized_skeleton:
-      additional_features_html: Bike Index offre funzionalità aggiuntive per le forze
-        dell'ordine verificate. Contatta %{email_link} per abilitarle.
-      admin_panel: Pannello di amministrazione
-      how_integration_works: come funziona l'integrazione
-      integrate_bike_index_with_ascend: Integra Bike Index con Lightspeed
-      integrate_bike_index_with_lightspeed: Integra Bike Index con Lightspeed
-      link_to_register_html: "<strong>%{link}</strong> per registrare automaticamente
-        le biciclette vendute ai clienti."
-      other_point_of_sale_system: Un altro sistema POS?
-      read_a_full_explanation_html: Leggi la spiegazione completa di %{link}.
-      register_bikes_with_link_html: Registra le biciclette con il nostro <strong>%{link}</strong>
-      streamlined_bike_shop_registration_page: pagina di registrazione del negozio
-        di biciclette semplificata
-      subscription_expired_html: Il tuo abbonamento a Bike Index è scaduto. Contatta
-        %{email_link} per riattivarlo.
-      use_ascend: Utilizzate Ascend?
-      use_lightspeed_retail_pos: Utilizzate Lightspeed Retail POS?
-      viewing_our_streamlined_page: Al momento stai visualizzando la nostra pagina
-        di registrazione semplificata per i negozi di biciclette, che è quella che
-        ti consigliamo di utilizzare
-    user_general_alert:
-      add_location_theft_bike_title_html: Aggiungere il luogo del furto del vostro
-        <strong>%{bike_title}</strong>
-      add_photo_theft_bike_title_html: Aggiungi una foto al tuo <strong>%{bike_title}</strong>
-      confirm_your_phone_number: Conferma il numero di telefono
-      location_critical_html: "<strong>È fondamentale per il recupero</strong> includere
-        l'indirizzo in cui la tua %{bike_type} è stata rubata."
-      missing_stolen_photo_title: Aggiungi una foto
-      photo_critical_html: Gli avvisi di successo <strong>devono avere un'immagine</strong>
-      stolen_missing_location_title: Aggiungi il luogo del furto
-      verification_code: Codice di verifica
-      verify_number: Verifica %{phone_number}
-      without_location_all_is_lost: Senza un luogo non possiamo diffondere la notizia
-        del furto e la gente non saprà dove cercare la tua %{bike_type}.
-      without_photo_all_is_lost: Se non hai foto della tua bicicletta, cerca un'immagine
-        stock su Internet e caricala. Senza un'immagine l'avviso non sarà efficace.
     recovery_display:
       bike: Bicicletta
       recovered_date: recuperato %{date}
       translated_from_english: tradotto dall'inglese
     shops_map:
       map_of_partner_locations: Mappa delle sedi dei partner
+    register_flow:
+      date_found_required: Per favore, dicci quando l'hai trovato
+      date_stolen_required: Per favore, dicci quando è stato rubato
+      email_required: Per registrarsi è necessario un indirizzo email.
+      location_found_required: Per favore, dicci dove l'hai trovato
+      location_stolen_required: Per favore, dicci dove è stato rubato
+      manufacturer_required: Il produttore è tenuto a registrarsi
+      name_required: Per registrarsi è necessario indicare il nome del proprietario.
+      unable_to_save: Non è stato possibile salvare la registrazione, riprova.
   stolen:
     index:
       ambassador: ambasciatore
@@ -5394,12 +5365,9 @@ it:
       agree_bikeindex_toc_html: Accetto i termini e le condizioni di Bike Index %{bikeindex_toc_link}.
       already_have_a_bike_index_account: Hai già un account Bike Index?
       already_have_an_account: hai già un account?
-      better_password: meglio
       get_bike_indexs_newsletter: Ricevi la newsletter di Bike Index
       get_on_bike_index: Indice di accesso alla bicicletta
       log_in: accedi
-      password_helper_text_html: La password deve essere composta da almeno 12 caratteri.
-        Più lunga è %{better_password_link}.
       sign_up: Iscriviti
       sign_up_using_facebook: Iscriviti con Facebook
       sign_up_using_globalid: Iscriviti utilizzando globaliD
@@ -5430,11 +5398,15 @@ it:
       stolen: Rubato!
       this_user_has_no_bikes_yet: Questo utente non possiede ancora biciclette!
       this_users_bikes: Le biciclette di questo utente
+      banned_only_visible_to_superusers: Il loro profilo è visibile solo perché sei
+        un superutente.
+      banned_user: Questo utente è stato bannato
+      profile_hidden: Questo profilo non è condiviso pubblicamente
+      profile_hidden_owner: È visibile solo a te perché è la tua pagina.
+      profile_hidden_superuser: È visibile solo perché sei un superutente.
     unsubscribe:
-      if_not_click_button: Se non lo sei, fai clic sul pulsante qui sotto
       unsubscribe: Annulla iscrizione
-      you_should_be_unsubscribed_automatically: L'iscrizione dovrebbe essere annullata
-        automaticamente.
+      confirm_unsubscribe: Conferma di voler annullare l'iscrizione
     update_password_form_with_reset_token:
       and_try_not_to_forget_it: e cercate di non dimenticarlo...
       better_password: meglio
@@ -5500,11 +5472,6 @@ it:
       index:
         loading_results: Caricamento dei risultati...
   components:
-    sessions:
-      sign_in_interstitial:
-        if_not_click_button: Se non lo sei, fai clic sul pulsante qui sotto
-        sign_in: Registrazione
-        you_should_be_signed_in_automatically: Dovresti essere connesso automaticamente.
     search:
       everything_combobox:
         query_items_description: Casella combinata delle descrizioni di ricerca
@@ -5540,9 +5507,6 @@ it:
         bike_box_view: Visualizza come elenco
         thumbnail_view: Visualizza come miniature
     search_results:
-      frame:
-        rate_limited: 'Troppe ricerche in troppo breve: il numero di ricerche è limitato.
-          Attendi un attimo, poi riprova.'
       bike_box:
         location: Luogo
         posted_at: Elencato
@@ -5558,6 +5522,12 @@ it:
         member: Membro di Bike Index
       container:
         no_results: Nessuna registrazione corrisponde esattamente alla tua ricerca
+      frame:
+        fetch_failed: 'Impossibile caricare questi risultati: verifica la tua connessione
+          e riprova.'
+        rate_limited: 'Troppe ricerche in troppo breve: il numero di ricerche è limitato.
+          Attendi un attimo, poi riprova.'
+        retry: Riprova
     page_block:
       marketplace_listing_panel:
         condition: Condizione
@@ -5609,9 +5579,11 @@ it:
         letter_opener_tooltip: Visualizza l'email inviata da questa app di recensioni
         pr_link: 'PR #%{number}'
         commit_tooltip: 'Commit corrente:'
-        label_sandbox: Sandbox
         superadmin_button: Accedi come superamministratore
         superadmin_signed_in: accesso effettuato come superamministratore
+        label_development: Sviluppo
+        label_sandbox: Sandbox
+        no_superadmin: Nessun superutente (impossibile accedere)
       footer:
         about: Di
         ambassadors: Ambasciatori
@@ -5627,7 +5599,6 @@ it:
           501(c)(3) - EIN 81-4296194"
         dev_and_design_resources: Risorse per lo sviluppo e la progettazione
         donate: Donare
-        faq_and_help: FAQ e aiuto
         how_to_get_your_stolen_bike_back: Recupera la tua bicicletta rubata
         language: Lingua
         law_enforcement: forze dell'ordine
@@ -5647,39 +5618,121 @@ it:
         who_we_serve: A chi ci rivolgiamo
         legal: Legale
         social_media: Social media
-        status_page: Pagina di stato
-        register_a_bike: Registra una bici
+        faq_and_help: Domande frequenti e assistenza
         marketplace: Mercato
+        register_a_bike: Registra una bicicletta
         search: Cerca
+        status_page: Pagina di stato
+      law_enforcement_donation:
+        bikeindex_is_a_nonprofit: Bike Index è un'organizzazione no-profit 501(c)(3).
+          Dipendiamo dalle donazioni per fornire questi servizi. Raccomandiamo alle
+          forze dell'ordine come %{org_name} di donare almeno 20 dollari all'anno
+          per sostenere le nostre attività.
+        contact_bike_owners: Contatta i proprietari delle biciclette prima che vengano
+          segnalate come rubate.
+        email_for_access_html: Invia un'e-mail a %{email_link} per accedere.
+        greeting: Ciao %{user_name},
+        law_enforcement_features: 'Disponiamo di diverse funzionalità progettate specificamente
+          per gli agenti delle forze dell''ordine:'
+        multiple_serial_search_pane: Pannello di ricerca seriale multiplo
+        thank_you: Grazie mille per aver utilizzato Bike Index!
+        thanks_for_using_bike_index: Grazie per aver utilizzato Bike Index!
+      main_content:
+        content:
+          about: Di
+          bicycle_serials: Serie di biciclette
+          bike_index_news: Tutte le notizie di Bike Index
+          bike_index_store: Negozio Bike Index
+          design_and_developer_resources: Risorse per la progettazione e lo sviluppo
+          donate: Donare
+          donate_today: Fai una donazione oggi
+          help: Aiuto
+          how_to_get_your_stolen_bike_back: Come recuperare la bicicletta rubata
+          make_a_difference: Contribuisci a fare la differenza nella lotta contro
+            il furto di biciclette.
+          other_pages: Altre pagine
+          protect_your_bike: Proteggi la tua bicicletta
+          related: Imparentato
+          sign_up_your_organization: Registra la tua organizzazione
+          where: Dove
+        edit_bike:
+          edit: Modifica
+          edit_pages: 'Modifica le pagine %{bike_type}:'
+          owned_but_hasnt_been_claimed_html: Di proprietà di <em>%{owner_email}</em>
+            ma non è stato ancora reclamato
+          owned_with_permission_to_edit_html: Di proprietà di <em>%{owner_email}</em>
+            ma %{org_name} ha il permesso di modificarlo
+          view_bike: Visualizza %{bike_type}
+          view_bike_version: Visualizza la versione %{bike_type}
+        organized:
+          additional_features_html: Bike Index offre funzionalità aggiuntive per le
+            forze dell'ordine verificate. Contatta %{email_link} per abilitarle.
+          admin_panel: Pannello di amministrazione
+          how_integration_works: come funziona l'integrazione
+          integrate_bike_index_with_ascend: Integra Bike Index con Lightspeed
+          integrate_bike_index_with_lightspeed: Integra Bike Index con Lightspeed
+          link_to_register_html: "<strong>%{link}</strong> per registrare automaticamente
+            le biciclette vendute ai clienti."
+          other_point_of_sale_system: Un altro sistema POS?
+          read_a_full_explanation_html: Leggi la spiegazione completa di %{link}.
+          register_bikes_with_link_html: Registra le biciclette con il nostro <strong>%{link}</strong>
+          streamlined_bike_shop_registration_page: pagina di registrazione del negozio
+            di biciclette semplificata
+          subscription_expired_html: Il tuo abbonamento a Bike Index è scaduto. Contatta
+            %{email_link} per riattivarlo.
+          use_ascend: Utilizzate Ascend?
+          use_lightspeed_retail_pos: Utilizzate Lightspeed Retail POS?
+          viewing_our_streamlined_page: Al momento stai visualizzando la nostra pagina
+            di registrazione semplificata per i negozi di biciclette, che è quella
+            che ti consigliamo di utilizzare
       navbar:
         primary_menu:
           blog: Blog
           donate: Donare
           help: Aiuto
           log_in: accedi
-          stolen_bike: Bicicletta rubata?
-          search: Cerca
           marketplace: Mercato
+          search: Cerca
           sign_up: Iscriviti
+          stolen_bike: Bicicletta rubata?
         settings_menu:
           logout: Disconnettiti
+          marketplace_messages: Messaggi del mercato
           register_a_new_bike: Registra una nuova bicicletta
+          settings_menu: Impostazioni
           user_settings: "%{user_email} impostazioni"
           view_org: Visualizza %{org_name}
-          marketplace_messages: Messaggi del mercato
           your_registrations: Le vostre registrazioni
-          settings_menu: Impostazioni
         wrapper:
-          sign_up: Iscriviti
-          the_nonprofit_bike_registry: il registro delle biciclette senza scopo di lucro
           menu: Menu
+          sign_up: Iscriviti
+          the_nonprofit_bike_registry: il registro delle biciclette senza scopo di
+            lucro
+      user_alerts:
+        phone_waiting_confirmation:
+          confirm_your_phone_number: Conferma il numero di telefono
+          verification_code: Codice di verifica
+          verify_number: Verifica %{phone_number}
+        stolen_bike_without_location:
+          add_location_theft_bike_title_html: Aggiungere il luogo del furto del vostro
+            <strong>%{bike_title}</strong>
+          location_critical_html: "<strong>È fondamentale per il recupero</strong>
+            includere l'indirizzo in cui la tua %{bike_type} è stata rubata."
+          stolen_missing_location_title: Aggiungi il luogo del furto
+          without_location_all_is_lost: Senza un luogo non possiamo diffondere la
+            notizia del furto e la gente non saprà dove cercare la tua %{bike_type}.
+        theft_alert_without_photo:
+          add_photo_theft_bike_title_html: Aggiungi una foto al tuo <strong>%{bike_title}</strong>
+          missing_stolen_photo_title: Aggiungi una foto
+          photo_critical_html: Gli avvisi di successo <strong>devono avere un'immagine</strong>
+          without_photo_all_is_lost: Se non hai foto del tuo %{bike_type}, trova un'immagine
+            di repertorio su internet e caricala. Senza un'immagine, l'avviso promozionale
+            non sarà efficace.
+        unfinished_registration:
+          finish_the_required_steps: completare i passaggi richiesti
+          not_registered_yet_html: Il tuo %{cycle_type} non è ancora registrato! Per
+            favore %{finish_link}
     emails:
-      confirmation_email:
-        click_to_sign_in_html: Fai clic sul pulsante <em>Accedi</em> per completare
-          la registrazione!
-        follow_this_link_to_sign_in: Segui questo link per accedere
-        sign_in: Accedi
-        youre_almost_there: Ci sei quasi!
       partials:
         bike_box:
           bike_photo: Foto della bicicletta
@@ -5787,6 +5840,22 @@ it:
           <strong>%{color_and_brand}</strong> sul registro di biciclette più completo
           al mondo!
         youre_almost_done: Hai quasi finito!
+      confirmation_email:
+        click_to_sign_in_html: Fai clic sul pulsante <em>Accedi</em> per completare
+          la registrazione!
+        follow_this_link_to_sign_in: Segui questo link per accedere
+        sign_in: Registrazione
+        youre_almost_there: Ci sei quasi!
+      partial_register_confirmation:
+        click_below_to_pick_up_where_you_left_off: Fai clic qui sotto per confermare
+          questo indirizzo email e riprendere da dove avevi interrotto.
+        confirm_and_continue: Conferma la mia email
+        confirm_your_email: Conferma il tuo indirizzo email
+        link_signs_you_in: Questo link ti permette di accedere a Bike Index, quindi
+          non inoltrarlo. È valido per %{days} giorni.
+        we_saved_your_registration_html: Abbiamo salvato la tua registrazione per
+          un <strong>%{color_and_brand}</strong> nel registro di biciclette più completo
+          al mondo.
     messages:
       thread_show:
         can_not_send_new_message: Spiacenti, non è possibile inviare un nuovo messaggio.
@@ -5824,10 +5893,6 @@ it:
         year: anno
       chart_async_frame:
         loading_chart: Caricamento del grafico...
-      alerts:
-        object_error:
-          errors_prevented_this_from_being_saved: "%{errors_count} ha impedito il
-            salvataggio di questo %{object_name}:"
       forms:
         legacy_form_well:
           address_record:
@@ -5847,88 +5912,51 @@ it:
           address_record_with_default:
             edit_my_account_path: modifica il mio account
             use_account_address: Utilizzare l'indirizzo dell'account
+        address_group:
+          address: Indirizzo
+          choose_country: Seleziona il paese
+          city: Città
+          country: Paese
+          postal_code: Codice postale
+          region: Regione
+          state: Stato
+          street_2: Riga indirizzo 2
+        combobox_manufacturer:
+          placeholder: Inizia a digitare ad esempio %{name}
+        combobox_manufacturer_options:
+          unknown_manufacturer: Produttore sconosciuto
+        email:
+          did_you_mean_html: Intendevi %{email}?
+          not_real: Questo non sembra essere il tuo vero indirizzo email. Inserisci
+            un indirizzo email a cui ricevi le email.
+          submit_anyway: Invia comunque il modulo
+        file_upload:
+          no_file_chosen: Nessun file selezionato
+          take_picture: Scatta una foto
+          upload: Caricamento
+          upload_failed: caricamento non riuscito
+          uploading: caricamento
+        group:
+          optional: opzionale
+      alerts:
+        base:
+          error: Errore
+          info: Informazioni
+          notice: Avviso
+          success: Successo
+          warning: Avvertimento
+        flash_message:
+          signed_in_html: Hai effettuato l'accesso! Puoi %{link} se preferisci non
+            accedere tramite un link inviato via email.
+          signed_in_link: imposta una password per accedere
+          signed_up_html: Ti sei registrato a Bike Index! Puoi %{link} se preferisci
+            non accedere tramite un link inviato via email.
+          signed_up_link: imposta una password per accedere
+        object_error:
+          error_prevented_this_from_being_saved:
+            one: 'L''errore %{count} ha impedito il salvataggio di %{object_name}:'
+            other: 'Gli errori %{count} hanno impedito il salvataggio di questo %{object_name}:'
     org:
-      search:
-        form:
-          doesnt_look_like_serial: Questo non sembra un numero di serie. I numeri di
-            serie sono solitamente composti da 6 o più lettere e numeri, e si trovano
-            sotto il movimento centrale.
-          search_for_serial_number: Cerca il numero di serie
-          submit: invia
-          search_notes: Note di ricerca
-          search_owner_email_or_name: Cerca l'indirizzo email o il nome del proprietario
-        wrapper:
-          affiliation: Affiliazione
-          avery_exportable: Avery Esportabile
-          bike: registrazione
-          e_vehicle_propulsion: Veicolo elettrico (propulsione)
-          e_vehicles_for_audit: 'Veicoli elettrici da sottoporre a verifica:'
-          link: Collegamento
-          matching_bikes_html: "%{count} %{cycle_type} corrispondente"
-          mfg_model_color_html: produttore, modello, <span class="less-strong">colore</span>
-          phone: Telefono
-          reg_address: Indirizzo
-          registered_bikes_html: "%{count} %{cycle_type} corrispondente a %{org_name}"
-          student_id: Tessera studentesca
-          vehicle: registrazione
-          view_matching_any_audit: visualizzazione corrispondente a qualsiasi audit
-        settings:
-          address: 'Indirizzo:'
-          all: Tutti
-          avery_cell: Avery Esportabile
-          bike: registrazione
-          color_cell: Colore
-          create_export_of_vehicles: Crea l'esportazione della ricerca %{cycle_type}
-          created_at_cell: Registrato
-          creation_description_cell: Fonte
-          cycle_type_cell: Tipo di veicolo
-          default: predefinito
-          filter_impounded_html: solo <strong>sequestrato</strong>
-          filter_no_address_html: solo <strong>nessun</strong> indirizzo
-          filter_no_sticker_html: solo <strong>senza</strong> adesivo
-          filter_not_impounded_html: solo <strong>non</strong> sequestrato
-          filter_not_stolen_or_impounded_html: non rubato o sequestrato
-          filter_stolen_html: solo rubato
-          filter_with_address_html: solo <strong>con</strong> indirizzo
-          filter_with_stickers_html: solo <strong>con</strong> adesivi
-          impound_id_cell: ID del sequestro
-          impounded_cell: Sequestrato
-          manufacturer_cell: Produttore
-          model_cell: Modello
-          none: nessuno
-          notes_cell: Note
-          owner_email_cell: Inviato a
-          owner_name_cell: Nome del proprietario
-          propulsion_type_cell: Veicolo elettrico (propulsione)
-          reg_address_cell: Indirizzo
-          reg_extra_registration_number_cell: Secondario#
-          reg_organization_affiliation_cell: Affiliazione
-          reg_phone_cell: Telefono
-          reg_student_id_cell: Tessera studentesca
-          serial_number_cell: Seriale
-          settings: impostazioni
-          show_notes_search: mostra le note cerca
-          status: 'Stato:'
-          status_cell: Stato
-          sticker_cell: Adesivo
-          stickers: 'Adesivi:'
-          stolen_cell: Rubata
-          updated_at_cell: Fatto
-          url_cell: URL
-          vehicle: registrazione
-          visible_columns: Colonne visibili
-          multi_search: ricerca seriale multipla
-      search_results:
-        multi_result_chip:
-          no_results: nessuna corrispondenza
-        multi_results:
-          first_n_shown_html: "— prima %{limit} mostrata,"
-          no_exact_matches: 'Nessuna corrispondenza esatta. Numeri di serie simili:'
-          no_matches_found: Nessuna corrispondenza trovata
-          result_count_html: "— %{count} %{results}"
-          serial_label: 'Seriale:'
-          view_all: visualizza tutto
-          sticker_label: 'Adesivo:'
       location_address_fields:
         address: Indirizzo
         choose_country: Seleziona il paese
@@ -6053,3 +6081,606 @@ it:
         reprocess_instruction: Torna qui e fai clic sul pulsante "rielabora l'importazione"
           qui sotto
         unknown_ascend_name: Nome di Ascend sconosciuto
+      parking_notification_details:
+        address: Indirizzo
+        bike: Bicicletta
+        by: Creato da
+        created: Creato a
+        internal_notes: Note interne
+        message: Messaggio
+        notification_number: Notifica#
+        resolved: Risolto
+      search:
+        form:
+          doesnt_look_like_serial: Questo non sembra un numero di serie. I numeri
+            di serie sono solitamente composti da 6 o più lettere e numeri, e si trovano
+            sotto il movimento centrale.
+          search_for_serial_number: Cerca il numero di serie
+          search_notes: Note di ricerca
+          search_owner_email_or_name: Cerca l'indirizzo email o il nome del proprietario
+          submit: invia
+        settings:
+          address: 'Indirizzo:'
+          all: Tutti
+          avery_cell: Avery Esportabile
+          bike: registrazione
+          color_cell: Colore
+          create_export_of_vehicles: Crea l'esportazione della ricerca %{cycle_type}
+          created_at_cell: Registrato
+          creation_description_cell: Fonte
+          cycle_type_cell: Tipo di veicolo
+          default: predefinito
+          filter_impounded_html: solo <strong>sequestrato</strong>
+          filter_no_address_html: solo <strong>nessun</strong> indirizzo
+          filter_no_sticker_html: solo <strong>senza</strong> adesivo
+          filter_not_impounded_html: solo <strong>non</strong> sequestrato
+          filter_not_stolen_or_impounded_html: non rubato o sequestrato
+          filter_stolen_html: solo rubato
+          filter_with_address_html: solo <strong>con</strong> indirizzo
+          filter_with_stickers_html: solo <strong>con</strong> adesivi
+          impound_id_cell: ID del sequestro
+          impounded_cell: Sequestrato
+          manufacturer_cell: Produttore
+          model_cell: Modello
+          multi_search: ricerca seriale multipla
+          none: nessuno
+          notes_cell: Note
+          owner_email_cell: Inviato a
+          owner_name_cell: Nome del proprietario
+          propulsion_type_cell: Veicolo elettrico (propulsione)
+          reg_address_cell: Indirizzo
+          reg_extra_registration_number_cell: Secondario#
+          reg_organization_affiliation_cell: Affiliazione
+          reg_phone_cell: Telefono
+          reg_student_id_cell: Tessera studentesca
+          serial_number_cell: Seriale
+          settings: impostazioni
+          show_notes_search: mostra le note cerca
+          status: 'Stato:'
+          status_cell: Stato
+          sticker_cell: Adesivo
+          stickers: 'Adesivi:'
+          stolen_cell: Rubata
+          updated_at_cell: Fatto
+          url_cell: URL
+          vehicle: registrazione
+          visible_columns: Colonne visibili
+        wrapper:
+          affiliation: Affiliazione
+          avery_exportable: Avery Esportabile
+          bike: registrazione
+          e_vehicle_propulsion: Veicolo elettrico (propulsione)
+          e_vehicles_for_audit: 'Veicoli elettrici da sottoporre a verifica:'
+          link: Collegamento
+          matching_bikes_html: "%{count} %{cycle_type} corrispondente"
+          mfg_model_color_html: produttore, modello, <span class="less-strong">colore</span>
+          phone: Telefono
+          reg_address: Indirizzo
+          registered_bikes_html: "%{count} %{cycle_type} corrispondente a %{org_name}"
+          student_id: Tessera studentesca
+          vehicle: registrazione
+          view_matching_any_audit: visualizzazione corrispondente a qualsiasi audit
+      search_results:
+        bikes_table:
+          assign_bike_sticker: Collegamento
+          avery: Avery?
+          color: Colore
+          email_hidden: email nascosto
+          hidden_not_registered: nascosto, non registrato con %{org_name}
+          impound_id: ID del sequestro
+          impounded: Sequestrato
+          link_sticker: adesivo di collegamento
+          manufacturer: Produttore
+          model: Modello
+          notes: Note
+          owner_name: Nome del proprietario
+          propulsion_type: Propulsione
+          registered: Registrato
+          secondary_number: Secondario#
+          sent_to: Inviato a
+          serial: Seriale
+          source: Fonte
+          status_cell: Stato
+          sticker: Adesivo
+          stolen: Rubata
+          updated: Fatto
+          url: URL
+          vehicle_type: Tipo di veicolo
+        multi_result_chip:
+          no_results: nessuna corrispondenza
+        multi_results:
+          first_n_shown_html: "— prima %{limit} mostrata,"
+          no_exact_matches: 'Nessuna corrispondenza esatta. Numeri di serie simili:'
+          no_matches_found: Nessuna corrispondenza trovata
+          result_count_html: "— %{count} %{results}"
+          serial_label: 'Seriale:'
+          sticker_label: 'Adesivo:'
+          view_all: visualizza tutto
+    atom:
+      serial:
+        hidden: nascosto
+        hidden_because_status: perché %{bike_type} è %{status}
+        hidden_for_unauthorized_users: nascosto agli utenti non autorizzati
+        made_without_serial: realizzato senza numero di serie
+        unknown: sconosciuto
+    register:
+      acknowledgment_check:
+        i_name_html: Io, %{name},
+        registrants_name: nome del registrante
+      acknowledgment_progress:
+        progress_saved: Progressi salvati · Conferma del veicolo elettrico · Fase
+          %{number} di %{total}
+      back_link:
+        back: Indietro
+      page:
+        retry_failed: 'Non è stato possibile salvare i dati in questo momento: nessuna
+          delle informazioni inserite andrà persa. Riprova tra un attimo.'
+      page_content:
+        electric_detected: "⚡️ Rilevato elettrico (motorizzato)"
+        have_questions: Avete domande in merito a queste politiche?
+        read_the_faq: Domande frequenti sulla conferma di ricezione dei veicoli elettrici
+      review_summary:
+        a_quick_review: Un breve riepilogo di tutto ciò che hai riconosciuto.
+        a_quick_review_tap: Un rapido riepilogo di tutto ciò che hai preso atto. Tocca
+          "Riepilogo" per rivedere un protocollo.
+        review: Revisione
+        youre_almost_done: Hai quasi finito.
+      step1:
+        bike_info_html: "%{cycle_type} info"
+        electric_helper: Verifichiamo che le e-bike siano elettriche, in modo da poterle
+          segnalare e verificarne la certificazione.
+        electric_motorized: "⚡️ Elettrico (motorizzato)"
+        email: Email
+        email_placeholder: tu@esempio.com
+        email_school: "%{org_name} email"
+        just_the_essentials: Solo l'essenziale per iniziare.
+        next: Prossimo
+        no_need_to_wait: 'Ti invieremo un link di conferma via email: non devi aspettare
+          per continuare.'
+        register_your_vehicle: Registra il tuo veicolo!
+        register_your_vehicle_with_org: Registra il tuo veicolo con %{org_name}!
+        start_over: Ricominciare
+        start_over_certain: Ricominciare?
+        start_over_discards: 'Questo avvia una nuova registrazione: nessuna delle
+          informazioni inserite qui verrà trasferita.'
+        vehicle_type: Tipo di veicolo
+        yes_start_over: Sì, ricomincia da capo
+        your_info: Le tue informazioni
+      step2:
+        add_another_color: Aggiungi un altro colore
+        add_your_bikes_details: Aggiungi i dettagli del tuo %{cycle_type}.
+        additional_serial_sticker_number: Numero di serie/etichetta aggiuntivo
+        affiliation: "%{org_name} affiliazione"
+        are_you_certain: Ne sei certo?
+        attach_photo: Allega la foto di %{cycle_type}
+        bike_details: "%{cycle_type} dettagli"
+        bottom_bracket: Movimento centrale
+        cm: cm
+        color: Colore
+        complete_registration: Completare la registrazione %{cycle_type}
+        confirmation_link_sent: 'Ti abbiamo inviato un link di conferma via email.
+          Non c''è bisogno di aspettare: puoi completare la registrazione subito.'
+        contact_info: Informazioni di contatto
+        database_public_note: Il nostro database è pubblico! Potrai modificare le
+          impostazioni sulla privacy delle singole foto presenti nella tua registrazione
+          in un secondo momento.
+        email: Email
+        enter_size: Inserisci la taglia
+        found: Trovato/Abbandonato
+        found_description: Ho trovato questo %{cycle_type}
+        frame_size: Taglia del telaio
+        from_step_1: Dal passo 1
+        head_tube: Tubo di testa
+        how_to_find_serial: come trovare il tuo numero di serie
+        i_just_dont_know_the_serial: Non conosco il numero di serie
+        im_100_sure: Sono sicuro al 100%
+        inches: pollici
+        information_for_org: Informazioni per %{org_name}
+        is_a_handmade_frame: È una cornice fatta a mano
+        it_probably_has_a_serial_number: Probabilmente ha un numero di serie.
+        missing_serial: Numero di serie mancante
+        model: Modello
+        model_placeholder: ad esempio Marlin 7
+        model_year: Anno del modello
+        model_year_placeholder: ad esempio 2023
+        more_useful_registration: Più informazioni aggiungi, più utile diventa la
+          registrazione.
+        nevermind: Non importa
+        next: Prossimo
+        optional: opzionale
+        or: O
+        owner_name: Nome del proprietario
+        owner_name_placeholder: Nome e cognome
+        owner_registration: Registrazione del proprietario
+        owner_registration_description: Registrazione per me stesso o per conto del
+          proprietario
+        phone: Telefono
+        phone_placeholder: "(555) 000-0000"
+        phone_required_found: È necessario il telefono per registrare un ritrovamento
+          %{cycle_type}
+        phone_required_stolen: È necessario un telefono per registrare un %{cycle_type}
+          rubato
+        primary_color_blank: Colore primario — ad esempio Nero
+        read_how_to_find_html: Leggi informazioni su %{how_to_find_link} <small>(si
+          apre in una nuova finestra)</small>
+        rear_dropouts: Forcellini posteriori
+        register_with_org: Registrati con %{org_name}
+        register_with_org_description: "%{org_name} potrà visualizzare e gestire questa
+          registrazione."
+        registration_type: Tipo di registrazione
+        remove_additional_color: Rimuovere il colore
+        second_color_blank: Secondo colore — ad esempio Rosso
+        serial_help_intro: 'La maggior parte delle biciclette ha il numero di serie
+          inciso sul telaio. Cerca il tuo numero di serie:'
+        serial_location_bottom_bracket: parte inferiore del movimento centrale
+        serial_location_head_tube: sul tubo sterzo
+        serial_location_rear_dropouts: sui forcellini posteriori
+        serial_number: Numero di serie
+        serial_placeholder: Obbligatorio — oppure contrassegnare come mancante
+        sticker_number: Numero adesivo Bike Index
+        sticker_placeholder: ad esempio A 471 829
+        stolen: Rubata
+        stolen_description: Questo %{cycle_type} è stato rubato
+        student_id: Tessera studentesca
+        third_color_blank: Terzo colore
+        up_to_3: fino a 3
+        very_very_few_bikes_html: 'Sono <em>pochissimi</em> i %{cycle_types} realizzati
+          senza numero di serie. A meno che non si tratti di questo %{cycle_type}:'
+        view_serial_guide: Visualizza la guida completa ai numeri di serie
+        was_made_before_1970: È stato prodotto prima del 1970
+        wheres_my_serial: Dove si trova il mio numero di serie?
+        without_serial: Questo %{cycle_type} è stato realizzato senza numero di serie
+        without_serial_number: Questo %{cycle_type} è stato realizzato senza numero
+          di serie
+      step_acknowledgment:
+        continue: Continuare
+      step_acknowledgment_review:
+        complete_registration: Completare la registrazione %{cycle_type}
+      step_confirm:
+        confirming_your_email: Conferma la tua email
+        continue: Continuare
+        continue_where_you_left_off: Continua, e riprenderemo da dove hai interrotto.
+      step_finished:
+        add_impound_details: Aggiungi dettagli su dove hai trovato %{cycle_type}
+        add_photos: Aggiungi le foto del tuo %{cycle_type}
+        confirming_lets_you: 'Confermare il tuo indirizzo email ti permette di:'
+        do_these_things: Fai queste cose per avere le migliori possibilità di riaverlo
+        finish_adding: Completa l'aggiunta del tuo %{cycle_type} a Bike Index
+        listed_as_found: Il %{bike_display} è elencato come trovato su Bike Index
+        listed_as_stolen: Il tuo %{bike_display} risulta rubato su Bike Index
+        owner_can_claim: 'Il proprietario può trovarlo qui e reclamarlo: ti invieremo
+          un''email non appena qualcuno lo farà.'
+        progress_saved: Progresso salvato
+        register_another: Registra un altro veicolo
+        registered_for_owner_html: Il %{bike_display} è registrato su Bike Index.
+          Abbiamo inviato un'email a %{email} affinché possa richiedere la registrazione.
+        registration_complete: Registrazione completata!
+        report_it_stolen: Completa la segnalazione del tuo %{cycle_type} rubato e
+          approfitta della nostra rete di comunità
+        reported_stolen: Segnalato come rubato
+        verify_your_email_html: 'Ancora un passaggio: verifica il tuo indirizzo email.
+          Ti abbiamo inviato un link di conferma a %{email}; cliccaci sopra per completare
+          la registrazione. Tutti i dati inseriti sono stati salvati.'
+        view_the_registration: Visualizza la registrazione
+        view_your_registration: Visualizza la tua registrazione
+        we_will_keep_watch: 'Il tuo %{bike_display} è registrato su Bike Index. Terremo
+          d''occhio la situazione: se dovesse mai essere segnalato come rubato, tutta
+          la comunità si metterà alla ricerca.'
+      step_report:
+        about_the_one_you_found: Riguardo a %{cycle_type} che hai trovato
+        address_where_you_found_it: Indirizzo dove l'hai trovato
+        complete_registration: Completare la registrazione %{cycle_type}
+        contact_and_sharing: Contatto e condivisione
+        department_city: Dipartimento/città
+        estimated_value: Valore stimato (%{currency})
+        have_proof_of_ownership: Ho la prova di possedere questo %{cycle_type}
+        help_us_reunite: Aiutateci a restituirlo al legittimo proprietario.
+        how_did_you_find_it: Come hai trovato %{cycle_type}?
+        how_was_it_locked: Come è stato bloccato %{cycle_type}?
+        how_was_the_lock_defeated: Come è stata forzata la serratura?
+        next: Prossimo
+        police_report: Rapporto della polizia
+        receive_notifications: Inviami un'email se pubblichiamo un tweet su questo
+          %{cycle_type} o se troviamo una possibile corrispondenza.
+        report_number: Numero del rapporto
+        report_your_stolen: Segnala il tuo %{cycle_type} rubato
+        show_phone_police: 'Polizia Stradale '
+        show_phone_shops: Negozi di biciclette
+        show_phone_users: Utenti registrati di Bike Index
+        the_more_we_know: Più ne sappiamo, maggiori saranno le possibilità di recuperarlo.
+        theft_details: Dettagli del furto
+        what_happened: Quello che è successo?
+        what_happened_placeholder: ad esempio, era chiuso a chiave a una rastrelliera
+          fuori dalla caffetteria, ma era sparito quando sono tornato fuori.
+        when_and_where: Quando e dove
+        when_did_you_find_it: Quando l'hai trovato?
+        when_was_it_stolen: Quando è stato rubato %{cycle_type}?
+        where_was_it_stolen: Dove è stato rubato?
+        who_can_see_your_phone: Chi può vedere il tuo numero di telefono?
+        without_a_report: Sporgere denuncia alla polizia offre al tuo %{cycle_type}
+          le migliori possibilità di tornare — puoi aggiungere il numero in seguito.
+    registrations:
+      show:
+        bike_details:
+          frame_material: Materiale del telaio
+          frame_size: Taglia del telaio
+          handlebar_type: Tipo di manubrio
+          manufacturer: Produttore
+          model: Modello
+          other_serial: Altri numeri di serie/registrazione/adesivi
+          serial: Seriale
+          title: "%{bike_type} dettagli"
+          vehicle_type: Tipo di veicolo
+          year: Anno
+        bike_index_card:
+          activity: Attività
+          frame_material: Materiale del telaio
+          id: ID
+          registered_since: Registrato dal
+          this_bike_on_bike_index: Questo %{bike_type} sull'indice delle biciclette
+        component_list:
+          component_no_info: "-"
+          componentyear: "%{componentyear}"
+          drivetrain: Trasmissione
+          drivetrain_fixed: Scatto fisso
+          drivetrain_front: Trasmissione anteriore
+          drivetrain_rear: Trasmissione posteriore
+          front: Anteriore
+          front_rear: Anteriore e posteriore
+          front_tire_width: Larghezza dello pneumatico anteriore
+          front_wheel_diameter: Diametro della ruota anteriore
+          full_spec_sheet: Scheda tecnica completa
+          hide: Nascondere
+          other: Altro
+          paint_description: Descrizione del colore
+          propulsion_type: Propulsione
+          rear: Posteriore
+          rear_tire_width: Larghezza del pneumatico posteriore
+          rear_wheel_diameter: Diametro ruota posteriore
+          show_all: Mostra tutto
+          tire_width: Larghezza del pneumatico
+          tire_width_narrow_false: Pneumatico largo
+          tire_width_narrow_true: Pneumatico stretto
+          wheel_diameter: Diametro della ruota
+        contact_owner:
+          contact_the_owner: Contatta il proprietario
+          know_something_about_this_bike_type: Sapete qualcosa di questa %{bike_type}?
+          link_url: Collegamento
+          send_message: Invia il messaggio
+          where_did_you_see_this_bike: Dove hai visto questo %{bike_type}? Se ci contatti
+            in merito a un annuncio che hai trovato online, includi il link nel campo
+            sottostante.
+        current_alerts:
+          claim_impound:
+            add_a_stolen_bike: aggiungi un %{bike_type} rubato
+            choose_stolen_bike: Scegli rubato %{bike_type}
+            claim_found_bike: Richiesta trovata %{bike_type}
+            claim_impounded_bike: Reclamo sequestrato %{bike_type}
+            claim_submitted: Questa richiesta è stata presentata
+            claim_was_status: La tua richiesta era %{status} — avresti dovuto ricevere
+              un'e-mail con i passaggi successivi.
+            claim_with_this_bike_type: Hai una rivendicazione %{status} con questo
+              %{bike_type}.
+            does_this_look_like_your_bike: Questo assomiglia al tuo %{bike_type}?
+            need_stolen_bike_html: Per presentare un reclamo è necessario registrare
+              un %{bike_type} rubato — %{add_link}.
+            no_editing_after_submitting: Dopo l'invio, non sarà più possibile modificare
+              la richiesta.
+            open_claim: Richiesta aperta
+            prove_its_yours: 'Verifica la tua proprietà: aggiungi dettagli che provino
+              che questo %{bike_type} è tuo.'
+            save_message: Salva messaggio
+            select_your_stolen_bike: Seleziona l'oggetto %{bike_type} rubato di tua
+              proprietà che corrisponde a questo sequestro
+            submit_claim: Invia reclamo
+            view_claimed_bike_type: visualizza il rivendicato %{kind} %{bike_type}
+            your_claim: La tua richiesta
+          claim_invitation:
+            claim_bike_type: Rivendica %{bike_type}
+            claim_it_so_you_can_update_your_listing: Rivendicala per poter aggiornare
+              il tuo annuncio.
+            claim_your_bike_type: Richiedi il tuo %{bike_type}
+            read_more: Per saperne di più
+            registered_your_bike_on_index_html: ho registrato il tuo %{bike_type}
+              su Bike Index, una piattaforma gratuita e senza scopo di lucro per la
+              registrazione di biciclette e il recupero di biciclette rubate %{read_more_link}.
+            sign_up: iscrizione
+            sign_up_to_claim: Iscriviti
+            to_see_your_bike_sign_up_html: Per visualizzare il tuo %{bike_type} e
+              rivendicarlo come tuo, %{sign_up_link} con l'indirizzo email a cui hai
+              ricevuto l'email di registrazione.
+            were_honored_to_have_your_bike: Siamo onorati di avere la tua %{bike_type}
+              sull'Index.
+          notification_token:
+            mark_graduated_resolved: Contrassegna %{bike_type} rimanente
+            mark_parking_resolved: Contrassegna %{bike_type} recuperata
+            no_futher_action_necessary: non sono necessarie altre azioni!
+            organization_sent_this_message: "%{org_name} ha inviato questa notifica"
+            please_email_organization_with_questions_html: Per qualsiasi domanda,
+              invia un'e-mail a %{email_link}
+            you_have_already_marked_remaining: Avete già contrassegnato questo %{bike_type}
+              rimanente
+            you_have_already_marked_resolved: Avete contrassegnato questa notifica
+              come risolta
+          recovery_prompt:
+            can_we_share_your_story: Possiamo condividere la sua storia?
+            did_we_help: Siamo stati di aiuto?
+            how_did_you_get_it_back: Come l'hai recuperata?
+            its_also_how_we_get_better_at_recovering: È anche così che miglioriamo
+              nel recupero %{bike_type}.
+            mark_recovered: Contrassegna recuperata
+            mark_your_bike_recovered: Contrassegna il tuo %{bike_type} come recuperato!
+            nevermind: Non importa
+            please_tell_us_how_you_got_your_bike: Raccontaci come hai recuperato la
+              tua %{bike_type}, ci interessa davvero!
+            when_did_you_recover_it: Quando l'hai recuperata?
+          scanned_sticker:
+            change_the_bike_sticker_linked_to: Modifica il %{bike_type} a cui è collegato
+            is_this_linked_to_incorrect_bike: Questo adesivo è collegato all'errore
+              %{bike_type}?
+            switch_to_new_bike_id: Passa a un nuovo ID %{bike_type}
+            update: Aggiorna
+            you_scanned_this_sticker_html: Hai scansionato %{sticker}, che è assegnato
+              a questo %{bike_type}.
+          sent_to_new_owner:
+            you_sent_this_bike_html: Hai inviato questo %{bike_type} a %{owner_email}
+              e non è ancora stato reclamato. Puoi aggiornarlo.
+        impound_details:
+          found_at: Trovato presso
+          found_details: Dettagli trovati
+          impound_details: Dettagli del sequestro
+          impounded_at: Sequestrato a
+          location: Luogo
+          org_impound_record: "%{org_name} registro dei sequestri"
+        impound_record_fields:
+          created: Creato
+          impounded_by: Sequestrato da
+          impounded_from: Sequestrato da
+          last_update_by: Ultimo aggiornamento di
+          status: Stato
+        legacy_view_link:
+          switch_to_classic: Torna al visualizzatore precedente
+          using_new_view: Stai provando il nuovo visualizzatore %{bike_type}.
+          view_in_legacy: visualizza %{bike_type} nel visualizzatore legacy
+        map:
+          unavailable: 'Impossibile caricare la mappa: il browser o il dispositivo
+            in uso potrebbero non supportarla.'
+        org_top_actions:
+          impound_update:
+            title: Aggiornare il registro dei sequestri
+          message_owner:
+            know_something_about_this_bike_type: Sapete qualcosa di questa %{bike_type}?
+            link_url: Collegamento
+            send_message: Invia il messaggio
+            where_did_you_see_this_bike: Dove hai visto questo %{bike_type}? Se ci
+              contatti in merito a un annuncio che hai trovato online, includi il
+              link nel campo sottostante.
+          parking_notification_form:
+            address_or_intersection: Indirizzo o incrocio
+            create_parking_notification: Crea una nuova notifica di parcheggio
+            impound_this_bike_type: Sequestrare questo %{bike_type}
+            map_hint: Trascina la mappa in modo che il segnaposto indichi il punto
+            map_unavailable: 'Impossibile caricare la mappa: la posizione è ancora
+              impostata dal tuo dispositivo.'
+            parking_notification_notes_html: "%{org_name} note interne <small>non
+              mostrate all'utente</small>"
+          parking_notification_show:
+            no_notifications: Nessuna notifica di parcheggio per questo %{bike_type}
+            parking_notifications: Notifiche di parcheggio
+            view_all: visualizza tutte le notifiche per questo %{bike_type}
+            view_notification: Visualizza la notifica
+          wrapper:
+            impound: Sequestrare
+            message_owner: Proprietario del messaggio
+            new_parking_notice: Nuovo avviso di parcheggio
+            update_impound_record: Aggiornare il registro dei sequestri
+            view_notifications: Visualizza le notifiche
+            view_notifications_active_html: "<strong>%{count}</strong> Attivo"
+            view_notifications_resolved_html: "<strong>%{count}</strong> Risolto"
+        owner_phone:
+          or_call: O chiamare
+        photos:
+          add_photo: Aggiungi foto
+          bike_photo: foto %{bike_type}
+          color_may_not_match: Il colore potrebbe non corrispondere!
+          stock_photo: Foto stock di un %{year} %{model}
+        primary_colors:
+          primary_color:
+            one: Colore primario
+            other: Colori primari
+        status:
+          found: Trovato
+          impounded: Sequestrato
+          not_stolen: Non rubato
+          stolen: Rubata
+          unregistered: Non registrato
+        stolen_details:
+          department_city: Dipartimento e città
+          description_of_incident: Descrizione dell'incidente
+          location: Luogo
+          locking_circumvented: Blocco aggirato
+          locking_description: Descrizione della chiusura
+          police_report: Rapporto della polizia n.
+          stolen_at: Rubato a
+          stolen_details: Dettagli del furto
+        toggle_view:
+          switch_to_legacy_default: Passa al visualizzatore legacy come impostazione
+            predefinita.
+          switch_to_new: Passa alla nuova visualizzazione
+          try_new_view: Prova il nuovo visualizzatore %{bike_type}!
+          view_in_new: Visualizza nel nuovo visualizzatore
+          viewing_in_legacy: Visualizzatore legacy (per impostazione predefinita si
+            utilizza il nuovo visualizzatore)
+        wrapper_consumer:
+          about_this_bike: Informazioni su questo %{bike_type}
+          audience_owner: Il vostro %{bike_type}
+          audience_public: Vista pubblica
+          audience_sent_away: Non più il tuo %{bike_type}
+          edit_this_bike: Modifica questo %{bike_type}
+          mark_stolen: Marchio rubato
+          registered_protected: Registrato e protetto
+          sell_on_marketplace: Vendi sul Marketplace
+          share: Condividere
+          share_my_page: Condividi la mia pagina
+        wrapper_org_admin:
+          about_this_bike: Informazioni su questo %{bike_type}
+          assign_sticker: Collegamento
+          audit: Audit dei veicoli elettrici
+          avery_exportable: Avery Esportabile
+          claimed: Rivendicato
+          creation_source: Fonte
+          creator: Creatore
+          credibility: Credibilità
+          edit: Modifica
+          has_duplicate_serials: ha numeri di serie duplicati.
+          internal_notes: Note interne
+          is_false: falso
+          is_true: VERO
+          link_sticker: Adesivo di collegamento
+          no_duplicate_serials: nessun numero di serie duplicato.
+          no_other_registrations: Nessun risultato trovato
+          no_registration_information: Nessuna informazione di registrazione visibile
+            a %{org_name}
+          not_audited: Non sottoposto a revisione contabile
+          not_registered_message: Non è possibile contattare il proprietario per le
+            biciclette al di fuori della propria organizzazione. È comunque possibile
+            aggiungere note interne.
+          not_registered_title: Non registrato con %{org_name}
+          note_by: Nota di %{user}
+          notes_placeholder: 'Nuova nota interna: le note precedenti vengono conservate
+            nella discussione.'
+          org_can_edit: "%{org_name} può modificare questo %{bike_type}"
+          org_can_edit_sub: Incluso dopo che %{bike_type} è stato rivendicato.
+          organization_registered: Organizzazione
+          other_registrations: Altre registrazioni di questo utente
+          other_registrations_count_html: "%{count} altre registrazioni"
+          owner_access: Proprietario e accesso
+          owner_email: Email
+          owner_name: Nome
+          owner_phone: Telefono
+          photo_archive: Archivio fotografico
+          post_note: Posta
+          posts_as: Pubblica come %{user}
+          registration_information: Informazioni di registrazione
+          registration_number: Registrazione Bike Index
+          restricted_message: Il contatto del proprietario è disponibile per amministratori
+            e personale. È possibile aggiungere note e richiedere il ritiro dell'animale.
+          restricted_title: Accesso limitato per il tuo ruolo
+          role_limited: Limitato
+          role_staff: Personale
+          showing_recent: Mostrando il %{count} più recente
+          sticker: Adesivo
+          sticker_claimed: reclamato
+          sticker_code: Codice adesivo
+          unregistered_owner: Questo %{bike_type} non è registrato a un utente. È
+            stato aggiunto per tenere traccia delle notifiche di parcheggio.
+          view_all_registrations: visualizza tutto →
+    sessions:
+      sign_in_interstitial:
+        click_button_to_continue: Fai clic sul pulsante qui sotto per continuare
+        finish_signing_in: Completare la procedura di accesso
+        sign_in: Registrazione
+  user_emails:
+    confirm:
+      confirm_email: Conferma email
+      confirm_this_email: Conferma %{user_email}

--- a/config/locales/translation.nb.yml
+++ b/config/locales/translation.nb.yml
@@ -747,7 +747,8 @@ nb:
         theft_description: Tyveribeskrivelse
         time: Tid
         tsved_at: Tsved kl
-        zipcode: Postnummer
+        postal_code: Postnummer
+        region_string: Region
       theft_alert:
         end_at: Slutt kl
         notes: Notater
@@ -1818,6 +1819,9 @@ nb:
       no_one_but_the_user_and_bike_index_admins: Ingen andre enn brukeren (og Bike
         Index-administratorer) kan se den
       test_registration: prøveregistrering
+    stolen_map:
+      unavailable: Kartet kunne ikke lastes inn – nettleseren eller enheten din støtter
+        det kanskje ikke.
   bikes_edit:
     accessories:
       add_a_component: Legg til en komponent
@@ -2173,9 +2177,9 @@ nb:
       sessionable:
         sign_in_and_redirect:
           logged_in: Logget inn!
-          organization_signed_in: Du er logget inn
           user_is_banned: Vi beklager, men det ser ut til at kontoen din har blitt
             låst. Hvis du er usikker på årsakene til dette, vennligst kontakt oss.
+          organization_signed_in: Du er logget inn
         skip_if_signed_in:
           already_signed_in: Du er allerede logget på!
     feedbacks:
@@ -2356,8 +2360,6 @@ nb:
       create:
         invalid_email_or_password: Ugyldig e-post/passord
       create_magic_link:
-        link_sent: Påloggingslenken er sendt! Bare klikk på lenken i e-posten din
-          for å logge på
         user_not_found: Kan ikke finne den brukeren
     stolen_notifications:
       create:
@@ -2457,6 +2459,20 @@ nb:
           Hvis dette fortsetter, er det sannsynlig at et VPN eller en personvernutvidelse
           fjerner informasjonen vi trenger. Prøv å slå av disse for bikeindex.org.
           Send en e-post til contact@bikeindex.org hvis du fortsatt står fast.
+    register:
+      acknowledge:
+        acknowledge_everything: Kryss av i hver boks for å godta disse reglene
+      confirm_email:
+        confirmation_link_expired: Bekreftelseslenken er utløpt – sjekk e-posten din
+          for en ny.
+        signed_in_as_other: Du er logget på som %{email}, så vi beholdt deg på den
+          kontoen. Registreringen er fortsatt lagret på adressen vi sendte e-post
+          til.
+      find_b_param:
+        registration_not_found: Vi fant ikke den registreringen – start en ny nedenfor
+      sign_in_confirmed_user:
+        unable_to_sign_in: Vi bekreftet e-postadressen din, men kunne ikke logge deg
+          på den kontoen
   customer_mailer:
     additional_email_confirmation:
       html:
@@ -3800,8 +3816,6 @@ nb:
       try_for_free: Prøv gratis
       year: år
   layouts:
-    application:
-      skip_to_main_content: Hopp til hovedinnhold
     application_bikehub:
       accounts_powered_by_bike_index: BikeHub-kontoer er drevet av Bike Index – det
         fremste sykkelregisteret.
@@ -3837,6 +3851,8 @@ nb:
     revised_messages:
       error: feil
       please_fix_the_following: Vennligst fiks følgende %{errors}
+    application:
+      skip_to_main_content: Hopp til hovedinnhold
   locales:
     en: Engelsk
     nb: norsk (bokmål)
@@ -3919,6 +3935,12 @@ nb:
     welcome_index: 'Det beste sykkelregisteret: Enkelt, sikkert og gratis.'
     registrations_embed: Innebygd %{organization} Bike Index registreringsskjema.
       Registrer sykkelen din gratis, akkurat nå
+    search_marketplace_index: Sykler til salgs på Bike Index. Søk på markedsplassen
+      etter produsent, pris og sted.
+    search_registrations_index: Søk etter sykler som er registrert på Bike Index
+    strava_search_index: Knytt Strava-utstyret ditt til Bike Index-registreringene
+      dine. Søk, filtrer og masseoppdater aktivitetene dine for å tilordne utstyr
+      til turer som mangler det.
   meta_titles:
     bikes_index: Søkeresultater
     bikes_new: Registrer en sykkel!
@@ -3960,6 +3982,16 @@ nb:
     my_accounts_show: Du på Bike Index
     search_registrations_index: Søkeresultater
     registrations_embed: Registrer en sykkel med %{organization}
+    register_acknowledgment: Sikkerhetssjekk for din %{cycle_type}
+    register_confirm: Bekrefter e-postadressen din
+    register_create: Registrer kjøretøyet ditt!
+    register_report: Fortell oss hva som skjedde
+    register_review: Gjennomgå sikkerhetssjekken din for %{cycle_type}
+    register_show: Din %{cycle_type}-registrering
+    register_step_1: Registrer kjøretøyet ditt!
+    register_step_2: Legg til detaljene dine for %{cycle_type}
+    search_marketplace_index: Sykkelindeksmarkedsplass
+    strava_search_index: Sykkelindeks Strava-søk
   money:
     currencies:
       en: USD
@@ -4504,7 +4536,6 @@ nb:
         save: Lagre
       show:
         abbreviation: Forkortelse
-        choose_file: Velg Fil...
         contact_to_update_html: Kontakt %{link} for å oppdatere forkortelsen
         delete_organization: Slett organisasjon
         i_would_like_to_terminate_my_account: Jeg ønsker å avslutte kontoen min med
@@ -4535,15 +4566,6 @@ nb:
       index:
         matches_visible: synlig
         parking_notifications: Parkeringsmeldinger
-      show_details:
-        address: Adresse
-        bike: Sykkel
-        by: Laget av
-        created: Opprettet kl
-        internal_notes: Interne notater
-        message: Beskjed
-        notification_number: Melding#
-        resolved: Løst
       table:
         address: Adresse
         bike: Sykkel
@@ -4664,6 +4686,15 @@ nb:
       subject: Bli med %{organization_name} på Bike Index
     partial_registration:
       subject: Fullfør registreringen av %{organization_name}Bike Index!
+    partial_register_confirmation:
+      subject: Bekreft e-postadressen din for å fullføre %{organization_name}-registreringen
+        din
+    partial_register_confirmation_abandoned:
+      subject: Fullfør rapporteringen av den forlatte %{cycle_type}
+    partial_register_confirmation_found:
+      subject: Fullfør rapporteringen av funnet %{cycle_type}
+    partial_register_confirmation_stolen:
+      subject: Fullfør rapporteringen av stjålet %{cycle_type}
   payments:
     form:
       donation_header: Bidra til å støtte vår innsats!
@@ -4754,9 +4785,11 @@ nb:
       sign_in_with_magic_link: Logg på uten passord
       unable_to_auth: Kan ikke autentisere det tokenet
       your_email_address: Din epostadresse
-    magic_link_sent:
-      follow_the_link_back: Følg lenken i e-posten for å logge på!
-      we_sent_a_magic_sign_in_link: Vi har sendt deg en magisk innloggingslenke
+      link_already_used: Den påloggingslenken er allerede brukt
+      link_expired: Den påloggingslenken er utløpt
+      links_work_for: Påloggingslenker fungerer for %{duration} etter at de er sendt.
+      only_the_newest_link_works: Du kan allerede være logget inn et annet sted. Hvis
+        du ba om mer enn én e-postadresse, fungerer bare lenken i den nyeste.
     new:
       email: e-post
       forgot_your_password: Glemt passordet?
@@ -4772,6 +4805,9 @@ nb:
       sign_in_without_password: Logg inn uten passord
     identify:
       different_email: Logg inn med en annen e-postadresse
+    magic_link_sent:
+      follow_the_link_back: Følg lenken i e-posten for å logge inn!
+      we_sent_a_magic_sign_in_link: Vi sendte deg en magisk påloggingslenke
   shared:
     bike_search_form:
       anywhere: Hvor som helst
@@ -4799,22 +4835,6 @@ nb:
         Legg til bilder og detaljer om %{bike_type} for å vise hva som gjør turen
         din til din. Forhåpentligvis vil ikke din %{bike_type} bli stjålet, men hvis
         det er det, er vi her når du trenger oss mest.
-    content_skeleton:
-      about: Om
-      bicycle_serials: Sykkelserier
-      bike_index_news: Alle Bike Index-nyheter
-      bike_index_store: Sykkelindeksbutikk
-      design_and_developer_resources: Design og utviklerressurser
-      donate: Donere
-      donate_today: Doner i dag
-      help: Hjelp
-      how_to_get_your_stolen_bike_back: Hvordan få tilbake den stjålne sykkelen
-      make_a_difference: Gjør en forskjell i sykkeltyveri
-      other_pages: Andre sider
-      protect_your_bike: Beskytt sykkelen din
-      related: Relatert
-      sign_up_your_organization: Registrer din organisasjon
-      where: Hvor
     donation_form:
       501c3_nonprofit: 501(c)(3) ideell organisasjon
       bike_index_is_a_nonprofit_html: Bike Index er en %{nonprofit_link} <small class="less-strong">EIN
@@ -4827,15 +4847,6 @@ nb:
       what_does_your_donation_do: Hva gjør donasjonen din?
     donation_modal:
       donation_header: Bidra til å støtte vår innsats!
-    edit_bike_skeleton:
-      edit: Endre
-      owned_but_hasnt_been_claimed_html: Eies av <em>%{owner_email}</em> , men det
-        er ikke gjort krav på det ennå
-      owned_with_permission_to_edit_html: Eies av <em>%{owner_email}</em> , men %{org_name}
-        har tillatelse til å redigere
-      view_bike: Se %{bike_type}
-      view_bike_version: Se %{bike_type} versjon
-      edit_pages: 'Rediger %{bike_type} sider:'
     email_bike_box:
       color: Farge
       color_may_be_incorrect: Fargen kan være feil. Oppdater den om nødvendig!
@@ -4960,20 +4971,6 @@ nb:
       you: Du
       your_bikes: Syklene dine
       your_preferences: Dine preferanser
-    law_enforcement_donation_modal:
-      bikeindex_is_a_nonprofit: Bike Index er en 501(c)(3) ideell organisasjon. Vi
-        er avhengige av donasjoner for å kunne tilby disse tjenestene. Vi anbefaler
-        at rettshåndhevelsesbyråer som %{org_name} donerer minst $20 i året for å
-        støtte vår innsats.
-      contact_bike_owners: Ta kontakt med sykkeleiere før syklene deres merkes som
-        stjålet
-      email_for_access_html: Send e-post til %{email_link} for tilgang.
-      greeting: Hei %{user_name},
-      law_enforcement_features: 'Vi har en rekke funksjoner spesielt utviklet for
-        rettshåndhevelsesoffiserer:'
-      multiple_serial_search_pane: Rute for flere serier
-      thank_you: Tusen takk for at du bruker Bike Index!
-      thanks_for_using_bike_index: Takk for at du bruker Bike Index!
     organized_menu_items:
       add_a_bike: Legg til en sykkel
       ascend_imports: Ascend Import
@@ -5005,48 +5002,21 @@ nb:
       super_admin_view: Superadministrator for %{org_name}
       multi_search: Multisøk
       manage_registration_sequences: Administrer registreringssekvenser
-    organized_skeleton:
-      additional_features_html: Bike Index gir tilleggsfunksjoner for verifiserte
-        rettshåndhevelsesorganisasjoner. Ta kontakt med %{email_link} for å få dem
-        aktivert.
-      admin_panel: Administrasjonspanel
-      how_integration_works: hvordan integreringen fungerer
-      integrate_bike_index_with_ascend: Integrer Bike Index med Ascend
-      integrate_bike_index_with_lightspeed: Integrer Bike Index med Lightspeed
-      link_to_register_html: "<strong>%{link}</strong> for automatisk å registrere
-        syklene du selger til kundene dine."
-      other_point_of_sale_system: Andre salgssteder?
-      read_a_full_explanation_html: Les en fullstendig forklaring av %{link}.
-      register_bikes_with_link_html: Registrer sykler med vår <strong>%{link}</strong>
-      streamlined_bike_shop_registration_page: strømlinjeformet Bike Shop registreringsside
-      subscription_expired_html: Ditt abonnement på Bike Index har utløpt. Ta kontakt
-        med %{email_link} for å få den aktivert på nytt.
-      use_ascend: Bruk Ascend?
-      use_lightspeed_retail_pos: Bruker du Lightspeed Retail POS?
-      viewing_our_streamlined_page: Du ser for øyeblikket på vår strømlinjeformede
-        Bike Shop-registreringsside, som er det vi anbefaler å bruke
-    user_general_alert:
-      add_location_theft_bike_title_html: Legg til stedet for tyveriet av din <strong>%{bike_title}</strong>
-      add_photo_theft_bike_title_html: Legg til et bilde på <strong>%{bike_title}</strong>
-      confirm_your_phone_number: Bekreft telefonnummeret ditt
-      location_critical_html: "<strong>Det er avgjørende for gjenoppretting</strong>
-        at du inkluderer adressen eller tverrgaten der %{bike_type} ble stjålet."
-      missing_stolen_photo_title: Legg til et bilde
-      photo_critical_html: Vellykkede markedsførte varsler <strong>må ha et bilde</strong>
-      stolen_missing_location_title: Vennligst legg til tyveristed
-      verification_code: Bekreftelseskode
-      verify_number: Bekreft %{phone_number}
-      without_location_all_is_lost: Uten et sted kan vi ikke spre ordet om tyveriet,
-        og folk vil ikke vite hvor de skal lete etter din %{bike_type}.
-      without_photo_all_is_lost: Hvis du ikke har noen bilder av sykkelen din, finn
-        et lagerbilde på internett og last det opp. Uten et bilde vil ikke det promoterte
-        varselet være effektivt.
     recovery_display:
       bike: Sykkel
       recovered_date: gjenopprettet %{date}
       translated_from_english: oversatt fra engelsk
     shops_map:
       map_of_partner_locations: Kart over partnerlokasjoner
+    register_flow:
+      date_found_required: Fortell oss når du fant den
+      date_stolen_required: Fortell oss når den ble stjålet
+      email_required: E-post kreves for å registrere seg
+      location_found_required: Fortell oss hvor du fant den
+      location_stolen_required: Fortell oss hvor den ble stjålet
+      manufacturer_required: Produsenten er pålagt å registrere seg
+      name_required: Eiernavn kreves for registrering
+      unable_to_save: Vi kan ikke lagre registreringen. Prøv på nytt.
   stolen:
     index:
       ambassador: ambassadør
@@ -5133,11 +5103,9 @@ nb:
       agree_bikeindex_toc_html: Jeg godtar Bike Index's %{bikeindex_toc_link}.
       already_have_a_bike_index_account: Har du allerede en Bike Index-konto?
       already_have_an_account: Har du allerede en konto?
-      better_password: bedre
       get_bike_indexs_newsletter: Få Bike Index sitt nyhetsbrev
       get_on_bike_index: Få på Bike Index
       log_in: Logg Inn
-      password_helper_text_html: Passordet må være på minst 12 tegn. Lengre er %{better_password_link}.
       sign_up: Melde deg på
       sign_up_using_facebook: Registrer deg ved hjelp av Facebook
       sign_up_using_globalid: Registrer deg med globaliD
@@ -5170,10 +5138,15 @@ nb:
       stolen: Stjålet!
       this_user_has_no_bikes_yet: Denne brukeren har ingen sykler ennå!
       this_users_bikes: Denne brukerens sykler
+      banned_only_visible_to_superusers: Profilen deres er bare synlig fordi du er
+        superbruker.
+      banned_user: Denne brukeren er utestengt
+      profile_hidden: Denne profilen deles ikke offentlig
+      profile_hidden_owner: Den er bare synlig for deg fordi det er siden din.
+      profile_hidden_superuser: Det er bare synlig fordi du er superbruker.
     unsubscribe:
-      if_not_click_button: Hvis du ikke er det, vennligst klikk på knappen nedenfor
       unsubscribe: Avslutte abonnementet
-      you_should_be_unsubscribed_automatically: Du bør avmeldes automatisk
+      confirm_unsubscribe: Bekreft at du vil avslutte abonnementet
     update_password_form_with_reset_token:
       and_try_not_to_forget_it: og prøv å ikke glemme det...
       better_password: bedre
@@ -5238,11 +5211,6 @@ nb:
       index:
         loading_results: Laster inn resultater...
   components:
-    sessions:
-      sign_in_interstitial:
-        if_not_click_button: Hvis du ikke er det, vennligst klikk på knappen nedenfor
-        sign_in: Logg inn
-        you_should_be_signed_in_automatically: Du bør logges på automatisk.
     search:
       everything_combobox:
         query_items_description: Søkebeskrivelser kombinasjonsboksen
@@ -5278,9 +5246,6 @@ nb:
         bike_box_view: Vis som liste
         thumbnail_view: Vis som miniatyrbilder
     search_results:
-      frame:
-        rate_limited: For mange søk for raskt – du er frekvensbegrenset. Vent et øyeblikk,
-          og prøv på nytt.
       bike_box:
         location: plassering
         posted_at: Oppført
@@ -5296,6 +5261,12 @@ nb:
         member: Medlem av sykkelindeksen
       container:
         no_results: Ingen registreringer samsvarte nøyaktig med søket ditt
+      frame:
+        fetch_failed: Kunne ikke laste inn disse resultatene – sjekk tilkoblingen
+          din og prøv på nytt.
+        rate_limited: For mange søk for raskt – du er frekvensbegrenset. Vent et øyeblikk,
+          og prøv på nytt.
+        retry: Prøv igjen
     page_block:
       marketplace_listing_panel:
         condition: Betingelse
@@ -5346,9 +5317,11 @@ nb:
         letter_opener_tooltip: Se e-posten som ble sendt av denne anmeldelsesappen
         pr_link: PR-nummer %{number}
         commit_tooltip: 'nåværende forpliktelse:'
-        label_sandbox: Sandbox
         superadmin_button: logg inn som superadministrator
         superadmin_signed_in: logget inn som superadministrator
+        label_development: Utvikling
+        label_sandbox: Sandkasse
+        no_superadmin: ingen superbruker (kan ikke logge inn)
       footer:
         about: Om
         ambassadors: Ambassadører
@@ -5364,7 +5337,6 @@ nb:
           81-4296194"
         dev_and_design_resources: Utviklings- og designressurser
         donate: Donere
-        faq_and_help: FAQ og hjelp
         how_to_get_your_stolen_bike_back: Få tilbake den stjålne sykkelen
         language: Språk
         law_enforcement: Rettshåndhevelse
@@ -5384,38 +5356,118 @@ nb:
         who_we_serve: Hvem vi tjener
         legal: Juridisk
         social_media: Sosiale medier
-        status_page: Statusside
-        register_a_bike: Registrer en sykkel
+        faq_and_help: Vanlige spørsmål og hjelp
         marketplace: Markedsplass
+        register_a_bike: Registrer en sykkel
         search: Søk
+        status_page: Statusside
+      law_enforcement_donation:
+        bikeindex_is_a_nonprofit: Bike Index er en 501(c)(3) ideell organisasjon.
+          Vi er avhengige av donasjoner for å kunne tilby disse tjenestene. Vi anbefaler
+          at rettshåndhevelsesbyråer som %{org_name} donerer minst $20 i året for
+          å støtte vår innsats.
+        contact_bike_owners: Ta kontakt med sykkeleiere før syklene deres merkes som
+          stjålet
+        email_for_access_html: Send e-post til %{email_link} for tilgang.
+        greeting: Hei %{user_name},
+        law_enforcement_features: 'Vi har en rekke funksjoner spesielt utviklet for
+          rettshåndhevelsesoffiserer:'
+        multiple_serial_search_pane: Rute for flere serier
+        thank_you: Tusen takk for at du bruker Bike Index!
+        thanks_for_using_bike_index: Takk for at du bruker Bike Index!
+      main_content:
+        content:
+          about: Om
+          bicycle_serials: Sykkelserier
+          bike_index_news: Alle Bike Index-nyheter
+          bike_index_store: Sykkelindeksbutikk
+          design_and_developer_resources: Design og utviklerressurser
+          donate: Donere
+          donate_today: Doner i dag
+          help: Hjelp
+          how_to_get_your_stolen_bike_back: Hvordan få tilbake den stjålne sykkelen
+          make_a_difference: Gjør en forskjell i sykkeltyveri
+          other_pages: Andre sider
+          protect_your_bike: Beskytt sykkelen din
+          related: Relatert
+          sign_up_your_organization: Registrer din organisasjon
+          where: Hvor
+        edit_bike:
+          edit: Endre
+          edit_pages: 'Rediger %{bike_type} sider:'
+          owned_but_hasnt_been_claimed_html: Eies av <em>%{owner_email}</em> , men
+            det er ikke gjort krav på det ennå
+          owned_with_permission_to_edit_html: Eies av <em>%{owner_email}</em> , men
+            %{org_name} har tillatelse til å redigere
+          view_bike: Se %{bike_type}
+          view_bike_version: Se %{bike_type} versjon
+        organized:
+          additional_features_html: Bike Index gir tilleggsfunksjoner for verifiserte
+            rettshåndhevelsesorganisasjoner. Ta kontakt med %{email_link} for å få
+            dem aktivert.
+          admin_panel: Administrasjonspanel
+          how_integration_works: hvordan integreringen fungerer
+          integrate_bike_index_with_ascend: Integrer Bike Index med Ascend
+          integrate_bike_index_with_lightspeed: Integrer Bike Index med Lightspeed
+          link_to_register_html: "<strong>%{link}</strong> for automatisk å registrere
+            syklene du selger til kundene dine."
+          other_point_of_sale_system: Andre salgssteder?
+          read_a_full_explanation_html: Les en fullstendig forklaring av %{link}.
+          register_bikes_with_link_html: Registrer sykler med vår <strong>%{link}</strong>
+          streamlined_bike_shop_registration_page: strømlinjeformet Bike Shop registreringsside
+          subscription_expired_html: Ditt abonnement på Bike Index har utløpt. Ta
+            kontakt med %{email_link} for å få den aktivert på nytt.
+          use_ascend: Bruk Ascend?
+          use_lightspeed_retail_pos: Bruker du Lightspeed Retail POS?
+          viewing_our_streamlined_page: Du ser for øyeblikket på vår strømlinjeformede
+            Bike Shop-registreringsside, som er det vi anbefaler å bruke
       navbar:
         primary_menu:
           blog: Blogg
           donate: Donere
           help: Hjelp
           log_in: Logg Inn
-          stolen_bike: Stjålet sykkel?
-          search: Søk
           marketplace: Markedsplass
-          sign_up: Registrer deg
+          search: Søk
+          sign_up: Melde deg på
+          stolen_bike: Stjålet sykkel?
         settings_menu:
           logout: Logg ut
+          marketplace_messages: Markedsplassmeldinger
           register_a_new_bike: Registrer en ny sykkel
+          settings_menu: Innstillinger
           user_settings: "%{user_email}-innstillinger"
           view_org: Se %{org_name}
-          marketplace_messages: Markedsplassmeldinger
           your_registrations: Dine registreringer
-          settings_menu: Innstillinger
         wrapper:
-          sign_up: Registrer deg
-          the_nonprofit_bike_registry: det ideelle sykkelregisteret
           menu: Meny
+          sign_up: Melde deg på
+          the_nonprofit_bike_registry: det ideelle sykkelregisteret
+      user_alerts:
+        phone_waiting_confirmation:
+          confirm_your_phone_number: Bekreft telefonnummeret ditt
+          verification_code: Bekreftelseskode
+          verify_number: Bekreft %{phone_number}
+        stolen_bike_without_location:
+          add_location_theft_bike_title_html: Legg til stedet for tyveriet av din
+            <strong>%{bike_title}</strong>
+          location_critical_html: "<strong>Det er avgjørende for gjenoppretting</strong>
+            at du inkluderer adressen eller tverrgaten der %{bike_type} ble stjålet."
+          stolen_missing_location_title: Vennligst legg til tyveristed
+          without_location_all_is_lost: Uten et sted kan vi ikke spre ordet om tyveriet,
+            og folk vil ikke vite hvor de skal lete etter din %{bike_type}.
+        theft_alert_without_photo:
+          add_photo_theft_bike_title_html: Legg til et bilde på <strong>%{bike_title}</strong>
+          missing_stolen_photo_title: Legg til et bilde
+          photo_critical_html: Vellykkede markedsførte varsler <strong>må ha et bilde</strong>
+          without_photo_all_is_lost: Hvis du ikke har noen bilder av din %{bike_type},
+            finn et arkivbilde på internett og last det opp. Uten et bilde vil ikke
+            det promoterte varselet være effektivt.
+        unfinished_registration:
+          finish_the_required_steps: fullfør de nødvendige trinnene
+          not_registered_yet_html: Din %{cycle_type} er ikke registrert ennå! Vennligst
+            %{finish_link}
     emails:
-      confirmation_email:
-        click_to_sign_in_html: Klikk på <em>Logg på</em>-knappen for å fullføre registreringen!
-        follow_this_link_to_sign_in: Følg denne lenken for å logge på
-        sign_in: Logg på
-        youre_almost_there: Du er nesten der!
       partials:
         bike_box:
           bike_photo: Sykkelbilde
@@ -5517,6 +5569,21 @@ nb:
         just_a_few_steps_away_html: Du er bare noen få skritt unna å registrere din
           <strong>%{color_and_brand}</strong> i verdens mest omfattende sykkelregister!
         youre_almost_done: Du er nesten ferdig!
+      confirmation_email:
+        click_to_sign_in_html: Klikk på <em>Logg inn</em> -knappen for å fullføre
+          registreringen!
+        follow_this_link_to_sign_in: Følg denne lenken for å logge inn
+        sign_in: Logg inn
+        youre_almost_there: Du er nesten der!
+      partial_register_confirmation:
+        click_below_to_pick_up_where_you_left_off: Klikk nedenfor for å bekrefte denne
+          e-postadressen og fortsette der du slapp.
+        confirm_and_continue: Bekreft e-postadressen min
+        confirm_your_email: Bekreft e-posten din
+        link_signs_you_in: Denne lenken logger deg på Bike Index, så ikke videresend
+          den. Den fungerer i %{days} dager.
+        we_saved_your_registration_html: Vi lagret registreringen din for en <strong>%{color_and_brand}</strong>
+          i verdens mest omfattende sykkelregister.
     messages:
       thread_show:
         can_not_send_new_message: Beklager, du kan ikke sende en ny melding.
@@ -5554,10 +5621,6 @@ nb:
         year: år
       chart_async_frame:
         loading_chart: Laster inn diagrammet ...
-      alerts:
-        object_error:
-          errors_prevented_this_from_being_saved: "%{errors_count} forhindret at denne
-            %{object_name} ble lagret:"
       forms:
         legacy_form_well:
           address_record:
@@ -5577,87 +5640,51 @@ nb:
           address_record_with_default:
             edit_my_account_path: redigering på kontoen min
             use_account_address: Bruk kontoadresse
+        address_group:
+          address: Adresse
+          choose_country: Velg land
+          city: By
+          country: Land
+          postal_code: Postnummer
+          region: Region
+          state: Stat
+          street_2: Adresselinje 2
+        combobox_manufacturer:
+          placeholder: Begynn å skrive, f.eks. %{name}
+        combobox_manufacturer_options:
+          unknown_manufacturer: Ukjent produsent
+        email:
+          did_you_mean_html: Mente du %{email}?
+          not_real: Det ser ikke ut som din virkelige e-postadresse. Vennligst skriv
+            inn en e-postadresse du mottar e-post fra
+          submit_anyway: Send inn skjemaet likevel
+        file_upload:
+          no_file_chosen: Ingen fil valgt
+          take_picture: Ta bilde
+          upload: Last opp
+          upload_failed: opplastingen mislyktes
+          uploading: opplasting
+        group:
+          optional: valgfri
+      alerts:
+        base:
+          error: Feil
+          info: Info
+          notice: Legge merke til
+          success: Suksess
+          warning: Advarsel
+        flash_message:
+          signed_in_html: Du er pålogget! Du kan %{link} hvis du ikke vil logge på
+            via en e-postlenke.
+          signed_in_link: angi et passord for å logge på
+          signed_up_html: Du har registrert deg for Bike Index! Du kan %{link} hvis
+            du ikke ønsker å logge inn via en lenke tilsendt på e-post.
+          signed_up_link: angi et passord for å logge på
+        object_error:
+          error_prevented_this_from_being_saved:
+            one: 'Feilen %{count} forhindret at denne %{object_name} ble lagret:'
+            other: "%{count}-feil forhindret at denne %{object_name}-en ble lagret:"
     org:
-      search:
-        form:
-          doesnt_look_like_serial: Dette ser ikke ut som et serienummer. Serienumre
-            er vanligvis 6+ bokstaver og tall, plassert under kranklageret.
-          search_for_serial_number: Søk etter serienummer
-          submit: sende inn
-          search_notes: Søk i notater
-          search_owner_email_or_name: Søk etter eierens e-postadresse eller navn
-        wrapper:
-          affiliation: Tilknytning
-          avery_exportable: Avery eksporterbar
-          bike: registrering
-          e_vehicle_propulsion: Elbil (fremdrift)
-          e_vehicles_for_audit: 'Elbiler for revisjon:'
-          link: Link
-          matching_bikes_html: "%{count} %{cycle_type} samsvarende"
-          mfg_model_color_html: produsent, modell, <span class="less-strong">farge</span>
-          phone: Telefon
-          reg_address: Adresse
-          registered_bikes_html: "%{count} %{cycle_type} samsvarer med %{org_name}"
-          student_id: Student ID
-          vehicle: registrering
-          view_matching_any_audit: visning som samsvarer med enhver revisjon
-        settings:
-          address: 'Adresse:'
-          all: Alle
-          avery_cell: Avery eksporterbar
-          bike: registrering
-          color_cell: Farge
-          create_export_of_vehicles: Opprett eksport av søkte %{cycle_type}
-          created_at_cell: Registrert
-          creation_description_cell: Kilde
-          cycle_type_cell: Bil type
-          default: misligholde
-          filter_impounded_html: bare <strong>beslaglagt</strong>
-          filter_no_address_html: bare <strong>ingen</strong> adresse
-          filter_no_sticker_html: bare <strong>uten</strong> klistremerke
-          filter_not_impounded_html: bare <strong>ikke</strong> beslaglagt
-          filter_not_stolen_or_impounded_html: ikke stjålet eller beslaglagt
-          filter_stolen_html: bare stjålet
-          filter_with_address_html: bare <strong>med</strong> adresse
-          filter_with_stickers_html: bare <strong>med</strong> klistremerker
-          impound_id_cell: Beslags-ID
-          impounded_cell: Beslaglagt
-          manufacturer_cell: Produsent
-          model_cell: Modell
-          none: ingen
-          notes_cell: Notater
-          owner_email_cell: Sendt til
-          owner_name_cell: Eiers navn
-          propulsion_type_cell: Elbil (fremdrift)
-          reg_address_cell: Adresse
-          reg_extra_registration_number_cell: Sekundærnr.
-          reg_organization_affiliation_cell: Tilknytning
-          reg_phone_cell: Telefon
-          reg_student_id_cell: Student ID
-          serial_number_cell: Serienummer
-          settings: innstillinger
-          show_notes_search: vis notatsøk
-          status: 'Status:'
-          status_cell: Status
-          sticker_cell: Klistremerke
-          stickers: 'Klistremerker:'
-          stolen_cell: Stjålet
-          updated_at_cell: Oppdatert
-          url_cell: URL-adresse
-          vehicle: registrering
-          visible_columns: Synlige kolonner
-          multi_search: søk i flere serier
-      search_results:
-        multi_result_chip:
-          no_results: ingen treff
-        multi_results:
-          first_n_shown_html: "— først vist %{limit},"
-          no_exact_matches: 'Ingen eksakte treff. Nære serier:'
-          no_matches_found: Ingen treff funnet
-          result_count_html: "— %{count} %{results}"
-          serial_label: 'Serie:'
-          view_all: se alle
-          sticker_label: 'Klistremerke:'
       location_address_fields:
         address: Adresse
         choose_country: Velg land
@@ -5778,3 +5805,591 @@ nb:
         reprocess_instruction: Gå tilbake hit og klikk på knappen «behandle importen
           på nytt» nedenfor
         unknown_ascend_name: Ukjent Ascend-navn
+      parking_notification_details:
+        address: Adresse
+        bike: Sykkel
+        by: Laget av
+        created: Opprettet kl
+        internal_notes: Interne notater
+        message: Beskjed
+        notification_number: Melding#
+        resolved: Løst
+      search:
+        form:
+          doesnt_look_like_serial: Dette ser ikke ut som et serienummer. Serienumre
+            er vanligvis 6+ bokstaver og tall, plassert under kranklageret.
+          search_for_serial_number: Søk etter serienummer
+          search_notes: Søk i notater
+          search_owner_email_or_name: Søk etter eierens e-postadresse eller navn
+          submit: sende inn
+        settings:
+          address: 'Adresse:'
+          all: Alle
+          avery_cell: Avery eksporterbar
+          bike: registrering
+          color_cell: Farge
+          create_export_of_vehicles: Opprett eksport av søkte %{cycle_type}
+          created_at_cell: Registrert
+          creation_description_cell: Kilde
+          cycle_type_cell: Bil type
+          default: misligholde
+          filter_impounded_html: bare <strong>beslaglagt</strong>
+          filter_no_address_html: bare <strong>ingen</strong> adresse
+          filter_no_sticker_html: bare <strong>uten</strong> klistremerke
+          filter_not_impounded_html: bare <strong>ikke</strong> beslaglagt
+          filter_not_stolen_or_impounded_html: ikke stjålet eller beslaglagt
+          filter_stolen_html: bare stjålet
+          filter_with_address_html: bare <strong>med</strong> adresse
+          filter_with_stickers_html: bare <strong>med</strong> klistremerker
+          impound_id_cell: Beslags-ID
+          impounded_cell: Beslaglagt
+          manufacturer_cell: Produsent
+          model_cell: Modell
+          multi_search: søk i flere serier
+          none: ingen
+          notes_cell: Notater
+          owner_email_cell: Sendt til
+          owner_name_cell: Eiers navn
+          propulsion_type_cell: Elbil (fremdrift)
+          reg_address_cell: Adresse
+          reg_extra_registration_number_cell: Sekundærnr.
+          reg_organization_affiliation_cell: Tilknytning
+          reg_phone_cell: Telefon
+          reg_student_id_cell: Student ID
+          serial_number_cell: Serienummer
+          settings: innstillinger
+          show_notes_search: vis notatsøk
+          status: 'Status:'
+          status_cell: Status
+          sticker_cell: Klistremerke
+          stickers: 'Klistremerker:'
+          stolen_cell: Stjålet
+          updated_at_cell: Oppdatert
+          url_cell: URL-adresse
+          vehicle: registrering
+          visible_columns: Synlige kolonner
+        wrapper:
+          affiliation: Tilknytning
+          avery_exportable: Avery eksporterbar
+          bike: registrering
+          e_vehicle_propulsion: Elbil (fremdrift)
+          e_vehicles_for_audit: 'Elbiler for revisjon:'
+          link: Link
+          matching_bikes_html: "%{count} %{cycle_type} samsvarende"
+          mfg_model_color_html: produsent, modell, <span class="less-strong">farge</span>
+          phone: Telefon
+          reg_address: Adresse
+          registered_bikes_html: "%{count} %{cycle_type} samsvarer med %{org_name}"
+          student_id: Student ID
+          vehicle: registrering
+          view_matching_any_audit: visning som samsvarer med enhver revisjon
+      search_results:
+        bikes_table:
+          assign_bike_sticker: Tildel klistremerke
+          avery: Avery?
+          color: Farge
+          email_hidden: e-post skjult
+          hidden_not_registered: skjult, ikke registrert hos %{org_name}
+          impound_id: Beslags-ID
+          impounded: Beslaglagt
+          link_sticker: lenkeklistremerke
+          manufacturer: Produsent
+          model: Modell
+          notes: Notater
+          owner_name: Eiers navn
+          propulsion_type: Fremdrift
+          registered: Registrert
+          secondary_number: Sekundærnr.
+          sent_to: Sendt til
+          serial: Serienummer
+          source: Kilde
+          status_cell: Status
+          sticker: Klistremerke
+          stolen: Stjålet
+          updated: Oppdatert
+          url: URL-adresse
+          vehicle_type: Bil type
+        multi_result_chip:
+          no_results: ingen treff
+        multi_results:
+          first_n_shown_html: "— først vist %{limit},"
+          no_exact_matches: 'Ingen eksakte treff. Nære serier:'
+          no_matches_found: Ingen treff funnet
+          result_count_html: "— %{count} %{results}"
+          serial_label: 'Serie:'
+          sticker_label: 'Klistremerke:'
+          view_all: se alle
+    atom:
+      serial:
+        hidden: skjult
+        hidden_because_status: fordi %{bike_type} er %{status}
+        hidden_for_unauthorized_users: skjult for uautoriserte brukere
+        made_without_serial: laget uten serie
+        unknown: ukjent
+    register:
+      acknowledgment_check:
+        i_name_html: Jeg, %{name},
+        registrants_name: registrantens navn
+      acknowledgment_progress:
+        progress_saved: Fremdrift lagret · Bekreftelse av elbil · Trinn %{number}
+          av %{total}
+      back_link:
+        back: Tilbake
+      page:
+        retry_failed: Vi kunne ikke lagre det akkurat nå – ingenting av det du skrev
+          inn er tapt. Prøv igjen om et øyeblikk.
+      page_content:
+        electric_detected: "⚡️ Elektrisk (motorisert) oppdaget"
+        have_questions: Har du spørsmål om disse retningslinjene?
+        read_the_faq: Vanlige spørsmål om bekreftelse av elbiler
+      review_summary:
+        a_quick_review: En rask gjennomgang av alt du har bekreftet.
+        a_quick_review_tap: En rask gjennomgang av alt du har bekreftet. Trykk på
+          Se gjennom for å se på en protokoll igjen.
+        review: Anmeldelse
+        youre_almost_done: Du er nesten ferdig.
+      step1:
+        bike_info_html: "%{cycle_type} informasjon"
+        electric_helper: Sjekk elektriske slik at vi flagger elsykler og verifiserer
+          sertifisering.
+        electric_motorized: "⚡️ Elektrisk (motorisert)"
+        email: E-post
+        email_placeholder: du@eksempel.com
+        email_school: "%{org_name} e-post"
+        just_the_essentials: Bare det viktigste for å komme i gang.
+        next: Neste
+        no_need_to_wait: Vi sender deg en bekreftelseslenke på e-post – du trenger
+          ikke å vente på at den skal fortsette.
+        register_your_vehicle: Registrer kjøretøyet ditt!
+        register_your_vehicle_with_org: Registrer kjøretøyet ditt med %{org_name}!
+        start_over: Start på nytt
+        start_over_certain: Starte på nytt?
+        start_over_discards: Dette starter en ny registrering – ingenting du har skrevet
+          inn her overføres.
+        vehicle_type: Bil type
+        yes_start_over: Ja, start på nytt
+        your_info: Din informasjon
+      step2:
+        add_another_color: Legg til en annen farge
+        add_your_bikes_details: Legg til detaljene dine for %{cycle_type}
+        additional_serial_sticker_number: Ekstra serie-/klistremerkenummer
+        affiliation: "%{org_name} tilknytning"
+        are_you_certain: Er du sikker?
+        attach_photo: Legg ved bilde av %{cycle_type}
+        bike_details: "%{cycle_type} detaljer"
+        bottom_bracket: Kranklager
+        cm: cm
+        color: Farge
+        complete_registration: Fullfør registreringen %{cycle_type}
+        confirmation_link_sent: Vi har sendt en bekreftelseslenke til e-posten din.
+          Du trenger ikke å vente – du kan fullføre registreringen nå.
+        contact_info: Kontaktinformasjon
+        database_public_note: Databasen vår er offentlig! Du kan justere personverninnstillingene
+          for individuelle bilder fra registreringen din senere.
+        email: E-post
+        enter_size: Angi størrelse
+        found: Funnet/Forlatt
+        found_description: Jeg fant dette %{cycle_type}
+        frame_size: Rammestørrelse
+        from_step_1: Fra trinn 1
+        head_tube: Styrerør
+        how_to_find_serial: hvordan du finner serienummeret ditt
+        i_just_dont_know_the_serial: Jeg kjenner bare ikke serien
+        im_100_sure: Jeg er 100% sikker
+        inches: tommer
+        information_for_org: Informasjon for %{org_name}
+        is_a_handmade_frame: Er en håndlaget ramme
+        it_probably_has_a_serial_number: Den har sannsynligvis et serienummer.
+        missing_serial: Mangler serie
+        model: Modell
+        model_placeholder: f.eks. Marlin 7
+        model_year: Årsmodell
+        model_year_placeholder: f.eks. 2023
+        more_useful_registration: Jo mer du legger til, desto mer nyttig er registreringen.
+        nevermind: Glem det
+        next: Neste
+        optional: valgfri
+        or: eller
+        owner_name: Eiers navn
+        owner_name_placeholder: For- og etternavn
+        owner_registration: Eierregistrering
+        owner_registration_description: Registrerer meg selv eller på vegne av eier
+        phone: Telefon
+        phone_placeholder: "(555) 000–0000"
+        phone_required_found: Telefon er nødvendig for å registrere en funnet %{cycle_type}
+        phone_required_stolen: Telefon kreves for å registrere en stjålet %{cycle_type}
+        primary_color_blank: Primærfarge — f.eks. svart
+        read_how_to_find_html: Les om %{how_to_find_link} <small>(åpnes i eget vindu)</small>
+        rear_dropouts: Bakre gaffelender
+        register_with_org: Registrer deg hos %{org_name}
+        register_with_org_description: "%{org_name} vil kunne se og hjelpe til med
+          å administrere denne registreringen."
+        registration_type: Registreringstype
+        remove_additional_color: Fjern farge
+        second_color_blank: Andre farge — f.eks. rød
+        serial_help_intro: 'De fleste sykler har serienummeret sitt gravert inn i
+          rammen. Se etter serienummeret ditt:'
+        serial_location_bottom_bracket: undersiden av kranklageret
+        serial_location_head_tube: på hoderøret
+        serial_location_rear_dropouts: på bakre utfall
+        serial_number: Serienummer
+        serial_placeholder: Obligatorisk — eller merk av for manglende
+        sticker_number: Sykkelindeksklistremerkenummer
+        sticker_placeholder: f.eks. A 471 829
+        stolen: Stjålet
+        stolen_description: Denne %{cycle_type} har blitt stjålet
+        student_id: Student ID
+        third_color_blank: Tredje farge
+        up_to_3: opptil 3
+        very_very_few_bikes_html: "<em>Svært</em> få %{cycle_types} lages uten serienummer.
+          Med mindre denne %{cycle_type}:"
+        view_serial_guide: Se hele serienummerguiden
+        was_made_before_1970: Ble laget før 1970
+        wheres_my_serial: Hvor er serienummeret mitt?
+        without_serial: Denne %{cycle_type} ble laget uten serienummer
+        without_serial_number: Denne %{cycle_type} ble laget uten serienummer
+      step_acknowledgment:
+        continue: Fortsette
+      step_acknowledgment_review:
+        complete_registration: Fullfør registreringen %{cycle_type}
+      step_confirm:
+        confirming_your_email: Bekrefter e-postadressen din
+        continue: Fortsette
+        continue_where_you_left_off: Fortsett, så fortsetter vi der du slapp.
+      step_finished:
+        add_impound_details: Legg til detaljer om hvor du fant %{cycle_type}
+        add_photos: Legg til bilder av din %{cycle_type}
+        confirming_lets_you: 'Ved å bekrefte e-postadressen din kan du:'
+        do_these_things: Gjør disse tingene for best mulig sjanse til å få det tilbake
+        finish_adding: Fullfør å legge til %{cycle_type}-en din i sykkelindeksen
+        listed_as_found: "%{bike_display} er oppført som funnet på Bike Index"
+        listed_as_stolen: Din %{bike_display} er oppført som stjålet på Bike Index
+        owner_can_claim: Eieren kan finne den her og gjøre krav på den – vi sender
+          deg en e-post når noen gjør det.
+        progress_saved: Fremdriften er lagret
+        register_another: Registrer et annet kjøretøy
+        registered_for_owner_html: "%{bike_display} er registrert hos Bike Index.
+          Vi har sendt en e-post til %{email} slik at de kan gjøre krav på registreringen."
+        registration_complete: Registreringen er fullført!
+        report_it_stolen: Fullfør rapporteringen av stjålet %{cycle_type} og dra nytte
+          av fellesskapsnettverket vårt
+        reported_stolen: Meldt stjålet
+        verify_your_email_html: Ett steg til – bekreft e-postadressen din. Vi sendte
+          en bekreftelseslenke til %{email}; klikk på den for å fullføre registreringen.
+          Alt du har skrevet inn er lagret.
+        view_the_registration: Se registreringen
+        view_your_registration: Se registreringen din
+        we_will_keep_watch: Din %{bike_display} er registrert hos Bike Index. Vi holder
+          utkikk – hvis den noen gang blir meldt stjålet, leter hele lokalsamfunnet
+          etter den.
+      step_report:
+        about_the_one_you_found: Om %{cycle_type} du fant
+        address_where_you_found_it: Adressen der du fant den
+        complete_registration: Fullfør registreringen %{cycle_type}
+        contact_and_sharing: Kontakt og deling
+        department_city: Avdeling/by
+        estimated_value: Estimert verdi (%{currency})
+        have_proof_of_ownership: Jeg har bevis på at jeg eier denne %{cycle_type}
+        help_us_reunite: Hjelp oss å få den tilbake til eieren.
+        how_did_you_find_it: Hvordan fant du %{cycle_type}?
+        how_was_it_locked: Hvordan ble %{cycle_type} låst?
+        how_was_the_lock_defeated: Hvordan ble låsen beseiret?
+        next: Neste
+        police_report: Politianmeldelse
+        receive_notifications: Send meg en e-post hvis vi tweeter om dette %{cycle_type},
+          eller finner en mulig match
+        report_number: Rapportnummer
+        report_your_stolen: Rapporter stjålet %{cycle_type}
+        show_phone_police: Politi
+        show_phone_shops: Sykkelbutikker
+        show_phone_users: Innloggede Bike Index-brukere
+        the_more_we_know: Jo mer vi vet, desto bedre er sjansene for å få det tilbake.
+        theft_details: Tyveridetaljer
+        what_happened: Hva skjedde?
+        what_happened_placeholder: f.eks. låst til et stativ utenfor kaffebaren, borte
+          da jeg kom ut igjen
+        when_and_where: Når og hvor
+        when_did_you_find_it: Når fant du den?
+        when_was_it_stolen: Når ble %{cycle_type} stjålet?
+        where_was_it_stolen: Hvor ble det stjålet?
+        who_can_see_your_phone: Hvem kan se telefonnummeret ditt?
+        without_a_report: Å sende inn en politianmeldelse gir din %{cycle_type} den
+          beste sjansen til å komme tilbake – du kan legge til nummeret senere.
+    registrations:
+      show:
+        bike_details:
+          frame_material: Rammemateriale
+          frame_size: Rammestørrelse
+          handlebar_type: Styre type
+          manufacturer: Produsent
+          model: Modell
+          other_serial: Annen serie/registrering/klistremerke
+          serial: Serienummer
+          title: "%{bike_type} detaljer"
+          vehicle_type: Bil type
+          year: år
+        bike_index_card:
+          activity: Aktivitet
+          frame_material: Rammemateriale
+          id: ID
+          registered_since: Registrert siden
+          this_bike_on_bike_index: Denne %{bike_type} på sykkelindeksen
+        component_list:
+          component_no_info: "-"
+          componentyear: "%{componentyear}"
+          drivetrain: Drivverk
+          drivetrain_fixed: Fast utstyr
+          drivetrain_front: Drivverk foran
+          drivetrain_rear: Drivverk bak
+          front: Front
+          front_rear: Foran bak
+          front_tire_width: Bredde på forhjulet
+          front_wheel_diameter: Forhjuls diameter
+          full_spec_sheet: Fullstendig spesifikasjonsark
+          hide: Gjemme
+          other: Annen
+          paint_description: Fargebeskrivelse
+          propulsion_type: Fremdrift
+          rear: Bak
+          rear_tire_width: Bakdekkbredde
+          rear_wheel_diameter: Bakhjuls diameter
+          show_all: Vis alle
+          tire_width: Dekkbredde
+          tire_width_narrow_false: Bredt dekk
+          tire_width_narrow_true: Smalt dekk
+          wheel_diameter: Hjuldiameter
+        contact_owner:
+          contact_the_owner: Kontakt eieren
+          know_something_about_this_bike_type: Vet du noe om dette %{bike_type}?
+          link_url: Link url
+          send_message: Sende melding
+          where_did_you_see_this_bike: Hvor så du dette %{bike_type}? Hvis du kontakter
+            om en annonse du fant på nettet, inkluderer du en lenke i feltet nedenfor
+        current_alerts:
+          claim_impound:
+            add_a_stolen_bike: legg til en stjålet %{bike_type}
+            choose_stolen_bike: Velg stjålet %{bike_type}
+            claim_found_bike: Krav funnet %{bike_type}
+            claim_impounded_bike: Krav beslaglagt %{bike_type}
+            claim_submitted: Dette kravet ble sendt inn
+            claim_was_status: Kravet ditt var %{status} – du skal ha mottatt en e-post
+              med de neste trinnene.
+            claim_with_this_bike_type: Du har et %{status}-krav med denne %{bike_type}.
+            does_this_look_like_your_bike: Ser dette ut som din %{bike_type}?
+            need_stolen_bike_html: Du må ha en stjålet %{bike_type} registrert for
+              å sende inn et krav — %{add_link}.
+            no_editing_after_submitting: Etter at du har sendt inn kravet, kan du
+              ikke redigere det.
+            open_claim: Åpent krav
+            prove_its_yours: Bekreft eierskapet ditt – legg til detaljer som beviser
+              at denne %{bike_type} er din
+            save_message: Lagre melding
+            select_your_stolen_bike: Velg den stjålne %{bike_type}-en du eier som
+              samsvarer med denne beslagleggelsen
+            submit_claim: Send inn krav
+            view_claimed_bike_type: se det påståtte %{kind} %{bike_type}
+            your_claim: Ditt krav
+          claim_invitation:
+            claim_bike_type: Krav %{bike_type}
+            claim_it_so_you_can_update_your_listing: Gjør krav på det slik at du kan
+              oppdatere oppføringen din.
+            claim_your_bike_type: Krev din %{bike_type}
+            read_more: les mer
+            registered_your_bike_on_index_html: registrerte din %{bike_type} på Bike
+              Index, en gratis, ideell plattform for sykkelregister og gjenfinning
+              av stjålne sykler %{read_more_link}.
+            sign_up: melde deg på
+            sign_up_to_claim: Melde deg på
+            to_see_your_bike_sign_up_html: For å se din %{bike_type} og gjøre krav
+              på den som din egen, %{sign_up_link} med e-postadressen du mottok registrerings-e-posten
+              fra.
+            were_honored_to_have_your_bike: Vi er beæret over å ha din %{bike_type}
+              på indeksen.
+          notification_token:
+            mark_graduated_resolved: Merk %{bike_type} gjenværende
+            mark_parking_resolved: Merk %{bike_type} hentet
+            no_futher_action_necessary: ingen ytterligere handling nødvendig!
+            organization_sent_this_message: "%{org_name} sendte dette varselet"
+            please_email_organization_with_questions_html: Send en e-post til %{email_link}
+              hvis du har spørsmål
+            you_have_already_marked_remaining: Du har allerede merket denne %{bike_type}
+              gjenværende
+            you_have_already_marked_resolved: Du har merket dette varselet som løst
+          recovery_prompt:
+            can_we_share_your_story: Kan vi dele historien din?
+            did_we_help: Har vi hjulpet til?
+            how_did_you_get_it_back: Hvordan fikk du det tilbake?
+            its_also_how_we_get_better_at_recovering: Det er også slik vi blir bedre
+              til å komme oss %{bike_type}.
+            mark_recovered: Mark ble frisk
+            mark_your_bike_recovered: Merk at %{bike_type} er gjenopprettet!
+            nevermind: Glem det
+            please_tell_us_how_you_got_your_bike: Fortell oss hvordan du fikk tilbake
+              %{bike_type}, vi bryr oss virkelig!
+            when_did_you_recover_it: Når gjenopprettet du det?
+          scanned_sticker:
+            change_the_bike_sticker_linked_to: Endre %{bike_type}-en den lenker til
+            is_this_linked_to_incorrect_bike: Er dette klistremerket knyttet til feil
+              %{bike_type}?
+            switch_to_new_bike_id: Bytt til en ny %{bike_type}-ID
+            update: Oppdater
+            you_scanned_this_sticker_html: Du skannet %{sticker}, som er tilordnet
+              denne %{bike_type}.
+          sent_to_new_owner:
+            you_sent_this_bike_html: Du sendte denne %{bike_type} til %{owner_email},
+              og den er ikke gjort krav på ennå. Du kan oppdatere den.
+        impound_details:
+          found_at: Funnet kl
+          found_details: Detaljer funnet
+          impound_details: Detaljer om beslag
+          impounded_at: Beslaglagt ved
+          location: plassering
+          org_impound_record: "%{org_name} beslaglagt post"
+        impound_record_fields:
+          created: Opprettet
+          impounded_by: Beslaglagt av
+          impounded_from: Beslaglagt fra
+          last_update_by: Sist oppdatert av
+          status: Status
+        legacy_view_link:
+          switch_to_classic: Bytt tilbake til den eldre visningsfunksjonen
+          using_new_view: Du prøver ut den nye %{bike_type}-visningsfunksjonen.
+          view_in_legacy: visning %{bike_type} i eldre visningsprogram
+        map:
+          unavailable: Kartet kunne ikke lastes inn – nettleseren eller enheten din
+            støtter det kanskje ikke.
+        org_top_actions:
+          impound_update:
+            title: Oppdater beslagsregister
+          message_owner:
+            know_something_about_this_bike_type: Vet du noe om dette %{bike_type}?
+            link_url: Link url
+            send_message: Sende melding
+            where_did_you_see_this_bike: Hvor så du dette %{bike_type}? Hvis du kontakter
+              om en annonse du fant på nettet, inkluderer du en lenke i feltet nedenfor
+          parking_notification_form:
+            address_or_intersection: Adresse eller veikryss
+            create_parking_notification: Opprett et nytt parkeringsvarsel
+            impound_this_bike_type: Beslaglegg dette %{bike_type}
+            map_hint: Dra kartet slik at nålen markerer stedet
+            map_unavailable: Kartet kunne ikke lastes inn – posisjonen var fortsatt
+              angitt fra enheten din.
+            parking_notification_notes_html: "%{org_name} interne notater <small>vises
+              ikke til brukeren</small>"
+          parking_notification_show:
+            no_notifications: Ingen parkeringsvarsler for denne %{bike_type}
+            parking_notifications: Parkeringsmeldinger
+            view_all: se alle varsler for denne %{bike_type}
+            view_notification: Se varsel
+          wrapper:
+            impound: Beslaglegge
+            message_owner: Meldingseier
+            new_parking_notice: Nytt parkeringsvarsel
+            update_impound_record: Oppdater beslagsregister
+            view_notifications: Vis varsler
+            view_notifications_active_html: "<strong>%{count}</strong> Aktiv"
+            view_notifications_resolved_html: "<strong>%{count}</strong> Løst"
+        owner_phone:
+          or_call: Eller ring
+        photos:
+          add_photo: Legg til bilde
+          bike_photo: "%{bike_type} bilde"
+          color_may_not_match: Fargen stemmer kanskje ikke!
+          stock_photo: Arkivbilde av en %{year} %{model}
+        primary_colors:
+          primary_color:
+            one: Primærfarge
+            other: Primærfarger
+        status:
+          found: Funnet
+          impounded: Beslaglagt
+          not_stolen: Ikke stjålet
+          stolen: Stjålet
+          unregistered: Uregistrert
+        stolen_details:
+          department_city: Avdeling og by
+          description_of_incident: Beskrivelse av hendelsen
+          location: plassering
+          locking_circumvented: Låsing omgås
+          locking_description: Låsebeskrivelse
+          police_report: 'Politi anmeldelse #'
+          stolen_at: Stjålet kl
+          stolen_details: Tyveridetaljer
+        toggle_view:
+          switch_to_legacy_default: Bytt til eldre visningsprogram som standard.
+          switch_to_new: Bytt til den nye visningen
+          try_new_view: Prøv ut den nye %{bike_type}-visningen!
+          view_in_new: Vis i nytt visningsprogram
+          viewing_in_legacy: Eldre visningsprogram (som standard bruker du det nye
+            visningsprogrammet)
+        wrapper_consumer:
+          about_this_bike: Om dette %{bike_type}
+          audience_owner: Din %{bike_type}
+          audience_public: Offentlig visning
+          audience_sent_away: Ikke lenger din %{bike_type}
+          edit_this_bike: Rediger dette %{bike_type}
+          mark_stolen: Merke stjålet
+          registered_protected: Registrert og beskyttet
+          sell_on_marketplace: Selg på markedsplassen
+          share: Dele
+          share_my_page: Del siden min
+        wrapper_org_admin:
+          about_this_bike: Om dette %{bike_type}
+          assign_sticker: Tildel klistremerke
+          audit: Revisjon av elbiler
+          avery_exportable: Avery eksporterbar
+          claimed: Hevdet
+          creation_source: Kilde
+          creator: Skaper
+          credibility: Troverdighet
+          edit: Endre
+          has_duplicate_serials: har duplikerte serier
+          internal_notes: Interne notater
+          is_false: falsk
+          is_true: ekte
+          link_sticker: Lenkeklistremerke
+          no_duplicate_serials: ingen duplikasjoner. serier
+          no_other_registrations: Ingen funnet
+          no_registration_information: Ingen registreringsinformasjon synlig for %{org_name}
+          not_audited: Ikke revidert
+          not_registered_message: Eierkontakt er ikke tilgjengelig for sykler utenfor
+            organisasjonen din. Du kan fortsatt legge til interne notater.
+          not_registered_title: Ikke registrert hos %{org_name}
+          note_by: Merknad av %{user}
+          notes_placeholder: Nytt internt notat – dine tidligere notater lagres i
+            tråden.
+          org_can_edit: "%{org_name} kan redigere denne %{bike_type}"
+          org_can_edit_sub: Inkludert etter at %{bike_type} er gjort krav på.
+          organization_registered: Organisasjon
+          other_registrations: Andre registreringer av denne brukeren
+          other_registrations_count_html: "%{count} andre registreringer"
+          owner_access: Eier og tilgang
+          owner_email: E-post
+          owner_name: Navn
+          owner_phone: Telefon
+          photo_archive: Fotoarkiv
+          post_note: Legg inn notat
+          posts_as: Innlegg som %{user}
+          registration_information: Registreringsinformasjon
+          registration_number: Registrering av sykkelindeks
+          restricted_message: Administrasjon og ansatte kan kontakte eieren. Du kan
+            legge til notater og be om beslag.
+          restricted_title: Begrenset for din rolle
+          role_limited: Begrenset
+          role_staff: Personale
+          showing_recent: Viser den nyeste %{count}
+          sticker: Klistremerke
+          sticker_claimed: hevdet
+          sticker_code: Klistremerkekode
+          unregistered_owner: Denne %{bike_type} er ikke registrert på en bruker.
+            Den ble lagt til for å spore parkeringsvarsler.
+          view_all_registrations: se alle →
+    sessions:
+      sign_in_interstitial:
+        click_button_to_continue: Klikk på knappen nedenfor for å fortsette
+        finish_signing_in: Fullfør påloggingen
+        sign_in: Logg inn
+  user_emails:
+    confirm:
+      confirm_email: Bekreft e-post
+      confirm_this_email: Bekreft %{user_email}

--- a/config/locales/translation.nl.yml
+++ b/config/locales/translation.nl.yml
@@ -726,8 +726,9 @@ nl:
         theft_description: Diefstal beschrijving
         time: tijd
         tsved_at: Tsved om
-        zipcode: Postcode
         recovered_at: Datum hersteld
+        postal_code: Postcode
+        region_string: Regio
       theft_alert:
         end_at: Eindig op
         notes: Notes
@@ -1838,6 +1839,9 @@ nl:
       no_one_but_the_user_and_bike_index_admins: niemand anders dan de gebruiker (en
         Bike Index-beheerders) kunnen het zien
       test_registration: proefregistratie
+    stolen_map:
+      unavailable: De kaart kon niet worden geladen. Uw browser of apparaat ondersteunt
+        deze mogelijk niet.
   controllers:
     bikes:
       edit:
@@ -1949,8 +1953,6 @@ nl:
       create:
         invalid_email_or_password: Ongeldig e-mailadres / wachtwoord
       create_magic_link:
-        link_sent: Aanmelden link verzonden! Klik op de link in uw e-mail om in te
-          loggen
         user_not_found: Kan die gebruiker niet vinden
     stolen_notifications:
       create:
@@ -2067,9 +2069,9 @@ nl:
       sessionable:
         sign_in_and_redirect:
           logged_in: Ingelogd!
-          organization_signed_in: Je bent ingelogd
           user_is_banned: Het spijt ons, maar het lijkt erop dat uw account is vergrendeld.
             Neem contact met ons op als u niet zeker weet waarom.
+          organization_signed_in: Je bent ingelogd.
         skip_if_signed_in:
           already_signed_in: Je bent al ingelogd!
     oauth:
@@ -2225,6 +2227,21 @@ nl:
           we nodig hebben geblokkeerd door een VPN of een privacy-extensie. Probeer
           deze uit te schakelen voor bikeindex.org. Stuur een e-mail naar contact@bikeindex.org
           als het probleem zich blijft voordoen.
+    register:
+      acknowledge:
+        acknowledge_everything: Vink alle vakjes aan om akkoord te gaan met deze regels.
+      confirm_email:
+        confirmation_link_expired: Die bevestigingslink is verlopen. Controleer je
+          e-mail voor een nieuwe link.
+        signed_in_as_other: Je bent ingelogd als %{email}, dus we hebben je in dat
+          account behouden. De registratiegegevens zijn nog steeds opgeslagen op het
+          e-mailadres waarnaar we je hebben gemaild.
+      find_b_param:
+        registration_not_found: We konden die registratie niet vinden. Start hieronder
+          een nieuwe registratie.
+      sign_in_confirmed_user:
+        unable_to_sign_in: We hebben je e-mailadres bevestigd, maar konden je niet
+          inloggen op dat account.
   customer_mailer:
     additional_email_confirmation:
       html:
@@ -3612,8 +3629,6 @@ nl:
     revised_messages:
       error: Fout
       please_fix_the_following: Corrigeer het volgende %{errors}
-    application:
-      skip_to_main_content: Ga direct naar de hoofdinhoud
     application_bikehub:
       contact: contact
       home: Thuis
@@ -3628,6 +3643,8 @@ nl:
         advocaten om herstelfietsen met hun eigenaars te verbinden.
       accounts_powered_by_bike_index: BikeHub-accounts worden mogelijk gemaakt door
         Bike Index - het belangrijkste fietsregister.
+    application:
+      skip_to_main_content: Ga direct naar de hoofdinhoud
   meta_descriptions:
     bikes_index: Zoeken naar fietsen die zijn geregistreerd op Bike Index
     bikes_new: Registreer een fiets snel, eenvoudig en gratis op Bike Index. Maak
@@ -3674,6 +3691,13 @@ nl:
     my_accounts_show: Uw fietsen op Bike Index
     registrations_embed: Insluitbaar %{organization} Fietsindex registratieformulier.
       Registreer je fiets nu gratis.
+    search_marketplace_index: Fietsen te koop op Bike Index. Zoek in de marktplaats
+      op fabrikant, prijs en locatie.
+    search_registrations_index: Zoeken naar fietsen die zijn geregistreerd op Bike
+      Index
+    strava_search_index: Koppel je Strava-uitrusting aan je Bike Index-registraties.
+      Zoek, filter en update je activiteiten in één keer om uitrusting toe te wijzen
+      aan ritten die deze nog niet hebben.
   meta_titles:
     bikes_index: Zoekresultaten
     bikes_new: Registreer een fiets!
@@ -3715,6 +3739,16 @@ nl:
     my_accounts_show: Jij op Bike Index
     search_registrations_index: Zoekresultaten
     registrations_embed: Registreer een fiets met %{organization}
+    register_acknowledgment: Veiligheidscontrole voor uw %{cycle_type}
+    register_confirm: Uw e-mailadres wordt bevestigd.
+    register_create: Registreer uw voertuig!
+    register_report: Vertel ons wat er gebeurde
+    register_review: Controleer uw %{cycle_type} veiligheidscontrole
+    register_show: Uw %{cycle_type} registratie
+    register_step_1: Registreer uw voertuig!
+    register_step_2: Voeg de gegevens van uw %{cycle_type} toe
+    search_marketplace_index: Fietsindex Marktplaats
+    strava_search_index: Fietsindex Strava-zoekfunctie
   organized:
     ambassador_dashboards:
       getting_started:
@@ -4083,15 +4117,6 @@ nl:
         address: Adres
         notification_number: Kennisgeving#
         resolved: Vastbesloten
-      show_details:
-        address: Adres
-        bike: Fiets
-        by: Gemaakt door
-        created: Gemaakt op
-        internal_notes: Interne notities
-        message: Bericht
-        notification_number: Kennisgeving#
-        resolved: Vastbesloten
     manages:
       location_fields:
         address: Adres
@@ -4107,7 +4132,6 @@ nl:
         save: Opslaan
       show:
         abbreviation: Afkorting
-        choose_file: Kies bestand...
         delete_organization: Organisatie verwijderen
         i_would_like_to_terminate_my_account: Ik wil mijn account bij Bike Index beëindigen
         name: Naam
@@ -4158,6 +4182,15 @@ nl:
       subject: Doe mee met %{organization_name} op Bike Index
     partial_registration:
       subject: Voltooi uw %{organization_name} registratie van de fietsindex!
+    partial_register_confirmation:
+      subject: Bevestig je e-mailadres om je %{organization_name}registratie af te
+        ronden.
+    partial_register_confirmation_abandoned:
+      subject: Voltooi de melding van uw verlaten %{cycle_type}
+    partial_register_confirmation_found:
+      subject: Voltooi de rapportage van uw gevonden %{cycle_type}
+    partial_register_confirmation_stolen:
+      subject: Voltooi de melding van uw gestolen %{cycle_type}
   plan_features:
     automatic_registration_through_pos: Automatische registratie via uw POS
     create_organization_account: Maak een organisatieaccount en neem contact op met
@@ -4176,9 +4209,12 @@ nl:
       sign_in_with_magic_link: Inloggen zonder wachtwoord
       unable_to_auth: Kan dat token niet verifiëren
       your_email_address: Uw e-mailadres
-    magic_link_sent:
-      follow_the_link_back: Volg de link in de e-mail om in te loggen!
-      we_sent_a_magic_sign_in_link: We hebben je een magische inloglink gestuurd
+      link_already_used: Die inloglink is al gebruikt.
+      link_expired: Die inloglink is verlopen.
+      links_work_for: Aanmeldlinks werken voor %{duration} nadat ze zijn verzonden.
+      only_the_newest_link_works: U bent mogelijk al ergens anders ingelogd. Als u
+        meerdere e-mailadressen hebt opgegeven, werkt alleen de link in het meest
+        recente adres.
     new:
       email: E-mail
       forgot_your_password: Wachtwoord vergeten?
@@ -4194,6 +4230,9 @@ nl:
       sign_in_without_password: Aanmelden zonder wachtwoord
     identify:
       different_email: Aanmelden met een ander e-mailadres
+    magic_link_sent:
+      follow_the_link_back: Volg de link in de e-mail om in te loggen!
+      we_sent_a_magic_sign_in_link: We hebben je een link gestuurd om je aan te melden.
   shared:
     email_bike_box:
       color: Kleur
@@ -4325,85 +4364,6 @@ nl:
       you: U
       your_bikes: Je fietsen
       your_preferences: Jouw voorkeuren
-    edit_bike_skeleton:
-      edit: Bewerken
-      owned_but_hasnt_been_claimed_html: Eigendom van <em>%{owner_email}</em> maar
-        het is nog niet geclaimd
-      owned_with_permission_to_edit_html: Eigendom van <em>%{owner_email}</em> maar
-        %{org_name} heeft toestemming om te bewerken
-      view_bike: Bekijk %{bike_type}
-      view_bike_version: Bekijk %{bike_type} versie
-      edit_pages: 'Bewerk %{bike_type} pagina''s:'
-    organized_skeleton:
-      additional_features_html: Bike Index biedt extra functies voor geverifieerde
-        wetshandhavingsorganisaties. Neem contact op met %{email_link} om ze ingeschakeld
-        te krijgen.
-      admin_panel: Admin panel
-      how_integration_works: hoe de integratie werkt
-      integrate_bike_index_with_ascend: Integreer Bike Index met Ascend
-      integrate_bike_index_with_lightspeed: Integreer Bike Index met Lightspeed
-      link_to_register_html: "<strong>%{link}</strong> om de fietsen die u aan uw
-        klanten verkoopt automatisch te registreren."
-      other_point_of_sale_system: Ander Point of Sale-systeem?
-      read_a_full_explanation_html: Lees een volledige uitleg van %{link}.
-      register_bikes_with_link_html: Registreer fietsen met onze <strong>%{link}</strong>
-      streamlined_bike_shop_registration_page: gestroomlijnde registratiepagina voor
-        Bike Shop
-      use_ascend: Ascend gebruiken?
-      use_lightspeed_retail_pos: Lightspeed Retail POS gebruiken?
-      viewing_our_streamlined_page: U bekijkt momenteel onze gestroomlijnde registratiepagina
-        voor Bike Shop, die wij aanbevelen te gebruiken
-      subscription_expired_html: Uw abonnement op Bike Index is verlopen. Neem contact
-        op met %{email_link} om het opnieuw in te schakelen.
-    content_skeleton:
-      about: Over
-      bicycle_serials: Fietsseries
-      bike_index_news: Bike Index nieuws
-      bike_index_store: Bike Index Winkel
-      design_and_developer_resources: Ontwerp- en ontwikkelaarbronnen
-      donate: Schenken
-      help: Helpen
-      other_pages: Andere pagina's
-      protect_your_bike: Bescherm je fiets
-      related: Verwant
-      sign_up_your_organization: Meld uw organisatie aan
-      where: Waar
-      donate_today: Doneer vandaag nog
-      make_a_difference: Maak een verschil bij fietsdiefstal
-      how_to_get_your_stolen_bike_back: Hoe u uw gestolen fiets terugkrijgt
-    law_enforcement_donation_modal:
-      bikeindex_is_a_nonprofit: Bike Index is een 501 (c) (3) non-profit. We zijn
-        afhankelijk van donaties om deze diensten te leveren. We raden wetshandhavingsinstanties
-        zoals %{org_name} aan om minimaal $ 20 per jaar te doneren om onze inspanningen
-        te ondersteunen.
-      contact_bike_owners: Neem contact op met fietsbezitters voordat hun fietsen
-        als gestolen worden gemarkeerd
-      email_for_access_html: E-mail %{email_link} voor toegang.
-      greeting: Hallo %{user_name},
-      law_enforcement_features: 'We hebben een aantal functies die speciaal zijn ontworpen
-        voor wetshandhavers:'
-      multiple_serial_search_pane: Meervoudig serieel zoekvenster
-      thank_you: Heel erg bedankt voor het gebruik van Bike Index!
-      thanks_for_using_bike_index: Bedankt voor het gebruik van Bike Index!
-    user_general_alert:
-      add_location_theft_bike_title_html: Voeg de locatie van de diefstal van uw <strong>%{bike_title}
-        toe</strong>
-      add_photo_theft_bike_title_html: Voeg een foto toe aan je <strong>%{bike_title}</strong>
-      location_critical_html: "<strong>Het is van cruciaal belang voor herstel</strong>
-        dat u het adres of kruispunt opgeeft waar uw %{bike_type} is gestolen."
-      missing_stolen_photo_title: Voeg een foto toe
-      photo_critical_html: Succesvolle gepromote waarschuwingen <strong>moeten een
-        afbeelding hebben</strong>
-      stolen_missing_location_title: Voeg diefstallocatie toe
-      without_location_all_is_lost: Zonder een locatie kunnen we het woord over de
-        diefstal niet verspreiden en mensen zullen niet weten waar ze naar uw %{bike_type}
-        moeten zoeken.
-      without_photo_all_is_lost: Als je geen foto's van je fiets hebt, zoek dan een
-        stockafbeelding op internet en upload deze. Zonder een afbeelding is de gepromote
-        waarschuwing niet effectief.
-      confirm_your_phone_number: Bevestig uw telefoonnummer
-      verification_code: Verificatie code
-      verify_number: Verifieer %{phone_number}
     claim_message:
       public_resource_reunited_value_html: Bike Index is een openbare bron voor het
         registreren van fietsen. We zijn tot nu toe meer dan <strong>%{value}</strong>
@@ -4479,6 +4439,16 @@ nl:
       translated_from_english: vertaald uit het Engels
     shops_map:
       map_of_partner_locations: Kaart met partnerlocaties
+    register_flow:
+      date_found_required: Kunt u ons laten weten wanneer u het gevonden heeft?
+      date_stolen_required: Kunt u ons vertellen wanneer het gestolen is?
+      email_required: Een e-mailadres is vereist om je te registreren.
+      location_found_required: Kunt u ons vertellen waar u het gevonden heeft?
+      location_stolen_required: Kunt u ons vertellen waar het gestolen is?
+      manufacturer_required: De fabrikant is verplicht zich te registreren.
+      name_required: De naam van de eigenaar is vereist voor registratie.
+      unable_to_save: Het is ons niet gelukt om uw registratie op te slaan. Probeer
+        het later opnieuw.
   users:
     accept_terms:
       i_agree_to_tos_html: Ik ga akkoord met de <strong>Servicevoorwaarden van</strong>
@@ -4510,9 +4480,6 @@ nl:
       sign_up_using_strava: Meld je aan met Strava
       terms_and_conditions: Termen en voorwaarden
       sign_up_using_globalid: Meld u aan met globaliD
-      better_password: beter
-      password_helper_text_html: Wachtwoord moet minimaal 12 tekens lang zijn. Langer
-        is %{better_password_link}.
     please_confirm_email:
       please_verify_your_email: Verifieer uw e-mailadres
       thanks_for_signing_up_for_bike_index: Bedankt voor het aanmelden voor Bike Index!
@@ -4529,6 +4496,14 @@ nl:
       stolen: Gestolen!
       this_user_has_no_bikes_yet: Deze gebruiker heeft nog geen fietsen!
       this_users_bikes: De fietsen van deze gebruiker
+      banned_only_visible_to_superusers: Hun profiel is alleen zichtbaar omdat je
+        een supergebruiker bent.
+      banned_user: Deze gebruiker is geblokkeerd.
+      profile_hidden: Dit profiel wordt niet openbaar gedeeld.
+      profile_hidden_owner: Het is alleen voor jou zichtbaar omdat het jouw pagina
+        is.
+      profile_hidden_superuser: Het is alleen zichtbaar omdat je een supergebruiker
+        bent.
     request_password_reset_form:
       enter_the_email_address: Voer het e-mailadres in dat je hebt gebruikt om je
         aan te melden. We sturen u een e-mail met een link om uw wachtwoord opnieuw
@@ -4552,9 +4527,8 @@ nl:
       update_password: password-update
       update_your_password: Update uw wachtwoord
     unsubscribe:
-      if_not_click_button: Zo niet, klik dan op de onderstaande knop
       unsubscribe: Afmelden
-      you_should_be_unsubscribed_automatically: U zou automatisch moeten worden afgemeld
+      confirm_unsubscribe: Bevestig dat u zich wilt afmelden.
   welcome:
     choose_registration:
       add_a_bike_through: Voeg een fiets toe door
@@ -5387,11 +5361,6 @@ nl:
       index:
         loading_results: Resultaten laden...
   components:
-    sessions:
-      sign_in_interstitial:
-        if_not_click_button: Zo niet, klik dan op de onderstaande knop
-        sign_in: Log in
-        you_should_be_signed_in_automatically: Je zou automatisch ingelogd moeten zijn.
     search:
       everything_combobox:
         query_items_description: Zoekbeschrijvingen combobox
@@ -5427,9 +5396,6 @@ nl:
         bike_box_view: Bekijk als lijst
         thumbnail_view: Bekijken als miniaturen
     search_results:
-      frame:
-        rate_limited: Te veel zoekopdrachten te snel achter elkaar — je hebt een limiet
-          bereikt. Wacht even en probeer het opnieuw.
       bike_box:
         location: Plaats
         posted_at: Genoteerd
@@ -5445,6 +5411,12 @@ nl:
         member: Lid van Bike Index
       container:
         no_results: Er zijn geen registraties die exact overeenkomen met uw zoekopdracht
+      frame:
+        fetch_failed: Deze resultaten konden niet worden geladen. Controleer uw verbinding
+          en probeer het opnieuw.
+        rate_limited: Te veel zoekopdrachten te snel achter elkaar — je hebt een limiet
+          bereikt. Wacht even en probeer het opnieuw.
+        retry: Probeer het opnieuw
     page_block:
       marketplace_listing_panel:
         condition: Voorwaarde
@@ -5496,9 +5468,11 @@ nl:
         letter_opener_tooltip: Bekijk de e-mail die door deze review-app is verzonden.
         pr_link: 'PR #%{number}'
         commit_tooltip: 'huidige commit:'
-        label_sandbox: Sandbox
         superadmin_button: Meld u aan als superbeheerder.
         superadmin_signed_in: ingelogd als superbeheerder
+        label_development: Ontwikkeling
+        label_sandbox: Zandbak
+        no_superadmin: geen supergebruiker (kan niet inloggen)
       footer:
         about: Over
         ambassadors: Ambassadors
@@ -5514,7 +5488,6 @@ nl:
           - EIN 81-4296194"
         dev_and_design_resources: Ontwikkelings- en ontwerpbronnen
         donate: Schenken
-        faq_and_help: FAQ en hulp
         how_to_get_your_stolen_bike_back: Haal je gestolen fiets terug
         language: Taal
         law_enforcement: Politie
@@ -5534,39 +5507,121 @@ nl:
         who_we_serve: Wie we dienen
         legal: Juridisch
         social_media: Sociale media
-        status_page: Statuspagina
-        register_a_bike: Registreer een fiets
+        faq_and_help: Veelgestelde vragen en hulp
         marketplace: Marktplaats
+        register_a_bike: Registreer een fiets
         search: Zoeken
+        status_page: Statuspagina
+      law_enforcement_donation:
+        bikeindex_is_a_nonprofit: Bike Index is een 501 (c) (3) non-profit. We zijn
+          afhankelijk van donaties om deze diensten te leveren. We raden wetshandhavingsinstanties
+          zoals %{org_name} aan om minimaal $ 20 per jaar te doneren om onze inspanningen
+          te ondersteunen.
+        contact_bike_owners: Neem contact op met fietsbezitters voordat hun fietsen
+          als gestolen worden gemarkeerd
+        email_for_access_html: E-mail %{email_link} voor toegang.
+        greeting: Hallo %{user_name},
+        law_enforcement_features: 'We hebben een aantal functies die speciaal zijn
+          ontworpen voor wetshandhavers:'
+        multiple_serial_search_pane: Meervoudig serieel zoekvenster
+        thank_you: Heel erg bedankt voor het gebruik van Bike Index!
+        thanks_for_using_bike_index: Bedankt voor het gebruik van Bike Index!
+      main_content:
+        content:
+          about: Over
+          bicycle_serials: Fietsseries
+          bike_index_news: Bike Index nieuws
+          bike_index_store: Bike Index Winkel
+          design_and_developer_resources: Ontwerp- en ontwikkelaarbronnen
+          donate: Schenken
+          donate_today: Doneer vandaag nog
+          help: Helpen
+          how_to_get_your_stolen_bike_back: Hoe u uw gestolen fiets terugkrijgt
+          make_a_difference: Maak een verschil bij fietsdiefstal
+          other_pages: Andere pagina's
+          protect_your_bike: Bescherm je fiets
+          related: Verwant
+          sign_up_your_organization: Meld uw organisatie aan
+          where: Waar
+        edit_bike:
+          edit: Bewerken
+          edit_pages: 'Bewerk %{bike_type} pagina''s:'
+          owned_but_hasnt_been_claimed_html: Eigendom van <em>%{owner_email}</em>
+            maar het is nog niet geclaimd
+          owned_with_permission_to_edit_html: Eigendom van <em>%{owner_email}</em>
+            maar %{org_name} heeft toestemming om te bewerken
+          view_bike: Bekijk %{bike_type}
+          view_bike_version: Bekijk %{bike_type} versie
+        organized:
+          additional_features_html: Bike Index biedt extra functies voor geverifieerde
+            wetshandhavingsorganisaties. Neem contact op met %{email_link} om ze ingeschakeld
+            te krijgen.
+          admin_panel: Admin panel
+          how_integration_works: hoe de integratie werkt
+          integrate_bike_index_with_ascend: Integreer Bike Index met Ascend
+          integrate_bike_index_with_lightspeed: Integreer Bike Index met Lightspeed
+          link_to_register_html: "<strong>%{link}</strong> om de fietsen die u aan
+            uw klanten verkoopt automatisch te registreren."
+          other_point_of_sale_system: Ander Point of Sale-systeem?
+          read_a_full_explanation_html: Lees een volledige uitleg van %{link}.
+          register_bikes_with_link_html: Registreer fietsen met onze <strong>%{link}</strong>
+          streamlined_bike_shop_registration_page: gestroomlijnde registratiepagina
+            voor Bike Shop
+          subscription_expired_html: Uw abonnement op Bike Index is verlopen. Neem
+            contact op met %{email_link} om het opnieuw in te schakelen.
+          use_ascend: Ascend gebruiken?
+          use_lightspeed_retail_pos: Lightspeed Retail POS gebruiken?
+          viewing_our_streamlined_page: U bekijkt momenteel onze gestroomlijnde registratiepagina
+            voor Bike Shop, die wij aanbevelen te gebruiken
       navbar:
         primary_menu:
           blog: Blog
           donate: Schenken
           help: Helpen
           log_in: Log in
-          stolen_bike: Fiets gestolen?
-          search: Zoeken
           marketplace: Marktplaats
+          search: Zoeken
           sign_up: Registreren
+          stolen_bike: Fiets gestolen?
         settings_menu:
           logout: Afmelden
+          marketplace_messages: Marktplaatsberichten
           register_a_new_bike: Registreer een nieuwe fiets
+          settings_menu: Instellingen
           user_settings: "%{user_email} instellingen"
           view_org: Bekijk %{org_name}
-          marketplace_messages: Marktplaatsberichten
           your_registrations: Uw registraties
-          settings_menu: Instellingen
         wrapper:
+          menu: Menu
           sign_up: Registreren
           the_nonprofit_bike_registry: het fietsregister zonder winstoogmerk
-          menu: Menu
+      user_alerts:
+        phone_waiting_confirmation:
+          confirm_your_phone_number: Bevestig uw telefoonnummer
+          verification_code: Verificatie code
+          verify_number: Verifieer %{phone_number}
+        stolen_bike_without_location:
+          add_location_theft_bike_title_html: Voeg de locatie van de diefstal van
+            uw <strong>%{bike_title} toe</strong>
+          location_critical_html: "<strong>Het is van cruciaal belang voor herstel</strong>
+            dat u het adres of kruispunt opgeeft waar uw %{bike_type} is gestolen."
+          stolen_missing_location_title: Voeg diefstallocatie toe
+          without_location_all_is_lost: Zonder een locatie kunnen we het woord over
+            de diefstal niet verspreiden en mensen zullen niet weten waar ze naar
+            uw %{bike_type} moeten zoeken.
+        theft_alert_without_photo:
+          add_photo_theft_bike_title_html: Voeg een foto toe aan je <strong>%{bike_title}</strong>
+          missing_stolen_photo_title: Voeg een foto toe
+          photo_critical_html: Succesvolle gepromote waarschuwingen <strong>moeten
+            een afbeelding hebben</strong>
+          without_photo_all_is_lost: Als je geen foto's hebt van je %{bike_type},
+            zoek dan een stockfoto op internet en upload deze. Zonder afbeelding zal
+            de promotiemelding niet effectief zijn.
+        unfinished_registration:
+          finish_the_required_steps: Voltooi de vereiste stappen.
+          not_registered_yet_html: Uw %{cycle_type} is nog niet geregistreerd! Gelieve
+            %{finish_link}
     emails:
-      confirmation_email:
-        click_to_sign_in_html: Klik op de knop <em>Inloggen</em> om het aanmelden te
-          voltooien!
-        follow_this_link_to_sign_in: Volg deze link om in te loggen
-        sign_in: Inloggen
-        youre_almost_there: Je bent er bijna!
       partials:
         bike_box:
           bike_photo: Fietsfoto
@@ -5673,6 +5728,21 @@ nl:
           het registreren van uw <strong>%{color_and_brand}</strong> in 's werelds
           meest uitgebreide <strong>fietsregister</strong> !
         youre_almost_done: Je bent bijna klaar!
+      confirmation_email:
+        click_to_sign_in_html: Klik op de knop <em>'Inloggen'</em> om je registratie
+          te voltooien!
+        follow_this_link_to_sign_in: Volg deze link om in te loggen.
+        sign_in: Log in
+        youre_almost_there: Je bent er bijna!
+      partial_register_confirmation:
+        click_below_to_pick_up_where_you_left_off: Klik hieronder om dit e-mailadres
+          te bevestigen en verder te gaan waar u gebleven was.
+        confirm_and_continue: Bevestig mijn e-mailadres
+        confirm_your_email: bevestig je email
+        link_signs_you_in: Deze link geeft je een account bij Bike Index, dus stuur
+          hem niet door. Hij is %{days} dagen geldig.
+        we_saved_your_registration_html: We hebben uw registratie voor een <strong>%{color_and_brand}</strong>
+          opgeslagen in 's werelds meest uitgebreide fietsregister.
     messages:
       thread_show:
         can_not_send_new_message: Helaas, u kunt geen nieuw bericht versturen.
@@ -5710,10 +5780,6 @@ nl:
         year: jaar
       chart_async_frame:
         loading_chart: Grafiek laden...
-      alerts:
-        object_error:
-          errors_prevented_this_from_being_saved: "%{errors_count} heeft voorkomen
-            dat dit %{object_name} wordt opgeslagen:"
       forms:
         legacy_form_well:
           address_record:
@@ -5732,88 +5798,52 @@ nl:
           address_record_with_default:
             edit_my_account_path: bewerken op mijn account
             use_account_address: Gebruik accountadres
+        address_group:
+          address: Adres
+          choose_country: Kies land
+          city: City
+          country: Land
+          postal_code: Postcode
+          region: Regio
+          state: Staat
+          street_2: Adresregel 2
+        combobox_manufacturer:
+          placeholder: Begin bijvoorbeeld met typen %{name}
+        combobox_manufacturer_options:
+          unknown_manufacturer: Fabrikant onbekend
+        email:
+          did_you_mean_html: Bedoelde je %{email}?
+          not_real: Dat lijkt niet uw echte e-mailadres te zijn. Voer een e-mailadres
+            in waarop u e-mails ontvangt.
+          submit_anyway: Formulier toch verzenden
+        file_upload:
+          no_file_chosen: Geen bestand gekozen
+          take_picture: Maak een foto
+          upload: Uploaden
+          upload_failed: Uploaden mislukt
+          uploading: uploaden
+        group:
+          optional: optioneel
+      alerts:
+        base:
+          error: Fout
+          info: Informatie
+          notice: Merk op
+          success: Succes
+          warning: waarschuwing
+        flash_message:
+          signed_in_html: Je bent ingelogd! Je kunt %{link} gebruiken als je liever
+            niet inlogt via een link in een e-mail.
+          signed_in_link: Stel een wachtwoord in om in te loggen.
+          signed_up_html: Je hebt je aangemeld voor Bike Index! Je kunt %{link} als
+            je liever niet via een link in de e-mail wilt inloggen.
+          signed_up_link: Stel een wachtwoord in om in te loggen.
+        object_error:
+          error_prevented_this_from_being_saved:
+            one: "%{count}-fout verhinderde dat dit %{object_name} werd opgeslagen:"
+            other: "%{count}-fouten hebben ervoor gezorgd dat %{object_name} niet
+              kon worden opgeslagen:"
     org:
-      search:
-        form:
-          doesnt_look_like_serial: Dit lijkt geen serienummer. Serienummers bestaan
-            meestal uit 6 of meer letters en cijfers en bevinden zich onder de trapas.
-          search_for_serial_number: Zoek naar framenummer
-          submit: Voorleggen
-          search_notes: Zoeknotities
-          search_owner_email_or_name: Zoek naar het e-mailadres of de naam van de eigenaar.
-        wrapper:
-          affiliation: Aansluiting
-          avery_exportable: Avery Exporteerbaar
-          bike: Registratie
-          e_vehicle_propulsion: Elektrisch voertuig (aandrijving)
-          e_vehicles_for_audit: 'Elektrische voertuigen voor audit:'
-          link: Link
-          matching_bikes_html: "%{count} %{cycle_type} overeenkomend"
-          mfg_model_color_html: fabrikant, model, <span class="less-strong">kleur</span>
-          phone: Telefoon
-          reg_address: Adres
-          registered_bikes_html: "%{count} %{cycle_type} overeenkomend met %{org_name}"
-          student_id: Student-ID
-          vehicle: Registratie
-          view_matching_any_audit: weergave die overeenkomt met elke audit
-        settings:
-          address: 'Adres:'
-          all: Alle
-          avery_cell: Avery Exporteerbaar
-          bike: Registratie
-          color_cell: Kleur
-          create_export_of_vehicles: Export maken van gezochte %{cycle_type}
-          created_at_cell: Geregistreerd
-          creation_description_cell: Bron
-          cycle_type_cell: 'Voertuigtype:'
-          default: standaard
-          filter_impounded_html: alleen <strong>in beslag genomen</strong>
-          filter_no_address_html: alleen <strong>geen</strong> adres
-          filter_no_sticker_html: alleen <strong>geen</strong> sticker
-          filter_not_impounded_html: alleen <strong>niet</strong> in beslag genomen
-          filter_not_stolen_or_impounded_html: niet gestolen of in beslag genomen
-          filter_stolen_html: alleen gestolen
-          filter_with_address_html: alleen <strong>met</strong> adres
-          filter_with_stickers_html: alleen <strong>met</strong> stickers
-          impound_id_cell: Inbeslagname-ID
-          impounded_cell: In beslag genomen bij
-          manufacturer_cell: Fabrikant
-          model_cell: Model
-          none: geen
-          notes_cell: Notes
-          owner_email_cell: Verzonden naar
-          owner_name_cell: Eigenaar naam
-          propulsion_type_cell: Elektrisch voertuig (aandrijving)
-          reg_address_cell: Adres
-          reg_extra_registration_number_cell: Secundair#
-          reg_organization_affiliation_cell: Aansluiting
-          reg_phone_cell: Telefoon
-          reg_student_id_cell: Student-ID
-          serial_number_cell: Serie
-          settings: Instellingen
-          show_notes_search: notities weergeven zoeken
-          status: 'Toestand:'
-          status_cell: Toestand
-          sticker_cell: Sticker
-          stickers: 'stickers:'
-          stolen_cell: Gestolen
-          updated_at_cell: Bijgewerkt
-          url_cell: URL
-          vehicle: Registratie
-          visible_columns: Zichtbare kolommen
-          multi_search: multi serieel zoeken
-      search_results:
-        multi_result_chip:
-          no_results: geen overeenkomsten
-        multi_results:
-          first_n_shown_html: "— eerst %{limit} weergegeven,"
-          no_exact_matches: 'Geen exacte overeenkomsten. Serienummers die er dichtbij
-            liggen:'
-          no_matches_found: Geen overeenkomsten gevonden
-          result_count_html: "— %{count} %{results}"
-          serial_label: 'Serial:'
-          view_all: alles bekijken
-          sticker_label: 'Sticker:'
       location_address_fields:
         address: Adres
         choose_country: Kies land
@@ -5937,3 +5967,602 @@ nl:
         reprocess_instruction: Ga terug naar deze pagina en klik op de knop 'import
           opnieuw verwerken' hieronder.
         unknown_ascend_name: Onbekende Ascend-naam
+      parking_notification_details:
+        address: Adres
+        bike: Fiets
+        by: Gemaakt door
+        created: Gemaakt op
+        internal_notes: Interne notities
+        message: Bericht
+        notification_number: Kennisgeving#
+        resolved: Vastbesloten
+      search:
+        form:
+          doesnt_look_like_serial: Dit lijkt geen serienummer. Serienummers bestaan
+            meestal uit 6 of meer letters en cijfers en bevinden zich onder de trapas.
+          search_for_serial_number: Zoek naar framenummer
+          search_notes: Zoeknotities
+          search_owner_email_or_name: Zoek naar het e-mailadres of de naam van de
+            eigenaar.
+          submit: Voorleggen
+        settings:
+          address: 'Adres:'
+          all: Alle
+          avery_cell: Avery Exporteerbaar
+          bike: Registratie
+          color_cell: Kleur
+          create_export_of_vehicles: Export maken van gezochte %{cycle_type}
+          created_at_cell: Geregistreerd
+          creation_description_cell: Bron
+          cycle_type_cell: 'Voertuigtype:'
+          default: standaard
+          filter_impounded_html: alleen <strong>in beslag genomen</strong>
+          filter_no_address_html: alleen <strong>geen</strong> adres
+          filter_no_sticker_html: alleen <strong>geen</strong> sticker
+          filter_not_impounded_html: alleen <strong>niet</strong> in beslag genomen
+          filter_not_stolen_or_impounded_html: niet gestolen of in beslag genomen
+          filter_stolen_html: alleen gestolen
+          filter_with_address_html: alleen <strong>met</strong> adres
+          filter_with_stickers_html: alleen <strong>met</strong> stickers
+          impound_id_cell: Inbeslagname-ID
+          impounded_cell: In beslag genomen bij
+          manufacturer_cell: Fabrikant
+          model_cell: Model
+          multi_search: multi serieel zoeken
+          none: geen
+          notes_cell: Notes
+          owner_email_cell: Verzonden naar
+          owner_name_cell: Eigenaar naam
+          propulsion_type_cell: Elektrisch voertuig (aandrijving)
+          reg_address_cell: Adres
+          reg_extra_registration_number_cell: Secundair#
+          reg_organization_affiliation_cell: Aansluiting
+          reg_phone_cell: Telefoon
+          reg_student_id_cell: Student-ID
+          serial_number_cell: Serie
+          settings: Instellingen
+          show_notes_search: notities weergeven zoeken
+          status: 'Toestand:'
+          status_cell: Toestand
+          sticker_cell: Sticker
+          stickers: 'stickers:'
+          stolen_cell: Gestolen
+          updated_at_cell: Bijgewerkt
+          url_cell: URL
+          vehicle: Registratie
+          visible_columns: Zichtbare kolommen
+        wrapper:
+          affiliation: Aansluiting
+          avery_exportable: Avery Exporteerbaar
+          bike: Registratie
+          e_vehicle_propulsion: Elektrisch voertuig (aandrijving)
+          e_vehicles_for_audit: 'Elektrische voertuigen voor audit:'
+          link: Link
+          matching_bikes_html: "%{count} %{cycle_type} overeenkomend"
+          mfg_model_color_html: fabrikant, model, <span class="less-strong">kleur</span>
+          phone: Telefoon
+          reg_address: Adres
+          registered_bikes_html: "%{count} %{cycle_type} overeenkomend met %{org_name}"
+          student_id: Student-ID
+          vehicle: Registratie
+          view_matching_any_audit: weergave die overeenkomt met elke audit
+      search_results:
+        bikes_table:
+          assign_bike_sticker: Sticker toewijzen
+          avery: Avery?
+          color: Kleur
+          email_hidden: email verborgen
+          hidden_not_registered: verborgen, niet geregistreerd bij %{org_name}
+          impound_id: Inbeslagname-ID
+          impounded: In beslag genomen bij
+          link_sticker: link sticker
+          manufacturer: Fabrikant
+          model: Model
+          notes: Notes
+          owner_name: Eigenaar naam
+          propulsion_type: Voortstuwing
+          registered: Geregistreerd
+          secondary_number: Secundair#
+          sent_to: Verzonden naar
+          serial: Serie
+          source: Bron
+          status_cell: Toestand
+          sticker: Sticker
+          stolen: Gestolen
+          updated: Bijgewerkt
+          url: URL
+          vehicle_type: 'Voertuigtype:'
+        multi_result_chip:
+          no_results: geen overeenkomsten
+        multi_results:
+          first_n_shown_html: "— eerst %{limit} weergegeven,"
+          no_exact_matches: 'Geen exacte overeenkomsten. Serienummers die er dichtbij
+            liggen:'
+          no_matches_found: Geen overeenkomsten gevonden
+          result_count_html: "— %{count} %{results}"
+          serial_label: 'Serial:'
+          sticker_label: 'Sticker:'
+          view_all: alles bekijken
+    atom:
+      serial:
+        hidden: verborgen
+        hidden_because_status: omdat %{bike_type} %{status} is
+        hidden_for_unauthorized_users: verborgen voor onbevoegde gebruikers
+        made_without_serial: gemaakt zonder serie
+        unknown: Onbekend
+    register:
+      acknowledgment_check:
+        i_name_html: Ik, %{name},
+        registrants_name: naam van de registrant
+      acknowledgment_progress:
+        progress_saved: Voortgang opgeslagen · Bevestiging e-voertuig · Stap %{number}
+          van %{total}
+      back_link:
+        back: Rug
+      page:
+        retry_failed: Dat is zojuist niet gelukt — er is niets verloren gegaan van
+          wat u hebt ingevoerd. Probeer het over een moment opnieuw.
+      page_content:
+        electric_detected: "⚡️ Elektrisch (gemotoriseerd) gedetecteerd"
+        have_questions: Heeft u vragen over dit beleid?
+        read_the_faq: Veelgestelde vragen over de bevestiging van elektrische voertuigen
+      review_summary:
+        a_quick_review: Een korte samenvatting van alles wat u hebt bevestigd.
+        a_quick_review_tap: Een kort overzicht van alles wat je hebt bevestigd. Tik
+          op 'Overzicht' om een protocol opnieuw te bekijken.
+        review: Beoordeling
+        youre_almost_done: Je bent er bijna.
+      step1:
+        bike_info_html: "%{cycle_type} info"
+        electric_helper: Vink 'elektrisch' aan, zodat we e-bikes kunnen markeren en
+          de certificering kunnen controleren.
+        electric_motorized: "⚡️ Elektrisch (gemotoriseerd)"
+        email: E-mailadres
+        email_placeholder: jij@example.com
+        email_school: "%{org_name} e-mail"
+        just_the_essentials: Om te beginnen alleen de essentiële zaken.
+        next: Volgende
+        no_need_to_wait: We sturen je een bevestigingslink via e-mail; je hoeft niet
+          te wachten om verder te gaan.
+        register_your_vehicle: Registreer uw voertuig!
+        register_your_vehicle_with_org: Registreer uw voertuig met %{org_name}!
+        start_over: Begin opnieuw
+        start_over_certain: Opnieuw beginnen?
+        start_over_discards: Dit is het begin van een nieuwe registratie — niets van
+          wat u hier hebt ingevoerd, wordt overgenomen.
+        vehicle_type: 'Voertuigtype:'
+        yes_start_over: Ja, opnieuw beginnen.
+        your_info: Uw gegevens
+      step2:
+        add_another_color: Voeg nog een kleur toe
+        add_your_bikes_details: Voeg de gegevens van uw %{cycle_type} toe
+        additional_serial_sticker_number: Extra framenummer / stickernummer
+        affiliation: "%{org_name} aansluiting"
+        are_you_certain: Weet je het zeker?
+        attach_photo: Voeg een foto van %{cycle_type} toe.
+        bike_details: "%{cycle_type} details"
+        bottom_bracket: Trapas
+        cm: cm
+        color: Kleur
+        complete_registration: Voltooi de %{cycle_type}-registratie
+        confirmation_link_sent: We hebben een bevestigingslink naar je e-mailadres
+          gestuurd. Je hoeft niet te wachten — je kunt de registratie nu meteen voltooien.
+        contact_info: Contactgegevens
+        database_public_note: Onze database is openbaar! Je kunt de privacyinstellingen
+          van individuele foto's uit je registratie later aanpassen.
+        email: E-mailadres
+        enter_size: Voer de maat in
+        found: Gevonden/Verlaten
+        found_description: Ik vond dit %{cycle_type}
+        frame_size: Kadergrootte
+        from_step_1: Vanaf stap 1
+        head_tube: Balhoofdbuis
+        how_to_find_serial: hoe je het framenummer kan vinden
+        i_just_dont_know_the_serial: Ik ken de serie gewoon niet
+        im_100_sure: Ik ben 100% zeker
+        inches: inch
+        information_for_org: Informatie voor %{org_name}
+        is_a_handmade_frame: Is een handgemaakt frame
+        it_probably_has_a_serial_number: Het heeft waarschijnlijk een framenummer.
+        missing_serial: Serie ontbreekt
+        model: Model
+        model_placeholder: bijv. Marlin 7
+        model_year: Modeljaar
+        model_year_placeholder: bijv. 2023
+        more_useful_registration: Hoe meer je toevoegt, hoe nuttiger de registratie
+          wordt.
+        nevermind: Laat maar
+        next: Volgende
+        optional: optioneel
+        or: of
+        owner_name: Eigenaar naam
+        owner_name_placeholder: Voor- en achternaam
+        owner_registration: Eigenaarsregistratie
+        owner_registration_description: Registratie voor mezelf of namens de eigenaar
+        phone: Telefoon
+        phone_placeholder: "(555) 000-0000"
+        phone_required_found: Een telefoon is vereist om een gevonden %{cycle_type}
+          te registreren.
+        phone_required_stolen: Een telefoon is vereist om een gestolen %{cycle_type}
+          te registreren.
+        primary_color_blank: Primaire kleur — bijvoorbeeld zwart
+        read_how_to_find_html: Lees over %{how_to_find_link} <small>(opent in een
+          apart venster)</small>
+        rear_dropouts: Achterste uitvalnaven
+        register_with_org: Registreer met %{org_name}
+        register_with_org_description: "%{org_name} kan deze registratie bekijken
+          en helpen beheren."
+        registration_type: Registratietype
+        remove_additional_color: Verwijder kleur
+        second_color_blank: Tweede kleur — bijvoorbeeld rood
+        serial_help_intro: 'Bij de meeste fietsen is het serienummer in het frame
+          gegraveerd. Zoek uw serienummer op:'
+        serial_location_bottom_bracket: onderkant van de trapas
+        serial_location_head_tube: op de balhoofdbuis
+        serial_location_rear_dropouts: op achterste uitvalpadden
+        serial_number: Framenummer
+        serial_placeholder: Vereist — of markeer als ontbrekend
+        sticker_number: Fietsindex stickernummer
+        sticker_placeholder: bijv. A 471 829
+        stolen: Gestolen
+        stolen_description: Dit %{cycle_type} is gestolen
+        student_id: Student-ID
+        third_color_blank: Derde kleur
+        up_to_3: maximaal 3
+        very_very_few_bikes_html: 'Er worden <em>zeer</em> weinig %{cycle_types}-exemplaren
+          zonder serienummer gemaakt. Tenzij dit %{cycle_type}:'
+        view_serial_guide: Bekijk de volledige handleiding voor serienummers
+        was_made_before_1970: Werd vóór 1970 gemaakt
+        wheres_my_serial: Waar is mijn serienummer?
+        without_serial: Deze %{cycle_type} is gemaakt zonder serienummer.
+        without_serial_number: Deze %{cycle_type} is gemaakt zonder serienummer.
+      step_acknowledgment:
+        continue: Doorgaan
+      step_acknowledgment_review:
+        complete_registration: Voltooi de %{cycle_type}-registratie
+      step_confirm:
+        confirming_your_email: Uw e-mailadres wordt bevestigd.
+        continue: Doorgaan
+        continue_where_you_left_off: Ga gerust verder, dan pakken we de draad weer
+          op.
+      step_finished:
+        add_impound_details: Voeg details toe over waar je de %{cycle_type} hebt gevonden.
+        add_photos: Voeg foto's van je %{cycle_type} toe
+        confirming_lets_you: 'Door je e-mailadres te bevestigen kun je:'
+        do_these_things: Doe deze dingen voor de beste kans om het terug te krijgen.
+        finish_adding: Voltooi het toevoegen van uw %{cycle_type} aan Bike Index
+        listed_as_found: De %{bike_display} staat vermeld zoals gevonden op Bike Index.
+        listed_as_stolen: Uw %{bike_display} staat als gestolen geregistreerd op Bike
+          Index.
+        owner_can_claim: De rechtmatige eigenaar kan het hier vinden en claimen -
+          we sturen je een e-mail zodra iemand dat doet.
+        progress_saved: Voortgang opgeslagen
+        register_another: Een ander voertuig registreren
+        registered_for_owner_html: De %{bike_display} is geregistreerd bij Bike Index.
+          We hebben %{email} een e-mail gestuurd zodat zij de registratie kunnen claimen.
+        registration_complete: Registratie voltooid!
+        report_it_stolen: Voltooi de melding van uw gestolen %{cycle_type} en profiteer
+          van ons communitynetwerk.
+        reported_stolen: Gemeld als gestolen
+        verify_your_email_html: 'Nog één stap: verifieer je e-mailadres. We hebben
+          een bevestigingslink naar %{email} gestuurd; klik erop om je registratie
+          te voltooien. Alle ingevoerde gegevens zijn opgeslagen.'
+        view_the_registration: Bekijk de registratie
+        view_your_registration: Bekijk uw registratie
+        we_will_keep_watch: Jouw %{bike_display} staat geregistreerd bij Bike Index.
+          We houden het in de gaten — mocht het ooit als gestolen worden opgegeven,
+          dan zoekt de hele gemeenschap mee.
+      step_report:
+        about_the_one_you_found: Over de %{cycle_type} die je gevonden hebt
+        address_where_you_found_it: Adres waar u het gevonden heeft
+        complete_registration: Voltooi de %{cycle_type}-registratie
+        contact_and_sharing: Contact en delen
+        department_city: Afdeling/stad
+        estimated_value: Geschatte waarde (%{currency})
+        have_proof_of_ownership: Ik heb bewijs dat ik dit bezit %{cycle_type}
+        help_us_reunite: Help ons het terug te geven aan de rechtmatige eigenaar.
+        how_did_you_find_it: Hoe heb je %{cycle_type} gevonden?
+        how_was_it_locked: Hoe werd de %{cycle_type} vergrendeld?
+        how_was_the_lock_defeated: Hoe werd het slot geforceerd?
+        next: Volgende
+        police_report: Politierapport
+        receive_notifications: Stuur me een e-mail als we hierover tweeten %{cycle_type},
+          of als we een mogelijke match vinden.
+        report_number: Rapportnummer
+        report_your_stolen: Meld uw gestolen %{cycle_type}
+        show_phone_police: Politie
+        show_phone_shops: Fietsenwinkels
+        show_phone_users: Aangemelde gebruikers van Bike Index
+        the_more_we_know: Hoe meer we weten, hoe groter de kans dat we het terugkrijgen.
+        theft_details: Diefstal details
+        what_happened: Wat is er gebeurd?
+        what_happened_placeholder: bijvoorbeeld vastgeketend aan een rek buiten de
+          koffiezaak, verdwenen toen ik weer naar buiten kwam.
+        when_and_where: Wanneer en waar
+        when_did_you_find_it: Wanneer heb je het gevonden?
+        when_was_it_stolen: Wanneer werd de %{cycle_type} gestolen?
+        where_was_it_stolen: Waar is het gestolen?
+        who_can_see_your_phone: Wie kan jouw telefoonnummer zien?
+        without_a_report: Door aangifte te doen bij de politie vergroot je de kans
+          dat je %{cycle_type} terugkomt — je kunt het nummer later toevoegen.
+    registrations:
+      show:
+        bike_details:
+          frame_material: Frame materiaal
+          frame_size: Kadergrootte
+          handlebar_type: Type stuur
+          manufacturer: Fabrikant
+          model: Model
+          other_serial: Andere serie / registratie / sticker
+          serial: Serie
+          title: "%{bike_type} details"
+          vehicle_type: 'Voertuigtype:'
+          year: jaar
+        bike_index_card:
+          activity: Activiteit
+          frame_material: Frame materiaal
+          id: ID
+          registered_since: Geregistreerd sinds
+          this_bike_on_bike_index: Dit %{bike_type} op Bike Index
+        component_list:
+          component_no_info: "-"
+          componentyear: "%{componentyear}"
+          drivetrain: drivetrain
+          drivetrain_fixed: Vaste versnelling
+          drivetrain_front: Aandrijflijn voor
+          drivetrain_rear: Aandrijflijn achter
+          front: Voorkant
+          front_rear: Voor en achter
+          front_tire_width: Breedte van de voorband
+          front_wheel_diameter: Diameter voorwiel
+          full_spec_sheet: Volledige specificatielijst
+          hide: Verbergen
+          other: Ander
+          paint_description: Kleurbeschrijving
+          propulsion_type: Voortstuwing
+          rear: achterkant
+          rear_tire_width: Breedte achterband
+          rear_wheel_diameter: Diameter achterwiel
+          show_all: Alles weergeven
+          tire_width: Bandbreedte
+          tire_width_narrow_false: Brede band
+          tire_width_narrow_true: Smalle band
+          wheel_diameter: Wiel diameter
+        contact_owner:
+          contact_the_owner: Neem contact op met de eigenaar
+          know_something_about_this_bike_type: Weet u hier iets over %{bike_type}?
+          link_url: Link url
+          send_message: Verstuur bericht
+          where_did_you_see_this_bike: Waar heb je dit gezien %{bike_type}? Als u
+            contact opneemt over een advertentie die u online hebt gevonden, neemt
+            u een link op in het onderstaande veld
+        current_alerts:
+          claim_impound:
+            add_a_stolen_bike: voeg een gestolen %{bike_type} toe
+            choose_stolen_bike: Kies gestolen %{bike_type}
+            claim_found_bike: Claim gevonden %{bike_type}
+            claim_impounded_bike: Claim in beslag genomen %{bike_type}
+            claim_submitted: Deze claim werd ingediend
+            claim_was_status: Uw claim was %{status} — u had een e-mail met de vervolgstappen
+              moeten ontvangen.
+            claim_with_this_bike_type: Je hebt een %{status} claim met deze %{bike_type}.
+            does_this_look_like_your_bike: Lijkt dit op jouw %{bike_type}?
+            need_stolen_bike_html: Je hebt een gestolen %{bike_type} nodig die geregistreerd
+              is om een claim in te dienen — %{add_link}.
+            no_editing_after_submitting: Na het indienen kunt u de claim niet meer
+              wijzigen.
+            open_claim: Open claim
+            prove_its_yours: Verifieer uw eigendom — voeg details toe die bewijzen
+              dat dit %{bike_type} van u is.
+            save_message: Bericht opslaan
+            select_your_stolen_bike: Selecteer de gestolen %{bike_type} die u bezit
+              en die overeenkomt met deze inbeslagname.
+            submit_claim: Dien een claim in
+            view_claimed_bike_type: bekijk de geclaimde %{kind} %{bike_type}
+            your_claim: Uw claim
+          claim_invitation:
+            claim_bike_type: Claim %{bike_type}
+            claim_it_so_you_can_update_your_listing: Claim het zodat u uw vermelding
+              kunt bijwerken.
+            claim_your_bike_type: Claim je %{bike_type}
+            read_more: lees meer
+            registered_your_bike_on_index_html: registreer je %{bike_type} op Bike
+              Index, een gratis, non-profit platform voor het registreren en terugvinden
+              van gestolen fietsen %{read_more_link}.
+            sign_up: Registreren
+            sign_up_to_claim: Registreren
+            to_see_your_bike_sign_up_html: Om je %{bike_type} te bekijken en als je
+              eigen te claimen, %{sign_up_link} met het e-mailadres waarop je je registratiemail
+              hebt ontvangen.
+            were_honored_to_have_your_bike: We zijn vereerd dat uw %{bike_type} op
+              de index staat.
+          notification_token:
+            mark_graduated_resolved: Markeer %{bike_type} resterend
+            mark_parking_resolved: Markeer %{bike_type} opgehaald
+            no_futher_action_necessary: geen verdere actie nodig!
+            organization_sent_this_message: "%{org_name} heeft deze melding verzonden"
+            please_email_organization_with_questions_html: Stuur een e-mail naar %{email_link}
+              als u vragen heeft
+            you_have_already_marked_remaining: U heeft deze %{bike_type} al gemarkeerd
+              als resterend
+            you_have_already_marked_resolved: Je hebt deze melding als opgelost gemarkeerd
+          recovery_prompt:
+            can_we_share_your_story: Kunnen we jouw verhaal delen?
+            did_we_help: Hebben we geholpen?
+            how_did_you_get_it_back: Hoe heb je het terug gekregen?
+            its_also_how_we_get_better_at_recovering: Het is ook hoe we beter worden
+              in herstellen %{bike_type}.
+            mark_recovered: Mark herstelde zich
+            mark_your_bike_recovered: Markeer uw %{bike_type} als hersteld!
+            nevermind: Laat maar
+            please_tell_us_how_you_got_your_bike: Vertel ons alsjeblieft hoe je je
+              %{bike_type} terug hebt gekregen, het kan ons echt schelen!
+            when_did_you_recover_it: Wanneer heb je het hersteld?
+          scanned_sticker:
+            change_the_bike_sticker_linked_to: Wijzig de %{bike_type} waarnaar het
+              linkt.
+            is_this_linked_to_incorrect_bike: Is deze sticker gekoppeld aan de verkeerde
+              %{bike_type}?
+            switch_to_new_bike_id: Schakel over naar een nieuwe %{bike_type} ID
+            update: Bijwerken
+            you_scanned_this_sticker_html: Je hebt %{sticker} gescand, dat is toegewezen
+              aan dit %{bike_type}.
+          sent_to_new_owner:
+            you_sent_this_bike_html: Je hebt dit %{bike_type} naar %{owner_email}
+              gestuurd en het is nog niet opgeëist. Je kunt het bijwerken.
+        impound_details:
+          found_at: Gevonden bij
+          found_details: Details gevonden
+          impound_details: Details over inbeslagname
+          impounded_at: In beslag genomen bij
+          location: Plaats
+          org_impound_record: "%{org_name} inbeslagname record"
+        impound_record_fields:
+          created: Gemaakt
+          impounded_by: In beslag genomen door
+          impounded_from: In beslag genomen van
+          last_update_by: Laatst bijgewerkt door
+          status: Toestand
+        legacy_view_link:
+          switch_to_classic: Schakel terug naar de oude viewer.
+          using_new_view: Je probeert de nieuwe %{bike_type} viewer uit.
+          view_in_legacy: bekijk %{bike_type} in de oude viewer
+        map:
+          unavailable: De kaart kon niet worden geladen. Uw browser of apparaat ondersteunt
+            deze mogelijk niet.
+        org_top_actions:
+          impound_update:
+            title: Update het inbeslagnameregister
+          message_owner:
+            know_something_about_this_bike_type: Weet u hier iets over %{bike_type}?
+            link_url: Link url
+            send_message: Verstuur bericht
+            where_did_you_see_this_bike: Waar heb je dit gezien %{bike_type}? Als
+              u contact opneemt over een advertentie die u online hebt gevonden, neemt
+              u een link op in het onderstaande veld
+          parking_notification_form:
+            address_or_intersection: Adres of kruispunt
+            create_parking_notification: Maak een nieuwe parkeermelding aan
+            impound_this_bike_type: Neem dit in beslag %{bike_type}
+            map_hint: Verschuif de kaart zodat de speld de gewenste plek markeert.
+            map_unavailable: De kaart kon niet worden geladen; de locatie was nog
+              steeds ingesteld via uw apparaat.
+            parking_notification_notes_html: "%{org_name} interne notities worden
+              <small>niet getoond aan de gebruiker</small>"
+          parking_notification_show:
+            no_notifications: Geen parkeermeldingen voor deze %{bike_type}
+            parking_notifications: Verlaten records
+            view_all: Bekijk alle meldingen voor dit %{bike_type}
+            view_notification: Melding bekijken
+          wrapper:
+            impound: Inbeslagname
+            message_owner: Bericht eigenaar
+            new_parking_notice: Nieuwe parkeermelding
+            update_impound_record: Update inbeslagnamegegevens
+            view_notifications: Meldingen bekijken
+            view_notifications_active_html: "<strong>%{count}</strong> Actief"
+            view_notifications_resolved_html: "<strong>%{count}</strong> Opgelost"
+        owner_phone:
+          or_call: Of bel
+        photos:
+          add_photo: Foto toevoegen
+          bike_photo: "%{bike_type} foto"
+          color_may_not_match: Kleur komt mogelijk niet overeen!
+          stock_photo: Stock foto van een %{year} %{model}
+        primary_colors:
+          primary_color:
+            one: Primaire kleur
+            other: Primaire kleuren
+        status:
+          found: Gevonden
+          impounded: In beslag genomen bij
+          not_stolen: Niet gestolen
+          stolen: Gestolen
+          unregistered: Niet geregistreerd
+        stolen_details:
+          department_city: Afdeling & stad
+          description_of_incident: Beschrijving van het incident
+          location: Plaats
+          locking_circumvented: Vergrendeling omzeild
+          locking_description: Beschrijving vergrendeling
+          police_report: 'Politierapport #'
+          stolen_at: Gestolen op
+          stolen_details: Diefstal details
+        toggle_view:
+          switch_to_legacy_default: Schakel standaard over naar de oude viewer.
+          switch_to_new: Schakel over naar de nieuwe weergave
+          try_new_view: Probeer de nieuwe %{bike_type} viewer eens uit!
+          view_in_new: Bekijken in een nieuwe viewer
+          viewing_in_legacy: Oude viewer (standaard gebruikt u de nieuwe viewer)
+        wrapper_consumer:
+          about_this_bike: Over dit %{bike_type}
+          audience_owner: Uw %{bike_type}
+          audience_public: Openbaar zicht
+          audience_sent_away: Niet langer jouw %{bike_type}
+          edit_this_bike: Bewerk dit %{bike_type}
+          mark_stolen: Gestolen merk
+          registered_protected: Geregistreerd en beschermd
+          sell_on_marketplace: Verkoop via de marktplaats
+          share: Deel
+          share_my_page: Deel mijn pagina
+        wrapper_org_admin:
+          about_this_bike: Over dit %{bike_type}
+          assign_sticker: Sticker toewijzen
+          audit: Audit van elektrische voertuigen
+          avery_exportable: Avery Exporteerbaar
+          claimed: beweerde
+          creation_source: Bron
+          creator: Schepper
+          credibility: Geloofwaardigheid
+          edit: Bewerken
+          has_duplicate_serials: heeft dubbele serienummers
+          internal_notes: Interne notities
+          is_false: vals
+          is_true: waar
+          link_sticker: Link sticker
+          no_duplicate_serials: geen dubbele serienummers
+          no_other_registrations: Geen gevonden
+          no_registration_information: Geen registratiegegevens zichtbaar voor %{org_name}
+          not_audited: Niet gecontroleerd
+          not_registered_message: Voor fietsen buiten uw organisatie is het niet mogelijk
+            om contact op te nemen met de eigenaar. U kunt wel interne notities toevoegen.
+          not_registered_title: Niet geregistreerd bij %{org_name}
+          note_by: Opmerking van %{user}
+          notes_placeholder: Nieuwe interne notitie — je vorige notities blijven in
+            dit gesprek bewaard.
+          org_can_edit: "%{org_name} kan deze %{bike_type} bewerken"
+          org_can_edit_sub: Ook nadat %{bike_type} is geclaimd.
+          organization_registered: Organisatie
+          other_registrations: Andere registraties door deze gebruiker
+          other_registrations_count_html: "%{count} andere registraties"
+          owner_access: Eigenaar & toegang
+          owner_email: E-mailadres
+          owner_name: Naam
+          owner_phone: Telefoon
+          photo_archive: Fotoarchief
+          post_note: Post-notitie
+          posts_as: Berichten als %{user}
+          registration_information: Registratiegegevens
+          registration_number: Fietsindexregistratie
+          restricted_message: De contactgegevens van de eigenaar zijn beschikbaar
+            voor de administratie en het personeel. U kunt notities toevoegen en een
+            inbeslagname aanvragen.
+          restricted_title: Beperkt voor uw rol
+          role_limited: Beperkt
+          role_staff: Personeel
+          showing_recent: De meest recente %{count} weergeven
+          sticker: Sticker
+          sticker_claimed: beweerde
+          sticker_code: Stickercode
+          unregistered_owner: Deze %{bike_type} is niet geregistreerd bij een gebruiker.
+            Het is toegevoegd om parkeermeldingen te volgen.
+          view_all_registrations: alles bekijken →
+    sessions:
+      sign_in_interstitial:
+        click_button_to_continue: Klik op de onderstaande knop om verder te gaan.
+        finish_signing_in: Voltooi het inlogproces
+        sign_in: Log in
+  user_emails:
+    confirm:
+      confirm_email: E-mail bevestigen
+      confirm_this_email: Bevestig %{user_email}

--- a/spec/components/admin/navbar/component_spec.rb
+++ b/spec/components/admin/navbar/component_spec.rb
@@ -41,24 +41,16 @@ RSpec.describe Admin::Navbar::Component, type: :component do
   end
 
   describe "the shortcut links" do
-    let(:active_shortcut) { "ul.navbar-nav a.active" }
-
-    context "on a shortcut's own page" do
-      let(:url) { admin_bikes }
-
-      it "marks only that shortcut active" do
-        expect(component.css(active_shortcut).map(&:text)).to eq(["Bikes"])
-      end
-    end
+    let(:shortcuts) { component.css("ul.navbar-nav a[data-controller='ui--active-link']") }
 
     # The shortcuts take their match from nav_select_links, so they stay active across a
-    # section rather than only on its index
-    context "on another page of the shortcut's controller" do
-      let(:url) { "#{admin_bikes}/duplicates" }
-
-      it "keeps that shortcut active" do
-        expect(component.css(active_shortcut).map(&:text)).to eq(["Bikes"])
-      end
+    # section rather than only on its index. UI::ActiveLink resolves that in the browser,
+    # against the route rendered here.
+    it "matches each shortcut on its controller" do
+      expect(shortcuts.map { |link| link["data-ui--active-link-match-value"] }.uniq).to eq(["controller"])
+      expect(shortcuts.map { |link| link["data-ui--active-link-route-value"] })
+        .to eq(%w[admin/users#index admin/bikes#index admin/organizations#index admin/news#index
+          admin/stolen_bikes#index])
     end
   end
 

--- a/spec/components/admin/navbar/component_spec.rb
+++ b/spec/components/admin/navbar/component_spec.rb
@@ -49,8 +49,7 @@ RSpec.describe Admin::Navbar::Component, type: :component do
     it "matches each shortcut on its controller" do
       expect(shortcuts.map { |link| link["data-ui--active-link-match-value"] }.uniq).to eq(["controller"])
       expect(shortcuts.map { |link| link["data-ui--active-link-routes-value"] })
-        .to eq(%w[admin/users#index admin/bikes#index admin/organizations#index admin/news#index
-          admin/stolen_bikes#index])
+        .to eq(%w[admin/users admin/bikes admin/organizations admin/news admin/stolen_bikes])
     end
   end
 

--- a/spec/components/admin/navbar/component_spec.rb
+++ b/spec/components/admin/navbar/component_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe Admin::Navbar::Component, type: :component do
     # against the route rendered here.
     it "matches each shortcut on its controller" do
       expect(shortcuts.map { |link| link["data-ui--active-link-match-value"] }.uniq).to eq(["controller"])
-      expect(shortcuts.map { |link| link["data-ui--active-link-route-value"] })
+      expect(shortcuts.map { |link| link["data-ui--active-link-routes-value"] })
         .to eq(%w[admin/users#index admin/bikes#index admin/organizations#index admin/news#index
           admin/stolen_bikes#index])
     end

--- a/spec/components/org/menu_items/component_spec.rb
+++ b/spec/components/org/menu_items/component_spec.rb
@@ -108,7 +108,7 @@ RSpec.describe Org::MenuItems::Component, type: :component do
           }
           link = rendered.css("a.nav-link").detect { |a| a.text.strip == "Manage Registration sequences" }
           expect(link["data-ui--active-link-routes-value"])
-            .to eq "organized/registration_sequences#index organized/registration_sequence_pages"
+            .to eq "organized/registration_sequences organized/registration_sequence_pages"
         end
       end
 

--- a/spec/components/org/menu_items/component_spec.rb
+++ b/spec/components/org/menu_items/component_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Org::MenuItems::Component, type: :component do
   let(:instance) do
     described_class.new(organization:, current_user:, controller_namespace:, controller_name:, action_name:)
   end
-  # The request drives UI::ActiveLink, which resolves the items the cache didn't mark
+  # The controller and action decide which links are injected, not which one is active
   let(:url) { "/o/#{organization.to_param}/#{controller_name}" }
   let(:component) { with_request_url(url) { render_inline(instance) } }
   let(:organization) { FactoryBot.create(:organization) }
@@ -97,15 +97,18 @@ RSpec.describe Org::MenuItems::Component, type: :component do
     context "as a superuser, with the org lacking the registration_sequences feature" do
       let(:current_user) { FactoryBot.create(:superuser) }
 
-      it "injects an active Manage Registration sequences link on the sequences and pages controllers" do
+      # The link covers both controllers, so the browser keeps it active while a page of a
+      # sequence is being edited
+      it "injects a Manage Registration sequences link on the sequences and pages controllers" do
         expect(organization.enabled?("registration_sequences")).to be false
         %w[registration_sequences registration_sequence_pages].each do |sequences_controller|
           rendered = with_request_url(url) {
             render_inline(described_class.new(organization:, current_user:, controller_namespace:,
               controller_name: sequences_controller, action_name:))
           }
-          active = rendered.css("a.nav-link.active").map { |a| a.text.strip }
-          expect(active).to include("Manage Registration sequences")
+          link = rendered.css("a.nav-link").detect { |a| a.text.strip == "Manage Registration sequences" }
+          expect(link["data-ui--active-link-routes-value"])
+            .to eq "organized/registration_sequences#index organized/registration_sequence_pages"
         end
       end
 

--- a/spec/components/page_block/footer/component_spec.rb
+++ b/spec/components/page_block/footer/component_spec.rb
@@ -19,6 +19,14 @@ RSpec.describe PageBlock::Footer::Component, type: :component do
     expect(component.to_html).to_not include("&quot;")
   end
 
+  # One cached render serves every page, so an action would send the language switch to
+  # whichever page filled the cache
+  it "renders the locale form without an action" do
+    form = component.css("form.locale-form").first
+    expect(form.attributes).to_not have_key("action")
+    expect(form["data-controller"]).to eq "page-block--locale-select"
+  end
+
   context "with skip_facebook" do
     let(:skip_facebook) { true }
     it "renders the footer without the facebook pixel" do

--- a/spec/components/page_block/footer/component_spec.rb
+++ b/spec/components/page_block/footer/component_spec.rb
@@ -5,7 +5,7 @@ require "rails_helper"
 RSpec.describe PageBlock::Footer::Component, type: :component do
   it_behaves_like "cached_markup_digest"
 
-  let(:instance) { described_class.new(current_user: nil, skip_facebook:, page_id: "welcome_index") }
+  let(:instance) { described_class.new(current_user: nil, skip_facebook:) }
   let(:component) { with_request_url("/") { render_inline(instance) } }
   let(:skip_facebook) { false }
   let(:pixel_id) { PageBlock::Footer::Component::FACEBOOK_PIXEL_ID }
@@ -34,7 +34,7 @@ RSpec.describe PageBlock::Footer::Component, type: :component do
     # one language serves the footer cached in another. See ApplicationComponentHelper#cache.
     it "varies the cached fragment by locale" do
       en = with_request_url("/") { render_inline(instance) }.to_html
-      nl = I18n.with_locale(:nl) { with_request_url("/") { render_inline(described_class.new(current_user: nil, skip_facebook:, page_id: "welcome_index")) } }.to_html
+      nl = I18n.with_locale(:nl) { with_request_url("/") { render_inline(described_class.new(current_user: nil, skip_facebook:)) } }.to_html
       expect(en).to include("Privacy policy")
       expect(nl).to_not include("Privacy policy")
     end

--- a/spec/components/page_block/footer/component_system_spec.rb
+++ b/spec/components/page_block/footer/component_system_spec.rb
@@ -7,8 +7,9 @@ RSpec.describe PageBlock::Footer::Component, :js, type: :system do
   before { FactoryBot.create(:exchange_rate_to_eur) }
 
   # The form carries no action, so the language has to land on the page the browser is on,
-  # keeping the params it was reached with
-  it "switches the language on the current page, and leaves the default language off the URL" do
+  # keeping the params it was reached with. Switching back names the language too, rather
+  # than dropping the param -- a visitor whose browser asks for Dutch needs it to reach English
+  it "switches the language on the current page, and back" do
     visit "/?example=1"
     wait_for_stimulus
     select "Nederlands (Dutch)", from: "locale"
@@ -16,23 +17,6 @@ RSpec.describe PageBlock::Footer::Component, :js, type: :system do
 
     wait_for_stimulus
     select "English (Engels)", from: "locale"
-    expect(page).to have_current_path("/?example=1")
-  end
-
-  # A Dutch browser renders Dutch with no param, so English is the language that needs one --
-  # dropping it for the default would land this visitor back in Dutch
-  context "with a browser asking for a non-default language" do
-    before do
-      page.driver.with_playwright_page do |playwright_page|
-        playwright_page.context.set_extra_http_headers("Accept-Language" => "nl,en;q=0.9")
-      end
-    end
-
-    it "adds the param for the default language" do
-      visit "/?example=1"
-      wait_for_stimulus
-      select "English (Engels)", from: "locale"
-      expect(page).to have_current_path("/?example=1&locale=en")
-    end
+    expect(page).to have_current_path("/?example=1&locale=en")
   end
 end

--- a/spec/components/page_block/footer/component_system_spec.rb
+++ b/spec/components/page_block/footer/component_system_spec.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe PageBlock::Footer::Component, :js, type: :system do
+  # Without a rate, rendering in euros redirects to the root url in the default locale
+  before { FactoryBot.create(:exchange_rate_to_eur) }
+
+  # The form carries no action, so the language has to land on the page the browser is on,
+  # keeping the params it was reached with
+  it "switches the language on the current page, and leaves the default language off the URL" do
+    visit "/?example=1"
+    wait_for_stimulus
+    select "Nederlands (Dutch)", from: "locale"
+    expect(page).to have_current_path("/?example=1&locale=nl")
+
+    wait_for_stimulus
+    select "English (Engels)", from: "locale"
+    expect(page).to have_current_path("/?example=1")
+  end
+
+  # A Dutch browser renders Dutch with no param, so English is the language that needs one --
+  # dropping it for the default would land this visitor back in Dutch
+  context "with a browser asking for a non-default language" do
+    before do
+      page.driver.with_playwright_page do |playwright_page|
+        playwright_page.context.set_extra_http_headers("Accept-Language" => "nl,en;q=0.9")
+      end
+    end
+
+    it "adds the param for the default language" do
+      visit "/?example=1"
+      wait_for_stimulus
+      select "English (Engels)", from: "locale"
+      expect(page).to have_current_path("/?example=1&locale=en")
+    end
+  end
+end

--- a/spec/components/page_block/main_content/content/component_spec.rb
+++ b/spec/components/page_block/main_content/content/component_spec.rb
@@ -34,10 +34,10 @@ RSpec.describe PageBlock::MainContent::Content::Component, type: :component do
 
     it "swaps the info links for the news links" do
       expect(component.text).to_not match "Where"
-      # The browser marks it current, and only on the index with no search of its own
+      # The related section's link replaces the one "Other pages" carries elsewhere
       link = component.css("a[href='#{news_index_path}']")
       expect(link.count).to eq 1
-      expect(link.first["data-ui--active-link-match-value"]).to eq "unfiltered_path"
+      expect(link.first["data-ui--active-link-match-value"]).to eq "path"
       expect(component.text).to match "Bike Index Store"
     end
   end

--- a/spec/components/page_block/main_content/content/component_spec.rb
+++ b/spec/components/page_block/main_content/content/component_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe PageBlock::MainContent::Content::Component, type: :component do
       # The browser marks it current, and only on the index with no search of its own
       link = component.css("a[href='#{news_index_path}']")
       expect(link.count).to eq 1
-      expect(link.first["data-ui--active-link-match-value"]).to eq "full_path"
+      expect(link.first["data-ui--active-link-match-value"]).to eq "unfiltered_path"
       expect(component.text).to match "Bike Index Store"
     end
   end

--- a/spec/components/page_block/main_content/content/component_spec.rb
+++ b/spec/components/page_block/main_content/content/component_spec.rb
@@ -34,7 +34,10 @@ RSpec.describe PageBlock::MainContent::Content::Component, type: :component do
 
     it "swaps the info links for the news links" do
       expect(component.text).to_not match "Where"
-      expect(component.css("a[href='#{news_index_path}'][aria-current]").count).to eq 1
+      # The browser marks it current, and only on the index with no search of its own
+      link = component.css("a[href='#{news_index_path}']")
+      expect(link.count).to eq 1
+      expect(link.first["data-ui--active-link-match-value"]).to eq "full_path"
       expect(component.text).to match "Bike Index Store"
     end
   end

--- a/spec/components/page_block/navbar/menu_link/component_spec.rb
+++ b/spec/components/page_block/navbar/menu_link/component_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe PageBlock::Navbar::MenuLink::Component, type: :component do
 
     it "matches on the controller rather than the path" do
       expect(link["data-ui--active-link-match-value"]).to eq "controller"
-      expect(link["data-ui--active-link-routes-value"]).to eq "news#index"
+      expect(link["data-ui--active-link-routes-value"]).to eq "news"
     end
   end
 

--- a/spec/components/page_block/navbar/menu_link/component_spec.rb
+++ b/spec/components/page_block/navbar/menu_link/component_spec.rb
@@ -7,56 +7,27 @@ RSpec.describe PageBlock::Navbar::MenuLink::Component, type: :component do
   let(:args) { {label: "Help", path: "/help"} }
   let(:link) { component.css("a").first }
 
-  # UI::ActiveLink resolves the state in the browser, so an item that passes no :active
-  # renders the controller rather than a class
-  it "leaves the current-page check to the path when active is omitted" do
+  # UI::ActiveLink resolves the state in the browser, so the item renders the controller
+  # rather than a class
+  it "matches on the path by default" do
     expect(component).to have_css "a.nav-link[href='/help']", text: "Help"
     expect(link["data-controller"]).to eq "ui--active-link"
     expect(link["data-ui--active-link-match-value"]).to eq "path"
   end
 
-  context "with active: false" do
-    let(:args) { {label: "Help", path: "/help", active: false} }
-
-    it "pins the link inactive, without the browser resolving it" do
-      expect(component).to_not have_css "a.active"
-      expect(link.attributes).to_not have_key("data-controller")
-    end
-  end
-
-  context "with active: true" do
-    let(:args) { {label: "Search", path: "/search/registrations", active: true} }
-
-    it "renders active regardless of the path" do
-      expect(component).to have_css "a.nav-link.active[href='/search/registrations']"
-      expect(link.attributes).to_not have_key("data-controller")
-    end
-  end
-
-  context "with active: :match_controller" do
-    let(:args) { {label: "Blog", path: "/news", active: :match_controller} }
+  context "with match: :controller" do
+    let(:args) { {label: "Blog", path: "/news", match: :controller} }
 
     it "matches on the controller rather than the path" do
       expect(link["data-ui--active-link-match-value"]).to eq "controller"
-      expect(link["data-ui--active-link-route-value"]).to eq "news#index"
+      expect(link["data-ui--active-link-routes-value"]).to eq "news#index"
     end
   end
 
-  # The manifests' vocabulary is an alias layer over UI::ActiveLink's own match names, which
-  # a caller can pass straight through
-  context "with active: :controller, UI::ActiveLink's name for it" do
-    let(:args) { {label: "Blog", path: "/news", active: :controller} }
-
-    it "matches the same as :match_controller" do
-      expect(link["data-ui--active-link-match-value"]).to eq "controller"
-    end
-  end
-
-  context "with an unrecognized active" do
-    # nil used to mean :auto, so a caller reaching for a falsey value has to say which
+  context "with an unrecognized match" do
     it "raises rather than picking a state" do
-      expect { described_class.new(label: "Help", path: "/help", active: nil) }
-        .to raise_error(ArgumentError, /Invalid active/)
+      expect { render_inline(described_class.new(label: "Help", path: "/help", match: :nonsense)) }
+        .to raise_error(ArgumentError, /match/)
     end
   end
 

--- a/spec/components/page_block/navbar/menu_link/component_spec.rb
+++ b/spec/components/page_block/navbar/menu_link/component_spec.rb
@@ -3,56 +3,42 @@
 require "rails_helper"
 
 RSpec.describe PageBlock::Navbar::MenuLink::Component, type: :component do
-  let(:component) { with_request_url(url) { render_inline(described_class.new(**args)) } }
-  let(:url) { "/help" }
+  let(:component) { render_inline(described_class.new(**args)) }
   let(:args) { {label: "Help", path: "/help"} }
+  let(:link) { component.css("a").first }
 
-  it "resolves active from the path when active is omitted" do
-    expect(component).to have_css "a.nav-link.active[href='/help']", text: "Help"
-  end
-
-  context "on another page" do
-    let(:url) { "/" }
-
-    it "renders inactive" do
-      expect(component).to have_css "a.nav-link[href='/help']"
-      expect(component).to_not have_css "a.active"
-    end
+  # UI::ActiveLink resolves the state in the browser, so an item that passes no :active
+  # renders the controller rather than a class
+  it "leaves the current-page check to the path when active is omitted" do
+    expect(component).to have_css "a.nav-link[href='/help']", text: "Help"
+    expect(link["data-controller"]).to eq "ui--active-link"
+    expect(link["data-ui--active-link-match-value"]).to eq "path"
   end
 
   context "with active: false" do
     let(:args) { {label: "Help", path: "/help", active: false} }
 
-    # active: false pins the link inactive even on its own page — index.coffee sets
-    # #getStolenBackLink's state, because the navbar renders from a cached fragment
-    it "stays inactive on its own page" do
+    it "pins the link inactive, without the browser resolving it" do
       expect(component).to_not have_css "a.active"
+      expect(link.attributes).to_not have_key("data-controller")
     end
   end
 
   context "with active: true" do
     let(:args) { {label: "Search", path: "/search/registrations", active: true} }
-    let(:url) { "/" }
 
     it "renders active regardless of the path" do
       expect(component).to have_css "a.nav-link.active[href='/search/registrations']"
+      expect(link.attributes).to_not have_key("data-controller")
     end
   end
 
   context "with active: :match_controller" do
     let(:args) { {label: "Blog", path: "/news", active: :match_controller} }
-    let(:url) { "/news/some-post" }
 
     it "matches on the controller rather than the path" do
-      expect(component).to have_css "a.nav-link.active[href='/news']"
-    end
-
-    context "on another controller" do
-      let(:url) { "/help" }
-
-      it "renders inactive" do
-        expect(component.css("a").first["class"]).to eq "nav-link"
-      end
+      expect(link["data-ui--active-link-match-value"]).to eq "controller"
+      expect(link["data-ui--active-link-route-value"]).to eq "news#index"
     end
   end
 
@@ -60,10 +46,9 @@ RSpec.describe PageBlock::Navbar::MenuLink::Component, type: :component do
   # a caller can pass straight through
   context "with active: :controller, UI::ActiveLink's name for it" do
     let(:args) { {label: "Blog", path: "/news", active: :controller} }
-    let(:url) { "/news/some-post" }
 
     it "matches the same as :match_controller" do
-      expect(component).to have_css "a.nav-link.active[href='/news']"
+      expect(link["data-ui--active-link-match-value"]).to eq "controller"
     end
   end
 
@@ -77,7 +62,6 @@ RSpec.describe PageBlock::Navbar::MenuLink::Component, type: :component do
 
   context "with link_class and html_options" do
     let(:args) { {label: "Sign up", path: "/users/new", link_class: "signup-link", html_options: {id: "signUp"}} }
-    let(:url) { "/" }
 
     it "adds them to the anchor" do
       expect(component).to have_css "a#signUp.nav-link.signup-link[href='/users/new']"

--- a/spec/components/page_block/navbar/primary_menu/component_spec.rb
+++ b/spec/components/page_block/navbar/primary_menu/component_spec.rb
@@ -23,9 +23,9 @@ RSpec.describe PageBlock::Navbar::PrimaryMenu::Component, type: :component do
   # The links carry a stolenness the page won't, and the page carries a query and a page
   # number they don't, so the route is what matches
   it "matches the search and marketplace links on their route" do
-    expect(links_named("Search").map { |link| link["data-ui--active-link-route-value"] })
+    expect(links_named("Search").map { |link| link["data-ui--active-link-routes-value"] })
       .to eq(["search/registrations#index"] * 2)
-    expect(links_named("Marketplace").map { |link| link["data-ui--active-link-route-value"] })
+    expect(links_named("Marketplace").map { |link| link["data-ui--active-link-routes-value"] })
       .to eq(["search/marketplace#index"] * 2)
     expect(links_named("Blog").map { |link| link["data-ui--active-link-match-value"] })
       .to eq(["controller"])

--- a/spec/components/page_block/navbar/primary_menu/component_spec.rb
+++ b/spec/components/page_block/navbar/primary_menu/component_spec.rb
@@ -4,53 +4,31 @@ require "rails_helper"
 
 RSpec.describe PageBlock::Navbar::PrimaryMenu::Component, type: :component do
   let(:current_user) { nil }
-  let(:request_url) { "/" }
   let(:instance) do
     described_class.new(current_user:, current_user_or_unconfirmed_user: current_user)
   end
-  # The request drives UI::ActiveLink, which resolves every item that passes no :active
-  let(:component) { with_request_url(request_url) { render_inline(instance) } }
+  let(:component) { render_inline(instance) }
   let(:menu_links) { component.css("#primary-main-menu a").map { |link| link.text.strip } }
 
-  it "renders the signed out menu" do
+  def links_named(label) = component.css("#primary-main-menu a").select { |link| link.text.strip == label }
+
+  it "renders the signed out menu, with every item's state left to the browser" do
     expect(menu_links).to eq(["Search", "Marketplace", "Sign up", "log in", "Help",
       "Stolen bike?", "Donate", "Blog", "Marketplace", "Search"])
     expect(component).to_not have_css "#setting_submenu"
     expect(component).to_not have_css "#primary-main-menu a.active"
+    expect(component.css("#primary-main-menu a[data-controller='ui--active-link']").count).to eq menu_links.count
   end
 
-  # The links carry query params the page won't, which is why they match on controller and action
-  context "on the registration search page" do
-    let(:request_url) { "/search/registrations?query=trek" }
-
-    it "marks both registration search links active" do
-      expect(component.css("#primary-main-menu a.active").map { |link| link.text.strip }).to eq(%w[Search Search])
-    end
-
-    context "on page 2" do
-      let(:request_url) { "/search/registrations?stolenness=all&page=2" }
-
-      it "marks them active" do
-        expect(component.css("#primary-main-menu a.active").map { |link| link.text.strip }).to eq(%w[Search Search])
-      end
-    end
-
-    # The link points at stolenness=all, but every stolenness is the same search page
-    context "searching a different stolenness" do
-      let(:request_url) { "/search/registrations?stolenness=stolen" }
-
-      it "marks them active" do
-        expect(component.css("#primary-main-menu a.active").map { |link| link.text.strip }).to eq(%w[Search Search])
-      end
-    end
-  end
-
-  context "on the marketplace search page" do
-    let(:request_url) { "/search/marketplace" }
-
-    it "marks both marketplace links active" do
-      expect(component.css("#primary-main-menu a.active").map { |link| link.text.strip }).to eq(%w[Marketplace Marketplace])
-    end
+  # The links carry a stolenness the page won't, and the page carries a query and a page
+  # number they don't, so the route is what matches
+  it "matches the search and marketplace links on their route" do
+    expect(links_named("Search").map { |link| link["data-ui--active-link-route-value"] })
+      .to eq(["search/registrations#index"] * 2)
+    expect(links_named("Marketplace").map { |link| link["data-ui--active-link-route-value"] })
+      .to eq(["search/marketplace#index"] * 2)
+    expect(links_named("Blog").map { |link| link["data-ui--active-link-match-value"] })
+      .to eq(["controller"])
   end
 
   context "with a current_user" do

--- a/spec/components/page_block/navbar/primary_menu/component_spec.rb
+++ b/spec/components/page_block/navbar/primary_menu/component_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe PageBlock::Navbar::PrimaryMenu::Component, type: :component do
     expect(menu_links).to eq(["Search", "Marketplace", "Sign up", "log in", "Help",
       "Stolen bike?", "Donate", "Blog", "Marketplace", "Search"])
     expect(component).to_not have_css "#setting_submenu"
-    expect(component).to_not have_css "#primary-main-menu a.active"
+    expect(component).to_not have_css "#primary-main-menu a[aria-current]"
     expect(component.css("#primary-main-menu a[data-controller='ui--active-link']").count).to eq menu_links.count
   end
 

--- a/spec/components/page_block/navbar/wrapper/component_spec.rb
+++ b/spec/components/page_block/navbar/wrapper/component_spec.rb
@@ -9,9 +9,8 @@ RSpec.describe PageBlock::Navbar::Wrapper::Component, type: :component do
   let(:passive_organization) { nil }
   let(:instance) do
     described_class.new(current_user:, current_user_or_unconfirmed_user: current_user, passive_organization:,
-      page_id: "welcome_index", controller_namespace: nil, controller_name: "welcome", action_name: "index")
+      controller_namespace: nil, controller_name: "welcome", action_name: "index")
   end
-  # The request drives UI::ActiveLink, which resolves the items that pass no :active
   let(:component) { with_request_url("/") { render_inline(instance) } }
 
   it "renders the logo, the primary menu and the signed out signup link" do
@@ -52,13 +51,6 @@ RSpec.describe PageBlock::Navbar::Wrapper::Component, type: :component do
     end
   end
 
-  context "without page_id" do
-    it "raises rather than caching every page under one key" do
-      expect { described_class.new(current_user: nil, current_user_or_unconfirmed_user: nil) }
-        .to raise_error(ArgumentError, /page_id/)
-    end
-  end
-
   describe "caching", :caching do
     include_context :caching_basic
 
@@ -69,6 +61,29 @@ RSpec.describe PageBlock::Navbar::Wrapper::Component, type: :component do
       nl = I18n.with_locale(:nl) { with_request_url("/") { render_inline(instance) } }.to_html
       expect(en).to include("Stolen bike?")
       expect(nl).to_not include("Stolen bike?")
+    end
+
+    # The organization menu renders outside the cache, so the link it re-adds on its own
+    # page isn't served to every other page from a fragment cached on one of them
+    context "with an organization lacking the bulk imports feature" do
+      let(:current_user) { FactoryBot.create(:organization_user, organization: passive_organization) }
+      let(:passive_organization) { FactoryBot.create(:organization) }
+      let(:on_bulk_imports) do
+        described_class.new(current_user:, current_user_or_unconfirmed_user: current_user,
+          passive_organization:, controller_namespace: "organized", controller_name: "bulk_imports",
+          action_name: "index")
+      end
+
+      it "re-adds its link on the bulk imports page, having cached another page first" do
+        expect(passive_organization.show_bulk_import?).to be false
+        expect(component).to_not have_css ".current-organization-submenu a", text: "Bulk Imports"
+
+        rendered = with_request_url("/o/#{passive_organization.to_param}/bulk_imports") do
+          render_inline(on_bulk_imports)
+        end
+        expect(rendered).to have_css ".current-organization-submenu a", text: "Bulk Imports"
+        expect(rendered).to have_css "#primary-main-menu"
+      end
     end
   end
 end

--- a/spec/components/ui/active_link/component_spec.rb
+++ b/spec/components/ui/active_link/component_spec.rb
@@ -40,20 +40,6 @@ RSpec.describe UI::ActiveLink::Component, type: :component do
       end
     end
 
-    context ":unfiltered_path" do
-      let(:path) { "/news" }
-      let(:options) { {match: :unfiltered_path} }
-
-      # The browser can't ask sortable_search_params?, so it gets the names it asks about
-      it "carries the params that count as a search" do
-        expect(link["data-ui--active-link-match-value"]).to eq "unfiltered_path"
-        filters = link["data-ui--active-link-filters-value"].split(" ")
-        expect(filters).to include("query", "stolenness", "serial")
-        # Paging and sorting don't narrow the page, so they aren't searches
-        expect(filters).to_not include("page", "per_page", "sort", "direction", "period")
-      end
-    end
-
     context ":controller" do
       let(:path) { "/news" }
       let(:options) { {match: :controller} }

--- a/spec/components/ui/active_link/component_spec.rb
+++ b/spec/components/ui/active_link/component_spec.rb
@@ -105,13 +105,13 @@ RSpec.describe UI::ActiveLink::Component, type: :component do
       expect(link["data-controller"]).to eq "ui--dropdown ui--active-link"
     end
 
+    # aria-current is the browser's to set, so the server leaves the caller's aria alone
     context "including aria" do
-      let(:request_url) { path }
       let(:options) { {aria: {label: "Help center"}} }
 
-      it "keeps them, alongside the current it marks" do
+      it "keeps them, and marks no current" do
         expect(link["aria-label"]).to eq "Help center"
-        expect(link["aria-current"]).to eq "page"
+        expect(link.attributes).to_not have_key("aria-current")
       end
     end
   end

--- a/spec/components/ui/active_link/component_spec.rb
+++ b/spec/components/ui/active_link/component_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe UI::ActiveLink::Component, type: :component do
     expect(link["data-controller"]).to eq "ui--active-link"
     expect(link["data-ui--active-link-match-value"]).to eq "path"
     # :path compares the URL the browser is already on, so there's no route to compare
-    expect(link.attributes).to_not have_key("data-ui--active-link-route-value")
+    expect(link.attributes).to_not have_key("data-ui--active-link-routes-value")
   end
 
   context "with html_class" do
@@ -28,13 +28,32 @@ RSpec.describe UI::ActiveLink::Component, type: :component do
   end
 
   describe "match" do
+    context ":full_path" do
+      let(:path) { "/o/example/bikes/new?parking_notification=true" }
+      let(:options) { {match: :full_path} }
+
+      it "compares in the browser, like :path" do
+        expect(link["data-ui--active-link-match-value"]).to eq "full_path"
+        expect(link.attributes).to_not have_key("data-ui--active-link-routes-value")
+      end
+    end
+
     context ":controller" do
       let(:path) { "/news" }
       let(:options) { {match: :controller} }
 
       it "carries the link's own route, which the page's is compared against" do
         expect(link["data-ui--active-link-match-value"]).to eq "controller"
-        expect(link["data-ui--active-link-route-value"]).to eq "news#index"
+        expect(link["data-ui--active-link-routes-value"]).to eq "news#index"
+      end
+
+      context "with matching_controllers" do
+        let(:options) { {match: :controller, matching_controllers: ["organized/registration_sequence_pages"]} }
+
+        it "adds them to the routes the browser compares" do
+          expect(link["data-ui--active-link-routes-value"])
+            .to eq "news#index organized/registration_sequence_pages"
+        end
       end
     end
 
@@ -44,7 +63,7 @@ RSpec.describe UI::ActiveLink::Component, type: :component do
 
       it "carries the route the params are dropped from" do
         expect(link["data-ui--active-link-match-value"]).to eq "controller_action"
-        expect(link["data-ui--active-link-route-value"]).to eq "search/registrations#index"
+        expect(link["data-ui--active-link-routes-value"]).to eq "search/registrations#index"
       end
     end
 
@@ -53,7 +72,7 @@ RSpec.describe UI::ActiveLink::Component, type: :component do
       let(:options) { {match: :controller} }
 
       it "renders no route, so the link never goes active" do
-        expect(link.attributes).to_not have_key("data-ui--active-link-route-value")
+        expect(link.attributes).to_not have_key("data-ui--active-link-routes-value")
       end
     end
 
@@ -62,104 +81,6 @@ RSpec.describe UI::ActiveLink::Component, type: :component do
 
       it "raises" do
         expect { component }.to raise_error(ArgumentError, /match/)
-      end
-    end
-  end
-
-  describe "active" do
-    context "true" do
-      let(:options) { {active: true, html_class: "nav-link"} }
-
-      it "renders the class, and no controller to resolve what it already knows" do
-        expect(link["class"]).to eq "nav-link active"
-        expect(link.attributes).to_not have_key("data-controller")
-      end
-    end
-
-    context "false" do
-      let(:options) { {active: false} }
-
-      it "renders neither" do
-        expect(link.attributes).to_not have_key("class")
-        expect(link.attributes).to_not have_key("data-controller")
-      end
-    end
-  end
-
-  # A menu picking out its current entry asks the class method, rather than rendering a link
-  # to find out — Admin::Navbar's picker does
-  describe ".active?" do
-    let(:match) { :path }
-    let(:request_url) { "/" }
-    let(:active) do
-      with_request_url(request_url) do
-        described_class.active?(path:, match:, view: vc_test_controller.view_context)
-      end
-    end
-
-    it "is false off the page the link points at" do
-      expect(active).to be false
-    end
-
-    context "on the linked page" do
-      let(:request_url) { path }
-
-      it "is true" do
-        expect(active).to be true
-      end
-    end
-
-    context "with match: :controller" do
-      let(:match) { :controller }
-      let(:path) { "/bikes/new" }
-      let(:request_url) { "/bikes/12" }
-
-      it "is true on another page of the same controller" do
-        expect(active).to be true
-      end
-
-      context "on a page of a different controller" do
-        let(:request_url) { "/help" }
-
-        it "is false" do
-          expect(active).to be false
-        end
-      end
-    end
-
-    context "with match: :controller_action" do
-      let(:match) { :controller_action }
-      let(:path) { "/search/registrations?stolenness=all" }
-      let(:request_url) { "/search/registrations?query=trek" }
-
-      # What a link carrying query params needs — the URL won't compare equal
-      it "is true on the same action, reached with different params" do
-        expect(active).to be true
-      end
-
-      context "on a different controller's index" do
-        let(:request_url) { "/search/marketplace" }
-
-        it "is false" do
-          expect(active).to be false
-        end
-      end
-
-      # A failed update re-renders the form, so the page is a PATCH dispatching bikes#update.
-      # Recognizing that URL as a GET compares bikes#show, and the link goes active on a page
-      # it doesn't point at
-      context "on a page rendered by a non-GET request" do
-        let(:path) { "/bikes/12" }
-        let(:request_url) { path }
-
-        it "compares the action the request dispatched, not the GET route's" do
-          expect(active).to be true
-
-          on_patch = with_request_url(request_url, method: "PATCH") do
-            described_class.active?(path:, match:, view: vc_test_controller.view_context)
-          end
-          expect(on_patch).to be false
-        end
       end
     end
   end
@@ -173,13 +94,13 @@ RSpec.describe UI::ActiveLink::Component, type: :component do
   end
 
   context "with html_options and data" do
-    let(:options) { {id: "footer-help", target: "_blank", data: {turbo: false}} }
+    let(:options) { {id: "footer-help", target: "_blank", data: {turbo: false, controller: "ui--dropdown"}} }
 
-    it "passes them through to the anchor, alongside the controller" do
+    it "passes them through to the anchor, and keeps the caller's controller" do
       expect(link["id"]).to eq "footer-help"
       expect(link["target"]).to eq "_blank"
       expect(link["data-turbo"]).to eq "false"
-      expect(link["data-controller"]).to eq "ui--active-link"
+      expect(link["data-controller"]).to eq "ui--dropdown ui--active-link"
     end
   end
 

--- a/spec/components/ui/active_link/component_spec.rb
+++ b/spec/components/ui/active_link/component_spec.rb
@@ -4,89 +4,144 @@ require "rails_helper"
 
 RSpec.describe UI::ActiveLink::Component, type: :component do
   let(:path) { "/help" }
-  let(:request_url) { "/" }
   let(:options) { {} }
   let(:instance) { described_class.new(text: "Help", path:, **options) }
-  let(:component) { with_request_url(request_url) { render_inline(instance) } }
+  let(:component) { render_inline(instance) }
   let(:link) { component.css("a").first }
 
-  it "renders a plain link when it isn't the current page" do
+  it "renders a link the browser resolves the state of" do
     expect(link["href"]).to eq path
     expect(link.text).to eq "Help"
     expect(link.attributes).to_not have_key("class")
-  end
-
-  context "on the linked page" do
-    let(:request_url) { path }
-
-    it "marks the link active" do
-      expect(link["class"]).to eq "active"
-    end
+    expect(link["data-controller"]).to eq "ui--active-link"
+    expect(link["data-ui--active-link-match-value"]).to eq "path"
+    # :path compares the URL the browser is already on, so there's no route to compare
+    expect(link.attributes).to_not have_key("data-ui--active-link-route-value")
   end
 
   context "with html_class" do
     let(:options) { {html_class: "nav-link"} }
 
-    it "renders the class on its own" do
+    it "renders the class on its own, for the controller to append to" do
       expect(link["class"]).to eq "nav-link"
+    end
+  end
+
+  describe "match" do
+    context ":controller" do
+      let(:path) { "/news" }
+      let(:options) { {match: :controller} }
+
+      it "carries the link's own route, which the page's is compared against" do
+        expect(link["data-ui--active-link-match-value"]).to eq "controller"
+        expect(link["data-ui--active-link-route-value"]).to eq "news#index"
+      end
+    end
+
+    context ":controller_action" do
+      let(:path) { "/search/registrations?stolenness=all" }
+      let(:options) { {match: :controller_action} }
+
+      it "carries the route the params are dropped from" do
+        expect(link["data-ui--active-link-match-value"]).to eq "controller_action"
+        expect(link["data-ui--active-link-route-value"]).to eq "search/registrations#index"
+      end
+    end
+
+    context "with a path that isn't a route" do
+      let(:path) { "/not-a-route" }
+      let(:options) { {match: :controller} }
+
+      it "renders no route, so the link never goes active" do
+        expect(link.attributes).to_not have_key("data-ui--active-link-route-value")
+      end
+    end
+
+    context "with an unknown match" do
+      let(:options) { {match: :nonsense} }
+
+      it "raises" do
+        expect { component }.to raise_error(ArgumentError, /match/)
+      end
+    end
+  end
+
+  describe "active" do
+    context "true" do
+      let(:options) { {active: true, html_class: "nav-link"} }
+
+      it "renders the class, and no controller to resolve what it already knows" do
+        expect(link["class"]).to eq "nav-link active"
+        expect(link.attributes).to_not have_key("data-controller")
+      end
+    end
+
+    context "false" do
+      let(:options) { {active: false} }
+
+      it "renders neither" do
+        expect(link.attributes).to_not have_key("class")
+        expect(link.attributes).to_not have_key("data-controller")
+      end
+    end
+  end
+
+  # A menu picking out its current entry asks the class method, rather than rendering a link
+  # to find out — Admin::Navbar's picker does
+  describe ".active?" do
+    let(:match) { :path }
+    let(:request_url) { "/" }
+    let(:active) do
+      with_request_url(request_url) do
+        described_class.active?(path:, match:, view: vc_test_controller.view_context)
+      end
+    end
+
+    it "is false off the page the link points at" do
+      expect(active).to be false
     end
 
     context "on the linked page" do
       let(:request_url) { path }
 
-      it "appends active" do
-        expect(link["class"]).to eq "nav-link active"
+      it "is true" do
+        expect(active).to be true
       end
     end
-  end
 
-  describe "match" do
-    let(:path) { "/bikes/new" }
-    let(:request_url) { "/bikes/12" }
+    context "with match: :controller" do
+      let(:match) { :controller }
+      let(:path) { "/bikes/new" }
+      let(:request_url) { "/bikes/12" }
 
-    it "defaults to :path, so another page of the controller isn't active" do
-      expect(link["class"]).to be_blank
-    end
-
-    context ":controller" do
-      let(:options) { {match: :controller} }
-
-      it "is active on another page of the same controller" do
-        expect(link["class"]).to eq "active"
+      it "is true on another page of the same controller" do
+        expect(active).to be true
       end
 
       context "on a page of a different controller" do
         let(:request_url) { "/help" }
 
-        it "isn't active" do
-          expect(link["class"]).to be_blank
+        it "is false" do
+          expect(active).to be false
         end
       end
     end
 
-    context ":controller_action" do
-      let(:options) { {match: :controller_action} }
-
-      it "isn't active on a different action of the same controller" do
-        expect(link["class"]).to be_blank
-      end
+    context "with match: :controller_action" do
+      let(:match) { :controller_action }
+      let(:path) { "/search/registrations?stolenness=all" }
+      let(:request_url) { "/search/registrations?query=trek" }
 
       # What a link carrying query params needs — the URL won't compare equal
-      context "on the same action, reached with different params" do
-        let(:path) { "/search/registrations?stolenness=all" }
-        let(:request_url) { "/search/registrations?query=trek" }
-
-        it "is active" do
-          expect(link["class"]).to eq "active"
-        end
+      it "is true on the same action, reached with different params" do
+        expect(active).to be true
       end
 
       context "on a different controller's index" do
-        let(:path) { "/search/registrations?stolenness=all" }
         let(:request_url) { "/search/marketplace" }
 
-        it "isn't active" do
-          expect(link["class"]).to be_blank
+        it "is false" do
+          expect(active).to be false
         end
       end
 
@@ -95,41 +150,16 @@ RSpec.describe UI::ActiveLink::Component, type: :component do
       # it doesn't point at
       context "on a page rendered by a non-GET request" do
         let(:path) { "/bikes/12" }
+        let(:request_url) { path }
 
         it "compares the action the request dispatched, not the GET route's" do
-          on_get = with_request_url(path) { render_inline(instance) }
-          expect(on_get.css("a").first["class"]).to eq "active"
+          expect(active).to be true
 
-          on_patch = with_request_url(path, method: "PATCH") { render_inline(instance) }
-          expect(on_patch.css("a").first["class"]).to be_blank
+          on_patch = with_request_url(request_url, method: "PATCH") do
+            described_class.active?(path:, match:, view: vc_test_controller.view_context)
+          end
+          expect(on_patch).to be false
         end
-      end
-    end
-  end
-
-  context "with an unknown match" do
-    let(:options) { {match: :nonsense} }
-
-    it "raises" do
-      expect { component }.to raise_error(ArgumentError, /match/)
-    end
-  end
-
-  describe "active" do
-    context "forced true off the linked page" do
-      let(:options) { {active: true} }
-
-      it "skips the current page check" do
-        expect(link["class"]).to eq "active"
-      end
-    end
-
-    context "forced false on the linked page" do
-      let(:request_url) { path }
-      let(:options) { {active: false} }
-
-      it "skips the current page check" do
-        expect(link.attributes).to_not have_key("class")
       end
     end
   end
@@ -142,20 +172,20 @@ RSpec.describe UI::ActiveLink::Component, type: :component do
     end
   end
 
-  context "with html_options" do
-    let(:options) { {id: "footer-help", target: "_blank"} }
+  context "with html_options and data" do
+    let(:options) { {id: "footer-help", target: "_blank", data: {turbo: false}} }
 
-    it "passes them through to the anchor" do
+    it "passes them through to the anchor, alongside the controller" do
       expect(link["id"]).to eq "footer-help"
       expect(link["target"]).to eq "_blank"
+      expect(link["data-turbo"]).to eq "false"
+      expect(link["data-controller"]).to eq "ui--active-link"
     end
   end
 
   context "with block content in place of text" do
     let(:instance) { described_class.new(path:) }
-    let(:component) do
-      with_request_url(request_url) { render_inline(instance) { "<strong>Block</strong>".html_safe } }
-    end
+    let(:component) { render_inline(instance) { "<strong>Block</strong>".html_safe } }
 
     it "renders the block inside the link" do
       expect(link.css("strong").text).to eq "Block"
@@ -170,7 +200,7 @@ RSpec.describe UI::ActiveLink::Component, type: :component do
     end
 
     context "with a block that renders blank" do
-      let(:component) { with_request_url(request_url) { render_inline(instance) { "" } } }
+      let(:component) { render_inline(instance) { "" } }
 
       it "raises too" do
         expect { component }.to raise_error(ArgumentError, /text:/)

--- a/spec/components/ui/active_link/component_spec.rb
+++ b/spec/components/ui/active_link/component_spec.rb
@@ -27,6 +27,13 @@ RSpec.describe UI::ActiveLink::Component, type: :component do
     end
   end
 
+  # The controller can't read the constant, so the copy in it drifts silently otherwise
+  it "keeps the browser's ROUTE_MATCHES list in step with its own" do
+    js = Rails.root.join("app/javascript/controllers/ui/active_link_controller.js").read
+    expect(js[/const ROUTE_MATCHES = \[(.*?)\]/m, 1].scan(/'([a-z_]+)'/).flatten)
+      .to eq described_class::ROUTE_MATCHES.map(&:to_s)
+  end
+
   # Only :path can say "page" — the widened matches go active on a page the link doesn't
   # point at, so they say "true"
   describe "match" do
@@ -46,7 +53,7 @@ RSpec.describe UI::ActiveLink::Component, type: :component do
 
       it "carries the link's own route, which the page's is compared against" do
         expect(link["data-ui--active-link-match-value"]).to eq "controller"
-        expect(link["data-ui--active-link-routes-value"]).to eq "news#index"
+        expect(link["data-ui--active-link-routes-value"]).to eq "news"
       end
 
       context "with matching_controllers" do
@@ -54,7 +61,7 @@ RSpec.describe UI::ActiveLink::Component, type: :component do
 
         it "adds them to the routes the browser compares" do
           expect(link["data-ui--active-link-routes-value"])
-            .to eq "news#index organized/registration_sequence_pages"
+            .to eq "news organized/registration_sequence_pages"
         end
       end
     end
@@ -66,6 +73,14 @@ RSpec.describe UI::ActiveLink::Component, type: :component do
       it "carries the route the params are dropped from" do
         expect(link["data-ui--active-link-match-value"]).to eq "controller_action"
         expect(link["data-ui--active-link-routes-value"]).to eq "search/registrations#index"
+      end
+    end
+
+    context "with matching_controllers on a match that can't use them" do
+      let(:options) { {match: :controller_action, matching_controllers: ["news"]} }
+
+      it "raises rather than rendering entries the browser will never compare" do
+        expect { component }.to raise_error(ArgumentError, /matching_controllers/)
       end
     end
 

--- a/spec/components/ui/active_link/component_spec.rb
+++ b/spec/components/ui/active_link/component_spec.rb
@@ -40,6 +40,20 @@ RSpec.describe UI::ActiveLink::Component, type: :component do
       end
     end
 
+    context ":unfiltered_path" do
+      let(:path) { "/news" }
+      let(:options) { {match: :unfiltered_path} }
+
+      # The browser can't ask sortable_search_params?, so it gets the names it asks about
+      it "carries the params that count as a search" do
+        expect(link["data-ui--active-link-match-value"]).to eq "unfiltered_path"
+        filters = link["data-ui--active-link-filters-value"].split(" ")
+        expect(filters).to include("query", "stolenness", "serial")
+        # Paging and sorting don't narrow the page, so they aren't searches
+        expect(filters).to_not include("page", "per_page", "sort", "direction", "period")
+      end
+    end
+
     context ":controller" do
       let(:path) { "/news" }
       let(:options) { {match: :controller} }

--- a/spec/components/ui/active_link/component_spec.rb
+++ b/spec/components/ui/active_link/component_spec.rb
@@ -19,10 +19,10 @@ RSpec.describe UI::ActiveLink::Component, type: :component do
     expect(link.attributes).to_not have_key("data-ui--active-link-routes-value")
   end
 
-  context "with html_class" do
-    let(:options) { {html_class: "nav-link"} }
+  context "with a class" do
+    let(:options) { {class: "nav-link"} }
 
-    it "renders the class on its own, for the controller to append to" do
+    it "renders it untouched -- the browser marks current with aria-current, not a class" do
       expect(link["class"]).to eq "nav-link"
     end
   end
@@ -84,14 +84,6 @@ RSpec.describe UI::ActiveLink::Component, type: :component do
       it "raises" do
         expect { component }.to raise_error(ArgumentError, /match/)
       end
-    end
-  end
-
-  context "with a class in html_options" do
-    let(:options) { {class: "nav-link"} }
-
-    it "raises, since html_class is the way in" do
-      expect { component }.to raise_error(ArgumentError, /html_class/)
     end
   end
 

--- a/spec/components/ui/active_link/component_system_spec.rb
+++ b/spec/components/ui/active_link/component_system_spec.rb
@@ -40,6 +40,26 @@ RSpec.describe UI::ActiveLink::Component, :js, type: :system do
     expect(page).to have_css "a[aria-current='page']", text: "This preview"
   end
 
+  # What sortable_search_params? draws the line at: paging and sorting leave the index this
+  # link's page, a search doesn't
+  it "keeps an unfiltered_path link current through paging, but not through a search" do
+    visit "#{preview_path}/match_unfiltered_path"
+    expect(page).to have_css "a[aria-current='page']", text: "This preview, unsearched"
+
+    visit "#{preview_path}/match_unfiltered_path?page=2&sort=title&direction=asc&period=all"
+    expect(page).to have_css "a[aria-current='page']", text: "This preview, unsearched"
+
+    visit "#{preview_path}/match_unfiltered_path?query=trek"
+    expect(page).to have_css "a.twlink", text: "This preview, unsearched"
+    expect(page).to_not have_css "a[aria-current]"
+
+    visit "#{preview_path}/match_unfiltered_path?period=week"
+    expect(page).to_not have_css "a[aria-current]"
+
+    visit "#{preview_path}/match_unfiltered_path?search_tags=commuting"
+    expect(page).to_not have_css "a[aria-current]"
+  end
+
   # The navbar renders from a fragment cache shared by every page it was rendered for, so
   # the current page can't be in the cached markup
   it "marks the navbar's link to the page being viewed" do

--- a/spec/components/ui/active_link/component_system_spec.rb
+++ b/spec/components/ui/active_link/component_system_spec.rb
@@ -26,6 +26,19 @@ RSpec.describe UI::ActiveLink::Component, :js, type: :system do
     expect(page).to_not have_css "a.active"
   end
 
+  # The param the page carries is what :path ignores and :full_path doesn't
+  it "counts the query string only where the match says to" do
+    visit "#{preview_path}/match_full_path"
+    expect(page).to have_css "a.active", text: "This preview, exactly"
+
+    visit "#{preview_path}/match_full_path?example=1"
+    expect(page).to have_css "a.nav-link", text: "This preview, exactly"
+    expect(page).to_not have_css "a.active"
+
+    visit "#{preview_path}/current_page?example=1"
+    expect(page).to have_css "a.active", text: "This preview"
+  end
+
   # The navbar renders from a fragment cache shared by every page it was rendered for, so
   # the active link can't be in the cached markup
   it "marks the navbar's link to the page being viewed" do

--- a/spec/components/ui/active_link/component_system_spec.rb
+++ b/spec/components/ui/active_link/component_system_spec.rb
@@ -7,47 +7,48 @@ RSpec.describe UI::ActiveLink::Component, :js, type: :system do
 
   it "resolves each match against the page in the browser" do
     visit "#{preview_path}/current_page"
-    expect(page).to have_css "a.active", text: "This preview"
+    expect(page).to have_css "a[aria-current='page']", text: "This preview"
 
     # Every scenario is served by the preview controller, so a link to a sibling scenario
     # is the same page to :controller and a different one to :path
     visit "#{preview_path}/match_path"
-    expect(page).to have_css "a.nav-link", text: "A sibling preview"
-    expect(page).to_not have_css "a.active"
+    expect(page).to have_css "a.twlink", text: "A sibling preview"
+    expect(page).to_not have_css "a[aria-current]"
 
+    # A widened match is only "true" -- the page isn't the one the link points at
     visit "#{preview_path}/match_controller"
-    expect(page).to have_css "a.active", text: "A sibling preview"
+    expect(page).to have_css "a[aria-current='true']", text: "A sibling preview"
 
     # The link carries a param the page doesn't
     visit "#{preview_path}/match_controller_action"
-    expect(page).to have_css "a.active", text: "This scenario, other params"
+    expect(page).to have_css "a[aria-current='true']", text: "This scenario, other params"
 
     visit "#{preview_path}/default"
-    expect(page).to_not have_css "a.active"
+    expect(page).to_not have_css "a[aria-current]"
   end
 
   # The param the page carries is what :path ignores and :full_path doesn't
   it "counts the query string only where the match says to" do
     visit "#{preview_path}/match_full_path"
-    expect(page).to have_css "a.active", text: "This preview, exactly"
+    expect(page).to have_css "a[aria-current='page']", text: "This preview, exactly"
 
     visit "#{preview_path}/match_full_path?example=1"
-    expect(page).to have_css "a.nav-link", text: "This preview, exactly"
-    expect(page).to_not have_css "a.active"
+    expect(page).to have_css "a.twlink", text: "This preview, exactly"
+    expect(page).to_not have_css "a[aria-current]"
 
     visit "#{preview_path}/current_page?example=1"
-    expect(page).to have_css "a.active", text: "This preview"
+    expect(page).to have_css "a[aria-current='page']", text: "This preview"
   end
 
   # The navbar renders from a fragment cache shared by every page it was rendered for, so
-  # the active link can't be in the cached markup
+  # the current page can't be in the cached markup
   it "marks the navbar's link to the page being viewed" do
     visit "/help"
-    expect(page).to have_css "#primary-main-menu a.active", text: "Help", visible: :all
-    expect(page).to have_css "#primary-main-menu a.active", count: 1, visible: :all
+    expect(page).to have_css "#primary-main-menu a[aria-current]", text: "Help", visible: :all
+    expect(page).to have_css "#primary-main-menu a[aria-current]", count: 1, visible: :all
 
     # Both search links carry a stolenness this page doesn't, so they match on route
     visit "/search/registrations?query=trek"
-    expect(page).to have_css "#primary-main-menu a.active", text: "Search", count: 2, visible: :all
+    expect(page).to have_css "#primary-main-menu a[aria-current='true']", text: "Search", count: 2, visible: :all
   end
 end

--- a/spec/components/ui/active_link/component_system_spec.rb
+++ b/spec/components/ui/active_link/component_system_spec.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe UI::ActiveLink::Component, :js, type: :system do
+  let(:preview_path) { "/rails/view_components/ui/active_link/component" }
+
+  it "resolves each match against the page in the browser" do
+    visit "#{preview_path}/current_page"
+    expect(page).to have_css "a.active", text: "This preview"
+
+    # Every scenario is served by the preview controller, so a link to a sibling scenario
+    # is the same page to :controller and a different one to :path
+    visit "#{preview_path}/match_path"
+    expect(page).to have_css "a.nav-link", text: "A sibling preview"
+    expect(page).to_not have_css "a.active"
+
+    visit "#{preview_path}/match_controller"
+    expect(page).to have_css "a.active", text: "A sibling preview"
+
+    # The link carries a param the page doesn't
+    visit "#{preview_path}/match_controller_action"
+    expect(page).to have_css "a.active", text: "This scenario, other params"
+
+    visit "#{preview_path}/default"
+    expect(page).to_not have_css "a.active"
+  end
+
+  # The navbar renders from a fragment cache shared by every page it was rendered for, so
+  # the active link can't be in the cached markup
+  it "marks the navbar's link to the page being viewed" do
+    visit "/help"
+    expect(page).to have_css "#primary-main-menu a.active", text: "Help", visible: :all
+    expect(page).to have_css "#primary-main-menu a.active", count: 1, visible: :all
+
+    # Both search links carry a stolenness this page doesn't, so they match on route
+    visit "/search/registrations?query=trek"
+    expect(page).to have_css "#primary-main-menu a.active", text: "Search", count: 2, visible: :all
+  end
+end

--- a/spec/components/ui/active_link/component_system_spec.rb
+++ b/spec/components/ui/active_link/component_system_spec.rb
@@ -40,26 +40,6 @@ RSpec.describe UI::ActiveLink::Component, :js, type: :system do
     expect(page).to have_css "a[aria-current='page']", text: "This preview"
   end
 
-  # What sortable_search_params? draws the line at: paging and sorting leave the index this
-  # link's page, a search doesn't
-  it "keeps an unfiltered_path link current through paging, but not through a search" do
-    visit "#{preview_path}/match_unfiltered_path"
-    expect(page).to have_css "a[aria-current='page']", text: "This preview, unsearched"
-
-    visit "#{preview_path}/match_unfiltered_path?page=2&sort=title&direction=asc&period=all"
-    expect(page).to have_css "a[aria-current='page']", text: "This preview, unsearched"
-
-    visit "#{preview_path}/match_unfiltered_path?query=trek"
-    expect(page).to have_css "a.twlink", text: "This preview, unsearched"
-    expect(page).to_not have_css "a[aria-current]"
-
-    visit "#{preview_path}/match_unfiltered_path?period=week"
-    expect(page).to_not have_css "a[aria-current]"
-
-    visit "#{preview_path}/match_unfiltered_path?search_tags=commuting"
-    expect(page).to_not have_css "a[aria-current]"
-  end
-
   # The navbar renders from a fragment cache shared by every page it was rendered for, so
   # the current page can't be in the cached markup
   it "marks the navbar's link to the page being viewed" do

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -79,13 +79,13 @@ RSpec.describe ApplicationHelper, type: :helper do
         allow(view).to receive(:controller_namespace) { "organized" }
       end
       it "returns organized-body" do
-        expect(helper.body_class).to eq "organized-body"
+        expect(helper.send(:body_class)).to eq "organized-body"
       end
     end
     context "landing_page controller" do
       before { allow(view).to receive(:controller_name) { "landing_pages" } }
       it "returns organized-body" do
-        expect(helper.body_class).to eq "landing-page-body"
+        expect(helper.send(:body_class)).to eq "landing-page-body"
       end
     end
     context "bikes controller" do
@@ -96,7 +96,7 @@ RSpec.describe ApplicationHelper, type: :helper do
         allow(view).to receive(:controller_namespace) { nil }
       end
       it "returns nil" do
-        expect(helper.body_class).to be_nil
+        expect(helper.send(:body_class)).to be_nil
       end
     end
     context "info controller resources" do
@@ -105,7 +105,7 @@ RSpec.describe ApplicationHelper, type: :helper do
         allow(view).to receive(:action_name) { "resources" }
       end
       it "returns kelsey_landing-page-body" do
-        expect(helper.body_class).to eq "kelsey_landing-page-body"
+        expect(helper.send(:body_class)).to eq "kelsey_landing-page-body"
       end
     end
   end

--- a/spec/integration/search/search_marketplace_spec.rb
+++ b/spec/integration/search/search_marketplace_spec.rb
@@ -78,6 +78,9 @@ RSpec.describe "Marketplace infinite scroll", :js, type: :system do
   # matching option, then submit. Works whether the combobox starts empty or
   # already has a selection (set replaces the existing text).
   def search_primary_activity(display_name)
+    # Each call follows a page load, and a combobox typed into before its controller connects
+    # swallows the first character
+    wait_for_stimulus
     type_into("#primary_activity", display_name)
     expect(page).to have_css(".hw-combobox__option", text: display_name, wait: 5)
     click_combobox_option(display_name)

--- a/spec/requests/api/v3/me_request_spec.rb
+++ b/spec/requests/api/v3/me_request_spec.rb
@@ -27,11 +27,11 @@ RSpec.describe "Me API V3", type: :request do
         [
           {type: "link", label: "#{organization.short_name} Bikes",
            path: "/o/#{organization.slug}/registrations",
-           secondary: false, active: "on_registrations_index"},
+           secondary: false, match: "controller_action", matching_controllers: []},
           {type: "disabled", label: "Incomplete registrations", secondary: true},
           {type: "link", label: "Add a bike",
            path: "/o/#{organization.slug}/bikes/new",
-           secondary: false, active: "on_bikes_new"},
+           secondary: false, match: "full_path", matching_controllers: []},
           {type: "divider"},
           {type: "disabled", label: "Registration stickers", secondary: false}
         ]

--- a/spec/requests/locale_detection_request_spec.rb
+++ b/spec/requests/locale_detection_request_spec.rb
@@ -128,15 +128,6 @@ RSpec.describe "Locale detection", type: :request do
         expect(current_user.reload.preferred_language).to eq nil
       end
 
-      # The footer's language switcher only adds ?locale= for a language other than this one,
-      # so it has to be the locale a param-less request lands on rather than the rendered one
-      it "hands the browser the locale a param-less request would render in" do
-        current_user.update_attribute :preferred_language, :nl
-        get "/", params: {locale: :en}, headers: {"HTTP_ACCEPT_LANGUAGE" => "en-US,en;q=0.9"}
-        expect(response.body).to match(/bike registration/i)
-        expect(response.body).to include(%(data-implicit-locale="nl"))
-      end
-
       it "falls back to the app default if no other locales are provided or recognized" do
         allow(I18n).to receive(:default_locale).and_return(:nl)
         current_user.update(preferred_language: nil)

--- a/spec/requests/locale_detection_request_spec.rb
+++ b/spec/requests/locale_detection_request_spec.rb
@@ -128,6 +128,15 @@ RSpec.describe "Locale detection", type: :request do
         expect(current_user.reload.preferred_language).to eq nil
       end
 
+      # The footer's language switcher only adds ?locale= for a language other than this one,
+      # so it has to be the locale a param-less request lands on rather than the rendered one
+      it "hands the browser the locale a param-less request would render in" do
+        current_user.update_attribute :preferred_language, :nl
+        get "/", params: {locale: :en}, headers: {"HTTP_ACCEPT_LANGUAGE" => "en-US,en;q=0.9"}
+        expect(response.body).to match(/bike registration/i)
+        expect(response.body).to include(%(data-implicit-locale="nl"))
+      end
+
       it "falls back to the app default if no other locales are provided or recognized" do
         allow(I18n).to receive(:default_locale).and_return(:nl)
         current_user.update(preferred_language: nil)

--- a/spec/services/organized_services/user_menu_items_spec.rb
+++ b/spec/services/organized_services/user_menu_items_spec.rb
@@ -6,17 +6,17 @@ RSpec.describe OrganizedServices::UserMenuItems do
   describe "for" do
     subject(:items) { described_class.for(organization:, current_user:) }
 
-    define_method(:link_item) do |label, path, secondary: false, active: :auto|
-      {type: :link, label:, path:, secondary:, active:}
+    define_method(:link_item) do |label, path, secondary: false, match: :path, matching_controllers: []|
+      {type: :link, label:, path:, secondary:, match:, matching_controllers:}
     end
 
     context "with a basic organization" do
       let(:organization) { FactoryBot.create(:organization) }
       let(:target) do
         [
-          link_item("#{organization.short_name} Bikes", "/o/#{organization.to_param}/registrations", active: :on_registrations_index),
+          link_item("#{organization.short_name} Bikes", "/o/#{organization.to_param}/registrations", match: :controller_action),
           {type: :disabled, label: "Incomplete registrations", secondary: true},
-          link_item("Add a bike", "/o/#{organization.to_param}/bikes/new", active: :on_bikes_new),
+          link_item("Add a bike", "/o/#{organization.to_param}/bikes/new", match: :full_path),
           {type: :divider},
           {type: :disabled, label: "Registration stickers", secondary: false}
         ]
@@ -47,10 +47,10 @@ RSpec.describe OrganizedServices::UserMenuItems do
       end
       let(:target) do
         [
-          link_item("#{organization.short_name} Bikes", "/o/#{organization.to_param}/registrations", active: :on_registrations_index),
-          link_item("Impounded Bikes", "/o/#{organization.to_param}/impound_records", secondary: true, active: :match_controller),
+          link_item("#{organization.short_name} Bikes", "/o/#{organization.to_param}/registrations", match: :controller_action),
+          link_item("Impounded Bikes", "/o/#{organization.to_param}/impound_records", secondary: true, match: :controller),
           {type: :disabled, label: "Incomplete registrations", secondary: true},
-          link_item("Add a bike", "/o/#{organization.to_param}/bikes/new", active: :on_bikes_new),
+          link_item("Add a bike", "/o/#{organization.to_param}/bikes/new", match: :full_path),
           {type: :divider},
           {type: :disabled, label: "Registration stickers", secondary: false}
         ]
@@ -64,12 +64,12 @@ RSpec.describe OrganizedServices::UserMenuItems do
       let(:current_user) { FactoryBot.create(:superuser) }
       let(:target) do
         [
-          link_item("#{organization.short_name} Bikes", "/o/#{organization.to_param}/registrations", active: :on_registrations_index),
+          link_item("#{organization.short_name} Bikes", "/o/#{organization.to_param}/registrations", match: :controller_action),
           {type: :disabled, label: "Incomplete registrations", secondary: true},
-          link_item("Add a bike", "/o/#{organization.to_param}/bikes/new", active: :on_bikes_new),
+          link_item("Add a bike", "/o/#{organization.to_param}/bikes/new", match: :full_path),
           {type: :divider},
           {type: :disabled, label: "Registration stickers", secondary: false},
-          link_item("Manage users", "/o/#{organization.to_param}/users", active: :match_controller),
+          link_item("Manage users", "/o/#{organization.to_param}/users", match: :controller),
           link_item("#{organization.short_name} profile", "/o/#{organization.to_param}/manage"),
           link_item("#{organization.short_name} locations", "/o/#{organization.to_param}/manage/locations")
         ]
@@ -83,12 +83,12 @@ RSpec.describe OrganizedServices::UserMenuItems do
       let(:current_user) { FactoryBot.create(:organization_admin, organization:) }
       let(:target) do
         [
-          link_item("#{organization.short_name} Bikes", "/o/#{organization.to_param}/registrations", active: :on_registrations_index),
+          link_item("#{organization.short_name} Bikes", "/o/#{organization.to_param}/registrations", match: :controller_action),
           {type: :disabled, label: "Incomplete registrations", secondary: true},
-          link_item("Add a bike", "/o/#{organization.to_param}/bikes/new", active: :on_bikes_new),
+          link_item("Add a bike", "/o/#{organization.to_param}/bikes/new", match: :full_path),
           {type: :divider},
           {type: :disabled, label: "Registration stickers", secondary: false},
-          link_item("Manage users", "/o/#{organization.to_param}/users", active: :match_controller),
+          link_item("Manage users", "/o/#{organization.to_param}/users", match: :controller),
           link_item("#{organization.short_name} profile", "/o/#{organization.to_param}/manage"),
           link_item("#{organization.short_name} locations", "/o/#{organization.to_param}/manage/locations")
         ]
@@ -105,15 +105,15 @@ RSpec.describe OrganizedServices::UserMenuItems do
       let(:current_user) { FactoryBot.create(:organization_admin, organization:) }
       let(:target) do
         [
-          link_item("#{organization.short_name} Bikes", "/o/#{organization.to_param}/registrations", active: :on_registrations_index),
+          link_item("#{organization.short_name} Bikes", "/o/#{organization.to_param}/registrations", match: :controller_action),
           {type: :disabled, label: "Incomplete registrations", secondary: true},
-          link_item("Add a bike", "/o/#{organization.to_param}/bikes/new", active: :on_bikes_new),
+          link_item("Add a bike", "/o/#{organization.to_param}/bikes/new", match: :full_path),
           {type: :divider},
           {type: :disabled, label: "Registration stickers", secondary: false},
-          link_item("Manage users", "/o/#{organization.to_param}/users", active: :match_controller),
+          link_item("Manage users", "/o/#{organization.to_param}/users", match: :controller),
           link_item("#{organization.short_name} profile", "/o/#{organization.to_param}/manage"),
           link_item("#{organization.short_name} locations", "/o/#{organization.to_param}/manage/locations"),
-          link_item("Manage Registration sequences", "/o/#{organization.to_param}/registration_sequences", active: :on_registration_sequences)
+          link_item("Manage Registration sequences", "/o/#{organization.to_param}/registration_sequences", match: :controller, matching_controllers: ["organized/registration_sequence_pages"])
         ]
       end
 


### PR DESCRIPTION
The navbar and footer render from fragment caches keyed on `page_id`, so the link they marked current was whichever page filled the cache — `PrimaryMenu` pinned "Stolen bike?" inactive and `welcome/index.coffee` re-marked it by hand on that one info page. `UI::ActiveLink` now renders what to compare and lets `ui/active_link_controller.js` set `aria-current` against the page, off a `<body data-page-route>` that `body_tag` gives every layout.

- **`match:` is the only control — there's no way to pass the answer in.** `:full_path` counts the link's query string, which tells the org menu's two `organized/bikes#new` links apart; `matching_controllers:` extends a match across a second controller, keeping "Manage Registration sequences" current while a page of one is edited.
- **Neither cache key carries `page_id`.** The footer's is the user, organization and pixel flag — its language switcher submits an action-less form the browser aims at the current URL, and `default_url_options` stops forwarding a `locale` that wouldn't change what renders. The navbar's one page-dependent part is the org menu, which renders outside the cache, leaving its key the user alone.
- **The org menu manifest carries `match:`** in place of the `:on_bikes_new`-style markers the component resolved per request, dropping `unregistered_parking_notification` from five components. Its cached payload — and the API v3 `me` menu it's serialized into — moves to v2.
- **`Admin::Navbar` keeps a server-side check**, since its picker names the current page in prose rather than marking a link. It calls `current_page_active?` directly, so the component offers no answer at all.
