### PR TITLE
Pin redis < 6 so ActionCable's pubsub adapter loads

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -47,7 +47,9 @@ gem "rails-i18n"
 gem "translation"
 
 # Redis and Redis dependents
-gem "redis"
+# actioncable's redis pubsub adapter declares gem "redis", ">= 4", "< 6" - 6.0.0 broke
+# hotwire-livereload's broadcast, taking the dev server down on every reload
+gem "redis", "< 6"
 gem "sidekiq" # Background job processing
 gem "sidekiq-failures" # Sidekiq failure tracking and viewing
 gem "sidekiq-logstash" # Better sidekiq logging

--- a/Gemfile
+++ b/Gemfile
@@ -47,8 +47,7 @@ gem "rails-i18n"
 gem "translation"
 
 # Redis and Redis dependents
-# actioncable's redis pubsub adapter declares gem "redis", ">= 4", "< 6" - 6.0.0 broke
-# hotwire-livereload's broadcast, taking the dev server down on every reload
+# actioncable's redis pubsub adapter declares gem "redis", ">= 4", "< 6"
 gem "redis", "< 6"
 gem "sidekiq" # Background job processing
 gem "sidekiq-failures" # Sidekiq failure tracking and viewing

--- a/Gemfile
+++ b/Gemfile
@@ -47,8 +47,7 @@ gem "rails-i18n"
 gem "translation"
 
 # Redis and Redis dependents
-# actioncable's redis pubsub adapter declares gem "redis", ">= 4", "< 6"
-gem "redis", "< 6"
+gem "redis", "< 6" # actioncable's declares gem "redis", ">= 4", "< 6"
 gem "sidekiq" # Background job processing
 gem "sidekiq-failures" # Sidekiq failure tracking and viewing
 gem "sidekiq-logstash" # Better sidekiq logging

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -688,8 +688,8 @@ GEM
       actionview (>= 7.0)
       herb (>= 0.9.0, < 1.0.0)
     redcarpet (3.6.1)
-    redis (6.0.0)
-      redis-client (= 0.30.1)
+    redis (5.4.1)
+      redis-client (>= 0.22.0)
     redis-client (0.30.1)
       connection_pool
     redlock (2.1.0)
@@ -995,7 +995,7 @@ DEPENDENCIES
   rails-controller-testing
   rails-i18n
   reactionview
-  redis
+  redis (< 6)
   redlock
   rerun
   responders

--- a/app/controllers/admin/bug_reports_controller.rb
+++ b/app/controllers/admin/bug_reports_controller.rb
@@ -15,9 +15,11 @@ module Admin
 
     def index
       @per_page = permitted_per_page(default: 50)
+      bug_reports = matching_bug_reports.includes(user: %i[membership_active email_bans_active])
+      # Only the JSON reaches for images, the HTML table renders the user badges instead
+      bug_reports = bug_reports.with_attached_images if request.format.json?
       @pagy, @collection = pagy(:countish,
-        matching_bug_reports.includes(:user).with_attached_images
-          .reorder("bug_reports.#{sort_column} #{sort_direction}"),
+        bug_reports.reorder("bug_reports.#{sort_column} #{sort_direction}"),
         limit: @per_page,
         page: permitted_page)
 

--- a/app/controllers/admin/bug_reports_controller.rb
+++ b/app/controllers/admin/bug_reports_controller.rb
@@ -16,7 +16,7 @@ module Admin
     def index
       @per_page = permitted_per_page(default: 50)
       bug_reports = matching_bug_reports.includes(user: %i[membership_active email_bans_active])
-      # Only the JSON reaches for images, the HTML table renders the user badges instead
+      # Only the JSON serializes images
       bug_reports = bug_reports.with_attached_images if request.format.json?
       @pagy, @collection = pagy(:countish,
         bug_reports.reorder("bug_reports.#{sort_column} #{sort_direction}"),

--- a/bin/dev
+++ b/bin/dev
@@ -1,17 +1,11 @@
 #!/bin/bash
-# Clear out logs (they balloon) and tmp (mainly used by tests). log:clear only
-# knows the per-environment logs - bullet.log and the .0 files newsyslog rotates
-# out grow to hundreds of MB behind it
+# Clear out logs (they balloon) and tmp (mainly used by tests)
 bin/rails log:clear tmp:clear
-rm -f log/bullet.log log/*.log.[0-9]*
 
-# Start Redis, if it isn't started already. --daemonize detaches it from this
-# shell's process group, so quitting bin/dev can't take Redis down under the
-# other workspaces sharing port 6379
-if ! redis-cli ping >/dev/null 2>&1; then
-  > log/redis.log
-  redis-server --daemonize yes --logfile "$PWD/log/redis.log"
-fi
+# Start Redis in the background, if it isn't started already
+touch log/redis.log
+> log/redis.log
+redis-server > log/redis.log &
 
 eval "$(ruby bin/env --export)"
 echo "Starting server on http://localhost:$DEV_PORT"

--- a/bin/dev
+++ b/bin/dev
@@ -1,11 +1,17 @@
 #!/bin/bash
-# Clear out logs (they balloon) and tmp (mainly used by tests)
+# Clear out logs (they balloon) and tmp (mainly used by tests). log:clear only
+# knows the per-environment logs - bullet.log and the .0 files newsyslog rotates
+# out grow to hundreds of MB behind it
 bin/rails log:clear tmp:clear
+rm -f log/bullet.log log/*.log.[0-9]*
 
-# Start Redis in the background, if it isn't started already
-touch log/redis.log
-> log/redis.log
-redis-server > log/redis.log &
+# Start Redis, if it isn't started already. --daemonize detaches it from this
+# shell's process group, so quitting bin/dev can't take Redis down under the
+# other workspaces sharing port 6379
+if ! redis-cli ping >/dev/null 2>&1; then
+  > log/redis.log
+  redis-server --daemonize yes --logfile "$PWD/log/redis.log"
+fi
 
 eval "$(ruby bin/env --export)"
 echo "Starting server on http://localhost:$DEV_PORT"


### PR DESCRIPTION
`redis` 6.0.0 (#4162) took the dev server down on every file save. actioncable 8.1.3.1 declares `gem "redis", ">= 4", "< 6"` in its redis pubsub adapter, which `cable.yml` names for development. The adapter is required lazily on the first broadcast, so boot succeeded and the next hotwire-livereload reload raised `Gem::LoadError` on a `listen` thread, taking puma and the rest of the Procfile with it. None of it reached `development.log`.

- **Pins `redis` to `< 6`** rather than pointing development at the `async` adapter — it restores the combination Rails supports across every environment, and nothing here uses what 6.0 added. Production was never affected: no channels, no broadcasts and no cable mount, so nothing reaches the adapter to load it.
- **Eager-loads the bug reports admin index** — `membership_active` and `email_bans_active` per user, and images only for the JSON, which is the only format that serializes them. Unrelated to the crash; it was the other thing Bullet was flagging in the same log.
