### PR TITLE
Finish the UI::JsonDisplay conversion, remove pretty_print_json and coderay

### DIFF
--- a/.claude/skills/pr/SKILL.md
+++ b/.claude/skills/pr/SKILL.md
@@ -158,10 +158,10 @@ Most runs turn up nothing — say so and stop.
 
 Two bars before you edit a skill, because a wrong edit here is permanent and costs every future run:
 
-- **Did the skill already say it?** Diff the steps you ran against the steps as written. Out of order, or skipped, is your deviation — not a gap. A new rule stacked on the one you didn't follow leaves the skill longer and no better followed.
+- **Did the skill already say it?** Diff the steps you ran against the steps as written. Out of order or skipped is your deviation, so don't stack a new rule on the one you didn't follow. Revise the existing rule instead — reword it, or move it to where it gets read — since a rule you missed is a rule that was missable.
 - **Does it pay for itself?** Weigh how often the guidance fires against what it saves when it does, and state both. Guidance that runs every time to catch something rare is negative, however cheap each run looks.
 
-Then: if it's small and related to this PR, commit it onto the branch, push, and update the body if the change is worth a bullet. If it's larger or unrelated, tell the user what you'd change and where, and let them decide.
+Then make the edit — commit it onto the branch, push, and update the body if it's worth a bullet. Prefer editing to reporting: a change you only describe is one the next run rediscovers.
 
 Then return the PR URL.
 

--- a/.claude/skills/pr/SKILL.md
+++ b/.claude/skills/pr/SKILL.md
@@ -154,7 +154,14 @@ Last, before reporting the PR URL. Look back over the whole run and ask whether 
 - **Did the branch establish a convention?** A new pattern, a rule you had to infer from existing code, or a guideline you found yourself explaining — that's `CLAUDE.md` (root, or the nested one nearest the code).
 - **Did `/simplify` or the CLAUDE.md pass flag the same thing more than once?** A repeated correction is a missing written rule.
 
-Most runs turn up nothing — say so and stop. When something does: if it's small and related to this PR, commit it onto the branch, push, and update the body if the change is worth a bullet. If it's larger or unrelated, tell the user what you'd change and where, and let them decide.
+Most runs turn up nothing — say so and stop.
+
+Two bars before you edit a skill, because a wrong edit here is permanent and costs every future run:
+
+- **Did the skill already say it?** Diff the steps you ran against the steps as written. Out of order, or skipped, is your deviation — not a gap. A new rule stacked on the one you didn't follow leaves the skill longer and no better followed.
+- **Does it pay for itself?** Weigh how often the guidance fires against what it saves when it does, and state both. Guidance that runs every time to catch something rare is negative, however cheap each run looks.
+
+Then: if it's small and related to this PR, commit it onto the branch, push, and update the body if the change is worth a bullet. If it's larger or unrelated, tell the user what you'd change and where, and let them decide.
 
 Then return the PR URL.
 

--- a/.claude/skills/pr/references/screenshots.md
+++ b/.claude/skills/pr/references/screenshots.md
@@ -47,7 +47,7 @@ If it returns failures it couldn't diagnose, report them and leave the PR withou
 
 ## 3. Host the branch screenshots and get inline URLs
 
-Invoke `github-pr-images` with the PNGs from step 2 and **no body** — that's its host-only call, and it returns the `user-attachments/assets/` URLs without posting anything. The comment gets composed here in step 5 and posted by that same skill in one go at the end, so nothing lands on the PR until the before/after is complete. GitHub mints persistent URLs that render inline in the browser (release assets would force a download on click).
+Invoke `github-pr-images` with the PNGs from step 2 and **no body** — that's its host-only call, and it returns the `user-attachments/assets/` URLs without posting anything. This runs before step 4, not after it: the upload is the first thing to touch GitHub, so an expired browser session surfaces here, having cost one capture round rather than two and a base checkout. The comment gets composed here in step 5 and posted by that same skill in one go at the end, so nothing lands on the PR until the before/after is complete. GitHub mints persistent URLs that render inline in the browser (release assets would force a download on click).
 
 Collect the returned URLs, keyed by `(page-slug, viewport)`.
 

--- a/.claude/skills/pr/references/screenshots.md
+++ b/.claude/skills/pr/references/screenshots.md
@@ -10,6 +10,14 @@ The flow: decide what to capture → capture the branch → upload → capture t
 
 The Claude Code web sandbox is the case that has neither: no GitHub CLI, and an MCP browser that rejects the egress proxy's CA, so github.com won't even load (`ERR_CERT_AUTHORITY_INVALID`) and a logged-in session can't be established headlessly. Capture alone would work there, which is the trap — PNGs nothing can host, and no way to post them.
 
+**Check the browser's GitHub session here, not at upload time.** `gh auth status` says nothing about it — the MCP browser authenticates from its own `--storage-state` file, which expires on its own schedule, and a stale one first shows itself as a "Sign in" page at `github-pr-images`'s step 3. That's after both capture rounds and the base-branch checkout have been paid for. Navigate to the PR and look for the comment form, which is what the upload actually needs:
+
+```js
+() => !!document.querySelector('textarea[id*="comment"]') || !!document.querySelector('[aria-label="Add a comment"]')
+```
+
+False → skip the phase per the rule above. Regenerating that file needs the user to sign in to a headed browser (`github-pr-images`'s `references/headless-relogin.md`), so it's theirs to fix rather than something to drive yourself.
+
 **Skipping means posting nothing at all**, not posting something else. Substitute evidence — a rendered-HTML diff, a note about what couldn't be captured — reads as a fine idea in the moment and leaves a comment the next run can't find or replace, because it isn't the `## Screenshots` comment. That's how #4126 ended up with three comments telling one story. If the evidence is worth having, put it in your summary to the user and let them decide where it goes.
 
 ## Preflight: a CSS diff needs a fresh tailwind build

--- a/.claude/skills/pr/references/screenshots.md
+++ b/.claude/skills/pr/references/screenshots.md
@@ -10,14 +10,6 @@ The flow: decide what to capture → capture the branch → upload → capture t
 
 The Claude Code web sandbox is the case that has neither: no GitHub CLI, and an MCP browser that rejects the egress proxy's CA, so github.com won't even load (`ERR_CERT_AUTHORITY_INVALID`) and a logged-in session can't be established headlessly. Capture alone would work there, which is the trap — PNGs nothing can host, and no way to post them.
 
-**Check the browser's GitHub session here, not at upload time.** `gh auth status` says nothing about it — the MCP browser authenticates from its own `--storage-state` file, which expires on its own schedule, and a stale one first shows itself as a "Sign in" page at `github-pr-images`'s step 3. That's after both capture rounds and the base-branch checkout have been paid for. Navigate to the PR and look for the comment form, which is what the upload actually needs:
-
-```js
-() => !!document.querySelector('textarea[id*="comment"]') || !!document.querySelector('[aria-label="Add a comment"]')
-```
-
-False → skip the phase per the rule above. Regenerating that file needs the user to sign in to a headed browser (`github-pr-images`'s `references/headless-relogin.md`), so it's theirs to fix rather than something to drive yourself.
-
 **Skipping means posting nothing at all**, not posting something else. Substitute evidence — a rendered-HTML diff, a note about what couldn't be captured — reads as a fine idea in the moment and leaves a comment the next run can't find or replace, because it isn't the `## Screenshots` comment. That's how #4126 ended up with three comments telling one story. If the evidence is worth having, put it in your summary to the user and let them decide where it goes.
 
 ## Preflight: a CSS diff needs a fresh tailwind build

--- a/Gemfile
+++ b/Gemfile
@@ -99,7 +99,6 @@ gem "grape_logging" # Grape logging. Also how we pass it to lograge. Always used
 
 # Frontend
 gem "chartkick" # Display charts
-gem "coderay" # Pretty print code
 gem "coffee-rails"
 gem "groupdate" # Required for charts
 gem "premailer-rails" # Inline styles for email, also auto-generates text versions of emails

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -922,7 +922,6 @@ DEPENDENCIES
   carrierwave_backgrounder!
   chartkick
   chunky_png
-  coderay
   coffee-rails
   csv
   dartsass-rails

--- a/app/assets/stylesheets/legacy_includes/admin_unvendored.scss
+++ b/app/assets/stylesheets/legacy_includes/admin_unvendored.scss
@@ -13312,25 +13312,6 @@ table code {
   word-break: break-all
 }
 
-table .data-cell pre {
-  padding: .25rem .5rem;
-  margin: 0 0 .5rem
-}
-
-table .data-cell.only-data {
-  padding: 0
-}
-
-table .data-cell.only-data pre {
-  margin-bottom: 0;
-  border: none;
-  background: none
-}
-
-table .data-cell.only-data code {
-  position: relative
-}
-
 table .less-strong-hold {
   position: relative;
   min-height: 1.25em

--- a/app/assets/stylesheets/revised/_new_table_extensions.scss
+++ b/app/assets/stylesheets/revised/_new_table_extensions.scss
@@ -120,24 +120,6 @@ table {
     word-break: break-all;
   }
 
-  .data-cell {
-    pre {
-      padding: 0.25rem 0.5rem;
-      margin: 0 0 0.5rem;
-    }
-    &.only-data {
-      padding: 0;
-      pre {
-        margin-bottom: 0;
-        border: none;
-        background: none;
-      }
-      code {
-        position: relative;
-      }
-    }
-  }
-
   .less-strong-hold {
     position: relative;
     min-height: 1.25em;

--- a/app/assets/tailwind/json_display.css
+++ b/app/assets/tailwind/json_display.css
@@ -37,6 +37,7 @@
     @apply tw:w-px tw:p-0!;
   }
 
+  /* Scoped, because a legacy table has no row borders to redraw the box this strips */
   .ui-table .highlightjs-json-cell {
     @apply tw:w-full;
   }

--- a/app/assets/tailwind/json_display.css
+++ b/app/assets/tailwind/json_display.css
@@ -37,11 +37,11 @@
     @apply tw:w-px tw:p-0!;
   }
 
-  .highlightjs-json-cell {
+  .ui-table .highlightjs-json-cell {
     @apply tw:w-full;
   }
 
-  .highlightjs-json-cell pre {
+  .ui-table .highlightjs-json-cell pre {
     @apply tw:rounded-none tw:border-0;
   }
 }

--- a/app/assets/tailwind/json_display.css
+++ b/app/assets/tailwind/json_display.css
@@ -3,12 +3,7 @@
 
 @layer components {
   .highlightjs-json pre {
-    @apply tw:m-0 tw:max-h-72 tw:overflow-auto tw:rounded-sm tw:border tw:border-gray-300 tw:bg-gray-50 tw:p-1 tw:dark:border-gray-700 tw:dark:bg-gray-900;
-  }
-
-  /* Ties with the cap above, so it only wins by sitting after it */
-  .highlightjs-json-no-max-height pre {
-    @apply tw:max-h-none;
+    @apply tw:m-0 tw:overflow-auto tw:rounded-sm tw:border tw:border-gray-300 tw:bg-gray-50 tw:p-1 tw:dark:border-gray-700 tw:dark:bg-gray-900;
   }
 
   /* Only the json grammar is registered, so these six scopes are the whole theme */

--- a/app/assets/tailwind/json_display.css
+++ b/app/assets/tailwind/json_display.css
@@ -6,6 +6,11 @@
     @apply tw:m-0 tw:max-h-72 tw:overflow-auto tw:rounded-sm tw:border tw:border-gray-300 tw:bg-gray-50 tw:p-1 tw:dark:border-gray-700 tw:dark:bg-gray-900;
   }
 
+  /* Ties with the cap above, so it only wins by sitting after it */
+  .highlightjs-json-no-max-height pre {
+    @apply tw:max-h-none;
+  }
+
   /* Only the json grammar is registered, so these six scopes are the whole theme */
   .highlightjs-json .hljs-attr {
     @apply tw:text-purple-800 tw:dark:text-purple-300;

--- a/app/components/ui/json_display/component.rb
+++ b/app/components/ui/json_display/component.rb
@@ -7,7 +7,7 @@ module UI
       TABLE_CELL_MAX_WIDTH = 500
       private_constant :TABLE_CELL_MAX_WIDTH
 
-      def initialize(data:, max_width: nil, small: false, skip_blank: false)
+      def initialize(data:, max_width: nil, small: false, skip_blank: false, no_max_height: false)
         unless max_width.nil? || max_width.is_a?(Integer) || max_width == :table_cell
           raise ArgumentError, "max_width must be an integer (for pixels) or :table_cell (to be the max width of a table cell)"
         end
@@ -16,6 +16,7 @@ module UI
         @max_width = @table_cell ? TABLE_CELL_MAX_WIDTH : max_width
         @small = small
         @skip_blank = skip_blank
+        @no_max_height = no_max_height
       end
 
       def call
@@ -34,7 +35,10 @@ module UI
         data.select { |_key, value| Binxtils::InputNormalizer.present_or_false?(value) }
       end
 
-      def classes = ["highlightjs-json", ("highlightjs-json-cell" if @table_cell), ("tw:text-xs" if @small)].compact
+      def classes
+        ["highlightjs-json", ("highlightjs-json-cell" if @table_cell),
+          ("highlightjs-json-no-max-height" if @no_max_height), ("tw:text-xs" if @small)].compact
+      end
 
       # Inline, because Tailwind can't generate a class for a width it only sees at runtime
       def box_style

--- a/app/components/ui/json_display/component.rb
+++ b/app/components/ui/json_display/component.rb
@@ -5,14 +5,15 @@ module UI
     class Component < ApplicationComponent
       # A cell's default cap, so one long line can't hand the JSON column half the table
       TABLE_CELL_MAX_WIDTH = 500
+      private_constant :TABLE_CELL_MAX_WIDTH
 
       def initialize(data:, max_width: nil, small: false, skip_blank: false)
+        unless max_width.nil? || max_width.is_a?(Integer) || max_width == :table_cell
+          raise ArgumentError, "max_width must be an integer (for pixels) or :table_cell (to be the max width of a table cell)"
+        end
         @data = data
         @table_cell = max_width == :table_cell
         @max_width = @table_cell ? TABLE_CELL_MAX_WIDTH : max_width
-        unless @max_width.nil? || @max_width.is_a?(Integer)
-          raise ArgumentError, "max_width must be an integer (for pixels) or :table_cell (to be the max width of a table cell)"
-        end
         @small = small
         @skip_blank = skip_blank
       end

--- a/app/components/ui/json_display/component.rb
+++ b/app/components/ui/json_display/component.rb
@@ -6,13 +6,15 @@ module UI
       # A cell's default cap, so one long line can't hand the JSON column half the table
       TABLE_CELL_MAX_WIDTH = 500
 
-      def initialize(data:, max_width: nil, small: false, skip_blank: false, table_cell: false)
+      def initialize(data:, max_width: nil, small: false, skip_blank: false)
         @data = data
-        @max_width = ((max_width == :table_cell) ? TABLE_CELL_MAX_WIDTH : max_width) ||
-          (TABLE_CELL_MAX_WIDTH if table_cell)
+        @table_cell = max_width == :table_cell
+        @max_width = @table_cell ? TABLE_CELL_MAX_WIDTH : max_width
+        unless @max_width.nil? || @max_width.is_a?(Integer)
+          raise ArgumentError, "max_width must be an integer (for pixels) or :table_cell (to be the max width of a table cell)"
+        end
         @small = small
         @skip_blank = skip_blank
-        @table_cell = table_cell
       end
 
       def call

--- a/app/components/ui/json_display/component.rb
+++ b/app/components/ui/json_display/component.rb
@@ -4,12 +4,12 @@ module UI
   module JsonDisplay
     class Component < ApplicationComponent
       # A cell's default cap, so one long line can't hand the JSON column half the table
-      MAX_WIDTHS = {table_cell: 500}.freeze
+      TABLE_CELL_MAX_WIDTH = 500
 
       def initialize(data:, max_width: nil, small: false, skip_blank: false, table_cell: false)
         @data = data
-        @max_width = (max_width.is_a?(Symbol) ? MAX_WIDTHS.fetch(max_width) : max_width) ||
-          (MAX_WIDTHS[:table_cell] if table_cell)
+        @max_width = ((max_width == :table_cell) ? TABLE_CELL_MAX_WIDTH : max_width) ||
+          (TABLE_CELL_MAX_WIDTH if table_cell)
         @small = small
         @skip_blank = skip_blank
         @table_cell = table_cell

--- a/app/components/ui/json_display/component.rb
+++ b/app/components/ui/json_display/component.rb
@@ -4,11 +4,12 @@ module UI
   module JsonDisplay
     class Component < ApplicationComponent
       # A cell's default cap, so one long line can't hand the JSON column half the table
-      TABLE_CELL_MAX_WIDTH = 500
+      MAX_WIDTHS = {table_cell: 500}.freeze
 
       def initialize(data:, max_width: nil, small: false, skip_blank: false, table_cell: false)
         @data = data
-        @max_width = max_width || (TABLE_CELL_MAX_WIDTH if table_cell)
+        @max_width = (max_width.is_a?(Symbol) ? MAX_WIDTHS.fetch(max_width) : max_width) ||
+          (MAX_WIDTHS[:table_cell] if table_cell)
         @small = small
         @skip_blank = skip_blank
         @table_cell = table_cell

--- a/app/components/ui/json_display/component.rb
+++ b/app/components/ui/json_display/component.rb
@@ -20,7 +20,7 @@ module UI
       end
 
       def call
-        tag.div(tag.pre(tag.code(pretty_json, class: "language-json")),
+        tag.div(tag.pre(tag.code(pretty_json, class: "language-json"), class: pre_class),
           class: classes, style: box_style, data: {controller: "ui--json-display"})
       end
 
@@ -35,9 +35,11 @@ module UI
         data.select { |_key, value| Binxtils::InputNormalizer.present_or_false?(value) }
       end
 
-      def classes
-        ["highlightjs-json", ("highlightjs-json-cell" if @table_cell),
-          ("highlightjs-json-no-max-height" if @no_max_height), ("tw:text-xs" if @small)].compact
+      def classes = ["highlightjs-json", ("highlightjs-json-cell" if @table_cell), ("tw:text-xs" if @small)].compact
+
+      # Not an endless method: the condition would be read at definition time, where the ivar is nil
+      def pre_class
+        "tw:max-h-72" unless @no_max_height
       end
 
       # Inline, because Tailwind can't generate a class for a width it only sees at runtime

--- a/app/components/ui/json_display/component_preview.rb
+++ b/app/components/ui/json_display/component_preview.rb
@@ -23,7 +23,7 @@ module UI
         data = sample_data
         render(UI::Table::Component.new(records: [1, 2])) do |table|
           table.column(label: "Registration") { |number| "b_param #{number}" }
-          table.column(label: "Data") { |_number| render(UI::JsonDisplay::Component.new(data:, small: true, table_cell: true)) }
+          table.column(label: "Data") { |_number| render(UI::JsonDisplay::Component.new(data:, small: true, max_width: :table_cell)) }
         end
       end
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -108,21 +108,6 @@ module ApplicationHelper
     [twitterable(user), instagramable(user), websiteable(user)].compact.to_sentence.html_safe
   end
 
-  def pretty_print_json(data, no_blank = false)
-    require "coderay"
-    cleaned_data = if no_blank
-      # Show false values, just not empty or nil things
-      data.select do |k, v|
-        next unless Binxtils::InputNormalizer.present_or_false?(v)
-
-        [k, v]
-      end.compact.to_h
-    else
-      data
-    end
-    CodeRay.scan(JSON.pretty_generate(cleaned_data), :json).div.html_safe
-  end
-
   private
 
   def body_class

--- a/app/views/admin/b_params/_table.html.erb
+++ b/app/views/admin/b_params/_table.html.erb
@@ -44,6 +44,6 @@
   <% end %>
 
   <% table.column(label: "Data") do |b_param| %>
-    <%= render UI::JsonDisplay::Component.new(data: b_param.params, small: true, table_cell: true) %>
+    <%= render UI::JsonDisplay::Component.new(data: b_param.params, small: true, max_width: :table_cell) %>
   <% end %>
 <% end %>

--- a/app/views/admin/bulk_imports/show.html.haml
+++ b/app/views/admin/bulk_imports/show.html.haml
@@ -90,7 +90,7 @@
             - elsif data.except("headers").blank?
               No data (except <code>headers</code>)
             - else
-              .small= pretty_print_json(data.except("headers"))
+              = render UI::JsonDisplay::Component.new(data: data.except("headers"), small: true)
 
 .mt-4.mb-4
   %h3 Errors

--- a/app/views/admin/dashboard/ip_location.html.haml
+++ b/app/views/admin/dashboard/ip_location.html.haml
@@ -9,10 +9,10 @@
 .row
   .col-md-6
     %h4 Cloudflare
-    = render UI::JsonDisplay::Component.new(data: @cloudflare_hash, max_width: 500)
+    = render UI::JsonDisplay::Component.new(data: @cloudflare_hash)
   .col-md-6
     %h4 Geocoder
-    = render UI::JsonDisplay::Component.new(data: @geocoder_hash, max_width: 500)
+    = render UI::JsonDisplay::Component.new(data: @geocoder_hash)
   .col-md-6
     %h4 Raw Headers
-    = render UI::JsonDisplay::Component.new(data: @headers, max_width: 500)
+    = render UI::JsonDisplay::Component.new(data: @headers)

--- a/app/views/admin/dashboard/ip_location.html.haml
+++ b/app/views/admin/dashboard/ip_location.html.haml
@@ -9,10 +9,10 @@
 .row
   .col-md-6
     %h4 Cloudflare
-    = pretty_print_json(@cloudflare_hash)
+    = render UI::JsonDisplay::Component.new(data: @cloudflare_hash, max_width: 500)
   .col-md-6
     %h4 Geocoder
-    = pretty_print_json(@geocoder_hash)
+    = render UI::JsonDisplay::Component.new(data: @geocoder_hash, max_width: 500)
   .col-md-6
     %h4 Raw Headers
-    = pretty_print_json(@headers)
+    = render UI::JsonDisplay::Component.new(data: @headers, max_width: 500)

--- a/app/views/admin/email_domains/show.html.haml
+++ b/app/views/admin/email_domains/show.html.haml
@@ -140,7 +140,7 @@
 
 .row.mt-4.mb-4.pb-4
   .col-md-4.pt-3
-    .only-dev-visible.small= pretty_print_json(@email_domain.data)
+    .only-dev-visible= render UI::JsonDisplay::Component.new(data: @email_domain.data, small: true)
   .col-md-68.pt-3
     = render "form",
       email_domain: @email_domain,

--- a/app/views/admin/external_registry_bikes/show.html.haml
+++ b/app/views/admin/external_registry_bikes/show.html.haml
@@ -26,9 +26,7 @@
           = bike_status_span(@bike)
       %tr
         %td Date Stolen
-        %td.localizeTime
-          - if @bike.date_stolen.present?
-            = l @bike.date_stolen, format: :convert_time
+        %td= render UI::Time::Component.new(time: @bike.date_stolen)
       %tr
         %td Location
         %td= @bike.location_found

--- a/app/views/admin/external_registry_bikes/show.html.haml
+++ b/app/views/admin/external_registry_bikes/show.html.haml
@@ -57,6 +57,6 @@
             %span.localizeTime.preciseTime= l @bike.updated_at, format: :convert_time
     .mt-2
       %p.mb-0 Info Hash
-      = render UI::JsonDisplay::Component.new(data: @bike.info_hash)
+      = render UI::JsonDisplay::Component.new(data: @bike.info_hash, no_max_height: true)
 
 

--- a/app/views/admin/external_registry_bikes/show.html.haml
+++ b/app/views/admin/external_registry_bikes/show.html.haml
@@ -26,7 +26,9 @@
           = bike_status_span(@bike)
       %tr
         %td Date Stolen
-        %td.localizeTime= l @bike.date_stolen, format: :convert_time
+        %td.localizeTime
+          - if @bike.date_stolen.present?
+            = l @bike.date_stolen, format: :convert_time
       %tr
         %td Location
         %td= @bike.location_found
@@ -55,9 +57,8 @@
           %td Updated
           %td
             %span.localizeTime.preciseTime= l @bike.updated_at, format: :convert_time
-    .mt-2.p-2.pb-0{style: "border: 1px solid rgba(0,0,0,0.15);"}
+    .mt-2
       %p.mb-0 Info Hash
-      %code{style: "overflow: scroll; display: block; width: 100%;"}
-        = pretty_print_json(@bike.info_hash)
+      = render UI::JsonDisplay::Component.new(data: @bike.info_hash)
 
 

--- a/app/views/admin/feedbacks/show.html.haml
+++ b/app/views/admin/feedbacks/show.html.haml
@@ -43,8 +43,8 @@
             %td
               - if @feedback.organization.present?
                 = link_to @feedback.organization.name, admin_organization_path(@feedback.organization.to_param)
-              .small.mt-2
-                = pretty_print_json(@feedback.feedback_hash)
+              .mt-2
+                = render UI::JsonDisplay::Component.new(data: @feedback.feedback_hash, small: true)
         %tr
           %td
             Bike

--- a/app/views/admin/logged_searches/_table.html.erb
+++ b/app/views/admin/logged_searches/_table.html.erb
@@ -61,7 +61,7 @@
           </td>
 
           <td>
-            <%= render UI::JsonDisplay::Component.new(data: logged_search.query_items, small: true, max_width: 500) %>
+            <%= render UI::JsonDisplay::Component.new(data: logged_search.query_items, small: true, max_width: UI::JsonDisplay::Component::TABLE_CELL_MAX_WIDTH) %>
 
             <% if logged_search.log_line.present? %>
               <div data-controller="ui--collapse">

--- a/app/views/admin/logged_searches/_table.html.erb
+++ b/app/views/admin/logged_searches/_table.html.erb
@@ -61,7 +61,7 @@
           </td>
 
           <td>
-            <%= render UI::JsonDisplay::Component.new(data: logged_search.query_items, small: true, max_width: UI::JsonDisplay::Component::TABLE_CELL_MAX_WIDTH) %>
+            <%= render UI::JsonDisplay::Component.new(data: logged_search.query_items, small: true, max_width: :table_cell) %>
 
             <% if logged_search.log_line.present? %>
               <div data-controller="ui--collapse">

--- a/app/views/admin/logged_searches/_table.html.erb
+++ b/app/views/admin/logged_searches/_table.html.erb
@@ -60,24 +60,20 @@
             </small>
           </td>
 
-          <td class="data-cell only-data small">
-            <div class="wrapper" style="position: relative">
-              <% if logged_search.query_items.present? %>
-                <%= pretty_print_json(logged_search.query_items) %>
-              <% end %>
+          <td>
+            <%= render UI::JsonDisplay::Component.new(data: logged_search.query_items, small: true, max_width: 500) %>
 
-              <% if logged_search.log_line.present? %>
-                <div data-controller="ui--collapse">
-                  <%= render(UI::Button::Component.new(text: "↔️", color: :link, html_class: "tw:absolute tw:top-2 tw:right-2",
-                        data: {action: "ui--collapse#toggle", "ui--collapse-target": "trigger"},
-                        aria: {expanded: false, label: "Toggle the full log line"})) %>
+            <% if logged_search.log_line.present? %>
+              <div data-controller="ui--collapse">
+                <%= render(UI::Button::Component.new(text: "↔️", color: :link,
+                      data: {action: "ui--collapse#toggle", "ui--collapse-target": "trigger"},
+                      aria: {expanded: false, label: "Toggle the full log line"})) %>
 
-                  <code class="tw:hidden" data-ui--collapse-target="content">
-                    <%= logged_search.log_line %>
-                  </code>
-                </div>
-              <% end %>
-            </div>
+                <code class="tw:hidden" data-ui--collapse-target="content">
+                  <%= logged_search.log_line %>
+                </code>
+              </div>
+            <% end %>
           </td>
 
           <td>

--- a/app/views/admin/mailchimp_data/_table.html.erb
+++ b/app/views/admin/mailchimp_data/_table.html.erb
@@ -94,11 +94,8 @@
           <% end %>
         </td>
 
-        <td
-          class="data-cell small tw:hidden"
-          data-ui--collapse-target="content"
-        >
-          <%= pretty_print_json(mailchimp_datum.data) %>
+        <td class="tw:hidden" data-ui--collapse-target="content">
+          <%= render UI::JsonDisplay::Component.new(data: mailchimp_datum.data, small: true, max_width: 500) %>
         </td>
       </tr>
     <% end %>

--- a/app/views/admin/mailchimp_data/_table.html.erb
+++ b/app/views/admin/mailchimp_data/_table.html.erb
@@ -95,7 +95,7 @@
         </td>
 
         <td class="tw:hidden" data-ui--collapse-target="content">
-          <%= render UI::JsonDisplay::Component.new(data: mailchimp_datum.data, small: true, max_width: UI::JsonDisplay::Component::TABLE_CELL_MAX_WIDTH) %>
+          <%= render UI::JsonDisplay::Component.new(data: mailchimp_datum.data, small: true, max_width: :table_cell) %>
         </td>
       </tr>
     <% end %>

--- a/app/views/admin/mailchimp_data/_table.html.erb
+++ b/app/views/admin/mailchimp_data/_table.html.erb
@@ -95,7 +95,7 @@
         </td>
 
         <td class="tw:hidden" data-ui--collapse-target="content">
-          <%= render UI::JsonDisplay::Component.new(data: mailchimp_datum.data, small: true, max_width: 500) %>
+          <%= render UI::JsonDisplay::Component.new(data: mailchimp_datum.data, small: true, max_width: UI::JsonDisplay::Component::TABLE_CELL_MAX_WIDTH) %>
         </td>
       </tr>
     <% end %>

--- a/app/views/admin/mailchimp_values/_table.html.erb
+++ b/app/views/admin/mailchimp_values/_table.html.erb
@@ -45,7 +45,7 @@
         </td>
 
         <td class="tw:hidden" data-ui--collapse-target="content">
-          <%= render UI::JsonDisplay::Component.new(data: mailchimp_value.data, small: true, max_width: 500) %>
+          <%= render UI::JsonDisplay::Component.new(data: mailchimp_value.data, small: true, max_width: UI::JsonDisplay::Component::TABLE_CELL_MAX_WIDTH) %>
         </td>
       </tr>
     <% end %>

--- a/app/views/admin/mailchimp_values/_table.html.erb
+++ b/app/views/admin/mailchimp_values/_table.html.erb
@@ -44,11 +44,8 @@
           </small>
         </td>
 
-        <td
-          class="data-cell small tw:hidden"
-          data-ui--collapse-target="content"
-        >
-          <%= pretty_print_json(mailchimp_value.data) %>
+        <td class="tw:hidden" data-ui--collapse-target="content">
+          <%= render UI::JsonDisplay::Component.new(data: mailchimp_value.data, small: true, max_width: 500) %>
         </td>
       </tr>
     <% end %>

--- a/app/views/admin/mailchimp_values/_table.html.erb
+++ b/app/views/admin/mailchimp_values/_table.html.erb
@@ -45,7 +45,7 @@
         </td>
 
         <td class="tw:hidden" data-ui--collapse-target="content">
-          <%= render UI::JsonDisplay::Component.new(data: mailchimp_value.data, small: true, max_width: UI::JsonDisplay::Component::TABLE_CELL_MAX_WIDTH) %>
+          <%= render UI::JsonDisplay::Component.new(data: mailchimp_value.data, small: true, max_width: :table_cell) %>
         </td>
       </tr>
     <% end %>

--- a/app/views/admin/ownerships/edit.html.haml
+++ b/app/views/admin/ownerships/edit.html.haml
@@ -82,4 +82,4 @@
   .row.mt-5
     .col-md-6
       %h5.only-dev-visible Registration info
-      = pretty_print_json(@ownership.registration_info, true)
+      = render UI::JsonDisplay::Component.new(data: @ownership.registration_info, skip_blank: true)

--- a/app/views/admin/ownerships/edit.html.haml
+++ b/app/views/admin/ownerships/edit.html.haml
@@ -82,4 +82,4 @@
   .row.mt-5
     .col-md-6
       %h5.only-dev-visible Registration info
-      = render UI::JsonDisplay::Component.new(data: @ownership.registration_info, skip_blank: true)
+      = render UI::JsonDisplay::Component.new(data: @ownership.registration_info, skip_blank: true, no_max_height: true)

--- a/app/views/admin/paper_trail_versions/_table.html.erb
+++ b/app/views/admin/paper_trail_versions/_table.html.erb
@@ -54,7 +54,7 @@
           </td>
 
           <td>
-            <%= render UI::JsonDisplay::Component.new(data: version.object_changes, small: true, max_width: UI::JsonDisplay::Component::TABLE_CELL_MAX_WIDTH) %>
+            <%= render UI::JsonDisplay::Component.new(data: version.object_changes, small: true, max_width: :table_cell) %>
           </td>
         </tr>
       <% end %>

--- a/app/views/admin/paper_trail_versions/_table.html.erb
+++ b/app/views/admin/paper_trail_versions/_table.html.erb
@@ -54,7 +54,7 @@
           </td>
 
           <td>
-            <%= render UI::JsonDisplay::Component.new(data: version.object_changes, small: true, max_width: 500) %>
+            <%= render UI::JsonDisplay::Component.new(data: version.object_changes, small: true, max_width: UI::JsonDisplay::Component::TABLE_CELL_MAX_WIDTH) %>
           </td>
         </tr>
       <% end %>

--- a/app/views/admin/paper_trail_versions/_table.html.erb
+++ b/app/views/admin/paper_trail_versions/_table.html.erb
@@ -54,11 +54,7 @@
           </td>
 
           <td>
-            <small>
-              <% if version.object_changes.present? %>
-                <small><%= pretty_print_json(version.object_changes) %></small>
-              <% end %>
-            </small>
+            <%= render UI::JsonDisplay::Component.new(data: version.object_changes, small: true, max_width: 500) %>
           </td>
         </tr>
       <% end %>

--- a/app/views/admin/social_posts/_display.html.haml
+++ b/app/views/admin/social_posts/_display.html.haml
@@ -57,4 +57,4 @@
 %hr.mt-4
 
 %h3 Platform Response Data
-= pretty_print_json(@social_post.platform_response)
+= render UI::JsonDisplay::Component.new(data: @social_post.platform_response)

--- a/app/views/admin/social_posts/_display.html.haml
+++ b/app/views/admin/social_posts/_display.html.haml
@@ -57,4 +57,4 @@
 %hr.mt-4
 
 %h3 Platform Response Data
-= render UI::JsonDisplay::Component.new(data: @social_post.platform_response)
+= render UI::JsonDisplay::Component.new(data: @social_post.platform_response, no_max_height: true)

--- a/app/views/admin/theft_alerts/edit.html.haml
+++ b/app/views/admin/theft_alerts/edit.html.haml
@@ -233,4 +233,4 @@
 - if display_dev_info?
   .mt-5.mb-1.only-dev-visible
     %h2 Raw facebook data
-  = pretty_print_json(@theft_alert.facebook_data)
+  = render UI::JsonDisplay::Component.new(data: @theft_alert.facebook_data)

--- a/app/views/admin/theft_alerts/edit.html.haml
+++ b/app/views/admin/theft_alerts/edit.html.haml
@@ -233,4 +233,4 @@
 - if display_dev_info?
   .mt-5.mb-1.only-dev-visible
     %h2 Raw facebook data
-  = render UI::JsonDisplay::Component.new(data: @theft_alert.facebook_data)
+  = render UI::JsonDisplay::Component.new(data: @theft_alert.facebook_data, no_max_height: true)

--- a/app/views/admin/user_registration_organizations/_table.html.erb
+++ b/app/views/admin/user_registration_organizations/_table.html.erb
@@ -21,7 +21,7 @@
   <% end %>
 
   <% table.column(label: "Registration info", header_classes: "tw:font-normal") do |user_registration_organization| %>
-    <%= render UI::JsonDisplay::Component.new(data: user_registration_organization.registration_info, small: true, table_cell: true) %>
+    <%= render UI::JsonDisplay::Component.new(data: user_registration_organization.registration_info, small: true, max_width: :table_cell) %>
   <% end %>
 
   <% table.column(label: "All bikes", classes: "tw:text-center") do |user_registration_organization| %>

--- a/spec/components/ui/json_display/component_spec.rb
+++ b/spec/components/ui/json_display/component_spec.rb
@@ -28,14 +28,6 @@ RSpec.describe UI::JsonDisplay::Component, type: :component do
       expect(component).to have_css("div.highlightjs-json[style='max-width: 500px;']")
       expect(component).to_not have_css("div.highlightjs-json-cell")
     end
-
-    context "with an unknown name" do
-      let(:options) { {max_width: :sidebar} }
-
-      it "raises" do
-        expect { component }.to raise_error(KeyError)
-      end
-    end
   end
 
   context "with table_cell" do

--- a/spec/components/ui/json_display/component_spec.rb
+++ b/spec/components/ui/json_display/component_spec.rb
@@ -21,6 +21,23 @@ RSpec.describe UI::JsonDisplay::Component, type: :component do
     end
   end
 
+  context "with a named max_width" do
+    let(:options) { {max_width: :table_cell} }
+
+    it "resolves the symbol to its pixel width, without the cell-filling class" do
+      expect(component).to have_css("div.highlightjs-json[style='max-width: 500px;']")
+      expect(component).to_not have_css("div.highlightjs-json-cell")
+    end
+
+    context "with an unknown name" do
+      let(:options) { {max_width: :sidebar} }
+
+      it "raises" do
+        expect { component }.to raise_error(KeyError)
+      end
+    end
+  end
+
   context "with table_cell" do
     let(:options) { {table_cell: true} }
 

--- a/spec/components/ui/json_display/component_spec.rb
+++ b/spec/components/ui/json_display/component_spec.rb
@@ -11,6 +11,15 @@ RSpec.describe UI::JsonDisplay::Component, type: :component do
     expect(component).to have_css("div.highlightjs-json[data-controller='ui--json-display'] pre code.language-json")
     expect(component.text).to include "bike_sticker"
     expect(component).to_not have_css("div.highlightjs-json[style]")
+    expect(component).to_not have_css("div.highlightjs-json-no-max-height")
+  end
+
+  context "with no_max_height" do
+    let(:options) { {no_max_height: true} }
+
+    it "adds the class that drops the height cap" do
+      expect(component).to have_css("div.highlightjs-json.highlightjs-json-no-max-height")
+    end
   end
 
   context "with small and max_width" do

--- a/spec/components/ui/json_display/component_spec.rb
+++ b/spec/components/ui/json_display/component_spec.rb
@@ -21,28 +21,28 @@ RSpec.describe UI::JsonDisplay::Component, type: :component do
     end
   end
 
-  context "with a named max_width" do
+  context "with max_width: :table_cell" do
     let(:options) { {max_width: :table_cell} }
 
-    it "resolves the symbol to its pixel width, without the cell-filling class" do
-      expect(component).to have_css("div.highlightjs-json[style='max-width: 500px;']")
-      expect(component).to_not have_css("div.highlightjs-json-cell")
+    it "resolves the name to its pixel width and adds the cell-filling class" do
+      expect(component).to have_css("div.highlightjs-json.highlightjs-json-cell[style='max-width: 500px;']")
     end
   end
 
-  context "with table_cell" do
-    let(:options) { {table_cell: true} }
+  context "with a max_width that is neither" do
+    let(:options) { {max_width: :sidebar} }
 
-    it "adds the cell-filling class and defaults the cap" do
-      expect(component).to have_css("div.highlightjs-json.highlightjs-json-cell[style='max-width: 500px;']")
+    it "raises" do
+      expect { component }.to raise_error(ArgumentError, /must be an integer .* or :table_cell/)
     end
+  end
 
-    context "with max_width passed" do
-      let(:options) { {table_cell: true, max_width: 300} }
+  context "with a pixel max_width" do
+    let(:options) { {max_width: 300} }
 
-      it "takes the given width over the default" do
-        expect(component).to have_css("div.highlightjs-json-cell[style='max-width: 300px;']")
-      end
+    it "does not add the cell-filling class" do
+      expect(component).to have_css("div.highlightjs-json[style='max-width: 300px;']")
+      expect(component).to_not have_css("div.highlightjs-json-cell")
     end
   end
 

--- a/spec/components/ui/json_display/component_spec.rb
+++ b/spec/components/ui/json_display/component_spec.rb
@@ -11,14 +11,14 @@ RSpec.describe UI::JsonDisplay::Component, type: :component do
     expect(component).to have_css("div.highlightjs-json[data-controller='ui--json-display'] pre code.language-json")
     expect(component.text).to include "bike_sticker"
     expect(component).to_not have_css("div.highlightjs-json[style]")
-    expect(component).to_not have_css("div.highlightjs-json-no-max-height")
+    expect(component).to have_css("div.highlightjs-json pre.tw\\:max-h-72")
   end
 
   context "with no_max_height" do
     let(:options) { {no_max_height: true} }
 
     it "adds the class that drops the height cap" do
-      expect(component).to have_css("div.highlightjs-json.highlightjs-json-no-max-height")
+      expect(component).to_not have_css("pre.tw\\:max-h-72")
     end
   end
 

--- a/spec/requests/admin/external_registry_bikes_request_spec.rb
+++ b/spec/requests/admin/external_registry_bikes_request_spec.rb
@@ -14,4 +14,13 @@ RSpec.describe Admin::ExternalRegistryBikesController, type: :request do
       expect(assigns(:bikes).pluck(:id)).to eq([external_registry_bike.id])
     end
   end
+
+  describe "show" do
+    let(:external_registry_bike) { FactoryBot.create(:external_registry_bike, info_hash: {"color" => "blue"}) }
+    it "renders" do
+      get "#{base_url}/#{external_registry_bike.id}"
+      expect(response.status).to eq(200)
+      expect(response).to render_template(:show)
+    end
+  end
 end


### PR DESCRIPTION
#4218 introduced `UI::JsonDisplay` but left `pretty_print_json` with its other 13 call sites, so CodeRay stayed a dependency and admin JSON dumps kept rendering with token colours baked in as inline styles — unreadable in dark mode.

- **Converts the remaining 13 call sites**, then deletes the helper, the `coderay` gem, and the `.data-cell` / `.data-cell.only-data` SCSS that styled the `pre` inside JSON table cells. Both copies of that CSS had to go: `admin_unvendored.scss` is what was actually in effect on these pages, `_new_table_extensions.scss` reaches them via `revised.scss`.
- **`table_cell:` gives way to `max_width: :table_cell`**, so a JSON cell is one argument rather than two that each half-set the width. The name carries the `.highlightjs-json-cell` chrome as well, and that chrome is now scoped to `.ui-table` — its `rounded-none border-0` leans on the row borders to redraw the box, and a Bootstrap `.table` only gives a `td` a `border-top`. So the four legacy tables get the cap with their border intact, and swapping them to `UI::Table` later needs no change here. `max_width:` takes an Integer or that one name, and raises otherwise.
- **Two fixes the conversion surfaced**: `/admin/external_registry_bikes/:id` 500'd on a null `date_stolen` (`l nil` raises, and `VerlorenOfGevondenBike.parse_date_found` can return one) — now `UI::Time::Component`, with the request spec that catches it. And logged searches' log-line toggle was absolutely positioned over what used to be a borderless dump, so it covered the new box; it moves into flow.

`/admin/ip_location` passes no width at all — its `col-md-6` already bounds the box, and a cap there only cost the Raw Headers dump 189px of every line.
