### PR TITLE
Give the chip groups UI::Button's secondary styling

### DIFF
--- a/app/components/org/search_results/bikes_table/component.rb
+++ b/app/components/org/search_results/bikes_table/component.rb
@@ -9,7 +9,7 @@ module Org
       # registrations on the show page). Pass render_sortable to enable sort links.
       class Component < ApplicationComponent
         # Digest of the markup inside the row cache — the cached_markup_digest spec keeps it current
-        MARKUP_DIGEST = "b1b88f27cf54"
+        MARKUP_DIGEST = "579ee5ab9811"
 
         delegate :additional_registration_fields, :column_renames, to: :settings_component
 

--- a/app/components/org/search_results/bikes_table/component.rb
+++ b/app/components/org/search_results/bikes_table/component.rb
@@ -9,7 +9,7 @@ module Org
       # registrations on the show page). Pass render_sortable to enable sort links.
       class Component < ApplicationComponent
         # Digest of the markup inside the row cache — the cached_markup_digest spec keeps it current
-        MARKUP_DIGEST = "579ee5ab9811"
+        MARKUP_DIGEST = "fee4dc752885"
 
         delegate :additional_registration_fields, :column_renames, to: :settings_component
 

--- a/app/components/registrations/show/wrapper/component.rb
+++ b/app/components/registrations/show/wrapper/component.rb
@@ -8,7 +8,7 @@ module Registrations
       class Component < ApplicationComponent
         # Digest of the markup inside the cache block — the cached_markup_digest spec
         # keeps it current, following what this tree renders out into UI:: and elsewhere
-        MARKUP_DIGEST = "45ae5ddb2be4"
+        MARKUP_DIGEST = "3af2a159de0a"
 
         def initialize(bike:, current_user:, view:, available_views:, bike_sticker: nil, current_alerts: {}, display_dev_info: false)
           @bike = bike

--- a/app/components/registrations/show/wrapper/component.rb
+++ b/app/components/registrations/show/wrapper/component.rb
@@ -8,7 +8,7 @@ module Registrations
       class Component < ApplicationComponent
         # Digest of the markup inside the cache block — the cached_markup_digest spec
         # keeps it current, following what this tree renders out into UI:: and elsewhere
-        MARKUP_DIGEST = "c7c5f02ca8e0"
+        MARKUP_DIGEST = "45ae5ddb2be4"
 
         def initialize(bike:, current_user:, view:, available_views:, bike_sticker: nil, current_alerts: {}, display_dev_info: false)
           @bike = bike

--- a/app/components/ui/button_group/component.rb
+++ b/app/components/ui/button_group/component.rb
@@ -5,7 +5,7 @@ module UI
     # A row of chips that navigate or act — the link/button counterpart of
     # UI::Forms::RadioButtonGroup, which chips off CHIP_CLASSES too.
     class Component < ApplicationComponent
-      CHIP_CLASSES = UI::Button::Component.build_classes(color: :secondary, size: :sm).freeze
+      CHIP_CLASSES = UI::Button::Component.build_classes(color: :secondary, size: :md).freeze
 
       # full_width lays the chips out as equal columns that wrap, staying the same width
       # on every line — flex would size each line independently. auto-fit needs a

--- a/app/components/ui/button_group/component.rb
+++ b/app/components/ui/button_group/component.rb
@@ -3,8 +3,7 @@
 module UI
   module ButtonGroup
     # A row of chips that navigate or act — the link/button counterpart of
-    # UI::Forms::RadioButtonGroup, which builds its <label> chips off the same
-    # UI::Button styling.
+    # UI::Forms::RadioButtonGroup, which chips off CHIP_CLASSES too.
     class Component < ApplicationComponent
       CHIP_CLASSES = UI::Button::Component.build_classes(color: :secondary, size: :sm).freeze
 

--- a/app/components/ui/button_group/component.rb
+++ b/app/components/ui/button_group/component.rb
@@ -3,22 +3,10 @@
 module UI
   module ButtonGroup
     # A row of chips that navigate or act — the link/button counterpart of
-    # UI::Forms::RadioButtonGroup, which chips off RESTING_CHIP_CLASSES too.
+    # UI::Forms::RadioButtonGroup, which builds its <label> chips off the same
+    # UI::Button styling.
     class Component < ApplicationComponent
-      # Mirrors UI::Button color: :secondary, so retuning it reaches the chips
-      RESTING_CHIP_CLASSES = [
-        "tw:cursor-pointer tw:select-none tw:inline-flex tw:items-center tw:justify-center tw:rounded tw:px-3 tw:py-1 tw:text-sm tw:leading-snug tw:transition-colors",
-        UI::Button::Component::COLORS[:secondary]
-      ].join(" ").freeze
-
-      # The radio group stops at the resting half, restating the rest off its checked input
-      CHIP_CLASSES = [
-        RESTING_CHIP_CLASSES,
-        "tw:no-underline",
-        UI::Button::Component::ACTIVE_COLORS[:secondary],
-        UI::Button::Component::FOCUS_CLASSES,
-        UI::Button::Component::DISABLED_CLASSES
-      ].join(" ").freeze
+      CHIP_CLASSES = UI::Button::Component.build_classes(color: :secondary, size: :sm).freeze
 
       # full_width lays the chips out as equal columns that wrap, staying the same width
       # on every line — flex would size each line independently. auto-fit needs a

--- a/app/components/ui/forms/radio_button_group/component.rb
+++ b/app/components/ui/forms/radio_button_group/component.rb
@@ -4,11 +4,10 @@ module UI
   module Forms
     module RadioButtonGroup
       class Component < ApplicationComponent
-        # The chip is UI::Button's secondary, so the two chip groups can't drift
-        # apart. Only checked and focus have to be restated, since those hang off
-        # the radio rather than the label's own :checked/:focus.
+        # Only checked and focus are restated, since those hang off the radio
+        # rather than the <label> the chip classes land on.
         CHIP_CLASSES = [
-          UI::Button::Component.build_classes(color: :secondary, size: :sm),
+          UI::ButtonGroup::Component::CHIP_CLASSES,
           "tw:mb-0", # the chip is a <label>, which legacy CSS gives a bottom margin
           "tw:has-[:checked]:bg-purple-500 tw:has-[:checked]:text-white tw:has-[:checked]:border-purple-500",
           # A <label> is never :disabled — these carry the specificity to beat the hover

--- a/app/components/ui/forms/radio_button_group/component.rb
+++ b/app/components/ui/forms/radio_button_group/component.rb
@@ -4,11 +4,11 @@ module UI
   module Forms
     module RadioButtonGroup
       class Component < ApplicationComponent
-        # The resting chip comes straight from UI::ButtonGroup, so the two groups look
-        # the same. Only the checked/focus states have to be restated, since those hang
-        # off the radio rather than the chip's own :active/:focus.
+        # The chip is UI::Button's secondary, so the two chip groups can't drift
+        # apart. Only checked and focus have to be restated, since those hang off
+        # the radio rather than the label's own :checked/:focus.
         CHIP_CLASSES = [
-          UI::ButtonGroup::Component::RESTING_CHIP_CLASSES,
+          UI::Button::Component.build_classes(color: :secondary, size: :sm),
           "tw:mb-0", # the chip is a <label>, which legacy CSS gives a bottom margin
           "tw:has-[:checked]:bg-purple-500 tw:has-[:checked]:text-white tw:has-[:checked]:border-purple-500",
           # A <label> is never :disabled — these carry the specificity to beat the hover

--- a/spec/components/ui/button_group/component_spec.rb
+++ b/spec/components/ui/button_group/component_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe UI::ButtonGroup::Component, type: :component do
 
   # Equality, not include: an extra utility here is a visual difference from the button
   it "styles the chips as UI::Button's secondary" do
-    expect(component.css("a").first["class"]).to eq(UI::Button::Component.build_classes(color: :secondary, size: :sm))
+    expect(component.css("a").first["class"]).to eq(UI::Button::Component.build_classes(color: :secondary, size: :md))
   end
 
   context "entries without an href" do

--- a/spec/components/ui/button_group/component_spec.rb
+++ b/spec/components/ui/button_group/component_spec.rb
@@ -18,8 +18,7 @@ RSpec.describe UI::ButtonGroup::Component, type: :component do
     expect(render_inline(described_class.new(entries: [{label: "only <strong>not</strong> impounded", href: "/x"}]))).to have_css("a span strong", text: "not")
   end
 
-  # Equality, not include: an extra utility here is a visual difference from the
-  # button, and the radio group's chips are built off the same call
+  # Equality, not include: an extra utility here is a visual difference from the button
   it "styles the chips as UI::Button's secondary" do
     expect(component.css("a").first["class"]).to eq(UI::Button::Component.build_classes(color: :secondary, size: :sm))
   end

--- a/spec/components/ui/button_group/component_spec.rb
+++ b/spec/components/ui/button_group/component_spec.rb
@@ -18,10 +18,10 @@ RSpec.describe UI::ButtonGroup::Component, type: :component do
     expect(render_inline(described_class.new(entries: [{label: "only <strong>not</strong> impounded", href: "/x"}]))).to have_css("a span strong", text: "not")
   end
 
-  # The chip carries the classes the radio group's <label> chips are built from, so the
-  # two groups can't drift apart
-  it "styles the chips like the radio group's" do
-    expect(component.css("a").first["class"].split).to include(*described_class::RESTING_CHIP_CLASSES.split)
+  # Equality, not include: an extra utility here is a visual difference from the
+  # button, and the radio group's chips are built off the same call
+  it "styles the chips as UI::Button's secondary" do
+    expect(component.css("a").first["class"]).to eq(UI::Button::Component.build_classes(color: :secondary, size: :sm))
   end
 
   context "entries without an href" do

--- a/spec/components/ui/forms/radio_button_group/component_spec.rb
+++ b/spec/components/ui/forms/radio_button_group/component_spec.rb
@@ -4,7 +4,7 @@ require "rails_helper"
 
 RSpec.describe UI::Forms::RadioButtonGroup::Component, type: :component do
   let(:entries) { [{value: "", label: "All"}, {value: "active", label: "Active"}] }
-  let(:button) { UI::Button::Component.build_classes(color: :secondary, size: :md) }
+  let(:button) { UI::Button::Component.build_classes(color: :secondary, size: :sm) }
   let(:button_active) { UI::Button::Component::ACTIVE_COLORS[:secondary] }
 
   # Every purple-* color utility a class string uses, ignoring variant prefixes

--- a/spec/components/ui/forms/radio_button_group/component_spec.rb
+++ b/spec/components/ui/forms/radio_button_group/component_spec.rb
@@ -4,7 +4,7 @@ require "rails_helper"
 
 RSpec.describe UI::Forms::RadioButtonGroup::Component, type: :component do
   let(:entries) { [{value: "", label: "All"}, {value: "active", label: "Active"}] }
-  let(:button) { UI::Button::Component.build_classes(color: :secondary, size: :sm) }
+  let(:button) { UI::Button::Component.build_classes(color: :secondary, size: :md) }
   let(:button_active) { UI::Button::Component::ACTIVE_COLORS[:secondary] }
 
   # Every purple-* color utility a class string uses, ignoring variant prefixes


### PR DESCRIPTION
`UI::ButtonGroup` took its colors from `UI::Button`'s secondary but restated the button's shape by hand, so the chips sat at a different radius, padding and weight from the button they were meant to match — and nothing failed when the two drifted.

- **Both chip groups derive from `UI::Button::Component.build_classes(color: :secondary, size: :md)`.** `UI::Forms::RadioButtonGroup` chips off `ButtonGroup::CHIP_CLASSES` as it did before, so one call still owns the answer, and its spec asserts equality against `build_classes` rather than inclusion — an extra utility on either side fails now.
- **The chip's own shape goes.** `rounded` → `rounded-lg` and `py-1` → `py-1.5`, plus `font-medium`; the hand-rolled `select-none` and `leading-snug` go, since the button carries neither. `text-sm` and `px-3` are the button's `:md` values already, so the type doesn't move — and colors, hover, focus ring, active fill and disabled were `UI::Button`'s constants before this branch.
- **A radio chip picks up press feedback.** `is-active` matches `:active` as well as `[data-active]`, so a `<label>` inheriting `ACTIVE_COLORS` alongside the resting half now flashes, while held, the same purple it lands on when checked.

Rendered by the org search settings, the register step-2 frame-size picker, the parking-notification forms, multi-search and the admin registration-sequence header.
