### PR TITLE
Point the account menu's register link into the register flow

### DIFF
--- a/app/services/user_services/menu_items_account.rb
+++ b/app/services/user_services/menu_items_account.rb
@@ -58,7 +58,7 @@ module UserServices
     def account_rows(current_user, user)
       [link(translation(:your_registrations), routes.my_account_path),
         marketplace_messages(current_user),
-        link(translation(:register_a_new_bike), routes.choose_registration_path),
+        link(translation(:register_a_new_bike), routes.register_path, match: :controller),
         link(translation(:user_settings, user_email: user.email), routes.edit_my_account_path,
           id: "navUserSettingLink", data: {email: user.email})].compact
     end

--- a/app/views/my_accounts/show.html.haml
+++ b/app/views/my_accounts/show.html.haml
@@ -148,7 +148,7 @@
         %h3.first-item
           = t(".register_new_items")
         .inner
-          = link_to t(".add_a_bike"), choose_registration_path, class: "btn btn-primary btn-lg"
+          = link_to t(".add_a_bike"), register_path, class: "btn btn-primary btn-lg"
           = link_to t(".add_a_lock"), new_lock_url, class: "btn btn-primary-offset btn-lg"
         %h3
           = t(".next")

--- a/app/views/shared/_faq.html.erb
+++ b/app/views/shared/_faq.html.erb
@@ -125,7 +125,7 @@
         <p><%= t(".comprehensive_public_database") %></p>
 
         <p>
-          <%= t(".visit_or_add_html", add_link: link_to(t(".add_a_stolen_bike_link"), new_bike_url(status: "stolen"))) %>
+          <%= t(".visit_or_add_html", add_link: link_to(t(".add_a_stolen_bike_link"), register_url(status: "status_stolen"))) %>
         </p>
       </dd>
 

--- a/app/views/stolen/index.html.haml
+++ b/app/views/stolen/index.html.haml
@@ -5,7 +5,7 @@
 
   %ol{class: "tw:list-decimal tw:ml-4"}
     %li= t(".file_a_police_report")
-    %li= t(".make_sure_your_bike_is_registered_html", new_bike_link: link_to(t(".bike_index"), new_bike_url(status: "stolen")))
+    %li= t(".make_sure_your_bike_is_registered_html", new_bike_link: link_to(t(".bike_index"), register_url(status: "status_stolen")))
     %li= t(".look_for_local_stolen_bike_groups_on_face")
     %li= t(".tell_everyone_you_know")
 
@@ -57,7 +57,7 @@
                 = f.radio_button :title, "Bike ChopShop report"
                 = t(".report_a_bicycle_chop_shop")
             %label
-              - register_it_link = link_to t(".register_it"), new_bike_path, style: "font-weight: bold; color: #fff; text-decoration: underline;"
+              - register_it_link = link_to t(".register_it"), register_path(status: "status_stolen"), style: "font-weight: bold; color: #fff; text-decoration: underline;"
               = t(".reporting_your_own_bike_stolen_html", register_it_link: register_it_link)
 
             .contact-text

--- a/spec/components/page_block/navbar/user_settings_menu/component_spec.rb
+++ b/spec/components/page_block/navbar/user_settings_menu/component_spec.rb
@@ -24,7 +24,9 @@ RSpec.describe PageBlock::Navbar::UserSettingsMenu::Component, type: :component 
 
     expect(rows.map { |row| row.text.strip }).to eq(links)
     expect(component).to have_no_css "a[aria-current]"
-    expect(rows.map { |row| row["data-ui--active-link-match-value"] }).to all(eq("path"))
+    # The registration row stays current across every step of the flow, so it matches wider
+    expect(rows.map { |row| row["data-ui--active-link-match-value"] })
+      .to eq(%w[path controller path path])
   end
 
   # Logging out is the only row that doesn't go somewhere, so it's the only one tinted

--- a/spec/integration/registration/edit_spec.rb
+++ b/spec/integration/registration/edit_spec.rb
@@ -89,8 +89,7 @@ RSpec.describe "Editing a registration", :js, type: :system do
     find("#donationModal .close").click
     expect(page).to have_no_css("#donationModal.in", wait: 5)
 
-    # The form the edit pages open out of, registered to the logged in user
-    # (owner_email defaults to their email)
+    # The form the edit pages open out of - owner_email defaults to the logged in user's
     visit new_bike_path
     fill_in "Serial number", with: "SERIAL-ORIGINAL-1"
     pick_remote_selectize(selectize_for("bike_manufacturer_id"), "Surly")

--- a/spec/integration/registration/edit_spec.rb
+++ b/spec/integration/registration/edit_spec.rb
@@ -89,11 +89,9 @@ RSpec.describe "Editing a registration", :js, type: :system do
     find("#donationModal .close").click
     expect(page).to have_no_css("#donationModal.in", wait: 5)
 
-    # Navigate to registration through the menus, then register a bike to the
-    # logged in user (owner_email defaults to their email)
-    find("#primary_nav_hamburgler").click
-    click_link "Register a new bike"
-    click_link "Register bike"
+    # The form the edit pages open out of, registered to the logged in user
+    # (owner_email defaults to their email)
+    visit new_bike_path
     fill_in "Serial number", with: "SERIAL-ORIGINAL-1"
     pick_remote_selectize(selectize_for("bike_manufacturer_id"), "Surly")
     pick_selectize("bike_primary_frame_color_id", "Black")

--- a/spec/integration/registration/edit_spec.rb
+++ b/spec/integration/registration/edit_spec.rb
@@ -89,18 +89,32 @@ RSpec.describe "Editing a registration", :js, type: :system do
     find("#donationModal .close").click
     expect(page).to have_no_css("#donationModal.in", wait: 5)
 
-    # The form the edit pages open out of - owner_email defaults to the logged in user's
-    visit new_bike_path
-    fill_in "Serial number", with: "SERIAL-ORIGINAL-1"
-    pick_remote_selectize(selectize_for("bike_manufacturer_id"), "Surly")
-    pick_selectize("bike_primary_frame_color_id", "Black")
-    click_button "Register"
-    expect(page).to have_content("Bike successfully added to the index!", wait: 10)
+    # Navigate to registration through the menus, then register a bike to the
+    # logged in user (owner_email defaults to their email)
+    find("#primary_nav_hamburgler").click
+    click_link "Register a new bike"
+
+    type_into("#b_param_manufacturer_id", "Surly")
+    click_combobox_option("Surly")
+    click_button "Next"
+
+    # Step 2 autofocuses the model, which is the render the pickings below need
+    expect(page).to have_css("input[name='bike[frame_model]']:focus", wait: 10)
+    wait_for_stimulus
+    fill_in "bike[serial_number]", with: "SERIAL-ORIGINAL-1"
+    type_into("#bike_primary_frame_color_id", "Black")
+    click_combobox_option("Black")
+    click_button "Complete Bike Registration"
+    expect(page).to have_content("Registration complete", wait: 10)
 
     bike = Bike.reorder(:created_at).last
     expect(bike.owner_email).to eq owner.email
     expect(bike.current_ownership.claimed?).to be_truthy
     expect(bike.manufacturer).to eq surly
+
+    # The registration itself is what the edit pages open out of
+    click_link "View your registration"
+    click_link "Edit"
 
     # ---- Details: fill every available field ----
     pick_selectize("bike_year", "2020")

--- a/spec/requests/register_request_spec.rb
+++ b/spec/requests/register_request_spec.rb
@@ -166,6 +166,17 @@ RSpec.describe RegisterController, type: :request do
         expect(response).to redirect_to register_path(b_param_token: new_b_param.id_token, step: 1)
       end
 
+      # /stolen and the FAQ link at the bare /register with a status, so nothing in
+      # progress has to reach new still naming it
+      it "sends the bare /register into new with the status it named" do
+        get "#{base_url}?status=status_stolen"
+        expect(response).to redirect_to new_register_path(status: "status_stolen")
+
+        follow_redirect!
+        expect(BParam.last.status).to eq "status_stolen"
+        expect(response).to redirect_to register_path(b_param_token: BParam.last.id_token, step: 1)
+      end
+
       # Each one waiting goes on alerting its creator to come back to a registration
       # they've moved on from
       it "leaves two waiting at most - the most recent, and the one it starts" do

--- a/spec/requests/register_request_spec.rb
+++ b/spec/requests/register_request_spec.rb
@@ -160,21 +160,16 @@ RSpec.describe RegisterController, type: :request do
       include_context :request_spec_logged_in_as_user
 
       it "prefills owner_email with the user's email, still landing on step 1" do
-        get "/register/new"
-        new_b_param = BParam.last
-        expect(new_b_param.owner_email).to eq current_user.email
-        expect(response).to redirect_to register_path(b_param_token: new_b_param.id_token, step: 1)
-      end
-
-      # /stolen and the FAQ link at the bare /register with a status, so nothing in
-      # progress has to reach new still naming it
-      it "sends the bare /register into new with the status it named" do
+        # /stolen and the FAQ link at the bare /register with a status, so nothing in
+        # progress has to reach new still naming it
         get "#{base_url}?status=status_stolen"
         expect(response).to redirect_to new_register_path(status: "status_stolen")
 
         follow_redirect!
-        expect(BParam.last.status).to eq "status_stolen"
-        expect(response).to redirect_to register_path(b_param_token: BParam.last.id_token, step: 1)
+        new_b_param = BParam.last
+        expect(new_b_param).to have_attributes(owner_email: current_user.email,
+          status: "status_stolen")
+        expect(response).to redirect_to register_path(b_param_token: new_b_param.id_token, step: 1)
       end
 
       # Each one waiting goes on alerting its creator to come back to a registration

--- a/spec/services/user_services/menu_items_account_spec.rb
+++ b/spec/services/user_services/menu_items_account_spec.rb
@@ -16,8 +16,6 @@ RSpec.describe UserServices::MenuItemsAccount do
       expect(items.map { |item| item[:type] }).to eq(%i[link link link divider link])
     end
 
-    # The registration flow itself, where the footer's link leads too - and every step of
-    # it is the page that row points at
     it "sends the registration row into the flow, matching on its controller" do
       registration = items.find { |item| item[:label] == "Register a new bike" }
 

--- a/spec/services/user_services/menu_items_account_spec.rb
+++ b/spec/services/user_services/menu_items_account_spec.rb
@@ -16,6 +16,15 @@ RSpec.describe UserServices::MenuItemsAccount do
       expect(items.map { |item| item[:type] }).to eq(%i[link link link divider link])
     end
 
+    # The registration flow itself, where the footer's link leads too - and every step of
+    # it is the page that row points at
+    it "sends the registration row into the flow, matching on its controller" do
+      registration = items.find { |item| item[:label] == "Register a new bike" }
+
+      expect(registration[:path]).to eq "/register"
+      expect(registration[:match]).to eq :controller
+    end
+
     # Each menu tints it for itself, so the row only says which one it is
     it "marks logout danger, and nothing else" do
       expect(items.select { |item| item[:danger] }.map { |item| item[:label] }).to eq(["Log out"])


### PR DESCRIPTION
#4167 pointed the footer and the organized add-a-bike link at `/register`. These are the entry points that still led into the `choose_registration` interstitial and the old `/bikes/new` form.

- **The account menu row goes to `/register`, matching on its controller**, so it stays current through every step of the flow, the way the footer's link does. That's the navbar's gear submenu and the org sidebar's dropdown both.
- **`/my_account`'s add-a-bike button, and the two "add a stolen bike" links** on `/stolen` and the FAQ, which carry `?status=status_stolen` in. Those two are public pages, and the flow takes an anonymous registration where `/bikes/new` bounced to sign-up.
- **`edit_spec` registers through the flow.** It clicked the account menu into the interstitial and the old form; it now walks step 1 and step 2, and opens the edit pages from the finished registration.

The API documentation pages' footer is the last link into `choose_registration`.
