### PR TITLE
Don't send user alert notifications for deleted users

### DIFF
--- a/app/mailers/customer_mailer.rb
+++ b/app/mailers/customer_mailer.rb
@@ -171,7 +171,7 @@ class CustomerMailer < ApplicationMailer
 
     I18n.with_locale(@user&.preferred_language) do
       mail(
-        to: @user_alert.user.email,
+        to: @user.email,
         from: "bryan@bikeindex.org",
         subject: @user_alert.email_subject,
         tag: __callee__

--- a/app/models/user_alert.rb
+++ b/app/models/user_alert.rb
@@ -242,9 +242,9 @@ class UserAlert < ApplicationRecord
   end
 
   def create_notification?
-    return false if user.blank? || inactive? || notification.present? ||
+    return false if inactive? || notification.present? ||
       !self.class.notify_period.cover?(updated_at) ||
-      self.class.notification_kinds.exclude?(kind)
+      self.class.notification_kinds.exclude?(kind) || user.blank?
 
     # Check if the relevant object is updated since
     if theft_alert_without_photo? || stolen_bike_without_location?

--- a/app/models/user_alert.rb
+++ b/app/models/user_alert.rb
@@ -58,7 +58,7 @@ class UserAlert < ApplicationRecord
   scope :dismissable, -> { where(kind: dismissable_kinds) }
   scope :with_notification, -> { joins(:notification).where.not(notifications: {id: nil}) }
   scope :create_notification, -> {
-    where(kind: notification_kinds, updated_at: notify_period)
+    joins(:user).where(kind: notification_kinds, updated_at: notify_period)
       .left_joins(:notification).where(notifications: {id: nil})
   }
 
@@ -242,7 +242,7 @@ class UserAlert < ApplicationRecord
   end
 
   def create_notification?
-    return false if inactive? || notification.present? ||
+    return false if user.blank? || inactive? || notification.present? ||
       !self.class.notify_period.cover?(updated_at) ||
       self.class.notification_kinds.exclude?(kind)
 

--- a/spec/models/user_alert_spec.rb
+++ b/spec/models/user_alert_spec.rb
@@ -221,6 +221,14 @@ RSpec.describe UserAlert, type: :model do
           expect(UserAlert.create_notification.pluck(:id)).to eq([])
         end
       end
+      context "user deleted" do
+        it "is false" do
+          user_alert.user.destroy
+          expect(user_alert.reload.user).to be_blank
+          expect(user_alert.create_notification?).to be_falsey
+          expect(UserAlert.create_notification.pluck(:id)).to eq([])
+        end
+      end
       context "stolen bike no_notify" do
         it "is false" do
           user_alert.bike.current_stolen_record.update(receive_notifications: false)

--- a/spec/models/user_alert_spec.rb
+++ b/spec/models/user_alert_spec.rb
@@ -224,8 +224,7 @@ RSpec.describe UserAlert, type: :model do
       context "user deleted" do
         it "is false" do
           user_alert.user.destroy
-          expect(user_alert.reload.user).to be_blank
-          expect(user_alert.create_notification?).to be_falsey
+          expect(user_alert.reload.create_notification?).to be_falsey
           expect(UserAlert.create_notification.pluck(:id)).to eq([])
         end
       end


### PR DESCRIPTION
`CreateUserAlertNotificationJob` raised `NoMethodError: undefined method 'email' for nil` in production. `User` is `acts_as_paranoid` and `has_many :user_alerts` declares no `dependent:`, so a deleted account leaves alerts whose `user` resolves to nil — and nothing on the path looked: the `create_notification` scope doesn't join `users`, and `create_notification?` checks the alert, the notification and the bike but never the user. A production-derived dump holds 550 orphaned alerts across 435 users.

- **Filters them at both gates** — `joins(:user)` on the scope so `enqueue_workers` skips them, and a `user.blank?` check in `create_notification?` for the job's direct-id path, last in the `||` chain so the free in-memory checks get to reject first.
- **Doesn't stop the orphaning.** Barely any of `User`'s `has_many` declare `dependent:`, so adding it here would hard-delete alerts on a *soft* delete — resolving them on deletion belongs in `AfterUserChangeJob#update_user_alerts` if we want it.
- **The same shape is still live in two other mailers**: `OrganizedMailer#impound_claim_approved_or_denied` and `CustomerMailer#theft_alert_email` both dereference `.user.email` off a record whose user can be deleted. Neither has fired, so they're untouched here.
