### PR TITLE
Resume OAuth when a sign-in email opens in another browser

### DIFF
--- a/.claude/skills/pr/SKILL.md
+++ b/.claude/skills/pr/SKILL.md
@@ -85,7 +85,7 @@ No `bin/env` eval is needed here — it's only relevant to the screenshot phase,
 
 The diff is frontend if a changed path matches one of these **and** renders a page a reviewer could look at:
 
-- `app/views/**` (`.erb`, `.html.erb`)
+- `app/views/**` (`.erb`, `.html.erb`, `.haml` — deprecated, but still most of the directory)
 - `app/components/**` (ViewComponent templates or Ruby)
 - `app/javascript/**`
 - `app/assets/**`

--- a/app/components/emails/confirmation_email/component.rb
+++ b/app/components/emails/confirmation_email/component.rb
@@ -6,12 +6,13 @@ module Emails
       def initialize(user:)
         @user = user
         @partner = user.partner_sign_up
+        @return_to = user.signup_return_to
       end
 
       private
 
       def tokenized_url
-        confirm_users_url(id: @user.id, code: @user.confirmation_token, partner: @partner)
+        confirm_users_url(id: @user.id, code: @user.confirmation_token, partner: @partner, return_to: @return_to)
       end
     end
   end

--- a/app/controllers/concerns/controller_helpers.rb
+++ b/app/controllers/concerns/controller_helpers.rb
@@ -238,6 +238,13 @@ module ControllerHelpers
     end
   end
 
+  # handle_target refuses an off-site target on arrival, too late to keep a caller-chosen
+  # URL out of mail we send. "//host" is off-site despite the leading slash.
+  def emailable_return_to
+    target = session[:return_to]
+    target if target&.start_with?("/") && !target.start_with?("//")
+  end
+
   def permitted_return_to
     target = (session[:return_to] || cookies[:return_to] || params[:return_to])&.downcase
     return nil if invalid_return_to?(target)

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -150,13 +150,6 @@ class SessionsController < ApplicationController
     redirect_to magic_link_sent_session_path(partner: sign_in_partner)
   end
 
-  # handle_target refuses an off-site target on arrival, too late to keep a caller-chosen
-  # URL out of mail we send. "//host" is off-site despite the leading slash.
-  def emailable_return_to
-    target = session[:return_to]
-    target if target&.start_with?("/") && !target.start_with?("//")
-  end
-
   def submitted_remember_me
     params.dig(:session, :remember_me).presence || params[:remember_me]
   end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -42,6 +42,7 @@ class SessionsController < ApplicationController
 
   def magic_link
     @token = params[:token]
+    @return_to = params[:return_to]
     @failure = magic_link_failure(params[:incorrect_token]) if params[:incorrect_token].present?
   end
 
@@ -100,6 +101,7 @@ class SessionsController < ApplicationController
     case action_name
     when "sign_in_with_magic_link"
       @token = params[:token]
+      @return_to = params[:return_to]
       render_partner_or_default_signin_layout(render_action: :magic_link)
     when "identify", "create", "create_magic_link"
       @email = submitted_email
@@ -144,7 +146,7 @@ class SessionsController < ApplicationController
     # Stash the remember-me choice so the emailed-link GET (which carries no form
     # params) can still honor it in sign_in_and_redirect.
     session[:magic_link_remember_me] = Binxtils::InputNormalizer.boolean(submitted_remember_me)
-    user.send_magic_link_email
+    user.send_magic_link_email(return_to: session[:return_to])
     redirect_to magic_link_sent_session_path(partner: sign_in_partner)
   end
 

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -146,8 +146,15 @@ class SessionsController < ApplicationController
     # Stash the remember-me choice so the emailed-link GET (which carries no form
     # params) can still honor it in sign_in_and_redirect.
     session[:magic_link_remember_me] = Binxtils::InputNormalizer.boolean(submitted_remember_me)
-    user.send_magic_link_email(return_to: session[:return_to])
+    user.send_magic_link_email(return_to: emailable_return_to)
     redirect_to magic_link_sent_session_path(partner: sign_in_partner)
+  end
+
+  # handle_target refuses an off-site target on arrival, too late to keep a caller-chosen
+  # URL out of mail we send. "//host" is off-site despite the leading slash.
+  def emailable_return_to
+    target = session[:return_to]
+    target if target&.start_with?("/") && !target.start_with?("//")
   end
 
   def submitted_remember_me

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -92,7 +92,7 @@ class UsersController < ApplicationController
   def send_password_reset_email
     @user = User.fuzzy_confirmed_or_unconfirmed_email_find(params[:email])
     if @user.present?
-      flash[:error] = translation(:reset_just_sent_wait_a_sec) unless @user.send_password_reset_email
+      flash[:error] = translation(:reset_just_sent_wait_a_sec) unless @user.send_password_reset_email(return_to: emailable_return_to)
     else
       flash[:error] = translation(:email_not_found)
       redirect_to request_password_reset_form_users_path
@@ -210,7 +210,13 @@ class UsersController < ApplicationController
     params.require(:user)
       .permit(:name, :email, :notification_newsletters, :notification_unstolen, :terms_of_service,
         :preferred_language, :additional)
-      .merge(sign_in_partner.present? ? {partner_data: {sign_up: sign_in_partner}} : {})
+      .merge(signup_context.present? ? {partner_data: signup_context} : {})
+  end
+
+  # The confirmation email is built from the user record alone - it's enqueued from an
+  # after_commit callback, two jobs from here - so anything it needs has to be stored
+  def signup_context
+    {sign_up: sign_in_partner, return_to: emailable_return_to}.compact_blank
   end
 
   def permitted_password_reset_parameters

--- a/app/jobs/email/magic_login_link_job.rb
+++ b/app/jobs/email/magic_login_link_job.rb
@@ -4,13 +4,13 @@ module Email
   class MagicLoginLinkJob < ApplicationJob
     sidekiq_options queue: "notify", retry: 3
 
-    def perform(user_id)
+    def perform(user_id, return_to = nil)
       user = User.find(user_id)
       unless user.magic_link_token.present?
         raise StandardError, "User #{user_id} does not have a magic_link_token"
       end
 
-      CustomerMailer.magic_login_link_email(user).deliver_now
+      CustomerMailer.magic_login_link_email(user, return_to:).deliver_now
       user_email_for(user)&.update_last_email_errored!(email_errored: false)
     rescue => e
       raise e if user.nil?

--- a/app/jobs/email/reset_password_job.rb
+++ b/app/jobs/email/reset_password_job.rb
@@ -6,7 +6,7 @@ module Email
 
     NOTIFICATION_KIND = "password_reset"
 
-    def perform(user_id)
+    def perform(user_id, return_to = nil)
       user = User.find(user_id)
       unless user.token_for_password_reset.present?
         raise StandardError, "User #{user_id} does not have a token_for_password_reset"
@@ -15,7 +15,7 @@ module Email
       return if user.banned?
 
       notification_for_password_reset_token(user).track_email_delivery do
-        CustomerMailer.password_reset_email(user).deliver_now
+        CustomerMailer.password_reset_email(user, return_to:).deliver_now
       end
     end
 

--- a/app/mailers/customer_mailer.rb
+++ b/app/mailers/customer_mailer.rb
@@ -35,7 +35,7 @@ class CustomerMailer < ApplicationMailer
 
   def magic_login_link_email(user, return_to: nil)
     @user = user
-    @url = magic_link_session_url(token: @user.magic_link_token, return_to: return_to.presence)
+    @url = magic_link_session_url(token: @user.magic_link_token, return_to:)
 
     I18n.with_locale(@user&.preferred_language) do
       mail(to: @user.email, tag: __callee__)

--- a/app/mailers/customer_mailer.rb
+++ b/app/mailers/customer_mailer.rb
@@ -33,9 +33,9 @@ class CustomerMailer < ApplicationMailer
     end
   end
 
-  def magic_login_link_email(user)
+  def magic_login_link_email(user, return_to: nil)
     @user = user
-    @url = magic_link_session_url(token: @user.magic_link_token)
+    @url = magic_link_session_url(token: @user.magic_link_token, return_to: return_to.presence)
 
     I18n.with_locale(@user&.preferred_language) do
       mail(to: @user.email, tag: __callee__)

--- a/app/mailers/customer_mailer.rb
+++ b/app/mailers/customer_mailer.rb
@@ -24,9 +24,9 @@ class CustomerMailer < ApplicationMailer
     end
   end
 
-  def password_reset_email(user)
+  def password_reset_email(user, return_to: nil)
     @user = user
-    @url = update_password_form_with_reset_token_users_url(token: @user.token_for_password_reset)
+    @url = update_password_form_with_reset_token_users_url(token: @user.token_for_password_reset, return_to:)
 
     I18n.with_locale(@user&.preferred_language) do
       mail(to: @user.email, tag: __callee__)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -430,9 +430,8 @@ class User < ApplicationRecord
     true
   end
 
-  # return_to travels in the emailed link because the link is often opened somewhere
-  # else (a native app hands OAuth to a webview, the email opens in Safari), where
-  # the session holding the pending destination isn't there to be read
+  # The emailed link is often opened in another browser, which has no session
+  # holding where the user was headed - so return_to rides along in the link
   def send_magic_link_email(return_to: nil)
     # If the auth token was just created, don't create a new one, it's too error prone
     return true if auth_token_time("magic_link_token") > Time.current - 1.minutes

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -420,13 +420,14 @@ class User < ApplicationRecord
     self.when_vendor_terms_of_service = Time.current
   end
 
-  def send_password_reset_email
+  # return_to rides in the link for the same reason it does on send_magic_link_email
+  def send_password_reset_email(return_to: nil)
     # If the auth token was just created, don't create a new one, it's too error prone
     return false if password_reset_just_sent?
 
     update_auth_token("token_for_password_reset")
     reload # Attempt to ensure the database is updated, so sidekiq doesn't send before update is committed
-    Email::ResetPasswordJob.perform_async(id)
+    Email::ResetPasswordJob.perform_async(id, return_to)
     true
   end
 
@@ -514,6 +515,11 @@ class User < ApplicationRecord
 
   def partner_sign_up
     (partner_data && partner_data["sign_up"].present?) ? partner_data["sign_up"] : nil
+  end
+
+  # Read by the confirmation email, which is built from the user record alone
+  def signup_return_to
+    partner_data && partner_data["return_to"].presence
   end
 
   def bikes(user_hidden = true)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -430,13 +430,16 @@ class User < ApplicationRecord
     true
   end
 
-  def send_magic_link_email
+  # return_to travels in the emailed link because the link is often opened somewhere
+  # else (a native app hands OAuth to a webview, the email opens in Safari), where
+  # the session holding the pending destination isn't there to be read
+  def send_magic_link_email(return_to: nil)
     # If the auth token was just created, don't create a new one, it's too error prone
     return true if auth_token_time("magic_link_token") > Time.current - 1.minutes
 
     update_auth_token("magic_link_token")
     reload # Attempt to ensure the database is updated, so sidekiq doesn't send before update is committed
-    Email::MagicLoginLinkJob.perform_async(id)
+    Email::MagicLoginLinkJob.perform_async(id, return_to)
   end
 
   # Unlike send_magic_link_email, reuses an unexpired token and sends no email

--- a/app/views/sessions/magic_link.html.haml
+++ b/app/views/sessions/magic_link.html.haml
@@ -1,6 +1,6 @@
 .container
   - if @token.present?
-    = render Sessions::SignInInterstitial::Component.new(url: sign_in_with_magic_link_session_path, fields: { token: @token })
+    = render Sessions::SignInInterstitial::Component.new(url: sign_in_with_magic_link_session_path, fields: { token: @token, return_to: @return_to })
   - else
     %h3= t(".sign_in_with_magic_link")
     - if @failure

--- a/app/views/users/confirm_interstitial.html.haml
+++ b/app/views/users/confirm_interstitial.html.haml
@@ -1,2 +1,2 @@
 .container
-  = render Sessions::SignInInterstitial::Component.new(url: confirm_users_path, fields: { id: params[:id], code: params[:code], partner: sign_in_partner })
+  = render Sessions::SignInInterstitial::Component.new(url: confirm_users_path, fields: { id: params[:id], code: params[:code], partner: sign_in_partner, return_to: params[:return_to] })

--- a/app/views/users/update_password_form_with_reset_token.html.haml
+++ b/app/views/users/update_password_form_with_reset_token.html.haml
@@ -4,6 +4,7 @@
 
   = form_for @user, url: "/users/update_password_with_reset_token", method: :post, html: { class: "form" } do |f|
     = hidden_field_tag :token, @token if @token.present?
+    = hidden_field_tag :return_to, params[:return_to] if params[:return_to].present?
     .row
       .col-sm-6
         .form-group

--- a/spec/mailers/customer_mailer_spec.rb
+++ b/spec/mailers/customer_mailer_spec.rb
@@ -64,6 +64,12 @@ RSpec.describe CustomerMailer, type: :mailer do
       expect(mail.tag).to eq "magic_login_link_email"
       expect(mail.deliver_now.text_part.body.to_s).to include(user.magic_link_token).and include("Sign in")
     end
+
+    it "carries return_to, for a link opened in a browser without the session" do
+      user.update_auth_token("magic_link_token")
+      mail = CustomerMailer.magic_login_link_email(user, return_to: "/oauth/authorize?client_id=xYz")
+      expect(mail.body.encoded).to match(CGI.escape("/oauth/authorize?client_id=xYz"))
+    end
   end
 
   describe "additional_email_confirmation" do

--- a/spec/mailers/customer_mailer_spec.rb
+++ b/spec/mailers/customer_mailer_spec.rb
@@ -64,12 +64,6 @@ RSpec.describe CustomerMailer, type: :mailer do
       expect(mail.tag).to eq "magic_login_link_email"
       expect(mail.deliver_now.text_part.body.to_s).to include(user.magic_link_token).and include("Sign in")
     end
-
-    it "carries return_to, for a link opened in a browser without the session" do
-      user.update_auth_token("magic_link_token")
-      mail = CustomerMailer.magic_login_link_email(user, return_to: "/oauth/authorize?client_id=xYz")
-      expect(mail.body.encoded).to match(CGI.escape("/oauth/authorize?client_id=xYz"))
-    end
   end
 
   describe "additional_email_confirmation" do

--- a/spec/requests/oauth_authorizations_request_spec.rb
+++ b/spec/requests/oauth_authorizations_request_spec.rb
@@ -14,14 +14,13 @@ RSpec.describe Oauth::AuthorizationsController, type: :request do
       expect(session[:partner]).to be_nil
       expect(flash).to be_blank
     end
-    # A native app hands OAuth to a webview, then the magic link opens in the phone's browser,
-    # which has none of that session — so the authorize URL has to travel in the link itself
+    # A native app hands OAuth to a webview; the magic link then opens in the phone's browser,
+    # which has none of that session
     context "signing in with a magic link opened in another browser" do
       let(:user) { FactoryBot.create(:user_confirmed, passwordless_user: true) }
 
       it "resumes the authorization" do
         get authorization_url
-        ActionMailer::Base.deliveries = []
         Sidekiq::Testing.inline! do
           post "/session/identify", params: {session: {email: user.email}}
         end
@@ -31,8 +30,7 @@ RSpec.describe Oauth::AuthorizationsController, type: :request do
         reset! # Wipe the session, as opening the link in a different browser does
         get emailed_url
         hidden_fields = Capybara.string(response.body).all("form input[type=hidden]", visible: :all)
-          .to_h { |input| [input[:name], input[:value]] }.except("authenticity_token")
-        expect(hidden_fields["return_to"]).to match(/#{doorkeeper_app.uid}/)
+          .to_h { |input| [input[:name], input[:value]] }
 
         post "/session/sign_in_with_magic_link", params: hidden_fields
         expect(response).to redirect_to(/#{doorkeeper_app.uid}/)

--- a/spec/requests/oauth_authorizations_request_spec.rb
+++ b/spec/requests/oauth_authorizations_request_spec.rb
@@ -14,6 +14,30 @@ RSpec.describe Oauth::AuthorizationsController, type: :request do
       expect(session[:partner]).to be_nil
       expect(flash).to be_blank
     end
+    # A native app hands OAuth to a webview, then the magic link opens in the phone's browser,
+    # which has none of that session — so the authorize URL has to travel in the link itself
+    context "signing in with a magic link opened in another browser" do
+      let(:user) { FactoryBot.create(:user_confirmed, passwordless_user: true) }
+
+      it "resumes the authorization" do
+        get authorization_url
+        ActionMailer::Base.deliveries = []
+        Sidekiq::Testing.inline! do
+          post "/session/identify", params: {session: {email: user.email}}
+        end
+        emailed_url = ActionMailer::Base.deliveries.last.body.parts.first.decoded[%r{https?://\S+/session/magic_link\S*}]
+        expect(emailed_url).to include CGI.escape("client_id=#{doorkeeper_app.uid}")
+
+        reset! # Wipe the session, as opening the link in a different browser does
+        get emailed_url
+        hidden_fields = Capybara.string(response.body).all("form input[type=hidden]", visible: :all)
+          .to_h { |input| [input[:name], input[:value]] }.except("authenticity_token")
+        expect(hidden_fields["return_to"]).to match(/#{doorkeeper_app.uid}/)
+
+        post "/session/sign_in_with_magic_link", params: hidden_fields
+        expect(response).to redirect_to(/#{doorkeeper_app.uid}/)
+      end
+    end
     context "partner parameter" do
       it "redirects to sign in with the partners parameter included" do
         get "#{authorization_url}&partner=bikehub"

--- a/spec/requests/oauth_authorizations_request_spec.rb
+++ b/spec/requests/oauth_authorizations_request_spec.rb
@@ -6,6 +6,16 @@ RSpec.describe Oauth::AuthorizationsController, type: :request do
   let(:scope_param) { "scope=read_bikes+read_user" }
   let(:authorization_url) { "/oauth/authorize?redirect_uri=#{CGI.escape(doorkeeper_app.redirect_uri)}&client_id=#{doorkeeper_app.uid}&response_type=code&#{scope_param}" }
 
+  def delivered_url(matcher)
+    ActionMailer::Base.deliveries.last.body.parts.first.decoded[matcher]
+  end
+
+  # What the emailed link's page posts onward - the destination rides in one of these
+  def hidden_fields
+    Capybara.string(response.body).all("form input[type=hidden]", visible: :all)
+      .to_h { |input| [input[:name], input[:value]] }
+  end
+
   context "no current user present" do
     it "redirects to sign in" do
       get authorization_url
@@ -24,15 +34,54 @@ RSpec.describe Oauth::AuthorizationsController, type: :request do
         Sidekiq::Testing.inline! do
           post "/session/identify", params: {session: {email: user.email}}
         end
-        emailed_url = ActionMailer::Base.deliveries.last.body.parts.first.decoded[%r{https?://\S+/session/magic_link\S*}]
+        emailed_url = delivered_url(%r{https?://\S+/session/magic_link\S*})
         expect(emailed_url).to include CGI.escape("client_id=#{doorkeeper_app.uid}")
 
         reset! # Wipe the session, as opening the link in a different browser does
         get emailed_url
-        hidden_fields = Capybara.string(response.body).all("form input[type=hidden]", visible: :all)
-          .to_h { |input| [input[:name], input[:value]] }
-
         post "/session/sign_in_with_magic_link", params: hidden_fields
+        expect(response).to redirect_to(/#{doorkeeper_app.uid}/)
+      end
+    end
+
+    # Reached from this sign-in page's "forgot your password" link
+    context "resetting a password in another browser" do
+      let(:user) { FactoryBot.create(:user_confirmed) }
+      let(:password) { "reasonable_password" }
+
+      it "resumes the authorization" do
+        get authorization_url
+        Sidekiq::Testing.inline! do
+          post "/users/send_password_reset_email", params: {email: user.email}
+        end
+        emailed_url = delivered_url(%r{https?://\S+/users/update_password_form_with_reset_token\S*})
+        expect(emailed_url).to include CGI.escape("client_id=#{doorkeeper_app.uid}")
+
+        reset!
+        get emailed_url
+        post "/users/update_password_with_reset_token",
+          params: hidden_fields.merge(user: {password:, password_confirmation: password})
+        expect(response).to redirect_to(/#{doorkeeper_app.uid}/)
+      end
+    end
+
+    # Reached because identify sends an email with no account to the signup form
+    context "signing up and confirming in another browser" do
+      let(:email) { "newperson@example.com" }
+
+      it "resumes the authorization" do
+        get authorization_url
+        Sidekiq::Testing.inline! do
+          post "/users", params: {user: {email:, name: "New Person", terms_of_service: "1"}}
+        end
+        user = User.find_by(email:)
+        emailed_url = delivered_url(%r{https?://\S+/users/confirm\S*})
+        expect(emailed_url).to include CGI.escape("client_id=#{doorkeeper_app.uid}")
+
+        reset!
+        get emailed_url
+        post "/users/confirm", params: hidden_fields
+        expect(user.reload.confirmed?).to be_truthy
         expect(response).to redirect_to(/#{doorkeeper_app.uid}/)
       end
     end

--- a/spec/requests/sessions_request_spec.rb
+++ b/spec/requests/sessions_request_spec.rb
@@ -385,25 +385,22 @@ RSpec.describe SessionsController, type: :request do
 
   describe "the return_to carried by the magic link email" do
     let!(:user) { FactoryBot.create(:user_confirmed) }
-    let(:emailed_url) do
+
+    # Without clearing the token no second mail is sent within the minute, and the
+    # assertion reads the previous one. reload - the token was minted on another copy.
+    def emailed_url_after(return_to)
+      user.reload.update(magic_link_token: nil)
+      get "/session/new?return_to=#{CGI.escape(return_to)}"
       Sidekiq::Testing.inline! { post "/session/create_magic_link", params: {email: user.email} }
       ActionMailer::Base.deliveries.last.body.parts.first.decoded[%r{https?://\S+/session/magic_link\S*}]
     end
 
-    it "carries a path this app owns" do
-      get "/session/new?return_to=%2Fbikes%2F12"
-      expect(emailed_url).to include CGI.escape("/bikes/12")
-    end
-
-    # Not an open redirect - handle_target refuses it - but it shouldn't reach the mail
-    it "drops an off-site one" do
-      get "/session/new?return_to=#{CGI.escape("https://evil.example/steal")}"
-      expect(emailed_url).to_not include "evil.example"
-    end
-
-    it "drops a protocol-relative one" do
-      get "/session/new?return_to=#{CGI.escape("//evil.example/steal")}"
-      expect(emailed_url).to_not include "evil.example"
+    # An off-site target isn't an open redirect - handle_target refuses it on arrival -
+    # but it shouldn't reach the mail. "//host" is off-site despite the leading slash.
+    it "carries a path this app owns, and drops anything else" do
+      expect(emailed_url_after("/bikes/12")).to include CGI.escape("/bikes/12")
+      expect(emailed_url_after("https://evil.example/steal")).to_not include "evil.example"
+      expect(emailed_url_after("//evil.example/steal")).to_not include "evil.example"
     end
   end
 

--- a/spec/requests/sessions_request_spec.rb
+++ b/spec/requests/sessions_request_spec.rb
@@ -371,6 +371,40 @@ RSpec.describe SessionsController, type: :request do
       expect(Capybara.string(response.body))
         .to have_css("form[action='/session/sign_in_with_magic_link'] input[name='token'][value='#{token}']", visible: :hidden)
     end
+
+    # The retry re-renders without the before_action that stores return_to, so the form
+    # is the only thing still holding where the user was headed
+    it "hands the magic link back where it was headed" do
+      post "/session/sign_in_with_magic_link",
+        params: {token: user.refreshed_magic_link_token, return_to: "/oauth/authorize?client_id=xYz"},
+        headers: {"HTTP_ORIGIN" => "null"}
+      expect(Capybara.string(response.body))
+        .to have_css("input[name='return_to'][value='/oauth/authorize?client_id=xYz']", visible: :hidden)
+    end
+  end
+
+  describe "the return_to carried by the magic link email" do
+    let!(:user) { FactoryBot.create(:user_confirmed) }
+    let(:emailed_url) do
+      Sidekiq::Testing.inline! { post "/session/create_magic_link", params: {email: user.email} }
+      ActionMailer::Base.deliveries.last.body.parts.first.decoded[%r{https?://\S+/session/magic_link\S*}]
+    end
+
+    it "carries a path this app owns" do
+      get "/session/new?return_to=%2Fbikes%2F12"
+      expect(emailed_url).to include CGI.escape("/bikes/12")
+    end
+
+    # Not an open redirect - handle_target refuses it - but it shouldn't reach the mail
+    it "drops an off-site one" do
+      get "/session/new?return_to=#{CGI.escape("https://evil.example/steal")}"
+      expect(emailed_url).to_not include "evil.example"
+    end
+
+    it "drops a protocol-relative one" do
+      get "/session/new?return_to=#{CGI.escape("//evil.example/steal")}"
+      expect(emailed_url).to_not include "evil.example"
+    end
   end
 
   describe "remember_me across the magic-link round-trip" do

--- a/spec/requests/users_request_spec.rb
+++ b/spec/requests/users_request_spec.rb
@@ -376,7 +376,7 @@ RSpec.describe UsersController, type: :request do
           expect(response).to render_template(:send_password_reset_email)
           expect(flash).to be_blank
         }.to change(Email::ResetPasswordJob.jobs, :size).by(1)
-        expect(Email::ResetPasswordJob).to have_enqueued_sidekiq_job(user.id)
+        expect(Email::ResetPasswordJob).to have_enqueued_sidekiq_job(user.id, nil)
         user.reload
         expect(user.token_for_password_reset).to be_present
       end


### PR DESCRIPTION
The 4iiii iOS app starts OAuth in a webview, so Bike Index stores the pending `/oauth/authorize` URL in `session[:return_to]` and redirects to sign in. The emailed link then opens in Safari, which has none of that session — the user signs in, lands on `/my_account`, and the app never receives its code. Reported by a user who couldn't link their account at all.

- **Where the user was headed rides in the emailed link** rather than staying in the session it began in — for all three emails that sign someone in: magic link, password reset, and confirmation. Each link's page re-posts it onward, which is also what carries it through a CSRF retry.
- **The confirmation email's destination is stored on the user record**, beside the partner that already travels that way. It's enqueued from an `after_commit` callback two jobs from the controller, so there's nothing to thread it through.
- **Only paths this app owns get emailed.** `store_return_to` accepts any target that isn't a sign-in path, and `handle_target` refuses an off-site one on arrival — too late to keep a caller-chosen URL out of mail we send.

Nothing changes on the 4iiii side; the authorize page hands off to their custom-scheme `redirect_uri` as it always did. An email sent before this deploys carries no destination, so anyone mid-flow needs a fresh link.
