### PR TITLE
Carry the PKCE code challenge through the authorization consent form

### DIFF
--- a/.claude/skills/integration-testing/SKILL.md
+++ b/.claude/skills/integration-testing/SKILL.md
@@ -29,6 +29,8 @@ If the UI path is hard, that's a real signal — usually a production bug (stale
 
 Legitimate exceptions: reference data that exists in production via migrations, admin accounts outside the user flow, and stubs for genuinely external services (third-party APIs, Stripe, geocoders).
 
+A step the browser never performs — a server-to-server token exchange, a webhook callback — goes over real HTTP to Capybara's own server rather than through the page: `Net::HTTP.post_form(URI.join(Capybara.current_session.server.base_url, "/oauth/token"), params)`. VCR's `ignore_hosts` covers `localhost`, so it isn't blocked. `spec/integration/oauth_spec.rb` is the pattern.
+
 ## One `it` per setup; many assertions per `it`
 
 Unit specs prefer one assertion per example. **Integration specs prefer the opposite**: when several assertions share the same fixture and the same initial `visit`, fold them into one example that walks through state transitions (click → assert → click → assert).

--- a/app/controllers/oauth/authorizations_controller.rb
+++ b/app/controllers/oauth/authorizations_controller.rb
@@ -3,8 +3,18 @@ module Oauth
     include ControllerHelpers
 
     before_action :authenticate_user_permit_unconfirmed_scope
+    helper_method :pre_auth_hidden_fields
 
     private
+
+    # #create rebuilds pre_auth from what the consent form posts, so a field the form
+    # omits is dropped from the grant
+    def pre_auth_hidden_fields
+      custom_attributes = pre_auth.custom_access_token_attributes.symbolize_keys
+      pre_auth_param_fields.index_with do |field|
+        (field == :client_id) ? pre_auth.client.uid : custom_attributes.fetch(field) { pre_auth.public_send(field) }
+      end
+    end
 
     def authenticate_user_permit_unconfirmed_scope
       unless params[:scope].to_s[/unconfirmed/i].present? && unconfirmed_current_user.present?

--- a/app/views/doorkeeper/authorizations/new.html.haml
+++ b/app/views/doorkeeper/authorizations/new.html.haml
@@ -31,6 +31,8 @@
               = hidden_field_tag :state, @pre_auth.state
               = hidden_field_tag :response_type, @pre_auth.response_type
               = hidden_field_tag :scope, @pre_auth.scope
+              = hidden_field_tag :code_challenge, @pre_auth.code_challenge
+              = hidden_field_tag :code_challenge_method, @pre_auth.code_challenge_method
               = submit_tag 'Authorize', class: 'btn btn-primary btn-lg'
           .col-xs-6
             = form_tag oauth_authorization_path, method: :delete, id: 'deny-authorization' do
@@ -39,6 +41,8 @@
               = hidden_field_tag :state, @pre_auth.state
               = hidden_field_tag :response_type, @pre_auth.response_type
               = hidden_field_tag :scope, @pre_auth.scope
+              = hidden_field_tag :code_challenge, @pre_auth.code_challenge
+              = hidden_field_tag :code_challenge_method, @pre_auth.code_challenge_method
               = submit_tag 'Deny', class: 'btn btn-secondary btn-lg'
 
 - if OauthRedirectUri.cleartext?(@pre_auth.redirect_uri)

--- a/app/views/doorkeeper/authorizations/new.html.haml
+++ b/app/views/doorkeeper/authorizations/new.html.haml
@@ -26,23 +26,13 @@
         .row
           .col-xs-6
             = form_tag oauth_authorization_path, method: :post do
-              = hidden_field_tag :client_id, @pre_auth.client.uid
-              = hidden_field_tag :redirect_uri, @pre_auth.redirect_uri
-              = hidden_field_tag :state, @pre_auth.state
-              = hidden_field_tag :response_type, @pre_auth.response_type
-              = hidden_field_tag :scope, @pre_auth.scope
-              = hidden_field_tag :code_challenge, @pre_auth.code_challenge
-              = hidden_field_tag :code_challenge_method, @pre_auth.code_challenge_method
+              - pre_auth_hidden_fields.each do |field, value|
+                = hidden_field_tag field, value
               = submit_tag 'Authorize', class: 'btn btn-primary btn-lg'
           .col-xs-6
             = form_tag oauth_authorization_path, method: :delete, id: 'deny-authorization' do
-              = hidden_field_tag :client_id, @pre_auth.client.uid
-              = hidden_field_tag :redirect_uri, @pre_auth.redirect_uri
-              = hidden_field_tag :state, @pre_auth.state
-              = hidden_field_tag :response_type, @pre_auth.response_type
-              = hidden_field_tag :scope, @pre_auth.scope
-              = hidden_field_tag :code_challenge, @pre_auth.code_challenge
-              = hidden_field_tag :code_challenge_method, @pre_auth.code_challenge_method
+              - pre_auth_hidden_fields.each do |field, value|
+                = hidden_field_tag field, value
               = submit_tag 'Deny', class: 'btn btn-secondary btn-lg'
 
 - if OauthRedirectUri.cleartext?(@pre_auth.redirect_uri)

--- a/spec/integration/oauth_spec.rb
+++ b/spec/integration/oauth_spec.rb
@@ -34,6 +34,12 @@ RSpec.describe "OAuth authorization", :js, type: :system do
     click_button "Log in"
 
     expect(page).to have_content("Would you like to authorize", wait: 5)
+    # Hidden inputs have no accessible name to match on. Anything #create reads back and
+    # the form doesn't post is dropped from the grant
+    posted = page.all("form:not(#deny-authorization) input[type=hidden]", visible: :all).map { it[:name] }
+    expect(posted).to include("client_id", "redirect_uri", "state", "response_type",
+      "response_mode", "scope", "code_challenge", "code_challenge_method")
+
     click_button "Authorize"
 
     code = find("#authorization_code").text

--- a/spec/integration/oauth_spec.rb
+++ b/spec/integration/oauth_spec.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "OAuth authorization", :js, type: :system do
+  let(:user) { FactoryBot.create(:user_confirmed) }
+  let(:password) { "testthisthing7$" }
+  # oob renders the code on a page instead of redirecting off-site, so the browser can read it
+  let(:doorkeeper_app) { FactoryBot.create(:doorkeeper_app, redirect_uri: "urn:ietf:wg:oauth:2.0:oob") }
+  let(:code_verifier) { "dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk" }
+  let(:code_challenge) { Base64.urlsafe_encode64(Digest::SHA256.digest(code_verifier), padding: false) }
+  let(:authorize_path) do
+    "/oauth/authorize?response_type=code&client_id=#{doorkeeper_app.uid}" \
+      "&redirect_uri=#{CGI.escape(doorkeeper_app.redirect_uri)}&scope=read_bikes" \
+      "&code_challenge=#{code_challenge}&code_challenge_method=S256"
+  end
+
+  # Redeeming is the client's own server call, not something the rider does. No
+  # client_secret - a public client is the case PKCE exists for
+  def redeem(code, code_verifier: nil)
+    params = {grant_type: "authorization_code", code:, client_id: doorkeeper_app.uid,
+              redirect_uri: doorkeeper_app.redirect_uri}
+    params[:code_verifier] = code_verifier if code_verifier
+    Net::HTTP.post_form(URI.join(Capybara.current_session.server.base_url, "/oauth/token"), params)
+  end
+
+  it "carries the challenge through the prompt, so only the verifier redeems the code" do
+    visit authorize_path
+    expect(page).to have_current_path("/session/new", wait: 5)
+
+    fill_in "Email", with: user.email
+    click_button "Continue"
+    fill_in "Password", with: password
+    click_button "Log in"
+
+    expect(page).to have_content("Would you like to authorize", wait: 5)
+    click_button "Authorize"
+
+    code = find("#authorization_code").text
+    expect(Doorkeeper::AccessGrant.find_by(token: code).code_challenge).to eq code_challenge
+
+    without_verifier = redeem(code)
+    expect(without_verifier.code).to eq "400"
+    expect(JSON.parse(without_verifier.body)["error"]).to eq "invalid_request"
+
+    wrong_verifier = redeem(code, code_verifier: code_verifier.reverse)
+    expect(wrong_verifier.code).to eq "400"
+    expect(JSON.parse(wrong_verifier.body)["error"]).to eq "invalid_grant"
+    expect(Doorkeeper::AccessToken.count).to eq 0
+
+    redeemed = redeem(code, code_verifier:)
+    expect(redeemed.code).to eq "200"
+    expect(Doorkeeper::AccessToken.count).to eq 1
+    expect(JSON.parse(redeemed.body)["access_token"]).to eq Doorkeeper::AccessToken.last.token
+  end
+end

--- a/spec/requests/oauth_authorizations_request_spec.rb
+++ b/spec/requests/oauth_authorizations_request_spec.rb
@@ -11,8 +11,8 @@ RSpec.describe Oauth::AuthorizationsController, type: :request do
   end
 
   # What the emailed link's page posts onward - the destination rides in one of these
-  def hidden_fields
-    Capybara.string(response.body).all("form input[type=hidden]", visible: :all)
+  def hidden_fields(selector = "form")
+    Capybara.string(response.body).all("#{selector} input[type=hidden]", visible: :all)
       .to_h { |input| [input[:name], input[:value]] }
   end
 
@@ -285,6 +285,39 @@ RSpec.describe Oauth::AuthorizationsController, type: :request do
           expect(response.code).to eq("400")
           expect(json_result["error"]).to eq "invalid_request"
           expect(Doorkeeper::AccessToken.count).to eq 0
+        end
+      end
+
+      # Everything above skips the prompt by leaving the challenge in the query string.
+      # A real client is sent to the prompt, and only its hidden fields survive to the grant
+      context "granted through the consent prompt" do
+        let(:prompt_fields) do
+          get "/oauth/authorize?#{authorize_params}"
+          expect(response.code).to eq("200")
+          hidden_fields("form:not(#deny-authorization)")
+        end
+        let(:auth_code) do
+          post "/oauth/authorize", params: prompt_fields
+          response.redirect_url[/code=[^&]*/i].gsub(/code=/i, "")
+        end
+
+        it "carries the challenge onto the grant, so only the verifier redeems the code" do
+          expect(prompt_fields).to include("code_challenge" => code_challenge,
+            "code_challenge_method" => code_challenge_method)
+          expect(Doorkeeper::AccessGrant.find_by(token: auth_code).code_challenge).to eq code_challenge
+
+          post "/oauth/token?#{token_params}&code=#{auth_code}"
+          expect(response.code).to eq("400")
+          expect(json_result["error"]).to eq "invalid_request"
+
+          post "/oauth/token?#{token_params}&code=#{auth_code}&code_verifier=#{code_verifier.reverse}"
+          expect(response.code).to eq("400")
+          expect(json_result["error"]).to eq "invalid_grant"
+          expect(Doorkeeper::AccessToken.count).to eq 0
+
+          post "/oauth/token?#{token_params}&code=#{auth_code}&code_verifier=#{code_verifier}"
+          expect(Doorkeeper::AccessToken.count).to eq 1
+          expect(json_result["access_token"]).to eq Doorkeeper::AccessToken.last.token
         end
       end
 

--- a/spec/requests/oauth_authorizations_request_spec.rb
+++ b/spec/requests/oauth_authorizations_request_spec.rb
@@ -11,8 +11,8 @@ RSpec.describe Oauth::AuthorizationsController, type: :request do
   end
 
   # What the emailed link's page posts onward - the destination rides in one of these
-  def hidden_fields(selector = "form")
-    Capybara.string(response.body).all("#{selector} input[type=hidden]", visible: :all)
+  def hidden_fields
+    Capybara.string(response.body).all("form input[type=hidden]", visible: :all)
       .to_h { |input| [input[:name], input[:value]] }
   end
 
@@ -285,39 +285,6 @@ RSpec.describe Oauth::AuthorizationsController, type: :request do
           expect(response.code).to eq("400")
           expect(json_result["error"]).to eq "invalid_request"
           expect(Doorkeeper::AccessToken.count).to eq 0
-        end
-      end
-
-      # Everything above skips the prompt by leaving the challenge in the query string.
-      # A real client is sent to the prompt, and only its hidden fields survive to the grant
-      context "granted through the consent prompt" do
-        let(:prompt_fields) do
-          get "/oauth/authorize?#{authorize_params}"
-          expect(response.code).to eq("200")
-          hidden_fields("form:not(#deny-authorization)")
-        end
-        let(:auth_code) do
-          post "/oauth/authorize", params: prompt_fields
-          response.redirect_url[/code=[^&]*/i].gsub(/code=/i, "")
-        end
-
-        it "carries the challenge onto the grant, so only the verifier redeems the code" do
-          expect(prompt_fields).to include("code_challenge" => code_challenge,
-            "code_challenge_method" => code_challenge_method)
-          expect(Doorkeeper::AccessGrant.find_by(token: auth_code).code_challenge).to eq code_challenge
-
-          post "/oauth/token?#{token_params}&code=#{auth_code}"
-          expect(response.code).to eq("400")
-          expect(json_result["error"]).to eq "invalid_request"
-
-          post "/oauth/token?#{token_params}&code=#{auth_code}&code_verifier=#{code_verifier.reverse}"
-          expect(response.code).to eq("400")
-          expect(json_result["error"]).to eq "invalid_grant"
-          expect(Doorkeeper::AccessToken.count).to eq 0
-
-          post "/oauth/token?#{token_params}&code=#{auth_code}&code_verifier=#{code_verifier}"
-          expect(Doorkeeper::AccessToken.count).to eq 1
-          expect(json_result["access_token"]).to eq Doorkeeper::AccessToken.last.token
         end
       end
 


### PR DESCRIPTION
Bike Index's copy of Doorkeeper's consent view hardcoded five hidden fields where the gem's own posts eight, and `#create` rebuilds `pre_auth` from what was posted — so a `code_challenge` that arrived on the GET was gone by the time the grant was written. A client following the PKCE flow the docs describe got `invalid_grant` on every exchange, against a grant that had no challenge on it to check.

- **Both forms loop over Doorkeeper's own `pre_auth_param_fields`** rather than repeating a list that has to be re-checked by hand on every upgrade. That picks up `response_mode` as well, which was the other field we'd drifted away from — inert today, since nothing sets it, but the same silent-drop if a client ever asked for `form_post`.
- **`spec/integration/oauth_spec.rb` walks the flow in a browser** — sign in, click Authorize, read the code off the oob page — then redeems it three ways: no verifier, wrong verifier, right one. The existing PKCE request specs post straight to `/oauth/authorize` with the challenge still in the query string, which is why none of them saw this.

Reported by a third-party integrator building against the API.
