### PR TITLE
Add the organization's registration notes as an export column

### DIFF
--- a/app/jobs/organization_export_job.rb
+++ b/app/jobs/organization_export_job.rb
@@ -40,7 +40,7 @@ class OrganizationExportJob < ApplicationJob
     axlsx_package.workbook.add_worksheet(name: "Basic Worksheet") do |sheet|
       sheet.add_row(export_headers)
       row_index = 0
-      @export.bikes_scoped.find_each(batch_size: 100) do |bike|
+      exported_bikes.find_each(batch_size: 100) do |bike|
         check_export_ebrake(row_index) # Run first thing in case it's already broken
         next unless export_bike?(bike)
 
@@ -67,7 +67,7 @@ class OrganizationExportJob < ApplicationJob
     require "csv"
     file.write(comma_wrapped_string(export_headers))
     row_index = 0
-    @export.bikes_scoped.find_each(batch_size: 100) do |bike|
+    exported_bikes.find_each(batch_size: 100) do |bike|
       check_export_ebrake(row_index) # Run first thing in case it's already broken
       next unless export_bike?(bike)
 
@@ -101,6 +101,12 @@ class OrganizationExportJob < ApplicationJob
     return false unless bike_or_b_param.is_a?(Bike)
 
     bike_or_b_param.avery_exportable?
+  end
+
+  def exported_bikes
+    return @export.bikes_scoped unless export_headers.include?("organization_notes")
+
+    @export.bikes_scoped.includes(:bike_organization_notes)
   end
 
   def bike_to_row(bike)
@@ -171,7 +177,12 @@ class OrganizationExportJob < ApplicationJob
     when "vehicle_type" then bike.type_titleize
     when "motorized" then bike.motorized?
     when "status" then bike.status_humanized_no_with_owner
+    when "organization_notes" then organization_note_body(bike)
     end
+  end
+
+  def organization_note_body(bike)
+    bike.bike_organization_notes.detect { it.organization_id == @export.organization_id }&.body
   end
 
   def assign_bike_code_and_increment(bike)

--- a/app/jobs/organization_export_job.rb
+++ b/app/jobs/organization_export_job.rb
@@ -40,7 +40,7 @@ class OrganizationExportJob < ApplicationJob
     axlsx_package.workbook.add_worksheet(name: "Basic Worksheet") do |sheet|
       sheet.add_row(export_headers)
       row_index = 0
-      exported_bikes.find_each(batch_size: 100) do |bike|
+      @export.bikes_scoped.find_each(batch_size: 100) do |bike|
         check_export_ebrake(row_index) # Run first thing in case it's already broken
         next unless export_bike?(bike)
 
@@ -67,7 +67,7 @@ class OrganizationExportJob < ApplicationJob
     require "csv"
     file.write(comma_wrapped_string(export_headers))
     row_index = 0
-    exported_bikes.find_each(batch_size: 100) do |bike|
+    @export.bikes_scoped.find_each(batch_size: 100) do |bike|
       check_export_ebrake(row_index) # Run first thing in case it's already broken
       next unless export_bike?(bike)
 
@@ -101,12 +101,6 @@ class OrganizationExportJob < ApplicationJob
     return false unless bike_or_b_param.is_a?(Bike)
 
     bike_or_b_param.avery_exportable?
-  end
-
-  def exported_bikes
-    return @export.bikes_scoped unless export_headers.include?("organization_notes")
-
-    @export.bikes_scoped.includes(:bike_organization_notes)
   end
 
   def bike_to_row(bike)
@@ -177,12 +171,14 @@ class OrganizationExportJob < ApplicationJob
     when "vehicle_type" then bike.type_titleize
     when "motorized" then bike.motorized?
     when "status" then bike.status_humanized_no_with_owner
-    when "organization_notes" then organization_note_body(bike)
+    when "organization_notes" then organization_note_bodies[bike.id]
     end
   end
 
-  def organization_note_body(bike)
-    bike.bike_organization_notes.detect { it.organization_id == @export.organization_id }&.body
+  # to_h can't collide: unique index on (bike_id, organization_id)
+  def organization_note_bodies
+    @organization_note_bodies ||= BikeOrganizationNote.where(organization_id: @export.organization_id)
+      .pluck(:bike_id, :body).to_h
   end
 
   def assign_bike_code_and_increment(bike)

--- a/app/models/export.rb
+++ b/app/models/export.rb
@@ -53,7 +53,7 @@ class Export < ApplicationRecord
     vehicle_type
   ].freeze
   PERMITTED_HEADERS = (DEFAULT_HEADERS + EXTRA_HEADERS).sort.freeze
-  FEATURE_HEADERS = %w[partial_registration is_impounded impounded_at].freeze
+  FEATURE_HEADERS = %w[partial_registration is_impounded impounded_at organization_notes].freeze
   HEADERS_FOR_AVERY_EXPORT = %w[address owner_name].freeze
 
   acts_as_paranoid
@@ -125,6 +125,7 @@ class Export < ApplicationRecord
         additional_headers = reg_field_headers(organization_or_overide.additional_registration_fields)
         additional_headers += %w[partial_registration] if organization_or_overide.enabled?("show_partial_registrations")
         additional_headers += %w[is_impounded impounded_at] if organization_or_overide.enabled?("impound_bikes")
+        additional_headers += %w[organization_notes] if organization_or_overide.enabled?("registration_notes")
       end
       additional_headers ||= []
       # We always give the option to export extra_registration_number, don't double up if org can add too

--- a/spec/jobs/organization_export_job_spec.rb
+++ b/spec/jobs/organization_export_job_spec.rb
@@ -332,8 +332,9 @@ RSpec.describe OrganizationExportJob, type: :job do
           end
         end
         context "including every available field + stickers" do
-          let(:enabled_feature_slugs) { OrganizationFeature::REG_FIELDS + %w[bike_stickers impound_bikes show_partial_registrations] }
+          let(:enabled_feature_slugs) { OrganizationFeature::REG_FIELDS + %w[bike_stickers impound_bikes registration_notes show_partial_registrations] }
           let(:export_options) { {headers: Export.permitted_headers(organization)} }
+          let!(:bike_organization_note) { FactoryBot.create(:bike_organization_note, bike:, organization:, body: "Sold at the fall swap") }
           let(:bike_row_hash) do
             {
               color: "Black",
@@ -358,6 +359,7 @@ RSpec.describe OrganizationExportJob, type: :job do
               partial_registration: nil,
               is_impounded: nil,
               impounded_at: nil,
+              organization_notes: "Sold at the fall swap",
               address: "717 Market St",
               address_2: nil,
               city: "San Francisco",
@@ -401,6 +403,21 @@ RSpec.describe OrganizationExportJob, type: :job do
             expect(line_hash).to match_hash_indifferently(bike_row_hash)
             expect(generated_csv_string).to eq csv_string
           end
+        end
+      end
+
+      context "header only organization_notes" do
+        let(:enabled_feature_slugs) { %w[csv_exports registration_notes] }
+        let(:target_headers) { %w[organization_notes] }
+        let(:export_options) { {headers: target_headers} }
+        let!(:bike_organization_note) { FactoryBot.create(:bike_organization_note, bike:, organization:, body: "Sold at the fall swap") }
+        let!(:other_organization_note) { FactoryBot.create(:bike_organization_note, bike:, organization: FactoryBot.create(:organization), body: "Not this org") }
+        it "returns the note from the export's organization" do
+          instance.perform(export.id)
+          export.reload
+          expect(instance.export_headers).to eq target_headers
+          expect(export.progress).to eq "finished"
+          expect(export.file.read.split("\n").last).to eq "\"Sold at the fall swap\""
         end
       end
 

--- a/spec/jobs/organization_export_job_spec.rb
+++ b/spec/jobs/organization_export_job_spec.rb
@@ -407,7 +407,6 @@ RSpec.describe OrganizationExportJob, type: :job do
       end
 
       context "header only organization_notes" do
-        let(:enabled_feature_slugs) { %w[csv_exports registration_notes] }
         let(:target_headers) { %w[organization_notes] }
         let(:export_options) { {headers: target_headers} }
         let!(:bike_organization_note) { FactoryBot.create(:bike_organization_note, bike:, organization:, body: "Sold at the fall swap") }

--- a/spec/models/export_spec.rb
+++ b/spec/models/export_spec.rb
@@ -311,6 +311,7 @@ RSpec.describe Export, type: :model do
         model
         motorized
         organization_affiliation
+        organization_notes
         owner_email
         owner_name
         partial_registration
@@ -331,10 +332,10 @@ RSpec.describe Export, type: :model do
       expect(organization_reg_phone.additional_registration_fields).to eq(["reg_phone"])
       expect(Export.permitted_headers(organization_reg_phone)).to eq(permitted_headers + ["phone"])
       expect(organization_full.additional_registration_fields.map { |s| s.gsub("reg_", "") }).to eq additional_headers
-      expect(Export.permitted_headers(organization_full).sort).to eq(all_headers - %w[is_impounded impounded_at partial_registration])
+      expect(Export.permitted_headers(organization_full).sort).to eq(all_headers - %w[is_impounded impounded_at organization_notes partial_registration])
     end
-    context "with impounded and partial" do
-      let!(:organization) { FactoryBot.create(:organization_with_organization_features, enabled_feature_slugs: %w[impound_bikes show_partial_registrations]) }
+    context "with impounded, partial and notes" do
+      let!(:organization) { FactoryBot.create(:organization_with_organization_features, enabled_feature_slugs: %w[impound_bikes registration_notes show_partial_registrations]) }
       # All headers except the reg_field headers
       let(:permitted_headers) { all_headers - %w[address bike_sticker organization_affiliation phone student_id] }
       it "returns the array we expect" do

--- a/spec/requests/organized/exports_request_spec.rb
+++ b/spec/requests/organized/exports_request_spec.rb
@@ -154,6 +154,19 @@ RSpec.describe Organized::ExportsController, type: :request do
           end
         end
       end
+      context "with the organization_notes header" do
+        let(:enabled_feature_slugs) { %w[csv_exports registration_notes] }
+        let(:export) do
+          FactoryBot.create(:export_organization, organization: current_organization,
+            options: Export.default_options("organization").merge("headers" => %w[link organization_notes]))
+        end
+        it "lists the notes column" do
+          get "#{base_url}/#{export.id}"
+          expect(response.code).to eq("200")
+          expect(export.written_headers).to eq(%w[link organization_notes])
+          expect(response.body).to include("Organization notes")
+        end
+      end
       context "with impounded_bikes only" do
         let(:export) { FactoryBot.create(:export_organization, organization: current_organization, options: Export.default_options("organization").merge("impounded_bikes" => true, "partial_registrations" => "none")) }
         it "shows Impounded" do
@@ -214,6 +227,15 @@ RSpec.describe Organized::ExportsController, type: :request do
           expect(response.code).to eq("200")
           expect(response).to render_template(:new)
           expect(flash).to_not be_present
+        end
+      end
+      context "organization with registration_notes" do
+        let(:enabled_feature_slugs) { %w[csv_exports registration_notes] }
+        it "offers the notes column" do
+          get "#{base_url}/new"
+          expect(response.code).to eq("200")
+          expect(response.body).to include("export_headers_organization_notes")
+          expect(response.body).to include("Organization Notes")
         end
       end
       context "passed properties" do

--- a/spec/requests/organized/exports_request_spec.rb
+++ b/spec/requests/organized/exports_request_spec.rb
@@ -154,19 +154,6 @@ RSpec.describe Organized::ExportsController, type: :request do
           end
         end
       end
-      context "with the organization_notes header" do
-        let(:enabled_feature_slugs) { %w[csv_exports registration_notes] }
-        let(:export) do
-          FactoryBot.create(:export_organization, organization: current_organization,
-            options: Export.default_options("organization").merge("headers" => %w[link organization_notes]))
-        end
-        it "lists the notes column" do
-          get "#{base_url}/#{export.id}"
-          expect(response.code).to eq("200")
-          expect(export.written_headers).to eq(%w[link organization_notes])
-          expect(response.body).to include("Organization notes")
-        end
-      end
       context "with impounded_bikes only" do
         let(:export) { FactoryBot.create(:export_organization, organization: current_organization, options: Export.default_options("organization").merge("impounded_bikes" => true, "partial_registrations" => "none")) }
         it "shows Impounded" do


### PR DESCRIPTION
Organizations with `registration_notes` can search their bikes' notes but had no way to export them — the note wasn't among the columns an export could carry.

- **`organization_notes` joins the feature-gated headers**, alongside `is_impounded` and `partial_registration`, so it shows up as a column choice on the new-export form and in the export's own column list. Both build those lists from the header set, so neither view needed changing.
- **A bike can carry notes from several organizations**; an export only ever writes the exporting organization's.
- **The notes load in one query per export**, keyed by bike id, rather than one per exported row.
