### PR TITLE
Persist the register step 1 draft, and re-space the org sidebar pages

### DIFF
--- a/.claude/skills/frontend-conventions/SKILL.md
+++ b/.claude/skills/frontend-conventions/SKILL.md
@@ -73,6 +73,12 @@ The same instinct applies beyond buttons: **check `app/components/ui/` and `app/
 
 **Every typeahead / autocomplete / combobox goes through `UI::Forms::Combobox::Component`** — never a new Stimulus controller that fetches matches and renders its own menu. See `app/components/ui/forms/combobox/` (component + `component_preview.rb`) and `spec/components/ui/forms/combobox` for how to invoke it.
 
+## Form drafts: always `form-persist`
+
+**A form worth not retyping mirrors itself to localStorage through the `form-persist` controller** — never one of your own. It takes a `data-form-persist-key-value` unique per record, since the derived key is the form's action. See `app/components/register/step1/component.rb` and `app/components/register/step2/component.html.erb`.
+
+**A controller whose UI hangs off a restored field reconciles in two places** — a `form-persist:restored@window->…` entry in the element's `data-action`, and the same call in its own `connect`. A hand-rolled `window.addEventListener` is the older idiom; don't add more. See `app/components/register/step1/component.html.erb` with `app/javascript/controllers/register/heading_controller.js`.
+
 ## Current-page links: always `UI::ActiveLink`
 
 **Every link that goes `aria-current` on the page it points at goes through `UI::ActiveLink::Component`** — never `current_page?` in a template, and never a Stimulus controller of your own comparing `window.location`. It always derives the state in the browser (`app/javascript/controllers/ui/active_link_controller.js`), so there's no way to pass the answer in: `match:` is the only control over what counts as the page it points at. Any layout rendering one opens its `<body>` with `body_tag`. See `app/components/ui/active_link/`.

--- a/app/assets/tailwind/application.css
+++ b/app/assets/tailwind/application.css
@@ -201,21 +201,32 @@ body {
 /* The org sidebar is fixed, so the page it covers is pushed over instead. The
    controller narrows --org-sidebar-width as it collapses; defaulting to the
    expanded width keeps the content still until stimulus connects. There's no
-   navbar on these pages for a full-bleed page to pull up under. */
+   navbar here, so main's inset stands in for its gap -- named the same so a
+   full-bleed page pulls up under it with the same -mt-(--nav-gap) */
 body.with-org-sidebar {
-  --nav-gap: 0px;
+  --nav-gap: 28px;
 
   margin-left: var(--org-sidebar-width, 266px);
   transition: margin-left 0.18s ease;
 }
 
 /* The sidebar runs the height of the window, so the content does too -- a short page
-   would otherwise end partway down it, with the footer riding up beside the rows.
-   The inset stands in for the navbar gap these pages no longer have */
+   would otherwise end partway down it, with the footer riding up beside the rows */
 body.with-org-sidebar main {
-  @apply tw:pt-4 tw:min-[760px]:pt-7;
+  @apply tw:pt-(--nav-gap);
 
   min-height: 100vh;
+}
+
+/* A page that is one shell stretches to fill that height, so a full-bleed background
+   reaches the bottom rather than stopping at its content. Guarded on :only-child so
+   a multi-element page keeps block layout, where its margins still collapse */
+body.with-org-sidebar main:has(> :only-child) {
+  @apply tw:flex tw:flex-col;
+}
+
+body.with-org-sidebar main > :only-child {
+  flex-grow: 1;
 }
 
 /* PageBlock::Navbar::OrgSidebar::Component::MOBILE_BREAKPOINT, below which the sidebar is
@@ -224,6 +235,8 @@ body.with-org-sidebar main {
    between the two doesn't land outside both this and the template's min-[760px] */
 @media (width < 760px) {
   body.with-org-sidebar {
+    --nav-gap: 16px;
+
     margin-left: 0;
   }
 

--- a/app/components/page_block/main_content/organized/component.html.erb
+++ b/app/components/page_block/main_content/organized/component.html.erb
@@ -2,7 +2,7 @@
   <div class="<%= helpers.organized_container %>">
     <%# the layout skips its own spot for this, so it lands inside the content column %>
     <% if @show_general_alert %>
-      <%= render PageBlock::UserAlerts::Wrapper::Component.new(current_user: @current_user, wrapper_class: nil) %>
+      <%= render PageBlock::UserAlerts::Wrapper::Component.new(current_user: @current_user, wrapper_class: "tw:my-4") %>
     <% end %>
 
     <% if OrganizationDisplayer.law_enforcement_missing_verified_features?(@current_organization) %>

--- a/app/components/page_block/user_alerts/wrapper/component.rb
+++ b/app/components/page_block/user_alerts/wrapper/component.rb
@@ -9,8 +9,7 @@ module PageBlock
         # container lines it up with the navbar above; z-20 because the homepage and
         # landing page bike tile grids are positioned, so they'd otherwise paint over
         # this in-flow banner; general-alert is what the landing pages hang their own
-        # spacing on. Blank where the page already places it - MainContent::Organized
-        # renders this inside its content column, which the menu doesn't cover
+        # spacing on
         def initialize(current_user:, wrapper_class: "general-alert container tw:relative tw:z-20")
           @current_user = current_user
           @wrapper_class = wrapper_class
@@ -25,8 +24,6 @@ module PageBlock
         end
 
         def call
-          return render(alert_component) if @wrapper_class.blank?
-
           tag.div(render(alert_component), class: @wrapper_class)
         end
 

--- a/app/components/register/step1/component.html.erb
+++ b/app/components/register/step1/component.html.erb
@@ -1,6 +1,7 @@
 <%= render Register::Page::Component.new(embed: @embed, data: {controller: "register--heading",
     "register--heading-names-value": cycle_type_names.to_json,
-    action: "hw-combobox:selection->register--heading#update"}) do %>
+    action: "hw-combobox:selection->register--heading#update " \
+      "form-persist:restored@window->register--heading#update"}) do %>
   <%= render Register::Progress::Component.new(steps: @steps, step: 1) %>
   <%= render UI::Header::Component.new(text: heading_text, subtitle: translation(".just_the_essentials")) %>
 
@@ -26,6 +27,7 @@
     <div
       class="tw:mb-4"
       data-controller="register--propulsion"
+      data-action="form-persist:restored@window->register--propulsion#update"
       data-register--propulsion-always-motorized-value="<%= CycleType::ALWAYS_MOTORIZED.to_json %>"
       data-register--propulsion-never-motorized-value="<%= CycleType::NEVER_MOTORIZED.to_json %>"
     >

--- a/app/components/register/step1/component.html.erb
+++ b/app/components/register/step1/component.html.erb
@@ -27,7 +27,10 @@
     <div
       class="tw:mb-4"
       data-controller="register--propulsion"
-      data-action="form-persist:restored@window->register--propulsion#update"
+      data-action="
+        hw-combobox:selection->register--propulsion#update
+        form-persist:restored@window->register--propulsion#update
+      "
       data-register--propulsion-always-motorized-value="<%= CycleType::ALWAYS_MOTORIZED.to_json %>"
       data-register--propulsion-never-motorized-value="<%= CycleType::NEVER_MOTORIZED.to_json %>"
     >

--- a/app/components/register/step1/component.rb
+++ b/app/components/register/step1/component.rb
@@ -16,10 +16,10 @@ module Register
 
       private
 
-      # Turbo ignores a form's target unless it names an iframe, so a Turbo submission would
-      # render step 2 back inside the frame. Nor does autofocus belong in one - it scrolls
-      # the embedding page down to the frame on load. Nor does form-persist - a frame's
-      # localStorage is partitioned per embedding site, and blocked outright in Safari
+      # What a frame can't have: a Turbo submission, which Turbo would render back inside it
+      # (the target is ignored unless it names an iframe); autofocus, which scrolls the
+      # embedding page down to the frame on load; and form-persist, whose localStorage is
+      # partitioned per embedding site and blocked outright in Safari
       def form_options
         return {data: {turbo: false}, html: {target: "_top"}} if @embed
 

--- a/app/components/register/step1/component.rb
+++ b/app/components/register/step1/component.rb
@@ -18,11 +18,15 @@ module Register
 
       # Turbo ignores a form's target unless it names an iframe, so a Turbo submission would
       # render step 2 back inside the frame. Nor does autofocus belong in one - it scrolls
-      # the embedding page down to the frame on load
+      # the embedding page down to the frame on load. Nor does form-persist - a frame's
+      # localStorage is partitioned per embedding site, and blocked outright in Safari
       def form_options
         return {data: {turbo: false}, html: {target: "_top"}} if @embed
 
-        {data: {turbo: true, controller: "autofocus register--retry"}}
+        {data: {turbo: true, controller: "autofocus form-persist register--retry",
+                form_persist_key_value: "register-start-#{@b_param.id_token}",
+                action: "input->form-persist#save hw-combobox:selection->form-persist#save " \
+                  "submit->form-persist#clear"}}
       end
 
       # Derived when the frame's src doesn't name one

--- a/app/javascript/controllers/form_persist_controller.js
+++ b/app/javascript/controllers/form_persist_controller.js
@@ -10,6 +10,9 @@ import { Controller } from '@hotwired/stimulus'
 // hw-combobox:selection->form-persist#save submit->form-persist#clear".
 // The storage key defaults to pathname + the form's action (see derivedKey);
 // set data-form-persist-key-value only when that isn't unique per form.
+// A restore is announced as form-persist:restored on window - a controller whose
+// UI hangs off restored fields listens for it and reconciles in its own connect,
+// since a lazily loaded module can arrive after the announcement.
 // Writes are debounced (DEBOUNCE_MS) and a restored draft is discarded once
 // older than TTL_MS.
 const DEBOUNCE_MS = 400

--- a/app/javascript/controllers/register/heading_controller.js
+++ b/app/javascript/controllers/register/heading_controller.js
@@ -8,6 +8,12 @@ export default class extends Controller {
   static targets = ['cycleType']
   static values = { names: Object }
 
+  // Modules load lazily, so this one can arrive after form-persist has announced
+  // the restore that filled the combobox
+  connect () {
+    this.update()
+  }
+
   update () {
     const slug = this.element.querySelector('input[name$="[cycle_type]"]')?.value
     const name = this.namesValue[slug]

--- a/app/javascript/controllers/register/propulsion_controller.js
+++ b/app/javascript/controllers/register/propulsion_controller.js
@@ -8,13 +8,10 @@ export default class extends Controller {
   static targets = ['motorized', 'motorizedWrapper']
   static values = { alwaysMotorized: Array, neverMotorized: Array }
 
+  // Modules load lazily, so this one can arrive after the selection - or after
+  // form-persist has announced the restore that filled the combobox
   connect () {
-    this.element.addEventListener('hw-combobox:selection', this.update)
     this.update()
-  }
-
-  disconnect () {
-    this.element.removeEventListener('hw-combobox:selection', this.update)
   }
 
   update = () => {

--- a/spec/integration/registration/register_spec.rb
+++ b/spec/integration/registration/register_spec.rb
@@ -68,49 +68,24 @@ RSpec.describe "Register flow", :js, type: :system do
     wait_for_details_step
   end
 
-  # An async combobox carries no options to map a saved id back to a name, so the server
-  # renders the display itself - and back to step 1 is where a raw id would show up instead
-  it "shows the manufacturer by name, not by id, when back returns to step 1" do
-    start_registration
-    page.go_back
-
-    expect(page).to have_field("b_param_manufacturer_id", with: "Surly")
-    # The id is what submits, and only ever from the hidden field
-    expect(find("input[name='b_param[manufacturer_id]']", visible: :all).value).to eq manufacturer.id.to_s
-    expect(page).to have_no_field("b_param_manufacturer_id", with: manufacturer.id.to_s)
-
-    # The manufacturer itself, rather than Manufacturer.other with the id as free text
-    expect(BParam.last.manufacturer_id).to eq manufacturer.id
-    expect(BParam.last.manufacturer_other).to be_blank
-
-    # This field is autofocused, so the click into it brings no focus event of its own -
-    # typing still replaces the restored name rather than mashing into the middle of it
-    find_field("b_param_manufacturer_id").click
-    send_keys("Kona")
-
-    expect(page).to have_field("b_param_manufacturer_id", with: "Kona")
-  end
-
-  # Step 1 saves nothing until it submits, so a reload before then has only the draft to go on
-  it "keeps a step 1 draft across a reload" do
+  it "keeps a step 1 draft across a reload, and comes back to what it submitted" do
     visit "/register/new"
     type_into("#b_param_manufacturer_id", "Surly")
     click_combobox_option("Surly")
     type_into("#b_param_cycle_type", "e-Scooter")
     click_combobox_option("e-Scooter")
     fill_in "b_param[owner_email]", with: owner_email
-    expect(page).to have_content("E-SCOOTER INFO")
     # An always-motorized type answers the electric question itself
     expect(page).to have_checked_field("Electric (motorized)", disabled: true)
 
+    # Nothing is saved until step 1 submits, so the reload has only the draft to go on
     visit page.current_url
 
     expect(page).to have_field("b_param_manufacturer_id", with: "Surly")
-    # The id is what submits, and it restores alongside the name it displays
-    expect(find("input[name='b_param[manufacturer_id]']", visible: :all).value).to eq manufacturer.id.to_s
     expect(page).to have_field("b_param_cycle_type", with: "e-Scooter")
     expect(page).to have_field("b_param[owner_email]", with: owner_email)
-    # A restored type reaches the section label a step away, and the electric checkbox
+    # The restored type reaches the section label and the electric checkbox, each of which
+    # is a controller away from the combobox that changed
     expect(page).to have_content("E-SCOOTER INFO")
     expect(page).to have_checked_field("Electric (motorized)", disabled: true)
 
@@ -120,6 +95,24 @@ RSpec.describe "Register flow", :js, type: :system do
     # The draft is what submits, not just what showed
     expect(BParam.last).to have_attributes(manufacturer_id: manufacturer.id, owner_email:,
       cycle_type: "e-scooter", motorized?: true)
+
+    # An async combobox carries no options to map a saved id back to a name, so the server
+    # renders the display itself - and back to step 1 is where a raw id would show up instead
+    page.go_back
+
+    expect(page).to have_field("b_param_manufacturer_id", with: "Surly")
+    # The id is what submits, and only ever from the hidden field
+    expect(find("input[name='b_param[manufacturer_id]']", visible: :all).value).to eq manufacturer.id.to_s
+    expect(page).to have_no_field("b_param_manufacturer_id", with: manufacturer.id.to_s)
+    # The manufacturer itself, rather than Manufacturer.other with the id as free text
+    expect(BParam.last.manufacturer_other).to be_blank
+
+    # This field is autofocused, so the click into it brings no focus event of its own -
+    # typing still replaces the restored name rather than mashing into the middle of it
+    find_field("b_param_manufacturer_id").click
+    send_keys("Kona")
+
+    expect(page).to have_field("b_param_manufacturer_id", with: "Kona")
   end
 
   it "starts a registration, keeps a full details draft across a reload, and completes" do

--- a/spec/integration/registration/register_spec.rb
+++ b/spec/integration/registration/register_spec.rb
@@ -91,6 +91,37 @@ RSpec.describe "Register flow", :js, type: :system do
     expect(page).to have_field("b_param_manufacturer_id", with: "Kona")
   end
 
+  # Step 1 saves nothing until it submits, so a reload before then has only the draft to go on
+  it "keeps a step 1 draft across a reload" do
+    visit "/register/new"
+    type_into("#b_param_manufacturer_id", "Surly")
+    click_combobox_option("Surly")
+    type_into("#b_param_cycle_type", "e-Scooter")
+    click_combobox_option("e-Scooter")
+    fill_in "b_param[owner_email]", with: owner_email
+    expect(page).to have_content("E-SCOOTER INFO")
+    # An always-motorized type answers the electric question itself
+    expect(page).to have_checked_field("Electric (motorized)", disabled: true)
+
+    visit page.current_url
+
+    expect(page).to have_field("b_param_manufacturer_id", with: "Surly")
+    # The id is what submits, and it restores alongside the name it displays
+    expect(find("input[name='b_param[manufacturer_id]']", visible: :all).value).to eq manufacturer.id.to_s
+    expect(page).to have_field("b_param_cycle_type", with: "e-Scooter")
+    expect(page).to have_field("b_param[owner_email]", with: owner_email)
+    # A restored type reaches the section label a step away, and the electric checkbox
+    expect(page).to have_content("E-SCOOTER INFO")
+    expect(page).to have_checked_field("Electric (motorized)", disabled: true)
+
+    click_button "Next"
+
+    expect(page).to have_content("Add your e-scooter", wait: 10)
+    # The draft is what submits, not just what showed
+    expect(BParam.last).to have_attributes(manufacturer_id: manufacturer.id, owner_email:,
+      cycle_type: "e-scooter", motorized?: true)
+  end
+
   it "starts a registration, keeps a full details draft across a reload, and completes" do
     ActionMailer::Base.deliveries = []
     visit "/register/new"


### PR DESCRIPTION
Nothing typed into register step 1 survived a reload — `form-persist` was wired onto step 2 and the report step, but never onto step 1.

- **Step 1 keeps a draft, keyed per registration.** A restore assigns values without firing events, so the two controllers a step away from the vehicle-type combobox — the section label and the electric checkbox — reconcile on `form-persist:restored` as well as in their own `connect`. The embed stays out of it: a frame's localStorage is partitioned per embedding site.
- **`--nav-gap` carries the org sidebar's top inset.** Those pages have no navbar, so the variable was `0px` and `main` hard-coded the same spacing itself — which left `-mt-(--nav-gap)`, the idiom a full-bleed page pulls up under the navbar with, cancelling nothing. The inset is unchanged at both breakpoints; what's new is that a full-bleed shell can pull up under it, and stretches to fill the window when it's `main`'s only child.
- **The user alerts wrapper always wraps.** The organized content column passes the spacing it wants rather than passing nothing and having the wrapper drop out.
