### PR TITLE
Move .twtext-color to bike_index_components.css as a utility

### DIFF
--- a/.claude/skills/frontend-conventions/SKILL.md
+++ b/.claude/skills/frontend-conventions/SKILL.md
@@ -33,7 +33,7 @@ Scope it rather than running bare `bin/lint`: a whole-repo run reformats files o
 - Labels should use the `twlabel` class.
 - Basic links should use the `twlink` class.
 - A link that should take the color of the text around it — inside an alert, a colored `<small>`, the review-app banner — uses `twlink-underlined` instead. Never hand-roll `tw:text-inherit tw:underline`. Its color must come from an ancestor, not a `tw:text-*` on the link itself, which would outrank the class at every state.
-- The default text color is `tw:twtext-color` (`tw:twtext-color!` to force it). Prefixed because it's an `@utility`, not a class in the `@layer components` block: **a Bike Index class that anything `@apply`s has to be an `@utility`** — v4's `@apply` rejects a components-layer class with "Cannot apply unknown utility class". Both live in `app/assets/tailwind/bike_index_components.css`; `tw:base-font` is the other one.
+- The default text color is `tw:twtext-color` (`tw:twtext-color!` to force it). It's an `@utility`, hence the `tw:` prefix — **any Bike Index class that something `@apply`s has to be an `@utility`**; v4's `@apply` rejects a `@layer components` class with "Cannot apply unknown utility class".
 - **Every number** should be rendered with `number_display(number)`. This applies even when a number is composed into a string with non-numeric values — wrap the number itself, not the surrounding string.
   - Good: `[number_display(@bike.year), @bike.mnfg_name].join(" ")`
   - Bad: `[@bike.year, @bike.mnfg_name].join(" ")`

--- a/.claude/skills/frontend-conventions/SKILL.md
+++ b/.claude/skills/frontend-conventions/SKILL.md
@@ -33,6 +33,7 @@ Scope it rather than running bare `bin/lint`: a whole-repo run reformats files o
 - Labels should use the `twlabel` class.
 - Basic links should use the `twlink` class.
 - A link that should take the color of the text around it — inside an alert, a colored `<small>`, the review-app banner — uses `twlink-underlined` instead. Never hand-roll `tw:text-inherit tw:underline`. Its color must come from an ancestor, not a `tw:text-*` on the link itself, which would outrank the class at every state.
+- The default text color is `tw:twtext-color` (`tw:twtext-color!` to force it). Prefixed because it's an `@utility`, not a class in the `@layer components` block: **a Bike Index class that anything `@apply`s has to be an `@utility`** — v4's `@apply` rejects a components-layer class with "Cannot apply unknown utility class". Both live in `app/assets/tailwind/bike_index_components.css`; `tw:base-font` is the other one.
 - **Every number** should be rendered with `number_display(number)`. This applies even when a number is composed into a string with non-numeric values — wrap the number itself, not the surrounding string.
   - Good: `[number_display(@bike.year), @bike.mnfg_name].join(" ")`
   - Bad: `[@bike.year, @bike.mnfg_name].join(" ")`

--- a/.claude/skills/pr/references/screenshots.md
+++ b/.claude/skills/pr/references/screenshots.md
@@ -53,6 +53,8 @@ Skip per-page only when the URL didn't exist on the base (a brand-new route or p
 
 Re-invoke `frontend-screenshots` with the same `(url-path, page-slug)` pairs, passing the base as its `BASE_REF` (`origin/main` unless **Orient** chose otherwise) — its "Cross-branch comparison" section does the rest, whether or not the base is `main`. Then re-invoke `github-pr-images` for those PNGs, host-only exactly as in step 3.
 
+`git rev-list --count HEAD..origin/main` first: **Prepare the branch**'s merge normally leaves it 0, but on a long run the remote moves after that merge, and the "before" then shows base commits the branch never saw.
+
 Two things the checkout itself does, either side of it:
 
 - **`bin/rails tailwindcss:build` after each checkout when the diff touches `app/assets/tailwind/**`.** The watcher doesn't rebuild on a checkout, so the base capture otherwise renders the branch's CSS — a before/after that silently shows the same styling twice. Verify by grepping `app/assets/builds/tailwind.css` for a class the branch adds; build again on the way back.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -75,7 +75,7 @@ Worth delegating enumeration at all rather than eyeballing a grep: in that same 
 
 Uses RSpec. All business logic should be tested. The `rspec-testing` skill covers project-specific style (`context`+`let`, request specs over controller specs, avoiding mocks). A test that fails intermittently is the `fixing-flaky-failures` skill — coverage is never what gives way to make CI green.
 
-**Verify with `bundle exec rspec` over the spec paths your change touches.** Not `bin/turbo_tests`, whose eight parallel workers are for the whole suite, and **not `bin/ci`** unless you're asked for it or a specific question needs the full suite — CI runs that on push. `bin/turbo_tests` is also what precompiles assets, so a `:js` spec run in a workspace where `bin/dev` has never run raises `Sprockets::Rails::Helper::AssetNotFound`; the fix is `bundle exec rails tailwindcss:build`, not switching runners.
+**Verify with `bundle exec rspec` over the spec paths your change touches** — not `bin/turbo_tests` or `bin/ci`, whole-suite runners CI already does on push. A `:js` spec failing on a missing Tailwind build is the `sandbox-test-setup` skill, not a reason to switch runners.
 
 **Never hand-edit a VCR cassette**, and never `git checkout` away one a spec run re-recorded — cassettes only change by being recorded, and a re-recording gets committed on whatever branch you're on. To clear stale contents, `rm` the file and re-run the spec.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -75,7 +75,7 @@ Worth delegating enumeration at all rather than eyeballing a grep: in that same 
 
 Uses RSpec. All business logic should be tested. The `rspec-testing` skill covers project-specific style (`context`+`let`, request specs over controller specs, avoiding mocks). A test that fails intermittently is the `fixing-flaky-failures` skill — coverage is never what gives way to make CI green.
 
-**Anything broader than a handful of files goes through `bin/ci`** — it runs locally what CI runs. A serial `bundle exec rspec` over a directory takes many times longer, and `bin/turbo_tests`, which it runs the suite through, is also what compiles assets and keeps the test Redis off the dev database.
+**Verify with `bundle exec rspec` over the spec paths your change touches.** Not `bin/turbo_tests`, whose eight parallel workers are for the whole suite, and **not `bin/ci`** unless you're asked for it or a specific question needs the full suite — CI runs that on push. `bin/turbo_tests` is also what precompiles assets, so a `:js` spec run in a workspace where `bin/dev` has never run raises `Sprockets::Rails::Helper::AssetNotFound`; the fix is `bundle exec rails tailwindcss:build`, not switching runners.
 
 **Never hand-edit a VCR cassette**, and never `git checkout` away one a spec run re-recorded — cassettes only change by being recorded, and a re-recording gets committed on whatever branch you're on. To clear stale contents, `rm` the file and re-run the spec.
 

--- a/app/assets/tailwind/application.css
+++ b/app/assets/tailwind/application.css
@@ -173,7 +173,7 @@
 }
 
 @utility base-font {
-  @apply tw:antialiased tw:font-sans tw:text-gray-900 tw:dark:text-gray-400;
+  @apply tw:antialiased tw:font-sans tw:twtext-color;
 }
 
 @layer base {
@@ -185,7 +185,7 @@
 }
 
 body {
-  @apply tw:base-font;
+  @apply tw:base-font tw:dark:bg-gray-900;
 
   /* .primary-header-nav's margin-bottom, which the full-bleed pages pull up by to sit
      flush under the navbar. Defined here rather than beside the nav in revised.scss,
@@ -198,22 +198,6 @@ body {
     --nav-gap: 60px;
   }
 }
-/*
-  'dark:' syntax isn't working for the body element, unclear why - hacking with this for now
-*/
-body.dark {
-  @apply tw:bg-gray-900 tw:text-gray-400;
-}
-
-/* TODO: use this in the body instead of separately */
-.twtext-color {
-  @apply tw:text-gray-900 tw:dark:text-gray-400;
-}
-
-.twtext-color\! {
-  @apply tw:text-gray-900! tw:dark:text-gray-400!;
-}
-
 /* select2 is used by everythingcombox. Here are styles to make it look like the other inputs */
 .select2 .select2-selection--multiple {
   /* There is some funky padding stuff that goes on in select2. This makes it mostly match */

--- a/app/assets/tailwind/bike_index_components.css
+++ b/app/assets/tailwind/bike_index_components.css
@@ -1,5 +1,12 @@
 /* Bike Index's own tw* classes. Rules that style one component's markup — .ui-table,
  * .search-results-frame-wrapper — stay in application.css */
+
+/* A utility rather than a class in the layer below, because `@apply` only takes
+ * utilities and base-font applies this one for the body */
+@utility twtext-color {
+  @apply tw:text-gray-900 tw:dark:text-gray-400;
+}
+
 @layer components {
   .twlink {
     @apply tw:text-blue-600 tw:dark:text-blue-400 tw:transition-colors;

--- a/app/assets/tailwind/bike_index_components.css
+++ b/app/assets/tailwind/bike_index_components.css
@@ -1,8 +1,7 @@
 /* Bike Index's own tw* classes. Rules that style one component's markup — .ui-table,
  * .search-results-frame-wrapper — stay in application.css */
 
-/* A utility rather than a class in the layer below: `@apply` only takes utilities,
- * and base-font applies this one */
+/* A utility rather than a class in the layer below: `@apply` only takes utilities */
 @utility twtext-color {
   @apply tw:text-gray-900 tw:dark:text-gray-400;
 }

--- a/app/assets/tailwind/bike_index_components.css
+++ b/app/assets/tailwind/bike_index_components.css
@@ -1,8 +1,8 @@
 /* Bike Index's own tw* classes. Rules that style one component's markup — .ui-table,
  * .search-results-frame-wrapper — stay in application.css */
 
-/* A utility rather than a class in the layer below, because `@apply` only takes
- * utilities and base-font applies this one for the body */
+/* A utility rather than a class in the layer below: `@apply` only takes utilities,
+ * and base-font applies this one */
 @utility twtext-color {
   @apply tw:text-gray-900 tw:dark:text-gray-400;
 }

--- a/app/components/admin/bikes_table/component.rb
+++ b/app/components/admin/bikes_table/component.rb
@@ -8,7 +8,7 @@ module Admin
     # checkboxes, and skip_user to drop the owner column.
     class Component < ApplicationComponent
       # Digest of the markup inside the row cache — the cached_markup_digest spec keeps it current
-      MARKUP_DIGEST = "b09ab1f70148"
+      MARKUP_DIGEST = "71b59f4c9141"
 
       def initialize(bikes:, no_show_header: false, show_serial: false, render_sortable: false,
         skip_user: false, render_multi_check: false)

--- a/app/components/admin/bug_reports_table/component.rb
+++ b/app/components/admin/bug_reports_table/component.rb
@@ -4,7 +4,7 @@ module Admin
   module BugReportsTable
     class Component < ApplicationComponent
       # Digest of the markup inside the row cache — the cached_markup_digest spec keeps it current
-      MARKUP_DIGEST = "6d0630261791"
+      MARKUP_DIGEST = "43efdd898fbc"
 
       def initialize(collection:, render_sortable: false)
         @collection = collection

--- a/app/components/admin/users_table/component.rb
+++ b/app/components/admin/users_table/component.rb
@@ -6,7 +6,7 @@ module Admin
     # render_deleted to show the deleted_at column.
     class Component < ApplicationComponent
       # Digest of the markup inside the row cache — the cached_markup_digest spec keeps it current
-      MARKUP_DIGEST = "aec822e6af49"
+      MARKUP_DIGEST = "b8991152771f"
 
       def initialize(users:, render_sortable: false, render_deleted: false)
         @users = users

--- a/app/components/bikes/stolen_checklist/component.html.erb
+++ b/app/components/bikes/stolen_checklist/component.html.erb
@@ -29,7 +29,7 @@
 
     <span class="<%= text_classes(street?) %>">
       <%= translation(:report_theft_html,
-            edit_bike_link: link_to(translation(:location_where_the_theft_occurred), edit_path("theft_details"))) %>
+            edit_bike_link: link_to(translation(:location_where_the_theft_occurred), edit_path("theft_details"), class: "twlink-underlined")) %>
     </span>
   </li>
 
@@ -38,7 +38,7 @@
 
     <span class="<%= text_classes(images?) %>">
       <%= translation(:add) %>
-      <%= link_to translation(:a_photo_of_your_bike_type, bike_type: @bike.type), edit_path("photos") %>
+      <%= link_to translation(:a_photo_of_your_bike_type, bike_type: @bike.type), edit_path("photos"), class: "twlink-underlined" %>
     </span>
   </li>
 
@@ -61,7 +61,7 @@
 
               <%= link_to translation(:nl_website_link_text),
                     "https://www.politie.nl/aangifte-of-melding-doen/voorbereiding-aangifte/diefstal-fiets.html",
-                    target: "_blank", rel: "noopener" %>
+                    target: "_blank", rel: "noopener", class: "twlink-underlined" %>
 
               <em><%= translation(:nl_digid_required) %></em>
             </span>
@@ -82,7 +82,7 @@
             <span class="checklist-text">
               <strong><%= translation(:nl_person) %></strong>
               <%= translation(:nl_person_report) %>
-              <%= link_to "www.politie.nl/mijn-buurt/politiebureaus", "https://www.politie.nl/mijn-buurt/politiebureaus" %>
+              <%= link_to "www.politie.nl/mijn-buurt/politiebureaus", "https://www.politie.nl/mijn-buurt/politiebureaus", class: "twlink-underlined" %>
             </span>
           </li>
         </ul>
@@ -95,7 +95,7 @@
 
     <span class="<%= text_classes(police_report?) %>">
       <%= translation(:add_bike_link_to_your_theft_report_html,
-            bike_link: link_to(translation(:your_police_report), edit_path("theft_details", anchor: "policeReportNumber"))) %>
+            bike_link: link_to(translation(:your_police_report), edit_path("theft_details", anchor: "policeReportNumber"), class: "twlink-underlined")) %>
     </span>
 
     <ul class="tw:m-0 tw:list-none tw:p-0">
@@ -104,7 +104,7 @@
 
         <span class="<%= text_classes(submitted_to_police_services?) %>">
           <%= translation(:push_bike_info_to) %>
-          <%= link_to translation(:leads_online), translation(:leads_online_url) %>
+          <%= link_to translation(:leads_online), translation(:leads_online_url), class: "twlink-underlined" %>
           <%= translation(:bike_index_does_this) %>
         </span>
 
@@ -141,7 +141,7 @@
     <%= box(false) %>
 
     <span class="<%= text_classes(false) %>">
-      <%= link_to translation(:share_widely_on_your_personal_social), edit_path("publicize") %>
+      <%= link_to translation(:share_widely_on_your_personal_social), edit_path("publicize"), class: "twlink-underlined" %>
       <%= translation(:facebook_instagram_etc) %>
     </span>
   </li>
@@ -151,7 +151,7 @@
 
     <span class="<%= text_classes(theft_alert?) %>">
       <%= translation(:supercharge_sharing_on_facebook) %>
-      <%= link_to translation(:promoted_stolen_bike_alerts), edit_path("alert") %>
+      <%= link_to translation(:promoted_stolen_bike_alerts), edit_path("alert"), class: "twlink-underlined" %>
     </span>
   </li>
 </ul>

--- a/app/components/org/search_results/bikes_table/component.rb
+++ b/app/components/org/search_results/bikes_table/component.rb
@@ -9,7 +9,7 @@ module Org
       # registrations on the show page). Pass render_sortable to enable sort links.
       class Component < ApplicationComponent
         # Digest of the markup inside the row cache — the cached_markup_digest spec keeps it current
-        MARKUP_DIGEST = "a385d2deb01a"
+        MARKUP_DIGEST = "facaa9412f4b"
 
         delegate :additional_registration_fields, :column_renames, to: :settings_component
 

--- a/app/components/page_block/marketplace_listing_panel/component.html.erb
+++ b/app/components/page_block/marketplace_listing_panel/component.html.erb
@@ -6,7 +6,7 @@
       tw:lg:justify-between
     "
   >
-    <h2 class="twtext-color! tw:my-2! tw:text-4xl! tw:font-normal">
+    <h2 class="tw:my-2! tw:text-4xl! tw:font-normal tw:twtext-color!">
       <%= amount_display(@marketplace_listing, currency_name_suffix: true) %>
 
       <span class="uncap tw:text-xl! tw:opacity-65">

--- a/app/components/registrations/show/wrapper/component.rb
+++ b/app/components/registrations/show/wrapper/component.rb
@@ -8,7 +8,7 @@ module Registrations
       class Component < ApplicationComponent
         # Digest of the markup inside the cache block — the cached_markup_digest spec
         # keeps it current, following what this tree renders out into UI:: and elsewhere
-        MARKUP_DIGEST = "1dad5b3f30ca"
+        MARKUP_DIGEST = "3287a4b7f84c"
 
         def initialize(bike:, current_user:, view:, available_views:, bike_sticker: nil, current_alerts: {})
           @bike = bike

--- a/app/components/ui/alerts/base/component.rb
+++ b/app/components/ui/alerts/base/component.rb
@@ -75,7 +75,7 @@ module UI
         end
 
         def header_color_classes
-          @default_header_color ? "twtext-color" : text_color_classes
+          @default_header_color ? "tw:twtext-color" : text_color_classes
         end
 
         def dismissable_color_classes

--- a/app/components/ui/modal/component.html.erb
+++ b/app/components/ui/modal/component.html.erb
@@ -60,7 +60,7 @@
       </div>
     <% end %>
 
-    <div class="twtext-color tw:px-5 tw:py-4">
+    <div class="tw:px-5 tw:py-4 tw:twtext-color">
       <%= body %>
     </div>
   </div>

--- a/app/components/ui/tooltip/component.rb
+++ b/app/components/ui/tooltip/component.rb
@@ -75,7 +75,7 @@ module UI
           role: "tooltip",
           id: tooltip_id,
           data: {"ui--tooltip-target": "tooltip"},
-          class: "twtext-color tw:hidden #{pointer} tw:whitespace-nowrap tw:rounded " \
+          class: "tw:twtext-color tw:hidden #{pointer} tw:whitespace-nowrap tw:rounded " \
             "tw:bg-white tw:px-2 tw:py-1 tw:text-xs tw:font-normal tw:border tw:border-gray-200 tw:shadow-lg tw:z-50 " \
             "tw:dark:bg-gray-800 tw:dark:border-gray-700"
         )

--- a/spec/components/ui/alerts/base/component_spec.rb
+++ b/spec/components/ui/alerts/base/component_spec.rb
@@ -63,7 +63,7 @@ RSpec.describe UI::Alerts::Base::Component, type: :component do
     context "default_header_color" do
       let(:options) { {text: "some text", header: "Banned user", kind: "error", default_header_color: true} }
       it "renders the header in the default text color" do
-        expect(component).to have_css("h4", class: "tw:twtext-color", text: "Banned user")
+        expect(component).to have_css("h4.tw\\:twtext-color", text: "Banned user")
         expect(component).to_not have_css("h4.tw:text-red-800")
       end
     end

--- a/spec/components/ui/alerts/base/component_spec.rb
+++ b/spec/components/ui/alerts/base/component_spec.rb
@@ -63,7 +63,7 @@ RSpec.describe UI::Alerts::Base::Component, type: :component do
     context "default_header_color" do
       let(:options) { {text: "some text", header: "Banned user", kind: "error", default_header_color: true} }
       it "renders the header in the default text color" do
-        expect(component).to have_css("h4.twtext-color", text: "Banned user")
+        expect(component).to have_css("h4", class: "tw:twtext-color", text: "Banned user")
         expect(component).to_not have_css("h4.tw:text-red-800")
       end
     end


### PR DESCRIPTION
`.twtext-color` and `.twtext-color\!` were the last `tw*` classes left behind in `application.css`, sitting unlayered under a TODO asking for the body to use them.

- **It's one `@utility` now rather than two classes.** Tailwind v4's `@apply` only takes utilities, and `base-font` applies this one, so the default text color is stated once; the `!` variant comes from Tailwind rather than a hand-escaped `.twtext-color\!` rule. Markup reads `tw:twtext-color`. As a utility instead of an unlayered rule it now loses to a `tw:text-*` on the same element rather than beating it — none of the four call sites carry one.
- **The `body.dark` block goes with it.** Its text color duplicated what `base-font` already emits, and "'dark:' syntax isn't working for the body element" was a v3 artifact: that mode generated `.dark body`, which can't match a `<body class="dark">`. v4's `&:where(.dark, .dark *)` does, so the background folds into the body rule.
- **The stolen checklist's eight links take `.twlink-underlined`**, the inherit-the-surrounding-color class from #4139. Nothing styled them before — the pages that render it load only `tailwind` and `revised`, neither of which colors a bare anchor — so "add a photo of your bike" read as plain text.

Compiled `tailwind.css` is the same but for those two folds, 17 bytes larger. Five `MARKUP_DIGEST` constants move because the renamed class sits in markup they cache.

Also: `frontend-conventions` gains the `tw:twtext-color` bullet and the rule behind the prefix — a class that anything `@apply`s has to be an `@utility`. And AGENTS.md's testing paragraph points verification at scoped `bundle exec rspec` instead of `bin/ci`, which is what the `rspec-testing`, `fixing-flaky-failures` and `pr` skills already said.
