### PR TITLE
Flag UI::ActiveLink's current page with aria-current

### DIFF
--- a/app/assets/javascripts/revised/pages/welcome/index.coffee
+++ b/app/assets/javascripts/revised/pages/welcome/index.coffee
@@ -24,8 +24,8 @@ class BikeIndex.WelcomeIndex extends BikeIndex
 
   updateActiveLink: ->
     if window.location.pathname.match("info/how-to-get-your-stolen-bike-back")
-      $(".primary-nav-item .active").removeClass("active")
-      $("#getStolenBackLink").addClass("active")
+      $(".primary-nav-item [aria-current]").removeAttr("aria-current")
+      $("#getStolenBackLink").attr("aria-current", "page")
 
   # Return the DOM node for the slide with index `index` in the slides
   # container element.

--- a/app/assets/stylesheets/revised/fonts.scss
+++ b/app/assets/stylesheets/revised/fonts.scss
@@ -36,9 +36,12 @@ $btn-font-size: 15px;
     color: $link-color;
     text-decoration: none;
 
+    // .container extends this, so both markers: the class the legacy views emit, and the
+    // attribute UI::ActiveLink does — the info sidebar's current link is styled from here
     &:hover,
     &:active,
-    &.active {
+    &.active,
+    &[aria-current] {
       text-decoration: underline;
       color: $link-color;
     }

--- a/app/assets/stylesheets/revised/sections/organized_menu.scss
+++ b/app/assets/stylesheets/revised/sections/organized_menu.scss
@@ -108,7 +108,7 @@ $organized-menu-bg: $gray-lighter;
         color: $less-strong-font-color;
       }
 
-      .active {
+      [aria-current] {
         color: $blue;
         position: relative;
         font-weight: bold;

--- a/app/assets/stylesheets/revised/sections/primary_footer.scss
+++ b/app/assets/stylesheets/revised/sections/primary_footer.scss
@@ -15,7 +15,7 @@ $primary-footer-top-margin: 6 * $vertical-height;
 
     &:hover,
     &:active,
-    &.active {
+    &[aria-current] {
       text-decoration: underline;
     }
   }

--- a/app/assets/stylesheets/revised/sections/primary_header_nav.scss
+++ b/app/assets/stylesheets/revised/sections/primary_header_nav.scss
@@ -216,21 +216,20 @@ $mobile-nav-height: 4 * $vertical-height;
           text-decoration: none;
         }
 
-        &:active {
-        }
-
+        // The two states the is-active variant folds together stay apart here:
+        // :active is the press, [data-active] the open menu, and they rotate differently
         &:active,
-        &.active {
+        &[data-active="true"] {
           color: #fff;
           text-decoration: none;
         }
 
         &:active,
-        &.active:active {
+        &[data-active="true"]:active {
           transform: rotate(45deg);
         }
 
-        &.active {
+        &[data-active="true"] {
           transform: rotate(90deg);
         }
       }

--- a/app/assets/stylesheets/revised/sections/primary_header_nav.scss
+++ b/app/assets/stylesheets/revised/sections/primary_header_nav.scss
@@ -57,7 +57,7 @@ $mobile-nav-height: 4 * $vertical-height;
 
       &:hover,
       &:active,
-      &.active {
+      &[aria-current] {
         color: #fff;
       }
     }
@@ -104,7 +104,7 @@ $mobile-nav-height: 4 * $vertical-height;
 
       &:hover,
       &:active,
-      &.active {
+      &[aria-current] {
         color: #fff;
 
         .caret-down {
@@ -176,7 +176,7 @@ $mobile-nav-height: 4 * $vertical-height;
 
     &:hover,
     &:active,
-    &.active {
+    &[aria-current] {
       color: #fff;
       text-decoration: none;
     }
@@ -256,7 +256,7 @@ $mobile-nav-height: 4 * $vertical-height;
         padding: $vertical-height (2 * $vertical-height);
 
         &:active,
-        &.active {
+        &[aria-current] {
           background: $gray-light;
           text-decoration: none;
         }
@@ -357,14 +357,14 @@ $mobile-nav-height: 4 * $vertical-height;
       a {
         padding: 8px (0.5 * $grid-gutter-width);
 
-        &.active,
+        &[aria-current],
         &:active {
           text-decoration: none;
         }
       }
 
       // Only apply to primary nav items, not submenus
-      & > a.active::after {
+      & > a[aria-current]::after {
         content: "";
         position: absolute;
         left: 50%;
@@ -386,7 +386,7 @@ $mobile-nav-height: 4 * $vertical-height;
           color: $primary-nav-text-color;
         }
 
-        &.active::after {
+        &[aria-current]::after {
           display: none;
         }
       }
@@ -439,7 +439,7 @@ $mobile-nav-height: 4 * $vertical-height;
       padding: (0.5 * ($primary-logo-fullsize-height - 34px)) 0
         (2 * $vertical-height);
 
-      a.active::after {
+      a[aria-current]::after {
         bottom: 2 * $vertical-height;
       }
     }

--- a/app/assets/tailwind/bike_index_components.css
+++ b/app/assets/tailwind/bike_index_components.css
@@ -3,21 +3,18 @@
 @layer components {
   .twlink {
     @apply tw:text-blue-600 tw:dark:text-blue-400 tw:transition-colors;
+
+    /* Outranks the hover below on specificity, so a selected link doesn't take the
+     * hover color when the pointer is over it */
+    @variant is-active {
+      @apply tw:text-blue-700 tw:underline tw:font-bold tw:dark:text-blue-300;
+    }
   }
 
   /* Guarded so a disabled UI::Button/UI::ButtonLink in link color holds its color.
-   * Every other color guards its hover in the utilities; link color's lives here.
-   * Both active markers, as the is-active variant: UI::TableColumn's sort link flags
-   * itself with the class, UI::ActiveLink with the attribute. */
-  .twlink:not(:disabled, [aria-disabled="true"]):hover,
-  .twlink:is(.active, [aria-current]),
-  .twlink:not(:disabled, [aria-disabled="true"]):active {
+   * Every other color guards its hover in the utilities; link color's lives here. */
+  .twlink:not(:disabled, [aria-disabled="true"]):hover {
     @apply tw:text-blue-700 tw:underline tw:dark:text-blue-300;
-  }
-
-  .twlink:is(.active, [aria-current]),
-  .twlink:not(:disabled, [aria-disabled="true"]):active {
-    @apply tw:font-bold;
   }
 
   /* For links that should inherit the color of the text they sit in. text-inherit rather
@@ -25,27 +22,29 @@
    * `a { color: #3498db }` would otherwise supply the color */
   .twlink-underlined {
     @apply tw:text-inherit tw:underline tw:transition-colors;
-  }
 
-  /* currentColor in a `color` declaration resolves to the inherited color, so the hover
-   * shifts whatever the link sits in — lightening in dark mode, where deepening would sink
-   * it into the background. Clamped, so text already at the floor lifts rather than hovering
-   * to itself; a browser too old for relative color syntax still gets the thicker underline */
-  .twlink-underlined:not(:disabled, [aria-disabled="true"]):hover,
-  .twlink-underlined:is(.active, [aria-current]),
-  .twlink-underlined:not(:disabled, [aria-disabled="true"]):active {
-    @apply tw:decoration-2;
-
-    color: oklch(from currentColor max(calc(l - 0.12), 0.2) c h);
+    /* Substituted into `color` rather than resolved here: currentColor in a `color`
+     * declaration is the inherited color, so hover and is-active below shift whatever the
+     * link sits in — lightening in dark mode, where deepening would sink it into the
+     * background. Clamped, so text already at the floor lifts rather than shifting to
+     * itself; a browser too old for relative color syntax still gets the thicker underline */
+    --twlink-underlined-shifted: oklch(from currentColor max(calc(l - 0.12), 0.2) c h);
 
     @variant dark {
-      color: oklch(from currentColor min(calc(l + 0.12), 0.8) c h);
+      --twlink-underlined-shifted: oklch(from currentColor min(calc(l + 0.12), 0.8) c h);
+    }
+
+    @variant is-active {
+      @apply tw:decoration-2 tw:font-bold;
+
+      color: var(--twlink-underlined-shifted);
     }
   }
 
-  .twlink-underlined:is(.active, [aria-current]),
-  .twlink-underlined:not(:disabled, [aria-disabled="true"]):active {
-    @apply tw:font-bold;
+  .twlink-underlined:not(:disabled, [aria-disabled="true"]):hover {
+    @apply tw:decoration-2;
+
+    color: var(--twlink-underlined-shifted);
   }
 
   /* Legacy's `.container` reaches into an alert two ways tailwind can't answer on

--- a/app/assets/tailwind/bike_index_components.css
+++ b/app/assets/tailwind/bike_index_components.css
@@ -6,14 +6,16 @@
   }
 
   /* Guarded so a disabled UI::Button/UI::ButtonLink in link color holds its color.
-   * Every other color guards its hover in the utilities; link color's lives here. */
+   * Every other color guards its hover in the utilities; link color's lives here.
+   * Both active markers, as the is-active variant: UI::TableColumn's sort link flags
+   * itself with the class, UI::ActiveLink with the attribute. */
   .twlink:not(:disabled, [aria-disabled="true"]):hover,
-  .twlink.active,
+  .twlink:is(.active, [aria-current]),
   .twlink:not(:disabled, [aria-disabled="true"]):active {
     @apply tw:text-blue-700 tw:underline tw:dark:text-blue-300;
   }
 
-  .twlink.active,
+  .twlink:is(.active, [aria-current]),
   .twlink:not(:disabled, [aria-disabled="true"]):active {
     @apply tw:font-bold;
   }
@@ -30,7 +32,7 @@
    * it into the background. Clamped, so text already at the floor lifts rather than hovering
    * to itself; a browser too old for relative color syntax still gets the thicker underline */
   .twlink-underlined:not(:disabled, [aria-disabled="true"]):hover,
-  .twlink-underlined.active,
+  .twlink-underlined:is(.active, [aria-current]),
   .twlink-underlined:not(:disabled, [aria-disabled="true"]):active {
     @apply tw:decoration-2;
 
@@ -41,7 +43,7 @@
     }
   }
 
-  .twlink-underlined.active,
+  .twlink-underlined:is(.active, [aria-current]),
   .twlink-underlined:not(:disabled, [aria-disabled="true"]):active {
     @apply tw:font-bold;
   }

--- a/app/components/admin/bikes_table/component.rb
+++ b/app/components/admin/bikes_table/component.rb
@@ -8,7 +8,7 @@ module Admin
     # checkboxes, and skip_user to drop the owner column.
     class Component < ApplicationComponent
       # Digest of the markup inside the row cache — the cached_markup_digest spec keeps it current
-      MARKUP_DIGEST = "b09ab1f70148"
+      MARKUP_DIGEST = "abd0fef28861"
 
       def initialize(bikes:, no_show_header: false, show_serial: false, render_sortable: false,
         skip_user: false, render_multi_check: false)

--- a/app/components/admin/bug_reports_table/component.rb
+++ b/app/components/admin/bug_reports_table/component.rb
@@ -4,7 +4,7 @@ module Admin
   module BugReportsTable
     class Component < ApplicationComponent
       # Digest of the markup inside the row cache — the cached_markup_digest spec keeps it current
-      MARKUP_DIGEST = "6d0630261791"
+      MARKUP_DIGEST = "0d7ced6958ab"
 
       def initialize(collection:, render_sortable: false)
         @collection = collection

--- a/app/components/admin/navbar/component.html.erb
+++ b/app/components/admin/navbar/component.html.erb
@@ -7,15 +7,15 @@
     <ul class="navbar-nav d-none d-lg-flex">
       <% shortcut_links.each do |link| %>
         <li class="nav-item">
-          <%# bootstrap's .nav-link.active color, keyed off a class this component doesn't emit %>
           <%= render UI::ActiveLink::Component.new(text: link[:title], path: link[:path],
-                html_class: "nav-link tw:is-active:text-black/90", match: link[:match]) %>
+                html_class: Admin::Navbar::Component::NAV_LINK_CLASS, match: link[:match]) %>
         </li>
       <% end %>
 
       <% if mailer_links.any? %>
         <li class="nav-item">
-          <%= render(UI::Dropdown::Component.new(name: "Mailers", button_class: "nav-link tw:mr-1 tw:cursor-pointer")) do |dropdown| %>
+          <%= render(UI::Dropdown::Component.new(name: "Mailers",
+                button_class: "#{Admin::Navbar::Component::NAV_LINK_CLASS} tw:mr-1 tw:cursor-pointer")) do |dropdown| %>
             <% mailer_links.each do |title, path| %>
               <% dropdown.with_entry_item { link_to title, path } %>
             <% end %>
@@ -24,7 +24,7 @@
       <% end %>
     </ul>
     <% if display_view_all? %>
-      <%= link_to current_nav_link[:path], class: "nav-link text-muted em" do %>
+      <%= link_to current_nav_link[:path], class: "#{Admin::Navbar::Component::VIEW_ALL_LINK_CLASS} text-muted em" do %>
         All
         <div class="d-none d-sm-inline-block d-lg-none d-xl-inline-block">
           <%= view_all_title %>

--- a/app/components/admin/navbar/component.html.erb
+++ b/app/components/admin/navbar/component.html.erb
@@ -7,7 +7,9 @@
     <ul class="navbar-nav d-none d-lg-flex">
       <% shortcut_links.each do |link| %>
         <li class="nav-item">
-          <%= render UI::ActiveLink::Component.new(text: link[:title], path: link[:path], html_class: "nav-link", match: link[:match]) %>
+          <%# is-active rather than bootstrap's .navbar-light .nav-link.active, which UI::ActiveLink no longer flags %>
+          <%= render UI::ActiveLink::Component.new(text: link[:title], path: link[:path],
+                html_class: "nav-link tw:is-active:text-black/90", match: link[:match]) %>
         </li>
       <% end %>
 

--- a/app/components/admin/navbar/component.html.erb
+++ b/app/components/admin/navbar/component.html.erb
@@ -7,7 +7,7 @@
     <ul class="navbar-nav d-none d-lg-flex">
       <% shortcut_links.each do |link| %>
         <li class="nav-item">
-          <%# is-active rather than bootstrap's .navbar-light .nav-link.active, which UI::ActiveLink no longer flags %>
+          <%# bootstrap's .nav-link.active color, keyed off a class this component doesn't emit %>
           <%= render UI::ActiveLink::Component.new(text: link[:title], path: link[:path],
                 html_class: "nav-link tw:is-active:text-black/90", match: link[:match]) %>
         </li>

--- a/app/components/admin/navbar/component.html.erb
+++ b/app/components/admin/navbar/component.html.erb
@@ -6,16 +6,16 @@
   <% if @current_user.superuser? %>
     <ul class="navbar-nav d-none d-lg-flex">
       <% shortcut_links.each do |link| %>
-        <li class="nav-item">
+        <li>
           <%= render UI::ActiveLink::Component.new(text: link[:title], path: link[:path],
-                html_class: Admin::Navbar::Component::NAV_LINK_CLASS, match: link[:match]) %>
+                html_class: NAV_LINK_CLASS, match: link[:match]) %>
         </li>
       <% end %>
 
       <% if mailer_links.any? %>
-        <li class="nav-item">
+        <li>
           <%= render(UI::Dropdown::Component.new(name: "Mailers",
-                button_class: "#{Admin::Navbar::Component::NAV_LINK_CLASS} tw:mr-1 tw:cursor-pointer")) do |dropdown| %>
+                button_class: "#{NAV_LINK_CLASS} tw:mr-1 tw:cursor-pointer")) do |dropdown| %>
             <% mailer_links.each do |title, path| %>
               <% dropdown.with_entry_item { link_to title, path } %>
             <% end %>
@@ -24,7 +24,8 @@
       <% end %>
     </ul>
     <% if display_view_all? %>
-      <%= link_to current_nav_link[:path], class: "#{Admin::Navbar::Component::VIEW_ALL_LINK_CLASS} text-muted em" do %>
+      <%# The same .nav-link outside the list, so it keeps the padding .navbar-nav overrode %>
+      <%= link_to current_nav_link[:path], class: "tw:block tw:py-2 tw:px-4 tw:no-underline text-muted em" do %>
         All
         <div class="d-none d-sm-inline-block d-lg-none d-xl-inline-block">
           <%= view_all_title %>

--- a/app/components/admin/navbar/component.rb
+++ b/app/components/admin/navbar/component.rb
@@ -6,15 +6,12 @@ module Admin
     # preceded by an "All" link back to the active page's index when this isn't it.
     # Picking an option navigates -- see admin/navbar_controller.js.
     class Component < ApplicationComponent
-      # The vendored dump's .navbar-light .navbar-nav .nav-link, as utilities — it keys its
-      # active color off a class UI::ActiveLink doesn't emit, and the dump isn't ours to edit.
-      # Horizontal padding is the navbar-expand-md value, the only one the d-lg-flex list is
-      # ever visible at.
+      # The vendored dump's .navbar-light .navbar-nav .nav-link, as utilities. admin.scss
+      # imports the dump unlayered, so it outranks every tailwind layer — dropping .nav-link
+      # is what lets a utility reach these links at all. Horizontal padding is the
+      # navbar-expand-md value, the only one the d-lg-flex list is ever visible at.
       NAV_LINK_CLASS = "tw:block tw:p-2 tw:no-underline tw:text-black/50 " \
         "tw:hover:text-black/70 tw:focus:text-black/70 tw:is-active:text-black/90"
-
-      # The same .nav-link outside the list, so it keeps the padding .navbar-nav overrode
-      VIEW_ALL_LINK_CLASS = "tw:block tw:py-2 tw:px-4 tw:no-underline"
 
       def initialize(current_user:)
         @current_user = current_user

--- a/app/components/admin/navbar/component.rb
+++ b/app/components/admin/navbar/component.rb
@@ -6,6 +6,16 @@ module Admin
     # preceded by an "All" link back to the active page's index when this isn't it.
     # Picking an option navigates -- see admin/navbar_controller.js.
     class Component < ApplicationComponent
+      # The vendored dump's .navbar-light .navbar-nav .nav-link, as utilities — it keys its
+      # active color off a class UI::ActiveLink doesn't emit, and the dump isn't ours to edit.
+      # Horizontal padding is the navbar-expand-md value, the only one the d-lg-flex list is
+      # ever visible at.
+      NAV_LINK_CLASS = "tw:block tw:p-2 tw:no-underline tw:text-black/50 " \
+        "tw:hover:text-black/70 tw:focus:text-black/70 tw:is-active:text-black/90"
+
+      # The same .nav-link outside the list, so it keeps the padding .navbar-nav overrode
+      VIEW_ALL_LINK_CLASS = "tw:block tw:py-2 tw:px-4 tw:no-underline"
+
       def initialize(current_user:)
         @current_user = current_user
       end

--- a/app/components/admin/users_table/component.rb
+++ b/app/components/admin/users_table/component.rb
@@ -6,7 +6,7 @@ module Admin
     # render_deleted to show the deleted_at column.
     class Component < ApplicationComponent
       # Digest of the markup inside the row cache — the cached_markup_digest spec keeps it current
-      MARKUP_DIGEST = "aec822e6af49"
+      MARKUP_DIGEST = "e189a7897e1f"
 
       def initialize(users:, render_sortable: false, render_deleted: false)
         @users = users

--- a/app/components/org/search_results/bikes_table/component.rb
+++ b/app/components/org/search_results/bikes_table/component.rb
@@ -9,7 +9,7 @@ module Org
       # registrations on the show page). Pass render_sortable to enable sort links.
       class Component < ApplicationComponent
         # Digest of the markup inside the row cache — the cached_markup_digest spec keeps it current
-        MARKUP_DIGEST = "a385d2deb01a"
+        MARKUP_DIGEST = "b20cc4a05592"
 
         delegate :additional_registration_fields, :column_renames, to: :settings_component
 

--- a/app/components/org/search_results/bikes_table/component.rb
+++ b/app/components/org/search_results/bikes_table/component.rb
@@ -9,7 +9,7 @@ module Org
       # registrations on the show page). Pass render_sortable to enable sort links.
       class Component < ApplicationComponent
         # Digest of the markup inside the row cache — the cached_markup_digest spec keeps it current
-        MARKUP_DIGEST = "b20cc4a05592"
+        MARKUP_DIGEST = "6059da0f1c8d"
 
         delegate :additional_registration_fields, :column_renames, to: :settings_component
 

--- a/app/components/page_block/footer/component.rb
+++ b/app/components/page_block/footer/component.rb
@@ -5,7 +5,7 @@ module PageBlock
     class Component < ApplicationComponent
       FACEBOOK_PIXEL_ID = "199066297131941"
       # Digest of the cached template — the cached_markup_digest spec keeps it current
-      MARKUP_DIGEST = "b0a6f8b24dea"
+      MARKUP_DIGEST = "5413f96ff547"
 
       def initialize(current_user:, skip_facebook:, page_id:, passive_organization: nil)
         @current_user = current_user

--- a/app/components/page_block/footer/component.rb
+++ b/app/components/page_block/footer/component.rb
@@ -5,7 +5,7 @@ module PageBlock
     class Component < ApplicationComponent
       FACEBOOK_PIXEL_ID = "199066297131941"
       # Digest of the cached template — the cached_markup_digest spec keeps it current
-      MARKUP_DIGEST = "1bcf45ead944"
+      MARKUP_DIGEST = "82b456e191f5"
 
       def initialize(current_user:, skip_facebook:, page_id:, passive_organization: nil)
         @current_user = current_user

--- a/app/components/page_block/footer/component.rb
+++ b/app/components/page_block/footer/component.rb
@@ -5,7 +5,7 @@ module PageBlock
     class Component < ApplicationComponent
       FACEBOOK_PIXEL_ID = "199066297131941"
       # Digest of the cached template — the cached_markup_digest spec keeps it current
-      MARKUP_DIGEST = "5413f96ff547"
+      MARKUP_DIGEST = "1bcf45ead944"
 
       def initialize(current_user:, skip_facebook:, page_id:, passive_organization: nil)
         @current_user = current_user

--- a/app/components/page_block/main_content/content/component.html.erb
+++ b/app/components/page_block/main_content/content/component.html.erb
@@ -66,8 +66,8 @@
           <ul class="tw:m-0 tw:mb-4 tw:list-none">
             <% if content_page_type == "news" %>
               <li>
-                <% all_active = @action_name == "index" && !helpers.sortable_search_params? %>
-                <%= link_to translation(".bike_index_news"), news_index_path, class: (all_active ? "active" : "") %>
+                <%= render UI::ActiveLink::Component.new(text: translation(".bike_index_news"), path: news_index_path,
+                      active: @action_name == "index" && !helpers.sortable_search_params?) %>
               </li>
             <% end %>
 

--- a/app/components/page_block/navbar/wrapper/component.rb
+++ b/app/components/page_block/navbar/wrapper/component.rb
@@ -7,7 +7,7 @@ module PageBlock
       # logo_only renders just the logo, for the OAuth authorization prompt.
       class Component < ApplicationComponent
         # Digest of the cached template — the cached_markup_digest spec keeps it current
-        MARKUP_DIGEST = "a727ee7c1f6a"
+        MARKUP_DIGEST = "362913db35d8"
 
         def initialize(logo_only: false, page_id: nil, current_user: nil, current_user_or_unconfirmed_user: nil,
           passive_organization: nil, controller_namespace: nil, controller_name: nil, action_name: nil,

--- a/app/components/page_block/navbar/wrapper/component.rb
+++ b/app/components/page_block/navbar/wrapper/component.rb
@@ -7,7 +7,7 @@ module PageBlock
       # logo_only renders just the logo, for the OAuth authorization prompt.
       class Component < ApplicationComponent
         # Digest of the cached template — the cached_markup_digest spec keeps it current
-        MARKUP_DIGEST = "b7be19369613"
+        MARKUP_DIGEST = "ee0cccd39559"
 
         def initialize(logo_only: false, page_id: nil, current_user: nil, current_user_or_unconfirmed_user: nil,
           passive_organization: nil, controller_namespace: nil, controller_name: nil, action_name: nil,

--- a/app/components/page_block/navbar/wrapper/component.rb
+++ b/app/components/page_block/navbar/wrapper/component.rb
@@ -7,7 +7,7 @@ module PageBlock
       # logo_only renders just the logo, for the OAuth authorization prompt.
       class Component < ApplicationComponent
         # Digest of the cached template — the cached_markup_digest spec keeps it current
-        MARKUP_DIGEST = "0dd52aae8351"
+        MARKUP_DIGEST = "b7be19369613"
 
         def initialize(logo_only: false, page_id: nil, current_user: nil, current_user_or_unconfirmed_user: nil,
           passive_organization: nil, controller_namespace: nil, controller_name: nil, action_name: nil,

--- a/app/components/page_block/navbar/wrapper/component.rb
+++ b/app/components/page_block/navbar/wrapper/component.rb
@@ -7,7 +7,7 @@ module PageBlock
       # logo_only renders just the logo, for the OAuth authorization prompt.
       class Component < ApplicationComponent
         # Digest of the cached template — the cached_markup_digest spec keeps it current
-        MARKUP_DIGEST = "362913db35d8"
+        MARKUP_DIGEST = "0dd52aae8351"
 
         def initialize(logo_only: false, page_id: nil, current_user: nil, current_user_or_unconfirmed_user: nil,
           passive_organization: nil, controller_namespace: nil, controller_name: nil, action_name: nil,

--- a/app/components/registrations/show/wrapper/component.rb
+++ b/app/components/registrations/show/wrapper/component.rb
@@ -8,7 +8,7 @@ module Registrations
       class Component < ApplicationComponent
         # Digest of the markup inside the cache block — the cached_markup_digest spec
         # keeps it current, following what this tree renders out into UI:: and elsewhere
-        MARKUP_DIGEST = "0390656f4964"
+        MARKUP_DIGEST = "f76bcbfaec39"
 
         def initialize(bike:, current_user:, view:, available_views:, bike_sticker: nil, current_alerts: {})
           @bike = bike

--- a/app/components/registrations/show/wrapper/component.rb
+++ b/app/components/registrations/show/wrapper/component.rb
@@ -8,7 +8,7 @@ module Registrations
       class Component < ApplicationComponent
         # Digest of the markup inside the cache block — the cached_markup_digest spec
         # keeps it current, following what this tree renders out into UI:: and elsewhere
-        MARKUP_DIGEST = "1dad5b3f30ca"
+        MARKUP_DIGEST = "0390656f4964"
 
         def initialize(bike:, current_user:, view:, available_views:, bike_sticker: nil, current_alerts: {})
           @bike = bike

--- a/app/components/ui/active_link/component.rb
+++ b/app/components/ui/active_link/component.rb
@@ -2,10 +2,11 @@
 
 module UI
   module ActiveLink
-    # Adds "active" to the link's class on the page it points at. match: widens what counts as
-    # that page — the target's controller, or its controller and action, which is what a link
-    # carrying query params (a search, a filtered index) needs. A caller that already knows the
-    # answer passes active: rather than being routed around the component.
+    # Marks the link aria-current on the page it points at, which the is-active variant
+    # (application.css) styles. match: widens what counts as that page — the target's controller,
+    # or its controller and action, which is what a link carrying query params (a search, a
+    # filtered index) needs. A caller that already knows the answer passes active: rather than
+    # being routed around the component.
     class Component < ApplicationComponent
       MATCHES = [:path, :controller, :controller_action].freeze
 
@@ -50,7 +51,7 @@ module UI
 
       def initialize(path:, text: nil, active: nil, match: :path, html_class: nil, **html_options)
         raise_if_invalid_value!(:match, match, MATCHES)
-        # The component builds its own class, so a passed one is dropped rather than merged
+        # html_class is what reaches the anchor, so a passed class would be dropped rather than merged
         raise ArgumentError, "class is not supported, you must use the keyword arg html_class" if html_options.key?(:class)
 
         @path = path
@@ -62,7 +63,7 @@ module UI
       end
 
       def call
-        link_to(link_text, @path, **@html_options, class: link_class)
+        link_to(link_text, @path, **@html_options, class: @html_class.presence, aria: aria_attributes)
       end
 
       private
@@ -74,8 +75,9 @@ module UI
           raise(ArgumentError, "text: or block content is required")
       end
 
-      def link_class
-        [@html_class, ("active" if active?)].compact.join(" ").presence
+      # Merged rather than passed beside @html_options, so a caller's aria: keeps its attributes
+      def aria_attributes
+        {**@html_options[:aria].to_h, current: ("page" if active?)}
       end
 
       def active?

--- a/app/components/ui/active_link/component.rb
+++ b/app/components/ui/active_link/component.rb
@@ -63,7 +63,7 @@ module UI
       end
 
       def call
-        link_to(link_text, @path, **@html_options, class: @html_class.presence, aria: aria_attributes)
+        link_to(link_text, @path, **@html_options.except(:aria), class: @html_class.presence, aria: aria_attributes)
       end
 
       private
@@ -75,9 +75,8 @@ module UI
           raise(ArgumentError, "text: or block content is required")
       end
 
-      # Merged rather than passed beside @html_options, so a caller's aria: keeps its attributes
       def aria_attributes
-        {**@html_options[:aria].to_h, current: ("page" if active?)}
+        @html_options[:aria].to_h.merge(current: ("page" if active?))
       end
 
       def active?

--- a/app/components/ui/active_link/component.rb
+++ b/app/components/ui/active_link/component.rb
@@ -76,7 +76,16 @@ module UI
       end
 
       def aria_attributes
-        @html_options[:aria].to_h.merge(current: ("page" if active?))
+        @html_options[:aria].to_h.merge(current: aria_current)
+      end
+
+      # "page" is reserved for the link whose own path is the current one. A widened match
+      # means the current page sits inside what the link points at, not that it is it —
+      # aria-current's "true", so a reader isn't told a link elsewhere is where it already is
+      def aria_current
+        return unless active?
+
+        (@match == :path) ? "page" : "true"
       end
 
       def active?

--- a/app/components/ui/active_link/component_preview.rb
+++ b/app/components/ui/active_link/component_preview.rb
@@ -7,32 +7,28 @@ module UI
       # differs on a path neither is served from
       PREVIEW_PATH = "/rails/view_components/ui/active_link/component"
 
-      # The component only marks the link aria-current; what that looks like is the caller's,
-      # through the is-active variant
-      LINK_CLASS = "twlink tw:is-active:font-bold tw:is-active:underline"
-
       # @!group Variants
       # Points at another page, so it stays a plain link
       def default
-        render(UI::ActiveLink::Component.new(text: "Support", path: "/support", html_class: LINK_CLASS))
+        render(UI::ActiveLink::Component.new(text: "Support", path: "/support", html_class: "twlink"))
       end
 
       # The path this scenario is served from — active, with no match_controller needed
       def current_page
         render(UI::ActiveLink::Component.new(text: "This preview", path: "#{PREVIEW_PATH}/current_page",
-          html_class: LINK_CLASS))
+          html_class: "twlink"))
       end
 
       # A different page of the same controller: active only because match: widens it
       def match_controller
         render(UI::ActiveLink::Component.new(text: "A sibling preview", path: "#{PREVIEW_PATH}/default",
-          match: :controller, html_class: LINK_CLASS))
+          match: :controller, html_class: "twlink"))
       end
 
       # The same link at the default match: :path, for the contrast
       def match_path
         render(UI::ActiveLink::Component.new(text: "A sibling preview", path: "#{PREVIEW_PATH}/default",
-          html_class: LINK_CLASS))
+          html_class: "twlink"))
       end
 
       # Ignores the query string, which match: :path wouldn't. Every scenario here shares one
@@ -40,13 +36,13 @@ module UI
       def match_controller_action
         render(UI::ActiveLink::Component.new(text: "This scenario, other params",
           path: "#{PREVIEW_PATH}/match_controller_action?example=1",
-          match: :controller_action, html_class: LINK_CLASS))
+          match: :controller_action, html_class: "twlink"))
       end
 
       # A caller that already knows the state passes active:, skipping the current-page check
       def active_forced
         render(UI::ActiveLink::Component.new(text: "Forced active", path: "/support",
-          active: true, html_class: LINK_CLASS))
+          active: true, html_class: "twlink"))
       end
 
       # Anything beyond html_class passes through to the anchor
@@ -57,7 +53,7 @@ module UI
 
       # Markup inside the link, in place of text:
       def with_block_content
-        render(UI::ActiveLink::Component.new(path: "#{PREVIEW_PATH}/with_block_content", html_class: LINK_CLASS)) do
+        render(UI::ActiveLink::Component.new(path: "#{PREVIEW_PATH}/with_block_content", html_class: "twlink")) do
           tag.strong("Block content")
         end
       end

--- a/app/components/ui/active_link/component_preview.rb
+++ b/app/components/ui/active_link/component_preview.rb
@@ -7,28 +7,32 @@ module UI
       # differs on a path neither is served from
       PREVIEW_PATH = "/rails/view_components/ui/active_link/component"
 
+      # The component only marks the link aria-current; what that looks like is the caller's,
+      # through the is-active variant
+      LINK_CLASS = "twlink tw:is-active:font-bold tw:is-active:underline"
+
       # @!group Variants
       # Points at another page, so it stays a plain link
       def default
-        render(UI::ActiveLink::Component.new(text: "Support", path: "/support", html_class: "nav-link"))
+        render(UI::ActiveLink::Component.new(text: "Support", path: "/support", html_class: LINK_CLASS))
       end
 
       # The path this scenario is served from — active, with no match_controller needed
       def current_page
         render(UI::ActiveLink::Component.new(text: "This preview", path: "#{PREVIEW_PATH}/current_page",
-          html_class: "nav-link"))
+          html_class: LINK_CLASS))
       end
 
       # A different page of the same controller: active only because match: widens it
       def match_controller
         render(UI::ActiveLink::Component.new(text: "A sibling preview", path: "#{PREVIEW_PATH}/default",
-          match: :controller, html_class: "nav-link"))
+          match: :controller, html_class: LINK_CLASS))
       end
 
       # The same link at the default match: :path, for the contrast
       def match_path
         render(UI::ActiveLink::Component.new(text: "A sibling preview", path: "#{PREVIEW_PATH}/default",
-          html_class: "nav-link"))
+          html_class: LINK_CLASS))
       end
 
       # Ignores the query string, which match: :path wouldn't. Every scenario here shares one
@@ -36,13 +40,13 @@ module UI
       def match_controller_action
         render(UI::ActiveLink::Component.new(text: "This scenario, other params",
           path: "#{PREVIEW_PATH}/match_controller_action?example=1",
-          match: :controller_action, html_class: "nav-link"))
+          match: :controller_action, html_class: LINK_CLASS))
       end
 
       # A caller that already knows the state passes active:, skipping the current-page check
       def active_forced
         render(UI::ActiveLink::Component.new(text: "Forced active", path: "/support",
-          active: true, html_class: "nav-link"))
+          active: true, html_class: LINK_CLASS))
       end
 
       # Anything beyond html_class passes through to the anchor
@@ -53,7 +57,7 @@ module UI
 
       # Markup inside the link, in place of text:
       def with_block_content
-        render(UI::ActiveLink::Component.new(path: "#{PREVIEW_PATH}/with_block_content", html_class: "nav-link")) do
+        render(UI::ActiveLink::Component.new(path: "#{PREVIEW_PATH}/with_block_content", html_class: LINK_CLASS)) do
           tag.strong("Block content")
         end
       end

--- a/app/components/ui/button/component.rb
+++ b/app/components/ui/button/component.rb
@@ -28,12 +28,14 @@ module UI
       # until the element flags itself active (see the is-active variant in application.css,
       # which sorts last, so these override the resting colors with no `!` important).
       # Literal strings so Tailwind's scanner generates them; the spec enforces the prefix.
+      #
+      # No :link — .twlink states its own active look under the same variant, and a utility
+      # here would win over it, so link color would stop following the class it's built from.
       ACTIVE_COLORS = {
         primary: "tw:is-active:bg-blue-800 tw:is-active:ring-2 tw:is-active:ring-blue-500/40 tw:is-active:dark:bg-blue-700",
         secondary: "tw:is-active:text-white tw:is-active:bg-purple-500 tw:is-active:border-purple-500 tw:is-active:ring-2 tw:is-active:ring-purple-500/40",
         error: "tw:is-active:bg-red-100 tw:is-active:border-[#c0392b] tw:is-active:ring-2 tw:is-active:ring-red-500/40 tw:is-active:dark:bg-red-950 tw:is-active:dark:border-red-700",
-        purple: "tw:is-active:bg-purple-700 tw:is-active:border-purple-700 tw:is-active:ring-2 tw:is-active:ring-purple-500/40",
-        link: "tw:is-active:text-blue-700 tw:is-active:dark:text-blue-300 tw:is-active:font-bold tw:is-active:underline"
+        purple: "tw:is-active:bg-purple-700 tw:is-active:border-purple-700 tw:is-active:ring-2 tw:is-active:ring-purple-500/40"
       }.freeze
 
       # No pointer-events-none: with pointer events off the browser takes the cursor from

--- a/app/components/ui/dropdown/component.rb
+++ b/app/components/ui/dropdown/component.rb
@@ -50,9 +50,11 @@ module UI
         classes = UI::Button::Component.new(color: @button_color, size: @button_size).button_classes
         return classes unless @button_color == :link
 
-        # button_content underlines the label span, so the trigger itself never does — and
-        # .twlink's underline is in the components layer, which only a utility outranks
-        "#{classes} tw:is-active:no-underline tw:px-1"
+        # button_content underlines the label span, so the trigger itself never does — the
+        # chevron would be underlined with it. .twlink underlines on both hover and active
+        # from the components layer, which is why it takes a utility to hold it off.
+        # UI::Button gives every other color this same tw:no-underline.
+        "#{classes} tw:no-underline tw:px-1"
       end
 
       def button_id

--- a/app/components/ui/dropdown/component.rb
+++ b/app/components/ui/dropdown/component.rb
@@ -48,11 +48,11 @@ module UI
         return @button_class if @button_class
 
         classes = UI::Button::Component.new(color: @button_color, size: @button_size).button_classes
-        if @button_color == :link
-          # button_content underlines the label span, so the trigger itself never does.
-          classes = classes.sub("tw:is-active:underline", "").squeeze(" ").strip + " tw:px-1"
-        end
-        classes
+        return classes unless @button_color == :link
+
+        # button_content underlines the label span, so the trigger itself never does — and
+        # .twlink's underline is in the components layer, which only a utility outranks
+        "#{classes} tw:is-active:no-underline tw:px-1"
       end
 
       def button_id

--- a/app/components/ui/dropdown/component_preview.rb
+++ b/app/components/ui/dropdown/component_preview.rb
@@ -14,6 +14,15 @@ module UI
         end
       end
 
+      # Link color, where only the label is underlined — hover and press it to see the
+      # chevron stay clear of the underline .twlink would otherwise put across both
+      def link_button
+        render(UI::Dropdown::Component.new(name: "Mailers", button_color: :link, active: true)) do |dropdown|
+          dropdown.with_entry_item { content_tag(:a, "Organized", href: "#") }
+          dropdown.with_entry_item { content_tag(:a, "Customer", href: "#") }
+        end
+      end
+
       def custom_button
         render(UI::Dropdown::Component.new(
           name: "User",

--- a/app/components/ui/table_column/component.rb
+++ b/app/components/ui/table_column/component.rb
@@ -73,22 +73,19 @@ module UI
 
       def render_sort_link(current_sort:, current_direction:, sortable_url:, sort_icon:)
         title = header_label
-        direction = (@sortable == current_sort && current_direction == "desc") ? "asc" : "desc"
-        css = "twlink"
+        sorted_by_this = @sortable == current_sort
+        direction = (sorted_by_this && current_direction == "desc") ? "asc" : "desc"
 
-        if @sortable == current_sort
-          css += " active"
-          arrow_spans = [
-            content_tag(:span, sort_icon.call(current_direction), class: "tw:group-hover:hidden"),
-            content_tag(:span, sort_icon.call(direction), class: "tw:hidden tw:group-hover:inline tw:opacity-50")
-          ]
+        arrow_spans = if sorted_by_this
+          [content_tag(:span, sort_icon.call(current_direction), class: "tw:group-hover:hidden"),
+            content_tag(:span, sort_icon.call(direction), class: "tw:hidden tw:group-hover:inline tw:opacity-50")]
         else
-          arrow_spans = [
-            content_tag(:span, sort_icon.call(direction), class: "tw:opacity-0 tw:group-hover:opacity-50 tw:transition-opacity")
-          ]
+          [content_tag(:span, sort_icon.call(direction), class: "tw:opacity-0 tw:group-hover:opacity-50 tw:transition-opacity")]
         end
 
-        link_to(sortable_url.call(@sortable, direction), class: "#{css} tw:group") do
+        # data-active rather than an `active` class: that's what the is-active variant matches
+        link_to(sortable_url.call(@sortable, direction), class: "twlink tw:group",
+          data: {active: sorted_by_this || nil}) do
           safe_join([title, NBSP, *arrow_spans])
         end
       end

--- a/app/javascript/controllers/page_block/navbar_controller.js
+++ b/app/javascript/controllers/page_block/navbar_controller.js
@@ -5,7 +5,7 @@ const TRANSITION_MS = 200
 
 // Connects to data-controller="page-block--navbar"
 //
-// The hamburgler menu and the two dropdowns. It toggles the classes
+// The hamburgler menu and the two dropdowns. It toggles the markers
 // primary_header_nav.scss already styles, so `open` lands on a toggle's parent
 // the way bootstrap's did.
 export default class extends Controller {
@@ -26,7 +26,7 @@ export default class extends Controller {
   openMenu () {
     this.positionMenu()
     this.element.classList.add('enabled')
-    this.hamburglerButtonTarget.classList.add('active')
+    this.hamburglerButtonTarget.dataset.active = 'true'
     this.hamburglerButtonTarget.setAttribute('aria-expanded', 'true')
     // So that it animates in, rather than appearing
     setTimeout(() => {
@@ -36,7 +36,7 @@ export default class extends Controller {
   }
 
   closeMenu () {
-    this.hamburglerButtonTarget.classList.remove('active')
+    this.hamburglerButtonTarget.dataset.active = 'false'
     this.hamburglerButtonTarget.setAttribute('aria-expanded', 'false')
     this.element.classList.remove('menu-in')
     document.body.classList.remove('menu-in')

--- a/spec/components/admin/navbar/component_spec.rb
+++ b/spec/components/admin/navbar/component_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe Admin::Navbar::Component, type: :component do
   end
 
   describe "the shortcut links" do
-    let(:active_shortcut) { "ul.navbar-nav a.active" }
+    let(:active_shortcut) { "ul.navbar-nav a[aria-current]" }
 
     context "on a shortcut's own page" do
       let(:url) { admin_bikes }

--- a/spec/components/admin/navbar/component_spec.rb
+++ b/spec/components/admin/navbar/component_spec.rb
@@ -8,8 +8,8 @@ RSpec.describe Admin::Navbar::Component, type: :component do
   let(:url) { "/bikes/new" }
   let(:current_user) { FactoryBot.create(:superuser) }
   let(:component) { with_request_url(url) { render_inline(described_class.new(current_user:)) } }
-  # The picker's "All" link, which the shortcuts also match on nav-link alone
-  let(:view_all_link) { "a.nav-link.text-muted" }
+  # The picker's "All" link
+  let(:view_all_link) { "a.text-muted" }
 
   it "renders the shortcut links and an option per admin page, minus the dev pages" do
     expect(component.css("ul.navbar-nav a").map(&:text)).to eq(%w[Users Bikes Organizations News Stolen])
@@ -36,7 +36,7 @@ RSpec.describe Admin::Navbar::Component, type: :component do
     it "renders only the brand and the exit link" do
       expect(component).to have_css("a", text: "Exit Admin")
       expect(component).to_not have_css("[role='option']", visible: :all)
-      expect(component).to_not have_css("a.nav-link")
+      expect(component).to_not have_css("ul.navbar-nav")
     end
   end
 

--- a/spec/components/org/menu_items/component_spec.rb
+++ b/spec/components/org/menu_items/component_spec.rb
@@ -104,7 +104,7 @@ RSpec.describe Org::MenuItems::Component, type: :component do
             render_inline(described_class.new(organization:, current_user:, controller_namespace:,
               controller_name: sequences_controller, action_name:))
           }
-          active = rendered.css("a.nav-link.active").map { |a| a.text.strip }
+          active = rendered.css("a.nav-link[aria-current]").map { |a| a.text.strip }
           expect(active).to include("Manage Registration sequences")
         end
       end

--- a/spec/components/page_block/main_content/content/component_spec.rb
+++ b/spec/components/page_block/main_content/content/component_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe PageBlock::MainContent::Content::Component, type: :component do
 
     it "swaps the info links for the news links" do
       expect(component.text).to_not match "Where"
-      expect(component.css("a[href='#{news_index_path}'].active").count).to eq 1
+      expect(component.css("a[href='#{news_index_path}'][aria-current]").count).to eq 1
       expect(component.text).to match "Bike Index Store"
     end
   end

--- a/spec/components/page_block/navbar/menu_link/component_spec.rb
+++ b/spec/components/page_block/navbar/menu_link/component_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe PageBlock::Navbar::MenuLink::Component, type: :component do
   let(:args) { {label: "Help", path: "/help"} }
 
   it "resolves active from the path when active is omitted" do
-    expect(component).to have_css "a.nav-link.active[href='/help']", text: "Help"
+    expect(component).to have_css "a.nav-link[aria-current][href='/help']", text: "Help"
   end
 
   context "on another page" do
@@ -16,7 +16,7 @@ RSpec.describe PageBlock::Navbar::MenuLink::Component, type: :component do
 
     it "renders inactive" do
       expect(component).to have_css "a.nav-link[href='/help']"
-      expect(component).to_not have_css "a.active"
+      expect(component).to_not have_css "a[aria-current]"
     end
   end
 
@@ -26,7 +26,7 @@ RSpec.describe PageBlock::Navbar::MenuLink::Component, type: :component do
     # active: false pins the link inactive even on its own page — index.coffee sets
     # #getStolenBackLink's state, because the navbar renders from a cached fragment
     it "stays inactive on its own page" do
-      expect(component).to_not have_css "a.active"
+      expect(component).to_not have_css "a[aria-current]"
     end
   end
 
@@ -35,7 +35,7 @@ RSpec.describe PageBlock::Navbar::MenuLink::Component, type: :component do
     let(:url) { "/" }
 
     it "renders active regardless of the path" do
-      expect(component).to have_css "a.nav-link.active[href='/search/registrations']"
+      expect(component).to have_css "a.nav-link[aria-current][href='/search/registrations']"
     end
   end
 
@@ -44,7 +44,7 @@ RSpec.describe PageBlock::Navbar::MenuLink::Component, type: :component do
     let(:url) { "/news/some-post" }
 
     it "matches on the controller rather than the path" do
-      expect(component).to have_css "a.nav-link.active[href='/news']"
+      expect(component).to have_css "a.nav-link[aria-current][href='/news']"
     end
 
     context "on another controller" do
@@ -63,7 +63,7 @@ RSpec.describe PageBlock::Navbar::MenuLink::Component, type: :component do
     let(:url) { "/news/some-post" }
 
     it "matches the same as :match_controller" do
-      expect(component).to have_css "a.nav-link.active[href='/news']"
+      expect(component).to have_css "a.nav-link[aria-current][href='/news']"
     end
   end
 

--- a/spec/components/page_block/navbar/primary_menu/component_spec.rb
+++ b/spec/components/page_block/navbar/primary_menu/component_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe PageBlock::Navbar::PrimaryMenu::Component, type: :component do
     expect(menu_links).to eq(["Search", "Marketplace", "Sign up", "log in", "Help",
       "Stolen bike?", "Donate", "Blog", "Marketplace", "Search"])
     expect(component).to_not have_css "#setting_submenu"
-    expect(component).to_not have_css "#primary-main-menu a.active"
+    expect(component).to_not have_css "#primary-main-menu a[aria-current]"
   end
 
   # The links carry query params the page won't, which is why they match on controller and action
@@ -24,14 +24,14 @@ RSpec.describe PageBlock::Navbar::PrimaryMenu::Component, type: :component do
     let(:request_url) { "/search/registrations?query=trek" }
 
     it "marks both registration search links active" do
-      expect(component.css("#primary-main-menu a.active").map { |link| link.text.strip }).to eq(%w[Search Search])
+      expect(component.css("#primary-main-menu a[aria-current]").map { |link| link.text.strip }).to eq(%w[Search Search])
     end
 
     context "on page 2" do
       let(:request_url) { "/search/registrations?stolenness=all&page=2" }
 
       it "marks them active" do
-        expect(component.css("#primary-main-menu a.active").map { |link| link.text.strip }).to eq(%w[Search Search])
+        expect(component.css("#primary-main-menu a[aria-current]").map { |link| link.text.strip }).to eq(%w[Search Search])
       end
     end
 
@@ -40,7 +40,7 @@ RSpec.describe PageBlock::Navbar::PrimaryMenu::Component, type: :component do
       let(:request_url) { "/search/registrations?stolenness=stolen" }
 
       it "marks them active" do
-        expect(component.css("#primary-main-menu a.active").map { |link| link.text.strip }).to eq(%w[Search Search])
+        expect(component.css("#primary-main-menu a[aria-current]").map { |link| link.text.strip }).to eq(%w[Search Search])
       end
     end
   end
@@ -49,7 +49,7 @@ RSpec.describe PageBlock::Navbar::PrimaryMenu::Component, type: :component do
     let(:request_url) { "/search/marketplace" }
 
     it "marks both marketplace links active" do
-      expect(component.css("#primary-main-menu a.active").map { |link| link.text.strip }).to eq(%w[Marketplace Marketplace])
+      expect(component.css("#primary-main-menu a[aria-current]").map { |link| link.text.strip }).to eq(%w[Marketplace Marketplace])
     end
   end
 

--- a/spec/components/ui/active_link/component_spec.rb
+++ b/spec/components/ui/active_link/component_spec.rb
@@ -14,13 +14,14 @@ RSpec.describe UI::ActiveLink::Component, type: :component do
     expect(link["href"]).to eq path
     expect(link.text).to eq "Help"
     expect(link.attributes).to_not have_key("class")
+    expect(link.attributes).to_not have_key("aria-current")
   end
 
   context "on the linked page" do
     let(:request_url) { path }
 
     it "marks the link active" do
-      expect(link["class"]).to eq "active"
+      expect(link["aria-current"]).to eq "page"
     end
   end
 
@@ -34,8 +35,9 @@ RSpec.describe UI::ActiveLink::Component, type: :component do
     context "on the linked page" do
       let(:request_url) { path }
 
-      it "appends active" do
-        expect(link["class"]).to eq "nav-link active"
+      it "keeps the class, and marks it active" do
+        expect(link["class"]).to eq "nav-link"
+        expect(link["aria-current"]).to eq "page"
       end
     end
   end
@@ -45,21 +47,21 @@ RSpec.describe UI::ActiveLink::Component, type: :component do
     let(:request_url) { "/bikes/12" }
 
     it "defaults to :path, so another page of the controller isn't active" do
-      expect(link["class"]).to be_blank
+      expect(link["aria-current"]).to be_blank
     end
 
     context ":controller" do
       let(:options) { {match: :controller} }
 
       it "is active on another page of the same controller" do
-        expect(link["class"]).to eq "active"
+        expect(link["aria-current"]).to eq "page"
       end
 
       context "on a page of a different controller" do
         let(:request_url) { "/help" }
 
         it "isn't active" do
-          expect(link["class"]).to be_blank
+          expect(link["aria-current"]).to be_blank
         end
       end
     end
@@ -68,7 +70,7 @@ RSpec.describe UI::ActiveLink::Component, type: :component do
       let(:options) { {match: :controller_action} }
 
       it "isn't active on a different action of the same controller" do
-        expect(link["class"]).to be_blank
+        expect(link["aria-current"]).to be_blank
       end
 
       # What a link carrying query params needs — the URL won't compare equal
@@ -77,7 +79,7 @@ RSpec.describe UI::ActiveLink::Component, type: :component do
         let(:request_url) { "/search/registrations?query=trek" }
 
         it "is active" do
-          expect(link["class"]).to eq "active"
+          expect(link["aria-current"]).to eq "page"
         end
       end
 
@@ -86,7 +88,7 @@ RSpec.describe UI::ActiveLink::Component, type: :component do
         let(:request_url) { "/search/marketplace" }
 
         it "isn't active" do
-          expect(link["class"]).to be_blank
+          expect(link["aria-current"]).to be_blank
         end
       end
 
@@ -98,10 +100,10 @@ RSpec.describe UI::ActiveLink::Component, type: :component do
 
         it "compares the action the request dispatched, not the GET route's" do
           on_get = with_request_url(path) { render_inline(instance) }
-          expect(on_get.css("a").first["class"]).to eq "active"
+          expect(on_get.css("a").first["aria-current"]).to eq "page"
 
           on_patch = with_request_url(path, method: "PATCH") { render_inline(instance) }
-          expect(on_patch.css("a").first["class"]).to be_blank
+          expect(on_patch.css("a").first["aria-current"]).to be_blank
         end
       end
     end
@@ -120,7 +122,7 @@ RSpec.describe UI::ActiveLink::Component, type: :component do
       let(:options) { {active: true} }
 
       it "skips the current page check" do
-        expect(link["class"]).to eq "active"
+        expect(link["aria-current"]).to eq "page"
       end
     end
 
@@ -129,7 +131,7 @@ RSpec.describe UI::ActiveLink::Component, type: :component do
       let(:options) { {active: false} }
 
       it "skips the current page check" do
-        expect(link.attributes).to_not have_key("class")
+        expect(link.attributes).to_not have_key("aria-current")
       end
     end
   end
@@ -148,6 +150,16 @@ RSpec.describe UI::ActiveLink::Component, type: :component do
     it "passes them through to the anchor" do
       expect(link["id"]).to eq "footer-help"
       expect(link["target"]).to eq "_blank"
+    end
+
+    context "including aria" do
+      let(:request_url) { path }
+      let(:options) { {aria: {label: "Help center"}} }
+
+      it "keeps them, alongside the current it marks" do
+        expect(link["aria-label"]).to eq "Help center"
+        expect(link["aria-current"]).to eq "page"
+      end
     end
   end
 

--- a/spec/components/ui/active_link/component_spec.rb
+++ b/spec/components/ui/active_link/component_spec.rb
@@ -139,7 +139,7 @@ RSpec.describe UI::ActiveLink::Component, type: :component do
   context "with a class in html_options" do
     let(:options) { {class: "nav-link"} }
 
-    it "raises, since the component builds its own" do
+    it "raises, since html_class is the way in" do
       expect { component }.to raise_error(ArgumentError, /html_class/)
     end
   end

--- a/spec/components/ui/active_link/component_spec.rb
+++ b/spec/components/ui/active_link/component_spec.rb
@@ -42,6 +42,8 @@ RSpec.describe UI::ActiveLink::Component, type: :component do
     end
   end
 
+  # Only :path can say "page" — the widened matches go active on a page the link doesn't
+  # point at, so they say "true"
   describe "match" do
     let(:path) { "/bikes/new" }
     let(:request_url) { "/bikes/12" }
@@ -53,8 +55,8 @@ RSpec.describe UI::ActiveLink::Component, type: :component do
     context ":controller" do
       let(:options) { {match: :controller} }
 
-      it "is active on another page of the same controller" do
-        expect(link["aria-current"]).to eq "page"
+      it "is active on another page of the same controller, without claiming to be it" do
+        expect(link["aria-current"]).to eq "true"
       end
 
       context "on a page of a different controller" do
@@ -79,7 +81,7 @@ RSpec.describe UI::ActiveLink::Component, type: :component do
         let(:request_url) { "/search/registrations?query=trek" }
 
         it "is active" do
-          expect(link["aria-current"]).to eq "page"
+          expect(link["aria-current"]).to eq "true"
         end
       end
 
@@ -100,7 +102,7 @@ RSpec.describe UI::ActiveLink::Component, type: :component do
 
         it "compares the action the request dispatched, not the GET route's" do
           on_get = with_request_url(path) { render_inline(instance) }
-          expect(on_get.css("a").first["aria-current"]).to eq "page"
+          expect(on_get.css("a").first["aria-current"]).to eq "true"
 
           on_patch = with_request_url(path, method: "PATCH") { render_inline(instance) }
           expect(on_patch.css("a").first["aria-current"]).to be_blank

--- a/spec/components/ui/button/component_spec.rb
+++ b/spec/components/ui/button/component_spec.rb
@@ -237,11 +237,18 @@ RSpec.describe UI::Button::Component, type: :component do
   describe "ACTIVE_COLORS" do
     # Every active class is variant-prefixed, so it can never compete with the resting
     # color it overrides — that's what lets both sets be emitted without `!` important.
-    it "covers every color, prefixed with tw:is-active:" do
-      expect(described_class::ACTIVE_COLORS.keys).to eq(described_class::COLORS.keys)
+    it "covers every color but link, prefixed with tw:is-active:" do
+      expect(described_class::ACTIVE_COLORS.keys).to eq(described_class::COLORS.keys - [:link])
       described_class::ACTIVE_COLORS.each_value do |classes|
         expect(classes.split.grep_v(/\Atw:is-active:/)).to eq([])
       end
+    end
+
+    # A utility here would outrank .twlink's own is-active rule, so link color would stop
+    # following the class it's built from
+    it "leaves link color to .twlink" do
+      expect(described_class.build_classes(color: :link, size: :md).split).to include("twlink")
+        .and(satisfy { |tokens| tokens.grep(/\Atw:is-active:(?!focus:)/).empty? })
     end
   end
 

--- a/spec/components/ui/dropdown/component_spec.rb
+++ b/spec/components/ui/dropdown/component_spec.rb
@@ -19,4 +19,21 @@ RSpec.describe UI::Dropdown::Component, type: :component do
     expect(fill).to be_present
     expect(described_class::ACTIVE_COLORS).to include(fill)
   end
+
+  context "with button_color: :link" do
+    let(:component) do
+      render_inline(described_class.new(name: "Menu", button_color: :link, active: true)) do |dropdown|
+        dropdown.with_entry_item { "Profile" }
+      end
+    end
+    let(:trigger) { component.css("button#menu").first }
+
+    # Only the label is underlined, so the chevron beside it isn't. .twlink underlines the
+    # trigger on hover and active alike, which is what the utility holds off
+    it "underlines the label rather than the trigger" do
+      expect(trigger["class"].split).to include("twlink", "tw:no-underline")
+      expect(trigger["data-active"]).to eq "true"
+      expect(component.css("button#menu span.tw\\:underline").text).to eq "Menu"
+    end
+  end
 end

--- a/spec/components/ui/table/component_spec.rb
+++ b/spec/components/ui/table/component_spec.rb
@@ -64,9 +64,9 @@ RSpec.describe UI::Table::Component, type: :component do
         table.column(sortable: "email") { |r| r.email }
       end
 
-      expect(result).to have_css("th a.twlink.active", text: /Name/)
+      expect(result).to have_css("th a.twlink[data-active='true']", text: /Name/)
       expect(result).to have_css("th a.twlink", text: /Email/)
-      expect(result).not_to have_css("th a.active", text: /Email/)
+      expect(result).not_to have_css("th a[data-active]", text: /Email/)
     end
 
     context "with custom label" do
@@ -76,7 +76,7 @@ RSpec.describe UI::Table::Component, type: :component do
           table.column(sortable: "code_integer", label: "Code #") { |r| r.email }
         end
 
-        expect(result).to have_css("th a.twlink.active", text: /Batch/)
+        expect(result).to have_css("th a.twlink[data-active='true']", text: /Batch/)
         expect(result).not_to have_css("th a", text: /Bike Sticker Batch/)
         expect(result).to have_css("th a.twlink", text: /Code #/)
         expect(result).not_to have_css("th a", text: /Code Integer/)
@@ -129,8 +129,8 @@ RSpec.describe UI::Table::Component, type: :component do
           table.column(sortable: "email") { |r| r.email }
         end
 
-        expect(result).to have_css("th a.twlink.active", text: /Created/)
-        expect(result).not_to have_css("th a.active", text: /Email/)
+        expect(result).to have_css("th a.twlink[data-active='true']", text: /Created/)
+        expect(result).not_to have_css("th a[data-active]", text: /Email/)
       end
     end
   end


### PR DESCRIPTION
`UI::ActiveLink` (#4133) marked the current page with an `active` class, but the `is-active` variant that every other selected button, menu item and toggle styles through already matches `[aria-current]` — which is also what a screen reader wants on a nav link. The component sets that instead.

- **The legacy nav, org menu and footer rules move to `[aria-current]`**, and `welcome/index.coffee` sets the attribute on the one link the cached navbar leaves to JS.
- **`.twlink` and `.twlink-underlined` state their active state as the variant**, rather than repeating a marker list that was already drifting from it — it covers the `:active` pseudo and the disabled guards those rules carried separately. `UI::TableColumn`'s sort link flags itself `data-active` to keep reaching them, and the underlined hover's oklch shift moves to a custom property so both states share one formula.
- **The admin navbar drops `.nav-link` for utilities.** Its display, padding and color came from the vendored bootstrap dump, which isn't ours to edit and keys the active color off the class; two constants carry the same declarations.
- **The news sidebar's hand-rolled active link becomes an `ActiveLink`**, passing `active:` for the `sortable_search_params?` condition the component can't derive.
