### PR TITLE
Split the org registrations menu row when bike_search is off

### DIFF
--- a/app/controllers/concerns/controller_helpers.rb
+++ b/app/controllers/concerns/controller_helpers.rb
@@ -192,8 +192,10 @@ module ControllerHelpers
     @show_general_alert = !no_alerts
   end
 
+  # Without bike_search the organization's index lists their registrations rather than
+  # searching them, so the whole registry is the search they get
   def default_bike_search_path
-    return every_bike_search_path if passive_organization.blank?
+    return every_bike_search_path unless passive_organization&.enabled?("bike_search")
 
     organization_registrations_path(organization_id: passive_organization.to_param)
   end

--- a/app/services/user_services/menu_items_org.rb
+++ b/app/services/user_services/menu_items_org.rb
@@ -103,7 +103,7 @@ module UserServices
       path = routes.organization_registrations_path(organization_id: organization.to_param)
       return [ComponentStructs::Shapes.link(translation(:search_registrations), path)] if organization.enabled?("bike_search")
 
-      [ComponentStructs::Shapes.link(translation(:org_registrations_index, org_name: organization.short_name), path),
+      [ComponentStructs::Shapes.link(translation(:org_registrations_index), path),
         ComponentStructs::Shapes.link(translation(:search_all_registrations),
           routes.search_registrations_path(stolenness: "all"))]
     end

--- a/app/services/user_services/menu_items_org.rb
+++ b/app/services/user_services/menu_items_org.rb
@@ -82,7 +82,8 @@ module UserServices
     end
 
     def registrations_group(organization)
-      children = registrations_links(organization) + [
+      children = [
+        *registrations_links(organization),
         enabled_link(organization, "show_partial_registrations", translation(:incomplete_registrations),
           routes.incompletes_organization_bikes_path(organization.to_param)),
         enabled_link(organization, "bike_search", translation(:multi_search),
@@ -97,14 +98,12 @@ module UserServices
         translation(:org_registrations, org_name: organization.short_name), "bike", children)
     end
 
-    # Without bike_search the index only lists the organization's own registrations, so
-    # searching means the whole registry
+    # Without bike_search the index lists the organization's own registrations rather than searching them
     def registrations_links(organization)
-      index = routes.organization_registrations_path(organization_id: organization.to_param)
-      return [ComponentStructs::Shapes.link(translation(:search_registrations), index)] if
-        organization.enabled?("bike_search")
+      path = routes.organization_registrations_path(organization_id: organization.to_param)
+      return [ComponentStructs::Shapes.link(translation(:search_registrations), path)] if organization.enabled?("bike_search")
 
-      [ComponentStructs::Shapes.link(translation(:org_registrations_index, org_name: organization.short_name), index),
+      [ComponentStructs::Shapes.link(translation(:org_registrations_index, org_name: organization.short_name), path),
         ComponentStructs::Shapes.link(translation(:search_all_registrations),
           routes.search_registrations_path(stolenness: "all"))]
     end

--- a/app/services/user_services/menu_items_org.rb
+++ b/app/services/user_services/menu_items_org.rb
@@ -82,9 +82,7 @@ module UserServices
     end
 
     def registrations_group(organization)
-      children = [
-        ComponentStructs::Shapes.link(translation(:search_registrations),
-          routes.organization_registrations_path(organization_id: organization.to_param)),
+      children = registrations_links(organization) + [
         enabled_link(organization, "show_partial_registrations", translation(:incomplete_registrations),
           routes.incompletes_organization_bikes_path(organization.to_param)),
         enabled_link(organization, "bike_search", translation(:multi_search),
@@ -97,6 +95,18 @@ module UserServices
 
       ComponentStructs::Shapes.group(:registrations,
         translation(:org_registrations, org_name: organization.short_name), "bike", children)
+    end
+
+    # Without bike_search the index only lists the organization's own registrations, so
+    # searching means the whole registry
+    def registrations_links(organization)
+      index = routes.organization_registrations_path(organization_id: organization.to_param)
+      return [ComponentStructs::Shapes.link(translation(:search_registrations), index)] if
+        organization.enabled?("bike_search")
+
+      [ComponentStructs::Shapes.link(translation(:org_registrations_index, org_name: organization.short_name), index),
+        ComponentStructs::Shapes.link(translation(:search_all_registrations),
+          routes.search_registrations_path(stolenness: "all"))]
     end
 
     # The old view puts this row on organized/bikes#new, which the parking notification row
@@ -253,7 +263,7 @@ module UserServices
     end
 
     conceal :build_items, :organization_sections, :super_admin_link, :ambassador_items,
-      :registrations_group, :add_bike_link, :impounded_group,
+      :registrations_group, :registrations_links, :add_bike_link, :impounded_group,
       :parking_group, :bulk_group, :lightspeed_link, :messaging_link, :model_audits_link, :graduated_link,
       :hot_sheet_link, :reports_link, :settings_group, :org_root, :enabled_link, :translation, :routes
   end

--- a/app/services/user_services/menu_items_org.rb
+++ b/app/services/user_services/menu_items_org.rb
@@ -103,7 +103,7 @@ module UserServices
       path = routes.organization_registrations_path(organization_id: organization.to_param)
       return [ComponentStructs::Shapes.link(translation(:search_registrations), path)] if organization.enabled?("bike_search")
 
-      [ComponentStructs::Shapes.link(translation(:org_registrations_index), path),
+      [ComponentStructs::Shapes.link(translation(:registrations_index), path),
         ComponentStructs::Shapes.link(translation(:search_all_registrations),
           routes.search_registrations_path(stolenness: "all"))]
     end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -5070,13 +5070,13 @@ en:
       org_locations: "%{org_name} locations"
       org_profile: "%{org_name} profile"
       org_registrations: "%{org_name} Registrations"
-      org_registrations_index: Organization Registrations
       org_settings: "%{org_name} Settings"
       parking_notification_unregistered: New unregistered notification
       parking_notifications_group: Parking Notifications
       recoveries: Recoveries
       registration_sequences: Registration sequences
       registration_stickers: Registration stickers
+      registrations_index: Organization Registrations
       reports: Reports
       resources: Resources
       search_all_registrations: Search all registrations

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -5009,6 +5009,7 @@ en:
       org_locations: "%{org_name} locations"
       org_profile: "%{org_name} profile"
       org_registrations: "%{org_name} Registrations"
+      org_registrations_index: "%{org_name} registrations"
       org_settings: "%{org_name} Settings"
       parking_notification_unregistered: New unregistered notification
       parking_notifications_group: Parking Notifications
@@ -5017,6 +5018,7 @@ en:
       registration_stickers: Registration stickers
       reports: Reports
       resources: Resources
+      search_all_registrations: Search all registrations
       search_impounded_vehicles: Search Impounded Vehicles
       search_parking_notifications: Search Parking Notifications
       search_registrations: Search Registrations

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -5070,7 +5070,7 @@ en:
       org_locations: "%{org_name} locations"
       org_profile: "%{org_name} profile"
       org_registrations: "%{org_name} Registrations"
-      org_registrations_index: "%{org_name} registrations"
+      org_registrations_index: Organization Registrations
       org_settings: "%{org_name} Settings"
       parking_notification_unregistered: New unregistered notification
       parking_notifications_group: Parking Notifications

--- a/spec/integration/mobile_nav_menu_spec.rb
+++ b/spec/integration/mobile_nav_menu_spec.rb
@@ -147,7 +147,7 @@ RSpec.describe "Navbar", :js, type: :system do
         # Clicking the group that was already open has to leave it open, not toggle it shut
         registrations.click
 
-        expect(page).to have_link("#{organization.short_name} registrations")
+        expect(page).to have_link("Organization Registrations")
         expect(registrations["aria-expanded"]).to eq "true"
 
         find("[data-shared-blocks--org-sidebar-target='collapseToggle']").click

--- a/spec/integration/mobile_nav_menu_spec.rb
+++ b/spec/integration/mobile_nav_menu_spec.rb
@@ -160,7 +160,7 @@ RSpec.describe "Navbar", :js, type: :system do
         # Clicking the group that was already open has to leave it open, not toggle it shut
         registrations.click
 
-        expect(page).to have_link("Search Registrations")
+        expect(page).to have_link("#{organization.short_name} registrations")
         expect(registrations["aria-expanded"]).to eq "true"
 
         find("[data-shared-blocks--org-sidebar-target='collapseToggle']").click

--- a/spec/integration/organized/sidebar_spec.rb
+++ b/spec/integration/organized/sidebar_spec.rb
@@ -68,13 +68,12 @@ RSpec.describe "Organization sidebar", :js, type: :system do
     expect_open("#{organization.short_name} Registrations")
     expect_current_group("Impounded Vehicles")
 
-    within("#org_sidebar_nav") { click_link "#{organization.short_name} registrations" }
+    within("#org_sidebar_nav") { click_link "Organization Registrations" }
 
     expect(page).to have_current_path("/o/#{slug}/registrations", ignore_query: true)
     expect_open("#{organization.short_name} Registrations")
     expect_current_group("#{organization.short_name} Registrations")
-    expect(page).to have_css "#org_sidebar_nav a[aria-current='page']",
-      text: "#{organization.short_name} registrations"
+    expect(page).to have_css "#org_sidebar_nav a[aria-current='page']", text: "Organization Registrations"
     expect(page).to have_no_css "#org_sidebar_nav a[aria-current]", text: "Search Impounded Vehicles"
 
     # Short enough that the menu scrolls, with Manage users past its fold

--- a/spec/integration/organized/sidebar_spec.rb
+++ b/spec/integration/organized/sidebar_spec.rb
@@ -72,12 +72,13 @@ RSpec.describe "Organization sidebar", :js, type: :system do
     expect_open("#{organization.short_name} Registrations")
     expect_current_group("Impounded Vehicles")
 
-    within("#org_sidebar_nav") { click_link "Search Registrations" }
+    within("#org_sidebar_nav") { click_link "#{organization.short_name} registrations" }
 
     expect(page).to have_current_path("/o/#{slug}/registrations", ignore_query: true)
     expect_open("#{organization.short_name} Registrations")
     expect_current_group("#{organization.short_name} Registrations")
-    expect(page).to have_css "#org_sidebar_nav a[aria-current='page']", text: "Search Registrations"
+    expect(page).to have_css "#org_sidebar_nav a[aria-current='page']",
+      text: "#{organization.short_name} registrations"
     expect(page).to have_no_css "#org_sidebar_nav a[aria-current]", text: "Search Impounded Vehicles"
 
     # Short enough that the menu scrolls, with Manage users past its fold

--- a/spec/requests/api/v3/me_request_spec.rb
+++ b/spec/requests/api/v3/me_request_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe "Me API V3", type: :request do
           {type: "group", key: "registrations", label: "#{organization.short_name} Registrations",
            icon: "bike",
            children: [
-             {type: "link", label: "#{organization.short_name} registrations",
+             {type: "link", label: "Organization Registrations",
               path: "/o/#{organization.slug}/registrations", icon: nil},
              {type: "link", label: "Search all registrations",
               path: "/search/registrations?stolenness=all", icon: nil}

--- a/spec/requests/api/v3/me_request_spec.rb
+++ b/spec/requests/api/v3/me_request_spec.rb
@@ -29,8 +29,10 @@ RSpec.describe "Me API V3", type: :request do
           {type: "group", key: "registrations", label: "#{organization.short_name} Registrations",
            icon: "bike",
            children: [
-             {type: "link", label: "Search Registrations", path: "/o/#{organization.slug}/registrations",
-              icon: nil}
+             {type: "link", label: "#{organization.short_name} registrations",
+              path: "/o/#{organization.slug}/registrations", icon: nil},
+             {type: "link", label: "Search all registrations",
+              path: "/search/registrations?stolenness=all", icon: nil}
            ]},
           {type: "link", label: "Add a bike", path: "/o/#{organization.slug}/registrations/new",
            icon: "plus-circle", match_params: {parking_notification: nil}}

--- a/spec/requests/info_request_spec.rb
+++ b/spec/requests/info_request_spec.rb
@@ -85,6 +85,32 @@ RSpec.describe InfoController, type: :request do
         end
       end
     end
+
+    # serials is the one static page that links default_bike_search_path
+    describe "serials search links" do
+      let(:organization) { FactoryBot.create(:organization) }
+      let(:current_user) { FactoryBot.create(:organization_user, organization:) }
+      let(:search_hrefs) do
+        get "/serials"
+        Nokogiri::HTML(response.body).css("a.serial-search-screenshot").map { |link| link["href"] }
+      end
+      before { log_in(current_user) }
+
+      it "sends a member of an organization that can't search to every registration" do
+        expect(search_hrefs).to eq([search_registrations_path(stolenness: "all")])
+      end
+
+      context "with bike_search" do
+        let(:organization) do
+          FactoryBot.create(:organization_with_organization_features, enabled_feature_slugs: ["bike_search"])
+        end
+
+        it "sends them to their own registrations" do
+          expect(search_hrefs).to eq([organization_registrations_path(organization_id: organization.to_param)])
+        end
+      end
+    end
+
     %w[image_resources dev_and_design].each do |page|
       context page do
         it "redirects to resources" do

--- a/spec/services/user_services/menu_items_org_spec.rb
+++ b/spec/services/user_services/menu_items_org_spec.rb
@@ -51,7 +51,8 @@ RSpec.describe UserServices::MenuItemsOrg do
       let(:target) do
         [
           group_item(:registrations, "#{organization.short_name} Registrations", "bike", [
-            link_item("Search Registrations", "/o/#{organization.to_param}/registrations")
+            link_item("#{organization.short_name} registrations", "/o/#{organization.to_param}/registrations"),
+            link_item("Search all registrations", "/search/registrations?stolenness=all")
           ]),
           link_item("Add a bike", "/o/#{organization.to_param}/registrations/new",
             icon: "plus-circle", match_params: {parking_notification: nil})

--- a/spec/services/user_services/menu_items_org_spec.rb
+++ b/spec/services/user_services/menu_items_org_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe UserServices::MenuItemsOrg do
       let(:target) do
         [
           group_item(:registrations, "#{organization.short_name} Registrations", "bike", [
-            link_item("#{organization.short_name} registrations", "/o/#{organization.to_param}/registrations"),
+            link_item("Organization Registrations", "/o/#{organization.to_param}/registrations"),
             link_item("Search all registrations", "/search/registrations?stolenness=all")
           ]),
           link_item("Add a bike", "/o/#{organization.to_param}/registrations/new",


### PR DESCRIPTION
Without the `bike_search` feature, `/o/<slug>/registrations` isn't a search — `Organized::RegistrationsController#index` branches on the feature and renders a plain paginated list of the organization's own registrations. Two places sent members there to look a bike up.

- **Splits the sidebar row in two for them** — "Organization Registrations" for their own list, plus "Search all registrations" into the public registry. Organizations with `bike_search` keep the single "Search Registrations" row, unchanged.
- **`default_bike_search_path` now requires the feature** rather than pointing every org member at their own index. Its one live caller is the `/serials` page's two search links; the primary navbar's Search never reaches the organization branch, since a member with a passive organization gets the org sidebar in the navbar's place.
