### PR TITLE
footer link non-organized search, so it's reachable by organized users

### DIFF
--- a/app/components/shared_blocks/footer/component.html.erb
+++ b/app/components/shared_blocks/footer/component.html.erb
@@ -11,7 +11,7 @@
 
             <ul class="tw:m-0 tw:list-none">
               <li>
-                <%= render UI::ActiveLink::Component.new(text: translation(".search"), path: helpers.default_bike_search_path) %>
+                <%= render UI::ActiveLink::Component.new(text: translation(".search"), path: helpers.every_bike_search_path) %>
               </li>
 
               <li>

--- a/app/components/shared_blocks/footer/component.rb
+++ b/app/components/shared_blocks/footer/component.rb
@@ -5,21 +5,19 @@ module SharedBlocks
     class Component < ApplicationComponent
       FACEBOOK_PIXEL_ID = "199066297131941"
       # Digest of the cached template — the cached_markup_digest spec keeps it current
-      MARKUP_DIGEST = "145075234a5d"
+      MARKUP_DIGEST = "12bf831f75b7"
 
-      def initialize(current_user:, skip_facebook:, passive_organization: nil)
+      def initialize(current_user:, skip_facebook:)
         @current_user = current_user
         @skip_facebook = skip_facebook
-        @passive_organization = passive_organization
       end
 
       private
 
       # No page_id: the links resolve their own active state in the browser and the locale
-      # form submits to whatever URL it's on, so one render serves every page.
-      # passive_organization because the Search link points at its registrations
+      # form submits to whatever URL it's on, so one render serves every page
       def cache_key
-        [MARKUP_DIGEST, @current_user, @passive_organization, @skip_facebook]
+        [MARKUP_DIGEST, @current_user, @skip_facebook]
       end
     end
   end

--- a/app/controllers/concerns/controller_helpers.rb
+++ b/app/controllers/concerns/controller_helpers.rb
@@ -12,7 +12,7 @@ module ControllerHelpers
   included do
     helper_method :current_user, :current_user_or_unconfirmed_user, :sign_in_partner, :user_root_url,
       :current_organization, :passive_organization, :current_location,
-      :page_id, :default_bike_search_path, :bikehub_url, :show_general_alert,
+      :page_id, :default_bike_search_path, :every_bike_search_path, :bikehub_url, :show_general_alert,
       :display_dev_info?, :current_country_id, :current_currency, :turbo_request?,
       :render_donation_request?, :old_register_view?, :sort_state, :admin_index_state
     before_action :enable_rack_profiler

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -125,7 +125,7 @@
     <%# auto-sends the URL query string) %>
     <% skip_facebook = controller_namespace.in?(%w[organized org_public oauth]) || controller_name == "organizations" || params.key?(:search_email) || params.key?(:proximity) %>
 
-    <%= render SharedBlocks::Footer::Component.new(current_user:, skip_facebook:, passive_organization:) %>
+    <%= render SharedBlocks::Footer::Component.new(current_user:, skip_facebook:) %>
 
     <script>
   I18n.defaultLocale = <%== I18n.default_locale.to_json %>

--- a/app/views/layouts/doorkeeper.html.erb
+++ b/app/views/layouts/doorkeeper.html.erb
@@ -41,7 +41,7 @@
     </div>
 
     <%# OAuth pages never load the marketing pixel %>
-    <%= render SharedBlocks::Footer::Component.new(current_user:, skip_facebook: true, passive_organization:) %>
+    <%= render SharedBlocks::Footer::Component.new(current_user:, skip_facebook: true) %>
     <%= render "/shared/analytics" %>
   <% end %>
 </html>

--- a/spec/requests/my_accounts_request_spec.rb
+++ b/spec/requests/my_accounts_request_spec.rb
@@ -165,33 +165,17 @@ RSpec.describe MyAccountsController, type: :request do
     end
   end
 
-  # every_bike_search_path rather than default_bike_search_path: the organized nav already
-  # links an organization's own registrations, so this is a member's only way to the whole registry
+  # The organized nav already links an organization's own registrations, so the footer
+  # is a member's only way to the whole registry
   describe "the footer's Search link" do
-    def footer_search_href
-      Nokogiri::HTML(response.body).css("footer.primary-footer a")
+    include_context :request_spec_logged_in_as_organization_user
+
+    it "points at every registration" do
+      get base_url
+      expect(assigns[:passive_organization]).to eq current_organization
+      footer_search_href = Nokogiri::HTML(response.body).css("footer.primary-footer a")
         .find { |link| link.text.strip == "Search" }&.attr("href")
-    end
-
-    context "with an organization" do
-      include_context :request_spec_logged_in_as_organization_user
-
-      it "points at every registration" do
-        get base_url
-        expect(assigns[:passive_organization]).to eq current_organization
-        expect(footer_search_href).to eq search_registrations_path(stolenness: "all")
-      end
-    end
-
-    context "without an organization" do
-      include_context :request_spec_logged_in_as_user
-      let(:current_user) { FactoryBot.create(:user_confirmed) }
-
-      it "points at every registration" do
-        get base_url
-        expect(assigns[:passive_organization]).to be_nil
-        expect(footer_search_href).to eq search_registrations_path(stolenness: "all")
-      end
+      expect(footer_search_href).to eq search_registrations_path(stolenness: "all")
     end
   end
 

--- a/spec/requests/my_accounts_request_spec.rb
+++ b/spec/requests/my_accounts_request_spec.rb
@@ -165,8 +165,8 @@ RSpec.describe MyAccountsController, type: :request do
     end
   end
 
-  # default_bike_search_path resolves off passive_organization, so a member's Search link
-  # follows them to their own registrations away from the organization's own pages
+  # every_bike_search_path rather than default_bike_search_path: the organized nav already
+  # links an organization's own registrations, so this is a member's only way to the whole registry
   describe "the footer's Search link" do
     def footer_search_href
       Nokogiri::HTML(response.body).css("footer.primary-footer a")
@@ -176,11 +176,10 @@ RSpec.describe MyAccountsController, type: :request do
     context "with an organization" do
       include_context :request_spec_logged_in_as_organization_user
 
-      it "points at the organization's registrations" do
+      it "points at every registration" do
         get base_url
         expect(assigns[:passive_organization]).to eq current_organization
-        expect(footer_search_href)
-          .to eq organization_registrations_path(organization_id: current_organization.to_param)
+        expect(footer_search_href).to eq search_registrations_path(stolenness: "all")
       end
     end
 


### PR DESCRIPTION
An organized user gets the org sidebar in place of the navbar, and that sidebar's search link goes to their organization's own registrations. The footer's Search link resolved off `passive_organization` too, so it went to the same place — leaving nothing on the page that reached the whole registry.

- **Points the footer's Search link at `every_bike_search_path`**, so an organized user can still search every registration.
- **Drops the footer component's `passive_organization` argument**, which only existed to vary the fragment cache — one cached footer now serves every organization.
