### PR TITLE
Merge the footer's FAQ and Help links, and fix the pagination hover

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -61,6 +61,8 @@ A registration is as often an e-scooter, a stroller or a wheelchair, so **never 
 
 Run `bundle exec rails prepare_translations` after hand-editing a `component.en.yml`; `bin/lint` doesn't normalize YAML.
 
+A spec that renders in another locale — `spec/components/page_block/footer/component_spec.rb` does, in `:nl` — fails on a key the sync-generated `config/locales/translation.*.yml` don't carry yet, since `raise_on_missing_translations` is on in test. Add the key inline to all four; the next sync overwrites them.
+
 ## Subagents
 
 When a command fans out to subagents — `/simplify`, `/code-review`, or an ad-hoc fan-out — pick the model by how much of the *search* the agent has to invent, not by how simple the task sounds:

--- a/app/components/page_block/footer/component.en.yml
+++ b/app/components/page_block/footer/component.en.yml
@@ -17,8 +17,7 @@ en:
           - EIN 81-4296194"
         dev_and_design_resources: Dev & Design Resources
         donate: Donate
-        faq: FAQ
-        help: Help
+        faq_and_help: FAQ & Help
         how_to_get_your_stolen_bike_back: Get your stolen bike back
         language: Language
         law_enforcement: Law Enforcement

--- a/app/components/page_block/footer/component.html.erb
+++ b/app/components/page_block/footer/component.html.erb
@@ -19,19 +19,15 @@
               </li>
 
               <li>
-                <%= render UI::ActiveLink::Component.new(text: translation(".register_a_bike"), path: new_register_path) %>
+                <%= render UI::ActiveLink::Component.new(text: translation(".register_a_bike"), path: new_register_path, match: :controller) %>
               </li>
 
               <li>
-                <%= render UI::ActiveLink::Component.new(text: translation(".faq"), path: support_path) %>
+                <%= render UI::ActiveLink::Component.new(text: translation(".faq_and_help"), path: help_path) %>
               </li>
 
               <li>
                 <%= render UI::ActiveLink::Component.new(text: translation(".blog"), path: news_index_path) %>
-              </li>
-
-              <li>
-                <%= render UI::ActiveLink::Component.new(text: translation(".help"), path: help_path) %>
               </li>
 
               <li>

--- a/app/components/page_block/footer/component.rb
+++ b/app/components/page_block/footer/component.rb
@@ -5,7 +5,7 @@ module PageBlock
     class Component < ApplicationComponent
       FACEBOOK_PIXEL_ID = "199066297131941"
       # Digest of the cached template — the cached_markup_digest spec keeps it current
-      MARKUP_DIGEST = "82b456e191f5"
+      MARKUP_DIGEST = "e7111b6ed4fe"
 
       def initialize(current_user:, skip_facebook:, page_id:, passive_organization: nil)
         @current_user = current_user

--- a/app/components/ui/pagination/component.rb
+++ b/app/components/ui/pagination/component.rb
@@ -40,8 +40,8 @@ module UI
       end
 
       # Multiline classes strings here were confusing tailwind somehow :(
-      # relative, because -space-x-px overlaps each border with its neighbor's — only a
-      # positioned item can raise its own above them with z-10
+      # relative, so the z-10s below lift an item's border above the neighbors
+      # -space-x-px overlaps it with
       def disabled_classes
         "tw:disabled:cursor-default tw:relative tw:px-3 tw:py-1 tw:leading-tight tw:border tw:border-gray-200 tw:dark:border-gray-700 tw:bg-white tw:dark:bg-gray-800 tw:text-gray-500 tw:dark:text-gray-400 tw:no-underline "
       end

--- a/app/components/ui/pagination/component.rb
+++ b/app/components/ui/pagination/component.rb
@@ -30,7 +30,7 @@ module UI
         elsif item.is_a?(String) # it's the current page
           content_tag(:a, number_display(item), role: "link", class: current_link_class, disabled: true, "aria-disabled": "true")
         else
-          content_tag(:a, pagy_t("pagy.gap").html_safe, role: "link", class: "px-2", disabled: true, "aria-disabled": "true")
+          content_tag(:a, pagy_t("pagy.gap").html_safe, role: "link", class: "tw:px-2", disabled: true, "aria-disabled": "true")
         end
       end
 

--- a/app/components/ui/pagination/component.rb
+++ b/app/components/ui/pagination/component.rb
@@ -40,12 +40,14 @@ module UI
       end
 
       # Multiline classes strings here were confusing tailwind somehow :(
+      # relative, because -space-x-px overlaps each border with its neighbor's — only a
+      # positioned item can raise its own above them with z-10
       def disabled_classes
-        "tw:disabled:cursor-default tw:px-3 tw:py-1 tw:leading-tight tw:border tw:border-gray-200 tw:dark:border-gray-700 tw:bg-white tw:dark:bg-gray-800 tw:text-gray-500 tw:dark:text-gray-400 "
+        "tw:disabled:cursor-default tw:relative tw:px-3 tw:py-1 tw:leading-tight tw:border tw:border-gray-200 tw:dark:border-gray-700 tw:bg-white tw:dark:bg-gray-800 tw:text-gray-500 tw:dark:text-gray-400 tw:no-underline "
       end
 
-      def active_classes(current = false)
-        disabled_classes + "tw:hover:border-purple-500 tw:hover:bg-purple-50 tw:hover:text-gray-800 tw:dark:hover:border-purple-500 tw:dark:hover:bg-purple-950 tw:dark:hover:text-white "
+      def active_classes
+        disabled_classes + "tw:hover:z-10 tw:hover:border-purple-500 tw:hover:bg-purple-50 tw:hover:text-gray-800 tw:dark:hover:border-purple-500 tw:dark:hover:bg-purple-950 tw:dark:hover:text-white "
       end
 
       def current_link_class
@@ -59,7 +61,7 @@ module UI
         end
         # The current page fills like an active UI::Button secondary
         extra_classes +
-          "tw:disabled:cursor-default tw:px-3 tw:py-1 tw:leading-tight tw:border tw:border-purple-500 tw:bg-purple-500 tw:text-white "
+          "tw:disabled:cursor-default tw:relative tw:z-10 tw:px-3 tw:py-1 tw:leading-tight tw:border tw:border-purple-500 tw:bg-purple-500 tw:text-white "
       end
 
       def pagy_series

--- a/bin/check_translations
+++ b/bin/check_translations
@@ -23,9 +23,18 @@ fi
 
 output "${CYAN}" "Checking Translations"
 
-# Quit as success if not on the branch to be synced
-if ! git branch --list | grep --silent "^* ${TRANSLATION_BRANCH}$"; then
-  output "${GREEN}" "Skipping: Not on TRANSLATION_BRANCH: ${TRANSLATION_BRANCH}"
+# The job runs as root over a workspace the runner owns, so git refuses to read the
+# repo at all without this. Only under $CI — locally it would write ~/.gitconfig.
+if [ -n "$CI" ]; then
+  git config --global --add safe.directory "$PWD"
+fi
+
+# Assigned rather than tested inline, so a git that can't answer aborts under `set -e`
+# instead of reading as "some other branch" and skipping green
+current_branch="$(git rev-parse --abbrev-ref HEAD)"
+
+if [ "$current_branch" != "$TRANSLATION_BRANCH" ]; then
+  output "${GREEN}" "Skipping: on ${current_branch}, not TRANSLATION_BRANCH: ${TRANSLATION_BRANCH}"
   exit 0
 fi
 

--- a/config/locales/translation.es.yml
+++ b/config/locales/translation.es.yml
@@ -5616,8 +5616,7 @@ es:
           de lucro 501(c)(3) - EIN 81-4296194"
         dev_and_design_resources: Recursos de desarrollo y diseño
         donate: Donar
-        faq: PREGUNTAS FRECUENTES
-        help: Ayuda
+        faq_and_help: Preguntas frecuentes y ayuda
         how_to_get_your_stolen_bike_back: Recupera su bicicleta
         language: Idioma
         law_enforcement: Fuerzas y Cuerpos de Seguridad

--- a/config/locales/translation.it.yml
+++ b/config/locales/translation.it.yml
@@ -5627,8 +5627,7 @@ it:
           501(c)(3) - EIN 81-4296194"
         dev_and_design_resources: Risorse per lo sviluppo e la progettazione
         donate: Donare
-        faq: FAQ
-        help: Aiuto
+        faq_and_help: FAQ e aiuto
         how_to_get_your_stolen_bike_back: Recupera la tua bicicletta rubata
         language: Lingua
         law_enforcement: forze dell'ordine

--- a/config/locales/translation.nb.yml
+++ b/config/locales/translation.nb.yml
@@ -5364,8 +5364,7 @@ nb:
           81-4296194"
         dev_and_design_resources: Utviklings- og designressurser
         donate: Donere
-        faq: FAQ
-        help: Hjelp
+        faq_and_help: FAQ og hjelp
         how_to_get_your_stolen_bike_back: Få tilbake den stjålne sykkelen
         language: Språk
         law_enforcement: Rettshåndhevelse

--- a/config/locales/translation.nl.yml
+++ b/config/locales/translation.nl.yml
@@ -5514,8 +5514,7 @@ nl:
           - EIN 81-4296194"
         dev_and_design_resources: Ontwikkelings- en ontwerpbronnen
         donate: Schenken
-        faq: FAQ
-        help: Helpen
+        faq_and_help: FAQ en hulp
         how_to_get_your_stolen_bike_back: Haal je gestolen fiets terug
         language: Taal
         law_enforcement: Politie


### PR DESCRIPTION
The footer's Bike Index column listed **FAQ** and **Help** separately, but `/support` redirects to `/help` — both links went to the same page.

- **They're one "FAQ & Help" link now.** The four sync-generated `translation.*.yml` files carry the new key inline, since the footer component spec renders in `:nl` under `raise_on_missing_translations` — a rule `AGENTS.md` now states.
- **"Register a bike" matches on controller**, so the footer flags it active across the registration flow rather than only on `/register/new`.
- **`UI::Pagination`'s hover stops underlining and keeps its border.** Bootstrap's reboot underlines every `a:hover` inside a `.container`, and `-space-x-px` overlaps each item's border with its neighbor's, so the hovered link's edge stayed gray under the item after it. The current page takes the same `z-10` — its purple border was covered the same way. The gap's `px-2` is prefixed too; unprefixed it was reaching bootstrap's, which only exists on a page that loads `revised`.
- **CI's translation sync has been skipping `main` since `f71c7a127`** — the container refuses the workspace as "dubious ownership", so `git branch --list` printed nothing and `bin/check_translations` read that as "some other branch" and exited 0. Last automated sync PR was #3783, on June 30. It sets `safe.directory` under `$CI`, and the branch now comes from an assignment, so a git that can't answer aborts instead of skipping green.
