### PR TITLE
Keep the org sidebar's content pages inside a phone's width

### DIFF
--- a/app/assets/tailwind/application.css
+++ b/app/assets/tailwind/application.css
@@ -228,8 +228,12 @@ body.with-org-sidebar main:has(> :only-child) {
   @apply tw:flex tw:flex-col;
 }
 
+/* Width asked for rather than left to the cross-axis stretch, which auto side margins
+   turn off -- bootstrap's .container has them, and unstretched it sizes to max-content,
+   which below 576px (where it has no max-width) is every paragraph on one line */
 body.with-org-sidebar main > :only-child {
   flex-grow: 1;
+  width: 100%;
 }
 
 /* PageBlock::Navbar::OrgSidebar::Component::MOBILE_BREAKPOINT, below which the sidebar is

--- a/app/assets/tailwind/application.css
+++ b/app/assets/tailwind/application.css
@@ -228,9 +228,8 @@ body.with-org-sidebar main:has(> :only-child) {
   @apply tw:flex tw:flex-col;
 }
 
-/* Width asked for rather than left to the cross-axis stretch, which auto side margins
-   turn off -- bootstrap's .container has them, and unstretched it sizes to max-content,
-   which below 576px (where it has no max-width) is every paragraph on one line */
+/* Bootstrap's .container has auto side margins, which opt it out of the cross-axis
+   stretch -- unstretched it goes max-content wide, so the width is asked for */
 body.with-org-sidebar main > :only-child {
   flex-grow: 1;
   width: 100%;

--- a/app/services/user_services/menu_items_org.rb
+++ b/app/services/user_services/menu_items_org.rb
@@ -9,14 +9,11 @@ module UserServices
   module MenuItemsOrg
     extend Functionable
 
-    # UpdateOrganizationAssociationsJob touches every member user when an org changes and
-    # SuperuserAbility touches its own, so user.cache_key_with_version covers per-user,
-    # org-feature and super admin changes alike. Nothing here depends on which page is
-    # current, so the key carries no path.
+    # Nothing here depends on which page is current
     def for(organization:, current_user:, old_register_view: false)
       return [] if organization.nil? || current_user.nil?
 
-      Rails.cache.fetch(["menu_items_org_v5", organization.id, current_user.cache_key_with_version,
+      Rails.cache.fetch(["menu_items_org_v1", organization, current_user,
         old_register_view]) do
         build_items(organization, current_user, old_register_view)
       end


### PR DESCRIPTION
The org sidebar lays `main` out as a flex column so a full-bleed shell can stretch to the window. On the content pages `main`'s only child is bootstrap's `.container`, whose auto side margins opt it out of the cross-axis stretch — unstretched it goes max-content wide, which is every paragraph on one line, and below 576px `.container` has no `max-width` to clamp it. [`/info/how-to-get-your-stolen-bike-back?organization_id=brakebills`](https://bikeindex.org/info/how-to-get-your-stolen-bike-back?organization_id=brakebills) laid out 56,730px wide on a 390px phone; every org-sidebar content page is exposed to it.

- **The only child asks for its width** rather than relying on a stretch it can't have. Desktop is untouched: `.container` still clamps to its breakpoint `max-width`, and flex hands the leftover back to the auto margins, so it stays centered.
- **It takes recovery-story records to reproduce**, which is why it looked fine locally — that block at the foot of the page is what makes the container's max-content enormous, and the seeded dev DB has none of them.
