### PR TITLE
Mark the current dropdown entry on its own link

### DIFF
--- a/app/assets/tailwind/bike_index_components.css
+++ b/app/assets/tailwind/bike_index_components.css
@@ -104,9 +104,7 @@
       tw:hover:bg-gray-100 tw:hover:text-gray-900
       tw:dark:text-gray-200 tw:dark:hover:bg-gray-700 tw:dark:hover:text-gray-100;
 
-    /* ui--active-link marks the link itself, so the entry reads its own state rather than
-     * the li's. The fill is UI::Button's secondary active, minus the border and ring a
-     * menu item has no room for */
+    /* UI::Button's secondary active fill, minus the border and ring a menu item has no room for */
     @variant is-active {
       @apply tw:bg-purple-500 tw:text-white;
     }

--- a/app/assets/tailwind/bike_index_components.css
+++ b/app/assets/tailwind/bike_index_components.css
@@ -103,6 +103,13 @@
     @apply tw:block tw:px-4 tw:py-1 tw:text-left tw:text-base tw:text-gray-700 tw:no-underline
       tw:hover:bg-gray-100 tw:hover:text-gray-900
       tw:dark:text-gray-200 tw:dark:hover:bg-gray-700 tw:dark:hover:text-gray-100;
+
+    /* ui--active-link marks the link itself, so the entry reads its own state rather than
+     * the li's. The fill is UI::Button's secondary active, minus the border and ring a
+     * menu item has no room for */
+    @variant is-active {
+      @apply tw:bg-purple-500 tw:text-white;
+    }
   }
 
   .twdropdown li[role="menuitem"]:has(+ li[role="separator"]) > a {

--- a/app/components/admin/index_skeleton/component.html.erb
+++ b/app/components/admin/index_skeleton/component.html.erb
@@ -23,10 +23,10 @@
           button_size: :sm,
           active: deleted_active?
         )) do |dropdown|
-          dropdown.with_entry_item(active: deleted_item_active?(nil)) { link_to "Only not deleted", url_for(sortable_search_params.merge(search_deleted: nil)) }
+          dropdown.with_entry_item { render UI::ActiveLink::Component.new(text: "Only not deleted", path: url_for(sortable_search_params.merge(search_deleted: nil)), match: :query, query: {search_deleted: nil}) }
           dropdown.with_entry_divider
-          dropdown.with_entry_item(active: deleted_item_active?("including")) { link_to "Including deleted", url_for(sortable_search_params.merge(search_deleted: "including")) }
-          dropdown.with_entry_item(active: deleted_item_active?("only")) { link_to "Only deleted", url_for(sortable_search_params.merge(search_deleted: "only")) }
+          dropdown.with_entry_item { render UI::ActiveLink::Component.new(text: "Including deleted", path: url_for(sortable_search_params.merge(search_deleted: "including")), match: :query, query: {search_deleted: "including"}) }
+          dropdown.with_entry_item { render UI::ActiveLink::Component.new(text: "Only deleted", path: url_for(sortable_search_params.merge(search_deleted: "only")), match: :query, query: {search_deleted: "only"}) }
         end %>
       </li>
     <% end %>

--- a/app/components/admin/index_skeleton/component.rb
+++ b/app/components/admin/index_skeleton/component.rb
@@ -104,10 +104,6 @@ module Admin
         end
       end
 
-      def deleted_item_active?(value)
-        value.nil? ? !deleted_active? : @render_deleted == value
-      end
-
       def default_table_view
         helpers.render(partial: "table", locals: {collection: @collection, render_sortable: @render_sortable})
       end

--- a/app/components/org/impound_records_index/component.html.erb
+++ b/app/components/org/impound_records_index/component.html.erb
@@ -19,7 +19,7 @@
           <% @available_statuses.each do |status| %>
             <% status_active = @search_status == status %>
             <% status_link_params = sortable_search_params.merge(organization_id: @current_organization.id, search_status: (status_active ? nil : status)) %>
-            <% dropdown.with_entry_item(active: status_active) { link_to display_status_for(status), organization_impound_records_path(status_link_params), data: {turbo_action: "advance"} } %>
+            <% dropdown.with_entry_item { render UI::ActiveLink::Component.new(text: display_status_for(status), path: organization_impound_records_path(status_link_params), match: :query, query: status_query(status), data: {turbo_action: "advance"}) } %>
 
             <%# Divider after "all" %>
             <% dropdown.with_entry_divider if status == "all" %>
@@ -29,9 +29,9 @@
 
       <div class="tw:ml-2 tw:inline-block">
         <%= render(UI::Dropdown::Component.new(name: unregisteredness_dropdown_text, button_size: :sm, active: @search_unregisteredness != "all")) do |dropdown| %>
-          <% dropdown.with_entry_item(active: @search_unregisteredness == "all") { link_to translation(".all_bikes"), organization_impound_records_path(sortable_search_params.except(:search_unregisteredness)), data: {turbo_action: "advance"} } %>
-          <% dropdown.with_entry_item(active: @search_unregisteredness == "only_unregistered") { link_to translation(".only_unregistered"), organization_impound_records_path(sortable_search_params.merge(search_unregisteredness: "only_unregistered")), data: {turbo_action: "advance"} } %>
-          <% dropdown.with_entry_item(active: @search_unregisteredness == "only_registered") { link_to translation(".only_user_registered"), organization_impound_records_path(sortable_search_params.merge(search_unregisteredness: "only_registered")), data: {turbo_action: "advance"} } %>
+          <% dropdown.with_entry_item { render UI::ActiveLink::Component.new(text: translation(".all_bikes"), path: organization_impound_records_path(sortable_search_params.except(:search_unregisteredness)), match: :query, query: {search_unregisteredness: nil}, data: {turbo_action: "advance"}) } %>
+          <% dropdown.with_entry_item { render UI::ActiveLink::Component.new(text: translation(".only_unregistered"), path: organization_impound_records_path(sortable_search_params.merge(search_unregisteredness: "only_unregistered")), match: :query, query: {search_unregisteredness: "only_unregistered"}, data: {turbo_action: "advance"}) } %>
+          <% dropdown.with_entry_item { render UI::ActiveLink::Component.new(text: translation(".only_user_registered"), path: organization_impound_records_path(sortable_search_params.merge(search_unregisteredness: "only_registered")), match: :query, query: {search_unregisteredness: "only_registered"}, data: {turbo_action: "advance"}) } %>
         <% end %>
       </div>
     </div>

--- a/app/components/org/impound_records_index/component.rb
+++ b/app/components/org/impound_records_index/component.rb
@@ -46,6 +46,10 @@ module Org
         end
       end
 
+      def status_query(status)
+        {search_status: (status == @available_statuses.first) ? [status, nil] : status}
+      end
+
       def unregisteredness_dropdown_text
         case @search_unregisteredness
         when "only_registered" then translation(".only_user_registered")

--- a/app/components/page_block/footer/component.rb
+++ b/app/components/page_block/footer/component.rb
@@ -5,7 +5,7 @@ module PageBlock
     class Component < ApplicationComponent
       FACEBOOK_PIXEL_ID = "199066297131941"
       # Digest of the cached template — the cached_markup_digest spec keeps it current
-      MARKUP_DIGEST = "803081e8c3de"
+      MARKUP_DIGEST = "c3ad8996f72b"
 
       def initialize(current_user:, skip_facebook:, passive_organization: nil)
         @current_user = current_user

--- a/app/components/page_block/navbar/org_sidebar/component.rb
+++ b/app/components/page_block/navbar/org_sidebar/component.rb
@@ -66,8 +66,7 @@ module PageBlock
 
         # text: is the caller's, since a top-level row's label sits inside a block with its icon
         def active_link(item, row_class:, text: nil)
-          UI::ActiveLink::Component.new(path: item[:path], text:, match: item[:match],
-            matching_controllers: item[:matching_controllers], class: row_class)
+          UI::ActiveLink::Component.from_item(item, html_class: row_class, text:)
         end
 
         def row_class

--- a/app/components/page_block/navbar/wrapper/component.rb
+++ b/app/components/page_block/navbar/wrapper/component.rb
@@ -8,7 +8,7 @@ module PageBlock
       # logo_only renders just the logo, for the OAuth authorization prompt.
       class Component < ApplicationComponent
         # Digest of the cached template — the cached_markup_digest spec keeps it current
-        MARKUP_DIGEST = "797d4c94a9ab"
+        MARKUP_DIGEST = "393118fb949c"
 
         def initialize(logo_only: false, current_user: nil, current_user_or_unconfirmed_user: nil,
           passive_organization: nil)

--- a/app/components/registrations/show/wrapper/component.rb
+++ b/app/components/registrations/show/wrapper/component.rb
@@ -8,7 +8,7 @@ module Registrations
       class Component < ApplicationComponent
         # Digest of the markup inside the cache block — the cached_markup_digest spec
         # keeps it current, following what this tree renders out into UI:: and elsewhere
-        MARKUP_DIGEST = "707d1d8ed7a8"
+        MARKUP_DIGEST = "3cc7812c56c4"
 
         def initialize(bike:, current_user:, view:, available_views:, bike_sticker: nil, current_alerts: {})
           @bike = bike

--- a/app/components/ui/active_link/component.rb
+++ b/app/components/ui/active_link/component.rb
@@ -7,23 +7,37 @@ module UI
     # rendered into a fragment cache doesn't carry the answer for whichever page filled it.
     # match: widens or narrows what counts as the page it points at: its query string too, or
     # only its controller, or its controller and action — which is what a link carrying query
-    # params (a search, a filtered index) needs.
+    # params (a search, a filtered index) needs. :query is for a filter entry, which stands for
+    # the params it applies rather than for a URL — see query: below.
     class Component < ApplicationComponent
-      MATCHES = [:path, :full_path, :controller, :controller_action].freeze
+      MATCHES = [:path, :full_path, :controller, :controller_action, :query].freeze
       # The matches the browser answers with a route rather than with the URL
       ROUTE_MATCHES = [:controller, :controller_action].freeze
 
-      def initialize(path:, text: nil, match: :path, matching_controllers: [], data: {}, **html_options)
+      # A menu manifest — OrganizedServices::UserMenuItems' or UserServices::AccountMenuItems' —
+      # carries a link as a hash, and every menu rendering one turns it into this component the
+      # same way. What differs is the class, and text: for a row whose label sits inside a block
+      # with its icon.
+      def self.from_item(item, html_class: nil, text: item[:label])
+        new(path: item[:path], text:, match: item[:match] || :path,
+          matching_controllers: item[:matching_controllers] || [], data: item[:data] || {},
+          id: item[:id], class: html_class)
+      end
+
+      def initialize(path:, text: nil, match: :path, matching_controllers: [], query: {}, data: {},
+        **html_options)
         raise_if_invalid_value!(:match, match, MATCHES)
         # Only a :controller match compares controllers, so anywhere else these would be
         # compared against a controller#action and never hit
         raise ArgumentError, "matching_controllers: needs match: :controller" if
           matching_controllers.any? && match != :controller
+        raise ArgumentError, "query: and match: :query go together" if query.any? != (match == :query)
 
         @path = path
         @text = text
         @match = match
         @matching_controllers = matching_controllers
+        @query = query
         @data = data
         @html_options = html_options
       end
@@ -44,7 +58,18 @@ module UI
       def link_data
         @data.merge(controller: [@data[:controller], "ui--active-link"].compact.join(" "),
           "ui--active-link-match-value": @match,
-          "ui--active-link-routes-value": link_routes).compact
+          "ui--active-link-routes-value": link_routes,
+          "ui--active-link-query-value": link_query).compact
+      end
+
+      # Each param the entry applies, and the values of it that mean the entry is the one in
+      # force. A nil among those values is the entry a controller falls back to with the param
+      # absent, which is "" once the browser reads the param off the URL
+      def link_query
+        return unless @match == :query
+
+        @query.to_h { |param, values| [param, (values.is_a?(Array) ? values : [values]).map(&:to_s)] }
+          .to_json
       end
 
       # What the browser compares the page against — it can't resolve a route itself. One

--- a/app/components/ui/active_link/component.rb
+++ b/app/components/ui/active_link/component.rb
@@ -8,16 +8,14 @@ module UI
     # match: widens or narrows what counts as the page it points at: its query string too, or
     # only its controller, or its controller and action — which is what a link carrying query
     # params (a search, a filtered index) needs. :query is for a filter entry, which stands for
-    # the params it applies rather than for a URL — see query: below.
+    # the params it applies rather than for a URL.
     class Component < ApplicationComponent
       MATCHES = [:path, :full_path, :controller, :controller_action, :query].freeze
       # The matches the browser answers with a route rather than with the URL
       ROUTE_MATCHES = [:controller, :controller_action].freeze
 
-      # A menu manifest — OrganizedServices::UserMenuItems' or UserServices::AccountMenuItems' —
-      # carries a link as a hash, and every menu rendering one turns it into this component the
-      # same way. What differs is the class, and text: for a row whose label sits inside a block
-      # with its icon.
+      # A menu manifest carries a link as a hash; what differs between the menus rendering one
+      # is the class, and text: for a row whose label sits inside a block with its icon
       def self.from_item(item, html_class: nil, text: item[:label])
         new(path: item[:path], text:, match: item[:match] || :path,
           matching_controllers: item[:matching_controllers] || [], data: item[:data] || {},
@@ -62,14 +60,10 @@ module UI
           "ui--active-link-query-value": link_query).compact
       end
 
-      # Each param the entry applies, and the values of it that mean the entry is the one in
-      # force. A nil among those values is the entry a controller falls back to with the param
-      # absent, which is "" once the browser reads the param off the URL
+      # A nil among a param's values is the entry a controller falls back to with the param
+      # absent, which is "" once the browser reads it off the URL
       def link_query
-        return unless @match == :query
-
-        @query.to_h { |param, values| [param, (values.is_a?(Array) ? values : [values]).map(&:to_s)] }
-          .to_json
+        @query.presence&.transform_values { |values| [values].flatten.map(&:to_s) }
       end
 
       # What the browser compares the page against — it can't resolve a route itself. One

--- a/app/components/ui/active_link/component_preview.rb
+++ b/app/components/ui/active_link/component_preview.rb
@@ -46,6 +46,21 @@ module UI
           path: "#{PREVIEW_PATH}/match_full_path", match: :full_path, class: "twlink"))
       end
 
+      # A filter entry, which stands for the param it applies rather than for a URL: it points
+      # away from its own filter, the way one already in force clears itself, and goes active
+      # on the param alone. Add &page=2 to see a param it doesn't name ignored.
+      def match_query
+        render(UI::ActiveLink::Component.new(text: "Filter: on", path: "#{PREVIEW_PATH}/match_query",
+          match: :query, query: {filter: "on"}, class: "twlink"))
+      end
+
+      # The entry a controller falls back to with the param absent, so "" is among its values
+      def match_query_default
+        render(UI::ActiveLink::Component.new(text: "Filter: off",
+          path: "#{PREVIEW_PATH}/match_query_default?filter=off", match: :query,
+          query: {filter: ["off", nil]}, class: "twlink"))
+      end
+
       # Anything beyond class passes through to the anchor
       def with_html_options
         render(UI::ActiveLink::Component.new(text: "Opens in a new tab", path: "#{PREVIEW_PATH}/with_html_options",

--- a/app/components/ui/dropdown/component.rb
+++ b/app/components/ui/dropdown/component.rb
@@ -3,16 +3,12 @@
 module UI
   module Dropdown
     class Component < ApplicationComponent
-      # Applied to the <li>; the `[&>a]` variant colors the item's link (the surface).
-      # The item flags itself aria-current rather than aria-pressed, which is invalid on
-      # role="menuitem" — the is-active variant (application.css) covers both.
-      # The fill is UI::Button's secondary active, minus the border and ring a menu item has no room for.
-      ACTIVE_COLORS = "tw:is-active:[&>a]:bg-purple-500 tw:is-active:[&>a]:text-white"
-
       renders_one :button
+      # Which entry is current is UI::ActiveLink's, on the entry's own link -- .twdropdown
+      # (bike_index_components.css) styles whichever one it marks
       renders_many :entries, types: {
-        item: lambda { |active: false, &block|
-          content_tag(:li, capture(&block), role: "menuitem", class: ACTIVE_COLORS, aria: {current: active || nil})
+        item: lambda { |&block|
+          content_tag(:li, capture(&block), role: "menuitem")
         },
         divider: lambda {
           content_tag(:li, "", role: "separator")

--- a/app/components/ui/dropdown/component.rb
+++ b/app/components/ui/dropdown/component.rb
@@ -5,7 +5,7 @@ module UI
     class Component < ApplicationComponent
       renders_one :button
       # Which entry is current is UI::ActiveLink's, on the entry's own link -- .twdropdown
-      # (bike_index_components.css) styles whichever one it marks
+      # styles whichever one it marks
       renders_many :entries, types: {
         item: lambda { |&block|
           content_tag(:li, capture(&block), role: "menuitem")

--- a/app/components/ui/dropdown/component_preview.rb
+++ b/app/components/ui/dropdown/component_preview.rb
@@ -3,6 +3,8 @@
 module UI
   module Dropdown
     class ComponentPreview < ApplicationComponentPreview
+      PREVIEW_PATH = "/rails/view_components/ui/dropdown/component"
+
       # @!group Variants
 
       def default
@@ -23,17 +25,10 @@ module UI
         end
       end
 
+      # A template, so the entries can render UI::ActiveLink -- the marked one points at the
+      # page it's shown on, so the browser fills it
       def custom_button
-        render(UI::Dropdown::Component.new(
-          name: "User",
-          button_class: avatar_button_class
-        )) do |dropdown|
-          dropdown.with_button { avatar_button }
-          dropdown.with_entry_item { content_tag(:span, "Last synced: 2 minutes ago", class: "tw:block tw:px-4 tw:py-2 tw:text-sm tw:text-gray-500 tw:dark:text-gray-400") }
-          dropdown.with_entry_divider
-          dropdown.with_entry_item { icon_link("⚙", "Settings") }
-          dropdown.with_entry_item(active: true) { icon_link("↻", "Sync (active)") }
-        end
+        {template: "ui/dropdown/component_preview/custom_button"}
       end
 
       # An entry wider than the button, which the menu sizes to rather than wrapping
@@ -45,25 +40,6 @@ module UI
       end
 
       # @!endgroup
-
-      private
-
-      def avatar_button
-        avatar = content_tag(:img, nil, src: ActionController::Base.helpers.asset_path("kelsey/illustrations/comic-assets_bike-love-1.png"), class: "tw:rounded-full tw:w-8 tw:h-8 tw:object-cover", alt: "Avatar")
-        content_tag(:span, class: "tw:flex tw:items-center tw:gap-2") do
-          safe_join([avatar, content_tag(:span, "seth herr")])
-        end
-      end
-
-      def avatar_button_class
-        "tw:flex tw:items-center tw:gap-1 tw:rounded-full tw:bg-gray-100 tw:pr-3 tw:pl-1 tw:py-1 tw:text-sm tw:font-medium tw:text-gray-700 tw:hover:bg-gray-200 tw:dark:bg-gray-700 tw:dark:text-gray-200 tw:dark:hover:bg-gray-600"
-      end
-
-      def icon_link(icon, label)
-        content_tag(:a, href: "#", class: "tw:flex tw:items-center tw:gap-2") do
-          safe_join([content_tag(:span, icon, class: "tw:text-base"), label])
-        end
-      end
     end
   end
 end

--- a/app/components/ui/dropdown/component_preview.rb
+++ b/app/components/ui/dropdown/component_preview.rb
@@ -25,8 +25,7 @@ module UI
         end
       end
 
-      # A template, so the entries can render UI::ActiveLink -- the marked one points at the
-      # page it's shown on, so the browser fills it
+      # A template, so the entries can render UI::ActiveLink
       def custom_button
         {template: "ui/dropdown/component_preview/custom_button"}
       end

--- a/app/components/ui/dropdown/component_preview/custom_button.html.erb
+++ b/app/components/ui/dropdown/component_preview/custom_button.html.erb
@@ -1,0 +1,35 @@
+<% avatar_class = "tw:flex tw:items-center tw:gap-1 tw:rounded-full tw:bg-gray-100 tw:pr-3 tw:pl-1 tw:py-1 tw:text-sm tw:font-medium tw:text-gray-700 tw:hover:bg-gray-200 tw:dark:bg-gray-700 tw:dark:text-gray-200 tw:dark:hover:bg-gray-600" %>
+
+<%= render(UI::Dropdown::Component.new(name: "User", button_class: avatar_class)) do |dropdown| %>
+  <% dropdown.with_button do %>
+    <span class="tw:flex tw:items-center tw:gap-2">
+      <%= image_tag "kelsey/illustrations/comic-assets_bike-love-1.png", class: "tw:rounded-full tw:w-8 tw:h-8 tw:object-cover", alt: "Avatar" %>
+
+      <span>seth herr</span>
+    </span>
+  <% end %>
+
+  <% dropdown.with_entry_item do %>
+    <span
+      class="
+        tw:block tw:px-4 tw:py-2 tw:text-sm tw:text-gray-500
+        tw:dark:text-gray-400
+      "
+    >
+      Last synced: 2 minutes ago
+    </span>
+  <% end %>
+
+  <% dropdown.with_entry_divider %>
+
+  <% dropdown.with_entry_item do %>
+    <%= render UI::ActiveLink::Component.new(text: "Settings",
+          path: "#{UI::Dropdown::ComponentPreview::PREVIEW_PATH}/default") %>
+  <% end %>
+
+  <%# Points at the page it's rendered on, so ui--active-link marks it and .twdropdown fills it %>
+  <% dropdown.with_entry_item do %>
+    <%= render UI::ActiveLink::Component.new(text: "Sync (active)",
+          path: "#{UI::Dropdown::ComponentPreview::PREVIEW_PATH}/custom_button") %>
+  <% end %>
+<% end %>

--- a/app/javascript/controllers/ui/active_link_controller.js
+++ b/app/javascript/controllers/ui/active_link_controller.js
@@ -58,11 +58,8 @@ export default class extends Controller {
     return trimSlash(url.pathname) === trimSlash(window.location.pathname)
   }
 
-  // A filter entry stands for the params it applies, which is not the same as pointing at the
-  // page they're applied on: the entry already in force links away from itself, to clear it,
-  // and the page carries a number and an organization slug the link needn't. So only the
-  // params the entry names are compared -- '' for one the URL leaves out, which is a filter
-  // sitting at whatever the controller falls back to
+  // The entry already in force links away from itself, to clear the filter, so its own href
+  // can't be what's compared -- only the params it names, with '' for one the URL leaves out
   queryMatches () {
     const current = new URLSearchParams(window.location.search)
 

--- a/app/javascript/controllers/ui/active_link_controller.js
+++ b/app/javascript/controllers/ui/active_link_controller.js
@@ -12,7 +12,7 @@ const ROUTE_MATCHES = ['controller', 'controller_action']
 // Renders UI::ActiveLink::Component's aria-current, which the server can't: these links are
 // cached fragments, so the markup is shared by every page it was rendered for.
 export default class extends Controller {
-  static values = { match: String, routes: String }
+  static values = { match: String, routes: String, query: Object }
 
   connect () {
     if (!this.isActive()) return this.element.removeAttribute('aria-current')
@@ -28,14 +28,20 @@ export default class extends Controller {
     return ROUTE_MATCHES.includes(this.matchValue)
   }
 
+  get queryMatch () {
+    return this.matchValue === 'query'
+  }
+
   // "page" is reserved for the link whose own URL is the current one. A widened match means
   // the current page sits inside what the link points at, not that it is it -- aria-current's
   // "true", so a reader isn't told a link elsewhere is where it already is
   ariaCurrent () {
-    return this.routeMatch ? 'true' : 'page'
+    return (this.routeMatch || this.queryMatch) ? 'true' : 'page'
   }
 
   isActive () {
+    if (this.queryMatch) return this.queryMatches()
+
     return this.routeMatch ? this.routeMatches() : this.pathMatches()
   }
 
@@ -50,6 +56,18 @@ export default class extends Controller {
     }
 
     return trimSlash(url.pathname) === trimSlash(window.location.pathname)
+  }
+
+  // A filter entry stands for the params it applies, which is not the same as pointing at the
+  // page they're applied on: the entry already in force links away from itself, to clear it,
+  // and the page carries a number and an organization slug the link needn't. So only the
+  // params the entry names are compared -- '' for one the URL leaves out, which is a filter
+  // sitting at whatever the controller falls back to
+  queryMatches () {
+    const current = new URLSearchParams(window.location.search)
+
+    return Object.entries(this.queryValue)
+      .every(([param, values]) => values.includes(current.get(param) ?? ''))
   }
 
   // The page's route comes off the body, since only the server can resolve one. A link whose

--- a/app/views/admin/bug_reports/index.html.erb
+++ b/app/views/admin/bug_reports/index.html.erb
@@ -5,10 +5,10 @@
       button_size: :sm,
       active: @searched_tag.present?
     )) do |dropdown|
-      dropdown.with_entry_item(active: @searched_tag.blank?) { link_to "All tags", url_for(sortable_search_params.merge(search_tag: nil)) }
+      dropdown.with_entry_item { render UI::ActiveLink::Component.new(text: "All tags", path: url_for(sortable_search_params.merge(search_tag: nil)), match: :query, query: {search_tag: nil}) }
       dropdown.with_entry_divider
       searchable_tags.each do |tag|
-        dropdown.with_entry_item(active: @searched_tag == tag) { link_to tag, url_for(sortable_search_params.merge(search_tag: tag)) }
+        dropdown.with_entry_item { render UI::ActiveLink::Component.new(text: tag, path: url_for(sortable_search_params.merge(search_tag: tag)), match: :query, query: {search_tag: tag}) }
       end
     end %>
   </li>
@@ -19,10 +19,10 @@
       button_size: :sm,
       active: @searched_receiver.present?
     )) do |dropdown|
-      dropdown.with_entry_item(active: @searched_receiver.blank?) { link_to "All receivers", url_for(sortable_search_params.merge(search_receiver: nil)) }
+      dropdown.with_entry_item { render UI::ActiveLink::Component.new(text: "All receivers", path: url_for(sortable_search_params.merge(search_receiver: nil)), match: :query, query: {search_receiver: nil}) }
       dropdown.with_entry_divider
       searchable_receivers.each do |receiver|
-        dropdown.with_entry_item(active: @searched_receiver == receiver) { link_to BugReport.display_receiver(receiver), url_for(sortable_search_params.merge(search_receiver: receiver)) }
+        dropdown.with_entry_item { render UI::ActiveLink::Component.new(text: BugReport.display_receiver(receiver), path: url_for(sortable_search_params.merge(search_receiver: receiver)), match: :query, query: {search_receiver: receiver}) }
       end
     end %>
   </li>
@@ -33,10 +33,10 @@
       button_size: :sm,
       active: @searched_membership.present?
     )) do |dropdown|
-      dropdown.with_entry_item(active: @searched_membership.blank?) { link_to "All membership status", url_for(sortable_search_params.merge(search_membership: nil)) }
+      dropdown.with_entry_item { render UI::ActiveLink::Component.new(text: "All membership status", path: url_for(sortable_search_params.merge(search_membership: nil)), match: :query, query: {search_membership: nil}) }
       dropdown.with_entry_divider
       membership_filters.each do |value, label|
-        dropdown.with_entry_item(active: @searched_membership == value) { link_to label, url_for(sortable_search_params.merge(search_membership: value)) }
+        dropdown.with_entry_item { render UI::ActiveLink::Component.new(text: label, path: url_for(sortable_search_params.merge(search_membership: value)), match: :query, query: {search_membership: value}) }
       end
     end %>
   </li>
@@ -47,11 +47,11 @@
       button_size: :sm,
       active: @searched_status != "investigate"
     )) do |dropdown|
-      dropdown.with_entry_item(active: @searched_status == "investigate") { link_to status_filters["investigate"], url_for(sortable_search_params.merge(search_status: "investigate")) }
-      dropdown.with_entry_item(active: @searched_status == "all") { link_to status_filters["all"], url_for(sortable_search_params.merge(search_status: "all")) }
+      dropdown.with_entry_item { render UI::ActiveLink::Component.new(text: status_filters["investigate"], path: url_for(sortable_search_params.merge(search_status: "investigate")), match: :query, query: {search_status: ["investigate", nil]}) }
+      dropdown.with_entry_item { render UI::ActiveLink::Component.new(text: status_filters["all"], path: url_for(sortable_search_params.merge(search_status: "all")), match: :query, query: {search_status: "all"}) }
       dropdown.with_entry_divider
       status_only_filters.each do |value, label|
-        dropdown.with_entry_item(active: @searched_status == value) { link_to label, url_for(sortable_search_params.merge(search_status: value)) }
+        dropdown.with_entry_item { render UI::ActiveLink::Component.new(text: label, path: url_for(sortable_search_params.merge(search_status: value)), match: :query, query: {search_status: value}) }
       end
     end %>
   </li>

--- a/app/views/admin/public_images/index.html.erb
+++ b/app/views/admin/public_images/index.html.erb
@@ -5,10 +5,10 @@
       button_size: :sm,
       active: @imageable_type.present?
     )) do |dropdown|
-      dropdown.with_entry_item(active: @imageable_type.blank?) { link_to "All types", url_for(sortable_search_params.merge(search_imageable_type: nil)) }
+      dropdown.with_entry_item { render UI::ActiveLink::Component.new(text: "All types", path: url_for(sortable_search_params.merge(search_imageable_type: nil)), match: :query, query: {search_imageable_type: nil}) }
       dropdown.with_entry_divider
       PublicImage::IMAGEABLE_TYPES.each do |imageable_type|
-        dropdown.with_entry_item(active: @imageable_type == imageable_type) { link_to "#{imageable_type} only", url_for(sortable_search_params.merge(search_imageable_type: imageable_type)) }
+        dropdown.with_entry_item { render UI::ActiveLink::Component.new(text: "#{imageable_type} only", path: url_for(sortable_search_params.merge(search_imageable_type: imageable_type)), match: :query, query: {search_imageable_type: imageable_type}) }
       end
     end %>
   </li>
@@ -19,10 +19,10 @@
       button_size: :sm,
       active: @kind.present?
     )) do |dropdown|
-      dropdown.with_entry_item(active: @kind.blank?) { link_to "All kinds", url_for(sortable_search_params.merge(search_kind: nil)) }
+      dropdown.with_entry_item { render UI::ActiveLink::Component.new(text: "All kinds", path: url_for(sortable_search_params.merge(search_kind: nil)), match: :query, query: {search_kind: nil}) }
       dropdown.with_entry_divider
       PublicImage.kinds.each do |kind|
-        dropdown.with_entry_item(active: @kind == kind) { link_to "#{kind.titleize} only", url_for(sortable_search_params.merge(search_kind: kind)) }
+        dropdown.with_entry_item { render UI::ActiveLink::Component.new(text: "#{kind.titleize} only", path: url_for(sortable_search_params.merge(search_kind: kind)), match: :query, query: {search_kind: kind}) }
       end
     end %>
   </li>
@@ -33,10 +33,10 @@
       button_size: :sm,
       active: @storage.present?
     )) do |dropdown|
-      dropdown.with_entry_item(active: @storage.blank?) { link_to "All storage", url_for(sortable_search_params.merge(search_storage: nil)) }
+      dropdown.with_entry_item { render UI::ActiveLink::Component.new(text: "All storage", path: url_for(sortable_search_params.merge(search_storage: nil)), match: :query, query: {search_storage: nil}) }
       dropdown.with_entry_divider
       storage_filters.each do |value, label|
-        dropdown.with_entry_item(active: @storage == value) { link_to "Only #{label}", url_for(sortable_search_params.merge(search_storage: value)) }
+        dropdown.with_entry_item { render UI::ActiveLink::Component.new(text: "Only #{label}", path: url_for(sortable_search_params.merge(search_storage: value)), match: :query, query: {search_storage: value}) }
       end
     end %>
   </li>

--- a/app/views/admin/registration_sequences/index.html.erb
+++ b/app/views/admin/registration_sequences/index.html.erb
@@ -5,10 +5,10 @@
       button_size: :sm,
       active: @status.present?
     )) do |dropdown|
-      dropdown.with_entry_item(active: @status.blank?) { link_to "All statuses", url_for(sortable_search_params.merge(search_status: nil)) }
+      dropdown.with_entry_item { render UI::ActiveLink::Component.new(text: "All statuses", path: url_for(sortable_search_params.merge(search_status: nil)), match: :query, query: {search_status: nil}) }
       dropdown.with_entry_divider
       searchable_statuses.each do |kind|
-        dropdown.with_entry_item(active: @status == kind) { link_to "#{kind.titleize} only", url_for(sortable_search_params.merge(search_status: kind)) }
+        dropdown.with_entry_item { render UI::ActiveLink::Component.new(text: "#{kind.titleize} only", path: url_for(sortable_search_params.merge(search_status: kind)), match: :query, query: {search_status: kind}) }
       end
     end %>
   </li>

--- a/app/views/organized/bikes/_list.html.erb
+++ b/app/views/organized/bikes/_list.html.erb
@@ -18,7 +18,8 @@
     <div class="col-sm-4">
       <%= render(UI::Dropdown::Component.new(name: "#{@search_claimedness.titleize} registrations", active: @search_claimedness != "all")) do |dropdown| %>
         <% %w[all initial transferred].each do |claimedness| %>
-          <% dropdown.with_entry_item(active: claimedness == @search_claimedness) { link_to "#{claimedness.titleize} registrations", organization_registrations_path(sortable_search_params.merge(search_claimedness: claimedness)) } %>
+          <% claimedness_query = {search_claimedness: (claimedness == "all") ? [claimedness, nil] : claimedness} %>
+          <% dropdown.with_entry_item { render UI::ActiveLink::Component.new(text: "#{claimedness.titleize} registrations", path: organization_registrations_path(sortable_search_params.merge(search_claimedness: claimedness)), match: :query, query: claimedness_query) } %>
           <% dropdown.with_entry_divider if claimedness == "all" %>
         <% end %>
       <% end %>

--- a/app/views/organized/graduated_notifications/_results.html.erb
+++ b/app/views/organized/graduated_notifications/_results.html.erb
@@ -43,8 +43,10 @@
         <% status_active = @search_status == status %>
         <% status_link_params = sortable_search_params.merge(organization_id: current_organization.id, search_status: (status_active ? nil : status)) %>
 
-        <% dropdown.with_entry_item(active: status_active) do %>
-          <%= link_to status_display.call(status), organization_graduated_notifications_path(status_link_params), data: {turbo_action: "advance"} %>
+        <% status_query = {search_status: (status == "current") ? [status, nil] : status} %>
+
+        <% dropdown.with_entry_item do %>
+          <%= render UI::ActiveLink::Component.new(text: status_display.call(status), path: organization_graduated_notifications_path(status_link_params), match: :query, query: status_query, data: {turbo_action: "advance"}) %>
         <% end %>
       <% end %>
     <% end %>

--- a/spec/components/ui/active_link/component_spec.rb
+++ b/spec/components/ui/active_link/component_spec.rb
@@ -17,6 +17,7 @@ RSpec.describe UI::ActiveLink::Component, type: :component do
     expect(link["data-ui--active-link-match-value"]).to eq "path"
     # :path compares the URL the browser is already on, so there's no route to compare
     expect(link.attributes).to_not have_key("data-ui--active-link-routes-value")
+    expect(link.attributes).to_not have_key("data-ui--active-link-query-value")
   end
 
   context "with a class" do
@@ -76,11 +77,57 @@ RSpec.describe UI::ActiveLink::Component, type: :component do
       end
     end
 
+    context ":query" do
+      let(:path) { "/o/example/impound_records" }
+      let(:options) { {match: :query, query: {search_status: "resolved"}} }
+
+      it "carries the params the browser compares the page's against" do
+        expect(link["data-ui--active-link-match-value"]).to eq "query"
+        expect(link["data-ui--active-link-query-value"]).to eq({search_status: ["resolved"]}.to_json)
+        expect(link.attributes).to_not have_key("data-ui--active-link-routes-value")
+      end
+
+      # An entry that's the fallback a controller reaches for is in force with the param
+      # absent, which is "" once the browser reads it off the URL
+      context "with a nil among the values" do
+        let(:options) { {match: :query, query: {search_status: ["current", nil]}} }
+
+        it "renders it as the empty string" do
+          expect(link["data-ui--active-link-query-value"])
+            .to eq({search_status: ["current", ""]}.to_json)
+        end
+      end
+
+      context "with a bare nil" do
+        let(:options) { {match: :query, query: {search_deleted: nil}} }
+
+        it "renders the one empty string, rather than no values at all" do
+          expect(link["data-ui--active-link-query-value"]).to eq({search_deleted: [""]}.to_json)
+        end
+      end
+    end
+
     context "with matching_controllers on a match that can't use them" do
       let(:options) { {match: :controller_action, matching_controllers: ["news"]} }
 
       it "raises rather than rendering entries the browser will never compare" do
         expect { component }.to raise_error(ArgumentError, /matching_controllers/)
+      end
+    end
+
+    context "with query on a match that can't use it" do
+      let(:options) { {match: :full_path, query: {search_status: "all"}} }
+
+      it "raises rather than rendering params the browser will never compare" do
+        expect { component }.to raise_error(ArgumentError, /query/)
+      end
+    end
+
+    context "with match: :query and nothing to compare" do
+      let(:options) { {match: :query} }
+
+      it "raises rather than going active on every page" do
+        expect { component }.to raise_error(ArgumentError, /query/)
       end
     end
 
@@ -98,6 +145,46 @@ RSpec.describe UI::ActiveLink::Component, type: :component do
 
       it "raises" do
         expect { component }.to raise_error(ArgumentError, /match/)
+      end
+    end
+  end
+
+  # Every menu renders its manifest's links through this, so the defaults are what a manifest
+  # that leaves a key out gets
+  describe "from_item" do
+    let(:item) { {type: :link, label: "Help", path: "/help"} }
+    let(:component) { render_inline(described_class.from_item(item, **options)) }
+
+    it "fills in the match, and renders no class" do
+      expect(link["href"]).to eq "/help"
+      expect(link.text).to eq "Help"
+      expect(link["data-ui--active-link-match-value"]).to eq "path"
+      expect(link.attributes).to_not have_key("class")
+      expect(link.attributes).to_not have_key("id")
+    end
+
+    context "with the keys a menu item can carry" do
+      let(:item) do
+        {type: :link, label: "Blog", path: "/news", match: :controller,
+         matching_controllers: ["blogs"], id: "navBlog", data: {email: "party@bikeindex.org"}}
+      end
+      let(:options) { {html_class: "nav-link"} }
+
+      it "passes each of them through" do
+        expect(link["class"]).to eq "nav-link"
+        expect(link["id"]).to eq "navBlog"
+        expect(link["data-email"]).to eq "party@bikeindex.org"
+        expect(link["data-ui--active-link-routes-value"]).to eq "news blogs"
+      end
+    end
+
+    # A sidebar row's label sits inside a block with its icon, so it isn't the link's text
+    context "with text: nil" do
+      let(:options) { {text: nil} }
+      let(:component) { render_inline(described_class.from_item(item, **options)) { "Block" } }
+
+      it "takes the block's content over the item's label" do
+        expect(link.text).to eq "Block"
       end
     end
   end

--- a/spec/components/ui/active_link/component_system_spec.rb
+++ b/spec/components/ui/active_link/component_system_spec.rb
@@ -5,7 +5,7 @@ require "rails_helper"
 RSpec.describe UI::ActiveLink::Component, :js, type: :system do
   let(:preview_path) { "/rails/view_components/ui/active_link/component" }
 
-  it "resolves each match against the page in the browser" do
+  it "resolves each match against the page the browser is on" do
     visit "#{preview_path}/current_page"
     expect(page).to have_css "a[aria-current='page']", text: "This preview"
 
@@ -25,10 +25,8 @@ RSpec.describe UI::ActiveLink::Component, :js, type: :system do
 
     visit "#{preview_path}/default"
     expect(page).to_not have_css "a[aria-current]"
-  end
 
-  # The param the page carries is what :path ignores and :full_path doesn't
-  it "counts the query string only where the match says to" do
+    # The param the page carries is what :path ignores and :full_path doesn't
     visit "#{preview_path}/match_full_path"
     expect(page).to have_css "a[aria-current='page']", text: "This preview, exactly"
 
@@ -38,11 +36,29 @@ RSpec.describe UI::ActiveLink::Component, :js, type: :system do
 
     visit "#{preview_path}/current_page?example=1"
     expect(page).to have_css "a[aria-current='page']", text: "This preview"
-  end
 
-  # The navbar renders from a fragment cache shared by every page it was rendered for, so
-  # the current page can't be in the cached markup
-  it "marks the navbar's link to the page being viewed" do
+    # A filter entry stands for the param it applies rather than for a URL, so it goes active
+    # on a page it doesn't point at and stays active under a page number it never carries
+    visit "#{preview_path}/match_query"
+    expect(page).to have_css "a.twlink", text: "Filter: on"
+    expect(page).to_not have_css "a[aria-current]"
+
+    # The entry links away from its own filter, the way one already in force clears itself
+    visit "#{preview_path}/match_query?filter=on&page=2"
+    expect(page).to have_css "a[aria-current='true']", text: "Filter: on"
+
+    # Absent is among the default entry's values, so it's current either way it's written
+    visit "#{preview_path}/match_query_default"
+    expect(page).to have_css "a[aria-current='true']", text: "Filter: off"
+
+    visit "#{preview_path}/match_query_default?filter=off"
+    expect(page).to have_css "a[aria-current='true']", text: "Filter: off"
+
+    visit "#{preview_path}/match_query_default?filter=on"
+    expect(page).to_not have_css "a[aria-current]"
+
+    # The navbar renders from a fragment cache shared by every page it was rendered for, so
+    # the current page can't be in the cached markup
     visit "/help"
     expect(page).to have_css "#primary-main-menu a[aria-current]", text: "Help", visible: :all
     expect(page).to have_css "#primary-main-menu a[aria-current]", count: 1, visible: :all

--- a/spec/components/ui/dropdown/component_spec.rb
+++ b/spec/components/ui/dropdown/component_spec.rb
@@ -13,11 +13,10 @@ RSpec.describe UI::Dropdown::Component, type: :component do
     expect(component).to have_css("[data-ui--dropdown-target='menu'].tw\\:w-max.tw\\:max-w-\\[75vw\\]", visible: :all)
   end
 
-  # The current entry fills like an active UI::Button, whose trigger sits right above it
-  it "fills the current entry with the button's active color" do
-    fill = UI::Button::Component::ACTIVE_COLORS[:secondary][/bg-purple-\d+/]
-    expect(fill).to be_present
-    expect(described_class::ACTIVE_COLORS).to include(fill)
+  # Which entry is current is UI::ActiveLink's, on the link -- the li carries neither the
+  # state nor the styling for it
+  it "leaves the entry unflagged" do
+    expect(component.css("li[role='menuitem']").first.attributes.keys).to eq(["role"])
   end
 
   context "with button_color: :link" do

--- a/spec/components/ui/dropdown/component_system_spec.rb
+++ b/spec/components/ui/dropdown/component_system_spec.rb
@@ -46,9 +46,12 @@ RSpec.describe UI::Dropdown::Component, :js, type: :system do
       expect(page).to have_text("Last synced: 2 minutes ago")
       expect(page).to have_text("Settings")
       expect(page).to have_text("Sync")
-      # The active item is marked aria-current; inactive items are not
-      expect(page).to have_css('li[role="menuitem"][aria-current]', text: "Sync")
-      expect(page).to have_css('li[role="menuitem"]:not([aria-current])', text: "Settings")
+      # ui--active-link marks the link that points at this page, and .twdropdown fills it
+      expect(page).to have_css('li[role="menuitem"] a[aria-current]', text: "Sync (active)")
+      expect(page).to have_no_css('li[role="menuitem"] a[aria-current]', text: "Settings")
+      expect(page.evaluate_script(<<~JS)).to eq "rgb(255, 255, 255)"
+        getComputedStyle(document.querySelector('li[role="menuitem"] a[aria-current]')).color
+      JS
       expect_axe_clean
 
       send_keys(:escape)


### PR DESCRIPTION
`UI::Dropdown` decided which of its entries was current on the server: the caller passed `active:` per entry, and the `<li>` carried both the `aria-current` and the fill. That's a second answer to a question `UI::ActiveLink` already answers in the browser, and `aria-current` isn't valid on `role="menuitem"` anyway.

- **The entry's own link carries the state.** `with_entry_item` takes no `active:`, the `<li>` is just `role="menuitem"`, and `.twdropdown` fills whichever anchor `ui--active-link` marks — the same purple as an active secondary `UI::Button`.
- **`match: :query` is what a filter entry needs.** It stands for the params it applies rather than for a URL: the entry in force links *away* from itself to clear the filter, and the page carries a page number and an org slug the link needn't. Only the params the entry names are compared, and a `nil` among a param's values means the entry a controller falls back to when the param is absent.
- **Every filter dropdown moves over** — admin bug reports, public images, registration sequences and the deleted-records picker, plus the organized impound, graduated-notification and registration lists.

Extracted from #4164 so the menu-manifest rename can land separately; `from_item` comes with it, with `OrgSidebar` as its caller here.
