### PR TITLE
Separate SAML configuration from activation, and add a test flow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -102,6 +102,7 @@ Check whether the dev server is up: `curl -fs "$BASE_URL/" >/dev/null`. If it is
 - **Soft delete**: some models use `acts_as_paranoid` with `deleted_at` column; use `unscoped` in admin controllers when needed
 - **Admin search**: `sortable_search_params` auto-includes any param starting with `search_`
 - **Admin record screens are tabs**: a record with more than one super-admin page gets `Admin::Headers::Tabs::Component`, with the section's own tabs named in a component of its own (`Admin::Organizations::Tabs` is the pattern) rather than in each view.
+- **Every user has a `password_digest`** — `User#set_calculated_attributes` gives passwordless accounts a random one so `has_secure_password` is satisfied. So it answers nothing about whether someone chose a password; `passwordless_user?` is that question.
 
 # Initial setup
 

--- a/app/components/admin/organizations/form/saml_sso/component.html.erb
+++ b/app/components/admin/organizations/form/saml_sso/component.html.erb
@@ -26,16 +26,18 @@
         ACS (callback) URL:
         <code><%= Saml::SettingsBuilder.assertion_consumer_service_url(saml_configuration) %></code>
       </li>
+
+      <li>
+        Test page: <%= link_to test_url, test_url %>
+        <small>a real SSO login that reports what the IdP sent, rather than signing in silently</small>
+      </li>
     </ul>
 
     <% unless saml_configuration.active? %>
       <%= render(UI::Alerts::Base::Component.new(kind: :notice)) do %>
         A complete SAML configuration requires the IdP entityID, SSO target URL,
-        certificate, and the organization's permitted email domain. Use the
-        <%= link_to "SAML test page", saml_test_path(org_slug: saml_configuration.organization.to_param), class: "twlink-underlined" %>
-        to validate an inactive configuration without provisioning or signing
-        anyone in. Activating it forces every user at that domain through the
-        IdP.
+        certificate, and the organization's permitted email domain. Activating
+        it forces every user at that domain through the IdP.
       <% end %>
     <% end %>
 

--- a/app/components/admin/organizations/form/saml_sso/component.html.erb
+++ b/app/components/admin/organizations/form/saml_sso/component.html.erb
@@ -28,6 +28,17 @@
       </li>
     </ul>
 
+    <% unless saml_configuration.active? %>
+      <%= render(UI::Alerts::Base::Component.new(kind: :notice)) do %>
+        A complete SAML configuration requires the IdP entityID, SSO target URL,
+        certificate, and the organization's permitted email domain. Use the
+        <%= link_to "SAML test page", saml_test_path(org_slug: saml_configuration.organization.to_param), class: "twlink-underlined" %>
+        to validate an inactive configuration without provisioning or signing
+        anyone in. Activating it forces every user at that domain through the
+        IdP.
+      <% end %>
+    <% end %>
+
     <%= @form_builder.fields_for :organization_saml_configuration, saml_configuration do |saml_f| %>
       <%= render(UI::Forms::Checkbox::Component.new(form_builder: saml_f, attribute: :active, label: "Force every user at this domain through live SAML SSO", class_name: "tw:mb-4")) %>
 

--- a/app/components/admin/organizations/form/saml_sso/component.html.erb
+++ b/app/components/admin/organizations/form/saml_sso/component.html.erb
@@ -29,7 +29,7 @@
     </ul>
 
     <%= @form_builder.fields_for :organization_saml_configuration, saml_configuration do |saml_f| %>
-      <%= render(UI::Forms::Checkbox::Component.new(form_builder: saml_f, attribute: :enabled, label: "Enable live SAML login for this organization", class_name: "tw:mb-4")) %>
+      <%= render(UI::Forms::Checkbox::Component.new(form_builder: saml_f, attribute: :active, label: "Force every user at this domain through live SAML SSO", class_name: "tw:mb-4")) %>
 
       <%= render(UI::Forms::Group::Component.new(form_builder: saml_f, attribute: :idp_entity_id, label_text: "IdP entityID")) %>
 

--- a/app/components/admin/organizations/form/saml_sso/component.rb
+++ b/app/components/admin/organizations/form/saml_sso/component.rb
@@ -20,6 +20,8 @@ module Admin
           def metadata_url = saml_metadata_url(org_slug: @organization.to_param)
 
           def certificate_url = saml_certificate_url(org_slug: @organization.to_param)
+
+          def test_url = saml_test_url(org_slug: @organization.to_param)
         end
       end
     end

--- a/app/components/saml/test/component.html.erb
+++ b/app/components/saml/test/component.html.erb
@@ -28,7 +28,12 @@
     <% end %>
   <% else %>
     <%= render(UI::Header::Component.new(text: "Assertion", tag: :h2)) %>
-    <dl class="tw:mb-8 tw:grid tw:grid-cols-[auto_1fr] tw:gap-x-4 tw:gap-y-2">
+    <dl
+      class="
+        tw:mb-8 tw:grid tw:grid-cols-1 tw:gap-x-4 tw:gap-y-1
+        tw:wrap-anywhere tw:sm:grid-cols-[auto_1fr] tw:sm:gap-y-2
+      "
+    >
       <% if @expected_email.present? %>
         <dt class="tw:font-semibold">Address entered</dt>
         <dd><code><%= @expected_email %></code></dd>
@@ -68,7 +73,12 @@
     <% if diagnostic? %>
       <%= render(UI::Header::Component.new(text: "Received attributes", tag: :h2)) %>
       <% if @result.attributes.present? %>
-        <dl class="tw:mb-8 tw:grid tw:grid-cols-[auto_1fr] tw:gap-x-4 tw:gap-y-2">
+        <dl
+          class="
+            tw:mb-8 tw:grid tw:grid-cols-1 tw:gap-x-4 tw:gap-y-1
+            tw:wrap-anywhere tw:sm:grid-cols-[auto_1fr] tw:sm:gap-y-2
+          "
+        >
           <% @result.attributes.each do |name, values| %>
             <dt class="tw:font-semibold"><code><%= name %></code></dt>
             <dd><code><%= Array(values).join(", ") %></code></dd>

--- a/app/components/saml/test/component.html.erb
+++ b/app/components/saml/test/component.html.erb
@@ -1,0 +1,61 @@
+<div class="tw:mx-auto tw:max-w-3xl tw:p-4">
+  <h1 class="tw:mb-6 tw:text-2xl tw:font-bold">SAML configuration test</h1>
+
+  <%= render(UI::Alerts::Base::Component.new(kind: @result.success? ? :success : :error)) do %>
+    <% if @result.success? %>
+      The assertion signature and SAML response validation passed. No account
+      was provisioned or signed in.
+    <% else %>
+      The assertion was not accepted:
+      <%= @result.error %>
+    <% end %>
+  <% end %>
+
+  <% if diagnostic? %>
+    <h2 class="tw:mb-3 tw:text-xl tw:font-semibold">Assertion</h2>
+    <dl class="tw:mb-8 tw:grid tw:grid-cols-[auto_1fr] tw:gap-x-4 tw:gap-y-2">
+      <dt class="tw:font-semibold">Signature certificate</dt>
+      <dd><code><%= @result.certificate %></code></dd>
+      <dt class="tw:font-semibold">NameID</dt>
+      <dd><code><%= @result.name_id.presence || "(missing)" %></code></dd>
+      <dt class="tw:font-semibold">NameID format</dt>
+
+      <dd>
+        <code><%= @result.name_id_format.presence || "(missing)" %></code>
+      </dd>
+
+      <dt class="tw:font-semibold">Configured email attribute</dt>
+      <dd><code><%= @result.email_attribute %></code></dd>
+      <dt class="tw:font-semibold">Asserted email</dt>
+      <dd><code><%= @result.email.presence || "(missing)" %></code></dd>
+      <dt class="tw:font-semibold">Asserted email domain</dt>
+      <dd><code><%= @result.email_domain.presence || "(missing)" %></code></dd>
+      <dt class="tw:font-semibold">Organization domain</dt>
+
+      <dd>
+        <code>
+          <%= @organization.user_email_domain.presence || "(missing)" %>
+        </code>
+      </dd>
+
+      <dt class="tw:font-semibold">Matching account</dt>
+      <dd><code><%= @result.user&.email || "(none)" %></code></dd>
+      <dt class="tw:font-semibold">Matching account has a password</dt>
+
+      <dd>
+        <%= @result.user ? (@result.user_has_password ? "Yes" : "No") : "(none)" %>
+      </dd>
+    </dl>
+    <h2 class="tw:mb-3 tw:text-xl tw:font-semibold">Received attributes</h2>
+    <% if @result.attributes.present? %>
+      <dl class="tw:grid tw:grid-cols-[auto_1fr] tw:gap-x-4 tw:gap-y-2">
+        <% @result.attributes.each do |name, values| %>
+          <dt class="tw:font-semibold"><code><%= name %></code></dt>
+          <dd><code><%= Array(values).join(", ") %></code></dd>
+        <% end %>
+      </dl>
+    <% else %>
+      <p>No attributes were received.</p>
+    <% end %>
+  <% end %>
+</div>

--- a/app/components/saml/test/component.html.erb
+++ b/app/components/saml/test/component.html.erb
@@ -2,22 +2,23 @@
   <%= render(UI::Header::Component.new(text: "SAML configuration test",
         subtitle: safe_join([@organization.short_name, " — ", tag.code(@organization.user_email_domain)]))) %>
 
-  <%= render(UI::Alerts::Base::Component.new(kind: summary_kind)) do %>
+  <%= render(UI::Alerts::Base::Component.new(kind: summary_kind, header: summary_header)) do %>
     <% if @result.blank? %>
-      Signing in here validates the IdP's assertion and reports what it
-      contained. No account is created and nobody is signed in, so this is safe
-      to run before the configuration is activated.
+      This is the real login: the IdP authenticates you, and Bike Index signs
+      you in — creating an account for the address the IdP releases if there
+      isn't one already. What comes back is reported here rather than dropping
+      you on your account page.
     <% elsif @result.success? %>
-      The assertion signature and SAML response validation passed. No account
-      was provisioned or signed in.
+      <code><%= @result.user.email %></code>
+      is signed in on this browser now — the same session an ordinary SSO login
+      creates.
     <% else %>
-      The assertion was not accepted:
       <%= @result.error %>
     <% end %>
   <% end %>
 
   <% if @result.blank? %>
-    <%= form_with url: saml_test_path(org_slug: @organization.to_param) do |f| %>
+    <%= form_with url: saml_test_start_path(org_slug: @organization.to_param) do |f| %>
       <%= render(UI::Forms::Group::Component.new(form_builder: f, attribute: :email, required: true,
             label_text: "Email address to sign in with")) do %>
         <%= render(UI::Forms::Email::Component.new(form_builder: f, required: true,
@@ -39,7 +40,7 @@
         <dd><code><%= @expected_email %></code></dd>
       <% end %>
 
-      <% if diagnostic? %>
+      <% if asserted? %>
         <dt class="tw:font-semibold">NameID</dt>
         <dd><code><%= @result.name_id.presence || "(missing)" %></code></dd>
         <dt class="tw:font-semibold">NameID format</dt>
@@ -62,15 +63,21 @@
         </dd>
         <dt class="tw:font-semibold">Organization domain</dt>
         <dd><code><%= @organization.user_email_domain %></code></dd>
-        <dt class="tw:font-semibold">Matching account</dt>
-        <dd><code><%= @result.user&.email || "(none)" %></code></dd>
-        <dt class="tw:font-semibold">Matching account has a password</dt>
+      <% end %>
+
+      <% if @result.user.present? %>
+        <dt class="tw:font-semibold">Account</dt>
         <dd>
-          <%= @result.user ? (@result.user_has_password ? "Yes" : "No") : "(none)" %>
+          <code><%= @result.user.email %></code>
+          <%= @result.signed_up ? "— created by this login" : "— already existed" %>
         </dd>
+        <% unless @result.signed_up %>
+          <dt class="tw:font-semibold">Account has a password</dt>
+          <dd><%= @result.user.passwordless_user? ? "No" : "Yes" %></dd>
+        <% end %>
       <% end %>
     </dl>
-    <% if diagnostic? %>
+    <% if asserted? %>
       <%= render(UI::Header::Component.new(text: "Received attributes", tag: :h2)) %>
       <% if @result.attributes.present? %>
         <dl

--- a/app/components/saml/test/component.html.erb
+++ b/app/components/saml/test/component.html.erb
@@ -9,9 +9,8 @@
       isn't one already. What comes back is reported here rather than dropping
       you on your account page.
     <% elsif @result.success? %>
-      <code><%= @result.user.email %></code>
-      is signed in on this browser now — the same session an ordinary SSO login
-      creates.
+      <code><%= @result.user.email %></code> is signed in on this browser now —
+      the same session an ordinary SSO login creates.
     <% else %>
       <%= @result.error %>
     <% end %>

--- a/app/components/saml/test/component.html.erb
+++ b/app/components/saml/test/component.html.erb
@@ -14,8 +14,6 @@
   <% if diagnostic? %>
     <h2 class="tw:mb-3 tw:text-xl tw:font-semibold">Assertion</h2>
     <dl class="tw:mb-8 tw:grid tw:grid-cols-[auto_1fr] tw:gap-x-4 tw:gap-y-2">
-      <dt class="tw:font-semibold">Signature certificate</dt>
-      <dd><code><%= @result.certificate %></code></dd>
       <dt class="tw:font-semibold">NameID</dt>
       <dd><code><%= @result.name_id.presence || "(missing)" %></code></dd>
       <dt class="tw:font-semibold">NameID format</dt>

--- a/app/components/saml/test/component.html.erb
+++ b/app/components/saml/test/component.html.erb
@@ -1,15 +1,9 @@
 <div class="tw:mx-auto tw:max-w-3xl tw:p-4">
-  <h1 class="tw:mb-2 tw:text-2xl tw:font-bold">SAML configuration test</h1>
-
-  <p class="tw:mb-6">
-    <%= @organization.short_name %> —
-    <code><%= @organization.user_email_domain %></code>
-  </p>
+  <%= render(UI::Header::Component.new(text: "SAML configuration test",
+        subtitle: safe_join([@organization.short_name, " — ", tag.code(@organization.user_email_domain)]))) %>
 
   <%= render(UI::Alerts::Base::Component.new(kind: summary_kind)) do %>
-    <% if @error.present? %>
-      <%= @error %>
-    <% elsif @result.blank? %>
+    <% if @result.blank? %>
       Signing in here validates the IdP's assertion and reports what it
       contained. No account is created and nobody is signed in, so this is safe
       to run before the configuration is activated.
@@ -23,21 +17,21 @@
   <% end %>
 
   <% if @result.blank? %>
-    <%= form_with url: saml_test_start_path(org_slug: @organization.to_param), method: :post do |f| %>
+    <%= form_with url: saml_test_path(org_slug: @organization.to_param) do |f| %>
       <%= render(UI::Forms::Group::Component.new(form_builder: f, attribute: :email, required: true,
             label_text: "Email address to sign in with")) do %>
         <%= render(UI::Forms::Email::Component.new(form_builder: f, required: true,
-              html_options: {value: @email, name: :email, autofocus: true})) %>
+              html_options: {autofocus: true})) %>
       <% end %>
 
       <%= render(UI::Button::Component.new(text: "Start test login", color: :primary, type: "submit")) %>
     <% end %>
   <% else %>
-    <h2 class="tw:mb-3 tw:text-xl tw:font-semibold">Assertion</h2>
+    <%= render(UI::Header::Component.new(text: "Assertion", tag: :h2)) %>
     <dl class="tw:mb-8 tw:grid tw:grid-cols-[auto_1fr] tw:gap-x-4 tw:gap-y-2">
-      <% if @email.present? %>
+      <% if @expected_email.present? %>
         <dt class="tw:font-semibold">Address entered</dt>
-        <dd><code><%= @email %></code></dd>
+        <dd><code><%= @expected_email %></code></dd>
       <% end %>
 
       <% if diagnostic? %>
@@ -53,7 +47,7 @@
         <dd>
           <code><%= @result.email.presence || "(missing)" %></code>
 
-          <% if @email.present? %>
+          <% if @expected_email.present? %>
             <%= asserted_expected_email? ? "— matches the address entered" : "— the IdP released a different address" %>
           <% end %>
         </dd>
@@ -62,11 +56,7 @@
           <code><%= @result.email_domain.presence || "(missing)" %></code>
         </dd>
         <dt class="tw:font-semibold">Organization domain</dt>
-        <dd>
-          <code>
-            <%= @organization.user_email_domain.presence || "(missing)" %>
-          </code>
-        </dd>
+        <dd><code><%= @organization.user_email_domain %></code></dd>
         <dt class="tw:font-semibold">Matching account</dt>
         <dd><code><%= @result.user&.email || "(none)" %></code></dd>
         <dt class="tw:font-semibold">Matching account has a password</dt>
@@ -76,7 +66,7 @@
       <% end %>
     </dl>
     <% if diagnostic? %>
-      <h2 class="tw:mb-3 tw:text-xl tw:font-semibold">Received attributes</h2>
+      <%= render(UI::Header::Component.new(text: "Received attributes", tag: :h2)) %>
       <% if @result.attributes.present? %>
         <dl class="tw:mb-8 tw:grid tw:grid-cols-[auto_1fr] tw:gap-x-4 tw:gap-y-2">
           <% @result.attributes.each do |name, values| %>

--- a/app/components/saml/test/component.html.erb
+++ b/app/components/saml/test/component.html.erb
@@ -1,8 +1,19 @@
 <div class="tw:mx-auto tw:max-w-3xl tw:p-4">
-  <h1 class="tw:mb-6 tw:text-2xl tw:font-bold">SAML configuration test</h1>
+  <h1 class="tw:mb-2 tw:text-2xl tw:font-bold">SAML configuration test</h1>
 
-  <%= render(UI::Alerts::Base::Component.new(kind: @result.success? ? :success : :error)) do %>
-    <% if @result.success? %>
+  <p class="tw:mb-6">
+    <%= @organization.short_name %> —
+    <code><%= @organization.user_email_domain %></code>
+  </p>
+
+  <%= render(UI::Alerts::Base::Component.new(kind: summary_kind)) do %>
+    <% if @error.present? %>
+      <%= @error %>
+    <% elsif @result.blank? %>
+      Signing in here validates the IdP's assertion and reports what it
+      contained. No account is created and nobody is signed in, so this is safe
+      to run before the configuration is activated.
+    <% elsif @result.success? %>
       The assertion signature and SAML response validation passed. No account
       was provisioned or signed in.
     <% else %>
@@ -11,49 +22,72 @@
     <% end %>
   <% end %>
 
-  <% if diagnostic? %>
+  <% if @result.blank? %>
+    <%= form_with url: saml_test_start_path(org_slug: @organization.to_param), method: :post do |f| %>
+      <%= render(UI::Forms::Group::Component.new(form_builder: f, attribute: :email, required: true,
+            label_text: "Email address to sign in with")) do %>
+        <%= render(UI::Forms::Email::Component.new(form_builder: f, required: true,
+              html_options: {value: @email, name: :email, autofocus: true})) %>
+      <% end %>
+
+      <%= render(UI::Button::Component.new(text: "Start test login", color: :primary, type: "submit")) %>
+    <% end %>
+  <% else %>
     <h2 class="tw:mb-3 tw:text-xl tw:font-semibold">Assertion</h2>
     <dl class="tw:mb-8 tw:grid tw:grid-cols-[auto_1fr] tw:gap-x-4 tw:gap-y-2">
-      <dt class="tw:font-semibold">NameID</dt>
-      <dd><code><%= @result.name_id.presence || "(missing)" %></code></dd>
-      <dt class="tw:font-semibold">NameID format</dt>
+      <% if @email.present? %>
+        <dt class="tw:font-semibold">Address entered</dt>
+        <dd><code><%= @email %></code></dd>
+      <% end %>
 
-      <dd>
-        <code><%= @result.name_id_format.presence || "(missing)" %></code>
-      </dd>
+      <% if diagnostic? %>
+        <dt class="tw:font-semibold">NameID</dt>
+        <dd><code><%= @result.name_id.presence || "(missing)" %></code></dd>
+        <dt class="tw:font-semibold">NameID format</dt>
+        <dd>
+          <code><%= @result.name_id_format.presence || "(missing)" %></code>
+        </dd>
+        <dt class="tw:font-semibold">Configured email attribute</dt>
+        <dd><code><%= @result.email_attribute %></code></dd>
+        <dt class="tw:font-semibold">Asserted email</dt>
+        <dd>
+          <code><%= @result.email.presence || "(missing)" %></code>
 
-      <dt class="tw:font-semibold">Configured email attribute</dt>
-      <dd><code><%= @result.email_attribute %></code></dd>
-      <dt class="tw:font-semibold">Asserted email</dt>
-      <dd><code><%= @result.email.presence || "(missing)" %></code></dd>
-      <dt class="tw:font-semibold">Asserted email domain</dt>
-      <dd><code><%= @result.email_domain.presence || "(missing)" %></code></dd>
-      <dt class="tw:font-semibold">Organization domain</dt>
-
-      <dd>
-        <code>
-          <%= @organization.user_email_domain.presence || "(missing)" %>
-        </code>
-      </dd>
-
-      <dt class="tw:font-semibold">Matching account</dt>
-      <dd><code><%= @result.user&.email || "(none)" %></code></dd>
-      <dt class="tw:font-semibold">Matching account has a password</dt>
-
-      <dd>
-        <%= @result.user ? (@result.user_has_password ? "Yes" : "No") : "(none)" %>
-      </dd>
+          <% if @email.present? %>
+            <%= asserted_expected_email? ? "— matches the address entered" : "— the IdP released a different address" %>
+          <% end %>
+        </dd>
+        <dt class="tw:font-semibold">Asserted email domain</dt>
+        <dd>
+          <code><%= @result.email_domain.presence || "(missing)" %></code>
+        </dd>
+        <dt class="tw:font-semibold">Organization domain</dt>
+        <dd>
+          <code>
+            <%= @organization.user_email_domain.presence || "(missing)" %>
+          </code>
+        </dd>
+        <dt class="tw:font-semibold">Matching account</dt>
+        <dd><code><%= @result.user&.email || "(none)" %></code></dd>
+        <dt class="tw:font-semibold">Matching account has a password</dt>
+        <dd>
+          <%= @result.user ? (@result.user_has_password ? "Yes" : "No") : "(none)" %>
+        </dd>
+      <% end %>
     </dl>
-    <h2 class="tw:mb-3 tw:text-xl tw:font-semibold">Received attributes</h2>
-    <% if @result.attributes.present? %>
-      <dl class="tw:grid tw:grid-cols-[auto_1fr] tw:gap-x-4 tw:gap-y-2">
-        <% @result.attributes.each do |name, values| %>
-          <dt class="tw:font-semibold"><code><%= name %></code></dt>
-          <dd><code><%= Array(values).join(", ") %></code></dd>
-        <% end %>
-      </dl>
-    <% else %>
-      <p>No attributes were received.</p>
+    <% if diagnostic? %>
+      <h2 class="tw:mb-3 tw:text-xl tw:font-semibold">Received attributes</h2>
+      <% if @result.attributes.present? %>
+        <dl class="tw:mb-8 tw:grid tw:grid-cols-[auto_1fr] tw:gap-x-4 tw:gap-y-2">
+          <% @result.attributes.each do |name, values| %>
+            <dt class="tw:font-semibold"><code><%= name %></code></dt>
+            <dd><code><%= Array(values).join(", ") %></code></dd>
+          <% end %>
+        </dl>
+      <% else %>
+        <p class="tw:mb-8">No attributes were received.</p>
+      <% end %>
     <% end %>
+    <%= link_to "Run another test", saml_test_path(org_slug: @organization.to_param), class: "twlink-underlined" %>
   <% end %>
 </div>

--- a/app/components/saml/test/component.rb
+++ b/app/components/saml/test/component.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module Saml
+  module Test
+    class Component < ApplicationComponent
+      def initialize(organization:, result:)
+        @organization = organization
+        @result = result
+      end
+
+      def diagnostic?
+        @result.respond_to?(:attributes)
+      end
+    end
+  end
+end

--- a/app/components/saml/test/component.rb
+++ b/app/components/saml/test/component.rb
@@ -9,7 +9,7 @@ module Saml
       end
 
       def diagnostic?
-        @result.respond_to?(:attributes)
+        @result.is_a?(Saml::AssertionProcessor::DiagnosticResult)
       end
     end
   end

--- a/app/components/saml/test/component.rb
+++ b/app/components/saml/test/component.rb
@@ -11,7 +11,9 @@ module Saml
 
       private
 
-      def diagnostic? = @result.is_a?(Saml::AssertionProcessor::DiagnosticResult)
+      # email_attribute is set only once the signature validated, so its absence means
+      # the assertion was rejected and there is nothing of it to report
+      def asserted? = @result&.email_attribute.present?
 
       # The assertion carries whoever the IdP decided to release, not who was typed in
       def asserted_expected_email? = @expected_email == @result.email
@@ -20,6 +22,13 @@ module Saml
         return :notice if @result.blank?
 
         @result.success? ? :success : :error
+      end
+
+      def summary_header
+        return if @result.blank?
+        return "You couldn't be signed in" unless @result.success?
+
+        @result.signed_up ? "You were signed up successfully!" : "You were signed in successfully!"
       end
     end
   end

--- a/app/components/saml/test/component.rb
+++ b/app/components/saml/test/component.rb
@@ -3,11 +3,10 @@
 module Saml
   module Test
     class Component < ApplicationComponent
-      def initialize(organization:, result: nil, email: nil, error: nil)
+      def initialize(organization:, result: nil, expected_email: nil)
         @organization = organization
         @result = result
-        @email = email
-        @error = error
+        @expected_email = expected_email
       end
 
       private
@@ -15,12 +14,9 @@ module Saml
       def diagnostic? = @result.is_a?(Saml::AssertionProcessor::DiagnosticResult)
 
       # The assertion carries whoever the IdP decided to release, not who was typed in
-      def asserted_expected_email?
-        diagnostic? && @email.present? && @email == @result.email
-      end
+      def asserted_expected_email? = @expected_email == @result.email
 
       def summary_kind
-        return :error if @error.present?
         return :notice if @result.blank?
 
         @result.success? ? :success : :error

--- a/app/components/saml/test/component.rb
+++ b/app/components/saml/test/component.rb
@@ -3,13 +3,27 @@
 module Saml
   module Test
     class Component < ApplicationComponent
-      def initialize(organization:, result:)
+      def initialize(organization:, result: nil, email: nil, error: nil)
         @organization = organization
         @result = result
+        @email = email
+        @error = error
       end
 
-      def diagnostic?
-        @result.is_a?(Saml::AssertionProcessor::DiagnosticResult)
+      private
+
+      def diagnostic? = @result.is_a?(Saml::AssertionProcessor::DiagnosticResult)
+
+      # The assertion carries whoever the IdP decided to release, not who was typed in
+      def asserted_expected_email?
+        diagnostic? && @email.present? && @email == @result.email
+      end
+
+      def summary_kind
+        return :error if @error.present?
+        return :notice if @result.blank?
+
+        @result.success? ? :success : :error
       end
     end
   end

--- a/app/controllers/admin/organizations_controller.rb
+++ b/app/controllers/admin/organizations_controller.rb
@@ -145,7 +145,7 @@ module Admin
           :spam_registrations,
           :website,
           [locations_attributes:],
-          organization_saml_configuration_attributes: %i[id enabled idp_entity_id
+          organization_saml_configuration_attributes: %i[id active idp_entity_id
             idp_sso_target_url idp_slo_target_url idp_cert idp_cert_fingerprint
             idp_cert_multi email_attribute_name name_id_format]
         ).merge(approved_kind).merge(registration_field_labels_param)

--- a/app/controllers/saml_controller.rb
+++ b/app/controllers/saml_controller.rb
@@ -27,18 +27,15 @@ class SamlController < ApplicationController
   # SP-initiated login: redirect to the IdP with a signed AuthnRequest, parking the request id
   # (replay protection) and org slug (cross-tenant binding) in RelayState for the callback.
   def init
-    settings = Saml::SettingsBuilder.build(configured_saml_configuration)
-    auth_request = OneLogin::RubySaml::Authrequest.new
-    # This leg is same-site, so the session is readable here; the callback's isn't, so where
-    # the user was headed has to travel with the rest of the transaction
-    relay_state = Saml::RequestStore.create(request_id: auth_request.request_id,
-      org_slug: params[:org_slug], return_to: session[:return_to])
-    redirect_to auth_request.create(settings, RelayState: relay_state), allow_other_host: true
+    redirect_to_saml(configured_saml_configuration)
+  end
+
+  def test
+    redirect_to_saml(configured_inactive_saml_configuration, mode: Saml::RequestStore::TEST_MODE)
   end
 
   # Assertion Consumer Service: validate the IdP's response and sign the user in.
   def callback
-    saml_configuration = configured_saml_configuration
     # RelayState is a bearer token, not bound to the browser that began the login, so an attacker
     # can hand their own token and assertion to a victim and land them in the attacker's account.
     # Accepted: binding it needs a cookie that survives the IdP's cross-site POST, and that
@@ -47,9 +44,15 @@ class SamlController < ApplicationController
     return saml_failure("this login has expired, please try again") if saml_request.blank?
     return saml_failure("SAML session mismatch") if saml_request[:org_slug] != params[:org_slug]
 
+    saml_configuration = saml_configuration_for(saml_request)
+    test_mode = saml_request[:mode] == Saml::RequestStore::TEST_MODE
+
     result = Saml::AssertionProcessor.call(saml_configuration:,
-      raw_response: params[:SAMLResponse], request_id: saml_request[:request_id])
+      raw_response: params[:SAMLResponse], request_id: saml_request[:request_id], dry_run: test_mode)
+    return render_test_result(saml_configuration, result) if test_mode && !result.success?
     return saml_failure(result.error) unless result.success?
+
+    return render_test_result(saml_configuration, result) if test_mode
 
     session[:return_to] = saml_request[:return_to]
     sign_in_and_redirect(result.user, via_saml: true)
@@ -75,6 +78,33 @@ class SamlController < ApplicationController
     raise ActiveRecord::RecordNotFound unless saml_configuration&.configured?
 
     saml_configuration
+  end
+
+  def configured_inactive_saml_configuration
+    saml_configuration = saml_organization.organization_saml_configuration
+    raise ActiveRecord::RecordNotFound unless saml_configuration &&
+      OrganizationSamlConfiguration.configured_inactive.where(id: saml_configuration.id).exists?
+
+    saml_configuration
+  end
+
+  def saml_configuration_for(saml_request)
+    return configured_inactive_saml_configuration if saml_request[:mode] == Saml::RequestStore::TEST_MODE
+
+    configured_saml_configuration
+  end
+
+  def redirect_to_saml(saml_configuration, mode: Saml::RequestStore::NORMAL_MODE)
+    settings = Saml::SettingsBuilder.build(saml_configuration)
+    auth_request = OneLogin::RubySaml::Authrequest.new
+    relay_state = Saml::RequestStore.create(request_id: auth_request.request_id,
+      org_slug: params[:org_slug], return_to: session[:return_to], mode:)
+    redirect_to auth_request.create(settings, RelayState: relay_state), allow_other_host: true
+  end
+
+  def render_test_result(saml_configuration, result)
+    response.headers["X-Robots-Tag"] = "noindex, nofollow"
+    render Saml::Test::Component.new(organization: saml_configuration.organization, result:)
   end
 
   def saml_failure(message)

--- a/app/controllers/saml_controller.rb
+++ b/app/controllers/saml_controller.rb
@@ -49,10 +49,8 @@ class SamlController < ApplicationController
 
     result = Saml::AssertionProcessor.call(saml_configuration:,
       raw_response: params[:SAMLResponse], request_id: saml_request[:request_id], dry_run: test_mode)
-    return render_test_result(saml_configuration, result) if test_mode && !result.success?
-    return saml_failure(result.error) unless result.success?
-
     return render_test_result(saml_configuration, result) if test_mode
+    return saml_failure(result.error) unless result.success?
 
     session[:return_to] = saml_request[:return_to]
     sign_in_and_redirect(result.user, via_saml: true)
@@ -82,8 +80,7 @@ class SamlController < ApplicationController
 
   def configured_inactive_saml_configuration
     saml_configuration = saml_organization.organization_saml_configuration
-    raise ActiveRecord::RecordNotFound unless saml_configuration &&
-      OrganizationSamlConfiguration.configured_inactive.where(id: saml_configuration.id).exists?
+    raise ActiveRecord::RecordNotFound unless saml_configuration&.configured? && !saml_configuration.active?
 
     saml_configuration
   end

--- a/app/controllers/saml_controller.rb
+++ b/app/controllers/saml_controller.rb
@@ -30,8 +30,18 @@ class SamlController < ApplicationController
     redirect_to_saml(configured_saml_configuration)
   end
 
+  # A rehearsal of the login the organization's users will get, minus the sign-in: the form
+  # collects the address to sign in with so the result can say whether the IdP asserted it.
   def test
-    redirect_to_saml(configured_inactive_saml_configuration, mode: Saml::RequestStore::TEST_MODE)
+    render_test_form(configured_inactive_saml_configuration)
+  end
+
+  def test_start
+    saml_configuration = configured_inactive_saml_configuration
+    email = EmailNormalizer.normalize(params[:email])
+    return render_test_form(saml_configuration, email:, error: "Enter the email address to sign in with") if email.blank?
+
+    redirect_to_saml(saml_configuration, mode: Saml::RequestStore::TEST_MODE, expected_email: email)
   end
 
   # Assertion Consumer Service: validate the IdP's response and sign the user in.
@@ -49,7 +59,9 @@ class SamlController < ApplicationController
 
     result = Saml::AssertionProcessor.call(saml_configuration:,
       raw_response: params[:SAMLResponse], request_id: saml_request[:request_id], dry_run: test_mode)
-    return render_test_result(saml_configuration, result) if test_mode
+    if test_mode
+      return render_test_result(saml_configuration, result, expected_email: saml_request[:expected_email])
+    end
     return saml_failure(result.error) unless result.success?
 
     session[:return_to] = saml_request[:return_to]
@@ -91,17 +103,30 @@ class SamlController < ApplicationController
     configured_saml_configuration
   end
 
-  def redirect_to_saml(saml_configuration, mode: Saml::RequestStore::NORMAL_MODE)
+  def redirect_to_saml(saml_configuration, mode: Saml::RequestStore::NORMAL_MODE, expected_email: nil)
     settings = Saml::SettingsBuilder.build(saml_configuration)
     auth_request = OneLogin::RubySaml::Authrequest.new
+    # This leg is same-site, so the session is readable here; the callback's isn't, so where
+    # the user was headed has to travel with the rest of the transaction
     relay_state = Saml::RequestStore.create(request_id: auth_request.request_id,
-      org_slug: params[:org_slug], return_to: session[:return_to], mode:)
+      org_slug: params[:org_slug], return_to: session[:return_to], mode:, expected_email:)
     redirect_to auth_request.create(settings, RelayState: relay_state), allow_other_host: true
   end
 
-  def render_test_result(saml_configuration, result)
+  def render_test_form(saml_configuration, email: nil, error: nil)
+    render_test_page(Saml::Test::Component.new(organization: saml_configuration.organization,
+      email:, error:))
+  end
+
+  def render_test_result(saml_configuration, result, expected_email:)
+    render_test_page(Saml::Test::Component.new(organization: saml_configuration.organization,
+      result:, email: expected_email))
+  end
+
+  def render_test_page(component)
+    @page_title = "SAML configuration test"
     response.headers["X-Robots-Tag"] = "noindex, nofollow"
-    render Saml::Test::Component.new(organization: saml_configuration.organization, result:)
+    render component
   end
 
   def saml_failure(message)

--- a/app/controllers/saml_controller.rb
+++ b/app/controllers/saml_controller.rb
@@ -30,16 +30,18 @@ class SamlController < ApplicationController
     redirect_to_saml(configured_saml_configuration)
   end
 
-  # A rehearsal of the login the organization's users will get, minus the sign-in: the form
-  # collects the address to sign in with so the result can say whether the IdP asserted it.
+  # A rehearsal of the login the organization's users will get, minus the sign-in
   def test
-    render_test_form(configured_inactive_saml_configuration)
+    render_saml_test(configured_inactive_saml_configuration)
   end
 
   def test_start
     saml_configuration = configured_inactive_saml_configuration
     email = EmailNormalizer.normalize(params[:email])
-    return render_test_form(saml_configuration, email:, error: "Enter the email address to sign in with") if email.blank?
+    if email.blank?
+      flash.now[:error] = "Enter the email address to sign in with"
+      return render_saml_test(saml_configuration)
+    end
 
     redirect_to_saml(saml_configuration, mode: Saml::RequestStore::TEST_MODE, expected_email: email)
   end
@@ -54,14 +56,12 @@ class SamlController < ApplicationController
     return saml_failure("this login has expired, please try again") if saml_request.blank?
     return saml_failure("SAML session mismatch") if saml_request[:org_slug] != params[:org_slug]
 
-    saml_configuration = saml_configuration_for(saml_request)
     test_mode = saml_request[:mode] == Saml::RequestStore::TEST_MODE
+    saml_configuration = test_mode ? configured_inactive_saml_configuration : configured_saml_configuration
 
     result = Saml::AssertionProcessor.call(saml_configuration:,
       raw_response: params[:SAMLResponse], request_id: saml_request[:request_id], dry_run: test_mode)
-    if test_mode
-      return render_test_result(saml_configuration, result, expected_email: saml_request[:expected_email])
-    end
+    return render_saml_test(saml_configuration, result:, expected_email: saml_request[:expected_email]) if test_mode
     return saml_failure(result.error) unless result.success?
 
     session[:return_to] = saml_request[:return_to]
@@ -97,12 +97,6 @@ class SamlController < ApplicationController
     saml_configuration
   end
 
-  def saml_configuration_for(saml_request)
-    return configured_inactive_saml_configuration if saml_request[:mode] == Saml::RequestStore::TEST_MODE
-
-    configured_saml_configuration
-  end
-
   def redirect_to_saml(saml_configuration, mode: Saml::RequestStore::NORMAL_MODE, expected_email: nil)
     settings = Saml::SettingsBuilder.build(saml_configuration)
     auth_request = OneLogin::RubySaml::Authrequest.new
@@ -113,20 +107,10 @@ class SamlController < ApplicationController
     redirect_to auth_request.create(settings, RelayState: relay_state), allow_other_host: true
   end
 
-  def render_test_form(saml_configuration, email: nil, error: nil)
-    render_test_page(Saml::Test::Component.new(organization: saml_configuration.organization,
-      email:, error:))
-  end
-
-  def render_test_result(saml_configuration, result, expected_email:)
-    render_test_page(Saml::Test::Component.new(organization: saml_configuration.organization,
-      result:, email: expected_email))
-  end
-
-  def render_test_page(component)
+  def render_saml_test(saml_configuration, **component_options)
     @page_title = "SAML configuration test"
     response.headers["X-Robots-Tag"] = "noindex, nofollow"
-    render component
+    render Saml::Test::Component.new(organization: saml_configuration.organization, **component_options)
   end
 
   def saml_failure(message)

--- a/app/controllers/saml_controller.rb
+++ b/app/controllers/saml_controller.rb
@@ -30,13 +30,14 @@ class SamlController < ApplicationController
     redirect_to_saml(configured_saml_configuration)
   end
 
-  # A rehearsal of the login the organization's users will get, minus the sign-in
+  # A rehearsal of the login the organization's users will get: the same transaction,
+  # landing on a page that reports what the IdP sent rather than where they were headed
   def test
-    render_saml_test(configured_inactive_saml_configuration)
+    render_saml_test(configured_saml_configuration)
   end
 
   def test_start
-    saml_configuration = configured_inactive_saml_configuration
+    saml_configuration = configured_saml_configuration
     email = EmailNormalizer.normalize(params[:email])
     if email.blank?
       flash.now[:error] = "Enter the email address to sign in with"
@@ -56,12 +57,14 @@ class SamlController < ApplicationController
     return saml_failure("this login has expired, please try again") if saml_request.blank?
     return saml_failure("SAML session mismatch") if saml_request[:org_slug] != params[:org_slug]
 
-    test_mode = saml_request[:mode] == Saml::RequestStore::TEST_MODE
-    saml_configuration = test_mode ? configured_inactive_saml_configuration : configured_saml_configuration
-
+    saml_configuration = configured_saml_configuration
     result = Saml::AssertionProcessor.call(saml_configuration:,
-      raw_response: params[:SAMLResponse], request_id: saml_request[:request_id], dry_run: test_mode)
-    return render_saml_test(saml_configuration, result:, expected_email: saml_request[:expected_email]) if test_mode
+      raw_response: params[:SAMLResponse], request_id: saml_request[:request_id])
+
+    if saml_request[:mode] == Saml::RequestStore::TEST_MODE
+      sign_in_user(result.user) if result.success?
+      return render_saml_test(saml_configuration, result:, expected_email: saml_request[:expected_email])
+    end
     return saml_failure(result.error) unless result.success?
 
     session[:return_to] = saml_request[:return_to]
@@ -86,13 +89,6 @@ class SamlController < ApplicationController
   def configured_saml_configuration
     saml_configuration = saml_organization.organization_saml_configuration
     raise ActiveRecord::RecordNotFound unless saml_configuration&.configured?
-
-    saml_configuration
-  end
-
-  def configured_inactive_saml_configuration
-    saml_configuration = saml_organization.organization_saml_configuration
-    raise ActiveRecord::RecordNotFound unless saml_configuration&.configured? && !saml_configuration.active?
 
     saml_configuration
   end

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -265,7 +265,10 @@ class Organization < ApplicationRecord
 
       permitted_domain_signin("saml_sso").where(user_email_domain: domain)
         .includes(:organization_saml_configuration)
-        .detect { |org| org.organization_saml_configuration&.configured? }
+        .detect do |org|
+          configuration = org.organization_saml_configuration
+          configuration&.active? && configuration.configured?
+        end
     end
 
     def example

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -271,6 +271,13 @@ class Organization < ApplicationRecord
         end
     end
 
+    def email_domain(str)
+      normalized = EmailNormalizer.normalize(str)
+      return nil unless normalized.present? && normalized.count("@") == 1 && normalized.match?(/.@.*\../)
+
+      normalized.split("@").last
+    end
+
     def example
       # In test, ids climb across examples so a factory org can land on 92 - look up by name instead
       found = Rails.env.test? ? Organization.find_by(name: "Example Bike Shop") : Organization.find_by_id(92)
@@ -281,13 +288,6 @@ class Organization < ApplicationRecord
 
     def permitted_domain_signin(feature_slug)
       where.not(user_email_domain: nil).with_enabled_feature_slugs(feature_slug)
-    end
-
-    def email_domain(str)
-      normalized = EmailNormalizer.normalize(str)
-      return nil unless normalized.present? && normalized.count("@") == 1 && normalized.match?(/.@.*\../)
-
-      normalized.split("@").last
     end
   end
   # never geocode, use default_location lat/long

--- a/app/models/organization_saml_configuration.rb
+++ b/app/models/organization_saml_configuration.rb
@@ -46,7 +46,9 @@ class OrganizationSamlConfiguration < ApplicationRecord
   after_commit :update_organization
 
   scope :configured, -> {
-    CONFIGURED_ATTRIBUTES.reduce(all) do |relation, attribute|
+    CONFIGURED_ATTRIBUTES.reduce(
+      joins(:organization).where.not(organizations: {user_email_domain: [nil, ""]})
+    ) do |relation, attribute|
       relation.where.not(attribute => [nil, ""])
     end
   }
@@ -58,7 +60,7 @@ class OrganizationSamlConfiguration < ApplicationRecord
   end
 
   def configured?
-    CONFIGURED_ATTRIBUTES.all? { |attribute| self[attribute].present? }
+    organization&.user_email_domain.present? && CONFIGURED_ATTRIBUTES.all? { |attribute| self[attribute].present? }
   end
 
   def email_attribute

--- a/app/models/organization_saml_configuration.rb
+++ b/app/models/organization_saml_configuration.rb
@@ -45,15 +45,6 @@ class OrganizationSamlConfiguration < ApplicationRecord
   before_validation :set_calculated_attributes
   after_commit :update_organization
 
-  scope :configured, -> {
-    CONFIGURED_ATTRIBUTES.reduce(
-      joins(:organization).where.not(organizations: {user_email_domain: [nil, ""]})
-    ) do |relation, attribute|
-      relation.where.not(attribute => [nil, ""])
-    end
-  }
-  scope :configured_inactive, -> { configured.where(active: false) }
-
   def self.format_cert(cert)
     return nil if cert.blank?
     OneLogin::RubySaml::Utils.format_cert(cert)

--- a/app/models/organization_saml_configuration.rb
+++ b/app/models/organization_saml_configuration.rb
@@ -32,6 +32,7 @@ class OrganizationSamlConfiguration < ApplicationRecord
     "emailAddress" => "urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress",
     "unspecified" => "urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified"
   }.freeze
+  CONFIGURED_ATTRIBUTES = %i[idp_entity_id idp_sso_target_url idp_cert].freeze
 
   belongs_to :organization
 
@@ -45,9 +46,9 @@ class OrganizationSamlConfiguration < ApplicationRecord
   after_commit :update_organization
 
   scope :configured, -> {
-    where.not(idp_entity_id: [nil, ""])
-      .where.not(idp_sso_target_url: [nil, ""])
-      .where.not(idp_cert: [nil, ""])
+    CONFIGURED_ATTRIBUTES.reduce(all) do |relation, attribute|
+      relation.where.not(attribute => [nil, ""])
+    end
   }
   scope :configured_inactive, -> { configured.where(active: false) }
 
@@ -57,7 +58,7 @@ class OrganizationSamlConfiguration < ApplicationRecord
   end
 
   def configured?
-    idp_entity_id.present? && idp_sso_target_url.present? && idp_cert.present?
+    CONFIGURED_ATTRIBUTES.all? { |attribute| self[attribute].present? }
   end
 
   def email_attribute

--- a/app/models/organization_saml_configuration.rb
+++ b/app/models/organization_saml_configuration.rb
@@ -5,7 +5,7 @@
 #
 #  id                   :bigint           not null, primary key
 #  email_attribute_name :string
-#  enabled              :boolean          default(FALSE), not null
+#  active               :boolean          default(FALSE), not null
 #  idp_cert             :text
 #  idp_cert_fingerprint :string
 #  idp_cert_multi       :text
@@ -36,22 +36,28 @@ class OrganizationSamlConfiguration < ApplicationRecord
   belongs_to :organization
 
   validates :organization_id, presence: true, uniqueness: true
-  validates :idp_entity_id, :idp_sso_target_url, :idp_cert, presence: true, if: :enabled?
+  validates :idp_entity_id, :idp_sso_target_url, :idp_cert, presence: true, if: :active?
   validates :name_id_format, inclusion: {in: NAME_ID_FORMATS.values}, allow_blank: true
   validate :idp_certificates_parseable
-  validate :organization_claims_a_domain, if: :enabled?
+  validate :organization_claims_a_domain, if: :active?
 
   before_validation :set_calculated_attributes
   after_commit :update_organization
+
+  scope :configured, -> {
+    where.not(idp_entity_id: [nil, ""])
+      .where.not(idp_sso_target_url: [nil, ""])
+      .where.not(idp_cert: [nil, ""])
+  }
+  scope :configured_inactive, -> { configured.where(active: false) }
 
   def self.format_cert(cert)
     return nil if cert.blank?
     OneLogin::RubySaml::Utils.format_cert(cert)
   end
 
-  # Ready to drive a live login: enabled and the IdP essentials are present
   def configured?
-    enabled? && idp_entity_id.present? && idp_sso_target_url.present? && idp_cert.present?
+    idp_entity_id.present? && idp_sso_target_url.present? && idp_cert.present?
   end
 
   def email_attribute

--- a/app/services/saml/assertion_processor.rb
+++ b/app/services/saml/assertion_processor.rb
@@ -28,7 +28,7 @@ module Saml
       # Guards the whole resolution, not just provisioning: otherwise an assertion for any address -
       # another org's admin, a superadmin - links or returns an existing account and signs it in.
       return failure("#{email} is not on this organization's SSO domain") unless
-        email.split("@").last == organization.user_email_domain
+        Organization.email_domain(email) == organization.user_email_domain
 
       # One lookup drives both the returning-user short-circuit and the post-login update.
       identity = SsoIdentity.for(organization:, provider:, uid: name_id) ||

--- a/app/services/saml/assertion_processor.rb
+++ b/app/services/saml/assertion_processor.rb
@@ -12,11 +12,20 @@ module Saml
       end
     end
 
-    def call(saml_configuration:, raw_response:, request_id:)
+    DiagnosticResult = Struct.new(:certificate, :name_id, :name_id_format, :attributes,
+      :email_attribute, :email, :email_domain, :user, :user_has_password, :error) do
+      def success?
+        error.nil?
+      end
+    end
+
+    def call(saml_configuration:, raw_response:, request_id:, dry_run: false)
       return failure("missing SAML response") if raw_response.blank?
 
       response = parse_response(saml_configuration, raw_response, request_id)
       return failure(response.errors.join("; ").presence || "invalid SAML response") unless response.is_valid?
+
+      return diagnostic(response, saml_configuration) if dry_run
 
       name_id = response.name_id.presence
       return failure("assertion is missing a NameID") if name_id.blank?
@@ -65,6 +74,45 @@ module Saml
       EmailNormalizer.normalize(raw)
     end
 
+    def diagnostic(response, saml_configuration)
+      organization = saml_configuration.organization
+      name_id = response.name_id.presence
+      email = asserted_email(response, saml_configuration)
+      email_domain = Organization.email_domain(email)
+      user = User.fuzzy_confirmed_or_unconfirmed_email_find(email) if email.present? &&
+        email_domain == organization.user_email_domain
+
+      DiagnosticResult.new(
+        certificate: certificate_source(response, saml_configuration),
+        name_id:, name_id_format: response.name_id_format,
+        attributes: response.attributes.all,
+        email_attribute: saml_configuration.email_attribute,
+        email:, email_domain:, user:, user_has_password: user&.password_digest.present?,
+        error: diagnostic_error(name_id:, email:, email_domain:, organization:)
+      )
+    end
+
+    def certificate_source(response, saml_configuration)
+      document = response.decrypted_document || response.document
+      certificate_element = REXML::XPath.first(document, "//ds:X509Certificate", {"ds" => OneLogin::RubySaml::Response::DSIG})
+      return "idp_cert" if saml_configuration.idp_certificates.one?
+      return "idp_cert_multi" if certificate_element.blank?
+
+      certificate = OpenSSL::X509::Certificate.new(Base64.decode64(certificate_element.text))
+      saml_configuration.idp_certificates.each_with_index do |configured_certificate, index|
+        return index.zero? ? "idp_cert" : "idp_cert_multi" if
+          certificate.to_pem == OpenSSL::X509::Certificate.new(configured_certificate).to_pem
+      end
+      "idp_cert_multi"
+    end
+
+    def diagnostic_error(name_id:, email:, email_domain:, organization:)
+      return "assertion is missing a NameID" if name_id.blank?
+      return "assertion is missing an email" if email.blank?
+      "#{email} is not on this organization's SSO domain" unless
+        email_domain.present? && email_domain == organization.user_email_domain
+    end
+
     # Provisioning grants no organization role - that is user_role_for_user_email_domain's job.
     def provision_user(email)
       UserServices::PasswordlessCreator.find_or_create(email).first
@@ -74,6 +122,7 @@ module Saml
       Result.new(error: message)
     end
 
-    conceal :provider, :parse_response, :asserted_email, :provision_user, :failure
+    conceal :provider, :parse_response, :asserted_email, :diagnostic, :certificate_source,
+      :diagnostic_error, :provision_user, :failure
   end
 end

--- a/app/services/saml/assertion_processor.rb
+++ b/app/services/saml/assertion_processor.rb
@@ -12,7 +12,7 @@ module Saml
       end
     end
 
-    DiagnosticResult = Struct.new(:certificate, :name_id, :name_id_format, :attributes,
+    DiagnosticResult = Struct.new(:name_id, :name_id_format, :attributes,
       :email_attribute, :email, :email_domain, :user, :user_has_password, :error) do
       def success?
         error.nil?
@@ -25,20 +25,12 @@ module Saml
       response = parse_response(saml_configuration, raw_response, request_id)
       return failure(response.errors.join("; ").presence || "invalid SAML response") unless response.is_valid?
 
-      return diagnostic(response, saml_configuration) if dry_run
-
-      name_id = response.name_id.presence
-      return failure("assertion is missing a NameID") if name_id.blank?
-
-      email = asserted_email(response, saml_configuration)
-      return failure("assertion is missing an email") if email.blank?
-
       organization = saml_configuration.organization
-      # Guards the whole resolution, not just provisioning: otherwise an assertion for any address -
-      # another org's admin, a superadmin - links or returns an existing account and signs it in.
-      asserted_domain = Organization.email_domain(email)
-      return failure("#{email} is not on this organization's SSO domain") unless
-        asserted_domain.present? && asserted_domain == organization.user_email_domain
+      name_id = response.name_id.presence
+      email = asserted_email(response, saml_configuration)
+      error = resolution_error(name_id:, email:, organization:)
+      return diagnostic(response, saml_configuration, name_id:, email:, error:) if dry_run
+      return failure(error) if error
 
       # One lookup drives both the returning-user short-circuit and the post-login update.
       identity = SsoIdentity.for(organization:, provider:, uid: name_id) ||
@@ -74,43 +66,30 @@ module Saml
       EmailNormalizer.normalize(raw)
     end
 
-    def diagnostic(response, saml_configuration)
-      organization = saml_configuration.organization
-      name_id = response.name_id.presence
-      email = asserted_email(response, saml_configuration)
+    def resolution_error(name_id:, email:, organization:)
+      return "assertion is missing a NameID" if name_id.blank?
+      return "assertion is missing an email" if email.blank?
+
+      # Guards the whole resolution, not just provisioning: otherwise an assertion for any address -
+      # another org's admin, a superadmin - links or returns an existing account and signs it in.
+      asserted_domain = Organization.email_domain(email)
+      "#{email} is not on this organization's SSO domain" unless
+        asserted_domain.present? && asserted_domain == organization.user_email_domain
+    end
+
+    def diagnostic(response, saml_configuration, name_id:, email:, error:)
       email_domain = Organization.email_domain(email)
-      user = User.fuzzy_confirmed_or_unconfirmed_email_find(email) if email.present? &&
-        email_domain == organization.user_email_domain
+      # Looked up only once the domain guard clears it, as the live path does
+      user = User.fuzzy_confirmed_or_unconfirmed_email_find(email) if
+        email_domain.present? && email_domain == saml_configuration.organization.user_email_domain
 
       DiagnosticResult.new(
-        certificate: certificate_source(response, saml_configuration),
         name_id:, name_id_format: response.name_id_format,
         attributes: response.attributes.all,
         email_attribute: saml_configuration.email_attribute,
-        email:, email_domain:, user:, user_has_password: user&.password_digest.present?,
-        error: diagnostic_error(name_id:, email:, email_domain:, organization:)
+        email:, email_domain:, user:,
+        user_has_password: user.present? && !user.passwordless_user?, error:
       )
-    end
-
-    def certificate_source(response, saml_configuration)
-      document = response.decrypted_document || response.document
-      certificate_element = REXML::XPath.first(document, "//ds:X509Certificate", {"ds" => OneLogin::RubySaml::Response::DSIG})
-      return "idp_cert" if saml_configuration.idp_certificates.one?
-      return "idp_cert_multi" if certificate_element.blank?
-
-      certificate = OpenSSL::X509::Certificate.new(Base64.decode64(certificate_element.text))
-      saml_configuration.idp_certificates.each_with_index do |configured_certificate, index|
-        return index.zero? ? "idp_cert" : "idp_cert_multi" if
-          certificate.to_pem == OpenSSL::X509::Certificate.new(configured_certificate).to_pem
-      end
-      "idp_cert_multi"
-    end
-
-    def diagnostic_error(name_id:, email:, email_domain:, organization:)
-      return "assertion is missing a NameID" if name_id.blank?
-      return "assertion is missing an email" if email.blank?
-      "#{email} is not on this organization's SSO domain" unless
-        email_domain.present? && email_domain == organization.user_email_domain
     end
 
     # Provisioning grants no organization role - that is user_role_for_user_email_domain's job.
@@ -122,7 +101,7 @@ module Saml
       Result.new(error: message)
     end
 
-    conceal :provider, :parse_response, :asserted_email, :diagnostic, :certificate_source,
-      :diagnostic_error, :provision_user, :failure
+    conceal :provider, :parse_response, :asserted_email, :resolution_error, :diagnostic,
+      :provision_user, :failure
   end
 end

--- a/app/services/saml/assertion_processor.rb
+++ b/app/services/saml/assertion_processor.rb
@@ -6,44 +6,45 @@ module Saml
   module AssertionProcessor
     extend Functionable
 
-    Result = Struct.new(:user, :error) do
+    # The asserted fields are carried whether or not resolution succeeded, so the test page
+    # can tell an attribute-release problem from a domain mismatch. They are set only once
+    # the signature validated, so their absence means there is no assertion to report.
+    Result = Struct.new(:user, :error, :signed_up, :name_id, :name_id_format, :attributes,
+      :email_attribute, :email, :email_domain) do
       def success?
         error.nil?
       end
     end
 
-    DiagnosticResult = Struct.new(:name_id, :name_id_format, :attributes,
-      :email_attribute, :email, :email_domain, :user, :user_has_password, :error) do
-      def success?
-        error.nil?
-      end
-    end
-
-    def call(saml_configuration:, raw_response:, request_id:, dry_run: false)
+    def call(saml_configuration:, raw_response:, request_id:)
       return failure("missing SAML response") if raw_response.blank?
 
       response = parse_response(saml_configuration, raw_response, request_id)
       return failure(response.errors.join("; ").presence || "invalid SAML response") unless response.is_valid?
 
       organization = saml_configuration.organization
-      name_id = response.name_id.presence
-      email = asserted_email(response, saml_configuration)
-      error = resolution_error(name_id:, email:, organization:)
-      return diagnostic(response, saml_configuration, name_id:, email:, error:) if dry_run
-      return failure(error) if error
+      asserted = asserted_fields(response, saml_configuration)
+      error = resolution_error(organization:, **asserted.slice(:name_id, :email))
+      return Result.new(error:, **asserted) if error
 
       # One lookup drives both the returning-user short-circuit and the post-login update.
-      identity = SsoIdentity.for(organization:, provider:, uid: name_id) ||
-        SsoIdentity.new(organization:, provider:, uid: name_id)
-      user = identity.user || User.fuzzy_confirmed_or_unconfirmed_email_find(email) || provision_user(email)
-      return failure("no Bike Index account for #{email}") if user.blank?
+      identity = SsoIdentity.for(organization:, provider:, uid: asserted[:name_id]) ||
+        SsoIdentity.new(organization:, provider:, uid: asserted[:name_id])
+      # Provisioning grants no organization role - that is user_role_for_user_email_domain's job.
+      user, signed_up = identity.user ? [identity.user, false] :
+        UserServices::PasswordlessCreator.find_or_create(asserted[:email])
+      return Result.new(error: "no Bike Index account for #{asserted[:email]}", **asserted) if user.blank?
+      # sign_in_and_redirect refuses a banned user too, but its redirect_back lands on the IdP
+      # for an assertion, and the test page needs a reason it can show
+      return Result.new(error: "#{asserted[:email]} is banned", **asserted) if user.banned?
 
       # The IdP vouched for this email, so confirm the account (as the magic-link path
       # does) — otherwise sign-in bounces an unconfirmed user to the confirm-email page.
       user.confirm(user.confirmation_token) unless user.confirmed?
 
-      identity.update(user:, email:, name_id_format: response.name_id_format, last_sign_in_at: Time.current)
-      Result.new(user:)
+      identity.update(user:, email: asserted[:email], name_id_format: asserted[:name_id_format],
+        last_sign_in_at: Time.current)
+      Result.new(user:, signed_up:, **asserted)
     rescue OneLogin::RubySaml::ValidationError => e
       failure(e.message)
     end
@@ -61,9 +62,12 @@ module Saml
         settings:, matches_request_id: request_id, allowed_clock_drift: 30.seconds)
     end
 
-    def asserted_email(response, saml_configuration)
-      raw = response.attributes[saml_configuration.email_attribute].presence || response.name_id
-      EmailNormalizer.normalize(raw)
+    def asserted_fields(response, saml_configuration)
+      email_attribute = saml_configuration.email_attribute
+      email = EmailNormalizer.normalize(response.attributes[email_attribute].presence || response.name_id)
+      {name_id: response.name_id.presence, name_id_format: response.name_id_format,
+       attributes: response.attributes.all, email_attribute:, email:,
+       email_domain: Organization.email_domain(email)}
     end
 
     def resolution_error(name_id:, email:, organization:)
@@ -77,31 +81,10 @@ module Saml
         asserted_domain.present? && asserted_domain == organization.user_email_domain
     end
 
-    def diagnostic(response, saml_configuration, name_id:, email:, error:)
-      email_domain = Organization.email_domain(email)
-      # Looked up only once the domain guard clears it, as the live path does
-      user = User.fuzzy_confirmed_or_unconfirmed_email_find(email) if
-        email_domain.present? && email_domain == saml_configuration.organization.user_email_domain
-
-      DiagnosticResult.new(
-        name_id:, name_id_format: response.name_id_format,
-        attributes: response.attributes.all,
-        email_attribute: saml_configuration.email_attribute,
-        email:, email_domain:, user:,
-        user_has_password: user.present? && !user.passwordless_user?, error:
-      )
-    end
-
-    # Provisioning grants no organization role - that is user_role_for_user_email_domain's job.
-    def provision_user(email)
-      UserServices::PasswordlessCreator.find_or_create(email).first
-    end
-
     def failure(message)
       Result.new(error: message)
     end
 
-    conceal :provider, :parse_response, :asserted_email, :resolution_error, :diagnostic,
-      :provision_user, :failure
+    conceal :provider, :parse_response, :asserted_fields, :resolution_error, :failure
   end
 end

--- a/app/services/saml/assertion_processor.rb
+++ b/app/services/saml/assertion_processor.rb
@@ -28,7 +28,7 @@ module Saml
       # Guards the whole resolution, not just provisioning: otherwise an assertion for any address -
       # another org's admin, a superadmin - links or returns an existing account and signs it in.
       return failure("#{email} is not on this organization's SSO domain") unless
-        organization == Organization.saml_email_matching(email)
+        email.split("@").last == organization.user_email_domain
 
       # One lookup drives both the returning-user short-circuit and the post-login update.
       identity = SsoIdentity.for(organization:, provider:, uid: name_id) ||

--- a/app/services/saml/assertion_processor.rb
+++ b/app/services/saml/assertion_processor.rb
@@ -27,8 +27,9 @@ module Saml
       organization = saml_configuration.organization
       # Guards the whole resolution, not just provisioning: otherwise an assertion for any address -
       # another org's admin, a superadmin - links or returns an existing account and signs it in.
+      asserted_domain = Organization.email_domain(email)
       return failure("#{email} is not on this organization's SSO domain") unless
-        Organization.email_domain(email) == organization.user_email_domain
+        asserted_domain.present? && asserted_domain == organization.user_email_domain
 
       # One lookup drives both the returning-user short-circuit and the post-login update.
       identity = SsoIdentity.for(organization:, provider:, uid: name_id) ||

--- a/app/services/saml/request_store.rb
+++ b/app/services/saml/request_store.rb
@@ -15,9 +15,11 @@ module Saml
     # intercepted RelayState is worthless by the time it's used.
     TTL = 10.minutes
 
-    def create(request_id:, org_slug:, return_to: nil, mode: NORMAL_MODE)
+    def create(request_id:, org_slug:, return_to: nil, mode: NORMAL_MODE, expected_email: nil)
       SecureRandom.urlsafe_base64(24).tap do |token|
-        RedisPool.conn { |r| r.set(key(token), [org_slug, request_id, return_to, mode].join(SEPARATOR), ex: TTL.to_i) }
+        RedisPool.conn do |r|
+          r.set(key(token), [org_slug, request_id, return_to, mode, expected_email].join(SEPARATOR), ex: TTL.to_i)
+        end
       end
     end
 
@@ -29,8 +31,9 @@ module Saml
       raw = RedisPool.conn { |r| r.getdel(key(token)) }
       return nil if raw.blank?
 
-      org_slug, request_id, return_to, mode = raw.split(SEPARATOR, 4)
-      {org_slug:, request_id:, return_to: return_to.presence, mode: mode.presence || NORMAL_MODE}
+      org_slug, request_id, return_to, mode, expected_email = raw.split(SEPARATOR, 5)
+      {org_slug:, request_id:, return_to: return_to.presence, mode: mode.presence || NORMAL_MODE,
+       expected_email: expected_email.presence}
     end
 
     #

--- a/app/services/saml/request_store.rb
+++ b/app/services/saml/request_store.rb
@@ -8,13 +8,16 @@ module Saml
   module RequestStore
     extend Functionable
 
+    NORMAL_MODE = "normal"
+    TEST_MODE = "test"
+
     # Long enough for a password prompt and an MFA challenge, short enough that an
     # intercepted RelayState is worthless by the time it's used.
     TTL = 10.minutes
 
-    def create(request_id:, org_slug:, return_to: nil)
+    def create(request_id:, org_slug:, return_to: nil, mode: NORMAL_MODE)
       SecureRandom.urlsafe_base64(24).tap do |token|
-        RedisPool.conn { |r| r.set(key(token), [org_slug, request_id, return_to].join(SEPARATOR), ex: TTL.to_i) }
+        RedisPool.conn { |r| r.set(key(token), [org_slug, request_id, return_to, mode].join(SEPARATOR), ex: TTL.to_i) }
       end
     end
 
@@ -26,8 +29,8 @@ module Saml
       raw = RedisPool.conn { |r| r.getdel(key(token)) }
       return nil if raw.blank?
 
-      org_slug, request_id, return_to = raw.split(SEPARATOR, 3)
-      {org_slug:, request_id:, return_to: return_to.presence}
+      org_slug, request_id, return_to, mode = raw.split(SEPARATOR, 4)
+      {org_slug:, request_id:, return_to: return_to.presence, mode: mode.presence || NORMAL_MODE}
     end
 
     #

--- a/app/services/saml/request_store.rb
+++ b/app/services/saml/request_store.rb
@@ -15,11 +15,12 @@ module Saml
     # intercepted RelayState is worthless by the time it's used.
     TTL = 10.minutes
 
+    DEFAULTS = {org_slug: nil, request_id: nil, return_to: nil, mode: NORMAL_MODE, expected_email: nil}.freeze
+
     def create(request_id:, org_slug:, return_to: nil, mode: NORMAL_MODE, expected_email: nil)
       SecureRandom.urlsafe_base64(24).tap do |token|
-        RedisPool.conn do |r|
-          r.set(key(token), [org_slug, request_id, return_to, mode, expected_email].join(SEPARATOR), ex: TTL.to_i)
-        end
+        payload = {org_slug:, request_id:, return_to:, mode:, expected_email:}.compact_blank
+        RedisPool.conn { |r| r.set(key(token), payload.to_json, ex: TTL.to_i) }
       end
     end
 
@@ -31,15 +32,16 @@ module Saml
       raw = RedisPool.conn { |r| r.getdel(key(token)) }
       return nil if raw.blank?
 
-      org_slug, request_id, return_to, mode, expected_email = raw.split(SEPARATOR, 5)
-      {org_slug:, request_id:, return_to: return_to.presence, mode: mode.presence || NORMAL_MODE,
-       expected_email: expected_email.presence}
+      DEFAULTS.merge(JSON.parse(raw, symbolize_names: true))
+    rescue JSON::ParserError
+      # Same answer as a token we never issued: create is the only writer, so an
+      # unparseable value is one it wrote in an older payload format
+      nil
     end
 
     #
     # private below here
     #
-    SEPARATOR = "\n"
 
     def key(token)
       "saml_request:#{token}"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -76,6 +76,7 @@ Rails.application.routes.draw do
     get "/sso/:org_slug/sp.crt", to: "saml#certificate", as: :saml_certificate
     get "/sso/:org_slug/init", to: "saml#init", as: :saml_init
     get "/sso/:org_slug/test", to: "saml#test", as: :saml_test
+    post "/sso/:org_slug/test", to: "saml#test_start", as: :saml_test_start
     post "/sso/:org_slug/callback", to: "saml#callback", as: :saml_callback
   end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -76,7 +76,7 @@ Rails.application.routes.draw do
     get "/sso/:org_slug/sp.crt", to: "saml#certificate", as: :saml_certificate
     get "/sso/:org_slug/init", to: "saml#init", as: :saml_init
     get "/sso/:org_slug/test", to: "saml#test", as: :saml_test
-    post "/sso/:org_slug/test", to: "saml#test_start"
+    post "/sso/:org_slug/test_start", to: "saml#test_start", as: :saml_test_start
     post "/sso/:org_slug/callback", to: "saml#callback", as: :saml_callback
   end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -76,7 +76,7 @@ Rails.application.routes.draw do
     get "/sso/:org_slug/sp.crt", to: "saml#certificate", as: :saml_certificate
     get "/sso/:org_slug/init", to: "saml#init", as: :saml_init
     get "/sso/:org_slug/test", to: "saml#test", as: :saml_test
-    post "/sso/:org_slug/test", to: "saml#test_start", as: :saml_test_start
+    post "/sso/:org_slug/test", to: "saml#test_start"
     post "/sso/:org_slug/callback", to: "saml#callback", as: :saml_callback
   end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -75,6 +75,7 @@ Rails.application.routes.draw do
     get "/sso/:org_slug/metadata", to: "saml#metadata", as: :saml_metadata
     get "/sso/:org_slug/sp.crt", to: "saml#certificate", as: :saml_certificate
     get "/sso/:org_slug/init", to: "saml#init", as: :saml_init
+    get "/sso/:org_slug/test", to: "saml#test", as: :saml_test
     post "/sso/:org_slug/callback", to: "saml#callback", as: :saml_callback
   end
 

--- a/db/migrate/20260821100000_rename_enabled_to_active_on_organization_saml_configurations.rb
+++ b/db/migrate/20260821100000_rename_enabled_to_active_on_organization_saml_configurations.rb
@@ -1,0 +1,5 @@
+class RenameEnabledToActiveOnOrganizationSamlConfigurations < ActiveRecord::Migration[8.1]
+  def change
+    rename_column :organization_saml_configurations, :enabled, :active
+  end
+end

--- a/db/primary_replica_structure.sql
+++ b/db/primary_replica_structure.sql
@@ -2864,7 +2864,7 @@ ALTER SEQUENCE public.organization_roles_id_seq OWNED BY public.organization_rol
 CREATE TABLE public.organization_saml_configurations (
     id bigint NOT NULL,
     organization_id bigint NOT NULL,
-    enabled boolean DEFAULT false NOT NULL,
+    active boolean DEFAULT false NOT NULL,
     idp_entity_id character varying,
     idp_sso_target_url character varying,
     idp_slo_target_url character varying,
@@ -7804,6 +7804,7 @@ ALTER TABLE ONLY public.bug_reports
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20260821100000'),
 ('20260819120000'),
 ('20260815152851'),
 ('20260813100000'),

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -2864,7 +2864,7 @@ ALTER SEQUENCE public.organization_roles_id_seq OWNED BY public.organization_rol
 CREATE TABLE public.organization_saml_configurations (
     id bigint NOT NULL,
     organization_id bigint NOT NULL,
-    enabled boolean DEFAULT false NOT NULL,
+    active boolean DEFAULT false NOT NULL,
     idp_entity_id character varying,
     idp_sso_target_url character varying,
     idp_slo_target_url character varying,
@@ -7804,6 +7804,7 @@ ALTER TABLE ONLY public.bug_reports
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20260821100000'),
 ('20260819120000'),
 ('20260815152851'),
 ('20260813100000'),

--- a/docs/sso.md
+++ b/docs/sso.md
@@ -9,10 +9,12 @@ them in. Everything is per-organization and slug-scoped:
 | `/sso/<slug>/metadata` | our SP metadata — the URL you hand an IdP admin |
 | `/sso/<slug>/sp.crt` | the SP certificate alone, for IdP tooling that wants a file |
 | `/sso/<slug>/init` | SP-initiated login |
+| `/sso/<slug>/test` | signed-assertion diagnostic flow; configured but inactive only |
 | `/sso/<slug>/callback` | Assertion Consumer Service |
 
-All of them 404 unless the organization has the `saml_sso` feature. `init` and `callback`
-additionally need the configuration marked live.
+All of them 404 unless the organization has the `saml_sso` feature. Metadata and certificate
+need no SAML configuration; `init` and `callback` need the IdP fields and permitted email
+domain; `test` additionally requires the configuration to be inactive.
 
 Metadata is served as `application/xml`, which browsers display; the registered
 `application/samlmetadata+xml` is an unknown type, so they download it instead. The path takes
@@ -72,7 +74,7 @@ regardless of the link they followed in. The accepted tradeoff is recorded in
    (`urn:oid:0.9.2342.19200300.100.1.3`). Some IdPs release an empty `mail` and carry the
    address in `eduPersonPrincipalName` (`urn:oid:1.3.6.1.4.1.5923.1.1.1.6`) instead — check
    their attribute release policy. With no attribute match we fall back to the NameID.
-6. **Tick "Enable live SAML login."**
+6. **Tick "Force every user at this domain through live SAML SSO."**
 
 Two things to know before promising anyone a smooth setup:
 
@@ -223,6 +225,13 @@ Review apps and sandbox get their own throwaway keypair, not production's.
 create: it has no accounts and no per-SP registration, reading the ACS URL and audience
 straight out of the AuthnRequest.
 
+Keep the configuration inactive while testing. Open `/sso/<slug>/test` to start the flow; the
+callback validates the signed assertion and shows its certificate, NameID, attributes, email
+domain, and matching account without provisioning or signing anyone in. The test endpoint is
+available only for a complete, inactive configuration. Activate SAML only when the diagnostic
+result is correct; `/sso/<slug>/init` is the live sign-in path and can provision an account even
+while the configuration is inactive.
+
 | Bike Index field | Value |
 |---|---|
 | IdP entityID | `https://saml.example.com/entityid` |
@@ -235,13 +244,10 @@ as `<username>@<domain>` with `id` / `email` / `firstName` / `lastName` attribut
 names, not the OIDs a university IdP sends, so the NameID fallback is what carries the email
 unless you set the attribute to `email`.
 
-**Last verified 8/15** on the Railway staging box against mocksaml over real HTTPS: a first
-login provisioned and confirmed a new account, a second login on the same address reused it,
-and a third linked to a pre-existing account. That exercises the signed AuthnRequest, the
-cross-site POST, RelayState claim, signature validation, `InResponseTo` matching, and
-provisioning. What it does **not** cover: encryption (mocksaml publishes only a signing key and
-never ingests an SP certificate, so it structurally cannot encrypt to us) and attribute
-mapping.
+The test flow exercises the signed AuthnRequest, cross-site POST, RelayState claim, signature
+validation, `InResponseTo` matching, and attribute mapping without creating an account. It does
+not cover encryption; mocksaml publishes only a signing key and never ingests an SP certificate,
+so it cannot encrypt to us.
 
 **Don't test IdP-initiated login.** Starting at the IdP produces an assertion with no
 `InResponseTo` and the callback rejects it. That is deliberate replay protection.
@@ -261,12 +267,14 @@ The reason is the real one — ruby-saml's validation errors are passed through,
 
 A configured but inactive organization is excluded from automatic email-domain routing. A direct
 `/sso/<slug>/init` transaction still reaches the normal callback, which can provision or link an
-account. Use that flow only for integration validation until a dry-run diagnostic flow is available.
+account. Use `/sso/<slug>/test` for integration validation while the configuration is inactive;
+it reaches the same callback but never provisions or signs anyone in.
 
 | Reason | Cause |
 |---|---|
 | `/sso/<slug>/metadata` 404s | feature not enabled, `UpdateOrganizationAssociationsJob` hasn't run, or the url carries a `.xml` extension |
-| `/sso/<slug>/init` 404s | config incomplete — needs entityID + SSO URL + cert |
+| `/sso/<slug>/init` 404s | config incomplete — needs entityID + SSO URL + cert + permitted email domain |
+| `/sso/<slug>/test` 404s | config incomplete, SAML feature disabled, or configuration is active |
 | `this login has expired` | RelayState token already claimed or older than 10 minutes |
 | `SAML session mismatch` | the `org_slug` in RelayState isn't the org being called back |
 | audience / destination errors | `BASE_URL` doesn't match the host you're browsing |

--- a/docs/sso.md
+++ b/docs/sso.md
@@ -262,7 +262,7 @@ The reason is the real one — ruby-saml's validation errors are passed through,
 | Reason | Cause |
 |---|---|
 | `/sso/<slug>/metadata` 404s | feature not enabled, `UpdateOrganizationAssociationsJob` hasn't run, or the url carries a `.xml` extension |
-| `/sso/<slug>/init` 404s | config incomplete — needs enabled + entityID + SSO URL + cert |
+| `/sso/<slug>/init` 404s | config incomplete — needs entityID + SSO URL + cert |
 | `this login has expired` | RelayState token already claimed or older than 10 minutes |
 | `SAML session mismatch` | the `org_slug` in RelayState isn't the org being called back |
 | audience / destination errors | `BASE_URL` doesn't match the host you're browsing |

--- a/docs/sso.md
+++ b/docs/sso.md
@@ -259,6 +259,10 @@ what they actually run, and the only way to exercise real attribute mapping on t
 Failures surface as a flash on `/session/new` reading `Unable to sign in via SSO: <reason>`.
 The reason is the real one — ruby-saml's validation errors are passed through, not swallowed.
 
+A configured but inactive organization is excluded from automatic email-domain routing. A direct
+`/sso/<slug>/init` transaction still reaches the normal callback, which can provision or link an
+account. Use that flow only for integration validation until a dry-run diagnostic flow is available.
+
 | Reason | Cause |
 |---|---|
 | `/sso/<slug>/metadata` 404s | feature not enabled, `UpdateOrganizationAssociationsJob` hasn't run, or the url carries a `.xml` extension |

--- a/docs/sso.md
+++ b/docs/sso.md
@@ -290,9 +290,6 @@ one that is switched off.
 - **Unconfirmed accounts are force-confirmed by the first assertion.** Deliberate — otherwise
   sign-in bounces to the confirm-email page — but an address the organization never verified
   becomes confirmed on the IdP's say-so.
-- **Banned users are rejected only after the identity is written.** `sign_in_and_redirect` blocks
-  them, so this isn't a way back in, but they accumulate `SsoIdentity` rows and a flipped
-  `confirmed` flag.
 - **Users on the domain who belong to a different organization** get routed through this
   organization's IdP. Their other role is untouched, but their login path is now owned by an org
   they may have no relationship with. Most likely with contractors and shared or alumni domains.

--- a/docs/sso.md
+++ b/docs/sso.md
@@ -290,6 +290,10 @@ inactive; it reaches the same callback but never provisions or signs anyone in.
 
 ## Accepted gaps
 
+- **`/sso/<slug>/test` is unauthenticated**, like `init`. Anyone can start a test transaction,
+  but the diagnostic it renders needs a valid signed assertion — so reading it means holding IdP
+  credentials for that organization. Deliberate: the person rehearsing an integration is often
+  the partner's IT contact, who has no superadmin account here.
 - **Nothing deprovisions.** Removing someone in the IdP stops them signing in again; it does not
   remove a role they already hold.
 - **Unconfirmed accounts are force-confirmed by the first assertion.** Deliberate — otherwise

--- a/docs/sso.md
+++ b/docs/sso.md
@@ -9,12 +9,11 @@ them in. Everything is per-organization and slug-scoped:
 | `/sso/<slug>/metadata` | our SP metadata — the URL you hand an IdP admin |
 | `/sso/<slug>/sp.crt` | the SP certificate alone, for IdP tooling that wants a file |
 | `/sso/<slug>/init` | SP-initiated login |
-| `/sso/<slug>/test` | diagnostic sign-in form; configured but inactive only |
+| `/sso/<slug>/test` | the same login, landing on a report of what the IdP sent |
 | `/sso/<slug>/callback` | Assertion Consumer Service |
 
 All of them 404 unless the organization has the `saml_sso` feature. Metadata and certificate
-need no SAML configuration; `init` and `callback` need the IdP fields and permitted email
-domain; `test` additionally requires the configuration to be inactive.
+need no SAML configuration; the rest need the IdP fields and a permitted email domain.
 
 Metadata is served as `application/xml`, which browsers display; the registered
 `application/samlmetadata+xml` is an unknown type, so they download it instead. The path takes
@@ -225,13 +224,8 @@ Review apps and sandbox get their own throwaway keypair, not production's.
 create: it has no accounts and no per-SP registration, reading the ACS URL and audience
 straight out of the AuthnRequest.
 
-Keep the configuration inactive while testing. `/sso/<slug>/test` is a form: enter the address
-you'll sign in with, and it starts the same transaction `init` does. The callback then validates
-the signed assertion and reports its NameID, attributes, email domain, matching account, and
-whether the IdP released the address you entered — provisioning nobody and signing nobody in.
-The endpoint is available only for a complete, inactive configuration. Activate SAML only once
-the result is correct; `/sso/<slug>/init` is the live sign-in path and can provision an account
-even while the configuration is inactive.
+Rehearse on `/sso/<slug>/test` and leave the configuration inactive until the result is right —
+activating it forces everyone at the domain through the IdP. The page explains itself.
 
 | Bike Index field | Value |
 |---|---|
@@ -245,13 +239,12 @@ as `<username>@<domain>` with `id` / `email` / `firstName` / `lastName` attribut
 names, not the OIDs a university IdP sends, so the NameID fallback is what carries the email
 unless you set the attribute to `email`.
 
-**Last verified 8/21** against the local Keycloak IdP: `/sso/<slug>/test` on a configured,
-inactive organization redirected to the IdP, and the callback reported a matching NameID,
-released attributes, and `(none)` for the account — with no user or `SsoIdentity` created. An
-earlier 8/15 run against mocksaml covered the live `init` path end to end: a first login
-provisioned and confirmed an account, a second reused it, a third linked a pre-existing one.
-Neither run covers encryption — mocksaml publishes only a signing key and never ingests an SP
-certificate, so it structurally cannot encrypt to us.
+**Last verified 8/23** against the local Keycloak IdP: `/sso/<slug>/test` on a configured,
+inactive organization provisioned and signed in a new account, and reported the NameID and
+released attributes. An earlier 8/15 run against mocksaml covered `init` end to end: a first
+login provisioned and confirmed an account, a second reused it, a third linked a pre-existing
+one. Neither run covers encryption — mocksaml publishes only a signing key and never ingests an
+SP certificate, so it structurally cannot encrypt to us.
 
 **Don't test IdP-initiated login.** Starting at the IdP produces an assertion with no
 `InResponseTo` and the callback rejects it. That is deliberate replay protection.
@@ -269,16 +262,15 @@ what they actually run, and the only way to exercise real attribute mapping on t
 Failures surface as a flash on `/session/new` reading `Unable to sign in via SSO: <reason>`.
 The reason is the real one — ruby-saml's validation errors are passed through, not swallowed.
 
-A configured but inactive organization is excluded from automatic email-domain routing. A direct
-`/sso/<slug>/init` transaction still reaches the normal callback, which can provision or link an
-account. Use the `/sso/<slug>/test` form for integration validation while the configuration is
-inactive; it reaches the same callback but never provisions or signs anyone in.
+A configured but inactive organization is excluded from automatic email-domain routing, but
+`init` and `test` still work — an inactive configuration is one nobody is *forced* through, not
+one that is switched off.
 
 | Reason | Cause |
 |---|---|
 | `/sso/<slug>/metadata` 404s | feature not enabled, `UpdateOrganizationAssociationsJob` hasn't run, or the url carries a `.xml` extension |
 | `/sso/<slug>/init` 404s | config incomplete — needs entityID + SSO URL + cert + permitted email domain |
-| `/sso/<slug>/test` 404s | config incomplete, SAML feature disabled, or configuration is active |
+| `/sso/<slug>/test` 404s | config incomplete, or the SAML feature is disabled |
 | `this login has expired` | RelayState token already claimed or older than 10 minutes |
 | `SAML session mismatch` | the `org_slug` in RelayState isn't the org being called back |
 | audience / destination errors | `BASE_URL` doesn't match the host you're browsing |
@@ -290,10 +282,9 @@ inactive; it reaches the same callback but never provisions or signs anyone in.
 
 ## Accepted gaps
 
-- **`/sso/<slug>/test` is unauthenticated**, like `init`. Anyone can start a test transaction,
-  but the diagnostic it renders needs a valid signed assertion — so reading it means holding IdP
-  credentials for that organization. Deliberate: the person rehearsing an integration is often
-  the partner's IT contact, who has no superadmin account here.
+- **`/sso/<slug>/test` is unauthenticated**, like `init`, and grants exactly what `init` does —
+  reaching the report means holding IdP credentials for that organization. Deliberate: the person
+  rehearsing an integration is often the partner's IT contact, who has no superadmin account here.
 - **Nothing deprovisions.** Removing someone in the IdP stops them signing in again; it does not
   remove a role they already hold.
 - **Unconfirmed accounts are force-confirmed by the first assertion.** Deliberate — otherwise

--- a/docs/sso.md
+++ b/docs/sso.md
@@ -9,7 +9,7 @@ them in. Everything is per-organization and slug-scoped:
 | `/sso/<slug>/metadata` | our SP metadata — the URL you hand an IdP admin |
 | `/sso/<slug>/sp.crt` | the SP certificate alone, for IdP tooling that wants a file |
 | `/sso/<slug>/init` | SP-initiated login |
-| `/sso/<slug>/test` | signed-assertion diagnostic flow; configured but inactive only |
+| `/sso/<slug>/test` | diagnostic sign-in form; configured but inactive only |
 | `/sso/<slug>/callback` | Assertion Consumer Service |
 
 All of them 404 unless the organization has the `saml_sso` feature. Metadata and certificate
@@ -225,12 +225,13 @@ Review apps and sandbox get their own throwaway keypair, not production's.
 create: it has no accounts and no per-SP registration, reading the ACS URL and audience
 straight out of the AuthnRequest.
 
-Keep the configuration inactive while testing. Open `/sso/<slug>/test` to start the flow; the
-callback validates the signed assertion and shows its NameID, attributes, email domain, and
-matching account without provisioning or signing anyone in. The test endpoint is available only
-for a complete, inactive configuration. Activate SAML only when the diagnostic result is correct;
-`/sso/<slug>/init` is the live sign-in path and can provision an account even while the
-configuration is inactive.
+Keep the configuration inactive while testing. `/sso/<slug>/test` is a form: enter the address
+you'll sign in with, and it starts the same transaction `init` does. The callback then validates
+the signed assertion and reports its NameID, attributes, email domain, matching account, and
+whether the IdP released the address you entered — provisioning nobody and signing nobody in.
+The endpoint is available only for a complete, inactive configuration. Activate SAML only once
+the result is correct; `/sso/<slug>/init` is the live sign-in path and can provision an account
+even while the configuration is inactive.
 
 | Bike Index field | Value |
 |---|---|
@@ -244,13 +245,13 @@ as `<username>@<domain>` with `id` / `email` / `firstName` / `lastName` attribut
 names, not the OIDs a university IdP sends, so the NameID fallback is what carries the email
 unless you set the attribute to `email`.
 
-**Last verified 8/15** against mocksaml over real HTTPS, before `/sso/<slug>/test` existed: a
-first login provisioned and confirmed a new account, a second on the same address reused it, and
-a third linked to a pre-existing account. That covers the signed AuthnRequest, the cross-site
-POST, RelayState claim, signature validation and `InResponseTo` matching — every leg the test
-flow shares with `init`. The test flow itself has only been exercised by specs, and neither run
-covers encryption: mocksaml publishes only a signing key and never ingests an SP certificate, so
-it structurally cannot encrypt to us.
+**Last verified 8/21** against the local Keycloak IdP: `/sso/<slug>/test` on a configured,
+inactive organization redirected to the IdP, and the callback reported a matching NameID,
+released attributes, and `(none)` for the account — with no user or `SsoIdentity` created. An
+earlier 8/15 run against mocksaml covered the live `init` path end to end: a first login
+provisioned and confirmed an account, a second reused it, a third linked a pre-existing one.
+Neither run covers encryption — mocksaml publishes only a signing key and never ingests an SP
+certificate, so it structurally cannot encrypt to us.
 
 **Don't test IdP-initiated login.** Starting at the IdP produces an assertion with no
 `InResponseTo` and the callback rejects it. That is deliberate replay protection.
@@ -270,8 +271,8 @@ The reason is the real one — ruby-saml's validation errors are passed through,
 
 A configured but inactive organization is excluded from automatic email-domain routing. A direct
 `/sso/<slug>/init` transaction still reaches the normal callback, which can provision or link an
-account. Use `/sso/<slug>/test` for integration validation while the configuration is inactive;
-it reaches the same callback but never provisions or signs anyone in.
+account. Use the `/sso/<slug>/test` form for integration validation while the configuration is
+inactive; it reaches the same callback but never provisions or signs anyone in.
 
 | Reason | Cause |
 |---|---|

--- a/docs/sso.md
+++ b/docs/sso.md
@@ -226,11 +226,11 @@ create: it has no accounts and no per-SP registration, reading the ACS URL and a
 straight out of the AuthnRequest.
 
 Keep the configuration inactive while testing. Open `/sso/<slug>/test` to start the flow; the
-callback validates the signed assertion and shows its certificate, NameID, attributes, email
-domain, and matching account without provisioning or signing anyone in. The test endpoint is
-available only for a complete, inactive configuration. Activate SAML only when the diagnostic
-result is correct; `/sso/<slug>/init` is the live sign-in path and can provision an account even
-while the configuration is inactive.
+callback validates the signed assertion and shows its NameID, attributes, email domain, and
+matching account without provisioning or signing anyone in. The test endpoint is available only
+for a complete, inactive configuration. Activate SAML only when the diagnostic result is correct;
+`/sso/<slug>/init` is the live sign-in path and can provision an account even while the
+configuration is inactive.
 
 | Bike Index field | Value |
 |---|---|
@@ -244,10 +244,13 @@ as `<username>@<domain>` with `id` / `email` / `firstName` / `lastName` attribut
 names, not the OIDs a university IdP sends, so the NameID fallback is what carries the email
 unless you set the attribute to `email`.
 
-The test flow exercises the signed AuthnRequest, cross-site POST, RelayState claim, signature
-validation, `InResponseTo` matching, and attribute mapping without creating an account. It does
-not cover encryption; mocksaml publishes only a signing key and never ingests an SP certificate,
-so it cannot encrypt to us.
+**Last verified 8/15** against mocksaml over real HTTPS, before `/sso/<slug>/test` existed: a
+first login provisioned and confirmed a new account, a second on the same address reused it, and
+a third linked to a pre-existing account. That covers the signed AuthnRequest, the cross-site
+POST, RelayState claim, signature validation and `InResponseTo` matching — every leg the test
+flow shares with `init`. The test flow itself has only been exercised by specs, and neither run
+covers encryption: mocksaml publishes only a signing key and never ingests an SP certificate, so
+it structurally cannot encrypt to us.
 
 **Don't test IdP-initiated login.** Starting at the IdP produces an assertion with no
 `InResponseTo` and the callback rejects it. That is deliberate replay protection.

--- a/spec/components/admin/organizations/form/saml_sso/component_spec.rb
+++ b/spec/components/admin/organizations/form/saml_sso/component_spec.rb
@@ -22,6 +22,10 @@ RSpec.describe Admin::Organizations::Form::SamlSso::Component, type: :component 
     expect(component).to have_link(href: "http://test.host/sso/#{organization.to_param}/sp.crt")
   end
 
+  it "warns that active SSO forces every domain user through the IdP" do
+    expect(component).to have_text("Force every user at this domain through live SAML SSO")
+  end
+
   context "with an existing configuration" do
     before { organization.create_organization_saml_configuration(idp_entity_id: "https://idp.example.edu/") }
 

--- a/spec/components/admin/organizations/form/saml_sso/component_spec.rb
+++ b/spec/components/admin/organizations/form/saml_sso/component_spec.rb
@@ -4,7 +4,8 @@ require "rails_helper"
 
 RSpec.describe Admin::Organizations::Form::SamlSso::Component, type: :component do
   let(:organization) do
-    FactoryBot.create(:organization_with_organization_features, enabled_feature_slugs: "saml_sso")
+    FactoryBot.create(:organization_with_organization_features,
+      enabled_feature_slugs: "saml_sso", user_email_domain: "example.edu")
   end
 
   def rendered_component(organization)
@@ -22,12 +23,25 @@ RSpec.describe Admin::Organizations::Form::SamlSso::Component, type: :component 
     expect(component).to have_link(href: "http://test.host/sso/#{organization.to_param}/sp.crt")
   end
 
+  it "shows the inactive configuration notice" do
+    expect(component).to have_css("[role=alert]")
+    expect(component).to have_css("[role=alert] a[href='/sso/#{organization.to_param}/test']")
+  end
+
   context "with an existing configuration" do
     before { organization.create_organization_saml_configuration(idp_entity_id: "https://idp.example.edu/") }
 
     it "renders its values rather than building a new one" do
       expect(component).to have_field("organization_organization_saml_configuration_attributes_idp_entity_id",
         with: "https://idp.example.edu/")
+    end
+  end
+
+  context "with an active configuration" do
+    before { FactoryBot.create(:organization_saml_configuration, :active, organization:) }
+
+    it "does not show the inactive configuration notice" do
+      expect(component).not_to have_css("[role=alert]")
     end
   end
 end

--- a/spec/components/admin/organizations/form/saml_sso/component_spec.rb
+++ b/spec/components/admin/organizations/form/saml_sso/component_spec.rb
@@ -22,10 +22,6 @@ RSpec.describe Admin::Organizations::Form::SamlSso::Component, type: :component 
     expect(component).to have_link(href: "http://test.host/sso/#{organization.to_param}/sp.crt")
   end
 
-  it "warns that active SSO forces every domain user through the IdP" do
-    expect(component).to have_text("Force every user at this domain through live SAML SSO")
-  end
-
   context "with an existing configuration" do
     before { organization.create_organization_saml_configuration(idp_entity_id: "https://idp.example.edu/") }
 

--- a/spec/components/admin/organizations/form/saml_sso/component_spec.rb
+++ b/spec/components/admin/organizations/form/saml_sso/component_spec.rb
@@ -18,14 +18,11 @@ RSpec.describe Admin::Organizations::Form::SamlSso::Component, type: :component 
 
   let(:component) { rendered_component(organization) }
 
-  it "gives the IdP admin the service provider URLs" do
+  it "gives the IdP admin the service provider URLs, and shows the inactive configuration notice" do
     expect(component).to have_link(href: "http://test.host/sso/#{organization.to_param}/metadata")
     expect(component).to have_link(href: "http://test.host/sso/#{organization.to_param}/sp.crt")
-  end
-
-  it "shows the inactive configuration notice" do
+    expect(component).to have_link(href: "http://test.host/sso/#{organization.to_param}/test")
     expect(component).to have_css("[role=alert]")
-    expect(component).to have_css("[role=alert] a[href='/sso/#{organization.to_param}/test']")
   end
 
   context "with an existing configuration" do

--- a/spec/factories/organization_saml_configurations.rb
+++ b/spec/factories/organization_saml_configurations.rb
@@ -6,11 +6,15 @@ FactoryBot.define do
         enabled_feature_slugs: "saml_sso", user_email_domain: "sso-#{n}.example.com")
     end
 
-    trait :active do
-      active { true }
+    trait :configured do
       idp_entity_id { "https://idp.example.edu/" }
       idp_sso_target_url { "https://idp.example.edu/idp/profile/SAML2/POST/SSO" }
       idp_cert { File.read(Rails.root.join("spec/fixtures/saml/idp_cert.pem")) }
+    end
+
+    trait :active do
+      configured
+      active { true }
     end
   end
 end

--- a/spec/factories/organization_saml_configurations.rb
+++ b/spec/factories/organization_saml_configurations.rb
@@ -6,8 +6,8 @@ FactoryBot.define do
         enabled_feature_slugs: "saml_sso", user_email_domain: "sso-#{n}.example.com")
     end
 
-    trait :enabled do
-      enabled { true }
+    trait :active do
+      active { true }
       idp_entity_id { "https://idp.example.edu/" }
       idp_sso_target_url { "https://idp.example.edu/idp/profile/SAML2/POST/SSO" }
       idp_cert { File.read(Rails.root.join("spec/fixtures/saml/idp_cert.pem")) }

--- a/spec/models/organization_saml_configuration_spec.rb
+++ b/spec/models/organization_saml_configuration_spec.rb
@@ -63,16 +63,26 @@ RSpec.describe OrganizationSamlConfiguration, type: :model do
       let!(:configured) { FactoryBot.create(:organization_saml_configuration, :active, organization:) }
       let!(:inactive) do
         FactoryBot.create(:organization_saml_configuration, organization: FactoryBot.create(:organization_with_organization_features,
+          enabled_feature_slugs: "saml_sso", user_email_domain: "inactive.example.com"), idp_entity_id: "https://idp.example.edu/",
+          idp_sso_target_url: "https://idp.example.edu/sso", idp_cert: idp_cert)
+      end
+      let!(:without_domain) do
+        FactoryBot.create(:organization_saml_configuration, organization: FactoryBot.create(:organization_with_organization_features,
           enabled_feature_slugs: "saml_sso"), idp_entity_id: "https://idp.example.edu/",
           idp_sso_target_url: "https://idp.example.edu/sso", idp_cert: idp_cert)
       end
 
       it "matches configurations with all IdP essentials" do
         expect(described_class.configured).to include(configured, inactive)
+        expect(described_class.configured).to_not include(without_domain)
       end
 
       it "matches configured inactive configurations" do
         expect(described_class.configured_inactive).to eq [inactive]
+      end
+
+      it "does not count a configuration without an organization domain" do
+        expect(without_domain).to_not be_configured
       end
     end
 

--- a/spec/models/organization_saml_configuration_spec.rb
+++ b/spec/models/organization_saml_configuration_spec.rb
@@ -5,15 +5,15 @@ RSpec.describe OrganizationSamlConfiguration, type: :model do
 
   describe "factory" do
     let(:saml_configuration) { FactoryBot.create(:organization_saml_configuration) }
-    it "is valid and disabled by default" do
+    it "is valid and inactive by default" do
       expect(saml_configuration).to be_valid
-      expect(saml_configuration.enabled?).to be_falsey
+      expect(saml_configuration.active?).to be_falsey
       expect(saml_configuration.configured?).to be_falsey
       expect(saml_configuration.organization.enabled?("saml_sso")).to be_truthy
     end
 
-    context "enabled trait" do
-      let(:saml_configuration) { FactoryBot.create(:organization_saml_configuration, :enabled) }
+    context "active trait" do
+      let(:saml_configuration) { FactoryBot.create(:organization_saml_configuration, :active) }
       it "is valid and configured" do
         expect(saml_configuration).to be_valid
         expect(saml_configuration.configured?).to be_truthy
@@ -22,14 +22,14 @@ RSpec.describe OrganizationSamlConfiguration, type: :model do
   end
 
   describe "validations" do
-    let(:saml_configuration) { FactoryBot.build(:organization_saml_configuration, enabled: true) }
-    it "requires idp essentials when enabled" do
+    let(:saml_configuration) { FactoryBot.build(:organization_saml_configuration, active: true) }
+    it "requires idp essentials when active" do
       expect(saml_configuration).to_not be_valid
       expect(saml_configuration.errors.attribute_names).to include(:idp_entity_id, :idp_sso_target_url, :idp_cert)
     end
 
-    it "permits blank idp fields when disabled" do
-      saml_configuration.enabled = false
+    it "permits blank idp fields when inactive" do
+      saml_configuration.active = false
       expect(saml_configuration).to be_valid
     end
 
@@ -43,15 +43,36 @@ RSpec.describe OrganizationSamlConfiguration, type: :model do
     end
 
     context "organization without a permitted domain" do
-      let(:saml_configuration) { FactoryBot.build(:organization_saml_configuration, :enabled, organization:) }
+      let(:saml_configuration) { FactoryBot.build(:organization_saml_configuration, :active, organization:) }
       let(:organization) { FactoryBot.create(:organization_with_organization_features, enabled_feature_slugs: "saml_sso") }
-      it "can't be enabled" do
+      it "can't be active" do
         expect(saml_configuration).to_not be_valid
         expect(saml_configuration.errors.full_messages)
           .to include("Organization must have a permitted domain to enable SAML SSO")
 
-        saml_configuration.enabled = false
+        saml_configuration.active = false
         expect(saml_configuration).to be_valid
+      end
+    end
+
+    context "configured" do
+      let(:organization) do
+        FactoryBot.create(:organization_with_organization_features,
+          enabled_feature_slugs: "saml_sso", user_email_domain: "configured.example.com")
+      end
+      let!(:configured) { FactoryBot.create(:organization_saml_configuration, :active, organization:) }
+      let!(:inactive) do
+        FactoryBot.create(:organization_saml_configuration, organization: FactoryBot.create(:organization_with_organization_features,
+          enabled_feature_slugs: "saml_sso"), idp_entity_id: "https://idp.example.edu/",
+          idp_sso_target_url: "https://idp.example.edu/sso", idp_cert: idp_cert)
+      end
+
+      it "matches configurations with all IdP essentials" do
+        expect(described_class.configured).to include(configured, inactive)
+      end
+
+      it "matches configured inactive configurations" do
+        expect(described_class.configured_inactive).to eq [inactive]
       end
     end
 

--- a/spec/models/organization_saml_configuration_spec.rb
+++ b/spec/models/organization_saml_configuration_spec.rb
@@ -55,34 +55,15 @@ RSpec.describe OrganizationSamlConfiguration, type: :model do
       end
     end
 
-    context "configured" do
-      let(:organization) do
-        FactoryBot.create(:organization_with_organization_features,
-          enabled_feature_slugs: "saml_sso", user_email_domain: "configured.example.com")
-      end
-      let!(:configured) { FactoryBot.create(:organization_saml_configuration, :active, organization:) }
-      let!(:inactive) do
-        FactoryBot.create(:organization_saml_configuration, organization: FactoryBot.create(:organization_with_organization_features,
-          enabled_feature_slugs: "saml_sso", user_email_domain: "inactive.example.com"), idp_entity_id: "https://idp.example.edu/",
-          idp_sso_target_url: "https://idp.example.edu/sso", idp_cert: idp_cert)
-      end
-      let!(:without_domain) do
-        FactoryBot.create(:organization_saml_configuration, organization: FactoryBot.create(:organization_with_organization_features,
-          enabled_feature_slugs: "saml_sso"), idp_entity_id: "https://idp.example.edu/",
-          idp_sso_target_url: "https://idp.example.edu/sso", idp_cert: idp_cert)
+    context "configured?" do
+      let(:organization_without_domain) do
+        FactoryBot.create(:organization_with_organization_features, enabled_feature_slugs: "saml_sso")
       end
 
-      it "matches configurations with all IdP essentials" do
-        expect(described_class.configured).to include(configured, inactive)
-        expect(described_class.configured).to_not include(without_domain)
-      end
-
-      it "matches configured inactive configurations" do
-        expect(described_class.configured_inactive).to eq [inactive]
-      end
-
-      it "does not count a configuration without an organization domain" do
-        expect(without_domain).to_not be_configured
+      it "doesn't require active, but does require the organization's permitted domain" do
+        expect(FactoryBot.build(:organization_saml_configuration, :configured)).to be_configured
+        expect(FactoryBot.build(:organization_saml_configuration, :configured, organization: organization_without_domain))
+          .to_not be_configured
       end
     end
 

--- a/spec/models/organization_spec.rb
+++ b/spec/models/organization_spec.rb
@@ -504,7 +504,7 @@ RSpec.describe Organization, type: :model do
   end
 
   describe "user_email_domain uniqueness" do
-    let(:saml_configuration) { FactoryBot.create(:organization_saml_configuration, :enabled) }
+    let(:saml_configuration) { FactoryBot.create(:organization_saml_configuration, :active) }
     let!(:sso_organization) { saml_configuration.organization }
     let(:organization) { FactoryBot.create(:organization_with_organization_features, enabled_feature_slugs: "saml_sso") }
     before { sso_organization.update!(user_email_domain: "example.edu") }
@@ -514,6 +514,14 @@ RSpec.describe Organization, type: :model do
       expect(organization).to_not be_valid
       expect(organization.errors.attribute_names).to include(:user_email_domain)
       expect(Organization.saml_email_matching("someone@example.edu")).to eq sso_organization
+    end
+
+    context "when the SAML configuration is inactive" do
+      before { saml_configuration.update!(active: false) }
+
+      it "does not match the organization's domain" do
+        expect(Organization.saml_email_matching("someone@example.edu")).to be_nil
+      end
     end
 
     it "permits the claiming organization to keep its own domain" do

--- a/spec/requests/admin/organizations_request_spec.rb
+++ b/spec/requests/admin/organizations_request_spec.rb
@@ -390,7 +390,7 @@ RSpec.describe Admin::OrganizationsController, type: :request do
           enabled_feature_slugs: "saml_sso", user_email_domain: "example.edu")
       end
       let(:saml_attributes) do
-        {enabled: "1", idp_entity_id: "https://idp.example.edu/",
+        {active: "1", idp_entity_id: "https://idp.example.edu/",
          idp_sso_target_url: "https://idp.example.edu/idp/profile/SAML2/POST/SSO",
          idp_cert: File.read(Rails.root.join("spec/fixtures/saml/idp_cert.pem")),
          name_id_format: OrganizationSamlConfiguration::NAME_ID_FORMATS["persistent"]}
@@ -400,7 +400,7 @@ RSpec.describe Admin::OrganizationsController, type: :request do
           put "#{base_url}/#{organization.to_param}", params: {organization: {organization_saml_configuration_attributes: saml_attributes}}
         end.to change(OrganizationSamlConfiguration, :count).by(1)
         saml_configuration = organization.reload.organization_saml_configuration
-        expect(saml_configuration.enabled?).to be_truthy
+        expect(saml_configuration.active?).to be_truthy
         expect(saml_configuration.idp_entity_id).to eq "https://idp.example.edu/"
         expect(saml_configuration.name_id_format).to eq OrganizationSamlConfiguration::NAME_ID_FORMATS["persistent"]
         expect(saml_configuration.configured?).to be_truthy

--- a/spec/requests/saml_callback_request_spec.rb
+++ b/spec/requests/saml_callback_request_spec.rb
@@ -174,11 +174,10 @@ RSpec.describe "SAML SSO login", :saml_env, type: :request do
         end
       end
 
-      context "asserted email has multiple @ characters" do
-        let(:email) { "attacker@evil.com@#{domain}" }
-
+      context "asserted email has no parseable domain" do
         it "does not provision or sign in" do
-          expect { post_callback }.not_to change(User, :count)
+          expect { post_callback(name_id: "transient-name-id", email_attribute: "unreleased-email") }
+            .not_to change(User, :count)
           expect(response).to redirect_to(new_session_path)
           expect(signed_in?).to be false
         end

--- a/spec/requests/saml_callback_request_spec.rb
+++ b/spec/requests/saml_callback_request_spec.rb
@@ -182,6 +182,16 @@ RSpec.describe "SAML SSO login", :saml_env, type: :request do
           expect(signed_in?).to be false
         end
       end
+
+      context "asserted email has multiple @ characters" do
+        let(:email) { "attacker@evil.com@#{domain}" }
+
+        it "does not provision or sign in" do
+          expect { post_callback }.not_to change(User, :count)
+          expect(response).to redirect_to(new_session_path)
+          expect(signed_in?).to be false
+        end
+      end
     end
 
     context "invalid assertions" do

--- a/spec/requests/saml_callback_request_spec.rb
+++ b/spec/requests/saml_callback_request_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe "SAML SSO login", :saml_env, type: :request do
     FactoryBot.create(:organization_with_organization_features,
       enabled_feature_slugs: "saml_sso", user_email_domain: domain)
   end
-  let(:saml_configuration) { FactoryBot.create(:organization_saml_configuration, :enabled, organization:) }
+  let(:saml_configuration) { FactoryBot.create(:organization_saml_configuration, :active, organization:) }
   let(:slug) { organization.to_param }
   let(:settings) { Saml::SettingsBuilder.build(saml_configuration) }
   let(:email) { "newperson@#{domain}" }
@@ -49,7 +49,7 @@ RSpec.describe "SAML SSO login", :saml_env, type: :request do
       expect(response.headers["Location"]).to include("SAMLRequest=")
     end
 
-    context "configuration not enabled" do
+    context "configuration inactive" do
       let(:saml_configuration) { FactoryBot.create(:organization_saml_configuration, organization:) }
       it "is not found" do
         get "/sso/#{slug}/init"
@@ -71,6 +71,16 @@ RSpec.describe "SAML SSO login", :saml_env, type: :request do
         expect(identity.user).to eq user
         expect(user.last_login_at).to be_within(5.seconds).of Time.current
         expect(signed_in?).to be true
+      end
+
+      context "inactive configuration" do
+        before { saml_configuration.update!(active: false) }
+
+        it "accepts an assertion for the organization's domain" do
+          expect { post_callback }.to change(User, :count).by(1)
+          expect(response).to have_http_status(:found)
+          expect(signed_in?).to be true
+        end
       end
 
       # The session that stored return_to is withheld on the IdP's cross-site POST, so the

--- a/spec/requests/saml_callback_request_spec.rb
+++ b/spec/requests/saml_callback_request_spec.rb
@@ -26,8 +26,8 @@ RSpec.describe "SAML SSO login", :saml_env, type: :request do
     [saml_request_id_from_redirect(location), Rack::Utils.parse_query(URI(location).query)["RelayState"]]
   end
 
-  def initiate_test_login
-    get "/sso/#{slug}/test"
+  def initiate_test_login(test_email: email)
+    post "/sso/#{slug}/test", params: {email: test_email}
     expect(response).to have_http_status(:found)
     location = response.headers["Location"]
     [saml_request_id_from_redirect(location), Rack::Utils.parse_query(URI(location).query)["RelayState"]]
@@ -44,8 +44,8 @@ RSpec.describe "SAML SSO login", :saml_env, type: :request do
                                            RelayState: (relay_state == :from_init) ? initiated_relay_state : relay_state}
   end
 
-  def post_test_callback(**overrides)
-    request_id, relay_state = initiate_test_login
+  def post_test_callback(test_email: email, **overrides)
+    request_id, relay_state = initiate_test_login(test_email:)
     params = {audience: settings.sp_entity_id, recipient: settings.assertion_consumer_service_url,
               in_response_to: request_id, issuer: saml_configuration.idp_entity_id, email:}.merge(overrides)
     post "/sso/#{slug}/callback", params: {SAMLResponse: signed_saml_response(**params), RelayState: relay_state}
@@ -87,10 +87,27 @@ RSpec.describe "SAML SSO login", :saml_env, type: :request do
     context "configuration inactive" do
       let(:saml_configuration) { FactoryBot.create(:organization_saml_configuration, :configured, organization:) }
 
-      it "redirects to the IdP" do
+      it "renders the form rather than leaving for the IdP" do
         get "/sso/#{slug}/test"
+        expect(response).to have_http_status(:ok)
+        expect(response.headers["X-Robots-Tag"]).to eq "noindex, nofollow"
+        expect(response.body).to include("SAML configuration test")
+        expect(Capybara.string(response.body))
+          .to have_css("form[action='/sso/#{slug}/test'] input[name=email]")
+      end
+
+      it "leaves for the IdP once the form is submitted" do
+        post "/sso/#{slug}/test", params: {email:}
         expect(response).to have_http_status(:found)
         expect(response.headers["Location"]).to start_with(saml_configuration.idp_sso_target_url)
+      end
+
+      it "re-renders the form without an email, having nothing to compare the assertion against" do
+        post "/sso/#{slug}/test", params: {email: " "}
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to include("Enter the email address to sign in with")
+        expect(Capybara.string(response.body))
+          .to have_css("form[action='/sso/#{slug}/test'] input[name=email]")
       end
     end
 
@@ -99,6 +116,11 @@ RSpec.describe "SAML SSO login", :saml_env, type: :request do
 
       it "is not found" do
         get "/sso/#{slug}/test"
+        expect(response).to have_http_status(:not_found)
+      end
+
+      it "is not found for the form submission either" do
+        post "/sso/#{slug}/test", params: {email:}
         expect(response).to have_http_status(:not_found)
       end
     end
@@ -380,6 +402,13 @@ RSpec.describe "SAML SSO login", :saml_env, type: :request do
         expect(diagnostic_value("Matching account has a password")).to eq "Yes"
       end
 
+      it "reports that the IdP released an address other than the one entered" do
+        post_test_callback(test_email: "someoneelse@#{domain}")
+        expect(response).to have_http_status(:ok)
+        expect(diagnostic_value("Address entered")).to eq "someoneelse@#{domain}"
+        expect(diagnostic_value("Asserted email")).to include "the IdP released a different address"
+      end
+
       it "reports a malformed email without provisioning" do
         malformed_email = "attacker@evil.com@#{domain}"
 
@@ -390,9 +419,12 @@ RSpec.describe "SAML SSO login", :saml_env, type: :request do
       end
 
       it "does not show assertion fields when signature validation fails" do
-        expect { post_test_callback(tamper: true) }.not_to change(User, :count)
+        # a different address than the assertion carries, so echoing the form back
+        # can't be mistaken for the assertion having been read
+        expect { post_test_callback(test_email: "typed@#{domain}", tamper: true) }.not_to change(User, :count)
         expect(response).to have_http_status(:ok)
         expect(response.body).to include("Invalid SAML Response")
+        expect(diagnostic_value("Address entered")).to eq "typed@#{domain}"
         expect(response.body).not_to include(email)
       end
     end

--- a/spec/requests/saml_callback_request_spec.rb
+++ b/spec/requests/saml_callback_request_spec.rb
@@ -173,6 +173,16 @@ RSpec.describe "SAML SSO login", :saml_env, type: :request do
           end
         end
       end
+
+      context "asserted email has multiple @ characters" do
+        let(:email) { "attacker@evil.com@#{domain}" }
+
+        it "does not provision or sign in" do
+          expect { post_callback }.not_to change(User, :count)
+          expect(response).to redirect_to(new_session_path)
+          expect(signed_in?).to be false
+        end
+      end
     end
 
     context "invalid assertions" do

--- a/spec/requests/saml_callback_request_spec.rb
+++ b/spec/requests/saml_callback_request_spec.rb
@@ -55,6 +55,11 @@ RSpec.describe "SAML SSO login", :saml_env, type: :request do
     cookies[ControllerHelpers::AUTH_COOKIE_KEY].present?
   end
 
+  def diagnostic_value(label)
+    Capybara.string(response.body)
+      .find(:xpath, "//dt[normalize-space()=#{label.inspect}]/following-sibling::dd[1]").text.strip
+  end
+
   describe "GET /sso/:org_slug/init" do
     it "redirects to the IdP" do
       get "/sso/#{slug}/init"
@@ -64,11 +69,7 @@ RSpec.describe "SAML SSO login", :saml_env, type: :request do
     end
 
     context "configuration inactive" do
-      let(:saml_configuration) do
-        FactoryBot.create(:organization_saml_configuration, :active, organization:).tap do |configuration|
-          configuration.update!(active: false)
-        end
-      end
+      let(:saml_configuration) { FactoryBot.create(:organization_saml_configuration, :configured, organization:) }
 
       it "redirects to the IdP" do
         get "/sso/#{slug}/init"
@@ -84,11 +85,7 @@ RSpec.describe "SAML SSO login", :saml_env, type: :request do
     end
 
     context "configuration inactive" do
-      let(:saml_configuration) do
-        FactoryBot.create(:organization_saml_configuration, :active, organization:).tap do |configuration|
-          configuration.update!(active: false)
-        end
-      end
+      let(:saml_configuration) { FactoryBot.create(:organization_saml_configuration, :configured, organization:) }
 
       it "redirects to the IdP" do
         get "/sso/#{slug}/test"
@@ -98,10 +95,7 @@ RSpec.describe "SAML SSO login", :saml_env, type: :request do
     end
 
     context "configuration incomplete" do
-      let(:saml_configuration) do
-        FactoryBot.create(:organization_saml_configuration, organization:, idp_entity_id: nil,
-          idp_sso_target_url: nil, idp_cert: nil)
-      end
+      let(:saml_configuration) { FactoryBot.create(:organization_saml_configuration, organization:) }
 
       it "is not found" do
         get "/sso/#{slug}/test"
@@ -359,11 +353,7 @@ RSpec.describe "SAML SSO login", :saml_env, type: :request do
 
   describe "POST /sso/:org_slug/callback in test mode" do
     context "configuration inactive" do
-      let(:saml_configuration) do
-        FactoryBot.create(:organization_saml_configuration, :active, organization:).tap do |configuration|
-          configuration.update!(active: false)
-        end
-      end
+      let(:saml_configuration) { FactoryBot.create(:organization_saml_configuration, :configured, organization:) }
 
       it "reports a valid assertion without provisioning or signing in" do
         identity_count = SsoIdentity.count
@@ -373,6 +363,21 @@ RSpec.describe "SAML SSO login", :saml_env, type: :request do
         expect(response.headers["X-Robots-Tag"]).to eq "noindex, nofollow"
         expect(response.body).to include("SAML configuration test", email)
         expect(signed_in?).to be false
+      end
+
+      it "reports a passwordless account as having no password of its own" do
+        FactoryBot.create(:user_confirmed, email:, passwordless_user: true)
+
+        post_test_callback
+        expect(diagnostic_value("Matching account")).to eq email
+        expect(diagnostic_value("Matching account has a password")).to eq "No"
+      end
+
+      it "reports a self-created account as having a password" do
+        FactoryBot.create(:user_confirmed, email:)
+
+        post_test_callback
+        expect(diagnostic_value("Matching account has a password")).to eq "Yes"
       end
 
       it "reports a malformed email without provisioning" do

--- a/spec/requests/saml_callback_request_spec.rb
+++ b/spec/requests/saml_callback_request_spec.rb
@@ -372,23 +372,28 @@ RSpec.describe "SAML SSO login", :saml_env, type: :request do
     end
   end
 
-  # Test mode is the same login, landing on a report of what the IdP sent
+  # Test mode is the same login, landing on a report of what the IdP sent. test_options
+  # carries what varies: test_email is typed into the form, the rest is what the IdP asserts.
   describe "POST /sso/:org_slug/callback in test mode" do
-    it "signs up and signs in, reporting the assertion" do
-      expect { post_test_callback }.to change(User, :count).by(1)
-      expect(response).to have_http_status(:ok)
-      expect(response.headers["X-Robots-Tag"]).to eq "noindex, nofollow"
-      expect(response.body).to include("You were signed up successfully!")
-      expect(diagnostic_value("Account")).to include(email, "created by this login")
-      expect(SsoIdentity.last.email).to eq email
-      expect(signed_in?).to be true
+    let(:test_options) { {} }
+
+    context "no Bike Index account for the asserted address" do
+      it "signs up and signs in, reporting the assertion" do
+        expect { post_test_callback(**test_options) }.to change(User, :count).by(1)
+        expect(response).to have_http_status(:ok)
+        expect(response.headers["X-Robots-Tag"]).to eq "noindex, nofollow"
+        expect(response.body).to include("You were signed up successfully!")
+        expect(diagnostic_value("Account")).to include(email, "created by this login")
+        expect(SsoIdentity.last.email).to eq email
+        expect(signed_in?).to be true
+      end
     end
 
-    context "an account already exists for the asserted email" do
+    context "an account already exists for the asserted address" do
       let!(:existing) { FactoryBot.create(:user_confirmed, email:) }
 
       it "signs it in, reporting that it has a password of its own" do
-        expect { post_test_callback }.not_to change(User, :count)
+        expect { post_test_callback(**test_options) }.not_to change(User, :count)
         expect(response.body).to include("You were signed in successfully!")
         expect(diagnostic_value("Account")).to include(email, "already existed")
         expect(diagnostic_value("Account has a password")).to eq "Yes"
@@ -399,37 +404,49 @@ RSpec.describe "SAML SSO login", :saml_env, type: :request do
         let!(:existing) { FactoryBot.create(:user_confirmed, email:, passwordless_user: true) }
 
         it "reports it as having no password of its own" do
-          post_test_callback
+          post_test_callback(**test_options)
           expect(diagnostic_value("Account has a password")).to eq "No"
         end
       end
     end
 
-    it "reports that the IdP released an address other than the one entered" do
-      post_test_callback(test_email: "someoneelse@#{domain}")
-      expect(response).to have_http_status(:ok)
-      expect(diagnostic_value("Address entered")).to eq "someoneelse@#{domain}"
-      expect(diagnostic_value("Asserted email")).to include "the IdP released a different address"
+    context "the IdP releases an address other than the one entered" do
+      let(:test_options) { {test_email: "someoneelse@#{domain}"} }
+
+      it "reports both, and that they differ" do
+        post_test_callback(**test_options)
+        expect(response).to have_http_status(:ok)
+        expect(diagnostic_value("Address entered")).to eq "someoneelse@#{domain}"
+        expect(diagnostic_value("Asserted email")).to include "the IdP released a different address"
+      end
     end
 
-    it "reports a malformed email without provisioning or signing in" do
-      expect { post_test_callback(email: "attacker@evil.com@#{domain}") }.not_to change(User, :count)
-      expect(response).to have_http_status(:ok)
-      # Capybara rather than the raw body: the copy has an apostrophe, which ERB escapes
-      expect(Capybara.string(response.body))
-        .to have_content("You couldn't be signed in").and have_content("is not on this organization's SSO domain")
-      expect(signed_in?).to be false
+    context "the asserted address is malformed" do
+      let(:test_options) { {email: "attacker@evil.com@#{domain}"} }
+
+      it "reports the failure without provisioning or signing in" do
+        expect { post_test_callback(**test_options) }.not_to change(User, :count)
+        expect(response).to have_http_status(:ok)
+        # Capybara rather than the raw body: the copy has an apostrophe, which ERB escapes
+        expect(Capybara.string(response.body))
+          .to have_content("You couldn't be signed in").and have_content("is not on this organization's SSO domain")
+        expect(signed_in?).to be false
+      end
     end
 
-    it "does not show assertion fields when signature validation fails" do
+    context "signature validation fails" do
       # a different address than the assertion carries, so echoing the form back
       # can't be mistaken for the assertion having been read
-      expect { post_test_callback(test_email: "typed@#{domain}", tamper: true) }.not_to change(User, :count)
-      expect(response).to have_http_status(:ok)
-      expect(response.body).to include("Invalid SAML Response")
-      expect(diagnostic_value("Address entered")).to eq "typed@#{domain}"
-      expect(response.body).not_to include(email)
-      expect(signed_in?).to be false
+      let(:test_options) { {test_email: "typed@#{domain}", tamper: true} }
+
+      it "shows no assertion fields, and doesn't provision or sign in" do
+        expect { post_test_callback(**test_options) }.not_to change(User, :count)
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to include("Invalid SAML Response")
+        expect(diagnostic_value("Address entered")).to eq "typed@#{domain}"
+        expect(response.body).not_to include(email)
+        expect(signed_in?).to be false
+      end
     end
   end
 end

--- a/spec/requests/saml_callback_request_spec.rb
+++ b/spec/requests/saml_callback_request_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe "SAML SSO login", :saml_env, type: :request do
   end
 
   def initiate_test_login(test_email: email)
-    post "/sso/#{slug}/test", params: {email: test_email}
+    post "/sso/#{slug}/test_start", params: {email: test_email}
     expect(response).to have_http_status(:found)
     location = response.headers["Location"]
     [saml_request_id_from_redirect(location), Rack::Utils.parse_query(URI(location).query)["RelayState"]]
@@ -78,49 +78,48 @@ RSpec.describe "SAML SSO login", :saml_env, type: :request do
     end
   end
 
-  describe "GET /sso/:org_slug/test" do
-    it "is not available for an active configuration" do
+  describe "/sso/:org_slug/test" do
+    it "renders the form rather than leaving for the IdP" do
       get "/sso/#{slug}/test"
-      expect(response).to have_http_status(:not_found)
+      expect(response).to have_http_status(:ok)
+      expect(response.headers["X-Robots-Tag"]).to eq "noindex, nofollow"
+      expect(response.body).to include("SAML configuration test")
+      expect(Capybara.string(response.body))
+        .to have_css("form[action='/sso/#{slug}/test_start'] input[name=email]")
     end
 
-    context "configuration inactive" do
-      let(:saml_configuration) { FactoryBot.create(:organization_saml_configuration, :configured, organization:) }
+    describe "POST test_start" do
+      before { post "/sso/#{slug}/test_start", params: }
 
-      it "renders the form rather than leaving for the IdP" do
-        get "/sso/#{slug}/test"
-        expect(response).to have_http_status(:ok)
-        expect(response.headers["X-Robots-Tag"]).to eq "noindex, nofollow"
-        expect(response.body).to include("SAML configuration test")
-        expect(Capybara.string(response.body))
-          .to have_css("form[action='/sso/#{slug}/test'] input[name=email]")
+      context "with an email" do
+        let(:params) { {email:} }
+
+        it "leaves for the IdP" do
+          expect(response).to have_http_status(:found)
+          expect(response.headers["Location"]).to start_with(saml_configuration.idp_sso_target_url)
+        end
       end
 
-      it "leaves for the IdP once the form is submitted" do
-        post "/sso/#{slug}/test", params: {email:}
-        expect(response).to have_http_status(:found)
-        expect(response.headers["Location"]).to start_with(saml_configuration.idp_sso_target_url)
-      end
+      context "with a blank email" do
+        let(:params) { {email: " "} }
 
-      it "re-renders the form without an email, having nothing to compare the assertion against" do
-        post "/sso/#{slug}/test", params: {email: " "}
-        expect(response).to have_http_status(:ok)
-        expect(response.body).to include("Enter the email address to sign in with")
-        expect(Capybara.string(response.body))
-          .to have_css("form[action='/sso/#{slug}/test'] input[name=email]")
+        it "re-renders the form, having nothing to compare the assertion against" do
+          expect(response).to have_http_status(:ok)
+          expect(response.body).to include("Enter the email address to sign in with")
+          expect(Capybara.string(response.body))
+            .to have_css("form[action='/sso/#{slug}/test_start'] input[name=email]")
+        end
       end
     end
 
     context "configuration incomplete" do
       let(:saml_configuration) { FactoryBot.create(:organization_saml_configuration, organization:) }
 
-      it "is not found" do
+      it "is not found, for the form or the submission" do
         get "/sso/#{slug}/test"
         expect(response).to have_http_status(:not_found)
-      end
 
-      it "is not found for the form submission either" do
-        post "/sso/#{slug}/test", params: {email:}
+        post "/sso/#{slug}/test_start", params: {email:}
         expect(response).to have_http_status(:not_found)
       end
     end
@@ -373,69 +372,64 @@ RSpec.describe "SAML SSO login", :saml_env, type: :request do
     end
   end
 
+  # Test mode is the same login, landing on a report of what the IdP sent
   describe "POST /sso/:org_slug/callback in test mode" do
-    context "configuration inactive" do
-      let(:saml_configuration) { FactoryBot.create(:organization_saml_configuration, :configured, organization:) }
+    it "signs up and signs in, reporting the assertion" do
+      expect { post_test_callback }.to change(User, :count).by(1)
+      expect(response).to have_http_status(:ok)
+      expect(response.headers["X-Robots-Tag"]).to eq "noindex, nofollow"
+      expect(response.body).to include("You were signed up successfully!")
+      expect(diagnostic_value("Account")).to include(email, "created by this login")
+      expect(SsoIdentity.last.email).to eq email
+      expect(signed_in?).to be true
+    end
 
-      it "reports a valid assertion without provisioning or signing in" do
-        identity_count = SsoIdentity.count
+    context "an account already exists for the asserted email" do
+      let!(:existing) { FactoryBot.create(:user_confirmed, email:) }
+
+      it "signs it in, reporting that it has a password of its own" do
         expect { post_test_callback }.not_to change(User, :count)
-        expect(response).to have_http_status(:ok)
-        expect(SsoIdentity.count).to eq identity_count
-        expect(response.headers["X-Robots-Tag"]).to eq "noindex, nofollow"
-        expect(response.body).to include("SAML configuration test", email)
-        expect(signed_in?).to be false
+        expect(response.body).to include("You were signed in successfully!")
+        expect(diagnostic_value("Account")).to include(email, "already existed")
+        expect(diagnostic_value("Account has a password")).to eq "Yes"
+        expect(signed_in?).to be true
       end
 
-      it "reports a passwordless account as having no password of its own" do
-        FactoryBot.create(:user_confirmed, email:, passwordless_user: true)
+      context "the account is passwordless" do
+        let!(:existing) { FactoryBot.create(:user_confirmed, email:, passwordless_user: true) }
 
-        post_test_callback
-        expect(diagnostic_value("Matching account")).to eq email
-        expect(diagnostic_value("Matching account has a password")).to eq "No"
-      end
-
-      it "reports a self-created account as having a password" do
-        FactoryBot.create(:user_confirmed, email:)
-
-        post_test_callback
-        expect(diagnostic_value("Matching account has a password")).to eq "Yes"
-      end
-
-      it "reports that the IdP released an address other than the one entered" do
-        post_test_callback(test_email: "someoneelse@#{domain}")
-        expect(response).to have_http_status(:ok)
-        expect(diagnostic_value("Address entered")).to eq "someoneelse@#{domain}"
-        expect(diagnostic_value("Asserted email")).to include "the IdP released a different address"
-      end
-
-      it "reports a malformed email without provisioning" do
-        malformed_email = "attacker@evil.com@#{domain}"
-
-        expect { post_test_callback(email: malformed_email) }.not_to change(User, :count)
-        expect(response).to have_http_status(:ok)
-        expect(response.body).to include("not on this organization")
-        expect(signed_in?).to be false
-      end
-
-      it "does not show assertion fields when signature validation fails" do
-        # a different address than the assertion carries, so echoing the form back
-        # can't be mistaken for the assertion having been read
-        expect { post_test_callback(test_email: "typed@#{domain}", tamper: true) }.not_to change(User, :count)
-        expect(response).to have_http_status(:ok)
-        expect(response.body).to include("Invalid SAML Response")
-        expect(diagnostic_value("Address entered")).to eq "typed@#{domain}"
-        expect(response.body).not_to include(email)
+        it "reports it as having no password of its own" do
+          post_test_callback
+          expect(diagnostic_value("Account has a password")).to eq "No"
+        end
       end
     end
 
-    context "configuration active" do
-      it "rejects a test transaction" do
-        relay_state = Saml::RequestStore.create(request_id: "_test", org_slug: slug,
-          mode: Saml::RequestStore::TEST_MODE)
-        post "/sso/#{slug}/callback", params: {RelayState: relay_state}
-        expect(response).to have_http_status(:not_found)
-      end
+    it "reports that the IdP released an address other than the one entered" do
+      post_test_callback(test_email: "someoneelse@#{domain}")
+      expect(response).to have_http_status(:ok)
+      expect(diagnostic_value("Address entered")).to eq "someoneelse@#{domain}"
+      expect(diagnostic_value("Asserted email")).to include "the IdP released a different address"
+    end
+
+    it "reports a malformed email without provisioning or signing in" do
+      expect { post_test_callback(email: "attacker@evil.com@#{domain}") }.not_to change(User, :count)
+      expect(response).to have_http_status(:ok)
+      # Capybara rather than the raw body: the copy has an apostrophe, which ERB escapes
+      expect(Capybara.string(response.body))
+        .to have_content("You couldn't be signed in").and have_content("is not on this organization's SSO domain")
+      expect(signed_in?).to be false
+    end
+
+    it "does not show assertion fields when signature validation fails" do
+      # a different address than the assertion carries, so echoing the form back
+      # can't be mistaken for the assertion having been read
+      expect { post_test_callback(test_email: "typed@#{domain}", tamper: true) }.not_to change(User, :count)
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("Invalid SAML Response")
+      expect(diagnostic_value("Address entered")).to eq "typed@#{domain}"
+      expect(response.body).not_to include(email)
+      expect(signed_in?).to be false
     end
   end
 end

--- a/spec/requests/saml_callback_request_spec.rb
+++ b/spec/requests/saml_callback_request_spec.rb
@@ -26,6 +26,13 @@ RSpec.describe "SAML SSO login", :saml_env, type: :request do
     [saml_request_id_from_redirect(location), Rack::Utils.parse_query(URI(location).query)["RelayState"]]
   end
 
+  def initiate_test_login
+    get "/sso/#{slug}/test"
+    expect(response).to have_http_status(:found)
+    location = response.headers["Location"]
+    [saml_request_id_from_redirect(location), Rack::Utils.parse_query(URI(location).query)["RelayState"]]
+  end
+
   def post_callback(relay_state: :from_init, drop_session: false, **overrides)
     request_id, initiated_relay_state = initiate_login
     # Rack::Test sends cookies whatever their SameSite, so a spec that needs the browser's
@@ -35,6 +42,13 @@ RSpec.describe "SAML SSO login", :saml_env, type: :request do
               in_response_to: request_id, issuer: saml_configuration.idp_entity_id, email:}.merge(overrides)
     post "/sso/#{slug}/callback", params: {SAMLResponse: signed_saml_response(**params),
                                            RelayState: (relay_state == :from_init) ? initiated_relay_state : relay_state}
+  end
+
+  def post_test_callback(**overrides)
+    request_id, relay_state = initiate_test_login
+    params = {audience: settings.sp_entity_id, recipient: settings.assertion_consumer_service_url,
+              in_response_to: request_id, issuer: saml_configuration.idp_entity_id, email:}.merge(overrides)
+    post "/sso/#{slug}/callback", params: {SAMLResponse: signed_saml_response(**params), RelayState: relay_state}
   end
 
   def signed_in?
@@ -50,9 +64,47 @@ RSpec.describe "SAML SSO login", :saml_env, type: :request do
     end
 
     context "configuration inactive" do
-      let(:saml_configuration) { FactoryBot.create(:organization_saml_configuration, organization:) }
-      it "is not found" do
+      let(:saml_configuration) do
+        FactoryBot.create(:organization_saml_configuration, :active, organization:).tap do |configuration|
+          configuration.update!(active: false)
+        end
+      end
+
+      it "redirects to the IdP" do
         get "/sso/#{slug}/init"
+        expect(response).to have_http_status(:found)
+      end
+    end
+  end
+
+  describe "GET /sso/:org_slug/test" do
+    it "is not available for an active configuration" do
+      get "/sso/#{slug}/test"
+      expect(response).to have_http_status(:not_found)
+    end
+
+    context "configuration inactive" do
+      let(:saml_configuration) do
+        FactoryBot.create(:organization_saml_configuration, :active, organization:).tap do |configuration|
+          configuration.update!(active: false)
+        end
+      end
+
+      it "redirects to the IdP" do
+        get "/sso/#{slug}/test"
+        expect(response).to have_http_status(:found)
+        expect(response.headers["Location"]).to start_with(saml_configuration.idp_sso_target_url)
+      end
+    end
+
+    context "configuration incomplete" do
+      let(:saml_configuration) do
+        FactoryBot.create(:organization_saml_configuration, organization:, idp_entity_id: nil,
+          idp_sso_target_url: nil, idp_cert: nil)
+      end
+
+      it "is not found" do
+        get "/sso/#{slug}/test"
         expect(response).to have_http_status(:not_found)
       end
     end
@@ -301,6 +353,51 @@ RSpec.describe "SAML SSO login", :saml_env, type: :request do
         expect { post_callback(relay_state: foreign_relay_state) }.not_to change(User, :count)
         expect(response).to redirect_to(new_session_path)
         expect(signed_in?).to be false
+      end
+    end
+  end
+
+  describe "POST /sso/:org_slug/callback in test mode" do
+    context "configuration inactive" do
+      let(:saml_configuration) do
+        FactoryBot.create(:organization_saml_configuration, :active, organization:).tap do |configuration|
+          configuration.update!(active: false)
+        end
+      end
+
+      it "reports a valid assertion without provisioning or signing in" do
+        identity_count = SsoIdentity.count
+        expect { post_test_callback }.not_to change(User, :count)
+        expect(response).to have_http_status(:ok)
+        expect(SsoIdentity.count).to eq identity_count
+        expect(response.headers["X-Robots-Tag"]).to eq "noindex, nofollow"
+        expect(response.body).to include("SAML configuration test", email)
+        expect(signed_in?).to be false
+      end
+
+      it "reports a malformed email without provisioning" do
+        malformed_email = "attacker@evil.com@#{domain}"
+
+        expect { post_test_callback(email: malformed_email) }.not_to change(User, :count)
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to include("not on this organization")
+        expect(signed_in?).to be false
+      end
+
+      it "does not show assertion fields when signature validation fails" do
+        expect { post_test_callback(tamper: true) }.not_to change(User, :count)
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to include("Invalid SAML Response")
+        expect(response.body).not_to include(email)
+      end
+    end
+
+    context "configuration active" do
+      it "rejects a test transaction" do
+        relay_state = Saml::RequestStore.create(request_id: "_test", org_slug: slug,
+          mode: Saml::RequestStore::TEST_MODE)
+        post "/sso/#{slug}/callback", params: {RelayState: relay_state}
+        expect(response).to have_http_status(:not_found)
       end
     end
   end

--- a/spec/requests/sessions_request_spec.rb
+++ b/spec/requests/sessions_request_spec.rb
@@ -92,7 +92,7 @@ RSpec.describe SessionsController, type: :request do
       end
 
       it "hands off to the IdP, skipping the credential step" do
-        FactoryBot.create(:organization_saml_configuration, :enabled, organization:)
+        FactoryBot.create(:organization_saml_configuration, :active, organization:)
         identify("student@sso.edu")
         expect(response).to redirect_to(saml_init_path(org_slug: organization.to_param))
       end
@@ -212,7 +212,7 @@ RSpec.describe SessionsController, type: :request do
         FactoryBot.create(:organization_with_organization_features,
           enabled_feature_slugs: ["saml_sso"], user_email_domain: "sso.edu")
       end
-      let!(:saml_configuration) { FactoryBot.create(:organization_saml_configuration, :enabled, organization:) }
+      let!(:saml_configuration) { FactoryBot.create(:organization_saml_configuration, :active, organization:) }
       it "forces SSO instead of sending a link" do
         ActionMailer::Base.deliveries = []
         post "/session/create_magic_link", params: {email: "student@sso.edu"}
@@ -490,7 +490,7 @@ RSpec.describe SessionsController, type: :request do
         FactoryBot.create(:organization_with_organization_features,
           enabled_feature_slugs: ["saml_sso"], user_email_domain: "sso.edu")
       end
-      let!(:saml_configuration) { FactoryBot.create(:organization_saml_configuration, :enabled, organization:) }
+      let!(:saml_configuration) { FactoryBot.create(:organization_saml_configuration, :active, organization:) }
       it "forces SSO instead of accepting the password" do
         post "/session", params: {session: {email: user.email, password:}}
         expect(response).to redirect_to(saml_init_path(org_slug: organization.to_param))

--- a/spec/requests/users_request_spec.rb
+++ b/spec/requests/users_request_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe UsersController, type: :request do
         FactoryBot.create(:organization_with_organization_features,
           enabled_feature_slugs: ["saml_sso"], user_email_domain: "sso.edu")
       end
-      let!(:saml_configuration) { FactoryBot.create(:organization_saml_configuration, :enabled, organization:) }
+      let!(:saml_configuration) { FactoryBot.create(:organization_saml_configuration, :active, organization:) }
 
       it "hands a claimed email off to the IdP, and renders the form for one it doesn't claim" do
         get "#{base_url}/new", params: {email: "student@sso.edu"}
@@ -72,7 +72,7 @@ RSpec.describe UsersController, type: :request do
         FactoryBot.create(:organization_with_organization_features,
           enabled_feature_slugs: ["saml_sso"], user_email_domain: "sso.edu")
       end
-      let!(:saml_configuration) { FactoryBot.create(:organization_saml_configuration, :enabled, organization:) }
+      let!(:saml_configuration) { FactoryBot.create(:organization_saml_configuration, :active, organization:) }
 
       it "forces SSO instead of creating an account the IdP doesn't know about" do
         expect {

--- a/spec/services/saml/request_store_spec.rb
+++ b/spec/services/saml/request_store_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Saml::RequestStore do
       expect(token).to be_present
       expect(RedisPool.conn { |r| r.ttl("saml_request:#{token}") })
         .to be_within(5).of(described_class::TTL.to_i)
-      expect(described_class.claim(token)).to eq({org_slug:, request_id:, return_to: nil, mode: "normal"})
+      expect(described_class.claim(token)).to eq({org_slug:, request_id:, return_to: nil, mode: "normal", expected_email: nil})
       expect(described_class.create(request_id:, org_slug:)).to_not eq token
     end
   end
@@ -19,13 +19,13 @@ RSpec.describe Saml::RequestStore do
     let(:token) { described_class.create(request_id:, org_slug:, return_to: "/bikes/new") }
 
     it "travels with the transaction, the callback having no session to read it from" do
-      expect(described_class.claim(token)).to eq({org_slug:, request_id:, return_to: "/bikes/new", mode: "normal"})
+      expect(described_class.claim(token)).to eq({org_slug:, request_id:, return_to: "/bikes/new", mode: "normal", expected_email: nil})
     end
   end
 
   describe "claim" do
     it "succeeds once, the token being single use" do
-      expect(described_class.claim(token)).to eq({org_slug:, request_id:, return_to: nil, mode: "normal"})
+      expect(described_class.claim(token)).to eq({org_slug:, request_id:, return_to: nil, mode: "normal", expected_email: nil})
       expect(described_class.claim(token)).to be_nil
     end
 
@@ -42,7 +42,15 @@ RSpec.describe Saml::RequestStore do
     it "round trips the test mode" do
       token = described_class.create(request_id:, org_slug:, mode: described_class::TEST_MODE)
 
-      expect(described_class.claim(token)).to eq({org_slug:, request_id:, return_to: nil, mode: "test"})
+      expect(described_class.claim(token)).to eq({org_slug:, request_id:, return_to: nil, mode: "test", expected_email: nil})
+    end
+
+    it "round trips the address the test form collected" do
+      token = described_class.create(request_id:, org_slug:, mode: described_class::TEST_MODE,
+        expected_email: "someone@example.edu")
+
+      expect(described_class.claim(token)).to eq({org_slug:, request_id:, return_to: nil, mode: "test",
+                                                  expected_email: "someone@example.edu"})
     end
   end
 end

--- a/spec/services/saml/request_store_spec.rb
+++ b/spec/services/saml/request_store_spec.rb
@@ -36,6 +36,14 @@ RSpec.describe Saml::RequestStore do
         expect(described_class.claim("not-a-real-token")).to be_nil
       end
     end
+
+    context "a payload create no longer writes" do
+      it "is nil rather than raising, the same as a token we never issued" do
+        RedisPool.conn { |r| r.set("saml_request:stale-format", "some-university\n_abc-123") }
+
+        expect(described_class.claim("stale-format")).to be_nil
+      end
+    end
   end
 
   describe "mode" do

--- a/spec/services/saml/request_store_spec.rb
+++ b/spec/services/saml/request_store_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Saml::RequestStore do
       expect(token).to be_present
       expect(RedisPool.conn { |r| r.ttl("saml_request:#{token}") })
         .to be_within(5).of(described_class::TTL.to_i)
-      expect(described_class.claim(token)).to eq({org_slug:, request_id:, return_to: nil})
+      expect(described_class.claim(token)).to eq({org_slug:, request_id:, return_to: nil, mode: "normal"})
       expect(described_class.create(request_id:, org_slug:)).to_not eq token
     end
   end
@@ -19,13 +19,13 @@ RSpec.describe Saml::RequestStore do
     let(:token) { described_class.create(request_id:, org_slug:, return_to: "/bikes/new") }
 
     it "travels with the transaction, the callback having no session to read it from" do
-      expect(described_class.claim(token)).to eq({org_slug:, request_id:, return_to: "/bikes/new"})
+      expect(described_class.claim(token)).to eq({org_slug:, request_id:, return_to: "/bikes/new", mode: "normal"})
     end
   end
 
   describe "claim" do
     it "succeeds once, the token being single use" do
-      expect(described_class.claim(token)).to eq({org_slug:, request_id:, return_to: nil})
+      expect(described_class.claim(token)).to eq({org_slug:, request_id:, return_to: nil, mode: "normal"})
       expect(described_class.claim(token)).to be_nil
     end
 
@@ -35,6 +35,14 @@ RSpec.describe Saml::RequestStore do
         expect(described_class.claim("")).to be_nil
         expect(described_class.claim("not-a-real-token")).to be_nil
       end
+    end
+  end
+
+  describe "mode" do
+    it "round trips the test mode" do
+      token = described_class.create(request_id:, org_slug:, mode: described_class::TEST_MODE)
+
+      expect(described_class.claim(token)).to eq({org_slug:, request_id:, return_to: nil, mode: "test"})
     end
   end
 end

--- a/spec/services/saml/settings_builder_spec.rb
+++ b/spec/services/saml/settings_builder_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Saml::SettingsBuilder, :saml_env do
     FactoryBot.create(:organization_with_organization_features,
       enabled_feature_slugs: "saml_sso", user_email_domain: "example.edu")
   end
-  let(:saml_configuration) { FactoryBot.create(:organization_saml_configuration, :enabled, organization:) }
+  let(:saml_configuration) { FactoryBot.create(:organization_saml_configuration, :active, organization:) }
   subject(:settings) { described_class.build(saml_configuration) }
 
   it "sets slug-scoped SP urls" do
@@ -51,7 +51,7 @@ RSpec.describe Saml::SettingsBuilder, :saml_env do
   context "with a configured name_id_format" do
     let(:name_id_format) { OrganizationSamlConfiguration::NAME_ID_FORMATS["persistent"] }
     let(:saml_configuration) do
-      FactoryBot.create(:organization_saml_configuration, :enabled, organization:, name_id_format:)
+      FactoryBot.create(:organization_saml_configuration, :active, organization:, name_id_format:)
     end
     it "asks the IdP for it" do
       expect(settings.name_identifier_format).to eq name_id_format
@@ -68,7 +68,7 @@ RSpec.describe Saml::SettingsBuilder, :saml_env do
 
   context "with a rotation-overlap cert" do
     let(:saml_configuration) do
-      FactoryBot.create(:organization_saml_configuration, :enabled, organization:, idp_cert_multi: idp_cert)
+      FactoryBot.create(:organization_saml_configuration, :active, organization:, idp_cert_multi: idp_cert)
     end
     it "uses idp_cert_multi for signing" do
       expect(settings.idp_cert_multi[:signing].length).to eq 2

--- a/spec/support/saml_helpers.rb
+++ b/spec/support/saml_helpers.rb
@@ -152,7 +152,7 @@ RSpec.shared_context "sso_organization" do
     FactoryBot.create(:organization_with_organization_features,
       enabled_feature_slugs: ["saml_sso"], user_email_domain: "sso.edu")
   end
-  let!(:saml_configuration) { FactoryBot.create(:organization_saml_configuration, :enabled, organization:) }
+  let!(:saml_configuration) { FactoryBot.create(:organization_saml_configuration, :active, organization:) }
 end
 
 RSpec.configure do |config|


### PR DESCRIPTION
One boolean meant two things: that an organization's IdP details were filled in, and that every user at its domain was forced through SSO. So saving the SAML card immediately redirected the whole domain to an IdP that hasn't registered us yet — those users land on the IdP's own error page, and since no assertion comes back we get no callback and nothing in the logs. There was no way to finish our side of an integration and wait for theirs.

- **`active` is the redirect; `configured?` is only the IdP details.** A configuration can be saved, and an integration validated end to end, without routing anyone. `Organization.saml_email_matching` — what the forced-SSO redirect asks — requires both, which is what keeps saving the card from switching a domain over. `configured?` also requires the organization to claim a domain, since one that can't authorize an assertion can't complete a login either.
- **`/sso/<slug>/test` is the real login, landing on a report instead of your account page.** Enter the address you'll sign in with; it runs the transaction `init` runs, signs you in, and then reports the NameID, the attributes actually released, the resolved email and domain, whether the IdP released the address you entered, and whether the account already existed — enough to tell an attribute-release problem from a domain mismatch. A dry run would stop short of the half that breaks: provisioning, the force-confirm, the `SsoIdentity` write and the automatic role grant all happen after the point it could report success. Test mode travels in RelayState rather than through a second endpoint, because the assertion has to come back to the ACS URL the IdP registered.
- **The assertion domain guard is a per-organization check rather than the routing lookup.** It compares `Organization.email_domain` (now public) against the organization's own domain and rejects a blank on either side. Reusing the routing lookup would have made every callback conditional on `active`, and the previous direct comparison let `nil == nil` pass for an address with no parseable domain — a transient NameID with the email attribute unreleased is exactly that.
- **`/sso/<slug>/init` and the callback stay open while inactive**, which is what makes the validation window possible. An inactive configuration is one nobody is *forced* through, not one that's switched off — so the test page grants exactly what `init` already grants to the same IdP credentials, and reaching either state takes a superadmin entering IdP details.

The column rename is the only schema change, and no organization has SAML active yet, so there's nothing to migrate around it.
