### PR TITLE
Stop a double tap from wedging the hamburgler menu

### DIFF
--- a/.claude/skills/integration-testing/SKILL.md
+++ b/.claude/skills/integration-testing/SKILL.md
@@ -106,6 +106,14 @@ drop the cap to 1ms and the assertions it protects should fail.
 
 `element.evaluate_script` may return a Promise; the driver awaits it before handing back.
 
+## A negative matcher can't wait for a state to settle
+
+`have_no_css`/`have_no_link` match the instant the condition holds, so a state that arrives
+*late* — a class an orphaned `setTimeout` re-adds — never gets asserted, and the example
+passes against the bug it was written for. Wait on a positive signal the sequence drops last,
+then assert the absence: `spec/integration/mobile_nav_menu_spec.rb` waits out
+`nav.primary-header-nav.enabled` before asserting `menu-in` is gone.
+
 ## Carry state forward, don't reset between phases
 
 You know what state the page is in after each click — write the next assertion against that state. Don't click a "Reset" / "Clear" between phases just to get a clean slate; resets cost a click (often two — clear, then re-establish), obscure what's actually happening, and tempt you to think of each phase as an isolated scenario rather than as one continuous user flow.

--- a/app/assets/stylesheets/revised/pages/landing/_home.scss
+++ b/app/assets/stylesheets/revised/pages/landing/_home.scss
@@ -89,7 +89,9 @@
   }
 }
 
-@media screen and (min-width: 991px) {
+// $grid-breakpoint-lg is where the menu stops being the hamburgler's and carries a
+// signup link of its own -- a pixel earlier and neither one shows
+@media screen and (min-width: $grid-breakpoint-lg) {
   .center-navbar-signup-link-container {
     display: none;
   }

--- a/app/assets/stylesheets/revised/pages/landing/_home.scss
+++ b/app/assets/stylesheets/revised/pages/landing/_home.scss
@@ -89,8 +89,7 @@
   }
 }
 
-// $grid-breakpoint-lg is where the menu stops being the hamburgler's and carries a
-// signup link of its own -- a pixel earlier and neither one shows
+// Below $grid-breakpoint-lg the menu's own signup link is still behind the hamburgler
 @media screen and (min-width: $grid-breakpoint-lg) {
   .center-navbar-signup-link-container {
     display: none;

--- a/app/components/shared_blocks/navbar/primary_menu/component.rb
+++ b/app/components/shared_blocks/navbar/primary_menu/component.rb
@@ -20,7 +20,7 @@ module SharedBlocks
             {label: translation(".stolen_bike"), path: get_your_stolen_bike_back_path},
             {label: translation(".donate"), path: why_donate_path},
             {label: translation(".blog"), path: news_index_path, match_paths: "#{news_index_path}/**"},
-            marketplace_item("d-lg-block"),
+            marketplace_item("d-none d-lg-block"),
             search_item("d-none d-lg-block")]
         end
 

--- a/app/components/shared_blocks/navbar/primary_menu/component.rb
+++ b/app/components/shared_blocks/navbar/primary_menu/component.rb
@@ -5,6 +5,10 @@ module SharedBlocks
     module PrimaryMenu
       # The navbar's main menu, rendered from a manifest of items rather than repeated markup
       class Component < ApplicationComponent
+        # Rows that exist on both sides of the navbar's breakpoint, so each has to hide
+        # on the other -- the desktop side takes two classes, mobile-first
+        SIDE_CLASSES = {mobile: "d-lg-none", desktop: "d-none d-lg-block"}.freeze
+
         def initialize(current_user_or_unconfirmed_user:)
           @current_user_or_unconfirmed_user = current_user_or_unconfirmed_user
         end
@@ -12,26 +16,28 @@ module SharedBlocks
         private
 
         def menu_items
-          [search_item("d-lg-none"),
-            marketplace_item("d-lg-none"),
-            {type: :divider, item_class: "d-lg-none"},
+          [search_item(:mobile),
+            marketplace_item(:mobile),
+            {type: :divider, item_class: SIDE_CLASSES.fetch(:mobile)},
             *account_items,
             {label: translation(".help"), path: help_path},
             {label: translation(".stolen_bike"), path: get_your_stolen_bike_back_path},
             {label: translation(".donate"), path: why_donate_path},
             {label: translation(".blog"), path: news_index_path, match_paths: "#{news_index_path}/**"},
-            marketplace_item("d-none d-lg-block"),
-            search_item("d-none d-lg-block")]
+            marketplace_item(:desktop),
+            search_item(:desktop)]
         end
 
         # Active anywhere in the registration search — any stolenness, a query, page 2 — which
         # naming no match_params gets: the stolenness this happens to link to isn't compared
-        def search_item(item_class)
-          {label: translation(".search"), path: helpers.default_bike_search_path, item_class:}
+        def search_item(side)
+          {label: translation(".search"), path: helpers.default_bike_search_path,
+           item_class: SIDE_CLASSES.fetch(side)}
         end
 
-        def marketplace_item(item_class)
-          {label: translation(".marketplace"), path: search_marketplace_path, item_class:}
+        def marketplace_item(side)
+          {label: translation(".marketplace"), path: search_marketplace_path,
+           item_class: SIDE_CLASSES.fetch(side)}
         end
 
         def account_items

--- a/app/components/shared_blocks/navbar/wrapper/component.rb
+++ b/app/components/shared_blocks/navbar/wrapper/component.rb
@@ -8,7 +8,7 @@ module SharedBlocks
       # logo_only renders just the logo, for the OAuth authorization prompt.
       class Component < ApplicationComponent
         # Digest of the cached template — the cached_markup_digest spec keeps it current
-        MARKUP_DIGEST = "9d184aaa2192"
+        MARKUP_DIGEST = "4df279b0c5ca"
 
         def initialize(logo_only: false, current_user: nil, current_user_or_unconfirmed_user: nil,
           passive_organization: nil, old_register_view: false)

--- a/app/components/shared_blocks/navbar/wrapper/component.rb
+++ b/app/components/shared_blocks/navbar/wrapper/component.rb
@@ -8,7 +8,7 @@ module SharedBlocks
       # logo_only renders just the logo, for the OAuth authorization prompt.
       class Component < ApplicationComponent
         # Digest of the cached template — the cached_markup_digest spec keeps it current
-        MARKUP_DIGEST = "ba04b4fef410"
+        MARKUP_DIGEST = "9d184aaa2192"
 
         def initialize(logo_only: false, current_user: nil, current_user_or_unconfirmed_user: nil,
           passive_organization: nil, old_register_view: false)

--- a/app/javascript/controllers/shared_blocks/navbar_controller.js
+++ b/app/javascript/controllers/shared_blocks/navbar_controller.js
@@ -25,10 +25,7 @@ export default class extends Controller {
     this.hamburglerButtonTarget.dataset.active = 'true'
     this.hamburglerButtonTarget.setAttribute('aria-expanded', 'true')
     // So that it animates in, rather than appearing
-    this.afterTransition(() => {
-      this.element.classList.add('menu-in')
-      document.body.classList.add('menu-in')
-    }, 50)
+    setTimeout(() => this.syncMenu(), 50)
   }
 
   closeMenu () {
@@ -37,15 +34,17 @@ export default class extends Controller {
     this.element.classList.remove('menu-in')
     document.body.classList.remove('menu-in')
     // Hide it once it has animated out, so it stays hidden even on opera mini
-    this.afterTransition(() => this.element.classList.remove('enabled'), TRANSITION_MS)
+    setTimeout(() => this.syncMenu(), TRANSITION_MS)
   }
 
-  // Both halves of the toggle finish in a timeout, so a second tap arriving before
-  // one ran left it to apply half of the state it had just undone: the backdrop up
-  // over an unscrollable page, or the menu display:none behind an open hamburgler
-  afterTransition (change, delay) {
-    clearTimeout(this.pendingTransition)
-    this.pendingTransition = setTimeout(change, delay)
+  // Both halves of the toggle land in a timeout, so read the state where it runs
+  // rather than where it was scheduled -- a tap in between makes the other stale
+  syncMenu () {
+    const open = this.menuOpen
+
+    this.element.classList.toggle('menu-in', open)
+    document.body.classList.toggle('menu-in', open)
+    this.element.classList.toggle('enabled', open)
   }
 
   toggleDropdown (event) {

--- a/app/javascript/controllers/shared_blocks/navbar_controller.js
+++ b/app/javascript/controllers/shared_blocks/navbar_controller.js
@@ -25,7 +25,7 @@ export default class extends Controller {
     this.hamburglerButtonTarget.dataset.active = 'true'
     this.hamburglerButtonTarget.setAttribute('aria-expanded', 'true')
     // So that it animates in, rather than appearing
-    setTimeout(() => {
+    this.afterTransition(() => {
       this.element.classList.add('menu-in')
       document.body.classList.add('menu-in')
     }, 50)
@@ -37,7 +37,15 @@ export default class extends Controller {
     this.element.classList.remove('menu-in')
     document.body.classList.remove('menu-in')
     // Hide it once it has animated out, so it stays hidden even on opera mini
-    setTimeout(() => this.element.classList.remove('enabled'), TRANSITION_MS)
+    this.afterTransition(() => this.element.classList.remove('enabled'), TRANSITION_MS)
+  }
+
+  // Both halves of the toggle finish in a timeout, so a second tap arriving before
+  // one ran left it to apply half of the state it had just undone: the backdrop up
+  // over an unscrollable page, or the menu display:none behind an open hamburgler
+  afterTransition (change, delay) {
+    clearTimeout(this.pendingTransition)
+    this.pendingTransition = setTimeout(change, delay)
   }
 
   toggleDropdown (event) {

--- a/spec/components/shared_blocks/navbar/primary_menu/component_spec.rb
+++ b/spec/components/shared_blocks/navbar/primary_menu/component_spec.rb
@@ -23,6 +23,15 @@ RSpec.describe SharedBlocks::Navbar::PrimaryMenu::Component, type: :component do
     expect(component.css("#primary-main-menu a.signup-link").map { |link| link.text.strip }).to eq(["Sign up"])
   end
 
+  # Search and Marketplace are listed twice, once for each side of the breakpoint, so
+  # a row missing its d-none shows alongside the one meant to replace it
+  it "hides the wrong side of each breakpoint-paired item" do
+    ["Search", "Marketplace"].each do |label|
+      expect(links_named(label).map { |link| link.parent["class"] })
+        .to eq(["primary-nav-item d-lg-none", "primary-nav-item d-none d-lg-block"])
+    end
+  end
+
   # The links carry a stolenness the page won't, and the page carries a query and a page
   # number they don't, so naming no params is what keeps them active across the search
   it "covers the search and marketplace pages whatever they're filtered by" do

--- a/spec/components/shared_blocks/navbar/primary_menu/component_spec.rb
+++ b/spec/components/shared_blocks/navbar/primary_menu/component_spec.rb
@@ -21,11 +21,7 @@ RSpec.describe SharedBlocks::Navbar::PrimaryMenu::Component, type: :component do
     # Every row is a nav-link; only the signup one carries a second class
     expect(component.css("#primary-main-menu a.nav-link").count).to eq menu_links.count
     expect(component.css("#primary-main-menu a.signup-link").map { |link| link.text.strip }).to eq(["Sign up"])
-  end
-
-  # Search and Marketplace are listed twice, once for each side of the breakpoint, so
-  # a row missing its d-none shows alongside the one meant to replace it
-  it "hides the wrong side of each breakpoint-paired item" do
+    # Search and Marketplace render a row per side of the breakpoint, so each hides on the other
     ["Search", "Marketplace"].each do |label|
       expect(links_named(label).map { |link| link.parent["class"] })
         .to eq(["primary-nav-item d-lg-none", "primary-nav-item d-none d-lg-block"])

--- a/spec/integration/mobile_nav_menu_spec.rb
+++ b/spec/integration/mobile_nav_menu_spec.rb
@@ -28,15 +28,13 @@ RSpec.describe "Navbar", :js, type: :system do
     within("nav.primary-header-nav") { expect(page).to have_no_link("Search") }
     expect_axe_clean
 
-    # An impatient double tap closes the menu before the open has animated in, and the
-    # tail of that open used to raise the backdrop over a page whose menu had already
-    # gone -- nothing below the navbar tappable, and the body left unscrollable.
-    # Absence matches the moment it's true, so wait the animations out before reading it
+    # A double tap closes the menu mid-open, and the tail of that open must not raise the
+    # backdrop over a page the menu has left -- which locks body scroll too. `enabled` is
+    # what the close drops last, so waiting on it is waiting for the settled state
     find("#primary_nav_hamburgler").double_click
     expect(page).to have_css(".hamburgler button[aria-expanded='false']")
-    sleep 0.3
+    expect(page).to have_no_css("nav.primary-header-nav.enabled")
     expect(page).to have_no_css("nav.primary-header-nav.menu-in")
-    expect(page).to have_no_css("body.menu-in")
 
     open_menu_and_search
 

--- a/spec/integration/mobile_nav_menu_spec.rb
+++ b/spec/integration/mobile_nav_menu_spec.rb
@@ -28,6 +28,16 @@ RSpec.describe "Navbar", :js, type: :system do
     within("nav.primary-header-nav") { expect(page).to have_no_link("Search") }
     expect_axe_clean
 
+    # An impatient double tap closes the menu before the open has animated in, and the
+    # tail of that open used to raise the backdrop over a page whose menu had already
+    # gone -- nothing below the navbar tappable, and the body left unscrollable.
+    # Absence matches the moment it's true, so wait the animations out before reading it
+    find("#primary_nav_hamburgler").double_click
+    expect(page).to have_css(".hamburgler button[aria-expanded='false']")
+    sleep 0.3
+    expect(page).to have_no_css("nav.primary-header-nav.menu-in")
+    expect(page).to have_no_css("body.menu-in")
+
     open_menu_and_search
 
     # The banner pushes the navbar down, further still when its title wraps


### PR DESCRIPTION
A tablet bug report: the hamburgler stopped responding to touch, and nothing below it could be tapped either. Both halves of the menu toggle finish in a `setTimeout` and each wrote its half blind, so a second tap inside the window left the stale one to apply what it had just undone — the backdrop raised over a closed menu, which locks body scroll as well, or the menu hidden behind a hamburgler showing open.

- **The deferred halves read the button rather than assuming the state they were scheduled in**, so a stale timer is a no-op instead of something to cancel. Reproduced on production at 810px, and the system spec double-taps for it.
- **The centred signup link hid a pixel before the desktop menu appeared** — at exactly 991px a signed-out visitor had no Sign up anywhere, one being hidden and the other still behind the hamburgler.
- **Marketplace rendered twice in the hamburgler menu.** Rows paired across the breakpoint go through `SIDE_CLASSES` now, so one can't lose its `d-none` the way this did.

Left alone: the hamburgler's tap target is 32×66 CSS px, well under the 44pt minimum and sitting ~60px in from the right edge of an iPad-portrait screen — which is plausibly what has people tapping it twice to begin with.
