### PR TITLE
Let a clicked-open tooltip's text be clicked and selected

### DIFF
--- a/.claude/skills/frontend-screenshots/SKILL.md
+++ b/.claude/skills/frontend-screenshots/SKILL.md
@@ -123,7 +123,7 @@ $BASE_URL/rails/view_components/<preview_path>/<scenario>
 
 `<preview_path>` is the preview class underscored with the `Preview` suffix dropped, and `<scenario>` is the preview method. `SharedBlocks::ReviewAppBanner::ComponentPreview#superadmin_signed_in` → `/rails/view_components/shared_blocks/review_app_banner/component/superadmin_signed_in`. If a scenario doesn't exist yet, add a method to the component's `*_preview.rb` first — a preview that renders the exact state (pass the args that trigger it) is often the fastest path to a clean shot.
 
-Use this bare route, not Lookbook's `/lookbook/...`, which wraps the component in its own browser chrome.
+Use this bare route, not Lookbook's `/lookbook/inspect/...`, which wraps the component in its own browser chrome. `/lookbook/preview/<preview_path>/<scenario>` renders bare as well, and it's the one route that puts a whole `@!group` on a single page — `/lookbook/preview/ui/tooltip/variants` for `UI::Tooltip::ComponentPreview`'s `# @!group Variants`. Reach for it when the shot needs several scenarios side by side; the component's system spec usually already visits it.
 
 The preview page loads Tailwind and renders the component standalone (no site chrome), so a preview that fits the viewport captures at `fullPage: false`; a small ViewComponent render-timing line at the bottom is harmless. **A preview taller than the viewport still captures `fullPage: true`** — page-sized components (a whole registration step, a long form) put the changed field below 900px, and cropping it out is the one thing the shot exists to show. Measure before choosing:
 

--- a/app/components/pages/admin/bikes/table/component.rb
+++ b/app/components/pages/admin/bikes/table/component.rb
@@ -10,7 +10,7 @@ module Pages
         # checkboxes, and skip_user to drop the owner column.
         class Component < ApplicationComponent
           # Digest of the markup inside the row cache — the cached_markup_digest spec keeps it current
-          MARKUP_DIGEST = "1ec53bba12a2"
+          MARKUP_DIGEST = "d6ad3706501d"
 
           def initialize(bikes:, sort_state: ComponentStructs::SortState.new, display_dev_info: false, no_show_header: false,
             show_serial: false, skip_manufacturer_link: false, render_sortable: false,

--- a/app/components/pages/admin/bug_reports_table/component.html.erb
+++ b/app/components/pages/admin/bug_reports_table/component.html.erb
@@ -58,7 +58,7 @@
             <div class="tw:w-96 tw:text-left">
               <%= content_tag(:strong, bug_report.display_subject) %>
 
-              <%# truncated because the tooltip can't be scrolled - it has no pointer events %>
+              <%# truncated because the tooltip has no scroll container %>
               <%= content_tag(:div, bug_report.body_stripped.truncate(1000), class: "tw:mt-1 tw:whitespace-pre-wrap") %>
             </div>
           <% end %>

--- a/app/components/pages/admin/bug_reports_table/component.rb
+++ b/app/components/pages/admin/bug_reports_table/component.rb
@@ -5,7 +5,7 @@ module Pages
     module BugReportsTable
       class Component < ApplicationComponent
         # Digest of the markup inside the row cache — the cached_markup_digest spec keeps it current
-        MARKUP_DIGEST = "c04dac65c964"
+        MARKUP_DIGEST = "6d302b939ecc"
 
         def initialize(collection:, searchable_tags:, sort_state: ComponentStructs::SortState.new, display_dev_info: false, render_sortable: false)
           @collection = collection

--- a/app/components/pages/admin/users/table/component.rb
+++ b/app/components/pages/admin/users/table/component.rb
@@ -8,7 +8,7 @@ module Pages
         # render_deleted to show the deleted_at column.
         class Component < ApplicationComponent
           # Digest of the markup inside the row cache — the cached_markup_digest spec keeps it current
-          MARKUP_DIGEST = "d159d4a54dcf"
+          MARKUP_DIGEST = "a50532e374ce"
 
           def initialize(users:, sort_state: ComponentStructs::SortState.new, display_dev_info: false, render_sortable: false, render_deleted: false)
             @users = users

--- a/app/components/pages/org/search_results/bikes_table/component.rb
+++ b/app/components/pages/org/search_results/bikes_table/component.rb
@@ -10,7 +10,7 @@ module Pages
         # registrations on the show page). Pass render_sortable to enable sort links.
         class Component < ApplicationComponent
           # Digest of the markup inside the row cache — the cached_markup_digest spec keeps it current
-          MARKUP_DIGEST = "8792c7903158"
+          MARKUP_DIGEST = "ecc893d19cb9"
 
           delegate :additional_registration_fields, :column_renames, to: :settings_component
 

--- a/app/components/pages/registrations/show/wrapper/component.rb
+++ b/app/components/pages/registrations/show/wrapper/component.rb
@@ -9,7 +9,7 @@ module Pages
         class Component < ApplicationComponent
           # Digest of the markup inside the cache block — the cached_markup_digest spec
           # keeps it current, following what this tree renders out into UI:: and elsewhere
-          MARKUP_DIGEST = "c15e0c686b2c"
+          MARKUP_DIGEST = "0088e0e23726"
 
           def initialize(bike:, current_user:, view:, available_views:, bike_sticker: nil, current_alerts: {}, display_dev_info: false)
             @bike = bike

--- a/app/components/ui/tooltip/component.rb
+++ b/app/components/ui/tooltip/component.rb
@@ -62,20 +62,14 @@ module UI
         body? ? body : @text
       end
 
-      # A link or button in the body means the tooltip is meant to be clicked
-      # into (it stays open on click), so the popup needs pointer events.
-      def interactive_body?
-        tooltip_body.to_s.match?(/<(a|button)[\s>]/)
-      end
-
+      # The controller drops pointer-events-none once the tooltip is held open
       def tooltip_span
-        pointer = interactive_body? ? "tw:pointer-events-auto" : "tw:pointer-events-none"
         tag.span(
           tooltip_body,
           role: "tooltip",
           id: tooltip_id,
           data: {"ui--tooltip-target": "tooltip"},
-          class: "tw:twtext-color tw:hidden #{pointer} tw:whitespace-nowrap tw:rounded " \
+          class: "tw:twtext-color tw:hidden tw:pointer-events-none tw:whitespace-nowrap tw:rounded " \
             "tw:bg-white tw:px-2 tw:py-1 tw:text-xs tw:font-normal tw:border tw:border-gray-200 tw:shadow-lg tw:z-50 " \
             "tw:dark:bg-gray-800 tw:dark:border-gray-700"
         )

--- a/app/javascript/controllers/ui/tooltip_controller.js
+++ b/app/javascript/controllers/ui/tooltip_controller.js
@@ -6,7 +6,8 @@ import { claimFloatingZIndex, releaseFloatingZIndex } from 'utils/floating_z_ind
 //
 // State model: two independent flags, OR'd together.
 //   hoverActive       toggled by mouseenter/mouseleave
-//   persistentActive  toggled by focus / cleared by focusout or click-outside
+//   persistentActive  toggled by focus / cleared by a click outside or focus moving
+//                     to another element in the page
 // The tooltip is visible whenever either flag is true.
 export default class extends Controller {
   static targets = ['trigger', 'tooltip']
@@ -44,7 +45,11 @@ export default class extends Controller {
     this.sync()
   }
 
-  hideOnFocusout () {
+  // Only focus landing on another element in the page dismisses. A focusout with
+  // nowhere to go is the browser window losing focus (the rider switched program)
+  // or a click on the tooltip itself - neither means they're done with it.
+  hideOnFocusout (event) {
+    if (!event.relatedTarget || this.element.contains(event.relatedTarget)) return
     this.persistentActive = false
     this.sync()
   }
@@ -63,6 +68,9 @@ export default class extends Controller {
   }
 
   sync () {
+    // Only a held-open tooltip takes pointer events, so its text can be clicked
+    // and selected; a hover-only one stays transparent to the mouse.
+    this.tooltipTarget.classList.toggle('tw:pointer-events-none', !this.persistentActive)
     if (this.hoverActive || this.persistentActive) this.open()
     else this.close()
   }

--- a/app/javascript/controllers/ui/tooltip_controller.js
+++ b/app/javascript/controllers/ui/tooltip_controller.js
@@ -45,9 +45,8 @@ export default class extends Controller {
     this.sync()
   }
 
-  // Only focus landing on another element in the page dismisses. A focusout with
-  // nowhere to go is the browser window losing focus (the rider switched program)
-  // or a click on the tooltip itself - neither means they're done with it.
+  // A focusout with a null relatedTarget is the window losing focus to another
+  // program - not a dismissal
   hideOnFocusout (event) {
     if (!event.relatedTarget || this.element.contains(event.relatedTarget)) return
     this.persistentActive = false
@@ -68,8 +67,8 @@ export default class extends Controller {
   }
 
   sync () {
-    // Only a held-open tooltip takes pointer events, so its text can be clicked
-    // and selected; a hover-only one stays transparent to the mouse.
+    // Pointer events only while held open - always-on would swallow clicks on
+    // whatever a hover-only tooltip overlaps
     this.tooltipTarget.classList.toggle('tw:pointer-events-none', !this.persistentActive)
     if (this.hoverActive || this.persistentActive) this.open()
     else this.close()

--- a/spec/components/ui/tooltip/component_spec.rb
+++ b/spec/components/ui/tooltip/component_spec.rb
@@ -12,10 +12,6 @@ RSpec.describe UI::Tooltip::Component, type: :component do
     expect(component.text).to include "trigger"
   end
 
-  it "starts the tooltip click-through" do
-    expect(component.css("[role='tooltip']").first["class"]).to include "tw:pointer-events-none"
-  end
-
   it "wires aria-describedby to the tooltip id" do
     tooltip_id = component.css("[role='tooltip']").attr("id").value
     expect(tooltip_id).to be_present

--- a/spec/components/ui/tooltip/component_spec.rb
+++ b/spec/components/ui/tooltip/component_spec.rb
@@ -12,6 +12,10 @@ RSpec.describe UI::Tooltip::Component, type: :component do
     expect(component.text).to include "trigger"
   end
 
+  it "starts the tooltip click-through" do
+    expect(component.css("[role='tooltip']").first["class"]).to include "tw:pointer-events-none"
+  end
+
   it "wires aria-describedby to the tooltip id" do
     tooltip_id = component.css("[role='tooltip']").attr("id").value
     expect(tooltip_id).to be_present
@@ -69,11 +73,10 @@ RSpec.describe UI::Tooltip::Component, type: :component do
       end
     end
 
-    it "keeps the trigger a button and makes the popup clickable, not nested in the button" do
+    it "keeps the trigger a button, with the link in the popup rather than nested in the button" do
       trigger = component.css("[aria-describedby]").first
       expect(trigger.name).to eq "button"
       tooltip = component.css("[role='tooltip']").first
-      expect(tooltip["class"]).to include "tw:pointer-events-auto"
       expect(tooltip.at_css("a")[:href]).to eq "/commit/abc"
       expect(component.css("button a")).to be_empty
     end

--- a/spec/components/ui/tooltip/component_system_spec.rb
+++ b/spec/components/ui/tooltip/component_system_spec.rb
@@ -14,7 +14,6 @@ RSpec.describe UI::Tooltip::Component, :js, type: :system do
     JS
   end
 
-  # The id of the tooltip the current text selection sits inside, if any
   def selected_tooltip_id
     page.evaluate_script(<<~JS)
       (() => {
@@ -109,21 +108,19 @@ RSpec.describe UI::Tooltip::Component, :js, type: :system do
     find("body").click
     expect(tooltip).not_to be_visible
 
-    # Clicking the trigger persists the tooltip through mouseleave until a body click
+    # Clicking the trigger persists the tooltip through mouseleave until a body click,
+    # and only a held-open tooltip takes pointer events rather than being click-through
     trigger.hover
+    expect(tooltip[:class]).to include "tw:pointer-events-none"
     trigger.click
+    expect(tooltip[:class]).not_to include "tw:pointer-events-none"
     find("body").hover
     expect(tooltip).to be_visible
     find("body").click
     expect(tooltip).not_to be_visible
 
-    # A hovered tooltip is click-through; clicking the trigger open makes its text clickable
-    trigger.hover
-    expect(tooltip[:class]).to include "tw:pointer-events-none"
-    trigger.click
-    expect(tooltip[:class]).not_to include "tw:pointer-events-none"
-
     # Clicking the tooltip text leaves it open, so it can be selected
+    trigger.click
     tooltip.click
     find("body").hover
     expect(tooltip).to be_visible

--- a/spec/components/ui/tooltip/component_system_spec.rb
+++ b/spec/components/ui/tooltip/component_system_spec.rb
@@ -14,6 +14,16 @@ RSpec.describe UI::Tooltip::Component, :js, type: :system do
     JS
   end
 
+  # The id of the tooltip the current text selection sits inside, if any
+  def selected_tooltip_id
+    page.evaluate_script(<<~JS)
+      (() => {
+        const node = document.getSelection().anchorNode
+        return node && node.parentElement.closest("[role='tooltip']")?.id
+      })()
+    JS
+  end
+
   def tooltip_z_index(id)
     page.evaluate_script("document.getElementById(#{id.to_json}).style.zIndex")
   end
@@ -70,15 +80,15 @@ RSpec.describe UI::Tooltip::Component, :js, type: :system do
     page.execute_script("arguments[0].focus()", trigger)
     find("body").hover
     expect(tooltip).to be_visible
-    page.execute_script("arguments[0].blur()", trigger)
+    find("body").click
     expect(tooltip).not_to be_visible
 
-    # Focus-then-hover is symmetric: stays through mouseleave until blur
+    # Focus-then-hover is symmetric: stays through mouseleave until the click outside
     page.execute_script("arguments[0].focus()", trigger)
     trigger.hover
     find("body").hover
     expect(tooltip).to be_visible
-    page.execute_script("arguments[0].blur()", trigger)
+    find("body").click
     expect(tooltip).not_to be_visible
 
     # Focus moving to another trigger hides the first
@@ -87,7 +97,17 @@ RSpec.describe UI::Tooltip::Component, :js, type: :system do
     expect(tooltips.first).to be_visible
     page.execute_script("arguments[0].focus()", triggers.last)
     expect(tooltips.first).not_to be_visible
-    page.execute_script("arguments[0].blur()", triggers.last)
+    find("body").click
+
+    # Focus leaving with nowhere else to land - the browser window losing focus to
+    # another program - is not a dismissal
+    page.execute_script("arguments[0].focus()", trigger)
+    find("body").hover
+    expect(tooltip).to be_visible
+    page.execute_script("arguments[0].blur()", trigger)
+    expect(tooltip).to be_visible
+    find("body").click
+    expect(tooltip).not_to be_visible
 
     # Clicking the trigger persists the tooltip through mouseleave until a body click
     trigger.hover
@@ -96,6 +116,33 @@ RSpec.describe UI::Tooltip::Component, :js, type: :system do
     expect(tooltip).to be_visible
     find("body").click
     expect(tooltip).not_to be_visible
+
+    # A hovered tooltip is click-through; clicking the trigger open makes its text clickable
+    trigger.hover
+    expect(tooltip[:class]).to include "tw:pointer-events-none"
+    trigger.click
+    expect(tooltip[:class]).not_to include "tw:pointer-events-none"
+
+    # Clicking the tooltip text leaves it open, so it can be selected
+    tooltip.click
+    find("body").hover
+    expect(tooltip).to be_visible
+    tooltip.double_click
+    expect(tooltip).to be_visible
+    expect(selected_tooltip_id).to eq tooltip_ids.first
+    find("body").click
+    expect(tooltip).not_to be_visible
+
+    # Tabbing from the trigger into a link in the popup keeps the tooltip open
+    commit_tooltip = find("a[href*='commit']", visible: :all).find(:xpath, "ancestor::*[@role='tooltip']", visible: :all)
+    commit_trigger = find("[aria-describedby='#{commit_tooltip[:id]}']")
+    commit_trigger.click
+    expect(commit_tooltip).to be_visible
+    commit_trigger.send_keys(:tab)
+    expect(commit_tooltip).to be_visible
+    expect(page.evaluate_script("document.activeElement.tagName")).to eq "A"
+    find("body").click
+    expect(commit_tooltip).not_to be_visible
 
     # Click layering pushes each clicked tooltip's z-index higher
     tooltip_ids.each { |id| find("[aria-describedby='#{id}']").click }


### PR DESCRIPTION
A tooltip's text couldn't be clicked or selected: the popup only took pointer events when its body happened to contain a link or button, sniffed with a regex over the rendered HTML. Even with pointer events, clicking the text moved focus to `<body>` and the `focusout` dismissed the tooltip out from under you — as did switching to another program's window.

- **Pointer events follow the state, not the body's markup.** The controller turns `pointer-events-none` off while the tooltip is held open, so a clicked-open one can be clicked and its text selected, while a hover-only one stays transparent to whatever it overlaps. A tooltip with a link in it now wants the trigger clicked first, which is the flow the preview already documented.
- **`focusout` only dismisses when focus lands somewhere else in the page.** A null `relatedTarget` means the window lost focus to another program, which isn't the rider being done with the tooltip. Clicking outside and Escape still dismiss, and Tab-away still does the job `focusout` is there for.
