### PR TITLE
Give SAML SSO its own admin card

### DIFF
--- a/app/components/admin/organization_form/feature_settings/component.html.erb
+++ b/app/components/admin/organization_form/feature_settings/component.html.erb
@@ -90,55 +90,5 @@
         </div>
       </div>
     <% end %>
-
-    <% if @organization.enabled?("saml_sso") %>
-      <div class="mt-4">
-        <h4>SAML SSO</h4>
-
-        <p class="text-success">
-          Service Provider details for the organization's IdP admin — or just
-          share the metadata URL, which contains all of them.
-        </p>
-
-        <ul>
-          <li>
-            Metadata URL:
-            <%= link_to saml_metadata_url(org_slug: @organization.to_param), saml_metadata_url(org_slug: @organization.to_param) %>
-          </li>
-
-          <li>
-            SP entityID:
-            <code><%= Saml::SettingsBuilder.sp_entity_id(saml_configuration) %></code>
-          </li>
-
-          <li>
-            ACS (callback) URL:
-            <code><%= Saml::SettingsBuilder.assertion_consumer_service_url(saml_configuration) %></code>
-          </li>
-        </ul>
-
-        <%= @form_builder.fields_for :organization_saml_configuration, saml_configuration do |saml_f| %>
-          <%= render(UI::Forms::Checkbox::Component.new(form_builder: saml_f, attribute: :enabled, label: "Enable live SAML login for this organization", class_name: "tw:mb-4")) %>
-
-          <%= render(UI::Forms::Group::Component.new(form_builder: saml_f, attribute: :idp_entity_id, label_text: "IdP entityID")) %>
-
-          <%= render(UI::Forms::Group::Component.new(form_builder: saml_f, attribute: :idp_sso_target_url, label_text: "IdP SSO target URL")) %>
-
-          <%= render(UI::Forms::Group::Component.new(form_builder: saml_f, attribute: :idp_slo_target_url, label_text: "IdP SLO target URL")) %>
-
-          <%= render(UI::Forms::Group::Component.new(form_builder: saml_f, attribute: :idp_cert, kind: :text_area, label_text: "IdP certificate (PEM or base64)", html_options: {rows: 4})) %>
-
-          <%= render(UI::Forms::Group::Component.new(form_builder: saml_f, attribute: :idp_cert_fingerprint, label_text: "IdP certificate fingerprint")) %>
-
-          <%= render(UI::Forms::Group::Component.new(form_builder: saml_f, attribute: :email_attribute_name, label_text: "Email attribute name", html_options: {placeholder: OrganizationSamlConfiguration::DEFAULT_EMAIL_ATTRIBUTE})) %>
-
-          <%= render(UI::Forms::Group::Component.new(form_builder: saml_f, attribute: :name_id_format, label_text: "NameID format")) do %>
-            <%= render(UI::Forms::Select::Component.new(form_builder: saml_f, attribute: :name_id_format,
-              option_tags: OrganizationSamlConfiguration::NAME_ID_FORMATS,
-              options: {include_blank: "No preference - the IdP chooses"})) %>
-          <% end %>
-        <% end %>
-      </div>
-    <% end %>
   </div>
 </div>

--- a/app/components/admin/organization_form/feature_settings/component.html.erb
+++ b/app/components/admin/organization_form/feature_settings/component.html.erb
@@ -7,7 +7,6 @@
         Interval for send graduated notifications, in days
         <small><span class="text-success">graduated_notifications setting</span></small>
       <% end %>
-
       <%= render(UI::Forms::Group::Component.new(form_builder: @form_builder, attribute: :graduated_notification_interval_days, kind: :number_field, label_text: graduated_label)) do |group| %>
         <% group.with_helper_text do %>
           <span class="text-warning">
@@ -23,7 +22,6 @@
         Search radius (<%= search_radius[:unit] %>)
         <small><span class="text-success">regional bike counts setting</span>, controls how large the region is to associate regional sub-organizations</small>
       <% end %>
-
       <%= render(UI::Forms::Group::Component.new(form_builder: @form_builder, attribute: search_radius[:attribute], kind: :number_field, label_text: radius_label)) do |group| %>
         <% group.with_helper_text do %>
           <span class="text-warning">
@@ -39,7 +37,6 @@
         permitted domain for <%= domain_uses.to_sentence %>
         <small><%= safe_join(domain_uses.map { |domain_use| tag.span("#{domain_use} feature", class: "text-success") }, " ") %></small>
       <% end %>
-
       <%= render(UI::Forms::Group::Component.new(form_builder: @form_builder, attribute: :user_email_domain, label_text: domain_label)) do |group| %>
         <% unless developer? %>
           <% group.with_helper_text { "Ask Seth for help changing this, it's delicate" } %>
@@ -134,6 +131,12 @@
           <%= render(UI::Forms::Group::Component.new(form_builder: saml_f, attribute: :idp_cert_fingerprint, label_text: "IdP certificate fingerprint")) %>
 
           <%= render(UI::Forms::Group::Component.new(form_builder: saml_f, attribute: :email_attribute_name, label_text: "Email attribute name", html_options: {placeholder: OrganizationSamlConfiguration::DEFAULT_EMAIL_ATTRIBUTE})) %>
+
+          <%= render(UI::Forms::Group::Component.new(form_builder: saml_f, attribute: :name_id_format, label_text: "NameID format")) do %>
+            <%= render(UI::Forms::Select::Component.new(form_builder: saml_f, attribute: :name_id_format,
+              option_tags: OrganizationSamlConfiguration::NAME_ID_FORMATS,
+              options: {include_blank: "No preference - the IdP chooses"})) %>
+          <% end %>
         <% end %>
       </div>
     <% end %>

--- a/app/components/admin/organization_form/feature_settings/component.rb
+++ b/app/components/admin/organization_form/feature_settings/component.rb
@@ -82,11 +82,6 @@ module Admin
              max: "#{OrganizationStolenMessage::MAX_SEARCH_RADIUS} miles"}
           end
         end
-
-        def saml_configuration
-          @saml_configuration ||= @organization.organization_saml_configuration ||
-            @organization.build_organization_saml_configuration
-        end
       end
     end
   end

--- a/app/components/admin/organization_form/location_fields/component.html.erb
+++ b/app/components/admin/organization_form/location_fields/component.html.erb
@@ -23,7 +23,6 @@
 
           <% if @organization.enabled?("impound_bikes") %>
             <%= checkbox(:impound_location) %>
-
             <%= checkbox(:default_impound_location) %>
           <% end %>
         </div>
@@ -31,7 +30,9 @@
         <div class="col-lg-6">
           <div class="form-group text-center">
             <% if @location.destroy_forbidden? %>
-              <small class="less-strong">can't remove, has impounded bikes</small>
+              <small class="less-strong">
+                can't remove, has impounded bikes
+              </small>
             <% else %>
               <%= @form_builder.hidden_field :_destroy %>
               <%= render(UI::Button::Component.new(text: "Remove", color: :error, data: {action: "click->#{UI::Forms::NestedFields::Component::CONTROLLER}#remove"})) %>

--- a/app/components/admin/organization_form/saml_configuration/component.html.erb
+++ b/app/components/admin/organization_form/saml_configuration/component.html.erb
@@ -41,6 +41,14 @@
         <%= render(UI::Forms::Group::Component.new(form_builder: saml_f, attribute: :idp_cert, kind: :text_area, label_text: "IdP certificate (PEM or base64)", required: saml_configuration.enabled?, required_toggleable: true, html_options: field_options.merge(rows: 4))) %>
       </div>
 
+      <%= render(UI::Forms::Group::Component.new(form_builder: saml_f, attribute: :idp_cert_multi, kind: :text_area, label_text: "IdP certificate, second", html_options: field_options.merge(rows: 4))) do |group| %>
+        <% group.with_helper_text do %>
+          Only during a rotation — assertions signed by <em>either</em>
+          certificate validate while the IdP switches over. Clear it once
+          they've finished.
+        <% end %>
+      <% end %>
+
       <%= render(UI::Forms::Group::Component.new(form_builder: saml_f, attribute: :idp_slo_target_url, label_text: "IdP SLO target URL", html_options: field_options)) %>
 
       <%= render(UI::Forms::Group::Component.new(form_builder: saml_f, attribute: :idp_cert_fingerprint, label_text: "IdP certificate fingerprint", html_options: field_options)) %>

--- a/app/components/admin/organization_form/saml_configuration/component.html.erb
+++ b/app/components/admin/organization_form/saml_configuration/component.html.erb
@@ -1,0 +1,58 @@
+<div class="card mt-4">
+  <div class="card-body">
+    <h4 class="mb-4">SAML SSO</h4>
+
+    <% unless developer? %>
+      <p class="text-warning">
+        These decide which identity provider the permitted domain's logins are
+        sent to, and which key their assertions are trusted against. Ask a
+        developer to change them.
+      </p>
+    <% end %>
+
+    <p class="text-success">
+      Service Provider details for the organization's IdP admin — or just share
+      the metadata URL, which contains all of them.
+    </p>
+
+    <ul>
+      <li>Metadata URL: <%= link_to metadata_url, metadata_url %></li>
+
+      <li>
+        SP entityID:
+        <code><%= Saml::SettingsBuilder.sp_entity_id(saml_configuration) %></code>
+      </li>
+
+      <li>
+        ACS (callback) URL:
+        <code><%= Saml::SettingsBuilder.assertion_consumer_service_url(saml_configuration) %></code>
+      </li>
+    </ul>
+
+    <%= @form_builder.fields_for :organization_saml_configuration, saml_configuration do |saml_f| %>
+      <%= render(UI::Forms::Checkbox::Component.new(form_builder: saml_f, attribute: :enabled, label: "Enable live SAML login for this organization", class_name: "tw:mb-4", disabled: !developer?, input_data: {"admin--organization-form-target": "samlEnabled", action: "change->admin--organization-form#toggleSamlRequired"})) %>
+
+      <%# Required only once it's live - the model validates the same condition %>
+      <div data-admin--organization-form-target="samlRequiredFields">
+        <%= render(UI::Forms::Group::Component.new(form_builder: saml_f, attribute: :idp_entity_id, label_text: "IdP entityID", required: saml_configuration.enabled?, required_toggleable: true, html_options: field_options)) %>
+
+        <%= render(UI::Forms::Group::Component.new(form_builder: saml_f, attribute: :idp_sso_target_url, label_text: "IdP SSO target URL", required: saml_configuration.enabled?, required_toggleable: true, html_options: field_options)) %>
+
+        <%= render(UI::Forms::Group::Component.new(form_builder: saml_f, attribute: :idp_cert, kind: :text_area, label_text: "IdP certificate (PEM or base64)", required: saml_configuration.enabled?, required_toggleable: true, html_options: field_options.merge(rows: 4))) %>
+      </div>
+
+      <%= render(UI::Forms::Group::Component.new(form_builder: saml_f, attribute: :idp_slo_target_url, label_text: "IdP SLO target URL", html_options: field_options)) %>
+
+      <%= render(UI::Forms::Group::Component.new(form_builder: saml_f, attribute: :idp_cert_fingerprint, label_text: "IdP certificate fingerprint", html_options: field_options)) %>
+
+      <%= render(UI::Forms::Group::Component.new(form_builder: saml_f, attribute: :email_attribute_name, label_text: "Email attribute name", html_options: field_options.merge(placeholder: OrganizationSamlConfiguration::DEFAULT_EMAIL_ATTRIBUTE))) %>
+
+      <%= render(UI::Forms::Group::Component.new(form_builder: saml_f, attribute: :name_id_format, label_text: "NameID format")) do %>
+        <%= render(UI::Forms::Select::Component.new(form_builder: saml_f, attribute: :name_id_format,
+          option_tags: OrganizationSamlConfiguration::NAME_ID_FORMATS,
+          options: {include_blank: "No preference - the IdP chooses"},
+          html_options: field_options)) %>
+      <% end %>
+    <% end %>
+  </div>
+</div>

--- a/app/components/admin/organization_form/saml_configuration/component.rb
+++ b/app/components/admin/organization_form/saml_configuration/component.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+module Admin
+  module OrganizationForm
+    module SamlConfiguration
+      class Component < ApplicationComponent
+        def initialize(form_builder:, current_user:)
+          @form_builder = form_builder
+          @organization = form_builder.object
+          @current_user = current_user
+        end
+
+        def render? = @organization.enabled?("saml_sso")
+
+        private
+
+        # The IdP details decide which identity provider an email domain is handed to, and
+        # which signing key its assertions are trusted against - the same reasoning that
+        # keeps user_email_domain developer-only
+        def developer? = @current_user.developer?
+
+        def saml_configuration
+          @saml_configuration ||= @organization.organization_saml_configuration ||
+            @organization.build_organization_saml_configuration
+        end
+
+        def metadata_url = saml_metadata_url(org_slug: @organization.to_param, format: :xml)
+
+        def field_options = {disabled: !developer?}
+      end
+    end
+  end
+end

--- a/app/components/admin/organization_form/wrapper/component.html.erb
+++ b/app/components/admin/organization_form/wrapper/component.html.erb
@@ -26,7 +26,9 @@
     <%= render(UI::Forms::Group::Component.new(form_builder: @form_builder, attribute: :short_name, label_text: "Short name (30 letters or less)")) do |group| %>
       <% if @organization.block_short_name_edit? %>
         <% group.with_helper_text do %>
-          <span class="em text-danger">warning - will change org URLs (landing pages, embeds)</span>
+          <span class="em text-danger">
+            warning - will change org URLs (landing pages, embeds)
+          </span>
         <% end %>
       <% end %>
     <% end %>
@@ -85,7 +87,13 @@
     <%= render(UI::Forms::Group::Component.new(form_builder: @form_builder, attribute: :parent_organization_id, label_text: label_with_note("Parent organization", parent_org_note))) do |group| %>
       <% group.with_helper_text do %>
         <strong>Use the "regional" feature instead.</strong>
-        <em>To add regional organizations rather than child/parent relationships, enable it through a paid invoice for the organization. All organizations with a location in the same area will automatically be associated.</em>
+
+        <em>
+          To add regional organizations rather than child/parent relationships,
+          enable it through a paid invoice for the organization. All
+          organizations with a location in the same area will automatically be
+          associated.
+        </em>
       <% end %>
 
       <%= render UI::Forms::Combobox::Component.new(name: :parent_organization_id, form: @form_builder, placeholder: "Choose organization", include_blank: true, options: parent_organization_options, aria: {describedby: group.helper_text_id}, data: AMBASSADOR_TARGETS[:input_data]) %>
@@ -97,7 +105,9 @@
       <div class="only-dev-visible mt-4">
         <%= render(UI::Forms::Group::Component.new(attribute: :manual_pos_kind, label_text: "Manually set POS kind")) do |group| %>
           <% group.with_helper_text do %>
-            <span class="text-danger">Warning - you can break things here!</span>
+            <span class="text-danger">
+              Warning - you can break things here!
+            </span>
           <% end %>
 
           <%= render(UI::Forms::RadioButtonGroup::Component.new(name: "organization[manual_pos_kind]", entries: manual_pos_kind_entries, selected: selected_manual_pos_kind)) %>
@@ -107,7 +117,6 @@
 
     <% if @organization.persisted? %>
       <% no_members = @organization.organization_roles.count == 0 %>
-
       <%= render(UI::Forms::Group::Component.new(form_builder: @form_builder, attribute: :embedable_user_email, label_text: label_with_note("Auto user email", "embed registration email"))) do |group| %>
         <% if no_members %>
           <% group.with_helper_text do %>
@@ -136,6 +145,8 @@
     <% end %>
 
     <%= render(Admin::OrganizationForm::FeatureSettings::Component.new(form_builder: @form_builder, current_user: @current_user)) %>
+
+    <%= render(Admin::OrganizationForm::SamlConfiguration::Component.new(form_builder: @form_builder, current_user: @current_user)) %>
   </div>
 </div>
 

--- a/app/components/ui/forms/checkbox/component.rb
+++ b/app/components/ui/forms/checkbox/component.rb
@@ -11,7 +11,7 @@ module UI
       # defaults to the model's value unless overridden.
       class Component < ApplicationComponent
         def initialize(label:, form_builder: nil, attribute: nil, name: nil, checked: nil, value: "1",
-          class_name: nil, data: {}, input_data: {})
+          class_name: nil, disabled: false, data: {}, input_data: {})
           scoped = form_builder && attribute
           raise ArgumentError, "pass form_builder + attribute, or name" unless scoped || name
 
@@ -22,6 +22,7 @@ module UI
           @checked = checked
           @value = value
           @class_name = class_name
+          @disabled = disabled
           @data = data
           @input_data = input_data
         end
@@ -35,7 +36,7 @@ module UI
         private
 
         def checkbox_input
-          base = {class: "tw:h-4 tw:w-4 tw:cursor-pointer", data: @input_data}
+          base = {class: "tw:h-4 tw:w-4 tw:cursor-pointer", data: @input_data, disabled: @disabled}
           if @form_builder
             @form_builder.check_box(@attribute, base.merge(@checked.nil? ? {} : {checked: @checked}), @value, "0")
           else

--- a/app/javascript/controllers/admin/organization_form_controller.js
+++ b/app/javascript/controllers/admin/organization_form_controller.js
@@ -7,18 +7,22 @@ import { collapse } from 'utils/collapse_utils'
 // (`#admin_organizations_(new|edit)` dispatch is no-op'd there). Two behaviors:
 //   1. When the organization "kind" is "ambassador", grey out the ambassador-irrelevant fields.
 //   2. When the stolen-message "kind" is "area", reveal the radius field.
+//   3. When SAML SSO is enabled, star the IdP fields the model then requires.
 export default class extends Controller {
   static targets = [
     'kind',
     'stolenMessageKind',
     'stolenMessageArea',
     'ambassadorField',
-    'ambassadorLabel'
+    'ambassadorLabel',
+    'samlEnabled',
+    'samlRequiredFields'
   ]
 
   connect () {
     this.toggleAmbassadorFields()
     this.toggleStolenMessageArea()
+    this.toggleSamlRequired()
   }
 
   toggleAmbassadorFields () {
@@ -32,5 +36,16 @@ export default class extends Controller {
     if (!this.hasStolenMessageKindTarget || !this.hasStolenMessageAreaTarget) return
     const action = this.stolenMessageKindTarget.value === 'area' ? 'show' : 'hide'
     collapse(action, this.stolenMessageAreaTarget)
+  }
+
+  // OrganizationSamlConfiguration validates these present when enabled, so an unchecked
+  // box is the one state where a half-filled configuration saves
+  toggleSamlRequired () {
+    if (!this.hasSamlEnabledTarget || !this.hasSamlRequiredFieldsTarget) return
+    const required = this.samlEnabledTarget.checked
+    const fields = this.samlRequiredFieldsTarget
+    fields.querySelectorAll('input, textarea').forEach((el) => { el.required = required })
+    fields.querySelectorAll('[data-required-marker]').forEach((el) => { el.hidden = !required })
+    fields.querySelectorAll('[data-optional-marker]').forEach((el) => { el.hidden = required })
   }
 }

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -139,6 +139,7 @@ class Organization < ApplicationRecord
   validates_uniqueness_of :slug, message: "Slug error. You shouldn't see this - please contact support@bikeindex.org"
   validates_uniqueness_of :manufacturer_id, allow_blank: true
   validate :user_email_domain_format
+  validate :slug_stable_while_saml_live
   # Two SSO orgs on one domain would make saml_email_matching's pick arbitrary (name order),
   # silently sending logins to the wrong org's IdP. Non-SSO orgs may still share a domain.
   validates_uniqueness_of :user_email_domain, allow_blank: true,
@@ -628,6 +629,16 @@ class Organization < ApplicationRecord
   end
 
   private
+
+  # The SP entityID and ACS URL are built from the slug, and the IdP has them registered from
+  # onboarding - renaming silently breaks every login until someone re-registers the metadata
+  def slug_stable_while_saml_live
+    return unless persisted? && slug_changed? && slug_was.present?
+    return unless organization_saml_configuration&.enabled?
+
+    errors.add(:short_name, "can't change while SAML SSO is live - it would move the " \
+      "entityID and callback URL the IdP has registered. Disable SAML SSO first.")
+  end
 
   def user_email_domain_format
     return if user_email_domain.blank?

--- a/app/models/organization_saml_configuration.rb
+++ b/app/models/organization_saml_configuration.rb
@@ -25,11 +25,19 @@ class OrganizationSamlConfiguration < ApplicationRecord
   PROVIDER = "saml"
   # Asserted attribute that carries the user's email, when it isn't the NameID
   DEFAULT_EMAIL_ATTRIBUTE = "urn:oid:0.9.2342.19200300.100.1.3"
+  # NameIDPolicy for the AuthnRequest; blank sends none, leaving the choice to the IdP
+  NAME_ID_FORMATS = {
+    "persistent" => "urn:oasis:names:tc:SAML:2.0:nameid-format:persistent",
+    "transient" => "urn:oasis:names:tc:SAML:2.0:nameid-format:transient",
+    "emailAddress" => "urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress",
+    "unspecified" => "urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified"
+  }.freeze
 
   belongs_to :organization
 
   validates :organization_id, presence: true, uniqueness: true
   validates :idp_entity_id, :idp_sso_target_url, :idp_cert, presence: true, if: :enabled?
+  validates :name_id_format, inclusion: {in: NAME_ID_FORMATS.values}, allow_blank: true
   validate :idp_certificates_parseable
   validate :organization_claims_a_domain, if: :enabled?
 

--- a/app/models/organization_saml_configuration.rb
+++ b/app/models/organization_saml_configuration.rb
@@ -25,7 +25,7 @@ class OrganizationSamlConfiguration < ApplicationRecord
   PROVIDER = "saml"
   # Asserted attribute that carries the user's email, when it isn't the NameID
   DEFAULT_EMAIL_ATTRIBUTE = "urn:oid:0.9.2342.19200300.100.1.3"
-  # NameIDPolicy for the AuthnRequest; blank sends none, leaving the choice to the IdP
+  # NameIDPolicy for the AuthnRequest; blank omits the element
   NAME_ID_FORMATS = {
     "persistent" => "urn:oasis:names:tc:SAML:2.0:nameid-format:persistent",
     "transient" => "urn:oasis:names:tc:SAML:2.0:nameid-format:transient",

--- a/docs/sso.md
+++ b/docs/sso.md
@@ -117,8 +117,9 @@ through the IdP, they link to the existing account rather than getting a duplica
 
 **Pin the NameID format with the IdP.** `SsoIdentity` is unique on
 `(organization_id, provider, uid)` where `uid` is the asserted NameID. A **transient** NameID
-mints a new identity row on every login. `name_id_format` is stored but never enforced — and
-there is no field for it on the admin form, though it is in the strong params.
+mints a new identity row on every login. The admin form's **NameID format** select is what asks
+for one; blank sends no `NameIDPolicy` at all, leaving the choice to the IdP. What the IdP
+actually returned is recorded on each `SsoIdentity` — nothing enforces a match.
 
 **Capture before you change anything**, so it's reversible: the org's `enabled_feature_slugs`,
 the ids of existing `organization_roles`, accounts on the domain split by has-a-password /

--- a/spec/models/organization_saml_configuration_spec.rb
+++ b/spec/models/organization_saml_configuration_spec.rb
@@ -55,6 +55,21 @@ RSpec.describe OrganizationSamlConfiguration, type: :model do
       end
     end
 
+    context "name_id_format" do
+      it "permits blank or a SAML 2.0 format, and rejects anything else" do
+        saml_configuration.assign_attributes(idp_entity_id: "https://idp.example.edu/",
+          idp_sso_target_url: "https://idp.example.edu/sso", idp_cert:)
+        expect(saml_configuration).to be_valid
+
+        saml_configuration.name_id_format = OrganizationSamlConfiguration::NAME_ID_FORMATS["persistent"]
+        expect(saml_configuration).to be_valid
+
+        saml_configuration.name_id_format = "persistent"
+        expect(saml_configuration).to_not be_valid
+        expect(saml_configuration.errors.attribute_names).to include(:name_id_format)
+      end
+    end
+
     context "invalid certificate" do
       it "adds an error" do
         saml_configuration.assign_attributes(idp_entity_id: "https://idp.example.edu/",

--- a/spec/models/organization_saml_configuration_spec.rb
+++ b/spec/models/organization_saml_configuration_spec.rb
@@ -56,10 +56,9 @@ RSpec.describe OrganizationSamlConfiguration, type: :model do
     end
 
     context "name_id_format" do
-      it "permits blank or a SAML 2.0 format, and rejects anything else" do
+      it "permits a known format, and rejects anything else" do
         saml_configuration.assign_attributes(idp_entity_id: "https://idp.example.edu/",
           idp_sso_target_url: "https://idp.example.edu/sso", idp_cert:)
-        expect(saml_configuration).to be_valid
 
         saml_configuration.name_id_format = OrganizationSamlConfiguration::NAME_ID_FORMATS["persistent"]
         expect(saml_configuration).to be_valid

--- a/spec/models/organization_spec.rb
+++ b/spec/models/organization_spec.rb
@@ -503,6 +503,31 @@ RSpec.describe Organization, type: :model do
     end
   end
 
+  describe "slug stability while SAML is live" do
+    let(:saml_configuration) { FactoryBot.create(:organization_saml_configuration, :enabled) }
+    let(:organization) { saml_configuration.organization }
+
+    it "blocks a short_name change, which would move the entityID the IdP has registered" do
+      original_slug = organization.slug
+      organization.short_name = "something-else"
+      expect(organization).to_not be_valid
+      expect(organization.errors.attribute_names).to include(:short_name)
+      expect(organization.reload.slug).to eq original_slug
+    end
+
+    it "permits changes that don't move the slug" do
+      expect(organization.update(name: "Renamed but same short_name")).to be_truthy
+    end
+
+    context "saml configuration not enabled" do
+      let(:saml_configuration) { FactoryBot.create(:organization_saml_configuration) }
+      it "permits the change, since no IdP has the urls yet" do
+        expect(organization.update(short_name: "something-else")).to be_truthy
+        expect(organization.reload.slug).to eq "something-else"
+      end
+    end
+  end
+
   describe "user_email_domain uniqueness" do
     let(:saml_configuration) { FactoryBot.create(:organization_saml_configuration, :enabled) }
     let!(:sso_organization) { saml_configuration.organization }

--- a/spec/requests/admin/organizations_request_spec.rb
+++ b/spec/requests/admin/organizations_request_spec.rb
@@ -77,6 +77,30 @@ RSpec.describe Admin::OrganizationsController, type: :request do
         expect(response.body).to include('name="organization[user_email_domain]"')
         expect(response.body).to include('name="organization[organization_saml_configuration_attributes][name_id_format]"')
       end
+
+      # The IdP fields decide where a domain's logins go and which key signs them, so they
+      # follow user_email_domain in being visible to every superuser but developer-only to edit
+      it "renders the IdP fields disabled" do
+        Country.united_states
+        get "#{base_url}/#{organization.to_param}/edit"
+        expect(response.status).to eq(200)
+        saml_inputs = response.body.scan(/<[^>]*organization_saml_configuration_attributes\]\[[^>]*>/)
+        expect(saml_inputs).to be_present
+        expect(saml_inputs.select { |input| input.exclude?("disabled") }).to eq([])
+      end
+
+      context "current_user is a developer" do
+        # admin access and the developer flag are separate - editing these needs both
+        let(:current_user) { FactoryBot.create(:superuser_developer) }
+        it "renders the IdP fields editable, and required because it isn't enabled yet" do
+          Country.united_states
+          get "#{base_url}/#{organization.to_param}/edit"
+          expect(response.status).to eq(200)
+          expect(response.body).to include('name="organization[organization_saml_configuration_attributes][idp_entity_id]"')
+          saml_inputs = response.body.scan(/<[^>]*organization_saml_configuration_attributes\]\[[^>]*>/)
+          expect(saml_inputs.select { |input| input.include?("disabled") }).to eq([])
+        end
+      end
     end
   end
 

--- a/spec/requests/admin/organizations_request_spec.rb
+++ b/spec/requests/admin/organizations_request_spec.rb
@@ -75,6 +75,7 @@ RSpec.describe Admin::OrganizationsController, type: :request do
         expect(response.body).to include("/sso/#{organization.to_param}/metadata")
         expect(response.body).to include("permitted domain for SAML SSO")
         expect(response.body).to include('name="organization[user_email_domain]"')
+        expect(response.body).to include('name="organization[organization_saml_configuration_attributes][name_id_format]"')
       end
     end
   end
@@ -279,7 +280,8 @@ RSpec.describe Admin::OrganizationsController, type: :request do
       let(:saml_attributes) do
         {enabled: "1", idp_entity_id: "https://idp.example.edu/",
          idp_sso_target_url: "https://idp.example.edu/idp/profile/SAML2/POST/SSO",
-         idp_cert: File.read(Rails.root.join("spec/fixtures/saml/idp_cert.pem"))}
+         idp_cert: File.read(Rails.root.join("spec/fixtures/saml/idp_cert.pem")),
+         name_id_format: OrganizationSamlConfiguration::NAME_ID_FORMATS["persistent"]}
       end
       it "creates the nested configuration" do
         expect do
@@ -288,6 +290,7 @@ RSpec.describe Admin::OrganizationsController, type: :request do
         saml_configuration = organization.reload.organization_saml_configuration
         expect(saml_configuration.enabled?).to be_truthy
         expect(saml_configuration.idp_entity_id).to eq "https://idp.example.edu/"
+        expect(saml_configuration.name_id_format).to eq OrganizationSamlConfiguration::NAME_ID_FORMATS["persistent"]
         expect(saml_configuration.configured?).to be_truthy
       end
     end

--- a/spec/requests/admin/organizations_request_spec.rb
+++ b/spec/requests/admin/organizations_request_spec.rb
@@ -76,6 +76,8 @@ RSpec.describe Admin::OrganizationsController, type: :request do
         expect(response.body).to include("permitted domain for SAML SSO")
         expect(response.body).to include('name="organization[user_email_domain]"')
         expect(response.body).to include('name="organization[organization_saml_configuration_attributes][name_id_format]"')
+        # permitted by the controller since SSO shipped, but never rendered
+        expect(response.body).to include('name="organization[organization_saml_configuration_attributes][idp_cert_multi]"')
       end
 
       # The IdP fields decide where a domain's logins go and which key signs them, so they

--- a/spec/services/saml/settings_builder_spec.rb
+++ b/spec/services/saml/settings_builder_spec.rb
@@ -32,7 +32,6 @@ RSpec.describe Saml::SettingsBuilder, :saml_env do
     expect(settings.idp_cert).to include("BEGIN CERTIFICATE")
   end
 
-  # ruby-saml omits NameIDPolicy entirely when the format is nil
   it "requests no NameID format by default" do
     expect(settings.name_identifier_format).to be_nil
     expect(OneLogin::RubySaml::Authrequest.new.create_authentication_xml_doc(settings).to_s)

--- a/spec/services/saml/settings_builder_spec.rb
+++ b/spec/services/saml/settings_builder_spec.rb
@@ -32,6 +32,23 @@ RSpec.describe Saml::SettingsBuilder, :saml_env do
     expect(settings.idp_cert).to include("BEGIN CERTIFICATE")
   end
 
+  # ruby-saml omits NameIDPolicy entirely when the format is nil
+  it "requests no NameID format by default" do
+    expect(settings.name_identifier_format).to be_nil
+    expect(OneLogin::RubySaml::Authrequest.new.create_authentication_xml_doc(settings).to_s)
+      .to_not include("NameIDPolicy")
+  end
+
+  context "with a configured name_id_format" do
+    let(:name_id_format) { OrganizationSamlConfiguration::NAME_ID_FORMATS["persistent"] }
+    let(:saml_configuration) do
+      FactoryBot.create(:organization_saml_configuration, :enabled, organization:, name_id_format:)
+    end
+    it "asks the IdP for it" do
+      expect(settings.name_identifier_format).to eq name_id_format
+    end
+  end
+
   it "enforces signed assertions + SHA-256, and offers an encryption key" do
     expect(settings.security[:want_assertions_signed]).to be true
     expect(settings.security[:authn_requests_signed]).to be true


### PR DESCRIPTION
Parked draft, from local commits dated Aug 19 — pushed to preserve the work, not ready for review.

**Main has since grown its own SAML card.** The admin form refactor moved `admin/organization_form/` to `admin/organizations/form/` and added `form/saml_sso/`, so this branch's card is superseded and its paths no longer exist. Two pieces here aren't on main:

- **The slug is locked while SAML SSO is live** (`Organization#slug_stable_while_saml_live`). The SP entityID and ACS URL are built from the slug and the IdP has both registered from onboarding, so renaming silently breaks every login. This is the part worth keeping.
- **Developer-gated SAML fields.** Main's card takes no `current_user`, so anyone who can edit an organization can edit its IdP details.

Needs porting onto main's component layout rather than merging as-is.
