### PR TITLE
Reject a duplicate impound notification, and don't re-email

### DIFF
--- a/.claude/skills/pr/SKILL.md
+++ b/.claude/skills/pr/SKILL.md
@@ -121,6 +121,8 @@ git push -u origin HEAD
 
 Don't report the local branch name differing from the name in the invocation when the branch has no upstream — pushing `HEAD` creates a matching remote, so it's benign. Only flag a mismatch when the local branch already tracks a differently-named upstream. If the push is rejected as non-fast-forward, go back to **Prepare the branch**.
 
+**A branch already tracking a differently-named upstream** — a Conductor `-v1` local on `origin/<name>` — takes `git push origin HEAD:<upstream-branch>` instead. `git push -u origin HEAD` creates a second remote branch and leaves the existing PR behind on the first.
+
 - **Open PR found above**: `gh pr edit <number> --title "..." --body-file <tmp-body-file>`. Refresh the title to match the current diff (that's what "update pr" expects) unless the user gave it a deliberate custom title — if unsure, keep the title and update only the body.
 
   **Read the current body before you replace it.** A human may have edited it since your last run — added a caveat, a reviewer note, a deploy instruction. Anything you can't account for as your own writing gets carried into the new body, or asked about. Don't overwrite it silently.

--- a/app/jobs/process_parking_notification_job.rb
+++ b/app/jobs/process_parking_notification_job.rb
@@ -36,11 +36,8 @@ class ProcessParkingNotificationJob < ApplicationJob
   def run(parking_notification_id)
     parking_notification = ParkingNotification.find(parking_notification_id)
 
-    if parking_notification.impound_notification? && parking_notification.impound_record_id.blank?
-      impound_record = ImpoundRecord.create!(bike_id: parking_notification.bike_id,
-        user_id: parking_notification.user_id,
-        organization_id: parking_notification.organization_id,
-        skip_update: true)
+    impound_record = impound_record_for(parking_notification)
+    if impound_record.present?
       parking_notification.resolved_at ||= Time.current
       parking_notification.update(impound_record_id: impound_record.id)
       ProcessImpoundUpdatesJob.new.perform(impound_record.id)
@@ -63,6 +60,21 @@ class ProcessParkingNotificationJob < ApplicationJob
     end
 
     send_notification_if_should(parking_notification)
+  end
+
+  # Organizations sometimes send a second impound notification for a bike they've already
+  # impounded - a bike only gets one current impound record, so reuse theirs. Another
+  # organization's record can't be reused: the notification email renders its location
+  def impound_record_for(parking_notification)
+    return nil unless parking_notification.impound_notification? && parking_notification.impound_record_id.blank?
+
+    current_records = ImpoundRecord.current.where(bike_id: parking_notification.bike_id)
+    return current_records.find_by(organization_id: parking_notification.organization_id) if current_records.any?
+
+    ImpoundRecord.create!(bike_id: parking_notification.bike_id,
+      user_id: parking_notification.user_id,
+      organization_id: parking_notification.organization_id,
+      skip_update: true)
   end
 
   def send_notification_if_should(parking_notification)

--- a/app/jobs/process_parking_notification_job.rb
+++ b/app/jobs/process_parking_notification_job.rb
@@ -62,14 +62,15 @@ class ProcessParkingNotificationJob < ApplicationJob
     send_notification_if_should(parking_notification)
   end
 
-  # Organizations sometimes send a second impound notification for a bike they've already
-  # impounded - a bike only gets one current impound record, so reuse theirs. Another
-  # organization's record can't be reused: the notification email renders its location
+  # An organization sometimes sends a second impound notification for a bike it already
+  # impounded. Only its own record is reusable - the email renders the record's location
   def impound_record_for(parking_notification)
     return nil unless parking_notification.impound_notification? && parking_notification.impound_record_id.blank?
 
-    current_records = ImpoundRecord.current.where(bike_id: parking_notification.bike_id)
-    return current_records.find_by(organization_id: parking_notification.organization_id) if current_records.any?
+    current_record = ImpoundRecord.current.find_by(bike_id: parking_notification.bike_id)
+    if current_record.present?
+      return (current_record.organization_id == parking_notification.organization_id) ? current_record : nil
+    end
 
     ImpoundRecord.create!(bike_id: parking_notification.bike_id,
       user_id: parking_notification.user_id,

--- a/app/jobs/process_parking_notification_job.rb
+++ b/app/jobs/process_parking_notification_job.rb
@@ -36,7 +36,14 @@ class ProcessParkingNotificationJob < ApplicationJob
   def run(parking_notification_id)
     parking_notification = ParkingNotification.find(parking_notification_id)
 
-    impound_record = impound_record_for(parking_notification)
+    current_record = current_impound_record(parking_notification)
+    # Another organization's record isn't ours to link to, but it still blocks creating one
+    impound_record = if current_record.blank?
+      new_impound_record(parking_notification)
+    elsif current_record.organization_id == parking_notification.organization_id
+      current_record
+    end
+
     if impound_record.present?
       parking_notification.resolved_at ||= Time.current
       parking_notification.update(impound_record_id: impound_record.id)
@@ -59,18 +66,31 @@ class ProcessParkingNotificationJob < ApplicationJob
       end
     end
 
-    send_notification_if_should(parking_notification)
+    # The owner was already emailed by the notification that impounded the bike
+    unless current_record.present? || earlier_impound_notification?(parking_notification)
+      send_notification_if_should(parking_notification)
+    end
   end
 
-  # An organization sometimes sends a second impound notification for a bike it already
-  # impounded. Only its own record is reusable - the email renders the record's location
-  def impound_record_for(parking_notification)
+  # ParkingNotification validates that its bike isn't already impounded, so a current record here
+  # means both notifications were created before either of them was processed
+  def current_impound_record(parking_notification)
     return nil unless parking_notification.impound_notification? && parking_notification.impound_record_id.blank?
 
-    current_record = ImpoundRecord.current.find_by(bike_id: parking_notification.bike_id)
-    if current_record.present?
-      return (current_record.organization_id == parking_notification.organization_id) ? current_record : nil
-    end
+    ImpoundRecord.current.find_by(bike_id: parking_notification.bike_id)
+  end
+
+  # Once a duplicate has been linked to the record, this is what keeps a re-run from emailing
+  def earlier_impound_notification?(parking_notification)
+    return false if parking_notification.impound_record_id.blank?
+
+    ParkingNotification.impound_notification
+      .where(impound_record_id: parking_notification.impound_record_id)
+      .where("id < ?", parking_notification.id).exists?
+  end
+
+  def new_impound_record(parking_notification)
+    return nil unless parking_notification.impound_notification? && parking_notification.impound_record_id.blank?
 
     ImpoundRecord.create!(bike_id: parking_notification.bike_id,
       user_id: parking_notification.user_id,

--- a/app/models/parking_notification.rb
+++ b/app/models/parking_notification.rb
@@ -68,6 +68,7 @@ class ParkingNotification < ActiveRecord::Base
   has_many :repeat_records, class_name: "ParkingNotification", foreign_key: :initial_record_id
   validates_presence_of :bike_id, :user_id
   validate :location_present, on: :create
+  validate :bike_not_impounded, on: :create
   attr_accessor :skip_geocoding, :is_repeat, :use_entered_address, :image_cache, :skip_update
 
   mount_uploader :image, ImageUploaderBackgrounded
@@ -372,6 +373,21 @@ class ParkingNotification < ActiveRecord::Base
     return true if latitude.present? && longitude.present? || formatted_address_string.present?
 
     errors.add(:base, "address is required")
+  end
+
+  # Organizations re-submit the impound form when the bike page hasn't caught up yet - tell them
+  # it worked rather than duplicating the record and re-emailing the owner
+  def bike_not_impounded
+    return unless impound_notification?
+
+    impound_record = ImpoundRecord.current.find_by(bike_id:)
+    return if impound_record.blank?
+
+    errors.add(:base, if impound_record.organization_id == organization_id
+      "This #{bike&.type} is already impounded (impound record ##{impound_record.display_id})"
+    else
+      "This #{bike&.type} is already impounded by another organization"
+    end)
   end
 
   def process_notification

--- a/spec/jobs/process_parking_notification_job_spec.rb
+++ b/spec/jobs/process_parking_notification_job_spec.rb
@@ -180,6 +180,40 @@ RSpec.describe ProcessParkingNotificationJob, type: :job do
     end
   end
 
+  describe "second impound notification for an already impounded bike" do
+    let(:organization) { FactoryBot.create(:organization_with_organization_features, enabled_feature_slugs: %w[parking_notifications impound_bikes]) }
+    let(:bike) { FactoryBot.create(:ownership).bike }
+    let(:parking_notification) { FactoryBot.create(:parking_notification_organized, organization: organization, bike: bike, kind: "impound_notification") }
+    let!(:parking_notification_duplicate) do
+      FactoryBot.create(:parking_notification_organized, organization: organization, bike: bike,
+        user: parking_notification.user, kind: "impound_notification")
+    end
+    before { instance.perform(parking_notification.id) }
+
+    it "links to the existing impound record" do
+      impound_record = parking_notification.reload.impound_record
+      expect(impound_record).to be_present
+      expect(bike.reload.current_impound_record).to eq impound_record
+
+      expect { instance.perform(parking_notification_duplicate.id) }.to_not change(ImpoundRecord, :count)
+      expect(parking_notification_duplicate.reload.impound_record).to eq impound_record
+      expect(parking_notification_duplicate.status).to eq "impounded"
+    end
+
+    context "impounded by a different organization" do
+      let(:organization2) { FactoryBot.create(:organization_with_organization_features, enabled_feature_slugs: %w[parking_notifications impound_bikes]) }
+      let!(:parking_notification_duplicate) do
+        FactoryBot.create(:parking_notification_organized, organization: organization2, bike: bike, kind: "impound_notification")
+      end
+
+      it "doesn't link to the other organization's impound record" do
+        expect { instance.perform(parking_notification_duplicate.id) }.to_not change(ImpoundRecord, :count)
+        expect(parking_notification_duplicate.reload.impound_record_id).to be_blank
+        expect(bike.reload.current_impound_record).to eq parking_notification.reload.impound_record
+      end
+    end
+  end
+
   describe "sending email" do
     let(:bike) { FactoryBot.create(:ownership).bike }
     let(:parking_notification) { FactoryBot.create(:parking_notification_organized, bike: bike) }

--- a/spec/jobs/process_parking_notification_job_spec.rb
+++ b/spec/jobs/process_parking_notification_job_spec.rb
@@ -190,14 +190,19 @@ RSpec.describe ProcessParkingNotificationJob, type: :job do
     end
     before { instance.perform(parking_notification.id) }
 
-    it "links to the existing impound record" do
+    it "links to the existing impound record without emailing the owner again" do
       impound_record = parking_notification.reload.impound_record
       expect(impound_record).to be_present
       expect(bike.reload.current_impound_record).to eq impound_record
+      expect(ActionMailer::Base.deliveries.count).to eq 1
 
       expect { instance.perform(parking_notification_duplicate.id) }.to_not change(ImpoundRecord, :count)
       expect(parking_notification_duplicate.reload.impound_record).to eq impound_record
       expect(parking_notification_duplicate.status).to eq "impounded"
+      expect(parking_notification_duplicate.notifications.count).to eq 0
+
+      instance.perform(parking_notification_duplicate.id)
+      expect(ActionMailer::Base.deliveries.count).to eq 1
     end
 
     context "impounded by a different organization" do
@@ -206,10 +211,12 @@ RSpec.describe ProcessParkingNotificationJob, type: :job do
         FactoryBot.create(:parking_notification_organized, organization: organization2, bike: bike, kind: "impound_notification")
       end
 
-      it "doesn't link to the other organization's impound record" do
+      it "doesn't link to the other organization's impound record, or email" do
         expect { instance.perform(parking_notification_duplicate.id) }.to_not change(ImpoundRecord, :count)
         expect(parking_notification_duplicate.reload.impound_record_id).to be_blank
         expect(bike.reload.current_impound_record).to eq parking_notification.reload.impound_record
+        expect(parking_notification_duplicate.notifications.count).to eq 0
+        expect(ActionMailer::Base.deliveries.count).to eq 1
       end
     end
   end

--- a/spec/models/parking_notification_spec.rb
+++ b/spec/models/parking_notification_spec.rb
@@ -100,6 +100,42 @@ RSpec.describe ParkingNotification, type: :model do
     end
   end
 
+  describe "bike_not_impounded" do
+    let(:organization) { FactoryBot.create(:organization_with_organization_features, enabled_feature_slugs: %w[parking_notifications impound_bikes]) }
+    let(:bike) { FactoryBot.create(:bike) }
+    let!(:impound_record) { FactoryBot.create(:impound_record_with_organization, organization: organization, bike: bike) }
+    let(:parking_notification) { FactoryBot.build(:parking_notification_organized, organization: organization, bike: bike, kind: "impound_notification") }
+    it "is invalid, naming the impound record" do
+      expect(parking_notification).to_not be_valid
+      expect(parking_notification.errors.full_messages.to_sentence)
+        .to eq "This bike is already impounded (impound record ##{impound_record.display_id})"
+    end
+
+    context "notification of another kind" do
+      let(:parking_notification) { FactoryBot.build(:parking_notification_organized, organization: organization, bike: bike, kind: "appears_abandoned_notification") }
+      it "is valid" do
+        expect(parking_notification).to be_valid
+      end
+    end
+
+    context "impound record resolved" do
+      let!(:impound_record) { FactoryBot.create(:impound_record_resolved, organization: organization, bike: bike) }
+      it "is valid" do
+        expect(impound_record.reload.resolved?).to be_truthy
+        expect(parking_notification).to be_valid
+      end
+    end
+
+    context "impounded by another organization" do
+      let!(:impound_record) { FactoryBot.create(:impound_record_with_organization, bike: bike) }
+      it "is invalid" do
+        expect(parking_notification).to_not be_valid
+        expect(parking_notification.errors.full_messages.to_sentence)
+          .to eq "This bike is already impounded by another organization"
+      end
+    end
+  end
+
   describe "unregistered" do
     let(:parking_notification) { FactoryBot.create(:parking_notification_unregistered) }
     let(:organization) { parking_notification.organization }


### PR DESCRIPTION
`ProcessParkingNotificationJob` created an `ImpoundRecord` for every impound notification, but a bike only gets one current record — so a second impound notification for a bike the organization had already impounded raised `Validation failed: Bike has already been taken`, aborting the run before the email.

Reusing the record and letting that second email go isn't what anyone wants, though. All 15 occurrences in production were the same person re-submitting the impound form minutes later because the bike page hadn't caught up, and 13 of the 15 would have emailed the organization's own shared address rather than an owner — impounding an unregistered bike gives the placeholder bike an ownership, so the duplicate is no longer `unregistered_bike`.

- **`ParkingNotification` rejects an impound notification for a bike that already has a current impound record**, naming the record so the organization gets the confirmation it was re-submitting for. Both bike panels already hide the form for an impounded bike, so this is the backstop for a stale page.
- **The job links a duplicate to the organization's own record rather than creating a second one, and skips the owner's email.** Linking re-enqueues the job, so the re-run checks the record's earlier notifications rather than the lookup that found it unlinked.
